### PR TITLE
Added docs for most of the to-sth commands

### DIFF
--- a/docs/commands/to-csv.md
+++ b/docs/commands/to-csv.md
@@ -19,3 +19,62 @@ X,filesystem,/home/shaurya
  ,filesystem,/home/shaurya/Pictures
  ,filesystem,/home/shaurya/Desktop
 ```
+
+```shell
+> open caco3_plastics.csv
+━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━━━
+ # │ importer     │ shipper      │ tariff_item │ name         │ origin   │ shipped_at │ arrived_at │ net_weight │ fob_price │ cif_price │ cif_per_net_ 
+   │              │              │             │              │          │            │            │            │           │           │ weight 
+───┼──────────────┼──────────────┼─────────────┼──────────────┼──────────┼────────────┼────────────┼────────────┼───────────┼───────────┼──────────────
+ 0 │ PLASTICOS    │ S A REVERTE  │ 2509000000  │ CARBONATO DE │ SPAIN    │ 18/03/2016 │ 17/04/2016 │ 81,000.00  │ 14,417.58 │ 18,252.34 │ 0.23 
+   │ RIVAL CIA    │              │             │ CALCIO TIPO  │          │            │            │            │           │           │  
+   │ LTDA         │              │             │ CALCIPORE    │          │            │            │            │           │           │  
+   │              │              │             │ 160 T AL     │          │            │            │            │           │           │  
+ 1 │ MEXICHEM     │ OMYA ANDINA  │ 2836500000  │ CARBONATO    │ COLOMBIA │ 07/07/2016 │ 10/07/2016 │ 26,000.00  │ 7,072.00  │ 8,127.18  │ 0.31 
+   │ ECUADOR S.A. │ S A          │             │              │          │            │            │            │           │           │  
+ 2 │ PLASTIAZUAY  │ SA REVERTE   │ 2836500000  │ CARBONATO DE │ SPAIN    │ 27/07/2016 │ 09/08/2016 │ 81,000.00  │ 8,100.00  │ 11,474.55 │ 0.14 
+   │ SA           │              │             │ CALCIO       │          │            │            │            │           │           │  
+ 3 │ PLASTICOS    │ AND          │ 2836500000  │ CALCIUM      │ TURKEY   │ 04/10/2016 │ 11/11/2016 │ 100,000.00 │ 17,500.00 │ 22,533.75 │ 0.23 
+   │ RIVAL CIA    │ ENDUSTRIYEL  │             │ CARBONATE    │          │            │            │            │           │           │  
+   │ LTDA         │ HAMMADDELER  │             │ ANADOLU      │          │            │            │            │           │           │  
+   │              │ DIS TCARET   │             │ ANDCARB CT-1 │          │            │            │            │           │           │  
+   │              │ LTD.STI.     │             │              │          │            │            │            │           │           │  
+ 4 │ QUIMICA      │ SA REVERTE   │ 2836500000  │ CARBONATO DE │ SPAIN    │ 24/06/2016 │ 12/07/2016 │ 27,000.00  │ 3,258.90  │ 5,585.00  │ 0.21 
+   │ COMERCIAL    │              │             │ CALCIO       │          │            │            │            │           │           │  
+   │ QUIMICIAL    │              │             │              │          │            │            │            │           │           │  
+   │ CIA. LTDA.   │              │             │              │          │            │            │            │           │           │  
+ 5 │ PICA         │ OMYA ANDINA  │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/01/1900 │ 18/01/2016 │ 66,500.00  │ 12,635.00 │ 18,670.52 │ 0.28 
+   │ PLASTICOS    │ S.A          │             │ CALCIO       │          │            │            │            │           │           │  
+   │ INDUSTRIALES │              │             │              │          │            │            │            │           │           │  
+   │ C.A.         │              │             │              │          │            │            │            │           │           │  
+ 6 │ PLASTIQUIM   │ OMYA ANDINA  │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/01/1900 │ 25/10/2016 │ 33,000.00  │ 6,270.00  │ 9,999.00  │ 0.30 
+   │ S.A.         │ S.A NIT      │             │ CALCIO       │          │            │            │            │           │           │  
+   │              │ 830.027.386- │             │ RECUBIERTO   │          │            │            │            │           │           │  
+   │              │ 6            │             │ CON ACIDO    │          │            │            │            │           │           │  
+   │              │              │             │ ESTEARICO    │          │            │            │            │           │           │  
+   │              │              │             │ OMYA CARB 1T │          │            │            │            │           │           │  
+   │              │              │             │ CG BBS 1000  │          │            │            │            │           │           │  
+ 7 │ QUIMICOS     │ SIBELCO      │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/11/2016 │ 03/11/2016 │ 52,000.00  │ 8,944.00  │ 13,039.05 │ 0.25 
+   │ ANDINOS      │ COLOMBIA SAS │             │ CALCIO       │          │            │            │            │           │           │  
+   │ QUIMANDI     │              │             │ RECUBIERTO   │          │            │            │            │           │           │  
+   │ S.A.         │              │             │              │          │            │            │            │           │           │  
+ 8 │ TIGRE        │ OMYA ANDINA  │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/01/1900 │ 28/10/2016 │ 66,000.00  │ 11,748.00 │ 18,216.00 │ 0.28 
+   │ ECUADOR S.A. │ S.A NIT      │             │ CALCIO       │          │            │            │            │           │           │  
+   │ ECUATIGRE    │ 830.027.386- │             │ RECUBIERTO   │          │            │            │            │           │           │  
+   │              │ 6            │             │ CON ACIDO    │          │            │            │            │           │           │  
+   │              │              │             │ ESTEARICO    │          │            │            │            │           │           │  
+   │              │              │             │ OMYACARB 1T  │          │            │            │            │           │           │  
+   │              │              │             │ CG BPA 25 NO │          │            │            │            │           │           │  
+━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━━━
+> open caco3_plastics.csv | to-csv
+importer,shipper,tariff_item,name,origin,shipped_at,arrived_at,net_weight,fob_price,cif_price,cif_per_net_weight
+PLASTICOS RIVAL CIA LTDA,S A REVERTE,2509000000,CARBONATO DE CALCIO TIPO CALCIPORE 160 T AL,SPAIN,18/03/2016,17/04/2016,"81,000.00","14,417.58","18,252.34",0.23
+MEXICHEM ECUADOR S.A.,OMYA ANDINA S A,2836500000,CARBONATO,COLOMBIA,07/07/2016,10/07/2016,"26,000.00","7,072.00","8,127.18",0.31
+PLASTIAZUAY SA,SA REVERTE,2836500000,CARBONATO DE CALCIO,SPAIN,27/07/2016,09/08/2016,"81,000.00","8,100.00","11,474.55",0.14
+PLASTICOS RIVAL CIA LTDA,AND ENDUSTRIYEL HAMMADDELER DIS TCARET LTD.STI.,2836500000,CALCIUM CARBONATE ANADOLU ANDCARB CT-1,TURKEY,04/10/2016,11/11/2016,"100,000.00","17,500.00","22,533.75",0.23
+QUIMICA COMERCIAL QUIMICIAL CIA. LTDA.,SA REVERTE,2836500000,CARBONATO DE CALCIO,SPAIN,24/06/2016,12/07/2016,"27,000.00","3,258.90","5,585.00",0.21
+PICA PLASTICOS INDUSTRIALES C.A.,OMYA ANDINA S.A,3824909999,CARBONATO DE CALCIO,COLOMBIA,01/01/1900,18/01/2016,"66,500.00","12,635.00","18,670.52",0.28
+PLASTIQUIM S.A.,OMYA ANDINA S.A NIT 830.027.386-6,3824909999,CARBONATO DE CALCIO RECUBIERTO CON ACIDO ESTEARICO OMYA CARB 1T CG BBS 1000,COLOMBIA,01/01/1900,25/10/2016,"33,000.00","6,270.00","9,999.00",0.30
+QUIMICOS ANDINOS QUIMANDI S.A.,SIBELCO COLOMBIA SAS,3824909999,CARBONATO DE CALCIO RECUBIERTO,COLOMBIA,01/11/2016,03/11/2016,"52,000.00","8,944.00","13,039.05",0.25
+TIGRE ECUADOR S.A. ECUATIGRE,OMYA ANDINA S.A NIT 830.027.386-6,3824909999,CARBONATO DE  CALCIO RECUBIERTO CON ACIDO ESTEARICO OMYACARB 1T CG BPA 25 NO,COLOMBIA,01/01/1900,28/10/2016,"66,000.00","11,748.00","18,216.00",0.28
+```

--- a/docs/commands/to-csv.md
+++ b/docs/commands/to-csv.md
@@ -1,0 +1,21 @@
+# to-csv
+
+Converts table data into csv text.
+
+## Example
+
+```shell
+> shells
+━━━┯━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━
+ # │   │ name       │ path 
+───┼───┼────────────┼────────────────────────
+ 0 │ X │ filesystem │ /home/shaurya 
+ 1 │   │ filesystem │ /home/shaurya/Pictures 
+ 2 │   │ filesystem │ /home/shaurya/Desktop 
+━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
+> shells | to-csv
+ ,name,path
+X,filesystem,/home/shaurya
+ ,filesystem,/home/shaurya/Pictures
+ ,filesystem,/home/shaurya/Desktop
+```

--- a/docs/commands/to-json.md
+++ b/docs/commands/to-json.md
@@ -27,7 +27,7 @@ Converts table data into json text.
 > open sgml_description.json | to-json
 {"glossary":{"title":"example glossary","GlossDiv":{"title":"S","GlossList":{"GlossEntry":{"ID":"SGML","SortAs":"SGML","GlossTerm":"Standard Generalized Markup Language","Acronym":"SGML","Abbrev":"ISO 8879:1986","Height":10,"GlossDef":{"para":"A meta-markup language, used to create markup languages such as DocBook.","GlossSeeAlso":["GML","XML"]},"Sections":[101,102],"GlossSee":"markup"}}}}}
 ```
