### PR TITLE
Improve parsing of pipelines, require pipes between segments

### DIFF
--- a/src/parser/parse/parser.rs
+++ b/src/parser/parse/parser.rs
@@ -552,7 +552,7 @@ pub fn node(input: NomSpan) -> IResult<NomSpan, TokenNode> {
 pub fn pipeline(input: NomSpan) -> IResult<NomSpan, TokenNode> {
     trace_step(input, "pipeline", |input| {
         let start = input.offset;
-        let (input, head) = opt(tuple((raw_call, opt(space1))))(input)?;
+        let (input, head) = opt(tuple((opt(space1), raw_call, opt(space1))))(input)?;
         let (input, items) = trace_step(
             input,
             "many0",
@@ -582,7 +582,11 @@ pub fn pipeline(input: NomSpan) -> IResult<NomSpan, TokenNode> {
 }
 
 fn make_call_list(
-    head: Option<(Tagged<CallNode>, Option<NomSpan>)>,
+    head: Option<(
+        Option<NomSpan>,
+        Tagged<CallNode>,
+        Option<NomSpan>
+    )>,
     items: Vec<(
         NomSpan,
         Option<NomSpan>,
@@ -593,7 +597,12 @@ fn make_call_list(
     let mut out = vec![];
 
     if let Some(head) = head {
-        let el = PipelineElement::new(None, None, head.0, head.1.map(Span::from));
+        let el = PipelineElement::new(
+            None,
+            head.0.map(Span::from),
+            head.1,
+            head.2.map(Span::from));
+
         out.push(el);
     }
 

--- a/src/parser/parse/pipeline.rs
+++ b/src/parser/parse/pipeline.rs
@@ -11,9 +11,9 @@ pub struct Pipeline {
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Getters, new)]
 pub struct PipelineElement {
+    pub pipe: Option<Span>,
     pub pre_ws: Option<Span>,
     #[get = "pub(crate)"]
     call: Tagged<CallNode>,
     pub post_ws: Option<Span>,
-    pub post_pipe: Option<Span>,
 }

--- a/src/parser/parse/token_tree_builder.rs
+++ b/src/parser/parse/token_tree_builder.rs
@@ -47,32 +47,31 @@ impl TokenTreeBuilder {
                 .next()
                 .expect("A pipeline must contain at least one element");
 
+            let pipe = None;
             let pre_span = pre.map(|pre| b.consume(&pre));
             let call = call(b);
             let post_span = post.map(|post| b.consume(&post));
-            let pipe = input.peek().map(|_| Span::from(b.consume("|")));
+
             out.push(PipelineElement::new(
+                pipe,
                 pre_span.map(Span::from),
                 call,
-                post_span.map(Span::from),
-                pipe,
-            ));
+                post_span.map(Span::from)));
 
             loop {
                 match input.next() {
                     None => break,
                     Some((pre, call, post)) => {
+                        let pipe = Some(Span::from(b.consume("|")));
                         let pre_span = pre.map(|pre| b.consume(&pre));
                         let call = call(b);
                         let post_span = post.map(|post| b.consume(&post));
 
-                        let pipe = input.peek().map(|_| Span::from(b.consume("|")));
-
                         out.push(PipelineElement::new(
+                            pipe,
                             pre_span.map(Span::from),
                             call,
                             post_span.map(Span::from),
-                            pipe,
                         ));
                     }
                 }

--- a/src/shell/helper.rs
+++ b/src/shell/helper.rs
@@ -147,6 +147,10 @@ fn paint_token_node(token_node: &TokenNode, line: &str) -> String {
 fn paint_pipeline_element(pipeline_element: &PipelineElement, line: &str) -> String {
     let mut styled = String::new();
 
+    if let Some(_) = pipeline_element.pipe {
+        styled.push_str(&Color::Purple.paint("|"));
+    }
+
     if let Some(ws) = pipeline_element.pre_ws {
         styled.push_str(&Color::White.normal().paint(ws.slice(line)));
     }
@@ -166,10 +170,6 @@ fn paint_pipeline_element(pipeline_element: &PipelineElement, line: &str) -> Str
 
     if let Some(ws) = pipeline_element.post_ws {
         styled.push_str(&Color::White.normal().paint(ws.slice(line)));
-    }
-
-    if let Some(_) = pipeline_element.post_pipe {
-        styled.push_str(&Color::Purple.paint("|"));
     }
 
     styled.to_string()


### PR DESCRIPTION
At the moment the pipeline parser does not enforce that there must be a pipe between each part of the pipeline, which can lead to confusing behaviour or misleading errors.

For example, it is possible to do things like:

```sh
> open Cargo.toml | get lib^echo 'woops'
woops
```

Or in other cases you will get a misleading error (found when investigating #474 ):

```sh
> open Cargo.toml | get lib.'name'
error: Invalid command
- shell:1:26
1 | open Cargo.toml | get lib.'name'
  |                           ^^^^^^
```

I have reworked the parser to require `|` between each segment, so the above examples now give:

```sh
> open Cargo.toml | get lib^echo 'whoops'
error: Parse Error
- shell:1:25
1 | open Cargo.toml | get lib^echo 'whoops'
  |                          ^^^^^^^^^^^^^^
```

```sh
> open Cargo.toml | get lib.'name'
error: Parse Error
- shell:1:26
1 | open Cargo.toml | get lib.'name'
  |                           ^^^^^^
```

----

The fix is achieved by making the `many0` have a mandatory leading pipe, so instead of:

```rust
many0(tuple((opt(space1), raw_call, opt(space1), opt(tag("|"))))),
```

it now reads:

```
many0(tuple((tag("|"), opt(space1), raw_call, opt(space1)))),
```

The rest of the change is updating the `PipelineElement` type to have a leading `pipe` instead of trailing and updating other code to work with the new definition.