### PR TITLE
External commands exec changes

### DIFF
--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -342,7 +342,7 @@ impl ExternalCommand {
                             continue;
                         }
 
-                        process = process.arg(&arg.replace("$it", &i.as_string().unwrap()));
+                        process = process.arg(&arg.replace("$it", &i.as_string()?));
                     }
                 }
             } else {


### PR DESCRIPTION
Trying to fix [this issue](https://github.com/nushell/nushell/issues/347#issuecomment-524815077).

I haven't touched the Windows code but there are only minor differences between the two blocks now. The main one being the optional span (`let mut span = None;`).

I wasn't sure how to test all the different cases the code is trying to cover so there's a good chance I've missed something major.

New behaviour:

```
/Users/odin/Dev/github/wycats/nushell(external-commands-exec-changes)> help
error: Command not found
- shell:1:0
1 | help
  | ^^^^ not found
/Users/odin/Dev/github/wycats/nushell(external-commands-exec-changes)> sleep
usage: sleep seconds
/Users/odin/Dev/github/wycats/nushell(external-commands-exec-changes)> ls
━━━━┯━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━
 #  │ name               │ type      │ readonly │ size     │ created       │ accessed       │ modified
────┼────────────────────┼───────────┼──────────┼──────────┼───────────────┼────────────────┼────────────────
  0 │ CODE_OF_CONDUCT.md │ File      │          │   3.4 KB │ an hour ago   │ an hour ago    │ an hour ago
````