-We can also convert files !
+We can also convert formats !
 ```shell
 > open jonathan.xml
 ━━━━━━━━━━━━━━━━

--- a/docs/commands/to-json.md
+++ b/docs/commands/to-json.md
@@ -1,0 +1,18 @@
+# to-json
+
+Converts table data into json text.
+
+## Example
+
+```shell
+> shells
+━━━┯━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━
+ # │   │ name       │ path 
+───┼───┼────────────┼────────────────────────
+ 0 │ X │ filesystem │ /home/shaurya 
+ 1 │   │ filesystem │ /home/shaurya/Pictures 
+ 2 │   │ filesystem │ /home/shaurya/Desktop 
+━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
+> shells | to-json
+[{" ":"X","name":"filesystem","path":"/home/shaurya"},{" ":" ","name":"filesystem","path":"/home/shaurya/Pictures"},{" ":" ","name":"filesystem","path":"/home/shaurya/Desktop"}]
+```

--- a/docs/commands/to-json.md
+++ b/docs/commands/to-json.md
@@ -16,3 +16,25 @@ Converts table data into json text.
 > shells | to-json
 [{" ":"X","name":"filesystem","path":"/home/shaurya"},{" ":" ","name":"filesystem","path":"/home/shaurya/Pictures"},{" ":" ","name":"filesystem","path":"/home/shaurya/Desktop"}]
 ```
