### PR TITLE
Move more parts to tags and away from spans

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -348,7 +348,7 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
                 Some(ClassifiedCommand::External(_)) => {}
                 _ => pipeline.commands.push(ClassifiedCommand::Sink(SinkCommand {
                     command: sink("autoview", Box::new(autoview::autoview)),
-                    name_span: None,
+                    name_span: Span::unknown(),
                     args: registry::Args {
                         positional: None,
                         named: None,
@@ -382,7 +382,7 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
                     }
 
                     (Some(ClassifiedCommand::Sink(SinkCommand { name_span, .. })), Some(_)) => {
-                        return LineResult::Error(line.clone(), ShellError::maybe_labeled_error("Commands like table, save, and autoview must come last in the pipeline", "must come last", name_span));
+                        return LineResult::Error(line.clone(), ShellError::labeled_error("Commands like table, save, and autoview must come last in the pipeline", "must come last", name_span));
                     }
 
                     (Some(ClassifiedCommand::Sink(left)), None) => {
@@ -496,7 +496,7 @@ fn classify_command(
 
                     Ok(ClassifiedCommand::Internal(InternalCommand {
                         command,
-                        name_span: Some(head.span().clone()),
+                        name_span: head.span().clone(),
                         args,
                     }))
                 }
@@ -510,7 +510,7 @@ fn classify_command(
 
                         Ok(ClassifiedCommand::Sink(SinkCommand {
                             command,
-                            name_span: Some(head.span().clone()),
+                            name_span: head.span().clone(),
                             args,
                         }))
                     }
@@ -521,7 +521,7 @@ fn classify_command(
                                 .iter()
                                 .filter_map(|i| match i {
                                     TokenNode::Whitespace(_) => None,
-                                    other => Some(Tagged::from_item(
+                                    other => Some(Tagged::from_simple_spanned_item(
                                         other.as_external_arg(source),
                                         other.span(),
                                     )),
@@ -532,7 +532,7 @@ fn classify_command(
 
                         Ok(ClassifiedCommand::External(ExternalCommand {
                             name: name.to_string(),
-                            name_span: Some(head.span().clone()),
+                            name_span: head.span().clone(),
                             args: arg_list_strings,
                         }))
                     }

--- a/src/commands/cd.rs
+++ b/src/commands/cd.rs
@@ -10,7 +10,7 @@ pub fn cd(args: CommandArgs) -> Result<OutputStream, ShellError> {
         None => match dirs::home_dir() {
             Some(o) => o,
             _ => {
-                return Err(ShellError::maybe_labeled_error(
+                return Err(ShellError::labeled_error(
                     "Can not change to home directory",
                     "can not go to home",
                     args.call_info.name_span,

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 pub struct CallInfo {
     pub args: Args,
     pub source_map: SourceMap,
-    pub name_span: Option<Span>,
+    pub name_span: Span,
 }
 
 #[derive(Getters)]
@@ -93,7 +93,9 @@ impl ReturnSuccess {
     }
 
     pub fn spanned_value(input: Value, span: Span) -> ReturnValue {
-        Ok(ReturnSuccess::Value(Tagged::from_item(input, span)))
+        Ok(ReturnSuccess::Value(Tagged::from_simple_spanned_item(
+            input, span,
+        )))
     }
 }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -61,10 +61,11 @@ pub fn config(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
             config::write_config(&result)?;
 
-            return Ok(
-                stream![Tagged::from_item(Value::Object(result.into()), v.span())]
-                    .from_input_stream(),
-            );
+            return Ok(stream![Tagged::from_simple_spanned_item(
+                Value::Object(result.into()),
+                v.span()
+            )]
+            .from_input_stream());
         }
     }
 
@@ -73,9 +74,11 @@ pub fn config(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
         config::write_config(&result)?;
 
-        return Ok(
-            stream![Tagged::from_item(Value::Object(result.into()), c.span())].from_input_stream(),
-        );
+        return Ok(stream![Tagged::from_simple_spanned_item(
+            Value::Object(result.into()),
+            c.span()
+        )]
+        .from_input_stream());
     }
 
     if let Some(v) = args.get("remove") {
@@ -90,12 +93,14 @@ pub fn config(args: CommandArgs) -> Result<OutputStream, ShellError> {
             )));
         }
 
-        let obj = VecDeque::from_iter(vec![Value::Object(result.into()).tagged(v)]);
+        let obj = VecDeque::from_iter(vec![Value::Object(result.into()).simple_spanned(v)]);
         return Ok(obj.from_input_stream());
     }
 
     if args.len() == 0 {
-        return Ok(vec![Value::Object(result.into()).tagged(args.call_info.name_span)].into());
+        return Ok(
+            vec![Value::Object(result.into()).simple_spanned(args.call_info.name_span)].into(),
+        );
     }
 
     Err(ShellError::string(format!("Unimplemented")))

--- a/src/commands/date.rs
+++ b/src/commands/date.rs
@@ -42,41 +42,41 @@ where
 
     indexmap.insert(
         "year".to_string(),
-        Tagged::from_item(Value::int(dt.year()), span),
+        Tagged::from_simple_spanned_item(Value::int(dt.year()), span),
     );
     indexmap.insert(
         "month".to_string(),
-        Tagged::from_item(Value::int(dt.month()), span),
+        Tagged::from_simple_spanned_item(Value::int(dt.month()), span),
     );
     indexmap.insert(
         "day".to_string(),
-        Tagged::from_item(Value::int(dt.day()), span),
+        Tagged::from_simple_spanned_item(Value::int(dt.day()), span),
     );
     indexmap.insert(
         "hour".to_string(),
-        Tagged::from_item(Value::int(dt.hour()), span),
+        Tagged::from_simple_spanned_item(Value::int(dt.hour()), span),
     );
     indexmap.insert(
         "minute".to_string(),
-        Tagged::from_item(Value::int(dt.minute()), span),
+        Tagged::from_simple_spanned_item(Value::int(dt.minute()), span),
     );
     indexmap.insert(
         "second".to_string(),
-        Tagged::from_item(Value::int(dt.second()), span),
+        Tagged::from_simple_spanned_item(Value::int(dt.second()), span),
     );
 
     let tz = dt.offset();
     indexmap.insert(
         "timezone".to_string(),
-        Tagged::from_item(Value::string(format!("{}", tz)), span),
+        Tagged::from_simple_spanned_item(Value::string(format!("{}", tz)), span),
     );
 
-    Tagged::from_item(Value::Object(Dictionary::from(indexmap)), span)
+    Tagged::from_simple_spanned_item(Value::Object(Dictionary::from(indexmap)), span)
 }
 
 pub fn date(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let mut date_out = VecDeque::new();
-    let span = args.call_info.name_span.unwrap();
+    let span = args.call_info.name_span;
 
     let value = if args.has("utc") {
         let utc: DateTime<Utc> = Utc::now();

--- a/src/commands/first.rs
+++ b/src/commands/first.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 
 pub fn first(args: CommandArgs) -> Result<OutputStream, ShellError> {
     if args.len() == 0 {
-        return Err(ShellError::maybe_labeled_error(
+        return Err(ShellError::labeled_error(
             "First requires an amount",
             "needs parameter",
             args.call_info.name_span,

--- a/src/commands/from_toml.rs
+++ b/src/commands/from_toml.rs
@@ -2,28 +2,28 @@ use crate::object::base::OF64;
 use crate::object::{Primitive, TaggedDictBuilder, Value};
 use crate::prelude::*;
 
-fn convert_toml_value_to_nu_value(v: &toml::Value, span: impl Into<Span>) -> Tagged<Value> {
-    let span = span.into();
+fn convert_toml_value_to_nu_value(v: &toml::Value, tag: impl Into<Tag>) -> Tagged<Value> {
+    let tag = tag.into();
 
     match v {
-        toml::Value::Boolean(b) => Value::Primitive(Primitive::Boolean(*b)).tagged(span),
-        toml::Value::Integer(n) => Value::Primitive(Primitive::Int(*n)).tagged(span),
-        toml::Value::Float(n) => Value::Primitive(Primitive::Float(OF64::from(*n))).tagged(span),
-        toml::Value::String(s) => Value::Primitive(Primitive::String(String::from(s))).tagged(span),
+        toml::Value::Boolean(b) => Value::Primitive(Primitive::Boolean(*b)).tagged(tag),
+        toml::Value::Integer(n) => Value::Primitive(Primitive::Int(*n)).tagged(tag),
+        toml::Value::Float(n) => Value::Primitive(Primitive::Float(OF64::from(*n))).tagged(tag),
+        toml::Value::String(s) => Value::Primitive(Primitive::String(String::from(s))).tagged(tag),
         toml::Value::Array(a) => Value::List(
             a.iter()
-                .map(|x| convert_toml_value_to_nu_value(x, span))
+                .map(|x| convert_toml_value_to_nu_value(x, tag))
                 .collect(),
         )
-        .tagged(span),
+        .tagged(tag),
         toml::Value::Datetime(dt) => {
-            Value::Primitive(Primitive::String(dt.to_string())).tagged(span)
+            Value::Primitive(Primitive::String(dt.to_string())).tagged(tag)
         }
         toml::Value::Table(t) => {
-            let mut collected = TaggedDictBuilder::new(span);
+            let mut collected = TaggedDictBuilder::new(tag);
 
             for (k, v) in t.iter() {
-                collected.insert_tagged(k.clone(), convert_toml_value_to_nu_value(v, span));
+                collected.insert_tagged(k.clone(), convert_toml_value_to_nu_value(v, tag));
             }
 
             collected.into_tagged_value()
@@ -33,10 +33,10 @@ fn convert_toml_value_to_nu_value(v: &toml::Value, span: impl Into<Span>) -> Tag
 
 pub fn from_toml_string_to_value(
     s: String,
-    span: impl Into<Span>,
+    tag: impl Into<Tag>,
 ) -> Result<Tagged<Value>, Box<dyn std::error::Error>> {
     let v: toml::Value = s.parse::<toml::Value>()?;
-    Ok(convert_toml_value_to_nu_value(&v, span))
+    Ok(convert_toml_value_to_nu_value(&v, tag))
 }
 
 pub fn from_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
@@ -45,22 +45,26 @@ pub fn from_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
     Ok(out
         .values
         .map(move |a| {
-            let value_span = a.span();
+            let value_tag = a.tag();
             match a.item {
                 Value::Primitive(Primitive::String(s)) => {
-                    match from_toml_string_to_value(s, value_span) {
+                    match from_toml_string_to_value(s, value_tag) {
                         Ok(x) => ReturnSuccess::value(x),
-                        Err(_) => Err(ShellError::maybe_labeled_error(
+                        Err(_) => Err(ShellError::labeled_error_with_secondary(
                             "Could not parse as TOML",
-                            "piped data failed TOML parse",
+                            "input cannot be parsed as TOML",
                             span,
+                            "value originates from here",
+                            value_tag.span,
                         )),
                     }
                 }
-                _ => Err(ShellError::maybe_labeled_error(
-                    "Expected string values from pipeline",
-                    "expects strings from pipeline",
+                _ => Err(ShellError::labeled_error_with_secondary(
+                    "Expected a string from pipeline",
+                    "requires string input",
                     span,
+                    "value originates from here",
+                    a.span(),
                 )),
             }
         })

--- a/src/commands/from_xml.rs
+++ b/src/commands/from_xml.rs
@@ -1,15 +1,15 @@
 use crate::object::{Primitive, TaggedDictBuilder, Value};
 use crate::prelude::*;
 
-fn from_node_to_value<'a, 'd>(n: &roxmltree::Node<'a, 'd>, span: impl Into<Span>) -> Tagged<Value> {
-    let span = span.into();
+fn from_node_to_value<'a, 'd>(n: &roxmltree::Node<'a, 'd>, tag: impl Into<Tag>) -> Tagged<Value> {
+    let tag = tag.into();
 
     if n.is_element() {
         let name = n.tag_name().name().trim().to_string();
 
         let mut children_values = vec![];
         for c in n.children() {
-            children_values.push(from_node_to_value(&c, span));
+            children_values.push(from_node_to_value(&c, tag));
         }
 
         let children_values: Vec<Tagged<Value>> = children_values
@@ -29,31 +29,31 @@ fn from_node_to_value<'a, 'd>(n: &roxmltree::Node<'a, 'd>, span: impl Into<Span>
             })
             .collect();
 
-        let mut collected = TaggedDictBuilder::new(span);
+        let mut collected = TaggedDictBuilder::new(tag);
         collected.insert(name.clone(), Value::List(children_values));
 
         collected.into_tagged_value()
     } else if n.is_comment() {
-        Value::string("<comment>").tagged(span)
+        Value::string("<comment>").tagged(tag)
     } else if n.is_pi() {
-        Value::string("<processing_instruction>").tagged(span)
+        Value::string("<processing_instruction>").tagged(tag)
     } else if n.is_text() {
-        Value::string(n.text().unwrap()).tagged(span)
+        Value::string(n.text().unwrap()).tagged(tag)
     } else {
-        Value::string("<unknown>").tagged(span)
+        Value::string("<unknown>").tagged(tag)
     }
 }
 
-fn from_document_to_value(d: &roxmltree::Document, span: impl Into<Span>) -> Tagged<Value> {
-    from_node_to_value(&d.root_element(), span)
+fn from_document_to_value(d: &roxmltree::Document, tag: impl Into<Tag>) -> Tagged<Value> {
+    from_node_to_value(&d.root_element(), tag)
 }
 
 pub fn from_xml_string_to_value(
     s: String,
-    span: impl Into<Span>,
+    tag: impl Into<Tag>,
 ) -> Result<Tagged<Value>, Box<dyn std::error::Error>> {
     let parsed = roxmltree::Document::parse(&s)?;
-    Ok(from_document_to_value(&parsed, span))
+    Ok(from_document_to_value(&parsed, tag))
 }
 
 pub fn from_xml(args: CommandArgs) -> Result<OutputStream, ShellError> {
@@ -61,20 +61,29 @@ pub fn from_xml(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let span = args.call_info.name_span;
     Ok(out
         .values
-        .map(move |a| match a.item {
-            Value::Primitive(Primitive::String(s)) => match from_xml_string_to_value(s, span) {
-                Ok(x) => ReturnSuccess::value(x),
-                Err(_) => Err(ShellError::maybe_labeled_error(
-                    "Could not parse as XML",
-                    "piped data failed XML parse",
+        .map(move |a| {
+            let value_tag = a.tag();
+            match a.item {
+                Value::Primitive(Primitive::String(s)) => {
+                    match from_xml_string_to_value(s, value_tag) {
+                        Ok(x) => ReturnSuccess::value(x),
+                        Err(_) => Err(ShellError::labeled_error_with_secondary(
+                            "Could not parse as XML",
+                            "input cannot be parsed as XML",
+                            span,
+                            "value originates from here",
+                            value_tag.span,
+                        )),
+                    }
+                }
+                _ => Err(ShellError::labeled_error_with_secondary(
+                    "Expected a string from pipeline",
+                    "requires string input",
                     span,
+                    "value originates from here",
+                    a.span(),
                 )),
-            },
-            _ => Err(ShellError::maybe_labeled_error(
-                "Expected string values from pipeline",
-                "expects strings from pipeline",
-                span,
-            )),
+            }
         })
         .to_output_stream())
 }

--- a/src/commands/from_yaml.rs
+++ b/src/commands/from_yaml.rs
@@ -2,31 +2,31 @@ use crate::object::base::OF64;
 use crate::object::{Primitive, TaggedDictBuilder, Value};
 use crate::prelude::*;
 
-fn convert_yaml_value_to_nu_value(v: &serde_yaml::Value, span: impl Into<Span>) -> Tagged<Value> {
-    let span = span.into();
+fn convert_yaml_value_to_nu_value(v: &serde_yaml::Value, tag: impl Into<Tag>) -> Tagged<Value> {
+    let tag = tag.into();
 
     match v {
-        serde_yaml::Value::Bool(b) => Value::Primitive(Primitive::Boolean(*b)).tagged(span),
+        serde_yaml::Value::Bool(b) => Value::Primitive(Primitive::Boolean(*b)).tagged(tag),
         serde_yaml::Value::Number(n) if n.is_i64() => {
-            Value::Primitive(Primitive::Int(n.as_i64().unwrap())).tagged(span)
+            Value::Primitive(Primitive::Int(n.as_i64().unwrap())).tagged(tag)
         }
         serde_yaml::Value::Number(n) if n.is_f64() => {
-            Value::Primitive(Primitive::Float(OF64::from(n.as_f64().unwrap()))).tagged(span)
+            Value::Primitive(Primitive::Float(OF64::from(n.as_f64().unwrap()))).tagged(tag)
         }
-        serde_yaml::Value::String(s) => Value::string(s).tagged(span),
+        serde_yaml::Value::String(s) => Value::string(s).tagged(tag),
         serde_yaml::Value::Sequence(a) => Value::List(
             a.iter()
-                .map(|x| convert_yaml_value_to_nu_value(x, span))
+                .map(|x| convert_yaml_value_to_nu_value(x, tag))
                 .collect(),
         )
-        .tagged(span),
+        .tagged(tag),
         serde_yaml::Value::Mapping(t) => {
-            let mut collected = TaggedDictBuilder::new(span);
+            let mut collected = TaggedDictBuilder::new(tag);
 
             for (k, v) in t.iter() {
                 match k {
                     serde_yaml::Value::String(k) => {
-                        collected.insert_tagged(k.clone(), convert_yaml_value_to_nu_value(v, span));
+                        collected.insert_tagged(k.clone(), convert_yaml_value_to_nu_value(v, tag));
                     }
                     _ => unimplemented!("Unknown key type"),
                 }
@@ -34,17 +34,17 @@ fn convert_yaml_value_to_nu_value(v: &serde_yaml::Value, span: impl Into<Span>) 
 
             collected.into_tagged_value()
         }
-        serde_yaml::Value::Null => Value::Primitive(Primitive::Nothing).tagged(span),
+        serde_yaml::Value::Null => Value::Primitive(Primitive::Nothing).tagged(tag),
         x => unimplemented!("Unsupported yaml case: {:?}", x),
     }
 }
 
 pub fn from_yaml_string_to_value(
     s: String,
-    span: impl Into<Span>,
+    tag: impl Into<Tag>,
 ) -> serde_yaml::Result<Tagged<Value>> {
     let v: serde_yaml::Value = serde_yaml::from_str(&s)?;
-    Ok(convert_yaml_value_to_nu_value(&v, span))
+    Ok(convert_yaml_value_to_nu_value(&v, tag))
 }
 
 pub fn from_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
@@ -53,22 +53,26 @@ pub fn from_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
     Ok(out
         .values
         .map(move |a| {
-            let value_span = a.span();
+            let value_tag = a.tag();
             match a.item {
                 Value::Primitive(Primitive::String(s)) => {
-                    match from_yaml_string_to_value(s, value_span) {
+                    match from_yaml_string_to_value(s, value_tag) {
                         Ok(x) => ReturnSuccess::value(x),
-                        Err(_) => Err(ShellError::maybe_labeled_error(
+                        Err(_) => Err(ShellError::labeled_error_with_secondary(
                             "Could not parse as YAML",
-                            "piped data failed YAML parse",
+                            "input cannot be parsed as YAML",
                             span,
+                            "value originates from here",
+                            value_tag.span,
                         )),
                     }
                 }
-                _ => Err(ShellError::maybe_labeled_error(
-                    "Expected string values from pipeline",
-                    "expects strings from pipeline",
+                _ => Err(ShellError::labeled_error_with_secondary(
+                    "Expected a string from pipeline",
+                    "requires string input",
                     span,
+                    "value originates from here",
+                    a.span(),
                 )),
             }
         })

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -22,7 +22,7 @@ fn get_member(path: &str, span: Span, obj: &Tagged<Value>) -> Result<Tagged<Valu
 
 pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
     if args.len() == 0 {
-        return Err(ShellError::maybe_labeled_error(
+        return Err(ShellError::labeled_error(
             "Get requires a field or field path",
             "needs parameter",
             args.call_info.name_span,

--- a/src/commands/lines.rs
+++ b/src/commands/lines.rs
@@ -27,10 +27,12 @@ pub fn lines(args: CommandArgs) -> Result<OutputStream, ShellError> {
             }
             _ => {
                 let mut result = VecDeque::new();
-                result.push_back(Err(ShellError::maybe_labeled_error(
-                    "Expected string values from pipeline",
-                    "expects strings from pipeline",
+                result.push_back(Err(ShellError::labeled_error_with_secondary(
+                    "Expected a string from pipeline",
+                    "requires string input",
                     span,
+                    "value originates from here",
+                    v.span(),
                 )));
                 result
             }

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -37,7 +37,7 @@ pub fn ls(args: CommandArgs) -> Result<OutputStream, ShellError> {
                                 s.span(),
                             ));
                         } else {
-                            return Err(ShellError::maybe_labeled_error(
+                            return Err(ShellError::labeled_error(
                                 e.to_string(),
                                 e.to_string(),
                                 args.call_info.name_span,
@@ -50,8 +50,11 @@ pub fn ls(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     let entry = entry?;
                     let filepath = entry.path();
                     let filename = filepath.strip_prefix(&cwd).unwrap();
-                    let value =
-                        dir_entry_dict(filename, &entry.metadata()?, args.call_info.name_span)?;
+                    let value = dir_entry_dict(
+                        filename,
+                        &entry.metadata()?,
+                        Tag::unknown_origin(args.call_info.name_span),
+                    )?;
                     shell_entries.push_back(ReturnSuccess::value(value))
                 }
                 return Ok(shell_entries.to_output_stream());
@@ -64,7 +67,11 @@ pub fn ls(args: CommandArgs) -> Result<OutputStream, ShellError> {
         if let Ok(entry) = entry {
             let filename = entry.strip_prefix(&cwd).unwrap();
             let metadata = std::fs::metadata(&entry)?;
-            let value = dir_entry_dict(filename, &metadata, args.call_info.name_span)?;
+            let value = dir_entry_dict(
+                filename,
+                &metadata,
+                Tag::unknown_origin(args.call_info.name_span),
+            )?;
             shell_entries.push_back(ReturnSuccess::value(value))
         }
     }

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 
 pub fn pick(args: CommandArgs) -> Result<OutputStream, ShellError> {
     if args.len() == 0 {
-        return Err(ShellError::maybe_labeled_error(
+        return Err(ShellError::labeled_error(
             "Pick requires fields",
             "needs parameter",
             args.call_info.name_span,
@@ -17,7 +17,7 @@ pub fn pick(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let objects = input
         .values
-        .map(move |value| select_fields(&value.item, &fields, value.span()));
+        .map(move |value| select_fields(&value.item, &fields, value.tag()));
 
     Ok(objects.from_input_stream())
 }

--- a/src/commands/ps.rs
+++ b/src/commands/ps.rs
@@ -10,7 +10,7 @@ pub fn ps(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let list = list
         .into_iter()
-        .map(|(_, process)| process_dict(process, args.call_info.name_span))
+        .map(|(_, process)| process_dict(process, Tag::unknown_origin(args.call_info.name_span)))
         .collect::<VecDeque<_>>();
 
     Ok(list.from_input_stream())

--- a/src/commands/reject.rs
+++ b/src/commands/reject.rs
@@ -3,10 +3,8 @@ use crate::object::base::reject_fields;
 use crate::prelude::*;
 
 pub fn reject(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let name_span = args.call_info.name_span;
-
     if args.len() == 0 {
-        return Err(ShellError::maybe_labeled_error(
+        return Err(ShellError::labeled_error(
             "Reject requires fields",
             "needs parameter",
             args.call_info.name_span,
@@ -16,11 +14,10 @@ pub fn reject(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let fields: Result<Vec<String>, _> = args.positional_iter().map(|a| a.as_string()).collect();
     let fields = fields?;
 
-    let stream = args.input.values.map(move |item| {
-        reject_fields(&item, &fields, item.span())
-            .into_tagged_value()
-            .tagged(name_span)
-    });
+    let stream = args
+        .input
+        .values
+        .map(move |item| reject_fields(&item, &fields, item.tag()).into_tagged_value());
 
     Ok(stream.from_input_stream())
 }

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -61,7 +61,7 @@ pub fn rm(args: CommandArgs) -> Result<OutputStream, ShellError> {
                         return Err(ShellError::labeled_error(
                             "is a directory",
                             "",
-                            args.call_info.name_span.unwrap(),
+                            args.call_info.name_span,
                         ));
                     }
                     std::fs::remove_dir_all(&path).expect("can not remove directory");

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -21,18 +21,14 @@ pub fn save(args: SinkCommandArgs) -> Result<(), ShellError> {
     if args.call_info.args.positional.is_none() {
         // If there is no filename, check the metadata for the origin filename
         if args.input.len() > 0 {
-            let span = args.input[0].span();
-            match span
-                .source
-                .map(|x| args.call_info.source_map.get(&x))
-                .flatten()
-            {
+            let origin = args.input[0].origin();
+            match origin.map(|x| args.call_info.source_map.get(&x)).flatten() {
                 Some(path) => match path {
                     SpanSource::File(file) => {
                         full_path.push(Path::new(file));
                     }
                     _ => {
-                        return Err(ShellError::maybe_labeled_error(
+                        return Err(ShellError::labeled_error(
                             "Save requires a filepath",
                             "needs path",
                             args.call_info.name_span,
@@ -40,7 +36,8 @@ pub fn save(args: SinkCommandArgs) -> Result<(), ShellError> {
                     }
                 },
                 None => {
-                    return Err(ShellError::maybe_labeled_error(
+                    println!("Could not find origin");
+                    return Err(ShellError::labeled_error(
                         "Save requires a filepath",
                         "needs path",
                         args.call_info.name_span,
@@ -48,7 +45,7 @@ pub fn save(args: SinkCommandArgs) -> Result<(), ShellError> {
                 }
             }
         } else {
-            return Err(ShellError::maybe_labeled_error(
+            return Err(ShellError::labeled_error(
                 "Save requires a filepath",
                 "needs path",
                 args.call_info.name_span,

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -4,20 +4,23 @@ use crate::prelude::*;
 
 pub fn size(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let input = args.input;
+    let span = args.call_info.name_span;
     Ok(input
         .values
         .map(move |v| match v.item {
-            Value::Primitive(Primitive::String(ref s)) => ReturnSuccess::value(count(s, v.span())),
-            _ => Err(ShellError::maybe_labeled_error(
-                "Expected string values from pipeline",
-                "expects strings from pipeline",
-                Some(v.span()),
+            Value::Primitive(Primitive::String(ref s)) => ReturnSuccess::value(count(s, v.tag())),
+            _ => Err(ShellError::labeled_error_with_secondary(
+                "Expected a string from pipeline",
+                "requires string input",
+                span,
+                "value originates from here",
+                v.span(),
             )),
         })
         .to_output_stream())
 }
 
-fn count(contents: &str, span: impl Into<Span>) -> Tagged<Value> {
+fn count(contents: &str, tag: impl Into<Tag>) -> Tagged<Value> {
     let mut lines: i64 = 0;
     let mut words: i64 = 0;
     let mut chars: i64 = 0;
@@ -42,7 +45,7 @@ fn count(contents: &str, span: impl Into<Span>) -> Tagged<Value> {
         }
     }
 
-    let mut dict = TaggedDictBuilder::new(span);
+    let mut dict = TaggedDictBuilder::new(tag);
     //TODO: add back in name when we have it in the span
     //dict.insert("name", Value::string(name));
     dict.insert("lines", Value::int(lines));

--- a/src/commands/skip_while.rs
+++ b/src/commands/skip_while.rs
@@ -27,7 +27,7 @@ impl Command for SkipWhile {
 
 pub fn skip_while(args: CommandArgs) -> Result<OutputStream, ShellError> {
     if args.len() == 0 {
-        return Err(ShellError::maybe_labeled_error(
+        return Err(ShellError::labeled_error(
             "Where requires a condition",
             "needs condition",
             args.call_info.name_span,

--- a/src/commands/split_column.rs
+++ b/src/commands/split_column.rs
@@ -8,7 +8,7 @@ pub fn split_column(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let span = args.call_info.name_span;
 
     if positional.len() == 0 {
-        return Err(ShellError::maybe_labeled_error(
+        return Err(ShellError::labeled_error(
             "Split-column needs more information",
             "needs parameter (eg split-column \",\")",
             args.call_info.name_span,
@@ -34,14 +34,14 @@ pub fn split_column(args: CommandArgs) -> Result<OutputStream, ShellError> {
                         gen_columns.push(format!("Column{}", i + 1));
                     }
 
-                    let mut dict = TaggedDictBuilder::new(v.span());
+                    let mut dict = TaggedDictBuilder::new(v.tag());
                     for (&k, v) in split_result.iter().zip(gen_columns.iter()) {
                         dict.insert(v.clone(), Primitive::String(k.into()));
                     }
 
                     ReturnSuccess::value(dict.into_tagged_value())
                 } else if split_result.len() == (positional.len() - 1) {
-                    let mut dict = TaggedDictBuilder::new(v.span());
+                    let mut dict = TaggedDictBuilder::new(v.tag());
                     for (&k, v) in split_result.iter().zip(positional.iter().skip(1)) {
                         dict.insert(
                             v.as_string().unwrap(),
@@ -50,17 +50,19 @@ pub fn split_column(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     }
                     ReturnSuccess::value(dict.into_tagged_value())
                 } else {
-                    let mut dict = TaggedDictBuilder::new(v.span());
+                    let mut dict = TaggedDictBuilder::new(v.tag());
                     for k in positional.iter().skip(1) {
                         dict.insert(k.as_string().unwrap().trim(), Primitive::String("".into()));
                     }
                     ReturnSuccess::value(dict.into_tagged_value())
                 }
             }
-            _ => Err(ShellError::maybe_labeled_error(
-                "Expected string values from pipeline",
-                "expects strings from pipeline",
+            _ => Err(ShellError::labeled_error_with_secondary(
+                "Expected a string from pipeline",
+                "requires string input",
                 span,
+                "value originates from here",
+                v.span(),
             )),
         })
         .to_output_stream())

--- a/src/commands/split_row.rs
+++ b/src/commands/split_row.rs
@@ -8,7 +8,7 @@ pub fn split_row(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let span = args.call_info.name_span;
 
     if positional.len() == 0 {
-        return Err(ShellError::maybe_labeled_error(
+        return Err(ShellError::labeled_error(
             "Split-row needs more information",
             "needs parameter (eg split-row \"\\n\")",
             args.call_info.name_span,
@@ -30,17 +30,19 @@ pub fn split_row(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 let mut result = VecDeque::new();
                 for s in split_result {
                     result.push_back(ReturnSuccess::value(
-                        Value::Primitive(Primitive::String(s.into())).tagged(v.span()),
+                        Value::Primitive(Primitive::String(s.into())).simple_spanned(v.span()),
                     ));
                 }
                 result
             }
             _ => {
                 let mut result = VecDeque::new();
-                result.push_back(Err(ShellError::maybe_labeled_error(
-                    "Expected string values from pipeline",
-                    "expects strings from pipeline",
+                result.push_back(Err(ShellError::labeled_error_with_secondary(
+                    "Expected a string from pipeline",
+                    "requires string input",
                     span,
+                    "value originates from here",
+                    v.span(),
                 )));
                 result
             }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -8,18 +8,19 @@ pub fn tags(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .input
         .values
         .map(move |v| {
-            let mut tags = TaggedDictBuilder::new(v.span());
+            let mut tags = TaggedDictBuilder::new(v.tag());
             {
+                let origin = v.origin();
                 let span = v.span();
-                let mut dict = TaggedDictBuilder::new(v.span());
+                let mut dict = TaggedDictBuilder::new(v.tag());
                 dict.insert("start", Value::int(span.start as i64));
                 dict.insert("end", Value::int(span.end as i64));
-                match span.source.map(|x| source_map.get(&x)).flatten() {
+                match origin.map(|x| source_map.get(&x)).flatten() {
                     Some(SpanSource::File(source)) => {
-                        dict.insert("source", Value::string(source));
+                        dict.insert("origin", Value::string(source));
                     }
                     Some(SpanSource::Url(source)) => {
-                        dict.insert("source", Value::string(source));
+                        dict.insert("origin", Value::string(source));
                     }
                     _ => {}
                 }

--- a/src/commands/to_csv.rs
+++ b/src/commands/to_csv.rs
@@ -42,8 +42,10 @@ pub fn to_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     Ok(out
         .values
         .map(move |a| match to_string(&value_to_csv_value(&a.item)) {
-            Ok(x) => ReturnSuccess::value(Value::Primitive(Primitive::String(x)).tagged(name_span)),
-            Err(_) => Err(ShellError::maybe_labeled_error(
+            Ok(x) => ReturnSuccess::value(
+                Value::Primitive(Primitive::String(x)).simple_spanned(name_span),
+            ),
+            Err(_) => Err(ShellError::labeled_error(
                 "Can not convert to CSV string",
                 "can not convert piped data to CSV string",
                 name_span,

--- a/src/commands/to_json.rs
+++ b/src/commands/to_json.rs
@@ -48,10 +48,10 @@ pub fn to_json(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .values
         .map(
             move |a| match serde_json::to_string(&value_to_json_value(&a)) {
-                Ok(x) => {
-                    ReturnSuccess::value(Value::Primitive(Primitive::String(x)).tagged(name_span))
-                }
-                Err(_) => Err(ShellError::maybe_labeled_error(
+                Ok(x) => ReturnSuccess::value(
+                    Value::Primitive(Primitive::String(x)).simple_spanned(name_span),
+                ),
+                Err(_) => Err(ShellError::labeled_error(
                     "Can not convert to JSON string",
                     "can not convert piped data to JSON string",
                     name_span,

--- a/src/commands/to_toml.rs
+++ b/src/commands/to_toml.rs
@@ -42,13 +42,13 @@ pub fn to_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .map(move |a| match toml::to_string(&value_to_toml_value(&a)) {
             Ok(val) => {
                 return ReturnSuccess::value(
-                    Value::Primitive(Primitive::String(val)).tagged(name_span),
+                    Value::Primitive(Primitive::String(val)).simple_spanned(name_span),
                 )
             }
 
             Err(err) => Err(ShellError::type_error(
                 "Can not convert to a TOML string",
-                format!("{:?} - {:?}", a.type_name(), err).tagged(name_span),
+                format!("{:?} - {:?}", a.type_name(), err).simple_spanned(name_span),
             )),
         })
         .to_output_stream())

--- a/src/commands/to_yaml.rs
+++ b/src/commands/to_yaml.rs
@@ -46,10 +46,10 @@ pub fn to_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .values
         .map(
             move |a| match serde_yaml::to_string(&value_to_yaml_value(&a)) {
-                Ok(x) => {
-                    ReturnSuccess::value(Value::Primitive(Primitive::String(x)).tagged(name_span))
-                }
-                Err(_) => Err(ShellError::maybe_labeled_error(
+                Ok(x) => ReturnSuccess::value(
+                    Value::Primitive(Primitive::String(x)).simple_spanned(name_span),
+                ),
+                Err(_) => Err(ShellError::labeled_error(
                     "Can not convert to YAML string",
                     "can not convert piped data to YAML string",
                     name_span,

--- a/src/commands/trim.rs
+++ b/src/commands/trim.rs
@@ -9,7 +9,7 @@ pub fn trim(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .values
         .map(move |v| {
             let string = String::extract(&v)?;
-            ReturnSuccess::value(Value::string(string.trim()).tagged(v.span()))
+            ReturnSuccess::value(Value::string(string.trim()).simple_spanned(v.span()))
         })
         .to_output_stream())
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,7 +79,7 @@ impl Context {
     crate fn run_sink(
         &mut self,
         command: Arc<dyn Sink>,
-        name_span: Option<Span>,
+        name_span: Span,
         args: Args,
         input: Vec<Tagged<Value>>,
     ) -> Result<(), ShellError> {
@@ -111,7 +111,7 @@ impl Context {
     crate fn run_command(
         &mut self,
         command: Arc<dyn Command>,
-        name_span: Option<Span>,
+        name_span: Span,
         source_map: SourceMap,
         args: Args,
         input: InputStream,

--- a/src/object/base.rs
+++ b/src/object/base.rs
@@ -168,7 +168,7 @@ impl Block {
         let scope = Scope::new(value.clone());
 
         if self.expressions.len() == 0 {
-            return Ok(Tagged::from_item(Value::nothing(), self.span));
+            return Ok(Value::nothing().simple_spanned(self.span));
         }
 
         let mut last = None;
@@ -227,7 +227,7 @@ impl fmt::Debug for ValueDebug<'a> {
 impl Tagged<Value> {
     crate fn tagged_type_name(&self) -> Tagged<String> {
         let name = self.type_name();
-        Tagged::from_item(name, self.span())
+        Tagged::from_simple_spanned_item(name, self.span())
     }
 }
 
@@ -352,7 +352,7 @@ impl Value {
         }
     }
 
-    pub fn get_data_by_path(&'a self, span: Span, path: &str) -> Option<Tagged<&Value>> {
+    pub fn get_data_by_path(&'a self, tag: Tag, path: &str) -> Option<Tagged<&Value>> {
         let mut current = self;
         for p in path.split(".") {
             match current.get_data_by_key(p) {
@@ -361,12 +361,12 @@ impl Value {
             }
         }
 
-        Some(Tagged::from_item(current, span))
+        Some(Tagged::from_item(current, tag))
     }
 
     pub fn insert_data_at_path(
         &'a self,
-        span: Span,
+        tag: Tag,
         path: &str,
         new_value: Value,
     ) -> Option<Tagged<Value>> {
@@ -384,13 +384,13 @@ impl Value {
                                 Value::Object(o) => {
                                     o.entries.insert(
                                         split_path[idx + 1].to_string(),
-                                        Tagged::from_item(new_value, span),
+                                        Tagged::from_item(new_value, tag),
                                     );
                                 }
                                 _ => {}
                             }
 
-                            return Some(Tagged::from_item(new_obj, span));
+                            return Some(Tagged::from_item(new_obj, tag));
                         } else {
                             match next.item {
                                 Value::Object(ref mut o) => {
@@ -410,7 +410,7 @@ impl Value {
 
     pub fn replace_data_at_path(
         &'a self,
-        span: Span,
+        tag: Tag,
         path: &str,
         replaced_value: Value,
     ) -> Option<Tagged<Value>> {
@@ -424,8 +424,8 @@ impl Value {
                 match current.entries.get_mut(split_path[idx]) {
                     Some(next) => {
                         if idx == (split_path.len() - 1) {
-                            *next = Tagged::from_item(replaced_value, span);
-                            return Some(Tagged::from_item(new_obj, span));
+                            *next = Tagged::from_item(replaced_value, tag);
+                            return Some(Tagged::from_item(new_obj, tag));
                         } else {
                             match next.item {
                                 Value::Object(ref mut o) => {
@@ -601,8 +601,8 @@ impl Value {
     }
 }
 
-crate fn select_fields(obj: &Value, fields: &[String], span: impl Into<Span>) -> Tagged<Value> {
-    let mut out = TaggedDictBuilder::new(span);
+crate fn select_fields(obj: &Value, fields: &[String], tag: impl Into<Tag>) -> Tagged<Value> {
+    let mut out = TaggedDictBuilder::new(tag);
 
     let descs = obj.data_descriptors();
 
@@ -616,8 +616,8 @@ crate fn select_fields(obj: &Value, fields: &[String], span: impl Into<Span>) ->
     out.into_tagged_value()
 }
 
-crate fn reject_fields(obj: &Value, fields: &[String], span: impl Into<Span>) -> Tagged<Value> {
-    let mut out = TaggedDictBuilder::new(span);
+crate fn reject_fields(obj: &Value, fields: &[String], tag: impl Into<Tag>) -> Tagged<Value> {
+    let mut out = TaggedDictBuilder::new(tag);
 
     let descs = obj.data_descriptors();
 

--- a/src/object/config.rs
+++ b/src/object/config.rs
@@ -47,7 +47,7 @@ crate fn config(span: impl Into<Span>) -> Result<IndexMap<String, Tagged<Value>>
     trace!("config file = {}", filename.display());
 
     let contents = fs::read_to_string(filename)
-        .map(|v| v.tagged(span))
+        .map(|v| v.simple_spanned(span))
         .map_err(|err| ShellError::string(&format!("Couldn't read config file:\n{}", err)))?;
 
     let parsed: Config = toml::from_str(&contents)

--- a/src/object/dict.rs
+++ b/src/object/dict.rs
@@ -102,20 +102,20 @@ impl Dictionary {
 }
 
 pub struct TaggedListBuilder {
-    span: Span,
+    tag: Tag,
     list: Vec<Tagged<Value>>,
 }
 
 impl TaggedListBuilder {
-    pub fn new(span: impl Into<Span>) -> TaggedListBuilder {
+    pub fn new(tag: impl Into<Tag>) -> TaggedListBuilder {
         TaggedListBuilder {
-            span: span.into(),
+            tag: tag.into(),
             list: vec![],
         }
     }
 
     pub fn push(&mut self, value: impl Into<Value>) {
-        self.list.push(value.into().tagged(self.span));
+        self.list.push(value.into().tagged(self.tag));
     }
 
     pub fn insert_tagged(&mut self, value: impl Into<Tagged<Value>>) {
@@ -123,7 +123,7 @@ impl TaggedListBuilder {
     }
 
     pub fn into_tagged_value(self) -> Tagged<Value> {
-        Value::List(self.list).tagged(self.span)
+        Value::List(self.list).tagged(self.tag)
     }
 }
 
@@ -135,20 +135,20 @@ impl From<TaggedListBuilder> for Tagged<Value> {
 
 #[derive(Debug)]
 pub struct TaggedDictBuilder {
-    span: Span,
+    tag: Tag,
     dict: IndexMap<String, Tagged<Value>>,
 }
 
 impl TaggedDictBuilder {
-    pub fn new(span: impl Into<Span>) -> TaggedDictBuilder {
+    pub fn new(tag: impl Into<Tag>) -> TaggedDictBuilder {
         TaggedDictBuilder {
-            span: span.into(),
+            tag: tag.into(),
             dict: IndexMap::default(),
         }
     }
 
     pub fn insert(&mut self, key: impl Into<String>, value: impl Into<Value>) {
-        self.dict.insert(key.into(), value.into().tagged(self.span));
+        self.dict.insert(key.into(), value.into().tagged(self.tag));
     }
 
     pub fn insert_tagged(&mut self, key: impl Into<String>, value: impl Into<Tagged<Value>>) {
@@ -160,7 +160,7 @@ impl TaggedDictBuilder {
     }
 
     pub fn into_tagged_dict(self) -> Tagged<Dictionary> {
-        Dictionary { entries: self.dict }.tagged(self.span)
+        Dictionary { entries: self.dict }.tagged(self.tag)
     }
 }
 

--- a/src/object/files.rs
+++ b/src/object/files.rs
@@ -12,9 +12,9 @@ pub enum FileType {
 crate fn dir_entry_dict(
     filename: &std::path::Path,
     metadata: &std::fs::Metadata,
-    span: impl Into<Span>,
+    tag: impl Into<Tag>,
 ) -> Result<Tagged<Value>, ShellError> {
-    let mut dict = TaggedDictBuilder::new(span);
+    let mut dict = TaggedDictBuilder::new(tag);
     dict.insert("name", Value::string(filename.to_string_lossy()));
 
     let kind = if metadata.is_dir() {

--- a/src/object/into.rs
+++ b/src/object/into.rs
@@ -17,6 +17,6 @@ impl<T: Into<Value>> Tagged<T> {
     pub fn into_tagged_value(self) -> Tagged<Value> {
         let value_span = self.span();
         let value = self.item.into();
-        value.tagged(value_span)
+        value.simple_spanned(value_span)
     }
 }

--- a/src/object/process.rs
+++ b/src/object/process.rs
@@ -3,8 +3,8 @@ use crate::prelude::*;
 use itertools::join;
 use sysinfo::ProcessExt;
 
-crate fn process_dict(proc: &sysinfo::Process, span: impl Into<Span>) -> Tagged<Value> {
-    let mut dict = TaggedDictBuilder::new(span);
+crate fn process_dict(proc: &sysinfo::Process, tag: impl Into<Tag>) -> Tagged<Value> {
+    let mut dict = TaggedDictBuilder::new(tag);
 
     let cmd = proc.cmd();
 

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -21,7 +21,7 @@ pub trait ExtractType: Sized {
 
 impl<T: ExtractType> ExtractType for Tagged<T> {
     fn extract(value: &Tagged<Value>) -> Result<Tagged<T>, ShellError> {
-        Ok(T::extract(value)?.tagged(value.span()))
+        Ok(T::extract(value)?.simple_spanned(value.span()))
     }
 
     fn check(value: &'value Tagged<Value>) -> Result<&'value Tagged<Value>, ShellError> {

--- a/src/parser/hir.rs
+++ b/src/parser/hir.rs
@@ -64,36 +64,36 @@ pub type Expression = Tagged<RawExpression>;
 
 impl Expression {
     fn int(i: impl Into<i64>, span: impl Into<Span>) -> Expression {
-        Tagged::from_item(RawExpression::Literal(Literal::Integer(i.into())), span)
+        Tagged::from_simple_spanned_item(RawExpression::Literal(Literal::Integer(i.into())), span)
     }
 
     fn size(i: impl Into<i64>, unit: impl Into<Unit>, span: impl Into<Span>) -> Expression {
-        Tagged::from_item(
+        Tagged::from_simple_spanned_item(
             RawExpression::Literal(Literal::Size(i.into(), unit.into())),
             span,
         )
     }
 
     fn string(inner: impl Into<Span>, outer: impl Into<Span>) -> Expression {
-        Tagged::from_item(
+        Tagged::from_simple_spanned_item(
             RawExpression::Literal(Literal::String(inner.into())),
             outer.into(),
         )
     }
 
     fn bare(span: impl Into<Span>) -> Expression {
-        Tagged::from_item(RawExpression::Literal(Literal::Bare), span.into())
+        Tagged::from_simple_spanned_item(RawExpression::Literal(Literal::Bare), span.into())
     }
 
     fn variable(inner: impl Into<Span>, outer: impl Into<Span>) -> Expression {
-        Tagged::from_item(
+        Tagged::from_simple_spanned_item(
             RawExpression::Variable(Variable::Other(inner.into())),
             outer.into(),
         )
     }
 
     fn it_variable(inner: impl Into<Span>, outer: impl Into<Span>) -> Expression {
-        Tagged::from_item(
+        Tagged::from_simple_spanned_item(
             RawExpression::Variable(Variable::It(inner.into())),
             outer.into(),
         )

--- a/src/parser/parse/parser.rs
+++ b/src/parser/parse/parser.rs
@@ -77,7 +77,7 @@ pub fn raw_integer(input: NomSpan) -> IResult<NomSpan, Tagged<i64>> {
 
         Ok((
             input,
-            Tagged::from_item(int(num.fragment, neg), (start, end)),
+            Tagged::from_simple_spanned_item(int(num.fragment, neg), (start, end)),
         ))
     })
 }
@@ -231,7 +231,7 @@ pub fn raw_unit(input: NomSpan) -> IResult<NomSpan, Tagged<Unit>> {
 
         Ok((
             input,
-            Tagged::from_item(Unit::from(unit.fragment), (start, end)),
+            Tagged::from_simple_spanned_item(Unit::from(unit.fragment), (start, end)),
         ))
     })
 }
@@ -1029,7 +1029,7 @@ mod tests {
         right: usize,
     ) -> TokenNode {
         let node = DelimitedNode::new(delimiter, children);
-        let spanned = Tagged::from_item(node, (left, right));
+        let spanned = Tagged::from_simple_spanned_item(node, (left, right));
         TokenNode::Delimited(spanned)
     }
 
@@ -1038,16 +1038,16 @@ mod tests {
             Box::new(head),
             tail.into_iter().map(TokenNode::Token).collect(),
         );
-        let spanned = Tagged::from_item(node, (left, right));
+        let spanned = Tagged::from_simple_spanned_item(node, (left, right));
         TokenNode::Path(spanned)
     }
 
     fn leaf_token(token: RawToken, left: usize, right: usize) -> TokenNode {
-        TokenNode::Token(Tagged::from_item(token, (left, right)))
+        TokenNode::Token(Tagged::from_simple_spanned_item(token, (left, right)))
     }
 
     fn token(token: RawToken, left: usize, right: usize) -> TokenNode {
-        TokenNode::Token(Tagged::from_item(token, (left, right)))
+        TokenNode::Token(Tagged::from_simple_spanned_item(token, (left, right)))
     }
 
     fn build<T>(block: CurriedNode<T>) -> T {

--- a/src/parser/parse/token_tree_builder.rs
+++ b/src/parser/parse/token_tree_builder.rs
@@ -92,7 +92,7 @@ impl TokenTreeBuilder {
         input: (Vec<PipelineElement>, Option<Span>),
         span: impl Into<Span>,
     ) -> TokenNode {
-        TokenNode::Pipeline(Tagged::from_item(
+        TokenNode::Pipeline(Tagged::from_simple_spanned_item(
             Pipeline::new(input.0, input.1.into()),
             span,
         ))
@@ -111,7 +111,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_op(input: impl Into<Operator>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Operator(Tagged::from_item(input.into(), span.into()))
+        TokenNode::Operator(Tagged::from_simple_spanned_item(input.into(), span.into()))
     }
 
     pub fn string(input: impl Into<String>) -> CurriedToken {
@@ -128,7 +128,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Token(Tagged::from_item(
+        TokenNode::Token(Tagged::from_simple_spanned_item(
             RawToken::String(input.into()),
             span.into(),
         ))
@@ -146,7 +146,10 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_bare(input: impl Into<Span>) -> TokenNode {
-        TokenNode::Token(Tagged::from_item(RawToken::Bare, input.into()))
+        TokenNode::Token(Tagged::from_simple_spanned_item(
+            RawToken::Bare,
+            input.into(),
+        ))
     }
 
     pub fn int(input: impl Into<i64>) -> CurriedToken {
@@ -161,7 +164,10 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_int(input: impl Into<i64>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Token(Token::from_item(RawToken::Integer(input.into()), span))
+        TokenNode::Token(Token::from_simple_spanned_item(
+            RawToken::Integer(input.into()),
+            span,
+        ))
     }
 
     pub fn size(int: impl Into<i64>, unit: impl Into<Unit>) -> CurriedToken {
@@ -183,7 +189,10 @@ impl TokenTreeBuilder {
     ) -> TokenNode {
         let (int, unit) = (input.0.into(), input.1.into());
 
-        TokenNode::Token(Tagged::from_item(RawToken::Size(int, unit), span))
+        TokenNode::Token(Tagged::from_simple_spanned_item(
+            RawToken::Size(int, unit),
+            span,
+        ))
     }
 
     pub fn path(head: CurriedToken, tail: Vec<CurriedToken>) -> CurriedToken {
@@ -206,7 +215,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_path(input: (TokenNode, Vec<TokenNode>), span: impl Into<Span>) -> TokenNode {
-        TokenNode::Path(Tagged::from_item(
+        TokenNode::Path(Tagged::from_simple_spanned_item(
             PathNode::new(Box::new(input.0), input.1),
             span,
         ))
@@ -224,7 +233,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_var(input: impl Into<Span>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Token(Tagged::from_item(
+        TokenNode::Token(Tagged::from_simple_spanned_item(
             RawToken::Variable(input.into()),
             span.into(),
         ))
@@ -242,7 +251,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_flag(input: impl Into<Span>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Flag(Tagged::from_item(
+        TokenNode::Flag(Tagged::from_simple_spanned_item(
             Flag::new(FlagKind::Longhand, input.into()),
             span.into(),
         ))
@@ -260,7 +269,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_shorthand(input: impl Into<Span>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Flag(Tagged::from_item(
+        TokenNode::Flag(Tagged::from_simple_spanned_item(
             Flag::new(FlagKind::Shorthand, input.into()),
             span.into(),
         ))
@@ -306,7 +315,7 @@ impl TokenTreeBuilder {
         let head = input.next().unwrap();
         let tail = input.collect();
 
-        Tagged::from_item(CallNode::new(Box::new(head), tail), span)
+        Tagged::from_simple_spanned_item(CallNode::new(Box::new(head), tail), span)
     }
 
     pub fn parens(input: Vec<CurriedToken>) -> CurriedToken {
@@ -324,7 +333,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_parens(input: impl Into<Vec<TokenNode>>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Delimited(Tagged::from_item(
+        TokenNode::Delimited(Tagged::from_simple_spanned_item(
             DelimitedNode::new(Delimiter::Paren, input.into()),
             span,
         ))
@@ -345,7 +354,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_square(input: impl Into<Vec<TokenNode>>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Delimited(Tagged::from_item(
+        TokenNode::Delimited(Tagged::from_simple_spanned_item(
             DelimitedNode::new(Delimiter::Square, input.into()),
             span,
         ))
@@ -366,7 +375,7 @@ impl TokenTreeBuilder {
     }
 
     pub fn spanned_brace(input: impl Into<Vec<TokenNode>>, span: impl Into<Span>) -> TokenNode {
-        TokenNode::Delimited(Tagged::from_item(
+        TokenNode::Delimited(Tagged::from_simple_spanned_item(
             DelimitedNode::new(Delimiter::Brace, input.into()),
             span,
         ))

--- a/src/parser/parse_command.rs
+++ b/src/parser/parse_command.rs
@@ -48,8 +48,8 @@ fn parse_command_head(head: &TokenNode) -> Result<hir::Expression, ShellError> {
 
         TokenNode::Token(Tagged {
             item: RawToken::String(inner_span),
-            tag: Tag { span },
-        }) => Ok(Tagged::from_item(
+            tag: Tag { span, origin: None },
+        }) => Ok(Tagged::from_simple_spanned_item(
             hir::RawExpression::Literal(hir::Literal::String(*inner_span)),
             *span,
         )),

--- a/src/parser/registry.rs
+++ b/src/parser/registry.rs
@@ -252,8 +252,10 @@ fn evaluate_args(
             for (name, value) in n.named.iter() {
                 match value {
                     hir::named::NamedValue::PresentSwitch(span) => {
-                        results
-                            .insert(name.clone(), Tagged::from_item(Value::boolean(true), *span));
+                        results.insert(
+                            name.clone(),
+                            Tagged::from_simple_spanned_item(Value::boolean(true), *span),
+                        );
                     }
                     hir::named::NamedValue::Value(expr) => {
                         results.insert(

--- a/src/plugins/add.rs
+++ b/src/plugins/add.rs
@@ -17,10 +17,10 @@ impl Add {
     }
 
     fn add(&self, value: Tagged<Value>) -> Result<Tagged<Value>, ShellError> {
-        let value_span = value.span();
+        let value_tag = value.tag();
         match (value.item, self.value.clone()) {
             (obj @ Value::Object(_), Some(v)) => match &self.field {
-                Some(f) => match obj.insert_data_at_path(value_span, &f, v) {
+                Some(f) => match obj.insert_data_at_path(value_tag, &f, v) {
                     Some(v) => return Ok(v),
                     None => {
                         return Err(ShellError::string(

--- a/src/plugins/binaryview.rs
+++ b/src/plugins/binaryview.rs
@@ -30,13 +30,10 @@ impl Plugin for BinaryView {
 
     fn sink(&mut self, call_info: CallInfo, input: Vec<Tagged<Value>>) {
         for v in input {
-            let value_span = v.span();
+            let value_origin = v.origin();
             match v.item {
                 Value::Binary(b) => {
-                    let source = value_span
-                        .source
-                        .map(|x| call_info.source_map.get(&x))
-                        .flatten();
+                    let source = value_origin.map(|x| call_info.source_map.get(&x)).flatten();
                     let _ = view_binary(&b, source, call_info.args.has("lores"));
                 }
                 _ => {}

--- a/src/plugins/edit.rs
+++ b/src/plugins/edit.rs
@@ -17,10 +17,10 @@ impl Edit {
     }
 
     fn edit(&self, value: Tagged<Value>) -> Result<Tagged<Value>, ShellError> {
-        let value_span = value.span();
+        let value_tag = value.tag();
         match (value.item, self.value.clone()) {
             (obj @ Value::Object(_), Some(v)) => match &self.field {
-                Some(f) => match obj.replace_data_at_path(value_span, &f, v) {
+                Some(f) => match obj.replace_data_at_path(value_tag, &f, v) {
                     Some(v) => return Ok(v),
                     None => {
                         return Err(ShellError::string(

--- a/src/plugins/inc.rs
+++ b/src/plugins/inc.rs
@@ -26,15 +26,15 @@ impl Inc {
         field: &Option<String>,
     ) -> Result<Tagged<Value>, ShellError> {
         match value.item {
-            Value::Primitive(Primitive::Int(i)) => Ok(Value::int(i + 1).tagged(value.span())),
+            Value::Primitive(Primitive::Int(i)) => Ok(Value::int(i + 1).tagged(value.tag())),
             Value::Primitive(Primitive::Bytes(b)) => {
-                Ok(Value::bytes(b + 1 as u64).tagged(value.span()))
+                Ok(Value::bytes(b + 1 as u64).tagged(value.tag()))
             }
             Value::Primitive(Primitive::String(ref s)) => {
                 if let Ok(i) = s.parse::<u64>() {
                     Ok(Tagged::from_item(
                         Value::string(format!("{}", i + 1)),
-                        value.span(),
+                        value.tag(),
                     ))
                 } else if let Ok(mut ver) = semver::Version::parse(&s) {
                     if self.major {
@@ -47,7 +47,7 @@ impl Inc {
                     }
                     Ok(Tagged::from_item(
                         Value::string(ver.to_string()),
-                        value.span(),
+                        value.tag(),
                     ))
                 } else {
                     Err(ShellError::string("string could not be incremented"))
@@ -55,7 +55,7 @@ impl Inc {
             }
             Value::Object(_) => match field {
                 Some(f) => {
-                    let replacement = match value.item.get_data_by_path(value.span(), f) {
+                    let replacement = match value.item.get_data_by_path(value.tag(), f) {
                         Some(result) => self.inc(result.map(|x| x.clone()), &None)?,
                         None => {
                             return Err(ShellError::string("inc could not find field to replace"))
@@ -63,7 +63,7 @@ impl Inc {
                     };
                     match value
                         .item
-                        .replace_data_at_path(value.span(), f, replacement.item.clone())
+                        .replace_data_at_path(value.tag(), f, replacement.item.clone())
                     {
                         Some(v) => return Ok(v),
                         None => {

--- a/src/plugins/sum.rs
+++ b/src/plugins/sum.rs
@@ -18,10 +18,11 @@ impl Sum {
                 match self.total {
                     Some(Tagged {
                         item: Value::Primitive(Primitive::Int(j)),
-                        tag: Tag { span },
+                        tag: Tag { span, .. },
                     }) => {
                         //TODO: handle overflow
-                        self.total = Some(Tagged::from_item(Value::int(i + j), span));
+                        self.total =
+                            Some(Tagged::from_simple_spanned_item(Value::int(i + j), span));
                         Ok(())
                     }
                     None => {
@@ -37,10 +38,11 @@ impl Sum {
                 match self.total {
                     Some(Tagged {
                         item: Value::Primitive(Primitive::Bytes(j)),
-                        tag: Tag { span },
+                        tag: Tag { span, .. },
                     }) => {
                         //TODO: handle overflow
-                        self.total = Some(Tagged::from_item(Value::bytes(b + j), span));
+                        self.total =
+                            Some(Tagged::from_simple_spanned_item(Value::bytes(b + j), span));
                         Ok(())
                     }
                     None => {

--- a/src/plugins/sys.rs
+++ b/src/plugins/sys.rs
@@ -6,7 +6,7 @@ use heim::{disk, memory};
 use indexmap::IndexMap;
 use nu::{
     serve_plugin, CallInfo, CommandConfig, Plugin, Primitive, ReturnSuccess, ReturnValue,
-    ShellError, Span, Tagged, TaggedDictBuilder, Value, OF64,
+    ShellError, Tag, Tagged, TaggedDictBuilder, Value, OF64,
 };
 use std::ffi::OsStr;
 
@@ -19,9 +19,9 @@ impl Sys {
 
 //TODO: add more error checking
 
-async fn cpu(span: Span) -> Option<Tagged<Value>> {
+async fn cpu(tag: Tag) -> Option<Tagged<Value>> {
     if let (Ok(num_cpu), Ok(cpu_speed)) = (sys_info::cpu_num(), sys_info::cpu_speed()) {
-        let mut cpu_idx = TaggedDictBuilder::new(span);
+        let mut cpu_idx = TaggedDictBuilder::new(tag);
         cpu_idx.insert("cores", Primitive::Int(num_cpu as i64));
         cpu_idx.insert("speed", Primitive::Int(cpu_speed as i64));
         Some(cpu_idx.into_tagged_value())
@@ -30,8 +30,8 @@ async fn cpu(span: Span) -> Option<Tagged<Value>> {
     }
 }
 
-async fn mem(span: Span) -> Tagged<Value> {
-    let mut dict = TaggedDictBuilder::new(span);
+async fn mem(tag: Tag) -> Tagged<Value> {
+    let mut dict = TaggedDictBuilder::new(tag);
 
     if let Ok(memory) = memory::memory().await {
         dict.insert("total", Value::bytes(memory.total().get()));
@@ -45,8 +45,8 @@ async fn mem(span: Span) -> Tagged<Value> {
     dict.into_tagged_value()
 }
 
-async fn host(span: Span) -> Tagged<Value> {
-    let mut dict = TaggedDictBuilder::new(span);
+async fn host(tag: Tag) -> Tagged<Value> {
+    let mut dict = TaggedDictBuilder::new(tag);
 
     // OS
     if let Ok(platform) = heim::host::platform().await {
@@ -58,7 +58,7 @@ async fn host(span: Span) -> Tagged<Value> {
 
     // Uptime
     if let Ok(uptime) = heim::host::uptime().await {
-        let mut uptime_dict = TaggedDictBuilder::new(span);
+        let mut uptime_dict = TaggedDictBuilder::new(tag);
 
         let uptime = uptime.get().round() as i64;
         let days = uptime / (60 * 60 * 24);
@@ -79,7 +79,7 @@ async fn host(span: Span) -> Tagged<Value> {
     let mut user_vec = vec![];
     while let Some(user) = users.next().await {
         if let Ok(user) = user {
-            user_vec.push(Tagged::from_item(Value::string(user.username()), span));
+            user_vec.push(Tagged::from_item(Value::string(user.username()), tag));
         }
     }
     let user_list = Value::List(user_vec);
@@ -88,12 +88,12 @@ async fn host(span: Span) -> Tagged<Value> {
     dict.into_tagged_value()
 }
 
-async fn disks(span: Span) -> Value {
+async fn disks(tag: Tag) -> Value {
     let mut output = vec![];
     let mut partitions = disk::partitions_physical();
     while let Some(part) = partitions.next().await {
         if let Ok(part) = part {
-            let mut dict = TaggedDictBuilder::new(span);
+            let mut dict = TaggedDictBuilder::new(tag);
             dict.insert(
                 "device",
                 Value::string(
@@ -117,14 +117,14 @@ async fn disks(span: Span) -> Value {
     Value::List(output)
 }
 
-async fn temp(span: Span) -> Value {
+async fn temp(tag: Tag) -> Value {
     use sysinfo::{ComponentExt, RefreshKind, SystemExt};
     let system = sysinfo::System::new_with_specifics(RefreshKind::new().with_system());
     let components_list = system.get_components_list();
     if components_list.len() > 0 {
         let mut v: Vec<Tagged<Value>> = vec![];
         for component in components_list {
-            let mut component_idx = TaggedDictBuilder::new(span);
+            let mut component_idx = TaggedDictBuilder::new(tag);
             component_idx.insert("name", Primitive::String(component.get_label().to_string()));
             component_idx.insert(
                 "temp",
@@ -145,7 +145,7 @@ async fn temp(span: Span) -> Value {
     }
 }
 
-async fn net(span: Span) -> Tagged<Value> {
+async fn net(tag: Tag) -> Tagged<Value> {
     use sysinfo::{NetworkExt, RefreshKind, SystemExt};
     let system = sysinfo::System::new_with_specifics(RefreshKind::new().with_network());
 
@@ -153,23 +153,23 @@ async fn net(span: Span) -> Tagged<Value> {
     let incoming = network.get_income();
     let outgoing = network.get_outcome();
 
-    let mut network_idx = TaggedDictBuilder::new(span);
+    let mut network_idx = TaggedDictBuilder::new(tag);
     network_idx.insert("incoming", Value::bytes(incoming));
     network_idx.insert("outgoing", Value::bytes(outgoing));
     network_idx.into_tagged_value()
 }
 
-async fn sysinfo(span: Span) -> Vec<Tagged<Value>> {
-    let mut sysinfo = TaggedDictBuilder::new(span);
+async fn sysinfo(tag: Tag) -> Vec<Tagged<Value>> {
+    let mut sysinfo = TaggedDictBuilder::new(tag);
 
-    sysinfo.insert_tagged("host", host(span).await);
-    if let Some(cpu) = cpu(span).await {
+    sysinfo.insert_tagged("host", host(tag).await);
+    if let Some(cpu) = cpu(tag).await {
         sysinfo.insert_tagged("cpu", cpu);
     }
-    sysinfo.insert("disks", disks(span).await);
-    sysinfo.insert_tagged("mem", mem(span).await);
-    sysinfo.insert("temp", temp(span).await);
-    sysinfo.insert_tagged("net", net(span).await);
+    sysinfo.insert("disks", disks(tag).await);
+    sysinfo.insert_tagged("mem", mem(tag).await);
+    sysinfo.insert("temp", temp(tag).await);
+    sysinfo.insert_tagged("net", net(tag).await);
 
     vec![sysinfo.into_tagged_value()]
 }
@@ -186,12 +186,10 @@ impl Plugin for Sys {
         })
     }
     fn begin_filter(&mut self, callinfo: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
-        Ok(block_on(sysinfo(
-            callinfo.name_span.unwrap_or_else(|| Span::unknown()),
-        ))
-        .into_iter()
-        .map(|x| ReturnSuccess::value(x))
-        .collect())
+        Ok(block_on(sysinfo(Tag::unknown_origin(callinfo.name_span)))
+            .into_iter()
+            .map(|x| ReturnSuccess::value(x))
+            .collect())
     }
 
     fn filter(&mut self, _: Tagged<Value>) -> Result<Vec<ReturnValue>, ShellError> {

--- a/src/plugins/textview.rs
+++ b/src/plugins/textview.rs
@@ -210,10 +210,10 @@ fn scroll_view(s: &str) {
 }
 
 fn view_text_value(value: &Tagged<Value>, source_map: &SourceMap) {
-    let value_span = value.span();
+    let value_origin = value.origin();
     match value.item {
         Value::Primitive(Primitive::String(ref s)) => {
-            let source = value_span.source.map(|x| source_map.get(&x)).flatten();
+            let source = value_origin.map(|x| source_map.get(&x)).flatten();
 
             if let Some(source) = source {
                 let extension: Option<String> = match source {


### PR DESCRIPTION
This moves more of the errors system to use tags, and separates the filename from the span. This may eventually move to a more permanent home, but for now the filename is under the `origin` in the tag information.

I've also updated the tags we create, so that when information has an origin and span where it was first made, we can also offer better error messages that use this information.