### PR TITLE
Clarify names of metadata

### DIFF
--- a/src/commands/autoview.rs
+++ b/src/commands/autoview.rs
@@ -58,7 +58,7 @@ pub fn autoview(
                         }
                     }
                 };
-            } else if is_single_origined_text_value(&input) {
+            } else if is_single_anchored_text_value(&input) {
                 let text = context.get_command("textview");
                 if let Some(text) = text {
                     let result = text.run(raw.with_input(input), &context.commands, false);
@@ -111,17 +111,17 @@ fn is_single_text_value(input: &Vec<Tagged<Value>>) -> bool {
     }
 }
 
-fn is_single_origined_text_value(input: &Vec<Tagged<Value>>) -> bool {
+fn is_single_anchored_text_value(input: &Vec<Tagged<Value>>) -> bool {
     if input.len() != 1 {
         return false;
     }
 
     if let Tagged {
         item: Value::Primitive(Primitive::String(_)),
-        tag: Tag { origin, .. },
+        tag: Tag { anchor, .. },
     } = input[0]
     {
-        origin != uuid::Uuid::nil()
+        anchor != uuid::Uuid::nil()
     } else {
         false
     }

--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -127,8 +127,8 @@ impl InternalCommand {
                     CommandAction::ChangePath(path) => {
                         context.shell_manager.set_path(path);
                     }
-                    CommandAction::AddSpanSource(uuid, span_source) => {
-                        context.add_span_source(uuid, span_source);
+                    CommandAction::AddAnchorLocation(uuid, anchor_location) => {
+                        context.add_anchor_location(uuid, anchor_location);
                     }
                     CommandAction::Exit => std::process::exit(0), // TODO: save history.txt
                     CommandAction::EnterHelpShell(value) => {

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -1,4 +1,4 @@
-use crate::context::{SourceMap, SpanSource};
+use crate::context::{AnchorLocation, SourceMap};
 use crate::data::Value;
 use crate::errors::ShellError;
 use crate::evaluate::Scope;
@@ -376,7 +376,7 @@ impl EvaluatedCommandArgs {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum CommandAction {
     ChangePath(String),
-    AddSpanSource(Uuid, SpanSource),
+    AddAnchorLocation(Uuid, AnchorLocation),
     Exit,
     EnterShell(String),
     EnterValueShell(Tagged<Value>),
@@ -390,7 +390,7 @@ impl ToDebug for CommandAction {
     fn fmt_debug(&self, f: &mut fmt::Formatter, _source: &str) -> fmt::Result {
         match self {
             CommandAction::ChangePath(s) => write!(f, "action:change-path={}", s),
-            CommandAction::AddSpanSource(u, source) => {
+            CommandAction::AddAnchorLocation(u, source) => {
                 write!(f, "action:add-span-source={}@{:?}", u, source)
             }
             CommandAction::Exit => write!(f, "action:exit"),

--- a/src/commands/enter.rs
+++ b/src/commands/enter.rs
@@ -75,10 +75,10 @@ impl PerItemCommand for Enter {
                             )
                             .await.unwrap();
 
-                        if contents_tag.origin != uuid::Uuid::nil() {
+                        if contents_tag.anchor != uuid::Uuid::nil() {
                             // If we have loaded something, track its source
                             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                                contents_tag.origin,
+                                contents_tag.anchor,
                                 span_source,
                             ));
                         }

--- a/src/commands/enter.rs
+++ b/src/commands/enter.rs
@@ -67,7 +67,7 @@ impl PerItemCommand for Enter {
 
                         let full_path = std::path::PathBuf::from(cwd);
 
-                        let (file_extension, contents, contents_tag, span_source) =
+                        let (file_extension, contents, contents_tag, anchor_location) =
                             crate::commands::open::fetch(
                                 &full_path,
                                 &location_clone,
@@ -77,9 +77,9 @@ impl PerItemCommand for Enter {
 
                         if contents_tag.anchor != uuid::Uuid::nil() {
                             // If we have loaded something, track its source
-                            yield ReturnSuccess::action(CommandAction::AddSpanSource(
+                            yield ReturnSuccess::action(CommandAction::AddAnchorLocation(
                                 contents_tag.anchor,
-                                span_source,
+                                anchor_location,
                             ));
                         }
 

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -76,10 +76,10 @@ fn run(
             file_extension.or(path_str.split('.').last().map(String::from))
         };
 
-        if contents_tag.origin != uuid::Uuid::nil() {
+        if contents_tag.anchor != uuid::Uuid::nil() {
             // If we have loaded something, track its source
             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                contents_tag.origin,
+                contents_tag.anchor,
                 span_source,
             ));
         }
@@ -158,7 +158,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Uuid::new_v4(),
+                            anchor: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -173,7 +173,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Uuid::new_v4(),
+                            anchor: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -190,7 +190,7 @@ pub async fn fetch(
                             Value::binary(buf),
                             Tag {
                                 span,
-                                origin: Uuid::new_v4(),
+                                anchor: Uuid::new_v4(),
                             },
                             SpanSource::Url(location.to_string()),
                         ))
@@ -206,7 +206,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Uuid::new_v4(),
+                            anchor: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -223,7 +223,7 @@ pub async fn fetch(
                             Value::binary(buf),
                             Tag {
                                 span,
-                                origin: Uuid::new_v4(),
+                                anchor: Uuid::new_v4(),
                             },
                             SpanSource::Url(location.to_string()),
                         ))
@@ -239,7 +239,7 @@ pub async fn fetch(
                         })?),
                         Tag {
                             span,
-                            origin: Uuid::new_v4(),
+                            anchor: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -266,7 +266,7 @@ pub async fn fetch(
                             })?),
                             Tag {
                                 span,
-                                origin: Uuid::new_v4(),
+                                anchor: Uuid::new_v4(),
                             },
                             SpanSource::Url(location.to_string()),
                         ))
@@ -276,7 +276,7 @@ pub async fn fetch(
                         Value::string(format!("Not yet supported MIME type: {} {}", ty, sub_ty)),
                         Tag {
                             span,
-                            origin: Uuid::new_v4(),
+                            anchor: Uuid::new_v4(),
                         },
                         SpanSource::Url(location.to_string()),
                     )),
@@ -287,7 +287,7 @@ pub async fn fetch(
                 Value::string(format!("No content type found")),
                 Tag {
                     span,
-                    origin: Uuid::new_v4(),
+                    anchor: Uuid::new_v4(),
                 },
                 SpanSource::Url(location.to_string()),
             )),

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -1,5 +1,5 @@
 use crate::commands::UnevaluatedCallInfo;
-use crate::context::SpanSource;
+use crate::context::AnchorLocation;
 use crate::data::meta::Span;
 use crate::data::Value;
 use crate::errors::ShellError;
@@ -67,7 +67,7 @@ fn run(
             yield Err(e);
             return;
         }
-        let (file_extension, contents, contents_tag, span_source) = result.unwrap();
+        let (file_extension, contents, contents_tag, anchor_location) = result.unwrap();
 
         let file_extension = if has_raw {
             None
@@ -79,9 +79,9 @@ fn run(
 
         if contents_tag.anchor != uuid::Uuid::nil() {
             // If we have loaded something, track its source
-            yield ReturnSuccess::action(CommandAction::AddSpanSource(
+            yield ReturnSuccess::action(CommandAction::AddAnchorLocation(
                 contents_tag.anchor,
-                span_source,
+                anchor_location,
             ));
         }
 
@@ -134,7 +134,7 @@ pub async fn fetch(
     cwd: &PathBuf,
     location: &str,
     span: Span,
-) -> Result<(Option<String>, Value, Tag, SpanSource), ShellError> {
+) -> Result<(Option<String>, Value, Tag, AnchorLocation), ShellError> {
     let mut cwd = cwd.clone();
 
     cwd.push(Path::new(location));
@@ -149,7 +149,7 @@ pub async fn fetch(
                         span,
                         anchor: Uuid::new_v4(),
                     },
-                    SpanSource::File(cwd.to_string_lossy().to_string()),
+                    AnchorLocation::File(cwd.to_string_lossy().to_string()),
                 )),
                 Err(_) => {
                     //Non utf8 data.
@@ -168,7 +168,7 @@ pub async fn fetch(
                                             span,
                                             anchor: Uuid::new_v4(),
                                         },
-                                        SpanSource::File(cwd.to_string_lossy().to_string()),
+                                        AnchorLocation::File(cwd.to_string_lossy().to_string()),
                                     )),
                                     Err(_) => Ok((
                                         None,
@@ -177,7 +177,7 @@ pub async fn fetch(
                                             span,
                                             anchor: Uuid::new_v4(),
                                         },
-                                        SpanSource::File(cwd.to_string_lossy().to_string()),
+                                        AnchorLocation::File(cwd.to_string_lossy().to_string()),
                                     )),
                                 }
                             } else {
@@ -188,7 +188,7 @@ pub async fn fetch(
                                         span,
                                         anchor: Uuid::new_v4(),
                                     },
-                                    SpanSource::File(cwd.to_string_lossy().to_string()),
+                                    AnchorLocation::File(cwd.to_string_lossy().to_string()),
                                 ))
                             }
                         }
@@ -206,7 +206,7 @@ pub async fn fetch(
                                             span,
                                             anchor: Uuid::new_v4(),
                                         },
-                                        SpanSource::File(cwd.to_string_lossy().to_string()),
+                                        AnchorLocation::File(cwd.to_string_lossy().to_string()),
                                     )),
                                     Err(_) => Ok((
                                         None,
@@ -215,7 +215,7 @@ pub async fn fetch(
                                             span,
                                             anchor: Uuid::new_v4(),
                                         },
-                                        SpanSource::File(cwd.to_string_lossy().to_string()),
+                                        AnchorLocation::File(cwd.to_string_lossy().to_string()),
                                     )),
                                 }
                             } else {
@@ -226,7 +226,7 @@ pub async fn fetch(
                                         span,
                                         anchor: Uuid::new_v4(),
                                     },
-                                    SpanSource::File(cwd.to_string_lossy().to_string()),
+                                    AnchorLocation::File(cwd.to_string_lossy().to_string()),
                                 ))
                             }
                         }