+
+```shell
+> open sgml_description.json 
+━━━━━━━━━━━━━━━━
+ glossary 
+────────────────
+ [table: 1 row] 
+━━━━━━━━━━━━━━━━
+> open sgml_description.json | to-json
+{"glossary":{"title":"example glossary","GlossDiv":{"title":"S","GlossList":{"GlossEntry":{"ID":"SGML","SortAs":"SGML","GlossTerm":"Standard Generalized Markup Language","Acronym":"SGML","Abbrev":"ISO 8879:1986","Height":10,"GlossDef":{"para":"A meta-markup language, used to create markup languages such as DocBook.","GlossSeeAlso":["GML","XML"]},"Sections":[101,102],"GlossSee":"markup"}}}}}
+```
+We can also convert files !
+```shell
+> open jonathan.xml
+━━━━━━━━━━━━━━━━
+ rss 
+────────────────
+ [table: 1 row] 
+━━━━━━━━━━━━━━━━
+> open jonathan.xml | to-json
+{"rss":[{"channel":[{"title":["Jonathan Turner"]},{"link":["http://www.jonathanturner.org"]},{"link":[]},{"item":[{"title":["Creating crossplatform Rust terminal apps"]},{"description":["<p><img src=\"/images/pikachu.jpg\" alt=\"Pikachu animation in Windows\" /></p>\n\n<p><em>Look Mom, Pikachu running in Windows CMD!</em></p>\n\n<p>Part of the adventure is not seeing the way ahead and going anyway.</p>\n"]},{"pubDate":["Mon, 05 Oct 2015 00:00:00 +0000"]},{"link":["http://www.jonathanturner.org/2015/10/off-to-new-adventures.html"]},{"guid":["http://www.jonathanturner.org/2015/10/off-to-new-adventures.html"]}]}]}]}
+```

