### PR TITLE
Tweaking nightly build - didnt seem to go off

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,13 @@ workflows:
                    docker push quay.io/nushell/nu:devel
 
   nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - docker/publish:
           image: nushell/nu-base
@@ -123,9 +130,6 @@ workflows:
           tag: nightly
           dockerfile: docker/Dockerfile.nu-base
           extra_build_args: --cache-from=quay.io/nushell/nu-base:nightly --build-arg RELEASE=true
-          filters:
-            branches:
-              only: master
           before_build:
             - run: docker pull quay.io/nushell/nu:nightly
             - run: docker pull quay.io/nushell/nu-base:nightly
@@ -139,11 +143,3 @@ workflows:
                 command: |
                    docker push quay.io/nushell/nu-base:nightly
                    docker push quay.io/nushell/nu:nightly
-
-    triggers:
-      - schedule:
-          cron: "0 22 * * *"
-          filters:
-            branches:
-              only:
-                - master


### PR DESCRIPTION
I didn't see that the nightly build ran (although if you look in the [parsed config](https://circleci.com/gh/nushell/nushell/198#config/containers/0) it does show up as docker/publish-4) so for this next test I'm removing the filter from the job itself, in the case that specifying the filter for both the trigger and job (even if the same) is leading to some bug that prevents it from running at all. I'm also moving triggers to the top of the nightly workflow, in case this is important. If this doesn't work I'll ping CircleCI support again.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>