### PR TITLE
Close a bunch of holes in external command args

### DIFF
--- a/src/commands/cp.rs
+++ b/src/commands/cp.rs
@@ -21,7 +21,7 @@ impl PerItemCommand for Cpy {
 
     fn signature(&self) -> Signature {
         Signature::build("cp")
-            .required("src", SyntaxType::Path)
+            .required("src", SyntaxType::Pattern)
             .required("dst", SyntaxType::Path)
             .named("file", SyntaxType::Any)
             .switch("recursive")

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -10,7 +10,7 @@ impl WholeStreamCommand for LS {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("ls").optional("path", SyntaxType::Path)
+        Signature::build("ls").optional("path", SyntaxType::Pattern)
     }
 
     fn usage(&self) -> &str {

--- a/src/commands/to_bson.rs
+++ b/src/commands/to_bson.rs
@@ -50,6 +50,7 @@ pub fn value_to_bson_value(v: &Tagged<Value>) -> Result<Bson, ShellError> {
         }
         Value::Primitive(Primitive::Nothing) => Bson::Null,
         Value::Primitive(Primitive::String(s)) => Bson::String(s.clone()),
+        Value::Primitive(Primitive::Pattern(p)) => Bson::String(p.clone()),
         Value::Primitive(Primitive::Path(s)) => Bson::String(s.display().to_string()),
         Value::Table(l) => Bson::Array(
             l.iter()

--- a/src/commands/to_json.rs
+++ b/src/commands/to_json.rs
@@ -45,6 +45,7 @@ pub fn value_to_json_value(v: &Tagged<Value>) -> Result<serde_json::Value, Shell
             CoerceInto::<i64>::coerce_into(i.tagged(v.tag), "converting to JSON number")?,
         )),
         Value::Primitive(Primitive::Nothing) => serde_json::Value::Null,
+        Value::Primitive(Primitive::Pattern(s)) => serde_json::Value::String(s.clone()),
         Value::Primitive(Primitive::String(s)) => serde_json::Value::String(s.clone()),
         Value::Primitive(Primitive::Path(s)) => serde_json::Value::String(s.display().to_string()),
 

--- a/src/commands/to_sqlite.rs
+++ b/src/commands/to_sqlite.rs
@@ -91,6 +91,7 @@ fn nu_value_to_sqlite_string(v: Value) -> String {
             Primitive::Int(i) => format!("{}", i),
             Primitive::Decimal(f) => format!("{}", f),
             Primitive::Bytes(u) => format!("{}", u),
+            Primitive::Pattern(s) => format!("'{}'", s.replace("'", "''")),
             Primitive::String(s) => format!("'{}'", s.replace("'", "''")),
             Primitive::Boolean(true) => "1".into(),
             Primitive::Boolean(_) => "0".into(),

--- a/src/commands/to_toml.rs
+++ b/src/commands/to_toml.rs
@@ -44,6 +44,7 @@ pub fn value_to_toml_value(v: &Tagged<Value>) -> Result<toml::Value, ShellError>
             toml::Value::Integer(i.tagged(v.tag).coerce_into("converting to TOML integer")?)
         }
         Value::Primitive(Primitive::Nothing) => toml::Value::String("<Nothing>".to_string()),
+        Value::Primitive(Primitive::Pattern(s)) => toml::Value::String(s.clone()),
         Value::Primitive(Primitive::String(s)) => toml::Value::String(s.clone()),
         Value::Primitive(Primitive::Path(s)) => toml::Value::String(s.display().to_string()),
 

--- a/src/commands/to_yaml.rs
+++ b/src/commands/to_yaml.rs
@@ -42,6 +42,7 @@ pub fn value_to_yaml_value(v: &Tagged<Value>) -> Result<serde_yaml::Value, Shell
             CoerceInto::<i64>::coerce_into(i.tagged(v.tag), "converting to YAML number")?,
         )),
         Value::Primitive(Primitive::Nothing) => serde_yaml::Value::Null,
+        Value::Primitive(Primitive::Pattern(s)) => serde_yaml::Value::String(s.clone()),
         Value::Primitive(Primitive::String(s)) => serde_yaml::Value::String(s.clone()),
         Value::Primitive(Primitive::Path(s)) => serde_yaml::Value::String(s.display().to_string()),
 

