### PR TITLE
Updating Docker Build instructions in README, and fixing tags for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ workflows:
             - run:
                 name: Build Multistage (smaller) container
                 command: |
-                  docker build -f docker/Dockerfile -t nushell/nu:devel .
+                  docker build --build-arg FROMTAG=devel -f docker/Dockerfile -t nushell/nu:devel .
             - run:
                 name: Publish Development Docker Tags
                 command: |

--- a/README.md
+++ b/README.md
@@ -51,18 +51,39 @@ The following optional features are currently supported:
 
 ## Docker
 
-Optionally, you can build a container with nu installed using the [Dockerfile](Dockerfile):
+If you want to pull a pre-built container, you can browse tags for the [nushell organization](https://quay.io/organization/nushell)
+on Quay.io. Pulling a container would come down to:
 
 ```bash
-$ docker build -t nu .
+$ docker pull quay.io/nushell/nu
+$ docker pull quay.io/nushell/nu-base
+```
+
+Both "nu-base" and "nu" provide the nu binary, however nu-base also includes the source code at `/code`
+in the container and all dependencies.
+
+Optionally, you can also build the containers locally using the [dockerfiles provided](docker):
+To build the base image:
+
+```bash
+$ docker build -f docker/Dockerfile.nu-base -t nushell/nu-base .
 ``` 
 
-And then run the container:
+And then to build the smaller container (using a Multistage build):
 
 ```bash
-$ docker run -it nu
+$ docker build -f docker/Dockerfile -t nushell/nu .
+``` 
+
+Either way, you can run either container as follows:
+
+```bash
+$ docker run -it nushell/nu-base
+$ docker run -it nushell/nu
 /> exit
 ```
+
+The second container is a bit smaller, if size is important to you.
 
 # Philosophy
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM nushell/nu-base as base
+ARG  FROMTAG=latest
+FROM nushell/nu-base:${FROMTAG} as base
 FROM rust:1.37-slim
 COPY --from=base /usr/local/bin/nu /usr/local/bin/nu
 ENTRYPOINT ["nu"]


### PR DESCRIPTION
Third time is the charm! This will update the README to include better instructions for doing the build (using the files in docker/), and referencing the containers provided in Quay.io. I was going to remove the multistage build with the devel tag, but I realized I just needed to set the base tag with a build arg:

```
ARG  FROMTAG=latest
FROM nushell/nu-base:${FROMTAG} as base
FROM rust:1.37-slim
COPY --from=base /usr/local/bin/nu /usr/local/bin/nu
ENTRYPOINT ["nu"]
```

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>