### PR TITLE
Informs passing flags is unimplemented instead of quitting.

### DIFF
--- a/src/parser/hir/baseline_parse_tokens.rs
+++ b/src/parser/hir/baseline_parse_tokens.rs
@@ -161,7 +161,7 @@ pub fn baseline_parse_semantic_token(
         TokenNode::Delimited(delimited) => baseline_parse_delimited(delimited, registry, source),
         TokenNode::Pipeline(_pipeline) => unimplemented!(),
         TokenNode::Operator(_op) => unreachable!(),
-        TokenNode::Flag(_flag) => unimplemented!(),
+        TokenNode::Flag(_flag) => Err(ShellError::unimplemented("passing flags is not supported yet.")),
         TokenNode::Identifier(_span) => unreachable!(),
         TokenNode::Whitespace(_span) => unreachable!(),
         TokenNode::Error(error) => Err(*error.item.clone()),


### PR DESCRIPTION
Most of the time commands such as `ls` everyone is used to passing flags. Since Nu currently doesn't support this feature yet we inform the case instead of quitting.