### PR TITLE
Add a simple read/parse plugin to better handle text data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ natural = "0.3.0"
 serde_urlencoded = "0.6.1"
 sublime_fuzzy = "0.5"
 trash = "1.0.0"
+regex = "1"
 
-regex = {version = "1", optional = true }
 neso = { version = "0.5.0", optional = true }
 crossterm = { version = "0.10.2", optional = true }
 syntect = {version = "3.2.0", optional = true }
@@ -135,6 +135,10 @@ path = "src/plugins/add.rs"
 [[bin]]
 name = "nu_plugin_edit"
 path = "src/plugins/edit.rs"
+
+[[bin]]
+name = "nu_plugin_read"
+path = "src/plugins/read.rs"
 
 [[bin]]
 name = "nu_plugin_str"

--- a/src/plugins/read.rs
+++ b/src/plugins/read.rs
@@ -1,0 +1,156 @@
+use nu::{
+    serve_plugin, CallInfo, Plugin, Primitive, ReturnSuccess, ReturnValue, ShellError, Signature,
+    SyntaxShape, Tagged, TaggedDictBuilder, Value,
+};
+
+use nom::{
+    bytes::complete::{tag, take_while},
+    IResult,
+};
+use regex::Regex;
+
+#[derive(Debug)]
+enum ReadCommand {
+    Text(String),
+    Column(String),
+}
+
+fn read(input: &str) -> IResult<&str, Vec<ReadCommand>> {
+    let mut output = vec![];
+
+    let mut loop_input = input;
+    loop {
+        let (input, before) = take_while(|c| c != '{')(loop_input)?;
+        if before.len() > 0 {
+            output.push(ReadCommand::Text(before.to_string()));
+        }
+        if input != "" {
+            // Look for column as we're now at one
+            let (input, _) = tag("{")(input)?;
+            let (input, column) = take_while(|c| c != '}')(input)?;
+            let (input, _) = tag("}")(input)?;
+
+            output.push(ReadCommand::Column(column.to_string()));
+            loop_input = input;
+        } else {
+            loop_input = input;
+        }
+        if loop_input == "" {
+            break;
+        }
+    }
+
+    Ok((loop_input, output))
+}
+
+fn column_names(commands: &[ReadCommand]) -> Vec<String> {
+    let mut output = vec![];
+
+    for command in commands {
+        match command {
+            ReadCommand::Column(c) => {
+                output.push(c.clone());
+            }
+            _ => {}
+        }
+    }
+
+    output
+}
+
+fn build_regex(commands: &[ReadCommand]) -> String {
+    let mut output = String::new();
+
+    for command in commands {
+        match command {
+            ReadCommand::Text(s) => {
+                output.push_str(&s.replace("(", "\\("));
+            }
+            ReadCommand::Column(_) => {
+                output.push_str("(.*)");
+            }
+        }
+    }
+
+    return output;
+}
+struct Read {
+    regex: Regex,
+    column_names: Vec<String>,
+}
+
+impl Read {
+    fn new() -> Self {
+        Read {
+            regex: Regex::new("").unwrap(),
+            column_names: vec![],
+        }
+    }
+}
+
+impl Plugin for Read {
+    fn config(&mut self) -> Result<Signature, ShellError> {
+        Ok(Signature::build("read")
+            .desc("Parse columns from string data using a simple pattern")
+            .required(
+                "pattern",
+                SyntaxShape::Any,
+                "the pattern to match. Eg) \"{foo}: {bar}\"",
+            )
+            .filter())
+    }
+    fn begin_filter(&mut self, call_info: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
+        if let Some(args) = call_info.args.positional {
+            match &args[0] {
+                Tagged {
+                    item: Value::Primitive(Primitive::String(pattern)),
+                    ..
+                } => {
+                    //self.pattern = s.clone();
+                    let read_pattern = read(&pattern).unwrap();
+                    let read_regex = build_regex(&read_pattern.1);
+
+                    self.column_names = column_names(&read_pattern.1);
+
+                    self.regex = Regex::new(&read_regex).unwrap();
+                }
+                Tagged { tag, .. } => {
+                    return Err(ShellError::labeled_error(
+                        "Unrecognized type in params",
+                        "value",
+                        tag,
+                    ));
+                }
+            }
+        }
+        Ok(vec![])
+    }
+
+    fn filter(&mut self, input: Tagged<Value>) -> Result<Vec<ReturnValue>, ShellError> {
+        let mut results = vec![];
+        match &input {
+            Tagged {
+                tag,
+                item: Value::Primitive(Primitive::String(s)),
+            } => {
+                //self.full_input.push_str(&s);
+
+                for cap in self.regex.captures_iter(&s) {
+                    let mut dict = TaggedDictBuilder::new(tag);
+
+                    for (idx, column_name) in self.column_names.iter().enumerate() {
+                        dict.insert(column_name, Value::string(&cap[idx + 1].to_string()));
+                    }
+
+                    results.push(ReturnSuccess::value(dict.into_tagged_value()));
+                }
+            }
+            _ => {}
+        }
+        Ok(results)
+    }
+}
+
+fn main() {
+    serve_plugin(&mut Read::new());
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -449,6 +449,10 @@ mod tests {
                     at: 0
                 },
                 Res {
+                    loc: fixtures().join("fileA.txt"),
+                    at: 0
+                },
+                Res {
                     loc: fixtures().join("jonathan.xml"),
                     at: 0
                 },

--- a/tests/fixtures/formats/fileA.txt
+++ b/tests/fixtures/formats/fileA.txt
@@ -1,0 +1,3 @@
+VAR1=Chill
+VAR2=StupidLongName
+VAR3=AlsoChill

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -57,6 +57,22 @@ fn add_plugin() {
 }
 
 #[test]
+fn read_plugin() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", h::pipeline(
+        r#"
+            open fileA.txt
+            | read "{Name}={Value}"
+            | nth 1
+            | get Value
+            | echo $it
+        "#
+    ));
+
+    assert_eq!(actual, "StupidLongName");
+}
+
+#[test]
 fn edit_plugin() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(


### PR DESCRIPTION
This adds a simple `read` plugin which can handle a matching pattern. The pattern describes how to handle the text data and convert it to a table.

Let's say we had the following file:

```
VAR1=Chill
VAR2=StupidLongName
VAR3=AlsoChill
```

Usually, we would turn this into a table using:
```
open file.txt | lines | split-columns "=" Name Value
```

With this new command, we can instead give a simple pattern that the data must match. If it does, we take the row of text and convert it to structured data:
```
open file.txt | read "{Name}={Value}"
```

The {Name} and {Value} denote where the columns of those names will get their data.

If a line does not match the pattern, its data is not included in the table.