### PR TITLE
to-json and to-toml output with pretty formatter in default

### DIFF
--- a/src/commands/to_json.rs
+++ b/src/commands/to_json.rs
@@ -96,7 +96,7 @@ fn to_json(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
         for value in to_process_input {
             match value_to_json_value(&value) {
                 Ok(json_value) => {
-                    match serde_json::to_string(&json_value) {
+                    match serde_json::to_string_pretty(&json_value) {
                         Ok(x) => yield ReturnSuccess::value(
                             Value::Primitive(Primitive::String(x)).tagged(name_tag),
                         ),

--- a/src/commands/to_toml.rs
+++ b/src/commands/to_toml.rs
@@ -91,7 +91,7 @@ fn to_toml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
         for value in to_process_input {
             match value_to_toml_value(&value) {
                 Ok(toml_value) => {
-                    match toml::to_string(&toml_value) {
+                    match toml::to_string_pretty(&toml_value) {
                         Ok(x) => yield ReturnSuccess::value(
                             Value::Primitive(Primitive::String(x)).tagged(name_tag),
                         ),


### PR DESCRIPTION
Maybe a new `to-json-pretty` is needed?