### PR TITLE
#194 Connect `rm` command to platform's recycle bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,6 +1558,7 @@ dependencies = [
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2494,6 +2495,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,6 +3102,7 @@ dependencies = [
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
+"checksum trash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f24d31505f49e989b1ee2c03c323251f6763d5907d471b71192dac92e323f8"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2e2e6bd1e59e56598518beb94fd6db628ded570326f0a98c679a304bd9f00150"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ bigdecimal = { version = "0.1.0", features = ["serde"] }
 natural = "0.3.0"
 serde_urlencoded = "0.6.1"
 sublime_fuzzy = "0.5"
+trash = "1.0.0"
 
 regex = {version = "1", optional = true }
 neso = { version = "0.5.0", optional = true }

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -11,6 +11,7 @@ pub struct Remove;
 pub struct RemoveArgs {
     pub target: Tagged<PathBuf>,
     pub recursive: Tagged<bool>,
+    pub trash: Tagged<bool>,
 }
 
 impl PerItemCommand for Remove {
@@ -21,11 +22,12 @@ impl PerItemCommand for Remove {
     fn signature(&self) -> Signature {
         Signature::build("rm")
             .required("path", SyntaxShape::Pattern)
+            .switch("trash")
             .switch("recursive")
     }
 
     fn usage(&self) -> &str {
-        "Remove a file, (for removing directory append '--recursive')"
+        "Remove a file. Append '--recursive' to remove directories and '--trash' for seding it to system recycle bin"
     }
 
     fn run(

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -8,6 +8,7 @@ use crate::prelude::*;
 use crate::shell::completer::NuCompleter;
 use crate::shell::shell::Shell;
 use crate::utils::FileStructure;
+use trash as SendToTrash;
 use rustyline::completion::FilenameCompleter;
 use rustyline::hint::{Hinter, HistoryHinter};
 use std::path::{Path, PathBuf};
@@ -860,7 +861,7 @@ impl Shell for FilesystemShell {
 
     fn rm(
         &self,
-        RemoveArgs { target, recursive }: RemoveArgs,
+        RemoveArgs { target, recursive, trash }: RemoveArgs,
         name: Tag,
         path: &str,
     ) -> Result<OutputStream, ShellError> {
@@ -946,7 +947,11 @@ impl Shell for FilesystemShell {
                     if path.is_dir() {
                         std::fs::remove_dir_all(&path)?;
                     } else if path.is_file() {
-                        std::fs::remove_file(&path)?;
+                        if trash.item {
+                            SendToTrash::remove(path).unwrap();
+                        } else {
+                            std::fs::remove_file(&path)?;
+                        }
                     }
                 }
                 Err(e) => {

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -8,11 +8,11 @@ use crate::prelude::*;
 use crate::shell::completer::NuCompleter;
 use crate::shell::shell::Shell;
 use crate::utils::FileStructure;
-use trash as SendToTrash;
 use rustyline::completion::FilenameCompleter;
 use rustyline::hint::{Hinter, HistoryHinter};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
+use trash as SendToTrash;
 
 pub struct FilesystemShell {
     pub(crate) path: String,
@@ -861,7 +861,11 @@ impl Shell for FilesystemShell {
 
     fn rm(
         &self,
-        RemoveArgs { target, recursive, trash }: RemoveArgs,
+        RemoveArgs {
+            target,
+            recursive,
+            trash,
+        }: RemoveArgs,
         name: Tag,
         path: &str,
     ) -> Result<OutputStream, ShellError> {

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -944,14 +944,12 @@ impl Shell for FilesystemShell {
                         ));
                     }
 
-                    if path.is_dir() {
+                    if trash.item {
+                        SendToTrash::remove(path).unwrap();
+                    } else if path.is_dir() {
                         std::fs::remove_dir_all(&path)?;
                     } else if path.is_file() {
-                        if trash.item {
-                            SendToTrash::remove(path).unwrap();
-                        } else {
-                            std::fs::remove_file(&path)?;
-                        }
+                        std::fs::remove_file(&path)?;
                     }
                 }
                 Err(e) => {


### PR DESCRIPTION
I have used  [trash](https://crates.io/crates/trash) crate.

I just added a flag to the `rm` command. I have recorded and example of use:

[![asciicast](https://asciinema.org/a/T4FePfmfjPQ2s3v5WQuGZGlH1.svg)](https://asciinema.org/a/T4FePfmfjPQ2s3v5WQuGZGlH1)