### PR TITLE
`from-ssv`: user-defined number of spaces to split on

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | from-ini | Parse text as .ini and create table |
 | from-json | Parse text as .json and create table |
 | from-sqlite | Parse binary data as sqlite .db and create table |
-| from-ssv  | Parse text as whitespace-separated values and create table|
+| from-ssv -n <min number of spaces to count as a separator> | Parse text as space-separated values and create table |
 | from-toml | Parse text as .toml and create table |
 | from-tsv  | Parse text as .tsv and create table  |
 | from-url | Parse urlencoded string and create a table |

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | from-ini | Parse text as .ini and create table |
 | from-json | Parse text as .json and create table |
 | from-sqlite | Parse binary data as sqlite .db and create table |
-| from-ssv -n <min number of spaces to count as a separator> | Parse text as space-separated values and create table |
+| from-ssv --minimum-spaces <minimum number of spaces to count as a separator> | Parse text as space-separated values and create table |
 | from-toml | Parse text as .toml and create table |
 | from-tsv  | Parse text as .tsv and create table  |
 | from-url | Parse urlencoded string and create a table |

--- a/src/commands/from_ssv.rs
+++ b/src/commands/from_ssv.rs
@@ -26,7 +26,7 @@ impl WholeStreamCommand for FromSSV {
     }
 
     fn usage(&self) -> &str {
-        "Parse text as space-separated values and create a table."
+        "Parse text as space-separated values and create a table. The default minimum number of spaces counted as a separator is 2."
     }
 
     fn run(

--- a/src/commands/from_ssv.rs
+++ b/src/commands/from_ssv.rs
@@ -12,7 +12,7 @@ pub struct FromSSVArgs {
 }
 
 const STRING_REPRESENTATION: &str = "from-ssv";
-const DEFAULT_ALLOWED_SPACES: usize = 0;
+const DEFAULT_MINIMUM_SPACES: usize = 2;
 
 impl WholeStreamCommand for FromSSV {
     fn name(&self) -> &str {
@@ -116,7 +116,7 @@ fn from_ssv(
         let mut latest_tag: Option<Tag> = None;
         let split_at = match minimum_spaces {
             Some(number) => number.item,
-            None => DEFAULT_ALLOWED_SPACES
+            None => DEFAULT_MINIMUM_SPACES
         };
 
         for value in values {

--- a/src/commands/from_ssv.rs
+++ b/src/commands/from_ssv.rs
@@ -184,4 +184,43 @@ mod tests {
         let result = string_to_table(input, true);
         assert_eq!(result, None);
     }
+
+    #[test]
+    fn it_allows_a_predefined_number_of_spaces() {
+        let input = r#"
+            column a   column b
+            entry 1   entry number  2
+            3   four
+        "#;
+
+        let result = string_to_table(input, false);
+        assert_eq!(
+            result,
+            Some(vec![
+                vec![
+                    owned("column a", "entry 1"),
+                    owned("column b", "entry number  2")
+                ],
+                vec![owned("column a", "3"), owned("column b", "four")]
+            ])
+        );
+    }
+
+    #[test]
+    fn it_trims_remaining_separator_space() {
+        let input = r#"
+            colA   colB     colC
+            val1   val2     val3
+        "#;
+
+        let trimmed = |s: &str| s.trim() == s;
+
+        let result = string_to_table(input, false).unwrap();
+        assert_eq!(
+            true,
+            result
+                .iter()
+                .all(|row| row.iter().all(|(a, b)| trimmed(a) && trimmed(b)))
+        )
+    }
 }

--- a/src/commands/from_ssv.rs
+++ b/src/commands/from_ssv.rs
@@ -25,7 +25,7 @@ impl WholeStreamCommand for FromSSV {
     }
 
     fn usage(&self) -> &str {
-        "Parse text as whitespace-separated values and create a table."
+        "Parse text as space-separated values and create a table."
     }
 
     fn run(

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -400,7 +400,7 @@ fn converts_from_ssv_text_to_structured_table_with_separator_specified() {
             cwd: dirs.test(), h::pipeline(
             r#"
                 open oc_get_svc.txt
-                | from-ssv -n 3
+                | from-ssv --minimum-spaces 3
                 | nth 0
                 | get IP
                 | echo $it

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -384,6 +384,34 @@ fn converts_from_ssv_text_to_structured_table() {
 }
 
 #[test]
+fn converts_from_ssv_text_to_structured_table_with_separator_specified() {
+    Playground::setup("filter_from_ssv_test_1", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "oc_get_svc.txt",
+            r#"
+                NAME              LABELS                                    SELECTOR                  IP              PORT(S)
+                docker-registry   docker-registry=default                   docker-registry=default   172.30.78.158   5000/TCP
+                kubernetes        component=apiserver,provider=kubernetes   <none>                    172.30.0.2      443/TCP
+                kubernetes-ro     component=apiserver,provider=kubernetes   <none>                    172.30.0.1      80/TCP
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), h::pipeline(
+            r#"
+                open oc_get_svc.txt
+                | from-ssv -n 3
+                | nth 0
+                | get IP
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual, "172.30.78.158");
+    })
+}
+
+#[test]
 fn converts_from_ssv_text_skipping_headers_to_structured_table() {
     Playground::setup("filter_from_ssv_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(


### PR DESCRIPTION
As mentioned in #830, this is an extension of the basic `from-ssv` command. The command now takes an optional argument to let the user decide how many spaces to use as a minimum for separation.

Current usage: `from-ssv -n <usize>`

# Discussion points
There are a few things I'd like to get some input on before getting this merged:

## How to pass the value
- Should it be a flag (as it's implemented now), or should it behave like `first`, where you can simply type the command followed by a number?

- What should the flag be called? I tried to use a more descriptive name, something like `allowed-spaces` or the like, but ran into various errors when the input was being parsed, regarding type errors, expecting booleans, integers, or getting flags. In the end, this was the only thing I got working. If we want something more verbose, I think I'd need some help to get it implemented. That said, I like that it's a short flag.