### PR TITLE
Use serde instead of specialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(generators)]
-#![feature(specialization)]
 #![feature(proc_macro_hygiene)]
 
 #[macro_use]

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -1,4 +1,3 @@
-use crate::object::base as value;
 use crate::prelude::*;
 use log::trace;
 
@@ -103,18 +102,6 @@ impl ExtractType for String {
                 ..
             } => Ok(string.clone()),
             other => Err(ShellError::type_error("String", other.tagged_type_name())),
-        }
-    }
-}
-
-impl ExtractType for value::Block {
-    fn extract(value: &Tagged<Value>) -> Result<value::Block, ShellError> {
-        match value {
-            Tagged {
-                item: Value::Block(block),
-                ..
-            } => Ok(block.clone()),
-            other => Err(ShellError::type_error("Block", other.tagged_type_name())),
         }
     }
 }

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -24,14 +24,6 @@ impl<T: ExtractType> ExtractType for Tagged<T> {
     }
 }
 
-impl ExtractType for Value {
-    fn extract(value: &Tagged<Value>) -> Result<Value, ShellError> {
-        trace!("<Tagged> Extracting {:?} for Value", value);
-
-        Ok(value.item().clone())
-    }
-}
-
 impl ExtractType for bool {
     fn extract(value: &Tagged<Value>) -> Result<bool, ShellError> {
         trace!("Extracting {:?} for bool", value);

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -15,19 +15,6 @@ impl<T> ExtractType for T {
         )))
     }
 }
-impl<T: ExtractType> ExtractType for Option<T> {
-    fn extract(value: &Tagged<Value>) -> Result<Option<T>, ShellError> {
-        let name = std::any::type_name::<T>();
-        trace!("<Option> Extracting {:?} for Option<{}>", value, name);
-
-        let result = match value.item() {
-            Value::Primitive(Primitive::Nothing) => None,
-            _ => Some(T::extract(value)?),
-        };
-
-        Ok(result)
-    }
-}
 
 impl<T: ExtractType> ExtractType for Tagged<T> {
     fn extract(value: &Tagged<Value>) -> Result<Tagged<T>, ShellError> {

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -5,16 +5,6 @@ pub trait ExtractType: Sized {
     fn extract(value: &Tagged<Value>) -> Result<Self, ShellError>;
 }
 
-impl<T> ExtractType for T {
-    default fn extract(_value: &Tagged<Value>) -> Result<T, ShellError> {
-        let name = std::any::type_name::<T>();
-        Err(ShellError::unimplemented(format!(
-            "<T> ExtractType for {}",
-            name
-        )))
-    }
-}
-
 impl<T: ExtractType> ExtractType for Tagged<T> {
     fn extract(value: &Tagged<Value>) -> Result<Tagged<T>, ShellError> {
         let name = std::any::type_name::<T>();

--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -300,15 +300,15 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut ConfigDeserializer<'de> {
             self.stack
         );
 
-        if self.saw_root {
-            let value = self.pop();
-            let name = std::any::type_name::<V::Value>();
-            trace!("Extracting {:?} for {:?}", value.val, name);
-            V::Value::extract(&value.val)
-        } else {
+        if !self.saw_root {
             self.saw_root = true;
-            visitor.visit_seq(StructDeserializer::new(&mut self, fields))
+            return visitor.visit_seq(StructDeserializer::new(&mut self, fields));
         }
+
+        let value = self.pop();
+        let name = std::any::type_name::<V::Value>();
+        trace!("Extracting {:?} for {:?}", value.val, name);
+        V::Value::extract(&value.val)
     }
     fn deserialize_enum<V>(
         self,


### PR DESCRIPTION
This is a continuation of #531 and #569 and concludes the series of PRs to get rid of specialization.

As #569 took care of `Option<>`, `Vec<>` and bare bools, we only had to cover the following types:
```
Tagged<i64>
Tagged<PathBuf>
Tagged<String>
Tagged<u64>
Tagged<Value>
value::Block
```
(list obtainable by the command `rg "\(Deserialize\)][^}]*\}" -U src/commands/* | rg ": .*: " | sed 's/^.*: //' | sort | uniq | sed 's/\(Option\|Vec\)<\(.*\)>/\2/;s/(\(.*\), \(.*\))/\1\n\2/;s/,$//;/bool/d' | sort | uniq`)

I chose an approach to first serialize the argument to json, to then deserialize it using serde. This way, the layout of the `Tagged` struct doesn't have to be hardcoded. The difficulty in this approach was recognizing the type that one has to serialize to: sometimes, the value has to be unwrapped to its contents, sometimes `Value` is expected or even an untagged `value::Block`. These were special cased with type name based checks.

With this PR, nushell is specialization free. 🎉🎉🎉 
cc #362

The trait itself was kept as it's still useful. Also it's still used by the `trim` command.