### PR TITLE
ci(github): replace docker.pkg.github.com with quay.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,11 @@ jobs:
         - x86_64-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v1
-    - run: cargo install cross
+    - name: Install rust-embedded/cross
+      env: { VERSION: v0.1.16 }
+      run: >-
+        wget -nv https://github.com/rust-embedded/cross/releases/download/${VERSION}/cross-${VERSION}-x86_64-unknown-linux-gnu.tar.gz
+        -O- | sudo tar xz -C /usr/local/bin/
     - name: compile for specific target
       env: { arch: '${{ matrix.arch }}' }
       run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,12 +68,13 @@ jobs:
         export PATCH=$([ ${{ matrix.use-patch }} = true ] && echo .${{ matrix.tag }} || echo '')
         chmod +x $NU_BINS
 
-        echo ${{ secrets.DOCKER_REGISTRY }} | docker login ${REGISTRY%%/*} -u ${{ github.actor }} --password-stdin
+        echo ${{ secrets.DOCKER_REGISTRY }} | docker login ${REGISTRY%/*} -u ${{ github.actor }} --password-stdin
         docker-compose --file docker/docker-compose.package.yml build
         docker-compose --file docker/docker-compose.package.yml push              # exact version
       env:
         BASE_IMAGE: ${{ matrix.base-image }}
-        REGISTRY: docker.pkg.github.com/${{ github.repository }}
+        # REGISTRY: docker.pkg.github.com/${{ github.repository }} #TODO: waiting support for GITHUB_TOKEN for docker.pkg.github.com
+        REGISTRY: quay.io/${{ github.actor }}
 
     #region semantics tagging
     - name: Retag and push without suffixing version
@@ -95,7 +96,9 @@ jobs:
         # latest version
         docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${{ matrix.tag }}
         docker push ${REGISTRY,,}/nu:${{ matrix.tag }}
-      env: { REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' }
+      env:
+        # REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' #TODO: waiting support for GITHUB_TOKEN for docker.pkg.github.com
+        REGISTRY: quay.io/${{ github.actor }}
     - name: Retag and push debian as latest
       if: matrix.tag == 'debian'
       run: |-
@@ -112,5 +115,7 @@ jobs:
         # latest version
         docker tag ${REGISTRY,,}/nu:${{ matrix.tag }} ${REGISTRY,,}/nu:latest
         docker push ${REGISTRY,,}/nu:latest
-      env: { REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' }
+      env:
+        # REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' #TODO: waiting support for GITHUB_TOKEN for docker.pkg.github.com
+        REGISTRY: quay.io/${{ github.actor }}
     #endregion semantics tagging

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,13 +62,13 @@ jobs:
     - uses: actions/download-artifact@master
       with: { name: '${{ matrix.arch }}', path: target/release }
     - name: Build and publish exact version
-      run: |
+      run: |-
         REGISTRY=${REGISTRY,,}; export TAG=${GITHUB_REF##*/}-${{ matrix.tag }};
         export NU_BINS=target/release/$( [ ${{ matrix.plugin }} = true ] && echo nu* || echo nu )
         export PATCH=$([ ${{ matrix.use-patch }} = true ] && echo .${{ matrix.tag }} || echo '')
         chmod +x $NU_BINS
 
-        echo ${{ secrets.DOCKER_REGISTRY }} | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+        echo ${{ secrets.DOCKER_REGISTRY }} | docker login ${REGISTRY%%/*} -u ${{ github.actor }} --password-stdin
         docker-compose --file docker/docker-compose.package.yml build
         docker-compose --file docker/docker-compose.package.yml push              # exact version
       env:
@@ -77,26 +77,40 @@ jobs:
 
     #region semantics tagging
     - name: Retag and push without suffixing version
-      run: |
+      run: |-
         VERSION=${GITHUB_REF##*/}
+
+        latest_version=${VERSION%%%.*}-${{ matrix.tag }}
+        latest_feature=${VERSION%%.*}-${{ matrix.tag }}
+        latest_patch=${VERSION%.*}-${{ matrix.tag }}
+        exact_version=${VERSION}-${{ matrix.tag }}
+
+        tags=( latest_version latest_feature latest_patch exact_version )
+
+        for tag in ${tags[@]}; do
+          docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${tag}
+          docker push ${REGISTRY,,}/nu:${tag}
+        done
+
+        # latest version
         docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${{ matrix.tag }}
