### PR TITLE
make "image" dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ pretty-hex = "0.1.0"
 neso = "0.5.0"
 crossterm = "0.10.2"
 tempfile = "3.1.0"
-image = "0.22.1"
+image = { version = "0.22.1", optional = true }
 semver = "0.9.0"
 uuid = {version = "0.7.4", features = [ "v4", "serde" ]}
 syntect = "3.2.0"

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ cargo install nu
 You can also install Nu with all the bells and whistles:
 
 ```
-cargo install nu --features rawkey,clipboard
+cargo install nu --features image,rawkey,clipboard
 ```
 
 The following optional features are currently supported:
 
+* **image** - PNG, JPEG support for `binaryview`
 * **rawkey** - direct keyboard input, which creates a smoother experience in viewing text and binaries
 * **clipboard** - integration with the native clipboard via the `clip` command
 

--- a/src/plugins/binaryview.rs
+++ b/src/plugins/binaryview.rs
@@ -1,5 +1,7 @@
 #![feature(option_flattening)]
-use crossterm::{cursor, terminal, Attribute, RawScreen};
+use crossterm::{cursor, terminal, Attribute};
+#[cfg(feature = "image")]
+use crossterm::RawScreen;
 use indexmap::IndexMap;
 use nu::{
     serve_plugin, CallInfo, NamedType, Plugin, ShellError, Signature, SpanSource, Tagged, Value,
@@ -213,6 +215,7 @@ impl RenderContext {
     }
 }
 
+#[cfg(feature = "image")]
 #[derive(Debug)]
 struct RawImageBuffer {
     dimensions: (u64, u64),
@@ -220,6 +223,7 @@ struct RawImageBuffer {
     buffer: Vec<u8>,
 }
 
+#[cfg(feature = "image")]
 fn load_from_png_buffer(buffer: &[u8]) -> Option<(RawImageBuffer)> {
     use image::ImageDecoder;
 
@@ -240,6 +244,7 @@ fn load_from_png_buffer(buffer: &[u8]) -> Option<(RawImageBuffer)> {
     })
 }
 
+#[cfg(feature = "image")]
 fn load_from_jpg_buffer(buffer: &[u8]) -> Option<(RawImageBuffer)> {
     use image::ImageDecoder;
 
@@ -260,6 +265,7 @@ fn load_from_jpg_buffer(buffer: &[u8]) -> Option<(RawImageBuffer)> {
     })
 }
 
+#[cfg(feature = "image")]
 pub fn view_contents(
     buffer: &[u8],
     _source: Option<&SpanSource>,
@@ -344,6 +350,16 @@ pub fn view_contents(
     #[allow(unused)]
     let screen = RawScreen::disable_raw_mode();
 
+    Ok(())
+}
+
+#[cfg(not(feature = "image"))]
+pub fn view_contents(
+    buffer: &[u8],
+    _source: Option<&SpanSource>,
+    _lores_mode: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{:?}", buffer.hex_dump());
     Ok(())
 }
 


### PR DESCRIPTION
This reduces dependency list by about 4% (428 down from 447 on linux).