### PR TITLE
Average Plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ name = "nu_plugin_sum"
 path = "src/plugins/sum.rs"
 
 [[bin]]
+name = "nu_plugin_average"
+path = "src/plugins/average.rs"
+
+[[bin]]
 name = "nu_plugin_embed"
 path = "src/plugins/embed.rs"
 

--- a/docs/commands/average.md
+++ b/docs/commands/average.md
@@ -1,0 +1,42 @@
+# average This command allows you to calculate the average of values in a column.  ## Examples 
+To get the average of the file sizes in a directory, simply pipe the size column from the ls command to the sum command.
+
+```shell
+> ls | get size | average
+━━━━━━━━━
+ <value>
+━━━━━━━━━
+2282.727272727273
+━━━━━━━━━
+```
+
+```shell
+> pwd | split-row / | size | get chars | average
+━━━━━━━━━
+ <value>
+━━━━━━━━━
+5.250000000000000
+━━━━━━━━━
+```
+
+Note that average only works for integer and byte values at the moment, and if the shell doesn't recognize the values in a column as one of those types, it will return an error.
+One way to solve this is to convert each row to an integer and then pipe the result to `average`
+
+```shell
+> open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | average
+error: Unrecognized type in stream: Primitive(String("2509000000"))
+- shell:1:0
+1 | open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | average
+  | ^^^^ source
+```
+
+```shell
+> open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | str --to-int | average
+━━━━━━━━━━━━━━━━━━━
+ <value>
+───────────────────
+ 3239404444.000000
+━━━━━━━━━━━━━━━━━━━
+```
+
+

--- a/docs/commands/average.md
+++ b/docs/commands/average.md
@@ -1,5 +1,8 @@
-# average This command allows you to calculate the average of values in a column.  ## Examples 
-To get the average of the file sizes in a directory, simply pipe the size column from the ls command to the sum command.
+# average 
+This command allows you to calculate the average of values in a column.  
+
+## Examples 
+To get the average of the file sizes in a directory, simply pipe the size column from the ls command to the average command.
 
 ```shell
 > ls | get size | average
@@ -19,8 +22,8 @@ To get the average of the file sizes in a directory, simply pipe the size column
 ━━━━━━━━━
 ```
 
-Note that average only works for integer and byte values at the moment, and if the shell doesn't recognize the values in a column as one of those types, it will return an error.
-One way to solve this is to convert each row to an integer and then pipe the result to `average`
+Note that average only works for integer and byte values. If the shell doesn't recognize the values in a column as one of those types, it will return an error.
+One way to solve this is to convert each row to an integer when possible and then pipe the result to `average`
 
 ```shell
 > open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | average

--- a/docs/commands/sum.md
+++ b/docs/commands/sum.md
@@ -1,9 +1,4 @@
-# sum
-
-This command allows you to calculate the sum of values in a column. 
-
-## Examples
-
+# sum This command allows you to calculate the sum of values in a column.  ## Examples 
 To get the sum of the file sizes in a directory, simply pipe the size column from the ls command to the sum command.
 
 ```shell
@@ -15,21 +10,34 @@ To get the sum of the file sizes in a directory, simply pipe the size column fro
 ━━━━━━━━━
 ```
 
+To get the sum of the characters in your present working directory.
+```shell
+> pwd | split-row / | size | get chars | sum
+━━━━━━━━━
+ <value>
+━━━━━━━━━
+21
+━━━━━━━━━
+```
+
+
+
 Note that sum only works for integer and byte values at the moment, and if the shell doesn't recognize the values in a column as one of those types, it will return an error.
+One way to solve this is to convert each row to an integer and then pipe the result to `sum`
 
 ```shell
-> open example.csv
-━━━┯━━━━━━━━━┯━━━━━━━━┯━━━━━━━━━━
- # │ fruit   │ amount │ quality
-───┼─────────┼────────┼──────────
- 0 │ apples  │ 1      │ fresh
- 1 │ bananas │ 2      │ old
- 2 │ oranges │ 7      │ fresh
- 3 │ kiwis   │ 25     │ rotten
-━━━┷━━━━━━━━━┷━━━━━━━━┷━━━━━━━━━━
+> open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | average
+error: Unrecognized type in stream: Primitive(String("2509000000"))
+- shell:1:0
+1 | open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | sum
+  | ^^^^ source
 ```
 
 ```shell
