### PR TITLE
Rename add to insert

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,8 @@ name = "nu_plugin_embed"
 path = "src/plugins/embed.rs"
 
 [[bin]]
-name = "nu_plugin_add"
-path = "src/plugins/add.rs"
+name = "nu_plugin_insert"
+path = "src/plugins/insert.rs"
 
 [[bin]]
 name = "nu_plugin_edit"

--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 ## Filters on tables (structured data)
 | command | description |
 | ------------- | ------------- |
-| add column-or-column-path value | Add a new column to the table |
 | append row-data | Append a row to the end of the table |
 | count | Show the total number of rows |
 | edit column-or-column-path value | Edit an existing column to have a new value |
@@ -257,6 +256,7 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | get column-or-column-path | Open column and get data from the corresponding cells |
 | group-by column | Creates a new table with the data from the table rows grouped by the column given |
 | inc (column-or-column-path) | Increment a value or version. Optionally use the column of a table |
+| insert column-or-column-path value | Insert a new column to the table |
 | last amount | Show only the last number of rows |
 | nth row-number | Return only the selected row |
 | pick ...columns | Down-select table to only these columns |

--- a/src/plugins/insert.rs
+++ b/src/plugins/insert.rs
@@ -6,19 +6,19 @@ use nu::{
 
 pub type ColumnPath = Vec<Tagged<String>>;
 
-struct Add {
+struct Insert {
     field: Option<ColumnPath>,
     value: Option<Value>,
 }
-impl Add {
-    fn new() -> Add {
-        Add {
+impl Insert {
+    fn new() -> Insert {
+        Insert {
             field: None,
             value: None,
         }
     }
 
-    fn add(&self, value: Tagged<Value>) -> Result<Tagged<Value>, ShellError> {
+    fn insert(&self, value: Tagged<Value>) -> Result<Tagged<Value>, ShellError> {
         let value_tag = value.tag();
         match (value.item, self.value.clone()) {
             (obj @ Value::Row(_), Some(v)) => match &self.field {
@@ -50,11 +50,15 @@ impl Add {
     }
 }
 
-impl Plugin for Add {
+impl Plugin for Insert {
     fn config(&mut self) -> Result<Signature, ShellError> {
-        Ok(Signature::build("add")
-            .desc("Add a new column to the table.")
-            .required("column", SyntaxShape::ColumnPath, "the column name to add")
+        Ok(Signature::build("insert")
+            .desc("Insert a new column to the table.")
+            .required(
+                "column",
+                SyntaxShape::ColumnPath,
+                "the column name to insert",
+            )
             .required(
                 "value",
                 SyntaxShape::String,
@@ -86,10 +90,10 @@ impl Plugin for Add {
     }
 
     fn filter(&mut self, input: Tagged<Value>) -> Result<Vec<ReturnValue>, ShellError> {
-        Ok(vec![ReturnSuccess::value(self.add(input)?)])
+        Ok(vec![ReturnSuccess::value(self.insert(input)?)])
     }
 }
 
 fn main() {
-    serve_plugin(&mut Add::new());
+    serve_plugin(&mut Insert::new());
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -42,12 +42,12 @@ fn external_has_correct_quotes() {
 }
 
 #[test]
-fn add_plugin() {
+fn insert_plugin() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", h::pipeline(
         r#"
             open cargo_sample.toml
-            | add dev-dependencies.newdep "1"
+            | insert dev-dependencies.newdep "1"
             | get dev-dependencies.newdep
             | echo $it
         "#


### PR DESCRIPTION
Renames `add` to `insert` to not confuse it with math operations.

Fixes #880