### PR TITLE
Fix setting configuration params

### DIFF
--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -467,3 +467,27 @@ impl<'a, 'de: 'a> de::SeqAccess<'de> for StructDeserializer<'a, 'de> {
         return Some(self.fields.len());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::any::type_name;
+    #[test]
+    fn check_type_name_properties() {
+        // This ensures that certain properties for the
+        // std::any::type_name function hold, that
+        // this code relies on. The type_name docs explicitly
+        // mention that the actual format of the output
+        // is unspecified and change is likely.
+        // This test makes sure that such change is detected
+        // by this test failing, and not things silently breaking.
+        // Specifically, we rely on this behaviour further above
+        // in the file to special case Tagged<Value> parsing.
+        let tuple = type_name::<()>();
+        let tagged_tuple = type_name::<Tagged<()>>();
+        let tagged_value = type_name::<Tagged<Value>>();
+        assert!(tuple != tagged_tuple);
+        assert!(tuple != tagged_value);
+        assert!(tagged_tuple != tagged_value);
+    }
+}

--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -328,7 +328,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut ConfigDeserializer<'de> {
         let type_name = std::any::type_name::<V::Value>();
         let tagged_val_name = std::any::type_name::<Tagged<Value>>();
 
-        if name == tagged_val_name {
+        if type_name == tagged_val_name {
             return visit::<Tagged<Value>, _>(value.val, name, fields, visitor);
         }
 


### PR DESCRIPTION
Fixes #627

Fixes a regression caused by #579, specifically commit cc8872b4eec3f39896ccb11d9c25a30a79c04dd7 .

The code was intended to perform a comparison between the wanted
output type and "Tagged<Value>" in order to be able to provide a
special-cased path for Tagged<Value>. When I wrote the code, I
used "name" as a variable name and only later realized that it
shadowed the "name" param to the function, so I renamed it to
type_name, but forgot to change the comparison.
This broke the special-casing, as the name param only contains
the name of the struct without generics (like "Tagged"), while
`std::any::type_name` (in the current implementation) contains
the full paths of the struct including all generic params
(like "nu::object::meta::Tagged<nu::object::base::Value>").