### PR TITLE
WIP: add support for vi mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ use crate::prelude::*;
 use log::{debug, trace};
 use regex::Regex;
 use rustyline::error::ReadlineError;
-use rustyline::{self, ColorMode, Config, Editor};
+use rustyline::{self, ColorMode, Config, Editor, config::Configurer, config::EditMode};
 use std::env;
 use std::error::Error;
 use std::io::{BufRead, BufReader, Write};
@@ -233,6 +233,17 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
         rl.set_helper(Some(crate::shell::Helper::new(
             context.shell_manager.clone(),
         )));
+
+        let edit_mode = crate::object::config::config(Span::unknown())?
+            .get("edit_mode")
+            .map(|s| match s.as_string().unwrap().as_ref() {
+                "vi" => EditMode::Vi,
+                "emacs" => EditMode::Emacs,
+                _ => EditMode::Emacs,
+            })
+            .unwrap_or(EditMode::Emacs);
+
+        rl.set_edit_mode(edit_mode);
 
         let readline = rl.readline(&format!(
             "{}{}> ",

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -111,6 +111,7 @@ pub fn config(
 
         if result.contains_key(&key) {
             result.remove(&key);
+            config::write_config(&result)?;
         } else {
             return Err(ShellError::string(&format!(
                 "{} does not exist in config",


### PR DESCRIPTION
This change adds support for vi editing mode. This is somewhat of a proof of concept. It works by reading the `edit_mode` value from the config file and setting the mode to `Emacs` or `Vi` depending on what the value is there.

Use `config --set [edit_mode vi]` and `config --set [edit_mode emacs]` (or `config --remove edit_mode`) to set the edit mode.

This also fixes what appears to be a bug with `config --remove` in which the modified config wasn't actually saved.

related to: #354