### PR TITLE
Reduce unwraps

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,9 +52,9 @@ fn load_plugin(path: &std::path::Path, context: &mut Context) -> Result<(), Shel
     let mut reader = BufReader::new(stdout);
 
     let request = JsonRpc::new("config", Vec::<Value>::new());
-    let request_raw = serde_json::to_string(&request).unwrap();
+    let request_raw = serde_json::to_string(&request)?;
     stdin.write(format!("{}\n", request_raw).as_bytes())?;
-    let path = dunce::canonicalize(path).unwrap();
+    let path = dunce::canonicalize(path)?;
 
     let mut input = String::new();
     match reader.read_line(&mut input) {
@@ -90,13 +90,13 @@ fn load_plugin(path: &std::path::Path, context: &mut Context) -> Result<(), Shel
 }
 
 fn load_plugins_in_dir(path: &std::path::PathBuf, context: &mut Context) -> Result<(), ShellError> {
-    let re_bin = Regex::new(r"^nu_plugin_[A-Za-z_]+$").unwrap();
-    let re_exe = Regex::new(r"^nu_plugin_[A-Za-z_]+\.exe$").unwrap();
+    let re_bin = Regex::new(r"^nu_plugin_[A-Za-z_]+$")?;
+    let re_exe = Regex::new(r"^nu_plugin_[A-Za-z_]+\.exe$")?;
 
     match std::fs::read_dir(path) {
         Ok(p) => {
             for entry in p {
-                let entry = entry.unwrap();
+                let entry = entry?;
                 let filename = entry.file_name();
                 let f_name = filename.to_string_lossy();
                 if re_bin.is_match(&f_name) || re_exe.is_match(&f_name) {
@@ -270,8 +270,7 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
                     &files,
                     &diag,
                     &language_reporting::DefaultConfig,
-                )
-                .unwrap();
+                )?;
             }
 
             LineResult::Break => {
@@ -288,7 +287,7 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
         }
         ctrlcbreak = false;
     }
-    rl.save_history("history.txt").unwrap();
+    rl.save_history("history.txt")?;
 
     Ok(())
 }

--- a/src/commands/autoview.rs
+++ b/src/commands/autoview.rs
@@ -17,7 +17,7 @@ impl WholeStreamCommand for Autoview {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        args.process_raw(registry, autoview)?.run()
+        Ok(args.process_raw(registry, autoview)?.run())
     }
 
     fn signature(&self) -> Signature {
@@ -40,28 +40,20 @@ pub fn autoview(
             } = input[0usize]
             {
                 let binary = context.expect_command("binaryview");
-                let result = binary.run(raw.with_input(input), &context.commands).await.unwrap();
+                let result = binary.run(raw.with_input(input), &context.commands);
                 result.collect::<Vec<_>>().await;
             } else if is_single_text_value(&input) {
                 let text = context.expect_command("textview");
-                let result = text.run(raw.with_input(input), &context.commands).await.unwrap();
+                let result = text.run(raw.with_input(input), &context.commands);
                 result.collect::<Vec<_>>().await;
             } else if equal_shapes(&input) {
                 let table = context.expect_command("table");
-                let result = table.run(raw.with_input(input), &context.commands).await.unwrap();
+                let result = table.run(raw.with_input(input), &context.commands);
                 result.collect::<Vec<_>>().await;
             } else {
                 let table = context.expect_command("table");
-                let result = table.run(raw.with_input(input), &context.commands).await.unwrap();
+                let result = table.run(raw.with_input(input), &context.commands);
                 result.collect::<Vec<_>>().await;
-                //println!("TODO!")
-                // TODO
-                // let mut host = context.host.lock().unwrap();
-                // for i in input.iter() {
-                //     let view = GenericView::new(&i);
-                //     handle_unexpected(&mut *host, |host| crate::format::print_view(&view, host));
-                //     host.stdout("");
-                // }
             }
         }
     }))

--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -117,16 +117,14 @@ impl InternalCommand {
         let objects: InputStream =
             trace_stream!(target: "nu::trace_stream::internal", "input" = input.objects);
 
-        let result = context
-            .run_command(
-                self.command,
-                self.name_span.clone(),
-                context.source_map.clone(),
-                self.args,
-                source,
-                objects,
-            )
-            .await?;
+        let result = context.run_command(
+            self.command,
+            self.name_span.clone(),
+            context.source_map.clone(),
+            self.args,
+            source,
+            objects,
+        );
 
         let mut result = result.values;
 
@@ -285,7 +283,7 @@ impl ExternalCommand {
                             continue;
                         }
 
-                        process = process.arg(&arg.replace("$it", &i.as_string().unwrap()));
+                        process = process.arg(&arg.replace("$it", &i.as_string()?));
                     }
                 }
             } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -115,7 +115,7 @@ impl Context {
         self.registry.get_command(name).unwrap()
     }
 
