### PR TITLE
Detach externals so they don't freeze while buffering

### DIFF
--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -307,10 +307,12 @@ impl ExternalCommand {
                 Ok(ClassifiedInputStream::new())
             }
             StreamNext::External => {
+                let _ = popen.detach();
                 let stdout = popen.stdout.take().unwrap();
                 Ok(ClassifiedInputStream::from_stdout(stdout))
             }
             StreamNext::Internal => {
+                let _ = popen.detach();
                 let stdout = popen.stdout.take().unwrap();
                 let file = futures::io::AllowStdIo::new(stdout);
                 let stream = Framed::new(file, LinesCodec {});


### PR DESCRIPTION
Related to https://github.com/nushell/nushell/issues/595, we're seeing issues where if an external gets to 64k it will freeze. This points to it filling its output buffer and not being able to continue. This in turn seemed to point to it not being running independently of the pipeline as it should. I've added detaches to external->external and external->internal so that they can run independently and the rest of the pipeline can pull as needed.