### PR TITLE
Protect autoview against missing plugins

### DIFF
--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -236,6 +236,10 @@ impl RunnableContext {
             .get_command(name)
             .expect(&format!("Expected command {}", name))
     }
+
+    pub fn get_command(&self, name: &str) -> Option<Arc<Command>> {
+        self.commands.get_command(name)
+    }
 }
 
 pub struct RunnablePerItemArgs<T> {


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/594

This makes autoview resilient against missing binaryview and textview.