### PR TITLE
Expand pwd command

### DIFF
--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -1,7 +1,7 @@
 use crate::context::{SourceMap, SpanSource};
+use crate::data::Value;
 use crate::errors::ShellError;
 use crate::evaluate::Scope;
-use crate::data::Value;
 use crate::parser::hir;
 use crate::parser::{registry, ConfigDeserializer};
 use crate::prelude::*;

--- a/src/commands/pwd.rs
+++ b/src/commands/pwd.rs
@@ -1,9 +1,9 @@
 use crate::commands::WholeStreamCommand;
+// use crate::data::{Dictionary, Value};
 use crate::errors::ShellError;
-use crate::data::{Dictionary, Value};
 use crate::parser::registry::Signature;
 use crate::prelude::*;
-use indexmap::IndexMap;
+// use indexmap::IndexMap;
 
 pub struct PWD;
 
@@ -30,15 +30,7 @@ impl WholeStreamCommand for PWD {
 }
 
 pub fn pwd(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+    let shell_manager = args.shell_manager.clone();
     let args = args.evaluate_once(registry)?;
-    let span = args.call_info.name_span;
-
-    let mut indexmap = IndexMap::new();
-    indexmap.insert(
-        "name".to_string(),
-        Tagged::from_simple_spanned_item(Value::string(std::env::current_dir()?.to_string_lossy()), span),
-    );
-
-    let value = Tagged::from_simple_spanned_item(Value::Row(Dictionary::from(indexmap)), span);
-    Ok(OutputStream::one(value))
+    shell_manager.pwd(args)
 }

--- a/src/commands/pwd.rs
+++ b/src/commands/pwd.rs
@@ -1,9 +1,7 @@
 use crate::commands::WholeStreamCommand;
-// use crate::data::{Dictionary, Value};
 use crate::errors::ShellError;
 use crate::parser::registry::Signature;
 use crate::prelude::*;
-// use indexmap::IndexMap;
 
 pub struct PWD;
 

--- a/src/shell/help_shell.rs
+++ b/src/shell/help_shell.rs
@@ -117,6 +117,10 @@ impl Shell for HelpShell {
         self.path.clone()
     }
 
+    fn pwd(&self, _: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {
+        Ok(OutputStream::empty())
+    }
+
     fn set_path(&mut self, path: String) {
         let _ = std::env::set_current_dir(&path);
         self.path = path.clone();

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -20,6 +20,7 @@ pub trait Shell: std::fmt::Debug {
     fn mv(&self, args: MoveArgs, name: Span, path: &str) -> Result<OutputStream, ShellError>;
     fn rm(&self, args: RemoveArgs, name: Span, path: &str) -> Result<OutputStream, ShellError>;
     fn path(&self) -> String;
+    fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError>;
     fn set_path(&mut self, path: String);
 
     fn complete(

--- a/src/shell/shell_manager.rs
+++ b/src/shell/shell_manager.rs
@@ -62,6 +62,12 @@ impl ShellManager {
         self.shells.lock().unwrap()[self.current_shell].path()
     }
 
+    pub fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {
+        let env = self.shells.lock().unwrap();
+
+        env[self.current_shell].pwd(args)
+    }
+
     pub fn set_path(&mut self, path: String) {
         self.shells.lock().unwrap()[self.current_shell].set_path(path)
     }

--- a/src/shell/value_shell.rs
+++ b/src/shell/value_shell.rs
@@ -199,6 +199,18 @@ impl Shell for ValueShell {
         self.path.clone()
     }
 
+    fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {
+        let path = PathBuf::from(&self.path());
+
+        let mut stream = VecDeque::new();
+        stream.push_back(ReturnSuccess::value(
+            Value::Primitive(Primitive::String(path.to_string_lossy().to_string()))
+                .simple_spanned(args.call_info.name_span),
+        ));
+
+        Ok(stream.into())
+    }
+
     fn set_path(&mut self, path: String) {
         let _ = std::env::set_current_dir(&path);
         self.path = path.clone();


### PR DESCRIPTION
Expand functionality of the pwd command to better handle the different
types of shells (e.g. FilesystemShell, ValueShell, etc.).