### PR TITLE
Fix compilation issue with missing case

### DIFF
--- a/src/commands/from_bson.rs
+++ b/src/commands/from_bson.rs
@@ -61,6 +61,7 @@ fn convert_bson_value_to_nu_value(v: &Bson, tag: impl Into<Tag>) -> Tagged<Value
         // TODO: Add Int32 to nushell?
         Bson::I32(n) => Value::Primitive(Primitive::Int(*n as i64)).tagged(tag),
         Bson::I64(n) => Value::Primitive(Primitive::Int(*n as i64)).tagged(tag),
+        Bson::Decimal128(n) => Value::Primitive(Primitive::Int((*n).into_i32() as i64)).tagged(tag),
         Bson::JavaScriptCode(js) => {
             let mut collected = TaggedDictBuilder::new(tag);
             collected.insert_tagged(


### PR DESCRIPTION
I was getting a compilation error when running `cargo install --path . --force --features raw-key,clipboard` due to a missing case with the bson parsing. This fixes that, though, casting to i32 might not be desired. 