### PR TITLE
Permit use of Windows Batch files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,7 +91,7 @@ fn load_plugin(path: &std::path::Path, context: &mut Context) -> Result<(), Shel
 
 fn load_plugins_in_dir(path: &std::path::PathBuf, context: &mut Context) -> Result<(), ShellError> {
     let re_bin = Regex::new(r"^nu_plugin_[A-Za-z_]+$")?;
-    let re_exe = Regex::new(r"^nu_plugin_[A-Za-z_]+\.exe$")?;
+    let re_exe = Regex::new(r"^nu_plugin_[A-Za-z_]+\.(exe|bat)$")?;
 
     match std::fs::read_dir(path) {
         Ok(p) => {


### PR DESCRIPTION
I don't have a Windows machine handy, so unfortunately I haven't actually tested this change. But I _believe_ that it is all that's necessary to allow writing plugins with `.bat` files (which would provide a simple, uniform entrypoint for scripting languages).

Ideally, it should be possible to have `nu_plugin_foo` and `nu_plugin_foo.bat` next to each other and use the latter only on Windows and the former everywhere else; I'm not sure what the current implementation will do in this case, though. (Presumably it will try to launch scripts without extensions even on Windows, which is probably not desirable.)