### PR TITLE
Attempt to fix issue with ^C in Windows

### DIFF
--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -342,7 +342,19 @@ impl ExternalCommand {
 
         match stream_next {
             StreamNext::Last => {
-                popen.wait()?;
+                let _ = popen.detach();
+                loop {
+                    match popen.poll() {
+                        None => {
+                            let _ = std::thread::sleep(std::time::Duration::new(0, 100000000));
+                        }
+                        _ => {
+                            let _ = popen.terminate();
+                            break;
+                        }
+                    }
+                }
+                println!("");
                 Ok(ClassifiedInputStream::new())
             }
             StreamNext::External => {


### PR DESCRIPTION
This fixes the error case if we ^C during running an external command.  This needs testing across platforms before it lands.