### PR TITLE
Ignore errors in `ls`.

### DIFF
--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -128,13 +128,16 @@ impl Shell for FilesystemShell {
                         }
                         if let Ok(entry) = entry {
                             let filepath = entry.path();
-                            let filename = if let Ok(fname) = filepath.strip_prefix(&cwd) {
-                                fname
-                            } else {
-                                Path::new(&filepath)
-                            };
-                            let value = dir_entry_dict(filename, &entry.metadata().unwrap(), &name_tag)?;
-                            yield ReturnSuccess::value(value);
+                            if let Ok(metadata) = std::fs::symlink_metadata(&filepath) {
+                                let filename = if let Ok(fname) = filepath.strip_prefix(&cwd) {
+                                    fname
+                                } else {
+                                    Path::new(&filepath)
+                                };
+
+                                let value = dir_entry_dict(filename, &metadata, &name_tag)?;
+                                yield ReturnSuccess::value(value);
+                            }
                         }
                     }
                 };
@@ -164,14 +167,16 @@ impl Shell for FilesystemShell {
                     break;
                 }
                 if let Ok(entry) = entry {
-                    let filename = if let Ok(fname) = entry.strip_prefix(&cwd) {
-                        fname
-                    } else {
-                        Path::new(&entry)
-                    };
-                    let metadata = std::fs::metadata(&entry).unwrap();
-                    if let Ok(value) = dir_entry_dict(filename, &metadata, &name_tag) {
-                        yield ReturnSuccess::value(value);
+                    if let Ok(metadata) = std::fs::symlink_metadata(&entry) {
+                        let filename = if let Ok(fname) = entry.strip_prefix(&cwd) {
+                            fname
+                        } else {
+                            Path::new(&entry)
+                        };
+
+                        if let Ok(value) = dir_entry_dict(filename, &metadata, &name_tag) {
+                            yield ReturnSuccess::value(value);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Ignore errors in `ls`.

`std::fs::metadata` will attempt to follow symlinks, which results in a "No such file or directory" error if the path pointed to by the symlink does not exist. This shouldn't prevent `ls` from succeeding, so we ignore errors.

Also, switching to use of `symlink_metadata` means we get stat info on the symlink itself, not what it points to. This means `ls` will now exhibit two new behaviours:

1. broken symlinks are included, and
2. working symlinks are labeled with type `Symlink`.

This is closer to what I experience in zsh. I discovered this issue when playing around with the command in https://github.com/nushell/nushell/issues/640. Related to https://github.com/nushell/nushell/issues/66.

Discussion points:
1. Is this the behaviour nushell desires?
2. Happy to write some tests, but I expect we'll need to do some work on `Playground` to support symlinks (not as easy, since the concept of a soft link differs between systems).