### PR TITLE
Add initial support for env vars

### DIFF
--- a/src/evaluate/evaluator.rs
+++ b/src/evaluate/evaluator.rs
@@ -169,7 +169,9 @@ fn evaluate_reference(
             x if x == "nu:env" => {
                 let mut dict = TaggedDictBuilder::new(&tag);
                 for v in std::env::vars() {
-                    dict.insert(v.0, Value::string(v.1));
+                    if v.0 != "PATH" && v.0 != "Path" {
+                        dict.insert(v.0, Value::string(v.1));
+                    }
                 }
                 Ok(dict.into_tagged_value())
             }


### PR DESCRIPTION
This adds support in the `config` for the `env` variable. If it is available, it will be used to set the environment variables that Nu and its subcommands will use.

As before, you can see the current contents of the environment variables with:

```
echo $nu:env
```

The path is in its own `$nu:path` variable, and is not modified in this PR.