### PR TITLE
WIP fetch command - support reading url from variable

### DIFF
--- a/src/data/base.rs
+++ b/src/data/base.rs
@@ -817,6 +817,7 @@ impl Tagged<Value> {
     pub(crate) fn as_path(&self) -> Result<PathBuf, ShellError> {
         match self.item() {
             Value::Primitive(Primitive::Path(path)) => Ok(path.clone()),
+            Value::Primitive(Primitive::String(path_str)) => Ok(PathBuf::from(&path_str).clone()),
             other => Err(ShellError::type_error(
                 "Path",
                 other.type_name().tagged(self.tag()),


### PR DESCRIPTION
Currently, when passing a variable, `$it`, to the `fetch` command, it breaks with a parse error because it is expecting a Path where it finds a String value. This PR adds support to create a `PathBuf` from a `Primitive::String` so values can be read from tables and passed into fetch.

Having this feature is helpful when calling APIs with long query strings.
### Example

Example json file, but could be data from anywhere.
```json
{ "url": "https://book.nushell.sh/" }
```

The following works as if we directly called `fetch https://book.nushell.sh`
`open test_file.json | get url | fetch $it`

### TODO
- Needs automated testing

