### PR TITLE
Updating nushell/nu base to have proper version of libssl-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,11 @@ workflows:
                 command: |
                    DOCKER_TAG=$(docker run quay.io/nushell/nu --version | cut -d' ' -f2)
                    echo "Version that would be used for Docker tag is v${DOCKER_TAG}"
+            - run:
+                name: Test Executable
+                command: |
+                   docker run --rm quay.io/nushell/nu-base --help
+                   docker run --rm quay.io/nushell/nu --help
 
   # workflow publishes to Docker Hub, with each job having different triggers
   build_with_deploy:
@@ -77,6 +82,11 @@ workflows:
                 name: Build Multistage (smaller) container
                 command: |
                   docker build -f docker/Dockerfile -t quay.io/nushell/nu .
+            - run:
+                name: Test Executable
+                command: |
+                   docker run --rm quay.io/nushell/nu --help
+                   docker run --rm quay.io/nushell/nu-base --help
             - run:
                 name: Publish Docker Tag with Nushell Version
                 command: |
@@ -110,6 +120,11 @@ workflows:
                 command: |
                   docker build --build-arg FROMTAG=devel -f docker/Dockerfile -t quay.io/nushell/nu:devel .
             - run:
+                name: Test Executable
+                command: |
+                   docker run --rm quay.io/nushell/nu:devel --help
+                   docker run --rm quay.io/nushell/nu-base:devel --help
+            - run:
                 name: Publish Development Docker Tags
                 command: |
                    docker push quay.io/nushell/nu-base:devel
@@ -138,6 +153,11 @@ workflows:
                 name: Build Multistage (smaller) container
                 command: |
                   docker build -f docker/Dockerfile -t quay.io/nushell/nu:nightly .
+            - run:
+                name: Test Executable
+                command: |
+                   docker run --rm quay.io/nushell/nu:nightly --help
+                   docker run --rm quay.io/nushell/nu-base:nightly --help
             - run:
                 name: Publish Nightly Nushell Containers
                 command: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,9 @@
-ARG  FROMTAG=latest
+ARG FROMTAG=latest
 FROM quay.io/nushell/nu-base:${FROMTAG} as base
-FROM rust:1.37-slim
+FROM ubuntu:18.04
 COPY --from=base /usr/local/bin/nu /usr/local/bin/nu
-RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y libssl-dev \
+    pkg-config
 ENTRYPOINT ["nu"]
 CMD ["-l", "info"]

--- a/docker/Dockerfile.nu-base
+++ b/docker/Dockerfile.nu-base
@@ -6,8 +6,6 @@ FROM ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y libssl-dev \
     libxcb-composite0-dev \
-    libx11-dev \
-    libssl-dev \
     pkg-config \
     curl
 


### PR DESCRIPTION
This will address #646 by updating the second base image to 16.04, and also adding a test after the builds in the circle config to ensure it doesn't pass if this error occurs.

Update: note that the PR originally had 18.04 (hence the name of the branch) but likely there was a local build error (it should work) so we are testing 16.04 now.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>