--- a/src/data/base.rs
+++ b/src/data/base.rs
@@ -20,6 +20,7 @@ pub enum Primitive {
     Decimal(BigDecimal),
     Bytes(u64),
     String(String),
+    Pattern(String),
     Boolean(bool),
     Date(DateTime<Utc>),
     Path(PathBuf),
@@ -53,6 +54,7 @@ impl Primitive {
             Int(_) => "int",
             Decimal(_) => "decimal",
             Bytes(_) => "bytes",
+            Pattern(_) => "pattern",
             String(_) => "string",
             Boolean(_) => "boolean",
             Date(_) => "date",
@@ -71,6 +73,7 @@ impl Primitive {
             Path(path) => write!(f, "{}", path.display()),
             Decimal(decimal) => write!(f, "{}", decimal),
             Bytes(bytes) => write!(f, "{}", bytes),
+            Pattern(string) => write!(f, "{:?}", string),
             String(string) => write!(f, "{:?}", string),
             Boolean(boolean) => write!(f, "{}", boolean),
             Date(date) => write!(f, "{}", date),
@@ -108,6 +111,7 @@ impl Primitive {
             }
             Primitive::Int(i) => format!("{}", i),
             Primitive::Decimal(decimal) => format!("{}", decimal),
+            Primitive::Pattern(s) => format!("{}", s),
             Primitive::String(s) => format!("{}", s),
             Primitive::Boolean(b) => match (b, field_name) {
                 (true, None) => format!("Yes"),
@@ -574,6 +578,10 @@ impl Value {
     }
 
     pub fn string(s: impl Into<String>) -> Value {
+        Value::Primitive(Primitive::String(s.into()))
+    }
+
+    pub fn pattern(s: impl Into<String>) -> Value {
         Value::Primitive(Primitive::String(s.into()))
     }
 

--- a/src/evaluate/evaluator.rs
+++ b/src/evaluate/evaluator.rs
@@ -114,6 +114,7 @@ fn evaluate_literal(literal: Tagged<&hir::Literal>, source: &Text) -> Tagged<Val
         hir::Literal::Number(int) => int.into(),
         hir::Literal::Size(int, unit) => unit.compute(int),
         hir::Literal::String(span) => Value::string(span.slice(source)),
+        hir::Literal::GlobPattern => Value::pattern(literal.span().slice(source)),
         hir::Literal::Bare => Value::string(literal.span().slice(source)),
     };
 

--- a/src/evaluate/evaluator.rs
+++ b/src/evaluate/evaluator.rs
@@ -1,5 +1,5 @@
 use crate::data::base::Block;
-use crate::errors::Description;
+use crate::errors::{ArgumentError, Description};
 use crate::parser::{
     hir::{self, Expression, RawExpression},
     CommandRegistry, Text,
@@ -39,6 +39,11 @@ pub(crate) fn evaluate_baseline_expr(
 ) -> Result<Tagged<Value>, ShellError> {
     match &expr.item {
         RawExpression::Literal(literal) => Ok(evaluate_literal(expr.copy_span(literal), source)),
+        RawExpression::ExternalWord => Err(ShellError::argument_error(
+            "Invalid external word",
+            ArgumentError::InvalidExternalWord,
+            expr.span(),
+        )),
         RawExpression::FilePath(path) => Ok(Value::path(path.clone()).tagged(expr.span())),
         RawExpression::Synthetic(hir::Synthetic::String(s)) => Ok(Value::string(s).tagged_unknown()),
         RawExpression::Variable(var) => evaluate_reference(var, scope, source),

--- a/src/parser/hir.rs
+++ b/src/parser/hir.rs
@@ -83,6 +83,7 @@ impl ToDebug for Call {
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum RawExpression {
     Literal(Literal),
+    ExternalWord,
     Synthetic(Synthetic),
     Variable(Variable),
     Binary(Box<Binary>),
@@ -113,6 +114,7 @@ impl RawExpression {
         match self {
             RawExpression::Literal(literal) => literal.type_name(),
             RawExpression::Synthetic(synthetic) => synthetic.type_name(),
+            RawExpression::ExternalWord => "externalword",
             RawExpression::FilePath(..) => "filepath",
             RawExpression::Variable(..) => "variable",
             RawExpression::List(..) => "list",
@@ -189,6 +191,7 @@ impl ToDebug for Expression {
         match self.item() {
             RawExpression::Literal(l) => l.tagged(self.span()).fmt_debug(f, source),
             RawExpression::FilePath(p) => write!(f, "{}", p.display()),
+            RawExpression::ExternalWord => write!(f, "{}", self.span().slice(source)),
             RawExpression::Synthetic(Synthetic::String(s)) => write!(f, "{:?}", s),
             RawExpression::Variable(Variable::It(_)) => write!(f, "$it"),
             RawExpression::Variable(Variable::Other(s)) => write!(f, "${}", s.slice(source)),
@@ -225,6 +228,11 @@ impl From<Tagged<Path>> for Expression {
     }
 }
 
+/// Literals are expressions that are:
+///
+/// 1. Copy
+/// 2. Can be evaluated without additional context
+/// 3. Evaluation cannot produce an error
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Literal {
     Number(Number),

--- a/src/parser/hir/baseline_parse.rs
+++ b/src/parser/hir/baseline_parse.rs
@@ -1,6 +1,7 @@
 use crate::context::Context;
 use crate::errors::ShellError;
 use crate::parser::{hir, RawToken, Token};
+use crate::TaggedItem;
 use crate::Text;
 use std::path::PathBuf;
 
@@ -20,6 +21,7 @@ pub fn baseline_parse_single_token(
         RawToken::Variable(span) => hir::Expression::variable(span, token.span()),
         RawToken::ExternalCommand(span) => hir::Expression::external_command(span, token.span()),
         RawToken::ExternalWord => return Err(ShellError::invalid_external_word(token.span())),
+        RawToken::GlobPattern => hir::Expression::pattern(token.span()),
         RawToken::Bare => hir::Expression::bare(token.span()),
     })
 }
@@ -40,6 +42,12 @@ pub fn baseline_parse_token_as_number(
             hir::Expression::size(number.to_number(source), unit, token.span())
         }
         RawToken::Bare => hir::Expression::bare(token.span()),
+        RawToken::GlobPattern => {
+            return Err(ShellError::type_error(
+                "Number",
+                "glob pattern".to_string().tagged(token.tag()),
+            ))
+        }
         RawToken::String(span) => hir::Expression::string(span, token.span()),
     })
 }
@@ -58,6 +66,12 @@ pub fn baseline_parse_token_as_string(
         RawToken::Number(_) => hir::Expression::bare(token.span()),
         RawToken::Size(_, _) => hir::Expression::bare(token.span()),
         RawToken::Bare => hir::Expression::bare(token.span()),
+        RawToken::GlobPattern => {
+            return Err(ShellError::type_error(
+                "String",
+                "glob pattern".tagged(token.tag()),
+            ))
+        }
         RawToken::String(span) => hir::Expression::string(span, token.span()),
     })
 }
@@ -76,6 +90,41 @@ pub fn baseline_parse_token_as_path(
         RawToken::Variable(span) => hir::Expression::variable(span, token.span()),
         RawToken::Number(_) => hir::Expression::bare(token.span()),
         RawToken::Size(_, _) => hir::Expression::bare(token.span()),
+        RawToken::Bare => hir::Expression::file_path(
+            expand_path(token.span().slice(source), context),
+            token.span(),
+        ),
+        RawToken::GlobPattern => {
+            return Err(ShellError::type_error(
+                "Path",
+                "glob pattern".tagged(token.tag()),
+            ))
+        }
+        RawToken::String(span) => {
+            hir::Expression::file_path(expand_path(span.slice(source), context), token.span())
+        }
+    })
+}
+
+pub fn baseline_parse_token_as_pattern(
+    token: &Token,
+    context: &Context,
+    source: &Text,
+) -> Result<hir::Expression, ShellError> {
+    Ok(match *token.item() {
+        RawToken::Variable(span) if span.slice(source) == "it" => {
+            hir::Expression::it_variable(span, token.span())
+        }
+        RawToken::ExternalCommand(_) => {
+            return Err(ShellError::syntax_error(
+                "Invalid external command".to_string().tagged(token.tag()),
+            ))
+        }
+        RawToken::ExternalWord => return Err(ShellError::invalid_external_word(token.span())),
+        RawToken::Variable(span) => hir::Expression::variable(span, token.span()),
+        RawToken::Number(_) => hir::Expression::bare(token.span()),
+        RawToken::Size(_, _) => hir::Expression::bare(token.span()),
+        RawToken::GlobPattern => hir::Expression::pattern(token.span()),
         RawToken::Bare => hir::Expression::file_path(
             expand_path(token.span().slice(source), context),
             token.span(),

--- a/src/parser/hir/baseline_parse.rs
+++ b/src/parser/hir/baseline_parse.rs
@@ -1,10 +1,14 @@
 use crate::context::Context;
+use crate::errors::ShellError;
 use crate::parser::{hir, RawToken, Token};
 use crate::Text;
 use std::path::PathBuf;
 
-pub fn baseline_parse_single_token(token: &Token, source: &Text) -> hir::Expression {
-    match *token.item() {
+pub fn baseline_parse_single_token(
+    token: &Token,
+    source: &Text,
+) -> Result<hir::Expression, ShellError> {
+    Ok(match *token.item() {
         RawToken::Number(number) => hir::Expression::number(number.to_number(source), token.span()),
         RawToken::Size(int, unit) => {
             hir::Expression::size(int.to_number(source), unit, token.span())
@@ -14,17 +18,22 @@ pub fn baseline_parse_single_token(token: &Token, source: &Text) -> hir::Express
             hir::Expression::it_variable(span, token.span())
         }
         RawToken::Variable(span) => hir::Expression::variable(span, token.span()),
-        RawToken::External(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalCommand(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalWord => return Err(ShellError::invalid_external_word(token.span())),
         RawToken::Bare => hir::Expression::bare(token.span()),
-    }
+    })
 }
 
-pub fn baseline_parse_token_as_number(token: &Token, source: &Text) -> hir::Expression {
-    match *token.item() {
+pub fn baseline_parse_token_as_number(
+    token: &Token,
+    source: &Text,
+) -> Result<hir::Expression, ShellError> {
+    Ok(match *token.item() {
         RawToken::Variable(span) if span.slice(source) == "it" => {
             hir::Expression::it_variable(span, token.span())
         }
-        RawToken::External(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalCommand(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalWord => return Err(ShellError::invalid_external_word(token.span())),
         RawToken::Variable(span) => hir::Expression::variable(span, token.span()),
         RawToken::Number(number) => hir::Expression::number(number.to_number(source), token.span()),
         RawToken::Size(number, unit) => {
@@ -32,33 +41,38 @@ pub fn baseline_parse_token_as_number(token: &Token, source: &Text) -> hir::Expr
         }
         RawToken::Bare => hir::Expression::bare(token.span()),
         RawToken::String(span) => hir::Expression::string(span, token.span()),
-    }
+    })
 }
 
-pub fn baseline_parse_token_as_string(token: &Token, source: &Text) -> hir::Expression {
-    match *token.item() {
+pub fn baseline_parse_token_as_string(
+    token: &Token,
+    source: &Text,
+) -> Result<hir::Expression, ShellError> {
+    Ok(match *token.item() {
         RawToken::Variable(span) if span.slice(source) == "it" => {
             hir::Expression::it_variable(span, token.span())
         }
-        RawToken::External(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalCommand(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalWord => return Err(ShellError::invalid_external_word(token.span())),
         RawToken::Variable(span) => hir::Expression::variable(span, token.span()),
         RawToken::Number(_) => hir::Expression::bare(token.span()),
         RawToken::Size(_, _) => hir::Expression::bare(token.span()),
         RawToken::Bare => hir::Expression::bare(token.span()),
         RawToken::String(span) => hir::Expression::string(span, token.span()),
-    }
+    })
 }
 
 pub fn baseline_parse_token_as_path(
     token: &Token,
     context: &Context,
     source: &Text,
-) -> hir::Expression {
-    match *token.item() {
+) -> Result<hir::Expression, ShellError> {
+    Ok(match *token.item() {
         RawToken::Variable(span) if span.slice(source) == "it" => {
             hir::Expression::it_variable(span, token.span())
         }
-        RawToken::External(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalCommand(span) => hir::Expression::external_command(span, token.span()),
+        RawToken::ExternalWord => return Err(ShellError::invalid_external_word(token.span())),
         RawToken::Variable(span) => hir::Expression::variable(span, token.span()),
         RawToken::Number(_) => hir::Expression::bare(token.span()),
         RawToken::Size(_, _) => hir::Expression::bare(token.span()),
@@ -69,7 +83,7 @@ pub fn baseline_parse_token_as_path(
         RawToken::String(span) => {
             hir::Expression::file_path(expand_path(span.slice(source), context), token.span())
         }
-    }
+    })
 }
 
 pub fn expand_path(string: &str, context: &Context) -> PathBuf {

--- a/src/parser/hir/baseline_parse_tokens.rs
+++ b/src/parser/hir/baseline_parse_tokens.rs
@@ -33,7 +33,6 @@ pub fn baseline_parse_tokens(
     Ok(exprs)
 }
 
-
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum SyntaxType {
     Any,
@@ -62,7 +61,7 @@ impl std::fmt::Display for SyntaxType {
             SyntaxType::Path => write!(f, "Path"),
             SyntaxType::Binary => write!(f, "Binary"),
             SyntaxType::Block => write!(f, "Block"),
-            SyntaxType::Boolean => write!(f, "Boolean")
+            SyntaxType::Boolean => write!(f, "Boolean"),
         }
     }
 }
@@ -81,7 +80,7 @@ pub fn baseline_parse_next_expr(
 
     match (syntax_type, next) {
         (SyntaxType::Path, TokenNode::Token(token)) => {
-            return Ok(baseline_parse_token_as_path(token, context, source))
+            return baseline_parse_token_as_path(token, context, source)
         }
 
         (SyntaxType::Path, token) => {
@@ -92,7 +91,7 @@ pub fn baseline_parse_next_expr(
         }
 
         (SyntaxType::String, TokenNode::Token(token)) => {
-            return Ok(baseline_parse_token_as_string(token, source));
+            return baseline_parse_token_as_string(token, source);
         }
 
         (SyntaxType::String, token) => {
@@ -103,7 +102,7 @@ pub fn baseline_parse_next_expr(
         }
 
         (SyntaxType::Number, TokenNode::Token(token)) => {
-            return Ok(baseline_parse_token_as_number(token, source));
+            return Ok(baseline_parse_token_as_number(token, source)?);
         }
 
         (SyntaxType::Number, token) => {
@@ -115,7 +114,7 @@ pub fn baseline_parse_next_expr(
 
         // TODO: More legit member processing
         (SyntaxType::Member, TokenNode::Token(token)) => {
-            return Ok(baseline_parse_token_as_string(token, source));
+            return baseline_parse_token_as_string(token, source);
         }
 
         (SyntaxType::Member, token) => {
@@ -245,7 +244,7 @@ pub fn baseline_parse_semantic_token(
     source: &Text,
 ) -> Result<hir::Expression, ShellError> {
     match token {
-        TokenNode::Token(token) => Ok(baseline_parse_single_token(token, source)),
+        TokenNode::Token(token) => baseline_parse_single_token(token, source),
         TokenNode::Call(_call) => unimplemented!(),
         TokenNode::Delimited(delimited) => baseline_parse_delimited(delimited, context, source),
         TokenNode::Pipeline(_pipeline) => unimplemented!(),
@@ -315,7 +314,8 @@ pub fn baseline_parse_path(
                 RawToken::Number(_)
                 | RawToken::Size(..)
                 | RawToken::Variable(_)
-                | RawToken::External(_) => {
+                | RawToken::ExternalCommand(_)
+                | RawToken::ExternalWord => {
                     return Err(ShellError::type_error(
                         "String",
                         token.type_name().simple_spanned(part),

--- a/src/parser/parse/call_node.rs
+++ b/src/parser/parse/call_node.rs
@@ -1,5 +1,7 @@
 use crate::parser::TokenNode;
+use crate::traits::ToDebug;
 use getset::Getters;
+use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Getters)]
 pub struct CallNode {
@@ -22,5 +24,19 @@ impl CallNode {
                 children: Some(children),
             }
         }
+    }
+}
+
+impl ToDebug for CallNode {
+    fn fmt_debug(&self, f: &mut fmt::Formatter, source: &str) -> fmt::Result {
+        write!(f, "{}", self.head.debug(source))?;
+
+        if let Some(children) = &self.children {
+            for child in children {
+                write!(f, "{}", child.debug(source))?
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/parser/parse/parser.rs
+++ b/src/parser/parse/parser.rs
@@ -713,6 +713,7 @@ fn is_bare_char(c: char) -> bool {
         '=' => true,
         '~' => true,
         ':' => true,
+        '?' => true,
         _ => false,
     }
 }

--- a/src/parser/parse/pipeline.rs
+++ b/src/parser/parse/pipeline.rs
@@ -1,12 +1,28 @@
 use crate::parser::CallNode;
+use crate::traits::ToDebug;
 use crate::{Span, Tagged};
 use derive_new::new;
 use getset::Getters;
+use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, new)]
 pub struct Pipeline {
     pub(crate) parts: Vec<PipelineElement>,
     pub(crate) post_ws: Option<Span>,
+}
+
+impl ToDebug for Pipeline {
+    fn fmt_debug(&self, f: &mut fmt::Formatter, source: &str) -> fmt::Result {
+        for part in &self.parts {
+            write!(f, "{}", part.debug(source))?;
+        }
+
+        if let Some(post_ws) = self.post_ws {
+            write!(f, "{}", post_ws.slice(source))?
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Getters, new)]
@@ -16,4 +32,24 @@ pub struct PipelineElement {
     #[get = "pub(crate)"]
     call: Tagged<CallNode>,
     pub post_ws: Option<Span>,
+}
+
+impl ToDebug for PipelineElement {
+    fn fmt_debug(&self, f: &mut fmt::Formatter, source: &str) -> fmt::Result {
+        if let Some(pipe) = self.pipe {
+            write!(f, "{}", pipe.slice(source))?;
+        }
+
+        if let Some(pre_ws) = self.pre_ws {
+            write!(f, "{}", pre_ws.slice(source))?;
+        }
+
+        write!(f, "{}", self.call.debug(source))?;
+
+        if let Some(post_ws) = self.post_ws {
+            write!(f, "{}", post_ws.slice(source))?;
+        }
+
+        Ok(())
+    }
 }

--- a/src/parser/parse/token_tree_builder.rs
+++ b/src/parser/parse/token_tree_builder.rs
@@ -152,6 +152,24 @@ impl TokenTreeBuilder {
         ))
     }
 
+    pub fn pattern(input: impl Into<String>) -> CurriedToken {
+        let input = input.into();
+
+        Box::new(move |b| {
+            let (start, end) = b.consume(&input);
+            b.pos = end;
+
+            TokenTreeBuilder::spanned_pattern((start, end))
+        })
+    }
+
+    pub fn spanned_pattern(input: impl Into<Span>) -> TokenNode {
+        TokenNode::Token(Tagged::from_simple_spanned_item(
+            RawToken::Bare,
+            input.into(),
+        ))
+    }
+
     pub fn external_word(input: impl Into<String>) -> CurriedToken {
         let input = input.into();
 

--- a/src/parser/parse/token_tree_builder.rs
+++ b/src/parser/parse/token_tree_builder.rs
@@ -14,15 +14,19 @@ use derive_new::new;
 pub struct TokenTreeBuilder {
     #[new(default)]
     pos: usize,
+
+    #[new(default)]
+    output: String,
 }
 
 pub type CurriedToken = Box<dyn FnOnce(&mut TokenTreeBuilder) -> TokenNode + 'static>;
 pub type CurriedCall = Box<dyn FnOnce(&mut TokenTreeBuilder) -> Tagged<CallNode> + 'static>;
 
 impl TokenTreeBuilder {
-    pub fn build(block: impl FnOnce(&mut Self) -> TokenNode) -> TokenNode {
+    pub fn build(block: impl FnOnce(&mut Self) -> TokenNode) -> (TokenNode, String) {
         let mut builder = TokenTreeBuilder::new();
-        block(&mut builder)
+        let node = block(&mut builder);
+        (node, builder.output)
     }
 
     pub fn pipeline(input: Vec<(Option<&str>, CurriedCall, Option<&str>)>) -> CurriedToken {
@@ -56,7 +60,8 @@ impl TokenTreeBuilder {
                 pipe,
                 pre_span.map(Span::from),
                 call,
-                post_span.map(Span::from)));
+                post_span.map(Span::from),
+            ));
 
             loop {
                 match input.next() {
@@ -147,9 +152,27 @@ impl TokenTreeBuilder {
         ))
     }
 
+    pub fn external_word(input: impl Into<String>) -> CurriedToken {
+        let input = input.into();
+
+        Box::new(move |b| {
+            let (start, end) = b.consume(&input);
+            b.pos = end;
+
+            TokenTreeBuilder::spanned_external_word((start, end))
+        })
+    }
+
+    pub fn spanned_external_word(input: impl Into<Span>) -> TokenNode {
+        TokenNode::Token(Tagged::from_simple_spanned_item(
+            RawToken::ExternalWord,
+            input.into(),
+        ))
+    }
+
     pub fn spanned_external(input: impl Into<Span>, span: impl Into<Span>) -> TokenNode {
         TokenNode::Token(Tagged::from_simple_spanned_item(
-            RawToken::External(input.into()),
+            RawToken::ExternalCommand(input.into()),
             span.into(),
         ))
     }
@@ -422,6 +445,7 @@ impl TokenTreeBuilder {
     fn consume(&mut self, input: &str) -> (usize, usize) {
         let start = self.pos;
         self.pos += input.len();
+        self.output.push_str(input);
         (start, self.pos)
     }
 }

--- a/src/parser/parse/tokens.rs
+++ b/src/parser/parse/tokens.rs
@@ -12,6 +12,7 @@ pub enum RawToken {
     Variable(Span),
     ExternalCommand(Span),
     ExternalWord,
+    GlobPattern,
     Bare,
 }
 
@@ -53,6 +54,7 @@ impl RawToken {
             RawToken::Variable(_) => "Variable",
             RawToken::ExternalCommand(_) => "ExternalCommand",
             RawToken::ExternalWord => "ExternalWord",
+            RawToken::GlobPattern => "GlobPattern",
             RawToken::Bare => "String",
         }
     }

--- a/src/parser/parse/tokens.rs
+++ b/src/parser/parse/tokens.rs
@@ -10,7 +10,8 @@ pub enum RawToken {
     Size(RawNumber, Unit),
     String(Span),
     Variable(Span),
-    External(Span),
+    ExternalCommand(Span),
+    ExternalWord,
     Bare,
 }
 
@@ -50,7 +51,8 @@ impl RawToken {
             RawToken::Size(..) => "Size",
             RawToken::String(_) => "String",
             RawToken::Variable(_) => "Variable",
-            RawToken::External(_) => "External",
+            RawToken::ExternalCommand(_) => "ExternalCommand",
+            RawToken::ExternalWord => "ExternalWord",
             RawToken::Bare => "String",
         }
     }

--- a/src/parser/parse_command.rs
+++ b/src/parser/parse_command.rs
@@ -6,6 +6,7 @@ use crate::parser::{
     hir::{self, NamedArguments},
     Flag, RawToken, TokenNode,
 };
+use crate::traits::ToDebug;
 use crate::{Span, Tag, Tagged, Text};
 use log::trace;
 
@@ -248,7 +249,7 @@ pub fn trace_remaining(desc: &'static str, tail: hir::TokensIterator<'_>, source
         itertools::join(
             tail.debug_remaining()
                 .iter()
-                .map(|i| format!("%{:?}%", i.debug(source))),
+                .map(|i| format!("%{}%", i.debug(&source))),
             " "
         )
     );

--- a/src/shell/helper.rs
+++ b/src/shell/helper.rs
@@ -124,6 +124,10 @@ fn paint_token_node(token_node: &TokenNode, line: &str) -> String {
             ..
         }) => Color::Purple.bold().paint(token_node.span().slice(line)),
         TokenNode::Token(Tagged {
+            item: RawToken::GlobPattern,
+            ..
+        }) => Color::Cyan.normal().paint(token_node.span().slice(line)),
+        TokenNode::Token(Tagged {
             item: RawToken::String(..),
             ..
         }) => Color::Green.normal().paint(token_node.span().slice(line)),

--- a/src/shell/helper.rs
+++ b/src/shell/helper.rs
@@ -136,9 +136,13 @@ fn paint_token_node(token_node: &TokenNode, line: &str) -> String {
             ..
         }) => Color::Green.normal().paint(token_node.span().slice(line)),
         TokenNode::Token(Tagged {
-            item: RawToken::External(..),
+            item: RawToken::ExternalCommand(..),
             ..
         }) => Color::Cyan.bold().paint(token_node.span().slice(line)),
+        TokenNode::Token(Tagged {
+            item: RawToken::ExternalWord,
+            ..
+        }) => Color::Black.bold().paint(token_node.span().slice(line)),
     };
 
     styled.to_string()


### PR DESCRIPTION
Previously, there was a single parsing rule for "bare words" that
applied to both internal and external commands.

This meant that, because `cargo +nightly` needed to work, we needed to
add `+` as a valid character in bare words.

The number of characters continued to grow, and the situation was
becoming untenable. The current strategy would eventually eat up all
syntax and make it impossible to add syntax like `@foo` to internal
commands.

This patch significantly restricts bare words and introduces a new token
type (`ExternalWord`). An `ExternalWord` expands to an error in the
internal syntax, but expands to a bare word in the external syntax.

`ExternalWords` are highlighted in grey in the shell.