### PR TITLE
Add origins back to open

### DIFF
--- a/src/commands/autoview.rs
+++ b/src/commands/autoview.rs
@@ -113,10 +113,7 @@ fn is_single_origined_text_value(input: &Vec<Tagged<Value>>) -> bool {
 
     if let Tagged {
         item: Value::Primitive(Primitive::String(_)),
-        tag: Tag {
-            origin: Some(origin),
-            ..
-        },
+        tag: Tag { origin, .. },
     } = input[0]
     {
         origin != uuid::Uuid::nil()

--- a/src/commands/autoview.rs
+++ b/src/commands/autoview.rs
@@ -110,6 +110,7 @@ fn is_single_origined_text_value(input: &Vec<Tagged<Value>>) -> bool {
     if input.len() != 1 {
         return false;
     }
+
     if let Tagged {
         item: Value::Primitive(Primitive::String(_)),
         tag: Tag {

--- a/src/commands/enter.rs
+++ b/src/commands/enter.rs
@@ -75,10 +75,10 @@ impl PerItemCommand for Enter {
                             )
                             .await.unwrap();
 
-                        if let Some(uuid) = contents_tag.origin {
+                        if contents_tag.origin != uuid::Uuid::nil() {
                             // If we have loaded something, track its source
                             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                                uuid,
+                                contents_tag.origin,
                                 span_source,
                             ));
                         }

--- a/src/commands/enter.rs
+++ b/src/commands/enter.rs
@@ -1,6 +1,7 @@
 use crate::commands::command::CommandAction;
 use crate::commands::PerItemCommand;
 use crate::commands::UnevaluatedCallInfo;
+use crate::data::meta::Span;
 use crate::errors::ShellError;
 use crate::parser::registry;
 use crate::prelude::*;
@@ -70,7 +71,7 @@ impl PerItemCommand for Enter {
                             crate::commands::open::fetch(
                                 &full_path,
                                 &location_clone,
-                                Tag::unknown(),
+                                Span::unknown(),
                             )
                             .await.unwrap();
 

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -76,10 +76,10 @@ fn run(
             file_extension.or(path_str.split('.').last().map(String::from))
         };
 
-        if let Some(uuid) = contents_tag.origin {
+        if contents_tag.origin != uuid::Uuid::nil() {
             // If we have loaded something, track its source
             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                uuid,
+                contents_tag.origin,
                 span_source,
             ));
         }
@@ -158,7 +158,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Some(Uuid::new_v4()),
+                            origin: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -173,7 +173,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Some(Uuid::new_v4()),
+                            origin: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -190,7 +190,7 @@ pub async fn fetch(
                             Value::binary(buf),
                             Tag {
                                 span,
-                                origin: Some(Uuid::new_v4()),
+                                origin: Uuid::new_v4(),
                             },
                             SpanSource::Url(location.to_string()),
                         ))
@@ -206,7 +206,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Some(Uuid::new_v4()),
+                            origin: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -223,7 +223,7 @@ pub async fn fetch(
                             Value::binary(buf),
                             Tag {
                                 span,
-                                origin: Some(Uuid::new_v4()),
+                                origin: Uuid::new_v4(),
                             },
                             SpanSource::Url(location.to_string()),
                         ))
@@ -239,7 +239,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Some(Uuid::new_v4()),
+                            origin: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -266,7 +266,7 @@ pub async fn fetch(
                             })?),
                             Tag {
                                 span,
-                                origin: Some(Uuid::new_v4()),
+                                origin: Uuid::new_v4(),
                             },
                             SpanSource::Url(location.to_string()),
                         ))
@@ -276,7 +276,7 @@ pub async fn fetch(
                         Value::string(format!("Not yet supported MIME type: {} {}", ty, sub_ty)),
                         Tag {
                             span,
-                            origin: Some(Uuid::new_v4()),
+                            origin: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -287,7 +287,7 @@ pub async fn fetch(
                 Value::string(format!("No content type found")),
                 Tag {
                     span,
-                    origin: Some(Uuid::new_v4()),
+                    origin: Uuid::new_v4(),
                 },
                 SpanSource::Url(location.to_string()),
             )),

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -77,10 +77,10 @@ fn run(
             file_extension.or(path_str.split('.').last().map(String::from))
         };
 
-        if let Some(uuid) = contents_tag.origin {
+        if contents_tag.origin != uuid::Uuid::nil() {
             // If we have loaded something, track its source
             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                uuid,
+                contents_tag.origin,
                 span_source,
             ));
         }
