### PR TITLE
Fixed last command crash

### DIFF
--- a/src/commands/last.rs
+++ b/src/commands/last.rs
@@ -38,10 +38,13 @@ fn last(
 ) -> Result<OutputStream, ShellError> {
     let stream = async_stream! {
         let v: Vec<_> = context.input.into_vec().await;
-        let k = v.len() - (*amount as usize);
-        for x in v[k..].iter() {
-            let y: Tagged<Value> = x.clone();
-            yield ReturnSuccess::value(y)
+        let count = (*amount as usize);
+        if count < v.len() {
+            let k = v.len() - count;
+            for x in v[k..].iter() {
+                let y: Tagged<Value> = x.clone();
+                yield ReturnSuccess::value(y)
+            }
         }
     };
     Ok(stream.to_output_stream())


### PR DESCRIPTION
When the last command has an input value larger than the data its
operating on it would crash.  Added a check to ensure there are enough
elements to take.  This is to address #718.