### PR TITLE
add regex match plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,6 +1561,7 @@ dependencies = [
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ptree 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rawkey 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "roxmltree 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ bigdecimal = { version = "0.1.0", features = ["serde"] }
 natural = "0.3.0"
 serde_urlencoded = "0.6.1"
 sublime_fuzzy = "0.5"
+regex = "1"
 
 neso = { version = "0.5.0", optional = true }
 crossterm = { version = "0.10.2", optional = true }
@@ -133,6 +134,10 @@ path = "src/plugins/str.rs"
 [[bin]]
 name = "nu_plugin_skip"
 path = "src/plugins/skip.rs"
+
+[[bin]]
+name = "nu_plugin_match"
+path = "src/plugins/match.rs"
 
 [[bin]]
 name = "nu_plugin_sys"

--- a/src/plugins/match.rs
+++ b/src/plugins/match.rs
@@ -1,0 +1,100 @@
+use nu::{
+    serve_plugin, CallInfo, CoerceInto, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError,
+    Signature, SyntaxShape, Tagged, TaggedItem, Value, EvaluatedArgs,
+};
+use indexmap::IndexMap;
+use regex::Regex;
+
+struct Match {
+    column: String,
+    regex: Regex,
+}
+
+impl Match {
+    fn new() -> Self {
+        Match { 
+            column: String::new(), 
+            regex: Regex::new("").unwrap(),
+        }
+    }
+}
+
+impl Plugin for Match {
+    fn config(&mut self) -> Result<Signature, ShellError> {
+        Ok(Signature::build("match")
+            .desc("filter rows by regex")
+            .required("member", SyntaxShape::Member)
+            .required("regex", SyntaxShape::String)
+            .filter())
+    }
+    fn begin_filter(&mut self, call_info: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
+        if let Some(args) = call_info.args.positional {
+            match &args[0] {
+                Tagged {
+                    item: Value::Primitive(Primitive::String(s)),
+                    ..
+                } => {
+                    self.column = s.clone();
+                }
+                _ => {
+                    return Err(ShellError::string(format!(
+                        "Unrecognized type in params: {:?}", args[0])));
+                }
+            }
+            match &args[1] {
+                Tagged {
+                    item: Value::Primitive(Primitive::String(s)),
+                    ..
+                } => {
+                    self.regex = Regex::new(s).unwrap();
+                }
+                _ => {
+                     return Err(ShellError::string(format!(
+                        "Unrecognized type in params: {:?}", args[0])));
+                }
+            }
+        }
+        Ok(vec![])
+    }
+
+    fn filter(&mut self, input: Tagged<Value>) -> Result<Vec<ReturnValue>, ShellError> {
+        let flag: bool;
+        match &input {
+            Tagged {
+                item: Value::Row(dict),
+                ..
+            } => {
+                if let Some(val) = dict.entries.get(&self.column) {
+                    match val {
+                        Tagged {
+                            item: Value::Primitive(Primitive::String(s)),
+                            ..
+                        } => {
+                            flag = self.regex.is_match(s);
+                        }
+                        _ => {
+                            return Err(ShellError::string(format!(
+                                "value is not a string! {:?}", &val)));
+                        }
+                    }
+                } else {
+                    return Err(ShellError::string(format!(
+                        "column not in row! {:?} {:?}", &self.column, dict)));
+                }
+            }
+            _ => {
+                return Err(ShellError::string(format!(
+                    "Not a row! {:?}", &input)));
+            }
+        }
+        if flag {
+            Ok(vec![Ok(ReturnSuccess::Value(input))]) 
+        } else {
+            Ok(vec![])
+        }
+    }
+}
+
+fn main() {
+    serve_plugin(&mut Match::new());
+}

--- a/src/plugins/match.rs
+++ b/src/plugins/match.rs
@@ -1,8 +1,7 @@
 use nu::{
-    serve_plugin, CallInfo, CoerceInto, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError,
-    Signature, SyntaxShape, Tagged, TaggedItem, Value, EvaluatedArgs,
+    serve_plugin, CallInfo, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError,
+    Signature, SyntaxShape, Tagged, Value, 
 };
-use indexmap::IndexMap;
 use regex::Regex;
 
 struct Match {

--- a/src/plugins/match.rs
+++ b/src/plugins/match.rs
@@ -52,7 +52,7 @@ impl Plugin for Match {
                 _ => {
                     return Err(ShellError::string(format!(
                         "Unrecognized type in params: {:?}",
-                        args[0]
+                        args[1]
                     )));
                 }
             }

--- a/src/plugins/match.rs
+++ b/src/plugins/match.rs
@@ -1,6 +1,6 @@
 use nu::{
-    serve_plugin, CallInfo, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError,
-    Signature, SyntaxShape, Tagged, Value, 
+    serve_plugin, CallInfo, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError, Signature,
+    SyntaxShape, Tagged, Value,
 };
 use regex::Regex;
 
@@ -11,8 +11,8 @@ struct Match {
 
 impl Match {
     fn new() -> Self {
-        Match { 
-            column: String::new(), 
+        Match {
+            column: String::new(),
             regex: Regex::new("").unwrap(),
         }
     }
@@ -37,7 +37,9 @@ impl Plugin for Match {
                 }
                 _ => {
                     return Err(ShellError::string(format!(
-                        "Unrecognized type in params: {:?}", args[0])));
+                        "Unrecognized type in params: {:?}",
+                        args[0]
+                    )));
                 }
             }
             match &args[1] {
@@ -48,8 +50,10 @@ impl Plugin for Match {
                     self.regex = Regex::new(s).unwrap();
                 }
                 _ => {
-                     return Err(ShellError::string(format!(
-                        "Unrecognized type in params: {:?}", args[0])));
+                    return Err(ShellError::string(format!(
+                        "Unrecognized type in params: {:?}",
+                        args[0]
+                    )));
                 }
             }
         }
@@ -73,21 +77,24 @@ impl Plugin for Match {
                         }
                         _ => {
                             return Err(ShellError::string(format!(
-                                "value is not a string! {:?}", &val)));
+                                "value is not a string! {:?}",
+                                &val
+                            )));
                         }
                     }
                 } else {
                     return Err(ShellError::string(format!(
-                        "column not in row! {:?} {:?}", &self.column, dict)));
+                        "column not in row! {:?} {:?}",
+                        &self.column, dict
+                    )));
                 }
             }
             _ => {
-                return Err(ShellError::string(format!(
-                    "Not a row! {:?}", &input)));
+                return Err(ShellError::string(format!("Not a row! {:?}", &input)));
             }
         }
         if flag {
-            Ok(vec![Ok(ReturnSuccess::Value(input))]) 
+            Ok(vec![Ok(ReturnSuccess::Value(input))])
         } else {
             Ok(vec![])
         }


### PR DESCRIPTION
This is a simple plugin that filters a table with a regular expression. It requires two arguments. The column of the string that should match and the regex itself. 
Example usage:
   Return all hidden files in current directory:
   `ls | match name "^\."`  

The implenetation fails when it encounters a row where no column/string pair is present. Alternatively it could drop the row silently.

**Advantages:**
- Few code changes
- Regex matching

**Disadvantages**
- Additional dependency on the `regex` crate
- Can only match on Primitive Strings
- Can't match on nested tables
- Copies the data because of the Plugin ipc

Personally I think regex matching should be a full fletched command. That way it could interact with all the other thinks that are already possible or will be possible in the future. (easy negation, boolean and, boolean or etc.), but this is a quick and easy solution that would cover the basic usecases for now.