### PR TITLE
Add expansion to from-* for lists

### DIFF
--- a/src/commands/from_csv.rs
+++ b/src/commands/from_csv.rs
@@ -97,7 +97,14 @@ fn from_csv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
         }
 
         match from_csv_string_to_value(concat_string, span) {
-            Ok(x) => yield ReturnSuccess::value(x),
+            Ok(x) => match x {
+                Tagged { item: Value::List(list), .. } => {
+                    for l in list {
+                        yield ReturnSuccess::value(l);
+                    }
+                }
+                x => yield ReturnSuccess::value(x),
+            },
             Err(_) => if let Some(last_tag) = latest_tag {
                 yield Err(ShellError::labeled_error_with_secondary(
                     "Could not parse as CSV",

--- a/src/commands/from_ini.rs
+++ b/src/commands/from_ini.rs
@@ -89,7 +89,14 @@ fn from_ini(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
         }
 
         match from_ini_string_to_value(concat_string, span) {
-            Ok(x) => yield ReturnSuccess::value(x),
+            Ok(x) => match x {
+                Tagged { item: Value::List(list), .. } => {
+                    for l in list {
+                        yield ReturnSuccess::value(l);
+                    }
+                }
+                x => yield ReturnSuccess::value(x),
+            },
             Err(_) => if let Some(last_tag) = latest_tag {
                 yield Err(ShellError::labeled_error_with_secondary(
                     "Could not parse as INI",

--- a/src/commands/from_json.rs
+++ b/src/commands/from_json.rs
@@ -95,7 +95,15 @@ fn from_json(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
         }
 
         match from_json_string_to_value(concat_string, span) {
-            Ok(x) => yield ReturnSuccess::value(x),
+            Ok(x) =>
+                match x {
+                    Tagged { item: Value::List(list), .. } => {
+                        for l in list {
+                            yield ReturnSuccess::value(l);
+                        }
+                    }
+                    x => yield ReturnSuccess::value(x),
+                }
             Err(_) => if let Some(last_tag) = latest_tag {
                 yield Err(ShellError::labeled_error_with_secondary(
                     "Could not parse as JSON",

--- a/src/commands/from_toml.rs
+++ b/src/commands/from_toml.rs
@@ -94,7 +94,14 @@ pub fn from_toml(
         }
 
         match from_toml_string_to_value(concat_string, span) {
-            Ok(x) => yield ReturnSuccess::value(x),
+            Ok(x) => match x {
+                Tagged { item: Value::List(list), .. } => {
+                    for l in list {
+                        yield ReturnSuccess::value(l);
+                    }
+                }
+                x => yield ReturnSuccess::value(x),
+            },
             Err(_) => if let Some(last_tag) = latest_tag {
                 yield Err(ShellError::labeled_error_with_secondary(
                     "Could not parse as TOML",

--- a/src/commands/from_xml.rs
+++ b/src/commands/from_xml.rs
@@ -108,7 +108,14 @@ fn from_xml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
         }
 
         match from_xml_string_to_value(concat_string, span) {
-            Ok(x) => yield ReturnSuccess::value(x),
+            Ok(x) => match x {
+                Tagged { item: Value::List(list), .. } => {
+                    for l in list {
+                        yield ReturnSuccess::value(l);
+                    }
+                }
+                x => yield ReturnSuccess::value(x),
+            },
             Err(_) => if let Some(last_tag) = latest_tag {
                 yield Err(ShellError::labeled_error_with_secondary(
                     "Could not parse as XML",

--- a/src/commands/from_yaml.rs
+++ b/src/commands/from_yaml.rs
@@ -99,7 +99,14 @@ fn from_yaml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
         }
 
         match from_yaml_string_to_value(concat_string, span) {
-            Ok(x) => yield ReturnSuccess::value(x),
+            Ok(x) => match x {
+                Tagged { item: Value::List(list), .. } => {
+                    for l in list {
+                        yield ReturnSuccess::value(l);
+                    }
+                }
+                x => yield ReturnSuccess::value(x),
+            },
             Err(_) => if let Some(last_tag) = latest_tag {
                 yield Err(ShellError::labeled_error_with_secondary(
                     "Could not parse as YAML",


### PR DESCRIPTION
This adds a step to expand lists that come from `from-*` commands. This helps formats, like json, which can transmit an array at top level to become a table in one step.