### PR TITLE
Fix build by pinning futures-async-stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ ordered-float = {version = "1.0.2", features = ["serde"]}
 prettyprint = "0.7.0"
 futures-preview = { version = "=0.3.0-alpha.17", features = ["compat", "io-compat"] }
 futures-sink-preview = "=0.3.0-alpha.17"
-futures-async-stream = "0.1.0-alpha.1"
+futures-async-stream = "=0.1.0-alpha.2"
 futures_codec = "0.2.5"
 term = "0.5.2"
 bytes = "0.4.12"


### PR DESCRIPTION
This pins futures-async-stream to fix the current build failure