### PR TITLE
Trim trailing whitespace and set it in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@ root = true
 indent_style = space
 indent_size = 4
 charset = utf-8
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 insert_final_newline = false
 end_of_line = lf

--- a/src/object/dict.rs
+++ b/src/object/dict.rs
@@ -146,7 +146,7 @@ impl TaggedDictBuilder {
             dict: IndexMap::default(),
         }
     }
-    
+
     pub fn with_capacity(tag: impl Into<Tag>, n: usize) -> TaggedDictBuilder {
         TaggedDictBuilder {
             tag: tag.into(),

--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -58,7 +58,7 @@ impl<'de> ConfigDeserializer<'de> {
 
         Ok(())
     }
-    
+
     pub fn top(&mut self) -> &DeserializerItem {
         let value = self.stack.last();
         trace!("inspecting top value :: {:?}", value);
@@ -191,7 +191,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut ConfigDeserializer<'de> {
     {
         unimplemented!("deserialize_byte_buf")
     }
-    
+
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,

--- a/tests/command_cp_tests.rs
+++ b/tests/command_cp_tests.rs
@@ -104,7 +104,7 @@ fn deep_copies_with_recursive_flag() {
         let yehudas_expected_copied_dir = expected_dir.join("contributors").join("yehuda");
 
         nu!(
-            cwd: dirs.test(), 
+            cwd: dirs.test(),
             "cp originals expected --recursive"
         );
 

--- a/tests/command_ls_tests.rs
+++ b/tests/command_ls_tests.rs
@@ -16,13 +16,13 @@ fn ls_lists_regular_files() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                ls 
-                | get name 
-                | lines 
-                | split-column "." 
-                | get Column2 
-                | str --to-int 
-                | sum 
+                ls
+                | get name
+                | lines
+                | split-column "."
+                | get Column2
+                | str --to-int
+                | sum
                 | echo $it
             "#
         ));
@@ -45,13 +45,13 @@ fn ls_lists_regular_files_using_asterisk_wildcard() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                ls *.txt 
-                | get name 
-                | lines 
-                | split-column "." 
-                | get Column2 
-                | str --to-int 
-                | sum 
+                ls *.txt
+                | get name
+                | lines
+                | split-column "."
+                | get Column2
+                | str --to-int
+                | sum
                 | echo $it
             "#
         ));
@@ -74,13 +74,13 @@ fn ls_lists_regular_files_using_question_mark_wildcard() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                ls *.??.txt 
-                | get name 
-                | lines 
-                | split-column "." 
-                | get Column2 
-                | str --to-int 
-                | sum 
+                ls *.??.txt
+                | get name
+                | lines
+                | split-column "."
+                | get Column2
+                | str --to-int
+                | sum
                 | echo $it
             "#
         ));

--- a/tests/command_mv_tests.rs
+++ b/tests/command_mv_tests.rs
@@ -28,7 +28,7 @@ fn overwrites_if_moving_to_existing_file() {
     Playground::setup("mv_test_2", |dirs, sandbox| {
         sandbox
             .with_files(vec![
-                EmptyFile("andres.txt"), 
+                EmptyFile("andres.txt"),
                 EmptyFile("jonathan.txt")
         ]);
 

--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -8,14 +8,14 @@ fn lines() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open cargo_sample.toml --raw 
-            | lines 
-            | skip-while $it != "[dependencies]" 
-            | skip 1 
-            | first 1 
-            | split-column "=" 
-            | get Column1 
-            | trim 
+            open cargo_sample.toml --raw
+            | lines
+            | skip-while $it != "[dependencies]"
+            | skip 1
+            | first 1
+            | split-column "="
+            | get Column1
+            | trim
             | echo $it
         "#
     ));

--- a/tests/filter_str_tests.rs
+++ b/tests/filter_str_tests.rs
@@ -73,7 +73,7 @@ fn upcases() {
             cwd: dirs.test(),
             "open sample.toml | str package.name --upcase | get package.name | echo $it"
         );
-    
+
         assert_eq!(actual, "NUSHELL");
     })
 }
@@ -83,11 +83,11 @@ fn converts_to_int() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open caco3_plastics.csv 
-            | first 1 
-            | str tariff_item --to-int 
-            | where tariff_item == 2509000000 
-            | get tariff_item 
+            open caco3_plastics.csv
+            | first 1
+            | str tariff_item --to-int
+            | where tariff_item == 2509000000
+            | get tariff_item
             | echo $it
         "#
     ));
@@ -110,9 +110,9 @@ fn replaces() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open sample.toml 
-                | str package.name --replace wykittenshell  
-                | get package.name 
+                open sample.toml
+                | str package.name --replace wykittenshell
+                | get package.name
                 | echo $it
             "#
         ));