-        docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${VERSION%%.*}-${{ matrix.tag }}
-        docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${VERSION%.*}-${{ matrix.tag }}
-        docker push ${REGISTRY,,}/nu:${VERSION%.*}-${{ matrix.tag }}              # latest patch
-        docker push ${REGISTRY,,}/nu:${VERSION%%.*}-${{ matrix.tag }}             # latest features
-        docker push ${REGISTRY,,}/nu:${{ matrix.tag }}                            # latest version
+        docker push ${REGISTRY,,}/nu:${{ matrix.tag }}
       env: { REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' }
     - name: Retag and push debian as latest
       if: matrix.tag == 'debian'
-      run: |
+      run: |-
         VERSION=${GITHUB_REF##*/}
+
+        # ${latest features} ${latest patch} ${exact version}
+        tags=( ${VERSION%%.*} ${VERSION%.*} ${VERSION} )
+
+        for tag in ${tags[@]}; do
+          docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${tag}
+          docker push ${REGISTRY,,}/nu:${tag}
+        done
+
+        # latest version
         docker tag ${REGISTRY,,}/nu:${{ matrix.tag }} ${REGISTRY,,}/nu:latest
-        docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${VERSION%.*}
-        docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${VERSION%%.*}
-        docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${VERSION}
-        docker push ${REGISTRY,,}/nu:${VERSION}       # exact version
-        docker push ${REGISTRY,,}/nu:${VERSION%%.*}   # latest features
-        docker push ${REGISTRY,,}/nu:${VERSION%.*}    # latest patch
-        docker push ${REGISTRY,,}/nu:latest           # latest version
+        docker push ${REGISTRY,,}/nu:latest
       env: { REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' }
     #endregion semantics tagging

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,21 +63,22 @@ jobs:
       with: { name: '${{ matrix.arch }}', path: target/release }
     - name: Build and publish exact version
       run: |-
-        REGISTRY=${REGISTRY,,}; export TAG=${GITHUB_REF##*/}-${{ matrix.tag }};
+        REGISTRY=${REGISTRY,,}; export TAG=${GITHUB_REF##*/}-${{ matrix.tag }}
         export NU_BINS=target/release/$( [ ${{ matrix.plugin }} = true ] && echo nu* || echo nu )
         export PATCH=$([ ${{ matrix.use-patch }} = true ] && echo .${{ matrix.tag }} || echo '')
         chmod +x $NU_BINS
 
-        echo ${{ secrets.DOCKER_REGISTRY }} | docker login ${REGISTRY%/*} -u ${{ github.actor }} --password-stdin
+        echo ${{ secrets.DOCKER_REGISTRY }} | docker login ${REGISTRY%/*} -u ${USER,,} --password-stdin
         docker-compose --file docker/docker-compose.package.yml build
         docker-compose --file docker/docker-compose.package.yml push              # exact version
       env:
         BASE_IMAGE: ${{ matrix.base-image }}
         # REGISTRY: docker.pkg.github.com/${{ github.repository }} #TODO: waiting support for GITHUB_TOKEN for docker.pkg.github.com
+        USER: ${{ github.actor }}+action
         REGISTRY: quay.io/${{ github.actor }}
 
     #region semantics tagging
-    - name: Retag and push without suffixing version
+    - name: Retag and push with suffixed version
       run: |-
         VERSION=${GITHUB_REF##*/}
 
@@ -86,7 +87,7 @@ jobs:
         latest_patch=${VERSION%.*}-${{ matrix.tag }}
         exact_version=${VERSION}-${{ matrix.tag }}
 
-        tags=( latest_version latest_feature latest_patch exact_version )
+        tags=( ${latest_version} ${latest_feature} ${latest_patch} ${exact_version} )
 
         for tag in ${tags[@]}; do
           docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${tag}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,6 +35,10 @@ jobs:
     name: Build and publish docker images
     needs: compile
     runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: quay.io/nushell
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_REGISTRY }}
+      DOCKER_USER: nushell+action # TBD
     strategy:
       matrix:
         tag:
@@ -63,19 +67,16 @@ jobs:
       with: { name: '${{ matrix.arch }}', path: target/release }
     - name: Build and publish exact version
       run: |-
-        REGISTRY=${REGISTRY,,}; export TAG=${GITHUB_REF##*/}-${{ matrix.tag }}
+        export DOCKER_TAG=${GITHUB_REF##*/}-${{ matrix.tag }}
         export NU_BINS=target/release/$( [ ${{ matrix.plugin }} = true ] && echo nu* || echo nu )
         export PATCH=$([ ${{ matrix.use-patch }} = true ] && echo .${{ matrix.tag }} || echo '')
         chmod +x $NU_BINS
 
-        echo ${{ secrets.DOCKER_REGISTRY }} | docker login ${REGISTRY%/*} -u ${USER,,} --password-stdin
+        echo ${DOCKER_PASSWORD} | docker login ${DOCKER_REGISTRY} -u ${DOCKER_USER} --password-stdin
         docker-compose --file docker/docker-compose.package.yml build
         docker-compose --file docker/docker-compose.package.yml push              # exact version
       env:
         BASE_IMAGE: ${{ matrix.base-image }}
-        # REGISTRY: docker.pkg.github.com/${{ github.repository }} #TODO: waiting support for GITHUB_TOKEN for docker.pkg.github.com
-        USER: ${{ github.actor }}+action
-        REGISTRY: quay.io/${{ github.actor }}
 
     #region semantics tagging
     - name: Retag and push with suffixed version
@@ -90,16 +91,14 @@ jobs:
         tags=( ${latest_version} ${latest_feature} ${latest_patch} ${exact_version} )
 
         for tag in ${tags[@]}; do
-          docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${tag}
-          docker push ${REGISTRY,,}/nu:${tag}
+          docker tag ${DOCKER_REGISTRY}/nu:${VERSION}-${{ matrix.tag }} ${DOCKER_REGISTRY}/nu:${tag}
+          docker push ${DOCKER_REGISTRY}/nu:${tag}
         done
 
         # latest version
-        docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${{ matrix.tag }}
-        docker push ${REGISTRY,,}/nu:${{ matrix.tag }}
-      env:
-        # REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' #TODO: waiting support for GITHUB_TOKEN for docker.pkg.github.com
-        REGISTRY: quay.io/${{ github.actor }}
+        docker tag ${DOCKER_REGISTRY}/nu:${VERSION}-${{ matrix.tag }} ${DOCKER_REGISTRY}/nu:${{ matrix.tag }}
+        docker push ${DOCKER_REGISTRY}/nu:${{ matrix.tag }}
+
     - name: Retag and push debian as latest
       if: matrix.tag == 'debian'
       run: |-
@@ -109,14 +108,11 @@ jobs:
         tags=( ${VERSION%%.*} ${VERSION%.*} ${VERSION} )
 
         for tag in ${tags[@]}; do
-          docker tag ${REGISTRY,,}/nu:${VERSION}-${{ matrix.tag }} ${REGISTRY,,}/nu:${tag}
-          docker push ${REGISTRY,,}/nu:${tag}
+          docker tag ${DOCKER_REGISTRY}/nu:${VERSION}-${{ matrix.tag }} ${DOCKER_REGISTRY}/nu:${tag}
+          docker push ${DOCKER_REGISTRY}/nu:${tag}
         done
 
         # latest version
-        docker tag ${REGISTRY,,}/nu:${{ matrix.tag }} ${REGISTRY,,}/nu:latest
-        docker push ${REGISTRY,,}/nu:latest
-      env:
-        # REGISTRY: 'docker.pkg.github.com/${{ github.repository }}' #TODO: waiting support for GITHUB_TOKEN for docker.pkg.github.com
-        REGISTRY: quay.io/${{ github.actor }}
+        docker tag ${DOCKER_REGISTRY}/nu:${{ matrix.tag }} ${DOCKER_REGISTRY}/nu:latest
+        docker push ${DOCKER_REGISTRY}/nu:latest
     #endregion semantics tagging

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       DOCKER_REGISTRY: quay.io/nushell
       DOCKER_PASSWORD: ${{ secrets.DOCKER_REGISTRY }}
-      DOCKER_USER: nushell+action # TBD
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     strategy:
       matrix:
         tag:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Publish consumable Docker images
 
 on:
   push:
-    tags: ['*.*.*']
+    tags: ['v?[0-9]+.[0-9]+.[0-9]+*']
 
 jobs:
   compile:

--- a/docker/docker-compose.package.yml
+++ b/docker/docker-compose.package.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   nushell:
-    image: ${REGISTRY}/nu:${TAG}
+    image: ${DOCKER_REGISTRY}/nu:${DOCKER_TAG}
     build:
       context: ..
       dockerfile: docker/Package${PATCH}.Dockerfile


### PR DESCRIPTION
<sup>related pr/issues: #701, #625</sup>
> see [here](https://quay.io/repository/drsensor/nu?tab=tags) for what it looks like
tips: sort list by **Tag** or **Size**

### Demo
```sh
docker run -it quay.io/drsensor/nu:$TAG
```

### Why
GitHub plan to move all access of their package registry using `GITHUB_TOKEN` ([ref1], [ref2], [ref3]). Until the migration reach `docker.pkg.github.com`, I want to change it into quay.io for the next release so I can test some stuff in an isolated environment.

[ref1]: https://github.blog/2019-09-11-proxying-packages-with-github-package-registry-and-other-updates/#using-packages-in-actions
[ref2]: https://github.blog/changelog/2019-09-06-publishing-a-package-no-longer-creates-a-release-and-other-github-package-registry-updates/
[ref3]: https://github.blog/changelog/2019-08-16-publishing-packages-from-a-github-action-to-github-package-registry/

### How to change the DOCKER_REGISTRY token to quay.io
0. login quay.io
1. visit <https://quay.io/user/nushell?tab=robots>
2. click **Create Robot Account** button then name it as `action`
![Create Robot Account dialog](https://user-images.githubusercontent.com/4953069/66449254-9f3f1080-ea7e-11e9-9ac9-9bd1ee7b6216.png)
3. Change **PERMISSION** to **Write**
![change permission dialog](https://user-images.githubusercontent.com/4953069/66449357-01981100-ea7f-11e9-90c3-a96681b8c2b4.png)
4. Click **View Credentials**
![options dialog](https://user-images.githubusercontent.com/4953069/66449060-ec6eb280-ea7d-11e9-8583-b705713b274d.png)
5. Copy the **Robot Token**
![credential dialog](https://user-images.githubusercontent.com/4953069/66449087-03150980-ea7e-11e9-8045-3ee6050ce913.png)
6. go to <https://github.com/nushell/nushell/settings/secrets>
7. overwrite *DOCKER_REGISTRY* secret with the copied **Robot Token**
![github secrets page](https://user-images.githubusercontent.com/4953069/66449104-14f6ac80-ea7e-11e9-8dd3-e5cb7277d622.png)