### PR TITLE
Fix the utf-8 width calculation

### DIFF
--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -78,13 +78,16 @@ impl TableView {
         for head in 0..headers.len() {
             let mut current_col_max = 0;
             for row in 0..values.len() {
-                let value_length = entries[row][head].0.len();
-                if head > entries[row].len() && value_length > current_col_max {
+                let value_length = entries[row][head].0.chars().count();
+                if value_length > current_col_max {
                     current_col_max = value_length;
                 }
             }
 
-            max_per_column.push(std::cmp::max(current_col_max, headers[head].len()));
+            max_per_column.push(std::cmp::max(
+                current_col_max,
+                headers[head].chars().count(),
+            ));
         }
 
         // Different platforms want different amounts of buffer, not sure why


### PR DESCRIPTION
We were previously using the string width in bytes instead of utf-8 chars.  Went ahead and fixed the cell wrapping as well.