### PR TITLE
Switch from_csv to output rows

### DIFF
--- a/src/commands/from_csv.rs
+++ b/src/commands/from_csv.rs
@@ -1,4 +1,4 @@
-use crate::object::{Primitive, SpannedDictBuilder, SpannedListBuilder, Value};
+use crate::object::{Primitive, SpannedDictBuilder, Value};
 use crate::prelude::*;
 use csv::ReaderBuilder;
 
@@ -13,8 +13,7 @@ pub fn from_csv_string_to_value(
 
     let mut fields: VecDeque<String> = VecDeque::new();
     let mut iter = reader.records();
-    let mut root = SpannedDictBuilder::new(span);
-    let mut rows = SpannedListBuilder::new(span);
+    let mut rows = vec![];
 
     if let Some(result) = iter.next() {
         let line = result?;
@@ -37,14 +36,16 @@ pub fn from_csv_string_to_value(
                 );
             }
 
-            rows.insert_spanned(row.into_spanned_value());
+            rows.push(row.into_spanned_value());
         } else {
             break;
         }
     }
 
-    root.insert_spanned("root", rows.into_spanned_value());
-    Ok(root.into_spanned_value())
+    Ok(Spanned {
+        item: Value::List(rows),
+        span,
+    })
 }
 
 pub fn from_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -39,14 +39,23 @@ command! {
         }
 
         match contents {
-            Value::Primitive(Primitive::String(string)) =>
-                stream.push_back(ReturnSuccess::value(parse_as_value(
+            Value::Primitive(Primitive::String(string)) => {
+                let value = parse_as_value(
                     file_extension,
                     string,
                     contents_span,
                     span,
-                )?)
-            ),
+                )?;
+
+                match value {
+                    Spanned { item: Value::List(list), .. } => {
+                        for elem in list {
+                            stream.push_back(ReturnSuccess::value(elem));
+                        }
+                    }
+                    x => stream.push_back(ReturnSuccess::value(x))
+                }
+            },
 
             other => stream.push_back(ReturnSuccess::value(other.spanned(contents_span))),
         };

--- a/src/object.rs
+++ b/src/object.rs
@@ -7,5 +7,5 @@ crate mod process;
 crate mod types;
 
 crate use base::{Block, Primitive, Switch, Value};
-crate use dict::{Dictionary, SpannedDictBuilder, SpannedListBuilder};
+crate use dict::{Dictionary, SpannedDictBuilder};
 crate use files::dir_entry_dict;

--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -17,7 +17,7 @@ fn open_csv() {
     nu!(
         output,
         cwd("tests/fixtures/formats"),
-        "open caco3_plastics.csv | get root | first 1 | get origin | echo $it"
+        "open caco3_plastics.csv | first 1 | get origin | echo $it"
     );
 
     assert_eq!(output, "SPAIN");


### PR DESCRIPTION
This adds the ability to load multiple objects from the same file, which allows us to load each row in a csv as a separate object.

Changes from_csv to output multiple rows via a list Value instead of an object