### PR TITLE
Yet more improvements to textview (and binaryview)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
  "prettyprint 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ptree 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rawkey 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rawkey 0.1.1 (git+https://github.com/jonathandturner/rawkey)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "roxmltree 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "rawkey"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/jonathandturner/rawkey#9769728a036f58b6e37c970d0a1576171f0196e3"
 dependencies = [
  "readkey 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3654,7 +3654,7 @@ dependencies = [
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum rawkey 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cd49689ad95f53f9ba07322fa4fa75f08c338f5f7556eb2952705071eaf681b"
+"checksum rawkey 0.1.1 (git+https://github.com/jonathandturner/rawkey)" = "<none>"
 "checksum rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b0186e22767d5b9738a05eab7c6ac90b15db17e5b5f9bd87976dd7d89a10a4"
 "checksum rayon-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe0df8435ac0c397d467b6cad6d25543d06e8a019ef3f6af3c384597515bd2"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ mime = "0.3.13"
 regex = "1.1.9"
 pretty-hex = "0.1.0"
 neso = "0.5.0"
-rawkey = "0.1.1"
+rawkey = {git = "https://github.com/jonathandturner/rawkey"}
 crossterm = "0.9.6"
 tempfile = "3.1.0"
 image = "0.21.2"

--- a/src/plugins/binaryview.rs
+++ b/src/plugins/binaryview.rs
@@ -378,10 +378,10 @@ pub fn view_contents_interactive(
         let cursor = cursor();
 
         let buttons = vec![
-            KeyCode::LShift,
-            KeyCode::LControl,
+            KeyCode::Alt,
+            KeyCode::LeftControl,
             KeyCode::Tab,
-            KeyCode::Back,
+            KeyCode::BackSpace,
             KeyCode::UpArrow,
             KeyCode::DownArrow,
             KeyCode::LeftArrow,

--- a/src/plugins/textview.rs
+++ b/src/plugins/textview.rs
@@ -11,7 +11,6 @@ use rawkey::RawKey;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{Style, ThemeSet};
 use syntect::parsing::SyntaxSet;
-use syntect::util::as_24_bit_terminal_escaped;
 
 use std::io::Write;
 use std::path::Path;
@@ -110,19 +109,20 @@ fn paint_textview(
         print!("{}", s);
     }
 
-    let _ = cursor.goto(0, size.1);
-    print!(
-        "{}",
-        ansi_term::Colour::Blue.paint("[ESC to quit, arrow keys to move]")
-    );
-    print!("{}", crossterm::Attribute::Reset);
+    if (frame_buffer.len() / width) > height {
+        let _ = cursor.goto(0, size.1);
+        print!(
+            "{}",
+            ansi_term::Colour::Blue.paint("[ESC to quit, arrow keys to move]")
+        );
+    }
 
     let _ = std::io::stdout().flush();
 
     frame_buffer.len() / width
 }
 
-fn scroll_view_lines(draw_commands: Vec<DrawCommand>, use_color_buffer: bool) {
+fn scroll_view_lines_if_needed(draw_commands: Vec<DrawCommand>, use_color_buffer: bool) {
     let mut starting_row = 0;
     let rawkey = RawKey::new();
 
@@ -135,34 +135,54 @@ fn scroll_view_lines(draw_commands: Vec<DrawCommand>, use_color_buffer: bool) {
 
         let terminal = terminal();
         let mut size = terminal.terminal_size();
-        let mut max_bottom_line = size.1 as usize;
+        let mut max_bottom_line = paint_textview(&draw_commands, starting_row, use_color_buffer);
 
-        paint_textview(&draw_commands, starting_row, use_color_buffer);
-        loop {
-            if rawkey.is_pressed(rawkey::KeyCode::Escape) {
-                break;
-            }
-            if rawkey.is_pressed(rawkey::KeyCode::UpArrow) {
-                if starting_row > 0 {
-                    starting_row -= 1;
+        // Only scroll if needed
+        if max_bottom_line > size.1 as usize {
+            loop {
+                if rawkey.is_pressed(rawkey::KeyCode::Escape) {
+                    break;
+                }
+                if rawkey.is_pressed(rawkey::KeyCode::UpArrow) {
+                    if starting_row > 0 {
+                        starting_row -= 1;
+                        max_bottom_line =
+                            paint_textview(&draw_commands, starting_row, use_color_buffer);
+                    }
+                }
+                if rawkey.is_pressed(rawkey::KeyCode::DownArrow) {
+                    if starting_row < (max_bottom_line - size.1 as usize) {
+                        starting_row += 1;
+                    }
                     max_bottom_line =
                         paint_textview(&draw_commands, starting_row, use_color_buffer);
                 }
-            }
-            if rawkey.is_pressed(rawkey::KeyCode::DownArrow) {
-                if starting_row < (max_bottom_line - size.1 as usize) {
-                    starting_row += 1;
+                if rawkey.is_pressed(rawkey::KeyCode::PageUp) {
+                    starting_row -= std::cmp::min(size.1 as usize, starting_row);
+                    max_bottom_line =
+                        paint_textview(&draw_commands, starting_row, use_color_buffer);
                 }
-                max_bottom_line = paint_textview(&draw_commands, starting_row, use_color_buffer);
-            }
+                if rawkey.is_pressed(rawkey::KeyCode::PageDown) {
+                    if starting_row < (max_bottom_line - size.1 as usize) {
+                        starting_row += size.1 as usize;
 
-            thread::sleep(Duration::from_millis(50));
+                        if starting_row > (max_bottom_line - size.1 as usize) {
+                            starting_row = max_bottom_line - size.1 as usize;
+                        }
+                    }
+                    max_bottom_line =
+                        paint_textview(&draw_commands, starting_row, use_color_buffer);
+                }
 
-            let new_size = terminal.terminal_size();
-            if size != new_size {
-                size = new_size;
-                let _ = terminal.clear(crossterm::ClearType::All);
-                max_bottom_line = paint_textview(&draw_commands, starting_row, use_color_buffer);
+                thread::sleep(Duration::from_millis(50));
+
+                let new_size = terminal.terminal_size();
+                if size != new_size {
+                    size = new_size;
+                    let _ = terminal.clear(crossterm::ClearType::All);
+                    max_bottom_line =
+                        paint_textview(&draw_commands, starting_row, use_color_buffer);
+                }
             }
         }
 
@@ -185,7 +205,7 @@ fn scroll_view(s: &str) {
         v.push(DrawCommand::DrawString(Style::default(), line.to_string()));
         v.push(DrawCommand::NextLine);
     }
-    scroll_view_lines(v, false);
+    scroll_view_lines_if_needed(v, false);
 }
 
 fn view_text_value(value: &Spanned<Value>, source_map: &SourceMap) {
@@ -220,9 +240,6 @@ fn view_text_value(value: &Spanned<Value>, source_map: &SourceMap) {
                                     for line in s.lines() {
                                         let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
 
-                                        // let escaped =
-                                        //     as_24_bit_terminal_escaped(&ranges[..], false);
-                                        // v.push(format!("{}", escaped));
                                         for range in ranges {
                                             v.push(DrawCommand::DrawString(
                                                 range.0,
@@ -232,7 +249,7 @@ fn view_text_value(value: &Spanned<Value>, source_map: &SourceMap) {
 
                                         v.push(DrawCommand::NextLine);
                                     }
-                                    scroll_view_lines(v, true);
+                                    scroll_view_lines_if_needed(v, true);
                                 } else {
                                     scroll_view(s);
                                 }


### PR DESCRIPTION
This only scrolls the view if there's enough text to warrant it.  Otherwise it just prints the file to the screen and returns to the prompt.

It also changes interactive binary view to use alt, which hopefully cuts down on unwanted key command interference. 