@@ -237,7 +237,7 @@ pub async fn fetch(
                                 span,
                                 anchor: Uuid::new_v4(),
                             },
-                            SpanSource::File(cwd.to_string_lossy().to_string()),
+                            AnchorLocation::File(cwd.to_string_lossy().to_string()),
                         )),
                     }
                 }

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -77,10 +77,10 @@ fn run(
             file_extension.or(path_str.split('.').last().map(String::from))
         };
 
-        if contents_tag.origin != uuid::Uuid::nil() {
+        if contents_tag.anchor != uuid::Uuid::nil() {
             // If we have loaded something, track its source
             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                contents_tag.origin,
+                contents_tag.anchor,
                 span_source,
             ));
         }
@@ -147,7 +147,7 @@ pub async fn fetch(
                     Value::string(s),
                     Tag {
                         span,
-                        origin: Uuid::new_v4(),
+                        anchor: Uuid::new_v4(),
                     },
                     SpanSource::File(cwd.to_string_lossy().to_string()),
                 )),
@@ -166,7 +166,7 @@ pub async fn fetch(
                                         Value::string(s),
                                         Tag {
                                             span,
-                                            origin: Uuid::new_v4(),
+                                            anchor: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -175,7 +175,7 @@ pub async fn fetch(
                                         Value::binary(bytes),
                                         Tag {
                                             span,
-                                            origin: Uuid::new_v4(),
+                                            anchor: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -186,7 +186,7 @@ pub async fn fetch(
                                     Value::binary(bytes),
                                     Tag {
                                         span,
-                                        origin: Uuid::new_v4(),
+                                        anchor: Uuid::new_v4(),
                                     },
                                     SpanSource::File(cwd.to_string_lossy().to_string()),
                                 ))
@@ -204,7 +204,7 @@ pub async fn fetch(
                                         Value::string(s),
                                         Tag {
                                             span,
-                                            origin: Uuid::new_v4(),
+                                            anchor: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -213,7 +213,7 @@ pub async fn fetch(
                                         Value::binary(bytes),
                                         Tag {
                                             span,
-                                            origin: Uuid::new_v4(),
+                                            anchor: Uuid::new_v4(),
                                         },
                                         SpanSource::File(cwd.to_string_lossy().to_string()),
                                     )),
@@ -224,7 +224,7 @@ pub async fn fetch(
                                     Value::binary(bytes),
                                     Tag {
                                         span,
-                                        origin: Uuid::new_v4(),
+                                        anchor: Uuid::new_v4(),
                                     },
                                     SpanSource::File(cwd.to_string_lossy().to_string()),
                                 ))
@@ -235,7 +235,7 @@ pub async fn fetch(
                             Value::binary(bytes),
                             Tag {
                                 span,
-                                origin: Uuid::new_v4(),
+                                anchor: Uuid::new_v4(),
                             },
                             SpanSource::File(cwd.to_string_lossy().to_string()),
                         )),

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -1,5 +1,5 @@
 use crate::commands::UnevaluatedCallInfo;
-use crate::context::SpanSource;
+use crate::context::AnchorLocation;
 use crate::data::Value;
 use crate::errors::ShellError;
 use crate::parser::hir::SyntaxShape;
@@ -74,7 +74,7 @@ fn run(
     let raw_args = raw_args.clone();
 
     let stream = async_stream! {
-        let (file_extension, contents, contents_tag, span_source) =
+        let (file_extension, contents, contents_tag, anchor_location) =
             post(&path_str, &body, user, password, path_span, &registry, &raw_args).await.unwrap();
 
         let file_extension = if has_raw {
@@ -87,9 +87,9 @@ fn run(
 
         if contents_tag.anchor != uuid::Uuid::nil() {
             // If we have loaded something, track its source
-            yield ReturnSuccess::action(CommandAction::AddSpanSource(
+            yield ReturnSuccess::action(CommandAction::AddAnchorLocation(
                 contents_tag.anchor,
-                span_source,
+                anchor_location,
             ));
         }
 
@@ -146,7 +146,7 @@ pub async fn post(
     tag: Tag,
     registry: &CommandRegistry,
     raw_args: &RawCommandArgs,
-) -> Result<(Option<String>, Value, Tag, SpanSource), ShellError> {
+) -> Result<(Option<String>, Value, Tag, AnchorLocation), ShellError> {
     let registry = registry.clone();
     let raw_args = raw_args.clone();
     if location.starts_with("http:") || location.starts_with("https:") {
@@ -248,7 +248,7 @@ pub async fn post(
                                 )
                             })?),
                             tag,
-                            SpanSource::Url(location.to_string()),
+                            AnchorLocation::Url(location.to_string()),
                         )),
                         (mime::APPLICATION, mime::JSON) => Ok((
                             Some("json".to_string()),
@@ -260,7 +260,7 @@ pub async fn post(
                                 )
                             })?),
                             tag,
-                            SpanSource::Url(location.to_string()),
+                            AnchorLocation::Url(location.to_string()),
                         )),
                         (mime::APPLICATION, mime::OCTET_STREAM) => {
                             let buf: Vec<u8> = r.body_bytes().await.map_err(|_| {
@@ -274,7 +274,7 @@ pub async fn post(
                                 None,
                                 Value::binary(buf),
                                 tag,
-                                SpanSource::Url(location.to_string()),
+                                AnchorLocation::Url(location.to_string()),
                             ))
                         }
                         (mime::IMAGE, image_ty) => {
@@ -289,7 +289,7 @@ pub async fn post(
                                 Some(image_ty.to_string()),
                                 Value::binary(buf),
                                 tag,
-                                SpanSource::Url(location.to_string()),
+                                AnchorLocation::Url(location.to_string()),
                             ))
                         }
                         (mime::TEXT, mime::HTML) => Ok((
@@ -302,7 +302,7 @@ pub async fn post(
                                 )
                             })?),
                             tag,
-                            SpanSource::Url(location.to_string()),
+                            AnchorLocation::Url(location.to_string()),
                         )),
                         (mime::TEXT, mime::PLAIN) => {
                             let path_extension = url::Url::parse(location)
@@ -326,7 +326,7 @@ pub async fn post(
                                     )
                                 })?),
                                 tag,
