### PR TITLE
Updating base to 18.04

### DIFF
--- a/docker/Dockerfile.nu-base
+++ b/docker/Dockerfile.nu-base
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # docker build -f docker/Dockerfile.nu-base -t nushell/nu-base .
 # docker run -it nushell/nu-base


### PR DESCRIPTION
Per discussion in https://github.com/nushell/nushell/issues/646, it looks like the only reason that 16.04 is used in Azure pipelines is because 18.04 simply isn't available yet. To afford using the latest LTS, and to adjust the current build so both images use the same base (now 18.04) I want to modify the nushell/nu-base image here to also use 18.04.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>