-    crate async fn run_command<'a>(
+    crate fn run_command<'a>(
         &mut self,
         command: Arc<Command>,
         name_span: Span,
@@ -123,9 +123,9 @@ impl Context {
         args: hir::Call,
         source: Text,
         input: InputStream,
-    ) -> Result<OutputStream, ShellError> {
+    ) -> OutputStream {
         let command_args = self.command_args(args, input, source, source_map, name_span);
-        command.run(command_args, self.registry()).await
+        command.run(command_args, self.registry())
     }
 
     fn call_info(

--- a/src/object/meta.rs
+++ b/src/object/meta.rs
@@ -197,6 +197,18 @@ impl From<&Span> for Tag {
     }
 }
 
+impl From<Tag> for Span {
+    fn from(tag: Tag) -> Self {
+        tag.span
+    }
+}
+
+impl From<&Tag> for Span {
+    fn from(tag: &Tag) -> Self {
+        tag.span
+    }
+}
+
 impl Tag {
     pub fn unknown_origin(span: Span) -> Tag {
         Tag { origin: None, span }

--- a/src/parser/registry.rs
+++ b/src/parser/registry.rs
@@ -142,6 +142,17 @@ pub struct EvaluatedArgs {
     pub named: Option<IndexMap<String, Tagged<Value>>>,
 }
 
+impl EvaluatedArgs {
+    pub fn slice_from(&self, from: usize) -> Vec<Tagged<Value>> {
+        let positional = &self.positional;
+
+        match positional {
+            None => vec![],
+            Some(list) => list[from..].to_vec(),
+        }
+    }
+}
+
 #[derive(new)]
 pub struct DebugEvaluatedPositional<'a> {
     positional: &'a Option<Vec<Tagged<Value>>>,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,7 +41,7 @@ crate use crate::context::CommandRegistry;
 crate use crate::context::{Context, SpanSource};
 crate use crate::env::host::handle_unexpected;
 crate use crate::env::Host;
-crate use crate::errors::ShellError;
+crate use crate::errors::{ShellError, ShellErrorUtils};
 crate use crate::object::base as value;
 crate use crate::object::meta::{Tag, Tagged, TaggedItem};
 crate use crate::object::types::ExtractType;

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -7,10 +7,17 @@ use crate::shell::shell::Shell;
 use rustyline::completion::FilenameCompleter;
 use rustyline::hint::{Hinter, HistoryHinter};
 use std::path::{Path, PathBuf};
+
 pub struct FilesystemShell {
     crate path: String,
     completer: NuCompleter,
     hinter: HistoryHinter,
+}
+
+impl std::fmt::Debug for FilesystemShell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FilesystemShell @ {}", self.path)
+    }
 }
 
 impl Clone for FilesystemShell {

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -3,7 +3,7 @@ use crate::context::SourceMap;
 use crate::errors::ShellError;
 use crate::stream::OutputStream;
 
-pub trait Shell {
+pub trait Shell: std::fmt::Debug {
     fn name(&self, source_map: &SourceMap) -> String;
     fn ls(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError>;
     fn cd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError>;

--- a/src/shell/shell_manager.rs
+++ b/src/shell/shell_manager.rs
@@ -7,7 +7,7 @@ use crate::stream::OutputStream;
 use std::error::Error;
 use std::sync::{Arc, Mutex};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ShellManager {
     crate shells: Arc<Mutex<Vec<Box<dyn Shell + Send>>>>,
 }

--- a/src/shell/value_shell.rs
+++ b/src/shell/value_shell.rs
@@ -5,7 +5,7 @@ use crate::shell::shell::Shell;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ValueShell {
     crate path: String,
     crate value: Tagged<Value>,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -75,6 +75,29 @@ impl OutputStream {
             values: input.map(ReturnSuccess::value).boxed(),
         }
     }
+
+    pub fn drain_vec(&mut self) -> impl Future<Output = Vec<ReturnValue>> {
+        let mut values: BoxStream<'static, ReturnValue> = VecDeque::new().boxed();
+        std::mem::swap(&mut values, &mut self.values);
+
+        values.collect()
+    }
+}
+
+impl std::ops::Try for OutputStream {
+    type Ok = OutputStream;
+    type Error = ShellError;
+    fn into_result(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self)
+    }
+
+    fn from_error(v: Self::Error) -> Self {
+        OutputStream::one(Err(v))
+    }
+
+    fn from_ok(v: Self::Ok) -> Self {
+        v
+    }
 }
 
 impl Stream for OutputStream {


### PR DESCRIPTION
Remove a number of unwraps. In some cases, a `?` just worked as is. I also made it possible to use `?` to go from Result<OutputStream, ShellError> to OutputStream. Finally, started updating PerItemCommand to be able to use the signature deserialization logic, which substantially reduces unwraps.

This is still in-progress work, but tests pass and it should be clear to merge and keep iterating on master.