### PR TITLE
Stop printing CTRL-D on EOF

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -451,10 +451,7 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
             LineResult::Success(line.clone())
         }
         Err(ReadlineError::Interrupted) => LineResult::CtrlC,
-        Err(ReadlineError::Eof) => {
-            println!("CTRL-D");
-            LineResult::Break
-        }
+        Err(ReadlineError::Eof) => LineResult::Break,
         Err(err) => {
             println!("Error: {:?}", err);
             LineResult::Break


### PR DESCRIPTION
Fix for issue https://github.com/nushell/nushell/issues/507