### PR TITLE
`from-ssv` logic updated

### DIFF
--- a/src/commands/from_ssv.rs
+++ b/src/commands/from_ssv.rs
@@ -75,7 +75,7 @@ fn string_to_table(
                     .filter_map(|(i, (start, col))| {
                         (match columns.get(i + 1) {
                             Some((end, _)) => l.get(*start..*end),
-                            None => l.get(*start..)?.split(&separator).next(),
+                            None => l.get(*start..),
                         })
                         .and_then(|s| Some((col.clone(), String::from(s.trim()))))
                     })
@@ -298,16 +298,16 @@ mod tests {
     }
 
     #[test]
-    fn it_drops_trailing_values() {
+    fn it_uses_the_full_final_column() {
         let input = r#"
             colA   col B
-            val1   val2   trailing value that should be ignored
+            val1   val2   trailing value that should be included
         "#;
 
         let result = string_to_table(input, false, 2).unwrap();
         assert_eq!(
             result,
-            vec![vec![owned("colA", "val1"), owned("col B", "val2"),],]
+            vec![vec![owned("colA", "val1"), owned("col B", "val2   trailing value that should be included"),],]
         )
     }
 }

--- a/src/commands/from_ssv.rs
+++ b/src/commands/from_ssv.rs
@@ -307,7 +307,10 @@ mod tests {
         let result = string_to_table(input, false, 2).unwrap();
         assert_eq!(
             result,
-            vec![vec![owned("colA", "val1"), owned("col B", "val2   trailing value that should be included"),],]
+            vec![vec![
+                owned("colA", "val1"),
+                owned("col B", "val2   trailing value that should be included"),
+            ],]
         )
     }
 }


### PR DESCRIPTION
Hey! So a pull request with no prior discussion may be bad form, but I was tinkering around with this problem I had and managed to solve it, and due to how we're seemingly in very different time zones, I just wanted to get it out there without too much delay. Hope you don't mind.

# What and why

Anyway: **I'd like to change the table creation algorithm for `from-ssv`**. Previously, the table would be created based only on an entries index in a row as decided by the separators in the row. This meant that two values, though vertically misaligned, could still belong together:
```
col1                col2
a        b
```
So in the above snippet, assuming a separator of two spaces, `a` belongs to `col1`, and `b` to `col2`. This makes a lot of sense to me, but it has one pretty big hole: **what about empty values**?

Given this table:
```
col1   col2   col3
a             c
```
It seems quite intuitive that `c` would go in `col3` and that `col2` just doesn't have a value in this case, but with the old (current) algorithm, `c` would belong to `col2` and `col3` would have an empty value.

With the new algorithm, the first table would give `col1` the value of `a        b` and `col2` and empty string. The second table would pair `col1` with `a`, `col3` with `c` and `col2` with an empty string again.

Thus, given that the only real world examples I have seen of space-separated values being used  are output from `kubectl` (Kubernetes) or `oc` (OpenShift), and that these output values sometimes _do_ have holes in them, I think this approach, **basing an entry's column on its horizontal alignment**, is more correct and intuitive. 

-----

Discussion on this is very welcome, and please do not feel any pressure to merge this if you disagree with the sentiment. I should have opened an issue for clarification but got a bit to absorbed by trying to solve the problem, so let this act as both a potential solution and a general discussion for the issue.
Cheers! 