### PR TITLE
Adding Dockerfile for easier usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.37-slim
+
+# docker build -t nu .
+# docker run -it nu
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y libssl-dev \
+    libxcb-composite0-dev \
+    libx11-dev \
+    pkg-config && \
+    mkdir -p /code
+
+ADD . /code
+WORKDIR /code
+RUN cargo install nu
+ENTRYPOINT ["nu"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ There is also a [book](https://book.nushell.sh) about Nu, currently in progress.
 
 # Installation
 
+## Local 
+
 Up-to-date installation instructions can be found in the [installation chapter of the book](https://book.nushell.sh/en/installation).
 
 To build Nu, you will need to use the **nightly** version of the compiler.
@@ -46,6 +48,21 @@ The following optional features are currently supported:
 
 * **rawkey** - direct keyboard input, which creates a smoother experience in viewing text and binaries
 * **clipboard** - integration with the native clipboard via the `clip` command
+
+## Docker
+
+Optionally, you can build a container with nu installed using the [Dockerfile](Dockerfile):
+
+```bash
+$ docker build -t nu .
+``` 
+
+And then run the container:
+
+```bash
+$ docker run -it nu
+/> exit
+```
 
 # Philosophy
 


### PR DESCRIPTION
Hey nu maintainers! I was really excited to [read about nushell](http://www.jonathanturner.org/2019/08/introducing-nushell.html), and wanted to put together an easy way to work / develop, without installing to my host. Ta da, Docker container! If you guys would want to make an organization on Docker Hub to provide an automated build with the shell ready to go, I could help with a CI recipe (in another PR) for that (and it could be done on a tag to indicate release, for example). Otherwise, I think just having a simple Dockerfile to install dependencies and instructions in the README for building is immensely helpful. 

It takes a while to install, so I'd definitely recommend some strategy to do an automated build to lower the barrier of entry to using it. I haven't seen a new shell in a while (at least one I'd want to try) so I'm pretty excited about nu!

I haven't tested out everything yet (but likely will in the week to come!) I just wanted to make this available for others that might be interested.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>