### PR TITLE
Attempt at fixing `get` command panic.

### DIFF
--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -73,21 +73,20 @@ fn get_member(path: &Tagged<String>, obj: &Tagged<Value>) -> Result<Tagged<Value
         }
     }
 
-    match obj {
-        Tagged {
-            item: Value::Primitive(Primitive::String(_)),
-            ..
-        } => current = Some(obj),
-        Tagged {
-            item: Value::Primitive(Primitive::Path(_)),
-            ..
-        } => current = Some(obj),
-        _ => {}
-    };
-
     match current {
         Some(v) => Ok(v.clone()),
-        None => Ok(Value::nothing().tagged(obj.tag)),
+        None => match obj {
+            // If its None check for certain values.
+            Tagged {
+                item: Value::Primitive(Primitive::String(_)),
+                ..
+            } => Ok(obj.clone()),
+            Tagged {
+                item: Value::Primitive(Primitive::Path(_)),
+                ..
+            } => Ok(obj.clone()),
+            _ => Ok(Value::nothing().tagged(obj.tag)),
+        },
     }
 }
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -58,17 +58,32 @@ fn get_member(path: &Tagged<String>, obj: &Tagged<Value>) -> Result<Tagged<Value
 
                             possible_matches.sort();
 
-                            return Err(ShellError::labeled_error(
-                                "Unknown column",
-                                format!("did you mean '{}'?", possible_matches[0].1),
-                                path.tag(),
-                            ));
+                            if possible_matches.len() > 0 {
+                                return Err(ShellError::labeled_error(
+                                    "Unknown column",
+                                    format!("did you mean '{}'?", possible_matches[0].1),
+                                    path.tag(),
+                                ));
+                            }
+                            None
                         }
                     }
                 }
             }
         }
     }
+
+    match obj {
+        Tagged {
+            item: Value::Primitive(Primitive::String(_)),
+            ..
+        } => current = Some(obj),
+        Tagged {
+            item: Value::Primitive(Primitive::Path(_)),
+            ..
+        } => current = Some(obj),
+        _ => {}
+    };
 
     match current {
         Some(v) => Ok(v.clone()),


### PR DESCRIPTION
If possible matches are not found then check if the passed in `obj` parameter is a `string` or a `path`, if so then return it.  I am not sure this is the right fix, but I figured I would make an attempt and get a conversation started about it. This PR is to address #707. 