### PR TITLE
Add and edit functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,14 @@ name = "nu_plugin_inc"
 path = "src/plugins/inc.rs"
 
 [[bin]]
+name = "nu_plugin_add"
+path = "src/plugins/add.rs"
+
+[[bin]]
+name = "nu_plugin_edit"
+path = "src/plugins/edit.rs"
+
+[[bin]]
 name = "nu_plugin_skip"
 path = "src/plugins/skip.rs"
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | sort-by ...columns | Sort by the given columns |
 | where condition | Filter table to match the condition |
 | inc (field) | Increment a value or version. Optional use the field of a table |
+| add field value | Add a new field to the table |
+| edit field value | Edit an existing field to have a new value |
 | skip amount | Skip a number of rows |
 | first amount | Show only the first number of rows |
 | to-array | Collapse rows into a single list |

--- a/src/commands/to_json.rs
+++ b/src/commands/to_json.rs
@@ -1,6 +1,5 @@
 use crate::object::{Primitive, Value};
 use crate::prelude::*;
-use log::trace;
 
 pub fn value_to_json_value(v: &Value) -> serde_json::Value {
     match v {

--- a/src/commands/to_toml.rs
+++ b/src/commands/to_toml.rs
@@ -36,36 +36,17 @@ pub fn to_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     Ok(out
         .values
-        .map(move |a| {
-            match toml::to_string(&value_to_toml_value(&a)) {
-                Ok(val) => {
-                    return ReturnSuccess::value(
-                        Value::Primitive(Primitive::String(val)).spanned(name_span),
-                    )
-                }
-
-                Err(err) => Err(ShellError::type_error(
-                    "serializable to toml",
-                    format!("{:?} - {:?}", a.type_name(), err).spanned(name_span),
-                )), // toml::Value::String(String) => {
-                    //     return ReturnSuccess::value(
-                    //         Value::Primitive(Primitive::String(x)).spanned(name_span),
-                    //     )
-                    // }
-                    // toml::Value::Integer(i64) => "Integer",
-                    // toml::Value::Float(f64) => "Decimal",
-                    // toml::Value::Boolean(bool) => "Boolean",
-                    // toml::Value::Datetime(Datetime) => "Date",
-                    // toml::Value::Array(Array) => "Array",
-                    // toml::Value::Table(Table) => "Table",
+        .map(move |a| match toml::to_string(&value_to_toml_value(&a)) {
+            Ok(val) => {
+                return ReturnSuccess::value(
+                    Value::Primitive(Primitive::String(val)).spanned(name_span),
+                )
             }
-            // return Err(ShellError::type_error("String", ty.spanned(name_span)));
 
-            // Err(_) => Err(ShellError::maybe_labeled_error(
-            //     "Can not convert to TOML string",
-            //     "can not convert piped data to TOML string",
-            //     name_span,
-            // )),
+            Err(err) => Err(ShellError::type_error(
+                "Can not convert to a TOML string",
+                format!("{:?} - {:?}", a.type_name(), err).spanned(name_span),
+            )),
         })
         .to_output_stream())
 }

--- a/src/plugins/add.rs
+++ b/src/plugins/add.rs
@@ -1,0 +1,89 @@
+use indexmap::IndexMap;
+use nu::{
+    serve_plugin, CallInfo, CommandConfig, Plugin, PositionalType, Primitive, ReturnSuccess,
+    ReturnValue, ShellError, Spanned, Value,
+};
+
+struct Add {
+    field: Option<String>,
+    value: Option<Value>,
+}
+impl Add {
+    fn new() -> Add {
+        Add {
+            field: None,
+            value: None,
+        }
+    }
+
+    fn add(&self, value: Spanned<Value>) -> Result<Spanned<Value>, ShellError> {
+        match (value.item, self.value.clone()) {
+            (obj @ Value::Object(_), Some(v)) => match &self.field {
+                Some(f) => match obj.insert_data_at_path(value.span, &f, v) {
+                    Some(v) => return Ok(v),
+                    None => {
+                        return Err(ShellError::string(
+                            "add could not find place to insert field",
+                        ))
+                    }
+                },
+                None => Err(ShellError::string(
+                    "add needs a field when adding a value to an object",
+                )),
+            },
+            x => Err(ShellError::string(format!(
+                "Unrecognized type in stream: {:?}",
+                x
+            ))),
+        }
+    }
+}
+
+impl Plugin for Add {
+    fn config(&mut self) -> Result<CommandConfig, ShellError> {
+        Ok(CommandConfig {
+            name: "add".to_string(),
+            positional: vec![
+                PositionalType::mandatory_any("Field"),
+                PositionalType::mandatory_any("Value"),
+            ],
+            is_filter: true,
+            is_sink: false,
+            named: IndexMap::new(),
+            rest_positional: true,
+        })
+    }
+    fn begin_filter(&mut self, call_info: CallInfo) -> Result<(), ShellError> {
+        if let Some(args) = call_info.args.positional {
+            match &args[0] {
+                Spanned {
+                    item: Value::Primitive(Primitive::String(s)),
+                    ..
+                } => {
+                    self.field = Some(s.clone());
+                }
+                _ => {
+                    return Err(ShellError::string(format!(
+                        "Unrecognized type in params: {:?}",
+                        args[0]
+                    )))
+                }
+            }
+            match &args[1] {
+                Spanned { item: v, .. } => {
+                    self.value = Some(v.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn filter(&mut self, input: Spanned<Value>) -> Result<Vec<ReturnValue>, ShellError> {
+        Ok(vec![ReturnSuccess::value(self.add(input)?)])
+    }
+}
+
+fn main() {
+    serve_plugin(&mut Add::new());
+}

--- a/src/plugins/edit.rs
+++ b/src/plugins/edit.rs
@@ -1,0 +1,89 @@
+use indexmap::IndexMap;
+use nu::{
+    serve_plugin, CallInfo, CommandConfig, Plugin, PositionalType, Primitive, ReturnSuccess,
+    ReturnValue, ShellError, Spanned, Value,
+};
+
+struct Edit {
+    field: Option<String>,
+    value: Option<Value>,
+}
+impl Edit {
+    fn new() -> Edit {
+        Edit {
+            field: None,
+            value: None,
+        }
+    }
+
+    fn edit(&self, value: Spanned<Value>) -> Result<Spanned<Value>, ShellError> {
+        match (value.item, self.value.clone()) {
+            (obj @ Value::Object(_), Some(v)) => match &self.field {
+                Some(f) => match obj.replace_data_at_path(value.span, &f, v) {
+                    Some(v) => return Ok(v),
+                    None => {
+                        return Err(ShellError::string(
+                            "edit could not find place to insert field",
+                        ))
+                    }
+                },
+                None => Err(ShellError::string(
+                    "edit needs a field when adding a value to an object",
+                )),
+            },
+            x => Err(ShellError::string(format!(
+                "Unrecognized type in stream: {:?}",
+                x
+            ))),
+        }
+    }
+}
+
+impl Plugin for Edit {
+    fn config(&mut self) -> Result<CommandConfig, ShellError> {
+        Ok(CommandConfig {
+            name: "edit".to_string(),
+            positional: vec![
+                PositionalType::mandatory_any("Field"),
+                PositionalType::mandatory_any("Value"),
+            ],
+            is_filter: true,
+            is_sink: false,
+            named: IndexMap::new(),
+            rest_positional: true,
+        })
+    }
+    fn begin_filter(&mut self, call_info: CallInfo) -> Result<(), ShellError> {
+        if let Some(args) = call_info.args.positional {
+            match &args[0] {
+                Spanned {
+                    item: Value::Primitive(Primitive::String(s)),
+                    ..
+                } => {
+                    self.field = Some(s.clone());
+                }
+                _ => {
+                    return Err(ShellError::string(format!(
+                        "Unrecognized type in params: {:?}",
+                        args[0]
+                    )))
+                }
+            }
+            match &args[1] {
+                Spanned { item: v, .. } => {
+                    self.value = Some(v.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn filter(&mut self, input: Spanned<Value>) -> Result<Vec<ReturnValue>, ShellError> {
+        Ok(vec![ReturnSuccess::value(self.edit(input)?)])
+    }
+}
+
+fn main() {
+    serve_plugin(&mut Edit::new());
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,10 +4,12 @@ use helpers::in_directory as cwd;
 
 #[test]
 fn external_num() {
-    nu!(output,
+    nu!(
+        output,
         cwd("tests/fixtures/formats"),
-        "open sgml_description.json | get glossary.GlossDiv.GlossList.GlossEntry.Height | echo $it");
-    
+        "open sgml_description.json | get glossary.GlossDiv.GlossList.GlossEntry.Height | echo $it"
+    );
+
     assert_eq!(output, "10");
 }
 
@@ -18,4 +20,22 @@ fn inc_plugin() {
         "open sgml_description.json | get glossary.GlossDiv.GlossList.GlossEntry.Height | inc | echo $it");
 
     assert_eq!(output, "11");
+}
+
+#[test]
+fn add_plugin() {
+    nu!(output,
+        cwd("tests/fixtures/formats"),
+        "open cargo_sample.toml | add dev-dependencies.newdep \"1\" | get dev-dependencies.newdep | echo $it");
+
+    assert_eq!(output, "1");
+}
+
+#[test]
+fn edit_plugin() {
+    nu!(output,
+        cwd("tests/fixtures/formats"),
+        "open cargo_sample.toml | edit dev-dependencies.pretty_assertions \"7\" | get dev-dependencies.pretty_assertions | echo $it");
+
+    assert_eq!(output, "7");
 }


### PR DESCRIPTION
Adds two new plugins: add and edit. 

'add' can add new fields to an existing object/table
'edit' can edit an existing field to give it a new value

Both are functional updates, so they return the newly changed object rather than doing any mutation (similarly to how inc works)