### PR TITLE
Start moving coloring into the token stream

### DIFF
--- a/features.toml
+++ b/features.toml
@@ -2,3 +2,12 @@
 
 description = "Adding hints based upon error states in the syntax highlighter"
 enabled = false
+
+[coloring_in_tokens]
+
+description = "Move coloring into the TokensIterator so they can be atomic with the rest of the iterator"
+reason = """
+This is laying the groundwork for merging coloring and parsing. It also makes token_nodes.atomic() naturally
+work with coloring, which is pretty useful on its own.
+"""
+enabled = false

--- a/src/parser/hir/syntax_shape/expression/list.rs
+++ b/src/parser/hir/syntax_shape/expression/list.rs
@@ -1,4 +1,6 @@
 use crate::errors::ShellError;
+#[cfg(not(coloring_in_tokens))]
+use crate::parser::hir::syntax_shape::FlatShape;
 use crate::parser::{
     hir,
     hir::syntax_shape::{
@@ -7,8 +9,8 @@ use crate::parser::{
         MaybeSpaceShape, SpaceShape,
     },
     hir::TokensIterator,
-    FlatShape,
 };
+#[cfg(not(coloring_in_tokens))]
 use crate::Spanned;
 
 #[derive(Debug, Copy, Clone)]
@@ -44,6 +46,7 @@ impl ExpandSyntax for ExpressionListShape {
     }
 }
 
+#[cfg(not(coloring_in_tokens))]
 impl ColorSyntax for ExpressionListShape {
     type Info = ();
     type Input = ();
@@ -113,10 +116,80 @@ impl ColorSyntax for ExpressionListShape {
     }
 }
 
