### PR TITLE
Add --reverse option for sort-by

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | pick ...columns | Down-select table to only these columns |
 | reject ...columns | Remove the given columns from the table |
 | get column-or-column-path | Open given cells as text |
-| sort-by ...columns | Sort by the given columns |
+| sort-by ...columns (--reverse) | Sort by the given columns |
 | where condition | Filter table to match the condition |
 | inc (field) | Increment a value or version. Optional use the field of a table |
 | add field value | Add a new field to the table |

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -58,6 +58,17 @@ fn can_sort_by_column() {
 }
 
 #[test]
+fn can_sort_by_column_reverse() {
+    nu!(
+        output,
+        cwd("tests/fixtures/formats"),
+        "open cargo_sample.toml --raw | lines | skip 1 | first 4 | split-column \"=\" | sort-by Column1 --reverse | skip 1 | first 1 | get Column1 | trim | echo $it"
+    );
+
+    assert_eq!(output, "name");
+}
+
+#[test]
 fn can_split_by_column() {
     nu!(
         output,


### PR DESCRIPTION
```
nushell(sort-by-reverse)> ls | sort-by type name --reverse
----+---------------+-----------+----------+----------+----------------+---------------
 #  | name          | type      | readonly | size     | accessed       | modified 
----+---------------+-----------+----------+----------+----------------+---------------
 0  | rustfmt.toml  | File      |          | 16 B     | 2 hours ago    | 2 hours ago 
 1  | history.txt   | File      |          | 353 B    | 11 seconds ago | 2 minutes ago 
 2  | README.md     | File      |          | 12.3 KB  | 5 minutes ago  | 5 minutes ago 
 3  | Makefile.toml | File      |          | 614 B    | 2 hours ago    | 2 hours ago 
 4  | LICENSE       | File      |          | 1.1 KB   | 2 hours ago    | 2 hours ago 
 5  | Cargo.toml    | File      |          | 2.9 KB   | 2 hours ago    | 2 hours ago 
 6  | Cargo.lock    | File      |          | 188.2 KB | 2 hours ago    | 2 hours ago 
 7  | .gitignore    | File      |          | 58 B     | 2 hours ago    | 2 hours ago 
 8  | .editorconfig | File      |          | 148 B    | 2 hours ago    | 2 hours ago 
 9  | tests         | Directory |          | 4.1 KB   | 2 hours ago    | 2 hours ago 
 10 | target        | Directory |          | 4.1 KB   | 16 minutes ago | 9 minutes ago 
 11 | src           | Directory |          | 4.1 KB   | 2 hours ago    | 2 hours ago 
 12 | images        | Directory |          | 4.1 KB   | 2 hours ago    | 2 hours ago 
 13 | docs          | Directory |          | 4.1 KB   | 2 hours ago    | 2 hours ago 
 14 | assets        | Directory |          | 4.1 KB   | 2 hours ago    | 2 hours ago 
 15 | .git          | Directory |          | 4.1 KB   | 2 hours ago    | 4 minutes ago 
 16 | .cargo        | Directory |          | 4.1 KB   | 2 hours ago    | 2 hours ago 
 17 | .azure        | Directory |          | 4.1 KB   | 2 hours ago    | 2 hours ago 
----+---------------+-----------+----------+----------+----------------+---------------

```