### PR TITLE
Switch to rustline git instead of crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://book.nushell.sh"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustyline = "5.0.2"
+rustyline = { git = "https://github.com/kkawakam/rustyline" }
 chrono = { version = "0.4.9", features = ["serde"] }
 derive-new = "0.5.8"
 prettytable-rs = "0.8.0"


### PR DESCRIPTION
There have been a few fixes in rustyline we want to help test, so let's switch to their latest master ahead of the next release.