### PR TITLE
Add end_plugin and sum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,10 @@ name = "nu_plugin_inc"
 path = "src/plugins/inc.rs"
 
 [[bin]]
+name = "nu_plugin_sum"
+path = "src/plugins/sum.rs"
+
+[[bin]]
 name = "nu_plugin_add"
 path = "src/plugins/add.rs"
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,6 +15,10 @@ pub trait Plugin {
         Err(ShellError::string("`filter` not implemented in plugin"))
     }
     #[allow(unused)]
+    fn end_filter(&mut self) -> Result<Vec<ReturnValue>, ShellError> {
+        Ok(vec![])
+    }
+    #[allow(unused)]
     fn sink(&mut self, call_info: CallInfo, input: Vec<Spanned<Value>>) {}
 
     fn quit(&mut self) {
@@ -42,6 +46,10 @@ pub fn serve_plugin(plugin: &mut dyn Plugin) {
                 Ok(NuCommand::filter { params }) => {
                     send_response(plugin.filter(params));
                 }
+                Ok(NuCommand::end_filter) => {
+                    send_response(plugin.end_filter());
+                }
+
                 Ok(NuCommand::sink { params }) => {
                     plugin.sink(params.0, params.1);
                     return;
@@ -78,6 +86,9 @@ pub fn serve_plugin(plugin: &mut dyn Plugin) {
                         }
                         Ok(NuCommand::filter { params }) => {
                             send_response(plugin.filter(params));
+                        }
+                        Ok(NuCommand::end_filter) => {
+                            send_response(plugin.end_filter());
                         }
                         Ok(NuCommand::sink { params }) => {
                             plugin.sink(params.0, params.1);
@@ -140,6 +151,7 @@ pub enum NuCommand {
     filter {
         params: Spanned<Value>,
     },
+    end_filter,
     sink {
         params: (CallInfo, Vec<Spanned<Value>>),
     },

--- a/src/plugins/sum.rs
+++ b/src/plugins/sum.rs
@@ -1,0 +1,99 @@
+use indexmap::IndexMap;
+use nu::{
+    serve_plugin, CallInfo, CommandConfig, Plugin, Primitive, ReturnSuccess, ReturnValue,
+    ShellError, Spanned, Value,
+};
+
+struct Sum {
+    total: Option<Spanned<Value>>,
+}
+impl Sum {
+    fn new() -> Sum {
+        Sum { total: None }
+    }
+
+    fn sum(&mut self, value: Spanned<Value>) -> Result<(), ShellError> {
+        match value.item {
+            Value::Primitive(Primitive::Int(i)) => {
+                match self.total {
+                    Some(Spanned {
+                        item: Value::Primitive(Primitive::Int(j)),
+                        span,
+                    }) => {
+                        //TODO: handle overflow
+                        self.total = Some(Spanned {
+                            item: Value::int(i + j),
+                            span,
+                        });
+                        Ok(())
+                    }
+                    None => {
+                        self.total = Some(value);
+                        Ok(())
+                    }
+                    _ => Err(ShellError::string(format!(
+                        "Could not sum non-integer or unrelated types"
+                    ))),
+                }
+            }
+            Value::Primitive(Primitive::Bytes(b)) => {
+                match self.total {
+                    Some(Spanned {
+                        item: Value::Primitive(Primitive::Bytes(j)),
+                        span,
+                    }) => {
+                        //TODO: handle overflow
+                        self.total = Some(Spanned {
+                            item: Value::bytes(b + j),
+                            span,
+                        });
+                        Ok(())
+                    }
+                    None => {
+                        self.total = Some(value);
+                        Ok(())
+                    }
+                    _ => Err(ShellError::string(format!(
+                        "Could not sum non-integer or unrelated types"
+                    ))),
+                }
+            }
+            x => Err(ShellError::string(format!(
+                "Unrecognized type in stream: {:?}",
+                x
+            ))),
+        }
+    }
+}
+
+impl Plugin for Sum {
+    fn config(&mut self) -> Result<CommandConfig, ShellError> {
+        Ok(CommandConfig {
+            name: "sum".to_string(),
+            positional: vec![],
+            is_filter: true,
+            is_sink: false,
+            named: IndexMap::new(),
+            rest_positional: true,
+        })
+    }
+    fn begin_filter(&mut self, _: CallInfo) -> Result<(), ShellError> {
+        Ok(())
+    }
+
+    fn filter(&mut self, input: Spanned<Value>) -> Result<Vec<ReturnValue>, ShellError> {
+        self.sum(input)?;
+        Ok(vec![])
+    }
+
+    fn end_filter(&mut self) -> Result<Vec<ReturnValue>, ShellError> {
+        match self.total {
+            None => Ok(vec![]),
+            Some(ref v) => Ok(vec![ReturnSuccess::value(v.clone())]),
+        }
+    }
+}
+
+fn main() {
+    serve_plugin(&mut Sum::new());
+}

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -2,10 +2,10 @@ mod helpers;
 
 use helpers::in_directory as cwd;
 
-
 #[test]
 fn can_convert_table_to_csv_text_and_from_csv_text_back_into_table() {
-    nu!(output,
+    nu!(
+        output,
         cwd("tests/fixtures/formats"),
         "open caco3_plastics.csv | to-csv | from-csv | first 1 | get origin | echo $it"
     );
@@ -87,6 +87,16 @@ fn can_inc_field() {
     assert_eq!(output, "2019");
 }
 
+#[test]
+fn can_sum() {
+    nu!(
+        output,
+        cwd("tests/fixtures/formats"),
+        "open sgml_description.json | get glossary.GlossDiv.GlossList.GlossEntry.Sections | sum | echo $it"
+    );
+
+    assert_eq!(output, "203")
+}
 #[test]
 fn can_filter_by_unit_size_comparison() {
     nu!(

--- a/tests/fixtures/formats/sample.ini
+++ b/tests/fixtures/formats/sample.ini
@@ -10,7 +10,7 @@ string2 = "Case 2"
 
 ; comment line
 key = new value
-integer = 1234
+integer = 5678
 real = 3.14
 string1 = 'Case 1'
 string2 = "Case 2"

--- a/tests/fixtures/formats/sgml_description.json
+++ b/tests/fixtures/formats/sgml_description.json
@@ -18,6 +18,10 @@
                             "XML"
                         ]
                     },
+                    "Sections": [
+                        101,
+                        102
+                    ],
                     "GlossSee": "markup"
                 }
             }


### PR DESCRIPTION
This PR adds a new end_plugin that plugins who want to return a final value can use.

It also adds a plugin that uses end_plugin: sum. Sum will add together int or size values and return the final total.