### PR TITLE
Add lighter-weight table output

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 
 use crate::commands::WholeStreamCommand;
-use crate::errors::ShellError;
 use crate::data::{config, Value};
+use crate::errors::ShellError;
 use crate::parser::hir::SyntaxType;
 use crate::parser::registry::{self};
 use std::iter::FromIterator;


### PR DESCRIPTION
This adds a lighter table output. You can enable it via config:

```
> config --set [table_mode light]
```

Example output:

![Screenshot from 2019-09-10 05-45-14](https://user-images.githubusercontent.com/547158/64553821-3b95ca80-d38e-11e9-8f8c-97131625717d.png)