@@ -136,9 +136,9 @@ fn find_and_replaces() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open sample.toml 
-                | str fortune.teller.phone --find-replace KATZ "5289" 
-                | get fortune.teller.phone 
+                open sample.toml
+                | str fortune.teller.phone --find-replace KATZ "5289"
+                | get fortune.teller.phone
                 | echo $it
             "#
         ));
@@ -162,9 +162,9 @@ fn find_and_replaces_without_passing_field() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open sample.toml 
-                | get fortune.teller.phone 
-                | str --find-replace KATZ "5289" 
+                open sample.toml
+                | get fortune.teller.phone
+                | str --find-replace KATZ "5289"
                 | echo $it
             "#
         ));

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -28,13 +28,13 @@ fn converts_structured_table_to_csv_text() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open csv_text_sample.txt 
-                | lines 
-                | split-column "," a b c d origin  
-                | last 1 
-                | to-csv 
-                | lines 
-                | nth 1 
+                open csv_text_sample.txt
+                | lines
+                | split-column "," a b c d origin
+                | last 1
+                | to-csv
+                | lines
+                | nth 1
                 | echo "$it"
             "#
         ));
@@ -58,11 +58,11 @@ fn converts_structured_table_to_csv_text_skipping_headers_after_conversion() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open csv_text_sample.txt 
-                | lines 
-                | split-column "," a b c d origin  
-                | last 1 
-                | to-csv --headerless 
+                open csv_text_sample.txt
+                | lines
+                | split-column "," a b c d origin
+                | last 1
+                | to-csv --headerless
                 | echo "$it"
             "#
         ));
@@ -87,11 +87,11 @@ fn converts_from_csv_text_to_structured_table() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open los_tres_caballeros.txt 
-                | from-csv 
-                | get rusty_luck 
-                | str --to-int 
-                | sum 
+                open los_tres_caballeros.txt
+                | from-csv
+                | get rusty_luck
+                | str --to-int
+                | sum
                 | echo $it
             "#
         ));
@@ -116,11 +116,11 @@ fn converts_from_csv_text_skipping_headers_to_structured_table() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open los_tres_amigos.txt 
-                | from-csv --headerless 
-                | get Column3 
-                | str --to-int 
-                | sum 
+                open los_tres_amigos.txt
+                | from-csv --headerless
+                | get Column3
+                | str --to-int
+                | sum
                 | echo $it
             "#
         ));
@@ -134,10 +134,10 @@ fn can_convert_table_to_json_text_and_from_json_text_back_into_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open sgml_description.json 
-            | to-json 
-            | from-json 
-            | get glossary.GlossDiv.GlossList.GlossEntry.GlossSee 
+            open sgml_description.json
+            | to-json
+            | from-json
+            | get glossary.GlossDiv.GlossList.GlossEntry.GlossSee
             | echo $it
         "#
     ));
@@ -153,8 +153,8 @@ fn converts_from_json_text_to_structured_table() {
             r#"
                 {
                     "katz": [
-                        {"name":   "Yehuda", "rusty_luck": 1}, 
-                        {"name": "Jonathan", "rusty_luck": 1}, 
+                        {"name":   "Yehuda", "rusty_luck": 1},
+                        {"name": "Jonathan", "rusty_luck": 1},
                         {"name":   "Andres", "rusty_luck": 1},
                         {"name":"GorbyPuff", "rusty_luck": 1}
                     ]
@@ -177,8 +177,8 @@ fn converts_from_json_text_recognizing_objects_independendtly_to_structured_tabl
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "katz.txt",
             r#"
-                {"name":   "Yehuda", "rusty_luck": 1} 
-                {"name": "Jonathan", "rusty_luck": 1} 
+                {"name":   "Yehuda", "rusty_luck": 1}
+                {"name": "Jonathan", "rusty_luck": 1}
                 {"name":   "Andres", "rusty_luck": 1}
                 {"name":"GorbyPuff", "rusty_luck": 3}
             "#,
@@ -187,10 +187,10 @@ fn converts_from_json_text_recognizing_objects_independendtly_to_structured_tabl
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open katz.txt 
-                | from-json --objects 
-                | where name == "GorbyPuff" 
-                | get rusty_luck 
+                open katz.txt
+                | from-json --objects
+                | where name == "GorbyPuff"
+                | get rusty_luck
                 | echo $it
             "#
         ));
@@ -213,14 +213,14 @@ fn converts_structured_table_to_json_text() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open sample.txt 
-                | lines 
-                | split-column "," name luck 
-                | pick name 
-                | to-json 
-                | nth 0 
-                | from-json 
-                | get name 
+                open sample.txt
+                | lines
+                | split-column "," name luck
+                | pick name
+                | to-json
+                | nth 0
+                | from-json
+                | get name
                 | echo $it
             "#
         ));
@@ -254,13 +254,13 @@ fn converts_structured_table_to_tsv_text() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open tsv_text_sample.txt 
-                | lines 
-                | split-column "\t" a b c d origin  
-                | last 1 
+                open tsv_text_sample.txt
+                | lines
+                | split-column "\t" a b c d origin
+                | last 1
                 | to-tsv
