### PR TITLE
use `clap::crate_version!()`, remove async feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let matches = App::new("nushell")
-        .version("0.1.3")
+        .version(clap::crate_version!())
         .arg(
             Arg::with_name("loglevel")
                 .short("l")


### PR DESCRIPTION
- `crate_version()!` will pull version from Cargo.toml
- `async_await` feature is now stable