### PR TITLE
Building akin to azure-pipelines to shorten CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,6 @@ version: 2.1
 
 commands:
 
-  check_token:
-    description: Check that QUAY_TOKEN is provided in environment
-    steps:
-      - run: 
-          if [[ -z "${QUAY_TOKEN}" ]]; then
-            echo "QUAY_TOKEN is undefined. Add to CircleCI environment to continue."
-            exit 1;
-          fi
-
   pull_cache:
     description: Pulls Quay.io docker images usable for our cache
     steps:
@@ -46,7 +37,6 @@ workflows:
               ignore: 
                 - master
           before_build:
-            - check_token
             - pull_cache
           after_build:
             - run:
@@ -76,7 +66,6 @@ workflows:
             tags:
               only: /^v.*/
           before_build:
-            - check_token
             - pull_cache
           after_build:
             - run:
@@ -90,7 +79,6 @@ workflows:
                    echo "Version for Docker tag is ${DOCKER_TAG}"
                    docker tag quay.io/nushell/nu-base:latest quay.io/nushell/nu-base:${DOCKER_TAG}
                    docker tag quay.io/nushell/nu:latest quay.io/nushell/nu:${DOCKER_TAG}
-                   docker login -u="nushell+circleci" -p="${QUAY_TOKEN}" quay.io
                    docker push quay.io/nushell/nu-base
                    docker push quay.io/nushell/nu
 
@@ -105,9 +93,8 @@ workflows:
           registry: quay.io
           tag: devel
           dockerfile: docker/Dockerfile.nu-base
-          extra_build_args: --cache-from=quay.io/nushell/nu-base:latest,quay.io/nushell/nu:latest
+          extra_build_args: --cache-from=quay.io/nushell/nu-base:latest,quay.io/nushell/nu:latest --build-arg RELEASE=true
           before_build:
-            - check_token
             - pull_cache
           filters:
             branches:
@@ -120,6 +107,5 @@ workflows:
             - run:
                 name: Publish Development Docker Tags
                 command: |
-                   docker login -u="nushell+circleci" -p="${QUAY_TOKEN}" quay.io
                    docker push quay.io/nushell/nu-base:devel
                    docker push quay.io/nushell/nu:devel

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,3 +3,4 @@ FROM quay.io/nushell/nu-base:${FROMTAG} as base
 FROM rust:1.37-slim
 COPY --from=base /usr/local/bin/nu /usr/local/bin/nu
 ENTRYPOINT ["nu"]
+CMD ["-l", "info"]

--- a/docker/Dockerfile.nu-base
+++ b/docker/Dockerfile.nu-base
@@ -1,4 +1,4 @@
-FROM rust:1.37-slim
+FROM ubuntu:16.04
 
 # docker build -f docker/Dockerfile.nu-base -t nushell/nu-base .
 # docker run -it nushell/nu-base
@@ -7,12 +7,20 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y libssl-dev \
     libxcb-composite0-dev \
     libx11-dev \
-    pkg-config
+    pkg-config \
+    curl
 
-RUN USER=root cargo new --bin /code
-
+ARG RELEASE=false
 WORKDIR /code
-ADD . /code
-RUN cargo build --release && cargo run --release
-RUN cp target/release/nu /usr/local/bin
+COPY ./rust-toolchain ./rust-toolchain
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain `cat rust-toolchain`
+ENV PATH=/root/.cargo/bin:$PATH
+COPY . /code
+RUN echo "##vso[task.prependpath]/root/.cargo/bin" && \
+    rustc -Vv && \
+    if $RELEASE; then cargo build --release && cargo run --release; \
+                   cp target/release/nu /usr/local/bin; \   
+                 else cargo build; \
+                   cp target/debug/nu /usr/local/bin; fi;
 ENTRYPOINT ["nu"]
+CMD ["-l", "info"]


### PR DESCRIPTION
This is a work in progress to test building on CircleCI (in debug, meaning we remove the --release tag) to see if the build times are shorter. Changes include:

 - I've removed the rust library base image in favor of the same base used in azure (ubuntu:16.04) to try and replicate to the best that we can. 
 - The command to install rust is also taken from azure-pipelines, targeting a specific nightly build
 - To control building release / debug, there is a `RELEASE` build arg. We only add it in the case of a tag/release, otherwise we build debug.

My wireless is out today so I've been developing on a remote instance, which isn't as great as local (so it's a bit slow). I figure it would be quicker / more reproducing of the actual build environment to open the PR and use CircleCI to test the timing. I'm testing a build (with release) on my instance, and we can test the debug build here.

I'm also:

 - removing extra dependencies that @jonathandturner mentioned aren't needed
 - removing the need for the QUAY_TOKEN in favor of the defaults, and the function to check

And of course, I'll update the PR if needed.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>