-                | lines 
-                | nth 1 
+                | lines
+                | nth 1
                 | echo "$it"
             "#
         ));
@@ -284,11 +284,11 @@ fn converts_structured_table_to_tsv_text_skipping_headers_after_conversion() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open tsv_text_sample.txt 
-                | lines 
-                | split-column "\t" a b c d origin  
-                | last 1 
-                | to-tsv --headerless 
+                open tsv_text_sample.txt
+                | lines
+                | split-column "\t" a b c d origin
+                | last 1
+                | to-tsv --headerless
                 | echo "$it"
             "#
         ));
@@ -313,11 +313,11 @@ fn converts_from_tsv_text_to_structured_table() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open los_tres_amigos.txt 
-                | from-tsv 
-                | get rusty_luck 
-                | str --to-int 
-                | sum 
+                open los_tres_amigos.txt
+                | from-tsv
+                | get rusty_luck
+                | str --to-int
+                | sum
                 | echo $it
             "#
         ));
@@ -412,10 +412,10 @@ fn can_convert_table_to_yaml_text_and_from_yaml_text_back_into_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open appveyor.yml 
-            | to-yaml 
-            | from-yaml 
-            | get environment.global.PROJECT_NAME 
+            open appveyor.yml
+            | to-yaml
+            | from-yaml
+            | get environment.global.PROJECT_NAME
             | echo $it
         "#
     ));
@@ -428,16 +428,16 @@ fn can_sort_by_column() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open cargo_sample.toml --raw 
-            | lines 
-            | skip 1 
-            | first 4 
-            | split-column "=" 
-            | sort-by Column1 
-            | skip 1 
-            | first 1 
-            | get Column1 
-            | trim 
+            open cargo_sample.toml --raw
+            | lines
+            | skip 1
+            | first 4
+            | split-column "="
+            | sort-by Column1
+            | skip 1
+            | first 1
+            | get Column1
+            | trim
             | echo $it
         "#
     ));
@@ -450,13 +450,13 @@ fn can_split_by_column() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open cargo_sample.toml --raw 
-            | lines 
-            | skip 1 
-            | first 1 
-            | split-column "=" 
-            | get Column1 
-            | trim 
+            open cargo_sample.toml --raw
+            | lines
+            | skip 1
+            | first 1
+            | split-column "="
+            | get Column1
+            | trim
             | echo $it
         "#
     ));
@@ -469,9 +469,9 @@ fn can_sum() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open sgml_description.json 
-            | get glossary.GlossDiv.GlossList.GlossEntry.Sections 
-            | sum 
+            open sgml_description.json
+            | get glossary.GlossDiv.GlossList.GlossEntry.Sections
+            | sum
             | echo $it
         "#
     ));
@@ -525,10 +525,10 @@ fn embed() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open los_tres_caballeros.txt 
+                open los_tres_caballeros.txt
                 | from-csv
-                | embed caballeros 
-                | get caballeros 
+                | embed caballeros
+                | get caballeros
                 | nth 0
                 | get last_name
                 | echo $it
@@ -555,8 +555,8 @@ fn get() {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
-                open los_tres_caballeros.txt 
-                | from-csv 
+                open los_tres_caballeros.txt
+                | from-csv
                 | nth 1
                 | get last_name
                 | echo $it

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,11 +6,11 @@ use helpers as h;
 fn pipeline_helper() {
     let actual = h::pipeline(
         r#"
-            open los_tres_amigos.txt 
-            | from-csv 
-            | get rusty_luck 
-            | str --to-int 
-            | sum 
+            open los_tres_amigos.txt
+            | from-csv
+            | get rusty_luck
+            | str --to-int
+            | sum
             | echo "$it"
         "#);
 
@@ -30,7 +30,7 @@ fn external_num() {
 #[test]
 fn external_has_correct_quotes() {
     let actual = nu!(
-        cwd: ".", 
+        cwd: ".",
         r#"echo "hello world""#
     );
 
@@ -44,9 +44,9 @@ fn add_plugin() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open cargo_sample.toml 
-            | add dev-dependencies.newdep "1" 
-            | get dev-dependencies.newdep 
+            open cargo_sample.toml
+            | add dev-dependencies.newdep "1"
+            | get dev-dependencies.newdep
             | echo $it
         "#
     ));
@@ -59,9 +59,9 @@ fn edit_plugin() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
-            open cargo_sample.toml 
-            | edit dev-dependencies.pretty_assertions "7" 
-            | get dev-dependencies.pretty_assertions 
+            open cargo_sample.toml
+            | edit dev-dependencies.pretty_assertions "7"
+            | get dev-dependencies.pretty_assertions
             | echo $it
         "#
     ));


### PR DESCRIPTION
Trailing spaces disrupt various tools and workflows. This PR removes trailing spaces and instructs editors to do this automatically.