--- a/docs/commands/to-toml.md
+++ b/docs/commands/to-toml.md
@@ -1,0 +1,32 @@
+# to-toml
+
+Converts table data into toml text.
+
+## Example
+
+```shell
+> shells
+━━━┯━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━
+ # │   │ name       │ path 
+───┼───┼────────────┼────────────────────────
+ 0 │ X │ filesystem │ /home/shaurya 
+ 1 │   │ filesystem │ /home/shaurya/Pictures 
+ 2 │   │ filesystem │ /home/shaurya/Desktop 
+━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
+> shells | to-toml
+[[]]
+" " = "X"
+name = "filesystem"
+path = "/home/shaurya"
+
+[[]]
+" " = " "
+name = "filesystem"
+path = "/home/shaurya/Pictures"
+
+[[]]
+" " = " "
+name = "filesystem"
+path = "/home/shaurya/Desktop"
+
+```

--- a/docs/commands/to-toml.md
+++ b/docs/commands/to-toml.md
@@ -30,3 +30,83 @@ name = "filesystem"
 path = "/home/shaurya/Desktop"
 
 ```
+
+```shell
+> open cargo_sample.toml
+━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━
+ dependencies   │ dev-dependencies │ package 
+────────────────┼──────────────────┼────────────────
+ [table: 1 row] │ [table: 1 row]   │ [table: 1 row] 
+━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━
+> open cargo_sample.toml | to-toml
+[dependencies]
+ansi_term = "0.11.0"
+app_dirs = "1.2.1"
+byte-unit = "2.1.0"
+bytes = "0.4.12"
+chrono-humanize = "0.0.11"
+chrono-tz = "0.5.1"
+clap = "2.33.0"
+conch-parser = "0.1.1"
+derive-new = "0.5.6"
+dunce = "1.0.0"
+futures-sink-preview = "0.3.0-alpha.16"
+futures_codec = "0.2.2"
+getset = "0.0.7"
+git2 = "0.8.0"
+itertools = "0.8.0"
+lalrpop-util = "0.17.0"
+language-reporting = "0.3.0"
+log = "0.4.6"
+logos = "0.10.0-rc2"
+logos-derive = "0.10.0-rc2"
+nom = "5.0.0-beta1"
+ordered-float = "1.0.2"
+pretty_env_logger = "0.3.0"
+prettyprint = "0.6.0"
+prettytable-rs = "0.8.0"
+regex = "1.1.6"
+rustyline = "4.1.0"
+serde = "1.0.91"
+serde_derive = "1.0.91"
+serde_json = "1.0.39"
+subprocess = "0.1.18"
+sysinfo = "0.8.4"
+term = "0.5.2"
+tokio-fs = "0.1.6"
+toml = "0.5.1"
+toml-query = "0.9.0"
+
+[dependencies.chrono]
+features = ["serde"]
+version = "0.4.6"
+
+[dependencies.cursive]
+default-features = false
+features = ["pancurses-backend"]
+version = "0.12.0"
+
+[dependencies.futures-preview]
+features = ["compat", "io-compat"]
+version = "0.3.0-alpha.16"
+
+[dependencies.indexmap]
+features = ["serde-1"]
+version = "1.0.2"
+
+[dependencies.pancurses]
+features = ["win32a"]
+version = "0.16"
+
+[dev-dependencies]
+pretty_assertions = "0.6.1"
+
+[package]
+authors = ["Yehuda Katz <wycats@gmail.com>"]
+description = "A shell for the GitHub era"
+edition = "2018"
+license = "ISC"
+name = "nu"
+version = "0.1.1"
+
+```

--- a/docs/commands/to-tsv.md
+++ b/docs/commands/to-tsv.md
@@ -18,3 +18,63 @@ Converts table data into tsv text.
 X	filesystem	/home/shaurya
  	
 ```
