### PR TITLE
Adding two Dockerfiles to deploy to Docker Hub with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,122 @@
+# CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/configuration-reference/ for more details
+# See https://circleci.com/docs/2.0/config-intro/#section=configuration for spec
+#
+version: 2.1
+
+orbs:
+  # https://circleci.com/orbs/registry/orb/circleci/docker
+  docker: circleci/docker@0.5.13
+
+
+workflows:
+  version: 2.0
+
+  # This builds on all pull requests to test, and ignores master
+  build_without_deploy:
+    jobs:
+      - docker/publish:
+          deploy: false
+          image: nushell/nu-base
+          tag: latest
+          dockerfile: docker/Dockerfile.nu-base
+          filters:
+            branches:
+              ignore: 
+                - master
+
+      - docker/publish:
+          deploy: false
+          image: nushell/nu
+          tag: latest
+          dockerfile: docker/Dockerfile
+          requires:
+            - docker/publish
+          after_build:
+            - run:
+                name: Preview Docker Tag for Build
+                command: |
+                   DOCKER_TAG=v$(docker run nushell/nushell --version | cut -d' ' -f2)
+                   echo "Version that would be used for Docker tag is v${DOCKER_TAG}"
+
+  # workflow publishes to Docker Hub, with each job having different triggers
+  build_with_deploy:
+    jobs:
+
+        # Deploy versioned and latest images on tags (releases) only.
+      - docker/publish:
+          image: nushell/nu-base
+          tag: latest
+          dockerfile: docker/Dockerfile.nu-base
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+          after_build:
+            - run:
+                name: Publish Docker Tag with Nushell Version
+                command: |
+                   DOCKER_TAG=v$(docker run nushell/nu-base --version | cut -d' ' -f2)
+                   echo "Version for Docker tag is ${DOCKER_TAG}"
+                   docker tag nushell/nu-base:latest nushell/nu-base:${DOCKER_TAG}
+
+      - docker/publish:
+          image: nushell/nu
+          tag: latest
+          dockerfile: docker/Dockerfile
+          requires:
+            - docker/publish
+          after_build:
+            - run:
+                name: Publish Docker Tag with Nushell Version
+                command: |
+                   DOCKER_TAG=v$(docker run nushell/nu --version | cut -d' ' -f2)
+                   echo "Version for Docker tag is ${DOCKER_TAG}"
+                   docker tag nushell/nu-base:latest nushell/nu:${DOCKER_TAG}
+
+
+  # publish devel to Docker Hub on merge to master
+  build_with_deploy_devel:
+    jobs:
+
+      # Deploy devel tag on merge to master
+      - docker/publish:
+          image: nushell/nu-base
+          tag: devel
+          dockerfile: docker/Dockerfile.nu-base
+          filters:
+            branches:
+              only: master
+
+      - docker/publish:
+          image: nushell/nu
+          tag: devel
+          dockerfile: docker/Dockerfile
+          requires: 
+            - docker/publish
+
+
+  # Nightly build
+  build_with_deploy_nightly:
+    triggers:
+      - schedule:
+          cron: "0 22 * * *"  # 22:00 UTC
+          filters:
+            branches:
+              only:
+                - master
+
+    jobs:
+      - docker/publish:
+          image: nushell/nu-base
+          tag: nightly
+          dockerfile: docker/Dockerfile.nu-base
+
+      - docker/publish:
+          image: nushell/nu
+          tag: nightly
+          requires: 
+            - docker/publish
+          dockerfile: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM nushell/nu-base as base
+FROM rust:1.37-slim
+COPY --from=base /usr/local/bin/nu /usr/local/bin/nu
+ENTRYPOINT ["nu"]

--- a/docker/Dockerfile.nu-base
+++ b/docker/Dockerfile.nu-base
@@ -1,7 +1,7 @@
 FROM rust:1.37-slim
 
-# docker build -t nu .
-# docker run -it nu
+# docker build -t nushell/nu-base .
+# docker run -it nushell/nu-base
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y libssl-dev \
@@ -12,5 +12,6 @@ RUN apt-get update && apt-get install -y libssl-dev \
 
 ADD . /code
 WORKDIR /code
-RUN cargo install nu
+RUN cargo build --release && cargo run --release && \
+    cp target/release/nu /usr/local/bin
 ENTRYPOINT ["nu"]


### PR DESCRIPTION
As discussed in https://github.com/nushell/nushell/pull/429, this PR will add a Circle configuration and two Dockerfiles to deploy the following containers to Docker Hub:

 - nushell/nu-base: is the rust slim base with all of the code added, and a release built, and the nu binary added to /usr/local/bin. The container is heftier in that it has all of the source code / dependencies. It builds from docker/Dockerfile.nu-base
 - nushell/nu is a multistage build that does nothing other than grab the nu binary from /usr/local/bin, with the same rust base. It should be somewhat smaller, although not tiny because I couldn't find a (rust maintained) busybox or similar image.

For the CircleCI config, we of course will need to test everything, but to setup we would want:
 - the repository connected to CircleCI
 - the settings updated to build on forked pull requests, to have workflows enabled, and to cancel redundant builds (this is my preference, you don't have to but it saves resources)
 - DOCKER_LOGIN and DOCKER_PASSWORD saved to encrypted CircleCI secrets. It can be any Docker Hub user that has push access to the repository.

For this first go at a configuration, the following should happen (needs to be tested of course!):
 - a build is triggered for nu-base, followed by nu, on any pull request (any branch other than master)
 - on official tags (releases) a version tag and "latest" are deployed
 - on merge to master, a "devel" tag is deployed
 - a nightly build is done, with tag "nightly"

Some questions I am wondering about:
 - I haven't ever tried a requires section for an orb, so we'll have to see how that works!
 - did I build and install correctly? For example I only grabbed the nu binary and didn't touch any of the plugins / libraries. Where should those go? If there is a procedure for doing it with some prefix, can we add that to the Makefile?
 - is there any way to cache / speed up the build/install? It's really really slow. :)

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>