### PR TITLE
Introduced to-int into str plugin and unit tests coverage along with it.

### DIFF
--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -23,7 +23,7 @@ impl Str {
         }
     }
 
-    fn fields(&self) -> u8 {
+    fn actions_desired(&self) -> u8 {
         [self.downcase, self.upcase, self.int].iter().fold(
             0,
             |acc, &field| {
@@ -41,11 +41,11 @@ impl Str {
     }
 
     fn at_most_one(&self) -> bool {
-        self.fields() == 1
+        self.actions_desired() == 1
     }
 
     fn none(&self) -> bool {
-        self.fields() == 0
+        self.actions_desired() == 0
     }
 
     fn log_error(&mut self, message: &str) {
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn str_accepts_only_one_flag() {
+    fn str_accepts_only_one_action() {
         let mut strutils = Str::new();
 
         assert!(strutils
@@ -333,15 +333,6 @@ mod tests {
     }
 
     #[test]
-    fn str_reports_error_if_no_field_given_for_object() {
-        let mut strutils = Str::new();
-        let subject = sample_record("name", "jotandrehuda");
-
-        assert!(strutils.begin_filter(CallStub::new().create()).is_ok());
-        assert!(strutils.filter(subject).is_err());
-    }
-
-    #[test]
     fn str_downcases() {
         let mut strutils = Str::new();
         strutils.for_downcase();
@@ -363,7 +354,7 @@ mod tests {
     }
 
     #[test]
-    fn str_applies_upcase() {
+    fn str_plugin_applies_upcase() {
         let mut strutils = Str::new();
 
         assert!(strutils
@@ -391,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn str_applies_downcase() {
+    fn str_plugin_applies_downcase() {
         let mut strutils = Str::new();
 
         assert!(strutils
@@ -419,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn str_applies_to_int() {
+    fn str_plugin_applies_to_int() {
         let mut strutils = Str::new();
 
         assert!(strutils

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -41,10 +41,8 @@ impl Str {
         self.field = Some(field);
     }
 
-    fn update(&mut self) {
-        if self.action.is_some() {
-            self.log_error("can only apply one");
-        }
+    fn permit(&mut self) -> bool {
+        self.action.is_none()
     }
 
     fn log_error(&mut self, message: &str) {
@@ -52,18 +50,27 @@ impl Str {
     }
 
     fn for_to_int(&mut self) {
-        self.update();
-        self.action = Some(Action::ToInteger);
+        if self.permit() {
+            self.action = Some(Action::ToInteger);
+        } else {
+            self.log_error("can only apply one");
+        }
     }
 
     fn for_downcase(&mut self) {
-        self.update();
-        self.action = Some(Action::Downcase);
+        if self.permit() {
+            self.action = Some(Action::Downcase);
+        } else {
+            self.log_error("can only apply one");
+        }
     }
 
     fn for_upcase(&mut self) {
-        self.update();
-        self.action = Some(Action::Upcase);
+        if self.permit() {
+            self.action = Some(Action::Upcase);
+        } else {
+            self.log_error("can only apply one");
+        }
     }
 
     fn usage(&self) -> &'static str {

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -32,7 +32,7 @@ impl Str {
             Some(Action::ToInteger) => match input.trim().parse::<i64>() {
                 Ok(v) => Value::int(v),
                 Err(_) => Value::string(input),
-            }
+            },
             None => Value::string(input.to_string()),
         }
     }
@@ -288,6 +288,22 @@ mod tests {
             .is_ok());
 
         assert_eq!(plugin.field, Some("package.description".to_string()));
+    }
+
+    #[test]
+    fn str_plugin_accepts_only_one_action() {
+        let mut plugin = Str::new();
+
+        assert!(plugin
+            .begin_filter(
+                CallStub::new()
+                    .with_long_flag("upcase")
+                    .with_long_flag("downcase")
+                    .with_long_flag("to-int")
+                    .create(),
+            )
+            .is_err());
+        assert_eq!(plugin.error, Some("can only apply one".to_string()));
     }
 
     #[test]

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -1,5 +1,4 @@
 use indexmap::IndexMap;
-use std::str;
 use nu::{
     serve_plugin, CallInfo, CommandConfig, NamedType, Plugin, PositionalType, Primitive,
     ReturnSuccess, ReturnValue, ShellError, Tagged, Value,

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -9,7 +9,7 @@ struct Str {
     error: Option<String>,
     downcase: bool,
     upcase: bool,
-    int: bool,
+    toint: bool,
 }
 
 impl Str {
@@ -19,12 +19,12 @@ impl Str {
             error: None,
             downcase: false,
             upcase: false,
-            int: false,
+            toint: false,
         }
     }
 
     fn actions(&self) -> Vec<bool> {
-        vec![self.downcase, self.upcase, self.int]
+        vec![self.downcase, self.upcase, self.toint]
     }
 
     fn actions_desired(&self) -> u8 {
@@ -54,7 +54,7 @@ impl Str {
     }
 
     fn for_to_int(&mut self) {
-        self.int = true;
+        self.toint = true;
 
         if !self.is_valid() {
             self.log_error("can only apply one")
@@ -86,7 +86,7 @@ impl Str {
             return Value::string(input.to_ascii_uppercase());
         }
 
-        if self.int {
+        if self.toint {
             match input.trim().parse::<i64>() {
                 Ok(v) => return Value::int(v),
                 Err(_) => return Value::string(input),
@@ -305,7 +305,7 @@ mod tests {
             .begin_filter(CallStub::new().with_long_flag("to-int").create())
             .is_ok());
         assert!(plugin.is_valid());
-        assert!(plugin.int);
+        assert!(plugin.toint);
     }
 
     #[test]
@@ -322,7 +322,7 @@ mod tests {
             )
             .is_err());
         assert!(!plugin.is_valid());
-        assert_eq!(Some("can only apply one".to_string()), plugin.error);
+        assert_eq!(plugin.error, Some("can only apply one".to_string()));
     }
 
     #[test]
@@ -337,28 +337,28 @@ mod tests {
             )
             .is_ok());
 
-        assert_eq!(Some("package.description".to_string()), plugin.field);
+        assert_eq!(plugin.field, Some("package.description".to_string()));
     }
 
     #[test]
     fn str_downcases() {
         let mut strutils = Str::new();
         strutils.for_downcase();
-        assert_eq!(Value::string("andres"), strutils.apply("ANDRES"));
+        assert_eq!(strutils.apply("ANDRES"), Value::string("andres"));
     }
 
     #[test]
     fn str_upcases() {
         let mut strutils = Str::new();
         strutils.for_upcase();
-        assert_eq!(Value::string("ANDRES"), strutils.apply("andres"));
+        assert_eq!(strutils.apply("andres"), Value::string("ANDRES"));
     }
 
     #[test]
     fn str_to_int() {
         let mut strutils = Str::new();
         strutils.for_to_int();
-        assert_eq!(Value::int(9999 as i64), strutils.apply("9999"));
+        assert_eq!(strutils.apply("9999"), Value::int(9999 as i64));
     }
 
     #[test]

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -298,6 +298,20 @@ mod tests {
     }
 
     #[test]
+    fn str_downcases() {
+        let mut strutils = Str::new();
+        strutils.for_downcase();
+        assert_eq!("andres", strutils.apply("ANDRES"));
+    }
+
+    #[test]
+    fn str_upcases() {
+        let mut strutils = Str::new();
+        strutils.for_upcase();
+        assert_eq!("ANDRES", strutils.apply("andres"));
+    }
+
+    #[test]
     fn str_applies_upcase() {
         let mut strutils = Str::new();
 

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -4,8 +4,6 @@ use nu::{
     ReturnSuccess, ReturnValue, ShellError, Tagged, Value,
 };
 
-use log::trace;
-
 struct Str {
     field: Option<String>,
     error: Option<String>,
@@ -136,8 +134,6 @@ impl Plugin for Str {
     }
 
     fn begin_filter(&mut self, call_info: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
-        trace!("{:?}", call_info);
-
         if call_info.args.has("downcase") {
             self.for_downcase();
         }

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -23,17 +23,14 @@ impl Str {
         }
     }
 
+    fn actions(&self) -> Vec<bool> {
+        vec![self.downcase, self.upcase, self.int]
+    }
+
     fn actions_desired(&self) -> u8 {
-        [self.downcase, self.upcase, self.int].iter().fold(
-            0,
-            |acc, &field| {
-                if field {
-                    acc + 1
-                } else {
-                    acc
-                }
-            },
-        )
+        self.actions()
+            .iter()
+            .fold(0, |acc, &field| if field { acc + 1 } else { acc })
     }
 
     fn is_valid(&self) -> bool {
@@ -265,6 +262,17 @@ mod tests {
         let mut record = SpannedDictBuilder::new(Span::unknown());
         record.insert(key.clone(), Value::string(value));
         record.into_spanned_value()
+    }
+
+    #[test]
+    fn str_plugin_configuration_flags_wired() {
+        let mut strutils = Str::new();
+
+        let config = strutils.config().unwrap();
+
+        for action_flag in &["downcase", "upcase", "to-int"] {
+            assert!(config.named.get(*action_flag).is_some());
+        }
     }
 
     #[test]

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -24,18 +24,16 @@ impl Str {
     }
 
     fn fields(&self) -> u8 {
-        [
-         self.downcase,
-         self.upcase,
-         self.int
-        ].iter()
-         .fold(0, |acc, &field| {
-             if field {
+        [self.downcase, self.upcase, self.int].iter().fold(
+            0,
+            |acc, &field| {
+                if field {
                     acc + 1
                 } else {
                     acc
                 }
-            })
+            },
+        )
     }
 
     fn is_valid(&self) -> bool {
@@ -57,7 +55,7 @@ impl Str {
     fn for_input(&mut self, field: String) {
         self.field = Some(field);
     }
-    
+
     fn for_to_int(&mut self) {
         self.int = true;
 
@@ -265,10 +263,7 @@ mod tests {
 
     fn sample_record(key: &str, value: &str) -> Spanned<Value> {
         let mut record = SpannedDictBuilder::new(Span::unknown());
-        record.insert(
-            key.clone(),
-            Value::string(value),
-        );
+        record.insert(key.clone(), Value::string(value));
         record.into_spanned_value()
     }
 

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -266,53 +266,53 @@ mod tests {
 
     #[test]
     fn str_plugin_configuration_flags_wired() {
-        let mut strutils = Str::new();
+        let mut plugin = Str::new();
 
-        let config = strutils.config().unwrap();
+        let configured = plugin.config().unwrap();
 
         for action_flag in &["downcase", "upcase", "to-int"] {
-            assert!(config.named.get(*action_flag).is_some());
+            assert!(configured.named.get(*action_flag).is_some());
         }
     }
 
     #[test]
-    fn str_accepts_downcase() {
-        let mut strutils = Str::new();
+    fn str_plugin_accepts_downcase() {
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(CallStub::new().with_long_flag("downcase").create())
             .is_ok());
-        assert!(strutils.is_valid());
-        assert!(strutils.downcase);
+        assert!(plugin.is_valid());
+        assert!(plugin.downcase);
     }
 
     #[test]
-    fn str_accepts_upcase() {
-        let mut strutils = Str::new();
+    fn str_plugin_accepts_upcase() {
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(CallStub::new().with_long_flag("upcase").create())
             .is_ok());
-        assert!(strutils.is_valid());
-        assert!(strutils.upcase);
+        assert!(plugin.is_valid());
+        assert!(plugin.upcase);
     }
 
     #[test]
-    fn str_accepts_to_int() {
-        let mut strutils = Str::new();
+    fn str_plugin_accepts_to_int() {
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(CallStub::new().with_long_flag("to-int").create())
             .is_ok());
-        assert!(strutils.is_valid());
-        assert!(strutils.int);
+        assert!(plugin.is_valid());
+        assert!(plugin.int);
     }
 
     #[test]
-    fn str_accepts_only_one_action() {
-        let mut strutils = Str::new();
+    fn str_plugin_accepts_only_one_action() {
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(
                 CallStub::new()
                     .with_long_flag("upcase")
@@ -321,15 +321,15 @@ mod tests {
                     .create(),
             )
             .is_err());
-        assert!(!strutils.is_valid());
-        assert_eq!(Some("can only apply one".to_string()), strutils.error);
+        assert!(!plugin.is_valid());
+        assert_eq!(Some("can only apply one".to_string()), plugin.error);
     }
 
     #[test]
-    fn str_accepts_field() {
-        let mut strutils = Str::new();
+    fn str_plugin_accepts_field() {
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(
                 CallStub::new()
                     .with_parameter("package.description")
@@ -337,7 +337,7 @@ mod tests {
             )
             .is_ok());
 
-        assert_eq!(Some("package.description".to_string()), strutils.field);
+        assert_eq!(Some("package.description".to_string()), plugin.field);
     }
 
     #[test]
@@ -363,9 +363,9 @@ mod tests {
 
     #[test]
     fn str_plugin_applies_upcase() {
-        let mut strutils = Str::new();
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(
                 CallStub::new()
                     .with_long_flag("upcase")
@@ -375,7 +375,7 @@ mod tests {
             .is_ok());
 
         let subject = sample_record("name", "jotandrehuda");
-        let output = strutils.filter(subject).unwrap();
+        let output = plugin.filter(subject).unwrap();
 
         match output[0].as_ref().unwrap() {
             ReturnSuccess::Value(Spanned {
@@ -391,9 +391,9 @@ mod tests {
 
     #[test]
     fn str_plugin_applies_downcase() {
-        let mut strutils = Str::new();
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(
                 CallStub::new()
                     .with_long_flag("downcase")
@@ -403,7 +403,7 @@ mod tests {
             .is_ok());
 
         let subject = sample_record("name", "JOTANDREHUDA");
-        let output = strutils.filter(subject).unwrap();
+        let output = plugin.filter(subject).unwrap();
 
         match output[0].as_ref().unwrap() {
             ReturnSuccess::Value(Spanned {
@@ -419,9 +419,9 @@ mod tests {
 
     #[test]
     fn str_plugin_applies_to_int() {
-        let mut strutils = Str::new();
+        let mut plugin = Str::new();
 
-        assert!(strutils
+        assert!(plugin
             .begin_filter(
                 CallStub::new()
                     .with_long_flag("to-int")
@@ -431,7 +431,7 @@ mod tests {
             .is_ok());
 
         let subject = sample_record("Nu_birthday", "10");
-        let output = strutils.filter(subject).unwrap();
+        let output = plugin.filter(subject).unwrap();
 
         match output[0].as_ref().unwrap() {
             ReturnSuccess::Value(Spanned {

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -73,7 +73,7 @@ fn str_can_only_apply_one() {
         "open caco3_plastics.csv | first 1 | str origin --downcase --upcase"
     );
 
-    assert!(output.contains("Usage: str field [--downcase|--upcase]"));
+    assert!(output.contains("Usage: str field [--downcase|--upcase|--to-int]"));
 }
 
 #[test]
@@ -96,6 +96,17 @@ fn str_upcases() {
     );
 
     assert_eq!(output, "NUSHELL");
+}
+
+#[test]
+fn str_converts_to_int() {
+    nu!(
+        output,
+        cwd("tests/fixtures/formats"),
+        "open caco3_plastics.csv | get 0 | str tariff_item --to-int | where tariff_item == 2509000000 | get tariff_item | echo $it"
+    );
+
+    assert_eq!(output, "2509000000");
 }
 
 #[test]

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -73,7 +73,7 @@ fn str_can_only_apply_one() {
         "open caco3_plastics.csv | first 1 | str origin --downcase --upcase"
     );
 
-    assert!(output.contains("Usage: str [--downcase, --upcase]"));
+    assert!(output.contains("Usage: str field [--downcase|--upcase]"));
 }
 
 #[test]


### PR DESCRIPTION
With this in place we could shed some light on design decisions at all levels, most importantly what steps to take at the module level organization, boundaries, what to expose or not, and so forth.

To run only the str plugin we can run like so: `cargo test --bin nu_plugin_str`