### PR TITLE
Add boolean and logic to nushell

### DIFF
--- a/src/object/base.rs
+++ b/src/object/base.rs
@@ -519,29 +519,34 @@ impl Value {
 
     #[allow(unused)]
     crate fn compare(&self, operator: &Operator, other: &Value) -> Result<bool, (String, String)> {
-        match operator {
-            _ => {
-                let coerced = coerce_compare(self, other)?;
-                let ordering = coerced.compare();
-
-                use std::cmp::Ordering;
-
-                let result = match (operator, ordering) {
-                    (Operator::Equal, Ordering::Equal) => true,
-                    (Operator::NotEqual, Ordering::Less)
-                    | (Operator::NotEqual, Ordering::Greater) => true,
-                    (Operator::LessThan, Ordering::Less) => true,
-                    (Operator::GreaterThan, Ordering::Greater) => true,
-                    (Operator::GreaterThanOrEqual, Ordering::Greater)
-                    | (Operator::GreaterThanOrEqual, Ordering::Equal) => true,
-                    (Operator::LessThanOrEqual, Ordering::Less)
-                    | (Operator::LessThanOrEqual, Ordering::Equal) => true,
-                    _ => false,
-                };
-
-                Ok(result)
+    Ok(match (self,other) {
+        (Value::Primitive(Primitive::Boolean(a)), Value::Primitive(Primitive::Boolean(b))) =>
+        {
+            match (a, b, operator) {
+                (true, true, Operator::And) => true,
+                _ => false
             }
         }
+        _ => {
+            let coerced = coerce_compare(self, other)?;
+            let ordering = coerced.compare();
+
+            use std::cmp::Ordering;
+
+            match (operator, ordering) {
+                (Operator::Equal, Ordering::Equal) => true,
+                (Operator::NotEqual, Ordering::Less)
+                | (Operator::NotEqual, Ordering::Greater) => true,
+                (Operator::LessThan, Ordering::Less) => true,
+                (Operator::GreaterThan, Ordering::Greater) => true,
+                (Operator::GreaterThanOrEqual, Ordering::Greater)
+                | (Operator::GreaterThanOrEqual, Ordering::Equal) => true,
+                (Operator::LessThanOrEqual, Ordering::Less)
+                | (Operator::LessThanOrEqual, Ordering::Equal) => true,
+                _ => false,
+            }
+        }
+    })
     }
 
     #[allow(unused)]

--- a/src/parser/parse/operator.rs
+++ b/src/parser/parse/operator.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub enum Operator {
+    And,
     Equal,
     NotEqual,
     LessThan,
@@ -27,6 +28,7 @@ impl Operator {
 
     pub fn as_str(&self) -> &str {
         match *self {
+            Operator::And => "&&",
             Operator::Equal => "==",
             Operator::NotEqual => "!=",
             Operator::LessThan => "<",
@@ -47,6 +49,7 @@ impl FromStr for Operator {
     type Err = ();
     fn from_str(input: &str) -> Result<Self, <Self as std::str::FromStr>::Err> {
         match input {
+            "&&" => Ok(Operator::And),
             "==" => Ok(Operator::Equal),
             "!=" => Ok(Operator::NotEqual),
             "<" => Ok(Operator::LessThan),

--- a/src/parser/parse/parser.rs
+++ b/src/parser/parse/parser.rs
@@ -48,6 +48,7 @@ operator! { gte: >= }
 operator! { lte: <= }
 operator! { eq:  == }
 operator! { neq: != }
+operator! { and:  &&  }
 
 fn trace_step<'a, T: Debug>(
     input: NomSpan<'a>,
@@ -84,7 +85,7 @@ pub fn raw_integer(input: NomSpan) -> IResult<NomSpan, Tagged<i64>> {
 
 pub fn operator(input: NomSpan) -> IResult<NomSpan, TokenNode> {
     trace_step(input, "operator", |input| {
-        let (input, operator) = alt((gte, lte, neq, gt, lt, eq))(input)?;
+        let (input, operator) = alt((gte, lte, neq, gt, lt, eq, and))(input)?;
 
         Ok((input, operator))
     })


### PR DESCRIPTION
This commit does a few things:

- Adds parsing for boolean and
- It allows us to handle arbitrary length boolean expressions
- It sets up a base upon which things like boolean or logic or other
  things like xor could use

The big thing here is that with arbitrary length boolean expressions we
can evaluate large complex expressions. The main motivation for this was
to allow the where command to have more expressivity. So instead of
something like:

ls | where size > 100b | where type == File

we can instead do the more readable expression of:

ls | where size > 100b && type == File

which more accurately represents the intent of the user.

------------------

I wanted to open up this PR to get some feedback on what would be a better approach to the error handling (panic is not really something I want to use here), whether the syntax for boolean and is what's wanted (I just went with the common && but I also like `and` personally), and feedback for cleanup of the code and whether this is readable for others. I don't consider this complete just yet till this gets cleaned up and reviewed.

Of course what's a PR without some proof that it works?
![Screen Shot 2019-08-27 at 19 00 41](https://user-images.githubusercontent.com/3514399/63814485-035aaa80-c8ff-11e9-934c-17556476797f.png)

As a side note it was pretty fun to hack on this and I'm really excited to see nushell succeed 😄 It's exactly the kind of thing I've wanted in a shell.