### PR TITLE
Remove use of ExtractType in deserialize_any

### DIFF
--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -15,36 +15,6 @@ impl<T> ExtractType for T {
         )))
     }
 }
-
-impl<T: ExtractType, U: ExtractType> ExtractType for (T, U) {
-    fn extract(value: &Tagged<Value>) -> Result<(T, U), ShellError> {
-        let t_name = std::any::type_name::<T>();
-        let u_name = std::any::type_name::<U>();
-
-        trace!("Extracting {:?} for ({}, {})", value, t_name, u_name);
-
-        match value.item() {
-            Value::List(items) => {
-                if items.len() == 2 {
-                    let first = &items[0];
-                    let second = &items[1];
-
-                    Ok((T::extract(first)?, U::extract(second)?))
-                } else {
-                    Err(ShellError::type_error(
-                        "two-element-tuple",
-                        "not-two".tagged(value.tag()),
-                    ))
-                }
-            }
-            other => Err(ShellError::type_error(
-                "two-element-tuple",
-                other.type_name().tagged(value.tag()),
-            )),
-        }
-    }
-}
-
 impl<T: ExtractType> ExtractType for Option<T> {
     fn extract(value: &Tagged<Value>) -> Result<Option<T>, ShellError> {
         let name = std::any::type_name::<T>();

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -16,29 +16,6 @@ impl<T> ExtractType for T {
     }
 }
 
-impl<T: ExtractType> ExtractType for Vec<Tagged<T>> {
-    fn extract(value: &Tagged<Value>) -> Result<Self, ShellError> {
-        let name = std::any::type_name::<T>();
-        trace!("<Vec> Extracting {:?} for Vec<{}>", value, name);
-
-        match value.item() {
-            Value::List(items) => {
-                let mut out = vec![];
-
-                for item in items {
-                    out.push(T::extract(item)?.tagged(item.tag()));
-                }
-
-                Ok(out)
-            }
-            other => Err(ShellError::type_error(
-                "Vec",
-                other.type_name().tagged(value.tag()),
-            )),
-        }
-    }
-}
-
 impl<T: ExtractType, U: ExtractType> ExtractType for (T, U) {
     fn extract(value: &Tagged<Value>) -> Result<(T, U), ShellError> {
         let t_name = std::any::type_name::<T>();

--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -80,11 +80,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut ConfigDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let value = self.pop();
-        let name = std::any::type_name::<V::Value>();
-        trace!("<Deserialize any> Extracting {:?}", name);
-
-        V::Value::extract(&value.val)
+        unimplemented!("deserialize_any")
     }
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where

--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -4,8 +4,7 @@ use serde::{de, forward_to_deserialize_any};
 
 #[derive(Debug)]
 pub struct DeserializerItem<'de> {
-    key: String,
-    struct_field: &'de str,
+    key_struct_field: Option<(String, &'de str)>,
     val: Tagged<Value>,
 }
 
@@ -44,8 +43,7 @@ impl<'de> ConfigDeserializer<'de> {
         trace!("pushing {:?}", value);
 
         self.stack.push(DeserializerItem {
-            key: name.to_string(),
-            struct_field: name,
+            key_struct_field: Some((name.to_string(), name)),
             val: value.unwrap_or_else(|| {
                 Value::nothing().tagged(Tag::unknown_origin(self.call.name_span))
             }),


### PR DESCRIPTION
This removes use of the ExtractType trait from the deserialize_any function by changing the code to never call it. The ultimate goal is to remove use of specialization.

ExtractType and its use of specialization exists to allow deserialization of cli arguments. For each command, there is a struct with some members and serde's Deserialize trait is being derived. This is the argument struct for the mv command:

```Rust
#[derive(Deserialize)]
pub struct MoveArgs {
    pub src: Tagged<PathBuf>,
    pub dst: Tagged<PathBuf>,
}
```

The cli arguments input by an user are being converted from a `CallInfo` struct to that command-specific struct using `ConfigDeserializer`. The only uses of the `ExtractType` trait in the codebase are in its `Deserializer` implementation where they help avoiding having to use serde beyond iterating over the fields of the command-specific structs: any field of a cli param is expected to be readable from a `Tagged<Value>`.

In order to reduce usage of `ExtractType`, this PR brings more data into format understandable by serde.

The command  `rg "\(Deserialize\)][^}]*\}" -U src/commands/*` provides a list of command-param-structs that we have to handle. The field types can be extracted using `rg "\(Deserialize\)][^}]*\}" -U src/commands/* | rg ": .*: " | sed 's/^.*: //' | sort | uniq`:
```
bool,
Option<Tagged<PathBuf>>,
Option<Tagged<String>>,
Option<(Tagged<String>, Tagged<Value>)>,
Tagged<bool>,
Tagged<i64>,
Tagged<PathBuf>,
Tagged<String>,
value::Block,
Vec<Tagged<PathBuf>>,
Vec<Tagged<String>>,
```
Previously, all these types were parsed from `Tagged<Value>` instances using the `ExtractType` trait. Now, serde with its outside-to-inside model is being used to handle the logic to deserialize Vec<>, bool, Option<>, tuples, but we still defer to `ExtractType` when something is encountered that doesn't fit into the serde data model like Tagged or Block. Handling these via serde as well is still possible and subject of future PRs.

Useful commands for testing:
```
open tests/fixtures/formats/sample.bson | pick _id root // tests vec
config --set [specialization false] // tests Option containing a tuple
```

cc #362 