### PR TITLE
Improve formatting of numeric values (float, int, bytes)

### DIFF
--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -1,7 +1,6 @@
 use crate::format::RenderView;
 use crate::object::Value;
 use crate::prelude::*;
-use ansi_term::Color;
 use derive_new::new;
 use prettytable::format::{FormatBuilder, LinePosition, LineSeparator};
 use textwrap::fill;

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -97,9 +97,9 @@ impl TableView {
                 entries[row].truncate(max_num_of_columns);
             }
 
-            headers.push("…".to_string());
+            headers.push("...".to_string());
             for row in 0..entries.len() {
-                entries[row].push(("…".to_string(), "c")); // ellipsis is centred
+                entries[row].push(("...".to_string(), "c")); // ellipsis is centred
             }
         }
 

--- a/src/object/base.rs
+++ b/src/object/base.rs
@@ -94,14 +94,14 @@ impl Primitive {
                 let byte = byte_unit::Byte::from_bytes(*b as u128);
 
                 if byte.get_bytes() == 0u128 {
-                    return "<empty>".to_string();
+                    return "    –   ".to_string();
                 }
 
                 let byte = byte.get_appropriate_unit(false);
 
                 match byte.get_unit() {
-                    byte_unit::ByteUnit::B => format!("{}", byte.format(0)),
-                    _ => format!("{}", byte.format(1)),
+                    byte_unit::ByteUnit::B => format!("{:>5} B ", byte.get_value()),
+                    _ => format!("{:>8}", byte.format(1)),
                 }
             }
             Primitive::Int(i) => format!("{}", i),

--- a/src/object/base.rs
+++ b/src/object/base.rs
@@ -94,14 +94,14 @@ impl Primitive {
                 let byte = byte_unit::Byte::from_bytes(*b as u128);
 
                 if byte.get_bytes() == 0u128 {
-                    return "    –   ".to_string();
+                    return "—".to_string();
                 }
 
                 let byte = byte.get_appropriate_unit(false);
 
                 match byte.get_unit() {
-                    byte_unit::ByteUnit::B => format!("{:>5} B ", byte.get_value()),
-                    _ => format!("{:>8}", byte.format(1)),
+                    byte_unit::ByteUnit::B => format!("{} B ", byte.get_value()),
+                    _ => format!("{}", byte.format(1)),
                 }
             }
             Primitive::Int(i) => format!("{}", i),
@@ -116,6 +116,16 @@ impl Primitive {
                 (false, Some(_)) => format!("No"),
             },
             Primitive::Date(d) => format!("{}", d.humanize()),
+        }
+    }
+
+    pub fn style(&self) -> &'static str {
+        match self {
+            Primitive::Bytes(0) => "c", // centre 'missing' indicator
+            Primitive::Int(_) |
+            Primitive::Bytes(_) |
+            Primitive::Float(_) => "r",
+            _ => ""
         }
     }
 }
@@ -456,6 +466,13 @@ impl Value {
                 if l.len() == 1 { "item" } else { "items" }
             ),
             Value::Binary(_) => format!("<binary>"),
+        }
+    }
+
+    crate fn style_leaf(&self) -> &'static str {
+        match self {
+            Value::Primitive(p) => p.style(),
+            _ => ""
         }
     }
 


### PR DESCRIPTION
* Add a style string for all entries, this simplifies some existing code around indices as well.
* Right-align indices.
* Right-align all numeric values in tables, so columns always have the numeric value. Thankfully float values were already formatted to two decimal places so they line up nicely. Padded bytes-only (i.e. 'B', not 'KB') values by one character so they line up.
* Replace the string `<empty>` for Bytes values with a less-noisy placeholder, and center it. (At the moment this is an em dash – do we need Unicode-output-detection?)
* Centred ellipses in truncated tables.

### Examples

| Program | Before | After |
|---|---|---|
| `ps` | ![image](https://user-images.githubusercontent.com/12575/63632917-f2f2c780-c693-11e9-8bd3-52b8ed6a5a2d.png) | ![image](https://user-images.githubusercontent.com/12575/63632923-030aa700-c694-11e9-88a8-a61fcea6a2ab.png) <small>Index, PID, CPU% are now right-aligned</small> |
| `ls` | ![image](https://user-images.githubusercontent.com/12575/63632948-698fc500-c694-11e9-85b3-b0918fdcd63d.png) | ![image](https://user-images.githubusercontent.com/12575/63632956-81674900-c694-11e9-84f1-c22641f10274.png) <small>Bytes are now aligned and `<empty>` is less cluttered</small> |

Again this is the first Rust code I’ve written so style/tips are appreciated 😃 

