### PR TITLE
feat(cli): add `ctrlc_exit` config option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -405,6 +405,18 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
             }
 
             LineResult::CtrlC => {
+                let config_ctrlc_exit = config::config(Tag::unknown())?
+                    .get("ctrlc_exit")
+                    .map(|s| match s.as_string().unwrap().as_ref() {
+                        "true" => true,
+                        _ => false,
+                    })
+                    .unwrap_or(false); // default behavior is to allow CTRL-C spamming similar to other shells
+
+                if !config_ctrlc_exit {
+                    continue;
+                }
+
                 if ctrlcbreak {
                     let _ = rl.save_history(&History::path());
                     std::process::exit(0);


### PR DESCRIPTION
This feature allows a user to set `ctrlc_exit` to `true` or `false` in their config to override how multiple CTRL-C invocations are handled. Without this change pressing CTRL-C multiple times will exit nu. With this change applied the user can configure the behavior to behave like other shells where multiple invocations will essentially clear the line.

This fixes #457.