### PR TITLE
Migrated numerics to BigInt/BigDecimal

### DIFF
--- a/src/commands/from_bson.rs
+++ b/src/commands/from_bson.rs
@@ -186,13 +186,14 @@ impl std::io::Read for BytesReader {
 pub fn from_bson_bytes_to_value(
     bytes: Vec<u8>,
     tag: impl Into<Tag>,
-) -> bson::DecoderResult<Tagged<Value>> {
+) -> Result<Tagged<Value>, ShellError> {
     let mut docs = Vec::new();
     let mut b_reader = BytesReader::new(bytes);
     while let Ok(v) = decode_document(&mut b_reader) {
         docs.push(Bson::Document(v));
     }
-    Ok(convert_bson_value_to_nu_value(&Bson::Array(docs), tag).expect("FIXME: Don't commit like this"))
+
+    convert_bson_value_to_nu_value(&Bson::Array(docs), tag)
 }
 
 fn from_bson(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {


### PR DESCRIPTION
This commit migrates Value's numeric types to BigInt and BigDecimal. The
basic idea is that overflow errors aren't great in a shell environment,
and not really necessary.

The main immediate consequence is that new errors can occur when
serializing Nu values to other formats. You can see this in changes to
the various serialization formats (JSON, TOML, etc.). There's a new
`CoerceInto` trait that uses the `ToPrimitive` trait from `num_traits`
to attempt to coerce a `BigNum` or `BigDecimal` into a target type, and
produces a `RangeError` (kind of `ShellError`) if the coercion fails.

Another possible future consequence is that certain performance-critical
numeric operations might be too slow. If that happens, we can introduce
specialized numeric types to help improve the performance of those
situations, based on the real-world experience.