### PR TITLE
Fix bug with multiple input objects to an external command.

### DIFF
--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -165,6 +165,28 @@ fn save_figures_out_intelligently_where_to_write_out_with_metadata() {
 }
 
 #[test]
+fn it_arg_works_with_many_inputs_to_external_command() {
+    Playground::setup("it_arg_works_with_many_inputs", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            FileWithContent("file1", "text"),
+            FileWithContent("file2", " and more text"),
+        ]);
+
+        let (stdout, stderr) = nu_combined!(
+            cwd: dirs.test(), h::pipeline(
+            r#"
+                echo file1 file2
+                | split-row " "
+                | cat $it
+            "#
+        ));
+
+        assert_eq!("text and more text", stdout);
+        assert!(!stderr.contains("No such file or directory"));
+    })
+}
+
+#[test]
 fn save_can_write_out_csv() {
     Playground::setup("save_test_2", |dirs, _| {
         let expected_file = dirs.test().join("cargo_sample.csv");

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -155,6 +155,60 @@ macro_rules! nu_error {
     }};
 }
 
+#[macro_export]
+macro_rules! nu_combined {
+    (cwd: $cwd:expr, $path:expr, $($part:expr),*) => {{
+        use $crate::helpers::DisplayPath;
+
+        let path = format!($path, $(
+            $part.display_path()
+        ),*);
+
+        nu_combined!($cwd, &path)
+    }};
+
+    (cwd: $cwd:expr, $path:expr) => {{
+        nu_combined!($cwd, $path)
+    }};
+
+    ($cwd:expr, $path:expr) => {{
+        pub use std::error::Error;
+        pub use std::io::prelude::*;
+        pub use std::process::{Command, Stdio};
+
+        let commands = &*format!(
+            "
+                            cd {}
+                            {}
+                            exit",
+            $crate::helpers::in_directory($cwd),
+            $crate::helpers::DisplayPath::display_path(&$path)
+        );
+
+        let mut process = Command::new(helpers::executable_path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("couldn't run test");
+
+        let stdin = process.stdin.as_mut().expect("couldn't open stdin");
+        stdin
+            .write_all(commands.as_bytes())
+            .expect("couldn't write to stdin");
+
+        let output = process
+            .wait_with_output()
+            .expect("couldn't read from stdout/stderr");
+
+        let err = String::from_utf8_lossy(&output.stderr).into_owned();
+        let out = String::from_utf8_lossy(&output.stdout).into_owned();
+        let out = out.replace("\r\n", "");
+        let out = out.replace("\n", "");
+        (out, err)
+    }};
+}
+
 pub enum Stub<'a> {
     FileWithContent(&'a str, &'a str),
     FileWithContentToBeTrimmed(&'a str, &'a str),


### PR DESCRIPTION
Previously, we would build a command that looked something like this:

```
<ex_cmd> "$it" "&&" "<ex_cmd>" "$it"
```

So that the "&&" and "<ex_cmd>" would also be arguments to the command, instead of the original intent of chaining commands together (edit: so you can imaging the command `cat` would try to look for a file called `&&`).

This PR adds a few things:

- Builds up a command string that can be passed to an external shell.
- Adds `nu_combined!` macro for tests, so we can assert against both stdout and stderr.
- Adds a test to verify correct behaviour.