### PR TITLE
Fix confusing unnamed column and crash

### DIFF
--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -60,11 +60,19 @@ pub fn get_column_path(
 
                     possible_matches.sort();
 
-                    return Err(ShellError::labeled_error(
-                        "Unknown column",
-                        format!("did you mean '{}'?", possible_matches[0].1),
-                        tag_for_tagged_list(path.iter().map(|p| p.tag())),
-                    ));
+                    if possible_matches.len() > 0 {
+                        return Err(ShellError::labeled_error(
+                            "Unknown column",
+                            format!("did you mean '{}'?", possible_matches[0].1),
+                            tag_for_tagged_list(path.iter().map(|p| p.tag())),
+                        ));
+                    } else {
+                        return Err(ShellError::labeled_error(
+                            "Unknown column",
+                            "row does not contain this column",
+                            tag_for_tagged_list(path.iter().map(|p| p.tag())),
+                        ));
+                    }
                 }
             }
         }

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -42,7 +42,7 @@ impl TableView {
         let mut headers = TableView::merge_descriptors(values);
 
         if headers.len() == 0 {
-            headers.push("value".to_string());
+            headers.push("<unknown>".to_string());
         }
 
         let mut entries = vec![];


### PR DESCRIPTION
This fixes a crash if you try to get the column named `value` when it's not actually named that (fix originally from #777). I've also gone ahead and renamed the empty column name to `<unknown>`

Fixes #707 