### PR TITLE
Mention pkg-config dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To build Nu, you will need to use the **nightly** version of the compiler.
 Required dependencies:
 
 * libssl (only needed on Linux)
-  * on Debian/Ubuntu: `apt install libssl-dev`
+  * on Debian/Ubuntu: `apt install libssl-dev pkg-config`
 
 Optional dependencies:
 


### PR DESCRIPTION
Related to #478. A corresponding PR for the book will be arriving soon.

I verified by trying to build with `cargo +nightly install nu` on the `rust:slim` Docker image, which fails unless both `libssl-dev` and `pkg-config` are installed first.