### PR TITLE
Use Unicode box-drawing characters for tables

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1,3 +1,4 @@
+crate mod consts;
 crate mod entries;
 crate mod generic;
 crate mod list;

--- a/src/format/consts.rs
+++ b/src/format/consts.rs
@@ -1,0 +1,14 @@
+use lazy_static::lazy_static;
+
+use prettytable::format::{FormatBuilder, LinePosition, LineSeparator, TableFormat};
+ 
+lazy_static! {
+    pub(crate) static ref TABLE_FORMAT: TableFormat =
+        FormatBuilder::new()
+            .column_separator('│')
+            .separator(LinePosition::Top, LineSeparator::new('━', '┯', ' ', ' '))
+            .separator(LinePosition::Title, LineSeparator::new('─', '┼', ' ', ' '))
+            .separator(LinePosition::Bottom, LineSeparator::new('━', '┷', ' ', ' '))
+            .padding(1, 1)
+            .build();
+}

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -1,9 +1,8 @@
-use crate::format::RenderView;
+use crate::format::{RenderView, consts};
 use crate::object::Value;
 use crate::prelude::*;
 use ansi_term::Color;
 use derive_new::new;
-use prettytable::format::{FormatBuilder, LinePosition, LineSeparator};
 use textwrap::fill;
 
 use prettytable::{color, Attr, Cell, Row, Table};
@@ -191,16 +190,7 @@ impl RenderView for TableView {
         }
 
         let mut table = Table::new();
-
-        let fb = FormatBuilder::new()
-            .separator(LinePosition::Top, LineSeparator::new('-', '+', ' ', ' '))
-            .separator(LinePosition::Bottom, LineSeparator::new('-', '+', ' ', ' '))
-            .separator(LinePosition::Title, LineSeparator::new('-', '+', '|', '|'))
-            .column_separator('|')
-            .padding(1, 1);
-
-        //table.set_format(*prettytable::format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
-        table.set_format(fb.build());
+        table.set_format(*consts::TABLE_FORMAT);
 
         let header: Vec<Cell> = self
             .headers

--- a/src/format/vtable.rs
+++ b/src/format/vtable.rs
@@ -1,8 +1,7 @@
-use crate::format::RenderView;
+use crate::format::{RenderView, consts};
 use crate::object::Value;
 use crate::prelude::*;
 use derive_new::new;
-use prettytable::format::{FormatBuilder, LinePosition, LineSeparator};
 
 use prettytable::{color, Attr, Cell, Row, Table};
 
@@ -47,14 +46,7 @@ impl RenderView for VTableView {
         }
 
         let mut table = Table::new();
-
-        let fb = FormatBuilder::new()
-            .separator(LinePosition::Top, LineSeparator::new('-', '+', ' ', ' '))
-            .separator(LinePosition::Bottom, LineSeparator::new('-', '+', ' ', ' '))
-            .column_separator('|')
-            .padding(1, 1);
-
-        table.set_format(fb.build());
+        table.set_format(*consts::TABLE_FORMAT);
 
         for row in &self.entries {
             table.add_row(Row::new(


### PR DESCRIPTION
Use box-drawing characters instead of `+-+` to draw tables (see issue #345):

![example of box-drawing characters in output](https://user-images.githubusercontent.com/12575/63631292-72bf6880-c679-11e9-9843-72299c3ca88b.png)

Two things:
1. This is literally the first Rust code I’ve ever written, so I’m not sure if this is acceptable style/use.
2. I’m not yet sure where the `vtable` output is used, to check what it looks like.