+#[cfg(coloring_in_tokens)]
+impl ColorSyntax for ExpressionListShape {
+    type Info = ();
+    type Input = ();
+
+    /// The intent of this method is to fully color an expression list shape infallibly.
+    /// This means that if we can't expand a token into an expression, we fall back to
+    /// a simpler coloring strategy.
+    ///
+    /// This would apply to something like `where x >`, which includes an incomplete
+    /// binary operator. Since we will fail to process it as a binary operator, we'll
+    /// fall back to a simpler coloring and move on.
+    fn color_syntax<'a, 'b>(
+        &self,
+        _input: &(),
+        token_nodes: &'b mut TokensIterator<'a>,
+        context: &ExpandContext,
+    ) {
+        // We encountered a parsing error and will continue with simpler coloring ("backoff
+        // coloring mode")
+        let mut backoff = false;
+
+        // Consume any leading whitespace
+        color_syntax(&MaybeSpaceShape, token_nodes, context);
+
+        loop {
+            // If we reached the very end of the token stream, we're done
+            if token_nodes.at_end() {
+                return;
+            }
+
+            if backoff {
+                let len = token_nodes.shapes().len();
+
+                // If we previously encountered a parsing error, use backoff coloring mode
+                color_syntax(&SimplestExpression, token_nodes, context);
+
+                if len == token_nodes.shapes().len() && !token_nodes.at_end() {
+                    // This should never happen, but if it does, a panic is better than an infinite loop
+                    panic!("Unexpected tokens left that couldn't be colored even with SimplestExpression")
+                }
+            } else {
+                // Try to color the head of the stream as an expression
+                match color_fallible_syntax(&AnyExpressionShape, token_nodes, context) {
+                    // If no expression was found, switch to backoff coloring mode
+                    Err(_) => {
+                        backoff = true;
+                        continue;
+                    }
+                    Ok(_) => {}
+                }
+
+                // If an expression was found, consume a space
+                match color_fallible_syntax(&SpaceShape, token_nodes, context) {
+                    Err(_) => {
+                        // If no space was found, we're either at the end or there's an error.
+                        // Either way, switch to backoff coloring mode. If we're at the end
+                        // it won't have any consequences.
+                        backoff = true;
+                    }
+                    Ok(_) => {
+                        // Otherwise, move on to the next expression
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// BackoffColoringMode consumes all of the remaining tokens in an infallible way
 #[derive(Debug, Copy, Clone)]
 pub struct BackoffColoringMode;
 
+#[cfg(not(coloring_in_tokens))]
 impl ColorSyntax for BackoffColoringMode {
     type Info = ();
     type Input = ();
@@ -144,12 +217,40 @@ impl ColorSyntax for BackoffColoringMode {
     }
 }
 
+#[cfg(coloring_in_tokens)]
+impl ColorSyntax for BackoffColoringMode {
+    type Info = ();
+    type Input = ();
+
+    fn color_syntax<'a, 'b>(
+        &self,
+        _input: &Self::Input,
+        token_nodes: &'b mut TokensIterator<'a>,
+        context: &ExpandContext,
+    ) -> Self::Info {
+        loop {
+            if token_nodes.at_end() {
+                break;
+            }
+
+            let len = token_nodes.shapes().len();
+            color_syntax(&SimplestExpression, token_nodes, context);
+
+            if len == token_nodes.shapes().len() && !token_nodes.at_end() {
+                // This shouldn't happen, but if it does, a panic is better than an infinite loop
+                panic!("SimplestExpression failed to consume any tokens, but it's not at the end. This is unexpected\n== token nodes==\n{:#?}\n\n== shapes ==\n{:#?}", token_nodes, token_nodes.shapes());
+            }
+        }
+    }
+}
+
 /// The point of `SimplestExpression` is to serve as an infallible base case for coloring.
 /// As a last ditch effort, if we can't find any way to parse the head of the stream as an
 /// expression, fall back to simple coloring.
 #[derive(Debug, Copy, Clone)]
 pub struct SimplestExpression;
 
+#[cfg(not(coloring_in_tokens))]
 impl ColorSyntax for SimplestExpression {
     type Info = ();
     type Input = ();
@@ -171,6 +272,31 @@ impl ColorSyntax for SimplestExpression {
         match atom {
             Err(_) => {}
             Ok(atom) => atom.color_tokens(shapes),
+        }
+    }
+}
+
+#[cfg(coloring_in_tokens)]
+impl ColorSyntax for SimplestExpression {
+    type Info = ();
+    type Input = ();
+
+    fn color_syntax<'a, 'b>(
+        &self,
+        _input: &(),
+        token_nodes: &'b mut TokensIterator<'a>,
+        context: &ExpandContext,
+    ) {
+        let atom = expand_atom(
+            token_nodes,
+            "any token",
+            context,
+            ExpansionRule::permissive(),
+        );
+
+        match atom {
+            Err(_) => {}
+            Ok(atom) => atom.color_tokens(token_nodes.mut_shapes()),
         }
     }
 }

--- a/src/parser/hir/syntax_shape/expression/number.rs
+++ b/src/parser/hir/syntax_shape/expression/number.rs
@@ -44,6 +44,7 @@ impl ExpandExpression for NumberShape {
     }
 }
 
+#[cfg(not(coloring_in_tokens))]
 impl FallibleColorSyntax for NumberShape {
     type Info = ();
     type Input = ();
@@ -68,6 +69,35 @@ impl FallibleColorSyntax for NumberShape {
         };
 
         atom.color_tokens(shapes);
+
+        Ok(())
+    }
+}
+
+#[cfg(coloring_in_tokens)]
+impl FallibleColorSyntax for NumberShape {
+    type Info = ();
+    type Input = ();
+
+    fn color_syntax<'a, 'b>(
+        &self,
+        _input: &(),
+        token_nodes: &'b mut TokensIterator<'a>,
+        context: &ExpandContext,
+    ) -> Result<(), ShellError> {
+        let atom = token_nodes.spanned(|token_nodes| {
+            expand_atom(token_nodes, "number", context, ExpansionRule::permissive())
+        });
+
+        let atom = match atom {
+            Spanned { item: Err(_), span } => {
+                token_nodes.color_shape(FlatShape::Error.spanned(span));
+                return Ok(());
+            }
+            Spanned { item: Ok(atom), .. } => atom,
+        };
+
+        atom.color_tokens(token_nodes.mut_shapes());
 
         Ok(())
     }
@@ -106,6 +136,7 @@ impl ExpandExpression for IntShape {
     }
 }
 
+#[cfg(not(coloring_in_tokens))]
 impl FallibleColorSyntax for IntShape {
     type Info = ();
     type Input = ();
@@ -130,6 +161,35 @@ impl FallibleColorSyntax for IntShape {
         };
 
         atom.color_tokens(shapes);
+
+        Ok(())
+    }
+}
+
+#[cfg(coloring_in_tokens)]
+impl FallibleColorSyntax for IntShape {
+    type Info = ();
+    type Input = ();
+
+    fn color_syntax<'a, 'b>(
+        &self,
+        _input: &(),
+        token_nodes: &'b mut TokensIterator<'a>,
+        context: &ExpandContext,
+    ) -> Result<(), ShellError> {
+        let atom = token_nodes.spanned(|token_nodes| {
+            expand_atom(token_nodes, "integer", context, ExpansionRule::permissive())
+        });
+
+        let atom = match atom {
+            Spanned { item: Err(_), span } => {
+                token_nodes.color_shape(FlatShape::Error.spanned(span));
+                return Ok(());
+            }
+            Spanned { item: Ok(atom), .. } => atom,
+        };
+
+        atom.color_tokens(token_nodes.mut_shapes());
 
         Ok(())
     }


### PR DESCRIPTION
The benefit of this is that coloring can be made atomic alongside token
stream forwarding.

I put the feature behind a flag so I can continue to iterate on it
without possibly regressing existing functionality. It's a lot of places
where the flags have to go, but I expect it to be a short-lived flag,
and the flags are fully contained in the parser.