### PR TITLE
Serialize bigint/bigdecimal as i64/f64

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,7 @@ fn load_plugin(path: &std::path::Path, context: &mut Context) -> Result<(), Shel
     let result = match reader.read_line(&mut input) {
         Ok(count) => {
             trace!("processing response ({} bytes)", count);
+            trace!("response: {}", input);
 
             let response = serde_json::from_str::<JsonRpc<Result<Signature, ShellError>>>(&input);
             match response {


### PR DESCRIPTION
Switch to serializing bigint and bigdecimal as i64/f64 to make it easier to work with them from plugins. This does lose some of the precision for very large numbers, but if it's needed in the future, we could explore ways for plugins to request the full values.