### PR TITLE
Change from Windows Exec::shell to Exec::cmd

### DIFF
--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -222,7 +222,7 @@ impl ExternalCommand {
 
         #[cfg(windows)]
         {
-            process = Exec::shell(&self.name);
+            process = Exec::cmd(&self.name);
 
             if arg_string.contains("$it") {
                 let mut first = true;


### PR DESCRIPTION
Fixes #610 

It will also remove some of the additional capabilities of interacting with the Windows shell (like being able to reach `set`). As we add more environment support, this will be fine.