### PR TITLE
remove trailing newline after external command

### DIFF
--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -302,7 +302,6 @@ impl ExternalCommand {
                         }
                     }
                 }
-                println!("");
                 Ok(ClassifiedInputStream::new())
             }
             StreamNext::External => {


### PR DESCRIPTION
external commands shouldn't print additional newlines.
with this change `echo "text"` behaves the same as `^echo "text"`