### PR TITLE
Fix warnings

### DIFF
--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -1,5 +1,3 @@
-use crate::commands::command::EvaluatedCommandArgs;
-use crate::parser::registry::EvaluatedArgs;
 use crate::prelude::*;
 use log::trace;
 use serde::{de, forward_to_deserialize_any};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,7 +41,7 @@ crate use crate::context::CommandRegistry;
 crate use crate::context::{Context, SpanSource};
 crate use crate::env::host::handle_unexpected;
 crate use crate::env::Host;
-crate use crate::errors::{ShellError, ShellErrorUtils};
+crate use crate::errors::ShellError;
 crate use crate::object::base as value;
 crate use crate::object::meta::{Tag, Tagged, TaggedItem};
 crate use crate::object::types::ExtractType;


### PR DESCRIPTION
Should we be failing the build for warnings? They're quite distracting when developing.

This PR is more of a question. Feel free to close!