-                                SpanSource::Url(location.to_string()),
+                                AnchorLocation::Url(location.to_string()),
                             ))
                         }
                         (ty, sub_ty) => Ok((
@@ -336,7 +336,7 @@ pub async fn post(
                                 ty, sub_ty
                             )),
                             tag,
-                            SpanSource::Url(location.to_string()),
+                            AnchorLocation::Url(location.to_string()),
                         )),
                     }
                 }
@@ -344,7 +344,7 @@ pub async fn post(
                     None,
                     Value::string(format!("No content type found")),
                     tag,
-                    SpanSource::Url(location.to_string()),
+                    AnchorLocation::Url(location.to_string()),
                 )),
             },
             Err(_) => {

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -85,10 +85,10 @@ fn run(
             file_extension.or(path_str.split('.').last().map(String::from))
         };
 
-        if contents_tag.origin != uuid::Uuid::nil() {
+        if contents_tag.anchor != uuid::Uuid::nil() {
             // If we have loaded something, track its source
             yield ReturnSuccess::action(CommandAction::AddSpanSource(
-                contents_tag.origin,
+                contents_tag.anchor,
                 span_source,
             ));
         }

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -138,7 +138,7 @@ fn save(
                 let anchor = input[0].anchor();
                 match source_map.get(&anchor) {
                     Some(path) => match path {
-                        SpanSource::File(file) => {
+                        AnchorLocation::File(file) => {
                             full_path.push(Path::new(file));
                         }
                         _ => {

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -133,10 +133,10 @@ fn save(
     let stream = async_stream! {
         let input: Vec<Tagged<Value>> = input.values.collect().await;
         if path.is_none() {
-            // If there is no filename, check the metadata for the origin filename
+            // If there is no filename, check the metadata for the anchor filename
             if input.len() > 0 {
-                let origin = input[0].origin();
-                match source_map.get(&origin) {
+                let anchor = input[0].anchor();
+                match source_map.get(&anchor) {
                     Some(path) => match path {
                         SpanSource::File(file) => {
                             full_path.push(Path::new(file));

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -35,19 +35,19 @@ fn tags(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
         .map(move |v| {
             let mut tags = TaggedDictBuilder::new(v.tag());
             {
-                let origin = v.origin();
+                let anchor = v.anchor();
                 let span = v.tag().span;
                 let mut dict = TaggedDictBuilder::new(v.tag());
                 dict.insert("start", Value::int(span.start as i64));
                 dict.insert("end", Value::int(span.end as i64));
                 tags.insert_tagged("span", dict.into_tagged_value());
 
-                match source_map.get(&origin) {
+                match source_map.get(&anchor) {
                     Some(SpanSource::File(source)) => {
-                        tags.insert("origin", Value::string(source));
+                        tags.insert("anchor", Value::string(source));
                     }
                     Some(SpanSource::Url(source)) => {
-                        tags.insert("origin", Value::string(source));
+                        tags.insert("anchor", Value::string(source));
                     }
                     _ => {}
                 }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -43,10 +43,10 @@ fn tags(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
                 tags.insert_tagged("span", dict.into_tagged_value());
 
                 match source_map.get(&anchor) {
-                    Some(SpanSource::File(source)) => {
+                    Some(AnchorLocation::File(source)) => {
                         tags.insert("anchor", Value::string(source));
                     }
-                    Some(SpanSource::Url(source)) => {
+                    Some(AnchorLocation::Url(source)) => {
                         tags.insert("anchor", Value::string(source));
                     }
                     _ => {}

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,21 +11,21 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum SpanSource {
+pub enum AnchorLocation {
     Url(String),
     File(String),
     Source(Text),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SourceMap(HashMap<Uuid, SpanSource>);
+pub struct SourceMap(HashMap<Uuid, AnchorLocation>);
 
 impl SourceMap {
-    pub fn insert(&mut self, uuid: Uuid, span_source: SpanSource) {
-        self.0.insert(uuid, span_source);
+    pub fn insert(&mut self, uuid: Uuid, anchor_location: AnchorLocation) {
+        self.0.insert(uuid, anchor_location);
     }
 
-    pub fn get(&self, uuid: &Uuid) -> Option<&SpanSource> {
+    pub fn get(&self, uuid: &Uuid) -> Option<&AnchorLocation> {
         self.0.get(uuid)
     }
 
@@ -105,8 +105,8 @@ impl Context {
         }
     }
 
-    pub fn add_span_source(&mut self, uuid: Uuid, span_source: SpanSource) {
-        self.source_map.insert(uuid, span_source);
+    pub fn add_anchor_location(&mut self, uuid: Uuid, anchor_location: AnchorLocation) {
+        self.source_map.insert(uuid, anchor_location);
     }
 
     pub(crate) fn has_command(&self, name: &str) -> bool {

--- a/src/data/meta.rs
+++ b/src/data/meta.rs
@@ -1,4 +1,4 @@
-use crate::context::{SourceMap, SpanSource};
+use crate::context::{AnchorLocation, SourceMap};
 use crate::prelude::*;
 use crate::Text;
 use derive_new::new;
@@ -96,8 +96,8 @@ impl<T> Tagged<T> {
 
     pub fn anchor_name(&self, source_map: &SourceMap) -> Option<String> {
         match source_map.get(&self.tag.anchor) {
-            Some(SpanSource::File(file)) => Some(file.clone()),
-            Some(SpanSource::Url(url)) => Some(url.clone()),
+            Some(AnchorLocation::File(file)) => Some(file.clone()),
+            Some(AnchorLocation::Url(url)) => Some(url.clone()),
             _ => None,
         }
     }

--- a/src/data/meta.rs
+++ b/src/data/meta.rs
@@ -39,7 +39,7 @@ pub trait TaggedItem: Sized {
             self,
             Tag {
                 span: Span::unknown(),
-                origin: uuid::Uuid::nil(),
+                anchor: uuid::Uuid::nil(),
             },
         )
     }
@@ -90,12 +90,12 @@ impl<T> Tagged<T> {
         self.tag.span
     }
 
-    pub fn origin(&self) -> uuid::Uuid {
-        self.tag.origin
+    pub fn anchor(&self) -> uuid::Uuid {
+        self.tag.anchor
     }
 
-    pub fn origin_name(&self, source_map: &SourceMap) -> Option<String> {
-        match source_map.get(&self.tag.origin) {
+    pub fn anchor_name(&self, source_map: &SourceMap) -> Option<String> {
+        match source_map.get(&self.tag.anchor) {
             Some(SpanSource::File(file)) => Some(file.clone()),
             Some(SpanSource::Url(url)) => Some(url.clone()),
             _ => None,
@@ -167,14 +167,14 @@ impl From<&std::ops::Range<usize>> for Span {
     Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, Hash, Getters,
 )]
 pub struct Tag {
-    pub origin: Uuid,
+    pub anchor: Uuid,
     pub span: Span,
 }
 
 impl From<Span> for Tag {
     fn from(span: Span) -> Self {
         Tag {
-            origin: uuid::Uuid::nil(),
+            anchor: uuid::Uuid::nil(),
             span,
         }
     }
@@ -183,25 +183,25 @@ impl From<Span> for Tag {
 impl From<&Span> for Tag {
     fn from(span: &Span) -> Self {
         Tag {
-            origin: uuid::Uuid::nil(),
+            anchor: uuid::Uuid::nil(),
             span: *span,
         }
     }
 }
 
 impl From<(usize, usize, Uuid)> for Tag {
-    fn from((start, end, origin): (usize, usize, Uuid)) -> Self {
+    fn from((start, end, anchor): (usize, usize, Uuid)) -> Self {
         Tag {
-            origin,
+            anchor,
             span: Span { start, end },
         }
     }
 }
 
 impl From<(usize, usize, Option<Uuid>)> for Tag {
-    fn from((start, end, origin): (usize, usize, Option<Uuid>)) -> Self {
+    fn from((start, end, anchor): (usize, usize, Option<Uuid>)) -> Self {
         Tag {
-            origin: if let Some(uuid) = origin {
+            anchor: if let Some(uuid) = anchor {
                 uuid
             } else {
                 uuid::Uuid::nil()
@@ -214,7 +214,7 @@ impl From<(usize, usize, Option<Uuid>)> for Tag {
 impl From<nom_locate::LocatedSpanEx<&str, Uuid>> for Tag {
     fn from(input: nom_locate::LocatedSpanEx<&str, Uuid>) -> Tag {
         Tag {
-            origin: input.extra,
+            anchor: input.extra,
             span: Span {
                 start: input.offset,
                 end: input.offset + input.fragment.len(),
@@ -236,23 +236,23 @@ impl From<&Tag> for Span {
 }
 
 impl Tag {
-    pub fn unknown_origin(span: Span) -> Tag {
+    pub fn unknown_anchor(span: Span) -> Tag {
         Tag {
-            origin: uuid::Uuid::nil(),
+            anchor: uuid::Uuid::nil(),
             span,
         }
     }
 
-    pub fn unknown_span(origin: Uuid) -> Tag {
+    pub fn unknown_span(anchor: Uuid) -> Tag {
         Tag {
-            origin,
+            anchor,
             span: Span::unknown(),
         }
     }
 
     pub fn unknown() -> Tag {
         Tag {
-            origin: uuid::Uuid::nil(),
+            anchor: uuid::Uuid::nil(),
             span: Span::unknown(),
         }
     }
@@ -260,8 +260,8 @@ impl Tag {
     pub fn until(&self, other: impl Into<Tag>) -> Tag {
         let other = other.into();
         debug_assert!(
-            self.origin == other.origin,
-            "Can only merge two tags with the same origin"
+            self.anchor == other.anchor,
+            "Can only merge two tags with the same anchor"
         );
 
         Tag {
@@ -269,7 +269,7 @@ impl Tag {
                 start: self.span.start,
                 end: other.span.end,
             },
-            origin: self.origin,
+            anchor: self.anchor,
         }
     }
 
@@ -348,7 +348,7 @@ impl language_reporting::ReportingSpan for Tag {
                 start,
                 end: self.span.end,
             },
-            origin: self.origin,
+            anchor: self.anchor,
         }
     }
 
@@ -358,7 +358,7 @@ impl language_reporting::ReportingSpan for Tag {
                 start: self.span.start,
                 end,
             },
-            origin: self.origin,
+            anchor: self.anchor,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod traits;
 mod utils;
 
 pub use crate::commands::command::{CallInfo, ReturnSuccess, ReturnValue};
-pub use crate::context::{SourceMap, SpanSource};
+pub use crate::context::{AnchorLocation, SourceMap};
 pub use crate::env::host::BasicHost;
 pub use crate::parser::hir::SyntaxShape;
 pub use crate::parser::parse::token_tree_builder::TokenTreeBuilder;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,10 +21,10 @@ pub(crate) use parse::unit::Unit;
 pub(crate) use parse_command::parse_command;
 pub(crate) use registry::CommandRegistry;
 
-pub fn parse(input: &str, origin: uuid::Uuid) -> Result<TokenNode, ShellError> {
+pub fn parse(input: &str, anchor: uuid::Uuid) -> Result<TokenNode, ShellError> {
     let _ = pretty_env_logger::try_init();
 
-    match pipeline(nom_input(input, origin)) {
+    match pipeline(nom_input(input, anchor)) {
         Ok((_rest, val)) => Ok(val),
         Err(err) => Err(ShellError::parse_error(err)),
     }

--- a/src/parser/parse/files.rs
+++ b/src/parser/parse/files.rs
@@ -22,7 +22,7 @@ impl language_reporting::ReportingFiles for Files {
     }
 
     fn file_id(&self, tag: Self::Span) -> Self::FileId {
-        tag.origin
+        tag.anchor
     }
 
     fn file_name(&self, _file: Self::FileId) -> FileName {

--- a/src/parser/parse/parser.rs
+++ b/src/parser/parse/parser.rs
@@ -26,8 +26,8 @@ use uuid::Uuid;
 
 pub type NomSpan<'a> = LocatedSpanEx<&'a str, Uuid>;
 
-pub fn nom_input(s: &str, origin: Uuid) -> NomSpan<'_> {
-    LocatedSpanEx::new_extra(s, origin)
+pub fn nom_input(s: &str, anchor: Uuid) -> NomSpan<'_> {
+    LocatedSpanEx::new_extra(s, anchor)
 }
 
 macro_rules! operator {
@@ -149,7 +149,7 @@ impl Into<Number> for BigDecimal {
 }
 
 pub fn raw_number(input: NomSpan) -> IResult<NomSpan, Tagged<RawNumber>> {
-    let original = input;
+    let anchoral = input;
     let start = input.offset;
     trace_step(input, "raw_decimal", move |input| {
         let (input, neg) = opt(tag("-"))(input)?;
@@ -1308,7 +1308,7 @@ mod tests {
         right: usize,
     ) -> TokenNode {
         let node = DelimitedNode::new(*delimiter, children);
-        let spanned = node.tagged((left, right, delimiter.tag.origin));
+        let spanned = node.tagged((left, right, delimiter.tag.anchor));
         TokenNode::Delimited(spanned)
     }
 
@@ -1319,7 +1319,7 @@ mod tests {
             Box::new(head),
             tail.into_iter().map(TokenNode::Token).collect(),
         );
-        let spanned = node.tagged((left, right, tag.origin));
+        let spanned = node.tagged((left, right, tag.anchor));
         TokenNode::Path(spanned)
     }
 

--- a/src/parser/parse/token_tree_builder.rs
+++ b/src/parser/parse/token_tree_builder.rs
@@ -18,15 +18,15 @@ pub struct TokenTreeBuilder {
     #[new(default)]
     output: String,
 
-    origin: Uuid,
+    anchor: Uuid,
 }
 
 pub type CurriedToken = Box<dyn FnOnce(&mut TokenTreeBuilder) -> TokenNode + 'static>;
 pub type CurriedCall = Box<dyn FnOnce(&mut TokenTreeBuilder) -> Tagged<CallNode> + 'static>;
 
 impl TokenTreeBuilder {
-    pub fn build(origin: Uuid, block: impl FnOnce(&mut Self) -> TokenNode) -> (TokenNode, String) {
-        let mut builder = TokenTreeBuilder::new(origin);
+    pub fn build(anchor: Uuid, block: impl FnOnce(&mut Self) -> TokenNode) -> (TokenNode, String) {
+        let mut builder = TokenTreeBuilder::new(anchor);
         let node = block(&mut builder);
         (node, builder.output)
     }
@@ -76,7 +76,7 @@ impl TokenTreeBuilder {
 
             let end = b.pos;
 
-            TokenTreeBuilder::tagged_pipeline((out, None), (start, end, b.origin))
+            TokenTreeBuilder::tagged_pipeline((out, None), (start, end, b.anchor))
         })
     }
 
@@ -95,7 +95,7 @@ impl TokenTreeBuilder {
 
             b.pos = end;
 
-            TokenTreeBuilder::tagged_op(input, (start, end, b.origin))
+            TokenTreeBuilder::tagged_op(input, (start, end, b.anchor))
         })
     }
 
@@ -113,8 +113,8 @@ impl TokenTreeBuilder {
             b.pos = end;
 
             TokenTreeBuilder::tagged_string(
-                (inner_start, inner_end, b.origin),
-                (start, end, b.origin),
+                (inner_start, inner_end, b.anchor),
+                (start, end, b.anchor),
             )
         })
     }
@@ -130,7 +130,7 @@ impl TokenTreeBuilder {
             let (start, end) = b.consume(&input);
             b.pos = end;
 
-            TokenTreeBuilder::tagged_bare((start, end, b.origin))
+            TokenTreeBuilder::tagged_bare((start, end, b.anchor))
         })
     }
 
@@ -145,7 +145,7 @@ impl TokenTreeBuilder {
             let (start, end) = b.consume(&input);
             b.pos = end;
 
-            TokenTreeBuilder::tagged_pattern((start, end, b.origin))
+            TokenTreeBuilder::tagged_pattern((start, end, b.anchor))
         })
     }
 
@@ -160,7 +160,7 @@ impl TokenTreeBuilder {
             let (start, end) = b.consume(&input);
             b.pos = end;
 
-            TokenTreeBuilder::tagged_external_word((start, end, b.origin))
+            TokenTreeBuilder::tagged_external_word((start, end, b.anchor))
         })
     }
 
@@ -180,8 +180,8 @@ impl TokenTreeBuilder {
             b.pos = end;
 
             TokenTreeBuilder::tagged_number(
-                RawNumber::Int((start, end, b.origin).into()),
-                (start, end, b.origin),
+                RawNumber::Int((start, end, b.anchor).into()),
+                (start, end, b.anchor),
             )
         })
     }
@@ -194,8 +194,8 @@ impl TokenTreeBuilder {
             b.pos = end;
 
             TokenTreeBuilder::tagged_number(
-                RawNumber::Decimal((start, end, b.origin).into()),
-                (start, end, b.origin),
+                RawNumber::Decimal((start, end, b.anchor).into()),
+                (start, end, b.anchor),
             )
         })
     }
@@ -214,8 +214,8 @@ impl TokenTreeBuilder {
             b.pos = end_unit;
 
             TokenTreeBuilder::tagged_size(
-                (RawNumber::Int((start_int, end_int, b.origin).into()), unit),
-                (start_int, end_unit, b.origin),
+                (RawNumber::Int((start_int, end_int, b.anchor).into()), unit),
+                (start_int, end_unit, b.anchor),
             )
         })
     }
@@ -244,7 +244,7 @@ impl TokenTreeBuilder {
 
             let end = b.pos;
 
-            TokenTreeBuilder::tagged_path((head, output), (start, end, b.origin))
+            TokenTreeBuilder::tagged_path((head, output), (start, end, b.anchor))
         })
     }
 
@@ -259,7 +259,7 @@ impl TokenTreeBuilder {
             let (start, _) = b.consume("$");
             let (inner_start, end) = b.consume(&input);
 
-            TokenTreeBuilder::tagged_var((inner_start, end, b.origin), (start, end, b.origin))
+            TokenTreeBuilder::tagged_var((inner_start, end, b.anchor), (start, end, b.anchor))
         })
     }
 
@@ -274,7 +274,7 @@ impl TokenTreeBuilder {
             let (start, _) = b.consume("--");
             let (inner_start, end) = b.consume(&input);
 
-            TokenTreeBuilder::tagged_flag((inner_start, end, b.origin), (start, end, b.origin))
+            TokenTreeBuilder::tagged_flag((inner_start, end, b.anchor), (start, end, b.anchor))
         })
     }
 
@@ -289,7 +289,7 @@ impl TokenTreeBuilder {
             let (start, _) = b.consume("-");
             let (inner_start, end) = b.consume(&input);
 
-            TokenTreeBuilder::tagged_shorthand((inner_start, end, b.origin), (start, end, b.origin))
+            TokenTreeBuilder::tagged_shorthand((inner_start, end, b.anchor), (start, end, b.anchor))
         })
     }
 
@@ -302,7 +302,7 @@ impl TokenTreeBuilder {
 
         Box::new(move |b| {
             let (start, end) = b.consume(&input);
-            TokenTreeBuilder::tagged_member((start, end, b.origin))
+            TokenTreeBuilder::tagged_member((start, end, b.anchor))
         })
     }
 
@@ -323,7 +323,7 @@ impl TokenTreeBuilder {
 
             let end = b.pos;
 
-            TokenTreeBuilder::tagged_call(nodes, (start, end, b.origin))
+            TokenTreeBuilder::tagged_call(nodes, (start, end, b.anchor))
         })
     }
 
@@ -350,7 +350,7 @@ impl TokenTreeBuilder {
 
             let (_, end) = b.consume(")");
 
-            TokenTreeBuilder::tagged_parens(output, (start, end, b.origin))
+            TokenTreeBuilder::tagged_parens(output, (start, end, b.anchor))
         })
     }
 
@@ -368,7 +368,7 @@ impl TokenTreeBuilder {
 
             let (_, end) = b.consume("]");
 
-            TokenTreeBuilder::tagged_square(output, (start, end, b.origin))
+            TokenTreeBuilder::tagged_square(output, (start, end, b.anchor))
         })
     }
 
@@ -386,7 +386,7 @@ impl TokenTreeBuilder {
 
             let (_, end) = b.consume(" }");
 
-            TokenTreeBuilder::tagged_brace(output, (start, end, b.origin))
+            TokenTreeBuilder::tagged_brace(output, (start, end, b.anchor))
         })
     }
 
@@ -397,7 +397,7 @@ impl TokenTreeBuilder {
     pub fn sp() -> CurriedToken {
         Box::new(|b| {
             let (start, end) = b.consume(" ");
-            TokenNode::Whitespace(Tag::from((start, end, b.origin)))
+            TokenNode::Whitespace(Tag::from((start, end, b.anchor)))
         })
     }
 
@@ -406,7 +406,7 @@ impl TokenTreeBuilder {
 
         Box::new(move |b| {
             let (start, end) = b.consume(&input);
-            TokenTreeBuilder::tagged_ws((start, end, b.origin))
+            TokenTreeBuilder::tagged_ws((start, end, b.anchor))
         })
     }
 
@@ -425,6 +425,6 @@ impl TokenTreeBuilder {
         let start = self.pos;
         self.pos += input.len();
         self.output.push_str(input);
-        (start, self.pos, self.origin).into()
+        (start, self.pos, self.anchor).into()
     }
 }

--- a/src/plugins/binaryview.rs
+++ b/src/plugins/binaryview.rs
@@ -21,10 +21,10 @@ impl Plugin for BinaryView {
 
     fn sink(&mut self, call_info: CallInfo, input: Vec<Tagged<Value>>) {
         for v in input {
-            let value_origin = v.origin();
+            let value_anchor = v.anchor();
             match v.item {
                 Value::Primitive(Primitive::Binary(b)) => {
-                    let source = call_info.source_map.get(&value_origin);
+                    let source = call_info.source_map.get(&value_anchor);
                     let _ = view_binary(&b, source, call_info.args.has("lores"));
                 }
                 _ => {}

--- a/src/plugins/binaryview.rs
+++ b/src/plugins/binaryview.rs
@@ -1,6 +1,6 @@
 use crossterm::{cursor, terminal, Attribute, RawScreen};
 use nu::{
-    serve_plugin, CallInfo, Plugin, Primitive, ShellError, Signature, SpanSource, Tagged, Value,
+    serve_plugin, AnchorLocation, CallInfo, Plugin, Primitive, ShellError, Signature, Tagged, Value,
 };
 use pretty_hex::*;
 
@@ -35,7 +35,7 @@ impl Plugin for BinaryView {
 
 fn view_binary(
     b: &[u8],
-    source: Option<&SpanSource>,
+    source: Option<&AnchorLocation>,
     lores_mode: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if b.len() > 3 {
@@ -254,7 +254,7 @@ fn load_from_jpg_buffer(buffer: &[u8]) -> Option<(RawImageBuffer)> {
 
 pub fn view_contents(
     buffer: &[u8],
-    _source: Option<&SpanSource>,
+    _source: Option<&AnchorLocation>,
     lores_mode: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut raw_image_buffer = load_from_png_buffer(buffer);
@@ -341,12 +341,12 @@ pub fn view_contents(
 #[cfg(feature = "rawkey")]
 pub fn view_contents_interactive(
     buffer: &[u8],
-    source: Option<&SpanSource>,
+    source: Option<&AnchorLocation>,
     lores_mode: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use rawkey::{KeyCode, RawKey};
 
-    let sav_path = if let Some(SpanSource::File(f)) = source {
+    let sav_path = if let Some(AnchorLocation::File(f)) = source {
         let mut path = std::path::PathBuf::from(f);
         path.set_extension("sav");
         Some(path)

--- a/src/plugins/inc.rs
+++ b/src/plugins/inc.rs
@@ -186,15 +186,15 @@ mod tests {
     };
 
     struct CallStub {
-        origin: uuid::Uuid,
+        anchor: uuid::Uuid,
         positionals: Vec<Tagged<Value>>,
         flags: IndexMap<String, Tagged<Value>>,
     }
 
     impl CallStub {
-        fn new(origin: uuid::Uuid) -> CallStub {
+        fn new(anchor: uuid::Uuid) -> CallStub {
             CallStub {
-                origin,
+                anchor,
                 positionals: vec![],
                 flags: indexmap::IndexMap::new(),
             }
@@ -210,7 +210,7 @@ mod tests {
 
         fn with_parameter(&mut self, name: &str) -> &mut Self {
             self.positionals
-                .push(Value::string(name.to_string()).tagged(Tag::unknown_span(self.origin)));
+                .push(Value::string(name.to_string()).tagged(Tag::unknown_span(self.anchor)));
             self
         }
 
@@ -218,7 +218,7 @@ mod tests {
             CallInfo {
                 args: EvaluatedArgs::new(Some(self.positionals.clone()), Some(self.flags.clone())),
                 source_map: SourceMap::new(),
-                name_tag: Tag::unknown_span(self.origin),
+                name_tag: Tag::unknown_span(self.anchor),
             }
         }
     }

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -204,7 +204,7 @@ mod tests {
     use num_bigint::BigInt;
 
     struct CallStub {
-        origin: uuid::Uuid,
+        anchor: uuid::Uuid,
         positionals: Vec<Tagged<Value>>,
         flags: IndexMap<String, Tagged<Value>>,
     }
@@ -212,7 +212,7 @@ mod tests {
     impl CallStub {
         fn new() -> CallStub {
             CallStub {
-                origin: uuid::Uuid::nil(),
+                anchor: uuid::Uuid::nil(),
                 positionals: vec![],
                 flags: indexmap::IndexMap::new(),
             }
@@ -236,7 +236,7 @@ mod tests {
             CallInfo {
                 args: EvaluatedArgs::new(Some(self.positionals.clone()), Some(self.flags.clone())),
                 source_map: SourceMap::new(),
-                name_tag: Tag::unknown_span(self.origin),
+                name_tag: Tag::unknown_span(self.anchor),
             }
         }
     }

--- a/src/plugins/textview.rs
+++ b/src/plugins/textview.rs
@@ -1,7 +1,7 @@
 use crossterm::{cursor, terminal, RawScreen};
 use crossterm::{InputEvent, KeyEvent};
 use nu::{
-    serve_plugin, CallInfo, Plugin, Primitive, ShellError, Signature, SourceMap, SpanSource,
+    serve_plugin, AnchorLocation, CallInfo, Plugin, Primitive, ShellError, Signature, SourceMap,
     Tagged, Value,
 };
 
@@ -223,11 +223,11 @@ fn view_text_value(value: &Tagged<Value>, source_map: &SourceMap) {
 
             if let Some(source) = source {
                 let extension: Option<String> = match source {
-                    SpanSource::File(file) => {
+                    AnchorLocation::File(file) => {
                         let path = Path::new(file);
                         path.extension().map(|x| x.to_string_lossy().to_string())
                     }
-                    SpanSource::Url(url) => {
+                    AnchorLocation::Url(url) => {
                         let url = url::Url::parse(url);
                         if let Ok(url) = url {
                             let url = url.clone();
@@ -246,7 +246,7 @@ fn view_text_value(value: &Tagged<Value>, source_map: &SourceMap) {
                         }
                     }
                     //FIXME: this probably isn't correct
-                    SpanSource::Source(_source) => None,
+                    AnchorLocation::Source(_source) => None,
                 };
 
                 match extension {

--- a/src/plugins/textview.rs
+++ b/src/plugins/textview.rs
@@ -216,10 +216,10 @@ fn scroll_view(s: &str) {
 }
 
 fn view_text_value(value: &Tagged<Value>, source_map: &SourceMap) {
-    let value_origin = value.origin();
+    let value_anchor = value.anchor();
     match value.item {
         Value::Primitive(Primitive::String(ref s)) => {
-            let source = source_map.get(&value_origin);
+            let source = source_map.get(&value_anchor);
 
             if let Some(source) = source {
                 let extension: Option<String> = match source {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -54,7 +54,7 @@ pub(crate) use crate::commands::command::{
 pub(crate) use crate::commands::PerItemCommand;
 pub(crate) use crate::commands::RawCommandArgs;
 pub(crate) use crate::context::CommandRegistry;
-pub(crate) use crate::context::{Context, SpanSource};
+pub(crate) use crate::context::{AnchorLocation, Context};
 pub(crate) use crate::data::base as value;
 pub(crate) use crate::data::meta::{Tag, Tagged, TaggedItem};
 pub(crate) use crate::data::types::ExtractType;

--- a/src/shell/help_shell.rs
+++ b/src/shell/help_shell.rs
@@ -99,10 +99,10 @@ impl HelpShell {
 
 impl Shell for HelpShell {
     fn name(&self, source_map: &SourceMap) -> String {
-        let origin_name = self.value.origin_name(source_map);
+        let anchor_name = self.value.anchor_name(source_map);
         format!(
             "{}",
-            match origin_name {
+            match anchor_name {
                 Some(x) => format!("{{{}}}", x),
                 None => format!("<{}>", self.value.item.type_name(),),
             }

--- a/src/shell/value_shell.rs
+++ b/src/shell/value_shell.rs
@@ -73,10 +73,10 @@ impl ValueShell {
 
 impl Shell for ValueShell {
     fn name(&self, source_map: &SourceMap) -> String {
-        let origin_name = self.value.origin_name(source_map);
+        let anchor_name = self.value.anchor_name(source_map);
         format!(
             "{}",
-            match origin_name {
+            match anchor_name {
                 Some(x) => format!("{{{}}}", x),
                 None => format!("<{}>", self.value.item.type_name(),),
             }


### PR DESCRIPTION
To help readability, rename the metadata element meant to denote "the file/url this value was loaded from" to `Anchor` and the corresponding data value to `AnchorLocation`.