### PR TITLE
Don't run nu at end of release build

### DIFF
--- a/docker/Dockerfile.nu-base
+++ b/docker/Dockerfile.nu-base
@@ -17,7 +17,7 @@ ENV PATH=/root/.cargo/bin:$PATH
 COPY . /code
 RUN echo "##vso[task.prependpath]/root/.cargo/bin" && \
     rustc -Vv && \
-    if $RELEASE; then cargo build --release && cargo run --release; \
+    if $RELEASE; then cargo build --release; \
                    cp target/release/nu /usr/local/bin; \   
                  else cargo build; \
                    cp target/debug/nu /usr/local/bin; fi;


### PR DESCRIPTION
This pull request will fix the nightly build so that it doesn't run infinitely do to running nu after we build the release. The fix is to remove the `cargo run --release`, which I saw documented somewhere to optimize a docker build, and I can't find again at the moment.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>