### PR TITLE
K raw unit is a kilobyte.

### DIFF
--- a/src/parser/parse/parser.rs
+++ b/src/parser/parse/parser.rs
@@ -217,6 +217,8 @@ pub fn raw_unit(input: NomSpan) -> IResult<NomSpan, Spanned<Unit>> {
             tag("KB"),
             tag("kb"),
             tag("Kb"),
+            tag("K"),
+            tag("k"),
             tag("MB"),
             tag("mb"),
             tag("Mb"),

--- a/src/parser/parse/unit.rs
+++ b/src/parser/parse/unit.rs
@@ -46,8 +46,8 @@ impl FromStr for Unit {
     type Err = ();
     fn from_str(input: &str) -> Result<Self, <Self as std::str::FromStr>::Err> {
         match input {
-            "B" | "b" => Ok(Unit::B),
-            "KB" | "kb" | "Kb" => Ok(Unit::KB),
+             "B" |  "b" => Ok(Unit::B),
+            "KB" | "kb" | "Kb" | "K" | "k" => Ok(Unit::KB),
             "MB" | "mb" | "Mb" => Ok(Unit::MB),
             "GB" | "gb" | "Gb" => Ok(Unit::GB),
             "TB" | "tb" | "Tb" => Ok(Unit::TB),


### PR DESCRIPTION
Should handle "K" (see #155). 

`kb|kB|Kb|KB` and others could also be shortened by using nom's `tag_no_case`. I think it'd be better if things are kept more "verbose" (independently calling `tag` for all cases) while parsing matures.