### PR TITLE
Pin bson

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bytes = "0.4.12"
 log = "0.4.8"
 pretty_env_logger = "0.3.1"
 serde = { version = "1.0.98", features = ["derive"] }
-bson = "0.13.0"
+bson = "=0.13.0"
 serde_json = "1.0.40"
 serde-hjson = "0.9.1"
 serde_yaml = "0.8"


### PR DESCRIPTION
This pins the "bson" dependency to prevent the breaking change. We can remove the pin when they release the next version.