### PR TITLE
Fix bug with ls globbing a single directory

### DIFF
--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -106,8 +106,7 @@ impl Shell for FilesystemShell {
         if entries.len() == 1 {
             if let Ok(entry) = &entries[0] {
                 if entry.is_dir() {
-                    let entries = std::fs::read_dir(&full_path);
-
+                    let entries = std::fs::read_dir(&entry);
                     let entries = match entries {
                         Err(e) => {
                             if let Some(s) = args.nth(0) {
@@ -126,6 +125,7 @@ impl Shell for FilesystemShell {
                         }
                         Ok(o) => o,
                     };
+
                     for entry in entries {
                         let entry = entry?;
                         let filepath = entry.path();

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -125,7 +125,6 @@ impl Shell for FilesystemShell {
                         }
                         Ok(o) => o,
                     };
-
                     for entry in entries {
                         let entry = entry?;
                         let filepath = entry.path();


### PR DESCRIPTION
Previously, if you ls globbed a single directory you would get:

```
/home/pmeredit/git/nushell(master)> ls *src*
error: No such file or directory (os error 2)
- shell:1:3
1 | ls *src*
  |    ^^^^^ No such file or directory (os error 2)
```

Now it works:
```
/home/pmeredit/git/nushell(master)> ls *src*
━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━
 #  │ name            │ type      │ readonly │ size    │ accessed     │ modified 
────┼─────────────────┼───────────┼──────────┼─────────┼──────────────┼───────────────
  0 │ src/commands    │ Directory │          │  1.1 KB │ an hour ago  │ an hour ago 
  1 │ src/env         │ Directory │          │   14 B  │ an hour ago  │ a week ago 
  2 │ src/evaluate    │ Directory │          │   36 B  │ an hour ago  │ an hour ago 
  3 │ src/format      │ Directory │          │   88 B  │ an hour ago  │ an hour ago 
  4 │ src/parser      │ Directory │          │  128 B  │ an hour ago  │ an hour ago 
  5 │ src/plugins     │ Directory │          │  166 B  │ an hour ago  │ an hour ago 
  6 │ src/shell       │ Directory │          │  182 B  │ a minute ago │ 2 minutes ago 
  7 │ src/main.rs     │ File      │          │  1.5 KB │ an hour ago  │ 2 weeks ago 
  8 │ src/git.rs      │ File      │          │  527 B  │ an hour ago  │ a week ago 
  9 │ src/env.rs      │ File      │          │   55 B  │ an hour ago  │ a week ago 
 10 │ src/parser.rs   │ File      │          │  1.1 KB │ an hour ago  │ a week ago 
 11 │ src/stream.rs   │ File      │          │  4.3 KB │ an hour ago  │ a week ago 
 12 │ src/traits.rs   │ File      │          │  598 B  │ an hour ago  │ a week ago 
 13 │ src/context.rs  │ File      │          │  4.3 KB │ an hour ago  │ 3 days ago 
 14 │ src/errors.rs   │ File      │          │ 21.1 KB │ an hour ago  │ 3 days ago 
 15 │ src/format.rs   │ File      │          │  480 B  │ an hour ago  │ 3 days ago 
 16 │ src/plugin.rs   │ File      │          │  5.2 KB │ an hour ago  │ 3 days ago 
 17 │ src/shell.rs    │ File      │          │  221 B  │ an hour ago  │ 3 days ago 
 18 │ src/commands.rs │ File      │          │  3.4 KB │ an hour ago  │ 2 days ago 
 19 │ src/cli.rs      │ File      │          │ 19.2 KB │ an hour ago  │ an hour ago 
 20 │ src/data.rs     │ File      │          │  366 B  │ an hour ago  │ an hour ago 
 21 │ src/data        │ Directory │          │  170 B  │ an hour ago  │ an hour ago 
 22 │ src/lib.rs      │ File      │          │  999 B  │ an hour ago  │ an hour ago 
 23 │ src/prelude.rs  │ File      │          │  3.6 KB │ an hour ago  │ an hour ago 
 24 │ src/utils.rs    │ File      │          │ 12.5 KB │ an hour ago  │ an hour ago 
━━━━┷━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━```

The code was just using the wrong variable :)