+
+```shell
+> open caco3_plastics.tsv 
+━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━━━
+ # │ importer     │ shipper      │ tariff_item │ name         │ origin   │ shipped_at │ arrived_at │ net_weight │ fob_price │ cif_price │ cif_per_net_ 
+   │              │              │             │              │          │            │            │            │           │           │ weight 
+───┼──────────────┼──────────────┼─────────────┼──────────────┼──────────┼────────────┼────────────┼────────────┼───────────┼───────────┼──────────────
+ 0 │ PLASTICOS    │ S A REVERTE  │ 2509000000  │ CARBONATO DE │ SPAIN    │ 18/03/2016 │ 17/04/2016 │ 81,000.00  │ 14,417.58 │ 18,252.34 │ 0.23 
+   │ RIVAL CIA    │              │             │ CALCIO TIPO  │          │            │            │            │           │           │  
+   │ LTDA         │              │             │ CALCIPORE    │          │            │            │            │           │           │  
+   │              │              │             │ 160 T AL     │          │            │            │            │           │           │  
+ 1 │ MEXICHEM     │ OMYA ANDINA  │ 2836500000  │ CARBONATO    │ COLOMBIA │ 07/07/2016 │ 10/07/2016 │ 26,000.00  │ 7,072.00  │ 8,127.18  │ 0.31 
+   │ ECUADOR S.A. │ S A          │             │              │          │            │            │            │           │           │  
+ 2 │ PLASTIAZUAY  │ SA REVERTE   │ 2836500000  │ CARBONATO DE │ SPAIN    │ 27/07/2016 │ 09/08/2016 │ 81,000.00  │ 8,100.00  │ 11,474.55 │ 0.14 
+   │ SA           │              │             │ CALCIO       │          │            │            │            │           │           │  
+ 3 │ PLASTICOS    │ AND          │ 2836500000  │ CALCIUM      │ TURKEY   │ 04/10/2016 │ 11/11/2016 │ 100,000.00 │ 17,500.00 │ 22,533.75 │ 0.23 
+   │ RIVAL CIA    │ ENDUSTRIYEL  │             │ CARBONATE    │          │            │            │            │           │           │  
+   │ LTDA         │ HAMMADDELER  │             │ ANADOLU      │          │            │            │            │           │           │  
+   │              │ DIS TCARET   │             │ ANDCARB CT-1 │          │            │            │            │           │           │  
+   │              │ LTD.STI.     │             │              │          │            │            │            │           │           │  
+ 4 │ QUIMICA      │ SA REVERTE   │ 2836500000  │ CARBONATO DE │ SPAIN    │ 24/06/2016 │ 12/07/2016 │ 27,000.00  │ 3,258.90  │ 5,585.00  │ 0.21 
+   │ COMERCIAL    │              │             │ CALCIO       │          │            │            │            │           │           │  
+   │ QUIMICIAL    │              │             │              │          │            │            │            │           │           │  
+   │ CIA. LTDA.   │              │             │              │          │            │            │            │           │           │  
+ 5 │ PICA         │ OMYA ANDINA  │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/01/1900 │ 18/01/2016 │ 66,500.00  │ 12,635.00 │ 18,670.52 │ 0.28 
+   │ PLASTICOS    │ S.A          │             │ CALCIO       │          │            │            │            │           │           │  
+   │ INDUSTRIALES │              │             │              │          │            │            │            │           │           │  
+   │ C.A.         │              │             │              │          │            │            │            │           │           │  
+ 6 │ PLASTIQUIM   │ OMYA ANDINA  │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/01/1900 │ 25/10/2016 │ 33,000.00  │ 6,270.00  │ 9,999.00  │ 0.30 
+   │ S.A.         │ S.A NIT      │             │ CALCIO       │          │            │            │            │           │           │  
+   │              │ 830.027.386- │             │ RECUBIERTO   │          │            │            │            │           │           │  
+   │              │ 6            │             │ CON ACIDO    │          │            │            │            │           │           │  
+   │              │              │             │ ESTEARICO    │          │            │            │            │           │           │  
+   │              │              │             │ OMYA CARB 1T │          │            │            │            │           │           │  
+   │              │              │             │ CG BBS 1000  │          │            │            │            │           │           │  
+ 7 │ QUIMICOS     │ SIBELCO      │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/11/2016 │ 03/11/2016 │ 52,000.00  │ 8,944.00  │ 13,039.05 │ 0.25 
+   │ ANDINOS      │ COLOMBIA SAS │             │ CALCIO       │          │            │            │            │           │           │  
+   │ QUIMANDI     │              │             │ RECUBIERTO   │          │            │            │            │           │           │  
+   │ S.A.         │              │             │              │          │            │            │            │           │           │  
+ 8 │ TIGRE        │ OMYA ANDINA  │ 3824909999  │ CARBONATO DE │ COLOMBIA │ 01/01/1900 │ 28/10/2016 │ 66,000.00  │ 11,748.00 │ 18,216.00 │ 0.28 
+   │ ECUADOR S.A. │ S.A NIT      │             │ CALCIO       │          │            │            │            │           │           │  
+   │ ECUATIGRE    │ 830.027.386- │             │ RECUBIERTO   │          │            │            │            │           │           │  
+   │              │ 6            │             │ CON ACIDO    │          │            │            │            │           │           │  
+   │              │              │             │ ESTEARICO    │          │            │            │            │           │           │  
+   │              │              │             │ OMYACARB 1T  │          │            │            │            │           │           │  
+   │              │              │             │ CG BPA 25 NO │          │            │            │            │           │           │  
+━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━━━
+> open caco3_plastics.tsv | to-tsv
+importer        shipper tariff_item     name    origin  shipped_at      arrived_at      net_weight      fob_price       cif_price       cif_per_net_weight
+PLASTICOS RIVAL CIA LTDA        S A REVERTE     2509000000      CARBONATO DE CALCIO TIPO CALCIPORE 160 T AL     SPAIN   18/03/2016      17/04/2016    81,000.00        14,417.58       18,252.34       0.23
+MEXICHEM ECUADOR S.A.   OMYA ANDINA S A 2836500000      CARBONATO       COLOMBIA        07/07/2016      10/07/2016      26,000.00       7,072.00      8,127.18 0.31
+PLASTIAZUAY SA  SA REVERTE      2836500000      CARBONATO DE CALCIO     SPAIN   27/07/2016      09/08/2016      81,000.00       8,100.00        11,474.55      0.14
+PLASTICOS RIVAL CIA LTDA        AND ENDUSTRIYEL HAMMADDELER DIS TCARET LTD.STI. 2836500000      CALCIUM CARBONATE ANADOLU ANDCARB CT-1  TURKEY  04/10/2016     11/11/2016      100,000.00      17,500.00       22,533.75       0.23
+QUIMICA COMERCIAL QUIMICIAL CIA. LTDA.  SA REVERTE      2836500000      CARBONATO DE CALCIO     SPAIN   24/06/2016      12/07/2016      27,000.00     3,258.90 5,585.00        0.21
+PICA PLASTICOS INDUSTRIALES C.A.        OMYA ANDINA S.A 3824909999      CARBONATO DE CALCIO     COLOMBIA        01/01/1900      18/01/2016      66,500.00      12,635.00       18,670.52       0.28
+PLASTIQUIM S.A. OMYA ANDINA S.A NIT 830.027.386-6       3824909999      CARBONATO DE CALCIO RECUBIERTO CON ACIDO ESTEARICO OMYA CARB 1T CG BBS 1000   COLOMBIA 01/01/1900      25/10/2016      33,000.00       6,270.00        9,999.00        0.30
+QUIMICOS ANDINOS QUIMANDI S.A.  SIBELCO COLOMBIA SAS    3824909999      CARBONATO DE CALCIO RECUBIERTO  COLOMBIA        01/11/2016      03/11/2016    52,000.00        8,944.00        13,039.05       0.25
+TIGRE ECUADOR S.A. ECUATIGRE    OMYA ANDINA S.A NIT 830.027.386-6       3824909999      CARBONATO DE  CALCIO RECUBIERTO CON ACIDO ESTEARICO OMYACARB 1T CG BPA 25 NO   COLOMBIA        01/01/1900      28/10/2016      66,000.00       11,748.00       18,216.00       0.28
+
+```