@@ -147,7 +147,7 @@ pub async fn fetch(
                     Value::string(s),
                     Tag {
                         span,
-                        origin: Some(Uuid::new_v4()),
+                        origin: Uuid::new_v4(),
                     },
                     SpanSource::File(cwd.to_string_lossy().to_string()),
                 )),
@@ -166,7 +166,7 @@ pub async fn fetch(
                                         Value::string(s),
                                         Tag {
                                             span,
-                                            origin: Some(Uuid::new_v4()),
+                                            origin: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -175,7 +175,7 @@ pub async fn fetch(
                                         Value::binary(bytes),
                                         Tag {
                                             span,
-                                            origin: Some(Uuid::new_v4()),
+                                            origin: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -186,7 +186,7 @@ pub async fn fetch(
                                     Value::binary(bytes),
                                     Tag {
                                         span,
-                                        origin: Some(Uuid::new_v4()),
+                                        origin: Uuid::new_v4(),
                                     },
                                     SpanSource::File(cwd.to_string_lossy().to_string()),
                                 ))
@@ -204,7 +204,7 @@ pub async fn fetch(
                                         Value::string(s),
                                         Tag {
                                             span,
-                                            origin: Some(Uuid::new_v4()),
+                                            origin: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -213,7 +213,7 @@ pub async fn fetch(
                                         Value::binary(bytes),
                                         Tag {
                                             span,
-                                            origin: Some(Uuid::new_v4()),
+                                            origin: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -224,7 +224,7 @@ pub async fn fetch(
                                     Value::binary(bytes),
                                     Tag {
                                         span,
-                                        origin: Some(Uuid::new_v4()),
+                                        origin: Uuid::new_v4(),
                                     },
                                     SpanSource::File(cwd.to_string_lossy().to_string()),
                                 ))
@@ -235,7 +235,7 @@ pub async fn fetch(
                             Value::binary(bytes),
                             Tag {
                                 span,
-                                origin: Some(Uuid::new_v4()),
+                                origin: Uuid::new_v4(),
                             },
                             SpanSource::File(cwd.to_string_lossy().to_string()),
                         )),

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -1,11 +1,13 @@
 use crate::commands::UnevaluatedCallInfo;
 use crate::context::SpanSource;
+use crate::data::meta::Span;
 use crate::data::Value;
 use crate::errors::ShellError;
 use crate::parser::hir::SyntaxShape;
 use crate::parser::registry::Signature;
 use crate::prelude::*;
 use std::path::{Path, PathBuf};
+use uuid::Uuid;
 pub struct Open;
 
 impl PerItemCommand for Open {
@@ -52,7 +54,7 @@ fn run(
     };
     let path_buf = path.as_path()?;
     let path_str = path_buf.display().to_string();
-    let path_span = path.tag();
+    let path_span = path.span();
     let has_raw = call_info.args.has("raw");
     let registry = registry.clone();
     let raw_args = raw_args.clone();
@@ -131,7 +133,7 @@ fn run(
 pub async fn fetch(
     cwd: &PathBuf,
     location: &str,
-    tag: Tag,
+    span: Span,
 ) -> Result<(Option<String>, Value, Tag, SpanSource), ShellError> {
     let mut cwd = cwd.clone();
 
@@ -143,7 +145,10 @@ pub async fn fetch(
                     cwd.extension()
                         .map(|name| name.to_string_lossy().to_string()),
                     Value::string(s),
-                    tag,
+                    Tag {
+                        span,
+                        origin: Some(Uuid::new_v4()),
+                    },
                     SpanSource::File(cwd.to_string_lossy().to_string()),
                 )),
                 Err(_) => {
@@ -159,13 +164,19 @@ pub async fn fetch(
                                         cwd.extension()
                                             .map(|name| name.to_string_lossy().to_string()),
                                         Value::string(s),
-                                        tag,
+                                        Tag {
+                                            span,
+                                            origin: Some(Uuid::new_v4()),
+                                        },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
                                     Err(_) => Ok((
                                         None,
                                         Value::binary(bytes),
-                                        tag,
+                                        Tag {
+                                            span,
+                                            origin: Some(Uuid::new_v4()),
+                                        },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
                                 }
@@ -173,7 +184,10 @@ pub async fn fetch(
                                 Ok((
                                     None,
                                     Value::binary(bytes),
-                                    tag,
+                                    Tag {
+                                        span,
+                                        origin: Some(Uuid::new_v4()),
+                                    },
                                     SpanSource::File(cwd.to_string_lossy().to_string()),
                                 ))
                             }
@@ -188,13 +202,19 @@ pub async fn fetch(
                                         cwd.extension()
                                             .map(|name| name.to_string_lossy().to_string()),
                                         Value::string(s),
-                                        tag,
+                                        Tag {
+                                            span,
+                                            origin: Some(Uuid::new_v4()),
+                                        },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
                                     Err(_) => Ok((
                                         None,
                                         Value::binary(bytes),
-                                        tag,
+                                        Tag {
+                                            span,
+                                            origin: Some(Uuid::new_v4()),
+                                        },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
                                 }
@@ -202,7 +222,10 @@ pub async fn fetch(
                                 Ok((
                                     None,
                                     Value::binary(bytes),
-                                    tag,
+                                    Tag {
+                                        span,
+                                        origin: Some(Uuid::new_v4()),
+                                    },
                                     SpanSource::File(cwd.to_string_lossy().to_string()),
                                 ))
                             }
@@ -210,7 +233,10 @@ pub async fn fetch(
                         _ => Ok((
                             None,
                             Value::binary(bytes),
-                            tag,
+                            Tag {
+                                span,
+                                origin: Some(Uuid::new_v4()),
+                            },
                             SpanSource::File(cwd.to_string_lossy().to_string()),
                         )),
                     }
@@ -220,7 +246,7 @@ pub async fn fetch(
                 return Err(ShellError::labeled_error(
                     "File could not be opened",
                     "file not found",
-                    tag,
+                    span,
                 ));
             }
         }
@@ -228,7 +254,7 @@ pub async fn fetch(
         return Err(ShellError::labeled_error(
             "File could not be opened",
             "file not found",
-            tag,
+            span,
         ));
     }
 }

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -85,10 +85,10 @@ fn run(
             file_extension.or(path_str.split('.').last().map(String::from))
         };
 
-        if let Some(uuid) = contents_tag.origin {
+        if contents_tag.origin != uuid::Uuid::nil() {
             // If we have loaded something, track its source
             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                uuid,
+                contents_tag.origin,
                 span_source,
             ));
         }

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -136,7 +136,7 @@ fn save(
             // If there is no filename, check the metadata for the origin filename
             if input.len() > 0 {
                 let origin = input[0].origin();
-                match origin.and_then(|x| source_map.get(&x)) {
+                match source_map.get(&origin) {
                     Some(path) => match path {
                         SpanSource::File(file) => {
                             full_path.push(Path::new(file));

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -42,7 +42,7 @@ fn tags(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
                 dict.insert("end", Value::int(span.end as i64));
                 tags.insert_tagged("span", dict.into_tagged_value());
 
-                match origin.and_then(|x| source_map.get(&x)) {
+                match source_map.get(&origin) {
                     Some(SpanSource::File(source)) => {
                         tags.insert("origin", Value::string(source));
                     }

--- a/src/data/meta.rs
+++ b/src/data/meta.rs
@@ -86,6 +86,10 @@ impl<T> Tagged<T> {
         self.tag
     }
 
+    pub fn span(&self) -> Span {
+        self.tag.span
+    }
+
     // TODO: This should not be optional
     pub fn origin(&self) -> Option<uuid::Uuid> {
         self.tag.origin

--- a/src/parser/parse/files.rs
+++ b/src/parser/parse/files.rs
@@ -22,7 +22,7 @@ impl language_reporting::ReportingFiles for Files {
     }
 
     fn file_id(&self, tag: Self::Span) -> Self::FileId {
-        tag.origin.unwrap()
+        tag.origin
     }
 
     fn file_name(&self, _file: Self::FileId) -> FileName {

--- a/src/plugins/binaryview.rs
+++ b/src/plugins/binaryview.rs
@@ -24,7 +24,7 @@ impl Plugin for BinaryView {
             let value_origin = v.origin();
             match v.item {
                 Value::Primitive(Primitive::Binary(b)) => {
-                    let source = value_origin.and_then(|x| call_info.source_map.get(&x));
+                    let source = call_info.source_map.get(&value_origin);
                     let _ = view_binary(&b, source, call_info.args.has("lores"));
                 }
                 _ => {}

--- a/src/plugins/textview.rs
+++ b/src/plugins/textview.rs
@@ -219,7 +219,7 @@ fn view_text_value(value: &Tagged<Value>, source_map: &SourceMap) {
     let value_origin = value.origin();
     match value.item {
         Value::Primitive(Primitive::String(ref s)) => {
-            let source = value_origin.and_then(|x| source_map.get(&x));
+            let source = source_map.get(&value_origin);
 
             if let Some(source) = source {
                 let extension: Option<String> = match source {


### PR DESCRIPTION
Fixes #673 

This moves us to using Uuid::nil(), so that we always have an origin (it just might be empty). This approach was first proposed by @wycats, and this PR finishes the work he started with the Span->Tag conversion.

This also fixes the issue with autoview not opening files opened with `open`