-> open example.csv | get amount | sum
-error: Unrecognized type in stream: Primitive(String("1"))
+> open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | str --to-int | sum
+━━━━━━━━━━━━━
+ <value>
+─────────────
+ 29154639996
+━━━━━━━━━━━━━
 ```

--- a/docs/commands/sum.md
+++ b/docs/commands/sum.md
@@ -1,4 +1,7 @@
-# sum This command allows you to calculate the sum of values in a column.  ## Examples 
+# sum 
+This command allows you to calculate the sum of values in a column.  
+
+## Examples 
 To get the sum of the file sizes in a directory, simply pipe the size column from the ls command to the sum command.
 
 ```shell
@@ -10,7 +13,7 @@ To get the sum of the file sizes in a directory, simply pipe the size column fro
 ━━━━━━━━━
 ```
 
-To get the sum of the characters in your present working directory.
+To get the sum of the characters that make up your  present working directory.
 ```shell
 > pwd | split-row / | size | get chars | sum
 ━━━━━━━━━
@@ -20,13 +23,11 @@ To get the sum of the characters in your present working directory.
 ━━━━━━━━━
 ```
 
-
-
-Note that sum only works for integer and byte values at the moment, and if the shell doesn't recognize the values in a column as one of those types, it will return an error.
-One way to solve this is to convert each row to an integer and then pipe the result to `sum`
+Note that sum only works for integer and byte values. If the shell doesn't recognize the values in a column as one of those types, it will return an error.
+One way to solve this is to convert each row to an integer when possible and then pipe the result to `sum`
 
 ```shell
-> open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | average
+> open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | sum
 error: Unrecognized type in stream: Primitive(String("2509000000"))
 - shell:1:0
 1 | open tests/fixtures/formats/caco3_plastics.csv | get tariff_item | sum

--- a/src/plugins/average.rs
+++ b/src/plugins/average.rs
@@ -1,6 +1,6 @@
 use nu::{
-    serve_plugin, CoerceInto, CallInfo, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError, Signature,
-    Tagged, TaggedItem, Value,
+    serve_plugin, CallInfo, CoerceInto, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError,
+    Signature, Tagged, TaggedItem, Value,
 };
 
 #[derive(Debug)]
