### PR TITLE
Include config paths in env command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -212,7 +212,7 @@ fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
     Ok(())
 }
 
-struct History;
+pub struct History;
 
 impl History {
     pub fn path() -> PathBuf {

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -1,3 +1,4 @@
+use crate::cli::History;
 use crate::data::config;
 use crate::data::{Dictionary, Value};
 use crate::errors::ShellError;
@@ -44,6 +45,9 @@ pub fn get_environment(tag: Tag) -> Result<Tagged<Value>, Box<dyn std::error::Er
 
     let config = config::default_path()?;
     indexmap.insert("config".to_string(), Value::path(config).tagged(tag));
+
+    let history = History::path();
+    indexmap.insert("history".to_string(), Value::path(history).tagged(tag));
 
     let temp = std::env::temp_dir();
     indexmap.insert("temp".to_string(), Value::path(temp).tagged(tag));

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -1,3 +1,4 @@
+use crate::data::config;
 use crate::data::{Dictionary, Value};
 use crate::errors::ShellError;
 use crate::prelude::*;
@@ -40,6 +41,9 @@ pub fn get_environment(tag: Tag) -> Result<Tagged<Value>, Box<dyn std::error::Er
     if let Some(home) = dirs::home_dir() {
         indexmap.insert("home".to_string(), Value::path(home).tagged(tag));
     }
+
+    let config = config::default_path()?;
+    indexmap.insert("config".to_string(), Value::path(config).tagged(tag));
 
     let temp = std::env::temp_dir();
     indexmap.insert("temp".to_string(), Value::path(temp).tagged(tag));


### PR DESCRIPTION
Output:
```
> env
━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━┯━━━━━━━━━━━━━━━━
 cwd                       │ home     │ config                          │ history                              │ temp │ vars 
───────────────────────────┼──────────┼─────────────────────────────────┼──────────────────────────────────────┼──────┼────────────────
 /opt/pi/code/rust/nushell │ /home/pi │ /home/pi/.config/nu/config.toml │ /home/pi/.local/share/nu/history.txt │ /tmp │ [table: 1 row] 
━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━┷━━━━━━━━━━━━━━━━
```