--- a/docs/commands/to-tsv.md
+++ b/docs/commands/to-tsv.md
@@ -1,0 +1,20 @@
+# to-tsv
+
+Converts table data into tsv text.
+
+## Example
+
+```shell
+> shells
+━━━┯━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━
+ # │   │ name       │ path 
+───┼───┼────────────┼────────────────────────
+ 0 │ X │ filesystem │ /home/shaurya 
+ 1 │   │ filesystem │ /home/shaurya/Pictures 
+ 2 │   │ filesystem │ /home/shaurya/Desktop 
+━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
+> shells |to-tsv
+ 	name	path
+X	filesystem	/home/shaurya
+ 	
+```

--- a/docs/commands/to-url.md
+++ b/docs/commands/to-url.md
@@ -22,3 +22,14 @@ Converts table data into url-formatted text.
  2 │ +=+&name=filesystem&path=%2Fhome%2Fshaurya%2FDesktop 
 ━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
+
+```shell
+> open sample.url 
+━━━━━━━━━━┯━━━━━━━━┯━━━━━━┯━━━━━━━━
+ bread    │ cheese │ meat │ fat 
+──────────┼────────┼──────┼────────
+ baguette │ comté  │ ham  │ butter 
+━━━━━━━━━━┷━━━━━━━━┷━━━━━━┷━━━━━━━━
+> open sample.url  | to-url
+bread=baguette&cheese=comt%C3%A9&meat=ham&fat=butter
+```

