### PR TITLE
Remove sort-by --reverse flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | pick ...columns | Down-select table to only these columns |
 | reject ...columns | Remove the given columns from the table |
 | get column-or-column-path | Open given cells as text |
-| sort-by ...columns (--reverse) | Sort by the given columns |
+| sort-by ...columns | Sort by the given columns |
 | where condition | Filter table to match the condition |
 | inc (field) | Increment a value or version. Optional use the field of a table |
 | add field value | Add a new field to the table |

--- a/src/commands/sort_by.rs
+++ b/src/commands/sort_by.rs
@@ -7,7 +7,6 @@ pub struct SortBy;
 #[derive(Deserialize)]
 pub struct SortByArgs {
     rest: Vec<Tagged<String>>,
-    reverse: bool,
 }
 
 impl WholeStreamCommand for SortBy {
@@ -24,14 +23,12 @@ impl WholeStreamCommand for SortBy {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("sort-by")
-            .rest(SyntaxType::String)
-            .switch("reverse")
+        Signature::build("sort-by").rest(SyntaxType::String)
     }
 }
 
 fn sort_by(
-    SortByArgs { reverse, rest }: SortByArgs,
+    SortByArgs { rest }: SortByArgs,
     mut context: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
     Ok(OutputStream::new(async_stream_block! {
@@ -42,11 +39,7 @@ fn sort_by(
                 .map(|f| item.get_data_by_key(f).map(|i| i.clone()))
                 .collect::<Vec<Option<Tagged<Value>>>>()
         };
-        if reverse {
-            vec.sort_by_cached_key(|item| std::cmp::Reverse(calc_key(item)));
-        } else {
-            vec.sort_by_cached_key(calc_key);
-        };
+        vec.sort_by_cached_key(calc_key);
 
         for item in vec {
             yield item.into();

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -216,17 +216,6 @@ fn can_sort_by_column() {
 }
 
 #[test]
-fn can_sort_by_column_reverse() {
-    nu!(
-        output,
-        cwd("tests/fixtures/formats"),
-        r#"open cargo_sample.toml --raw | lines | skip 1 | first 4 | split-column "=" | sort-by Column1 --reverse | skip 1 | first 1 | get Column1 | trim | echo $it"#
-    );
-
-    assert_eq!(output, "name");
-}
-
-#[test]
 fn can_split_by_column() {
     nu!(
         output,


### PR DESCRIPTION
Prefer `ls | sort-by size | reverse` over `ls | sort-by size --reverse`.

> We'll eventually want to optimize things like this (#437), but "less flags, more pipes" is a pretty good guiding principle.

Should we add this to a list of guiding principles somewhere? Perhaps the contributing guide when it exists.

Fixes https://github.com/nushell/nushell/issues/452.