### PR TITLE
Make echo more flexible with data types

### DIFF
--- a/src/commands/echo.rs
+++ b/src/commands/echo.rs
@@ -35,37 +35,34 @@ fn run(
     _registry: &CommandRegistry,
     _raw_args: &RawCommandArgs,
 ) -> Result<OutputStream, ShellError> {
-    let name = call_info.name_tag.clone();
-
-    let mut output = String::new();
-
-    let mut first = true;
+    let mut output = vec![];
 
     if let Some(ref positional) = call_info.args.positional {
         for i in positional {
             match i.as_string() {
                 Ok(s) => {
-                    if !first {
-                        output.push_str(" ");
-                    } else {
-                        first = false;
+                    output.push(Ok(ReturnSuccess::Value(
+                        Value::string(s).tagged(i.tag.clone()),
+                    )));
+                }
+                _ => match i {
+                    Tagged {
+                        item: Value::Table(table),
+                        ..
+                    } => {
+                        for item in table {
+                            output.push(Ok(ReturnSuccess::Value(item.clone())));
+                        }
                     }
-
-                    output.push_str(&s);
-                }
-                _ => {
-                    return Err(ShellError::type_error(
-                        "a string-compatible value",
-                        i.tagged_type_name(),
-                    ))
-                }
+                    _ => {
+                        output.push(Ok(ReturnSuccess::Value(i.clone())));
+                    }
+                },
             }
         }
     }
 
-    let stream = VecDeque::from(vec![Ok(ReturnSuccess::Value(
-        Value::string(output).tagged(name),
-    ))]);
+    let stream = VecDeque::from(output);
 
     Ok(stream.to_output_stream())
 }


### PR DESCRIPTION
Rather than requiring everything be a string, this version of echo tries to be a little more flexible with data types and will attempt to pass-through other kinds of types in a natural way.

This let's you do things like:

```
> echo $nu:path
```