--- a/docs/commands/to-url.md
+++ b/docs/commands/to-url.md
@@ -1,0 +1,24 @@
+# to-url
+
+Converts table data into url-formatted text.
+
+## Example
+
+```shell
+> shells
+━━━┯━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━
+ # │   │ name       │ path 
+───┼───┼────────────┼────────────────────────
+ 0 │ X │ filesystem │ /home/shaurya 
+ 1 │   │ filesystem │ /home/shaurya/Pictures 
+ 2 │   │ filesystem │ /home/shaurya/Desktop 
+━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
+> shells | to-url
+━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ # │ value 
+───┼───────────────────────────────────────────────────────
+ 0 │ +=X&name=filesystem&path=%2Fhome%2Fshaurya 
+ 1 │ +=+&name=filesystem&path=%2Fhome%2Fshaurya%2FPictures 
+ 2 │ +=+&name=filesystem&path=%2Fhome%2Fshaurya%2FDesktop 
+━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/docs/commands/to-yaml.md
+++ b/docs/commands/to-yaml.md
@@ -1,0 +1,27 @@
+# to-yaml
+
+Converts table data into yaml text.
+
+## Example
+
+```shell
+> shells
+━━━┯━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━
+ # │   │ name       │ path 
+───┼───┼────────────┼────────────────────────
+ 0 │ X │ filesystem │ /home/shaurya 
+ 1 │   │ filesystem │ /home/shaurya/Pictures 
+ 2 │   │ filesystem │ /home/shaurya/Desktop 
+━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
+> shells | to-yaml
+---
+- " ": X
+  name: filesystem
+  path: /home/shaurya
+- " ": " "
+  name: filesystem
+  path: /home/shaurya/Pictures
+- " ": " "
+  name: filesystem
+  path: /home/shaurya/Desktop
+```

--- a/docs/commands/to-yaml.md
+++ b/docs/commands/to-yaml.md
@@ -25,3 +25,36 @@ Converts table data into yaml text.
   name: filesystem
   path: /home/shaurya/Desktop
 ```
+
+```shell
+> open appveyor.yml 
+━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━
+ image              │ environment    │ install         │ build │ test_script     │ cache 
+────────────────────┼────────────────┼─────────────────┼───────┼─────────────────┼─────────────────
+ Visual Studio 2017 │ [table: 1 row] │ [table: 5 rows] │       │ [table: 2 rows] │ [table: 2 rows] 
+━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━┷━━━━━━━┷━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━
+> open appveyor.yml | to-yaml
+---
+image: Visual Studio 2017
+environment:
+  global:
+    PROJECT_NAME: nushell
+    RUST_BACKTRACE: 1
+  matrix:
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: nightly
+      BITS: 64
+install:
+  - "set PATH=C:\\msys64\\mingw%BITS%\\bin;C:\\msys64\\usr\\bin;%PATH%"
+  - "curl -sSf -o rustup-init.exe https://win.rustup.rs"
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %CHANNEL%-%TARGET%
+  - "set PATH=%PATH%;C:\\Users\\appveyor\\.cargo\\bin"
+  - "call \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat\""
+build: false
+test_script:
+  - cargo build --verbose
+  - cargo test --all --verbose
+cache:
+  - target -> Cargo.lock
+  - "C:\\Users\\appveyor\\.cargo\\registry -> Cargo.lock"
+```


### PR DESCRIPTION
Partial fix of issue #711
Docs for the following commands were added -
```
to-csv
to-json
to-toml
to-tsv
to-url
to-yaml
```

Docs for `to-db`, ` to-bson`, `to-sqlite` have not been added as I don't recognize and understand those formats.