### PR TITLE
--locked is required when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Optional dependencies:
 To install Nu via cargo:
 
 ```
-cargo install nu
+cargo install --locked nu
 ```
 
 You can also install Nu with all the bells and whistles:
 
 ```
-cargo install nu --features rawkey,clipboard
+cargo install --locked nu --features rawkey,clipboard
 ```
 
 The following optional features are currently supported:


### PR DESCRIPTION
```bash
git clone https://github.com/nushell/nushell.git  
cd nushell
cargo install --path .
```
Errors with:
```hs
Compiling futures-async-stream v0.1.0-alpha.3
error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
  --> /home/host/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-async-stream-0.1.0-alpha.3/src/stream.rs:43:20
   |
42 |     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
   |                  ---- help: consider changing this to be mutable: `mut self`
43 |         let this = self.project();
   |                    ^^^^ cannot borrow as mutable

error: aborting due to previous error
```

The lock file includes `futures-async-stream v0.1.0-alpha.2` `cargo install --locked --path .` works.