@@ -11,56 +11,61 @@ struct Average {
 
 impl Average {
     fn new() -> Average {
-        Average { total: None, count: 1 }
+        Average {
+            total: None,
+            count: 0,
+        }
     }
 
     fn average(&mut self, value: Tagged<Value>) -> Result<(), ShellError> {
         match value.item() {
             Value::Primitive(Primitive::Nothing) => Ok(()),
-            Value::Primitive(Primitive::Int(i)) => {
-                match &self.total {
-                    Some(Tagged {
-                        item: Value::Primitive(Primitive::Int(j)),
-                        tag,
-                    }) => {
-                        self.total = Some(Value::int(i + j).tagged(tag));
-                        self.count = self.count + 1;
-                        Ok(())
-                    }
-                    None => {
-                        self.total = Some(value.clone());
-                        Ok(())
-                    }
-                    _ => Err(ShellError::string(format!(
-                        "Could not calculate average of non-integer or unrelated types"
-                    ))),
+            Value::Primitive(Primitive::Int(i)) => match &self.total {
+                Some(Tagged {
+                    item: Value::Primitive(Primitive::Int(j)),
+                    tag,
+                }) => {
+                    self.total = Some(Value::int(i + j).tagged(tag));
+                    self.count += 1;
+                    Ok(())
                 }
-            }
-            Value::Primitive(Primitive::Bytes(b)) => {
-                match self.total {
-                    Some(Tagged {
-                        item: Value::Primitive(Primitive::Bytes(j)),
-                        tag,
-                    }) => {
-                        self.total = Some(Value::int(b + j).tagged(tag));
-                        self.count = self.count + 1;
-                        Ok(())
-                    }
-                    None => {
-                        self.total = Some(value);
-                        Ok(())
-                    }
-                    _ => Err(ShellError::string(format!(
-                        "Could not calculate average of non-integer or unrelated types"
-                    ))),
+                None => {
+                    self.total = Some(value.clone());
+                    self.count += 1;
+                    Ok(())
                 }
-            }
-            x => Err(ShellError::string(format!(
-                "Unrecognized type in stream: {:?}",
-                x
-            ))),
+                _ => Err(ShellError::labeled_error(
+                    "Could calculate average of non-integer or unrelated types",
+                    "source",
+                    value.tag,
+                )),
+            },
+            Value::Primitive(Primitive::Bytes(b)) => match &self.total {
+                Some(Tagged {
+                    item: Value::Primitive(Primitive::Bytes(j)),
+                    tag,
+                }) => {
+                    self.total = Some(Value::bytes(b + j).tagged(tag));
+                    self.count += 1;
+                    Ok(())
+                }
+                None => {
+                    self.total = Some(value);
+                    self.count += 1;
+                    Ok(())
+                }
+                _ => Err(ShellError::labeled_error(
+                    "Could calculate average of non-integer or unrelated types",
+                    "source",
+                    value.tag,
+                )),
+            },
+            x => Err(ShellError::labeled_error(
+                format!("Unrecognized type in stream: {:?}", x),
+                "source",
+                value.tag,
+            )),
         }
-
     }
 }
 
@@ -83,19 +88,27 @@ impl Plugin for Average {
     fn end_filter(&mut self) -> Result<Vec<ReturnValue>, ShellError> {
         match self.total {
             None => Ok(vec![]),
-            Some(ref v) =>  {
-                match v.item() {
+            Some(ref inner) => {
+                match inner.item() {
                     Value::Primitive(Primitive::Int(i)) => {
-                        let total: u64 = i.tagged(v.tag).coerce_into("converting for average")?;
+                        let total: u64 = i
+                            .tagged(inner.tag.clone())
+                            .coerce_into("converting for average")?;
                         let avg = total as f64 / self.count as f64;
-                        let decimal_value: Value=  Primitive::from(avg).into();
-                        let tagged_value = decimal_value.tagged(v.tag);
+                        let primitive_value: Value = Primitive::from(avg).into();
+                        let tagged_value = primitive_value.tagged(inner.tag.clone());
                         Ok(vec![ReturnSuccess::value(tagged_value)])
                     }
-                    _ => unreachable!()
-
+                    Value::Primitive(Primitive::Bytes(bytes)) => {
+                        // let total: u64 = b.tagged(inner.tag.clone()).coerce_into("converting for average")?;
+                        let avg = *bytes as f64 / self.count as f64;
+                        let primitive_value: Value = Primitive::from(avg).into();
+                        let tagged_value = primitive_value.tagged(inner.tag.clone());
+                        Ok(vec![ReturnSuccess::value(tagged_value)])
+                    }
+                    _ => Ok(vec![]),
                 }
-            },
+            }
         }
     }
 }
@@ -103,4 +116,3 @@ impl Plugin for Average {
 fn main() {
     serve_plugin(&mut Average::new());
 }
-

--- a/src/plugins/average.rs
+++ b/src/plugins/average.rs
@@ -1,0 +1,106 @@
+use nu::{
+    serve_plugin, CoerceInto, CallInfo, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError, Signature,
+    Tagged, TaggedItem, Value,
+};
+
+#[derive(Debug)]
+struct Average {
+    total: Option<Tagged<Value>>,
+    count: u64,
+}
+
+impl Average {
+    fn new() -> Average {
+        Average { total: None, count: 1 }
+    }
+
+    fn average(&mut self, value: Tagged<Value>) -> Result<(), ShellError> {
+        match value.item() {
+            Value::Primitive(Primitive::Nothing) => Ok(()),
+            Value::Primitive(Primitive::Int(i)) => {
+                match &self.total {
+                    Some(Tagged {
+                        item: Value::Primitive(Primitive::Int(j)),
+                        tag,
+                    }) => {
+                        self.total = Some(Value::int(i + j).tagged(tag));
+                        self.count = self.count + 1;
+                        Ok(())
+                    }
+                    None => {
+                        self.total = Some(value.clone());
+                        Ok(())
+                    }
+                    _ => Err(ShellError::string(format!(
+                        "Could not calculate average of non-integer or unrelated types"
+                    ))),
+                }
+            }
+            Value::Primitive(Primitive::Bytes(b)) => {
+                match self.total {
+                    Some(Tagged {
+                        item: Value::Primitive(Primitive::Bytes(j)),
+                        tag,
+                    }) => {
+                        self.total = Some(Value::int(b + j).tagged(tag));
+                        self.count = self.count + 1;
+                        Ok(())
+                    }
+                    None => {
+                        self.total = Some(value);
+                        Ok(())
+                    }
+                    _ => Err(ShellError::string(format!(
+                        "Could not calculate average of non-integer or unrelated types"
+                    ))),
+                }
+            }
+            x => Err(ShellError::string(format!(
+                "Unrecognized type in stream: {:?}",
+                x
+            ))),
+        }
+
+    }
+}
+
+impl Plugin for Average {
+    fn config(&mut self) -> Result<Signature, ShellError> {
+        Ok(Signature::build("average")
+            .desc("Compute the average of a column of numerical values.")
+            .filter())
+    }
+
+    fn begin_filter(&mut self, _: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
+        Ok(vec![])
+    }
+
+    fn filter(&mut self, input: Tagged<Value>) -> Result<Vec<ReturnValue>, ShellError> {
+        self.average(input)?;
+        Ok(vec![])
+    }
+
+    fn end_filter(&mut self) -> Result<Vec<ReturnValue>, ShellError> {
+        match self.total {
+            None => Ok(vec![]),
+            Some(ref v) =>  {
+                match v.item() {
+                    Value::Primitive(Primitive::Int(i)) => {
+                        let total: u64 = i.tagged(v.tag).coerce_into("converting for average")?;
+                        let avg = total as f64 / self.count as f64;
+                        let decimal_value: Value=  Primitive::from(avg).into();
+                        let tagged_value = decimal_value.tagged(v.tag);
+                        Ok(vec![ReturnSuccess::value(tagged_value)])
+                    }
+                    _ => unreachable!()
+
+                }
+            },
+        }
+    }
+}
+
+fn main() {
+    serve_plugin(&mut Average::new());
+}
+

--- a/src/plugins/average.rs
+++ b/src/plugins/average.rs
@@ -88,27 +88,24 @@ impl Plugin for Average {
     fn end_filter(&mut self) -> Result<Vec<ReturnValue>, ShellError> {
         match self.total {
             None => Ok(vec![]),
-            Some(ref inner) => {
-                match inner.item() {
-                    Value::Primitive(Primitive::Int(i)) => {
-                        let total: u64 = i
-                            .tagged(inner.tag.clone())
-                            .coerce_into("converting for average")?;
-                        let avg = total as f64 / self.count as f64;
-                        let primitive_value: Value = Primitive::from(avg).into();
-                        let tagged_value = primitive_value.tagged(inner.tag.clone());
-                        Ok(vec![ReturnSuccess::value(tagged_value)])
-                    }
-                    Value::Primitive(Primitive::Bytes(bytes)) => {
-                        // let total: u64 = b.tagged(inner.tag.clone()).coerce_into("converting for average")?;
-                        let avg = *bytes as f64 / self.count as f64;
-                        let primitive_value: Value = Primitive::from(avg).into();
-                        let tagged_value = primitive_value.tagged(inner.tag.clone());
-                        Ok(vec![ReturnSuccess::value(tagged_value)])
-                    }
-                    _ => Ok(vec![]),
+            Some(ref inner) => match inner.item() {
+                Value::Primitive(Primitive::Int(i)) => {
+                    let total: u64 = i
+                        .tagged(inner.tag.clone())
+                        .coerce_into("converting for average")?;
+                    let avg = total as f64 / self.count as f64;
+                    let primitive_value: Value = Primitive::from(avg).into();
+                    let tagged_value = primitive_value.tagged(inner.tag.clone());
+                    Ok(vec![ReturnSuccess::value(tagged_value)])
                 }
-            }
+                Value::Primitive(Primitive::Bytes(bytes)) => {
+                    let avg = *bytes as f64 / self.count as f64;
+                    let primitive_value: Value = Primitive::from(avg).into();
+                    let tagged_value = primitive_value.tagged(inner.tag.clone());
+                    Ok(vec![ReturnSuccess::value(tagged_value)])
+                }
+                _ => Ok(vec![]),
+            },
         }
     }
 }

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -580,7 +580,7 @@ fn can_sum() {
 }
 
 #[test]
-fn can_average() {
+fn can_average_numbers() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
@@ -592,6 +592,16 @@ fn can_average() {
     ));
 
     assert_eq!(actual, "101.5000000000000")
+}
+
+#[test]
+fn can_average_bytes() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "ls | get size | average | echo $it"
+    );
+
+    assert_eq!(actual, "2282.727272727273");
 }
 
 #[test]

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -598,10 +598,10 @@ fn can_average_numbers() {
 fn can_average_bytes() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | get size | average | echo $it"
+        "ls | sort-by name | skip 1 | first 2 | get size | average | echo $it"
     );
 
-    assert_eq!(actual, "2282.727272727273");
+    assert_eq!(actual, "1600.000000000000");
 }
 
 #[test]

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -580,6 +580,21 @@ fn can_sum() {
 }
 
 #[test]
+fn can_average() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", h::pipeline(
+        r#"
+            open sgml_description.json
+            | get glossary.GlossDiv.GlossList.GlossEntry.Sections
+            | average
+            | echo $it
+        "#
+    ));
+
+    assert_eq!(actual, "101.5000000000000")
+}
+
+#[test]
 fn can_filter_by_unit_size_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",


### PR DESCRIPTION
This is a work in progress and I'm looking for feedback.

### Objective
- Create a plugin similar to `sum`, but it computes the `average` numerical value of all the rows. I used `sum` as a template while I learn more about the plugin system.
- Adds some `help` documentation for `average`
- Tests for averaging byte columns as well as integer columns.


### TODO
- [x] Add help message documentation. See #711 
- [x] Add test for Bytes
