### PR TITLE
Deletes impl From<&str> for Unit

### DIFF
--- a/src/parser/parse/unit.rs
+++ b/src/parser/parse/unit.rs
@@ -39,12 +39,6 @@ impl Unit {
     }
 }
 
-impl From<&str> for Unit {
-    fn from(input: &str) -> Unit {
-        Unit::from_str(input).unwrap()
-    }
-}
-
 impl FromStr for Unit {
     type Err = ();
     fn from_str(input: &str) -> Result<Self, <Self as std::str::FromStr>::Err> {


### PR DESCRIPTION
Based on #300, this PR removes the PR in Unit.rs. It does so by deleting the Impl block. It seems drastic, but the project still compiles, and filtering with 'where' on file size still seems to act the same, so I assume things are alright.