### PR TITLE
Fix internal $it paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,7 @@ dependencies = [
  "rawkey 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "roxmltree 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustyline 5.0.2 (git+https://github.com/kkawakam/rustyline)",
+ "rustyline 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-hjson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2195,8 +2195,8 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "5.0.2"
-source = "git+https://github.com/kkawakam/rustyline#5e68e972810133a7343b75db30addc98aea63ba0"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3216,7 +3216,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustyline 5.0.2 (git+https://github.com/kkawakam/rustyline)" = "<none>"
+"checksum rustyline 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4795e277e6e57dec9df62b515cd4991371daa80e8dc8d80d596e58722b89c417"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum safemem 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e133ccc4f4d1cd4f89cc8a7ff618287d56dc7f638b8e38fc32c5fdcadc339dd5"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"

--- a/src/commands/autoview.rs
+++ b/src/commands/autoview.rs
@@ -45,7 +45,7 @@ pub fn autoview(
             {
                 let binary = context.get_command("binaryview");
                 if let Some(binary) = binary {
-                    let result = binary.run(raw.with_input(input), &context.commands);
+                    let result = binary.run(raw.with_input(input), &context.commands, false);
                     result.collect::<Vec<_>>().await;
                 } else {
                     for i in input {
@@ -61,7 +61,7 @@ pub fn autoview(
             } else if is_single_origined_text_value(&input) {
                 let text = context.get_command("textview");
                 if let Some(text) = text {
-                    let result = text.run(raw.with_input(input), &context.commands);
+                    let result = text.run(raw.with_input(input), &context.commands, false);
                     result.collect::<Vec<_>>().await;
                 } else {
                     for i in input {
@@ -84,7 +84,7 @@ pub fn autoview(
                 }
             } else {
                 let table = context.expect_command("table");
-                let result = table.run(raw.with_input(input), &context.commands);
+                let result = table.run(raw.with_input(input), &context.commands, false);
                 result.collect::<Vec<_>>().await;
             }
         }

--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -96,6 +96,7 @@ impl InternalCommand {
         context: &mut Context,
         input: ClassifiedInputStream,
         source: Text,
+        is_first_command: bool,
     ) -> Result<InputStream, ShellError> {
         if log_enabled!(log::Level::Trace) {
             trace!(target: "nu::run::internal", "->");
@@ -113,6 +114,7 @@ impl InternalCommand {
             self.args,
             &source,
             objects,
+            is_first_command,
         );
 
         let result = trace_out_stream!(target: "nu::trace_stream::internal", source: &source, "output" = result);

--- a/src/commands/enter.rs
+++ b/src/commands/enter.rs
@@ -109,6 +109,7 @@ impl PerItemCommand for Enter {
                                         let mut result = converter.run(
                                             new_args.with_input(vec![tagged_contents]),
                                             &registry,
+                                            false
                                         );
                                         let result_vec: Vec<Result<ReturnSuccess, ShellError>> =
                                             result.drain_vec().await;

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -101,7 +101,7 @@ fn run(
                         name_tag: raw_args.call_info.name_tag,
                     }
                 };
-                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry);
+                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry, false);
                 let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                 for res in result_vec {
                     match res {

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -102,7 +102,7 @@ fn run(
                         name_tag: raw_args.call_info.name_tag,
                     }
                 };
-                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry);
+                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry, false);
                 let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                 for res in result_vec {
                     match res {

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -112,7 +112,7 @@ fn run(
                         name_tag: raw_args.call_info.name_tag,
                     }
                 };
-                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry);
+                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry, false);
                 let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                 for res in result_vec {
                     match res {
@@ -195,6 +195,7 @@ pub async fn post(
                     let mut result = converter.run(
                         new_args.with_input(vec![item.clone().tagged(tag.clone())]),
                         &registry,
+                        false,
                     );
                     let result_vec: Vec<Result<ReturnSuccess, ShellError>> =
                         result.drain_vec().await;

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -188,7 +188,7 @@ fn save(
                             name_tag: raw_args.call_info.name_tag,
                         }
                     };
-                    let mut result = converter.run(new_args.with_input(input), &registry);
+                    let mut result = converter.run(new_args.with_input(input), &registry, false);
                     let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                     if converter.is_binary() {
                         process_binary_return_success!(result_vec, name_tag)

--- a/src/context.rs
+++ b/src/context.rs
@@ -125,9 +125,10 @@ impl Context {
         args: hir::Call,
         source: &Text,
         input: InputStream,
+        is_first_command: bool,
     ) -> OutputStream {
         let command_args = self.command_args(args, input, source, source_map, name_tag);
-        command.run(command_args, self.registry())
+        command.run(command_args, self.registry(), is_first_command)
     }
 
     fn call_info(


### PR DESCRIPTION
* Fixes internal commands so that they fire either:
  * Once, if it's the producer/head of the pipeline
  * Once for each value in the pipeline

Previously, this behavior was controlled by whether $it was detected or not

