### PR TITLE
Mention pkg-config package in installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ To build Nu, you will need to use the **nightly** version of the compiler.
 
 Required dependencies:
 
-* libssl (only needed on Linux)
-  * on Debian/Ubuntu: `apt install libssl-dev`
+* pkg-config and libssl (only needed on Linux)
+  * on Debian/Ubuntu: `apt install pkg-config libssl-dev`
 
 Optional dependencies:
 


### PR DESCRIPTION
Ubuntu distributions does not came with pkg-config by default.
OpenSSL package's documentation mention pkg-config as requirement:
https://docs.rs/openssl/0.10.24/openssl/#automatic