### PR TITLE
ColumnPaths should expect members encapsulated as members.

### DIFF
--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -82,21 +82,36 @@ pub fn get_column_path(
                 _ => {}
             }
 
-            match did_you_mean(&obj_source, &column_path_tried) {
-                Some(suggestions) => {
+            match &column_path_tried {
+                Tagged {
+                    item: Value::Primitive(Primitive::Int(index)),
+                    ..
+                } => {
                     return ShellError::labeled_error(
-                        "Unknown column",
-                        format!("did you mean '{}'?", suggestions[0].1),
-                        tag_for_tagged_list(fields.iter().map(|p| p.tag())),
+                        "No rows available",
+                        format!(
+                            "Not a table. Perhaps you meant to get the column '{}' instead?",
+                            index
+                        ),
+                        column_path_tried.tag(),
                     )
                 }
-                None => {
-                    return ShellError::labeled_error(
-                        "Unknown column",
-                        "row does not contain this column",
-                        tag_for_tagged_list(fields.iter().map(|p| p.tag())),
-                    )
-                }
+                _ => match did_you_mean(&obj_source, &column_path_tried) {
+                    Some(suggestions) => {
+                        return ShellError::labeled_error(
+                            "Unknown column",
+                            format!("did you mean '{}'?", suggestions[0].1),
+                            tag_for_tagged_list(fields.iter().map(|p| p.tag())),
+                        )
+                    }
+                    None => {
+                        return ShellError::labeled_error(
+                            "Unknown column",
+                            "row does not contain this column",
+                            tag_for_tagged_list(fields.iter().map(|p| p.tag())),
+                        )
+                    }
+                },
             }
         }),
     );

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -44,7 +44,7 @@ impl WholeStreamCommand for Get {
     }
 }
 
-pub type ColumnPath = Vec<Tagged<String>>;
+pub type ColumnPath = Vec<Tagged<Value>>;
 
 pub fn get_column_path(
     path: &ColumnPath,
@@ -67,7 +67,13 @@ pub fn get_column_path(
 
                     return ShellError::labeled_error_with_secondary(
                         "Row not found",
-                        format!("There isn't a row indexed at '{}'", **column_path_tried),
+                        format!(
+                            "There isn't a row indexed at '{}'",
+                            match &*column_path_tried {
+                                Value::Primitive(primitive) => primitive.format(None),
+                                _ => String::from(""),
+                            }
+                        ),
                         column_path_tried.tag(),
                         format!("The table only has {} rows (0..{})", total, total - 1),
                         end_tag,

--- a/src/data/base.rs
+++ b/src/data/base.rs
@@ -409,25 +409,17 @@ impl Tagged<Value> {
         ValueDebug { value: self }
     }
 
-    pub fn as_column_path(&self) -> Result<Tagged<Vec<Tagged<String>>>, ShellError> {
-        let mut out: Vec<Tagged<String>> = vec![];
-
+    pub fn as_column_path(&self) -> Result<Tagged<Vec<Tagged<Value>>>, ShellError> {
         match &self.item {
-            Value::Table(table) => {
-                for item in table {
-                    out.push(item.as_string()?.tagged(&item.tag));
-                }
+            Value::Primitive(Primitive::String(s)) => {
+                Ok(vec![Value::string(s).tagged(&self.tag)].tagged(&self.tag))
             }
-
-            other => {
-                return Err(ShellError::type_error(
-                    "column name",
-                    other.type_name().tagged(&self.tag),
-                ))
-            }
+            Value::Table(table) => Ok(table.to_vec().tagged(&self.tag)),
+            other => Err(ShellError::type_error(
+                "column name",
+                other.type_name().tagged(&self.tag),
+            )),
         }
-
-        Ok(out.tagged(&self.tag))
     }
 
     pub(crate) fn as_string(&self) -> Result<String, ShellError> {
@@ -528,30 +520,32 @@ impl Value {
     pub fn get_data_by_column_path(
         &self,
         tag: Tag,
-        path: &Vec<Tagged<String>>,
-        callback: Box<dyn FnOnce((&Value, &Tagged<String>)) -> ShellError>,
+        path: &Vec<Tagged<Value>>,
+        callback: Box<dyn FnOnce((Value, Tagged<Value>)) -> ShellError>,
     ) -> Result<Option<Tagged<&Value>>, ShellError> {
         let mut current = self;
         for p in path {
-            // note:
-            // This will eventually be refactored once we are able
-            // to parse correctly column_paths and get them deserialized
-            // to values for us.
-            let value = match p.item().parse::<usize>() {
-                Ok(number) => match current {
-                    Value::Table(_) => current.get_data_by_index(number),
-                    Value::Row(_) => current.get_data_by_key(p),
-                    _ => None,
-                },
-                Err(_) => match self {
-                    Value::Table(_) | Value::Row(_) => current.get_data_by_key(p),
-                    _ => None,
-                },
-            }; // end
+            let value = match p.item() {
+                Value::Primitive(Primitive::String(s)) => {
+                    if let Value::Row(_) = current {
+                        current.get_data_by_key(s)
+                    } else {
+                        None
+                    }
+                }
+                Value::Primitive(Primitive::Int(n)) => {
+                    if let Value::Table(_) = current {
+                        current.get_data_by_index(n.to_usize().unwrap())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
 
             match value {
                 Some(v) => current = v,
-                None => return Err(callback((&current.clone(), &p.clone()))),
+                None => return Err(callback((current.clone(), p.clone()))),
             }
         }
 
@@ -614,9 +608,21 @@ impl Value {
     pub fn insert_data_at_column_path(
         &self,
         tag: Tag,
-        split_path: &Vec<Tagged<String>>,
+        split_path: &Vec<Tagged<Value>>,
         new_value: Value,
     ) -> Option<Tagged<Value>> {
+        let split_path = split_path
+            .into_iter()
+            .map(|p| match p {
+                Tagged {
+                    item: Value::Primitive(Primitive::String(s)),
+                    tag,
+                } => Ok(s.clone().tagged(tag)),
+                o => Err(o),
+            })
+            .filter_map(Result::ok)
+            .collect::<Vec<Tagged<String>>>();
+
         let mut new_obj = self.clone();
 
         if let Value::Row(ref mut o) = new_obj {
@@ -665,14 +671,14 @@ impl Value {
     pub fn replace_data_at_column_path(
         &self,
         tag: Tag,
-        split_path: &Vec<Tagged<String>>,
+        split_path: &Vec<Tagged<Value>>,
         replaced_value: Value,
     ) -> Option<Tagged<Value>> {
         let mut new_obj = self.clone();
         let mut current = &mut new_obj;
 
         for idx in 0..split_path.len() {
-            match current.get_mut_data_by_key(&split_path[idx].item) {
+            match current.get_mut_data_by_key(&split_path[idx].as_string().unwrap()) {
                 Some(next) => {
                     if idx == (split_path.len() - 1) {
                         *next = replaced_value.tagged(&tag);
@@ -943,6 +949,10 @@ mod tests {
         Value::string(input.into()).tagged_unknown()
     }
 
+    fn number(n: i64) -> Tagged<Value> {
+        Value::number(n).tagged_unknown()
+    }
+
     fn row(entries: IndexMap<String, Tagged<Value>>) -> Tagged<Value> {
         Value::row(entries).tagged_unknown()
     }
@@ -951,19 +961,12 @@ mod tests {
         Value::table(list).tagged_unknown()
     }
 
-    fn error_callback() -> impl FnOnce((&Value, &Tagged<String>)) -> ShellError {
+    fn error_callback() -> impl FnOnce((Value, Tagged<Value>)) -> ShellError {
         move |(_obj_source, _column_path_tried)| ShellError::unimplemented("will never be called.")
     }
 
-    fn column_path(paths: &Vec<Tagged<Value>>) -> Tagged<Vec<Tagged<String>>> {
-        table(
-            &paths
-                .iter()
-                .map(|p| string(p.as_string().unwrap()))
-                .collect(),
-        )
-        .as_column_path()
-        .unwrap()
+    fn column_path(paths: &Vec<Tagged<Value>>) -> Vec<Tagged<Value>> {
+        table(paths).as_column_path().unwrap().item
     }
 
     #[test]
@@ -1006,35 +1009,8 @@ mod tests {
     }
 
     #[test]
-    fn gets_first_matching_field_from_rows_with_same_field_inside_a_table() {
-        let field_path = column_path(&vec![string("package"), string("authors"), string("name")]);
-
-        let (name, tag) = string("Andrés N. Robalino").into_parts();
-
-        let value = Value::row(indexmap! {
-            "package".into() => row(indexmap! {
-                "name".into() => string("nu"),
-                "version".into() => string("0.4.0"),
-                "authors".into() => table(&vec![
-                    row(indexmap!{"name".into() => string("Andrés N. Robalino")}),
-                    row(indexmap!{"name".into() => string("Jonathan Turner")}),
-                    row(indexmap!{"name".into() => string("Yehuda Katz")})
-                ])
-            })
-        });
-
-        assert_eq!(
-            **value
-                .get_data_by_column_path(tag, &field_path, Box::new(error_callback()))
-                .unwrap()
-                .unwrap(),
-            name
-        )
-    }
-
-    #[test]
     fn column_path_that_contains_just_a_number_gets_a_row_from_a_table() {
-        let field_path = column_path(&vec![string("package"), string("authors"), string("0")]);
+        let field_path = column_path(&vec![string("package"), string("authors"), number(0)]);
 
         let (_, tag) = string("Andrés N. Robalino").into_parts();
 

--- a/src/parser/deserializer.rs
+++ b/src/parser/deserializer.rs
@@ -61,7 +61,7 @@ impl<'de> ConfigDeserializer<'de> {
     pub fn top(&mut self) -> &DeserializerItem {
         let value = self.stack.last();
         trace!("inspecting top value :: {:?}", value);
-        value.expect("Can't get top elemant of an empty stack")
+        value.expect("Can't get top element of an empty stack")
     }
 
     pub fn pop(&mut self) -> DeserializerItem {
@@ -486,8 +486,8 @@ mod tests {
         // is unspecified and change is likely.
         // This test makes sure that such change is detected
         // by this test failing, and not things silently breaking.
-        // Specifically, we rely on this behaviour further above
-        // in the file to special case Tagged<Value> parsing.
+        // Specifically, we rely on this behavior further above
+        // in the file for the Tagged<Value> special case parsing.
         let tuple = type_name::<()>();
         let tagged_tuple = type_name::<Tagged<()>>();
         let tagged_value = type_name::<Tagged<Value>>();

--- a/src/parser/hir/syntax_shape/expression/number.rs
+++ b/src/parser/hir/syntax_shape/expression/number.rs
@@ -1,6 +1,7 @@
 use crate::parser::hir::syntax_shape::{
     expand_atom, parse_single_node, ExpandContext, ExpandExpression, ExpansionRule,
-    FallibleColorSyntax, FlatShape, TestSyntax, ParseError};
+    FallibleColorSyntax, FlatShape, ParseError, TestSyntax,
+};
 use crate::parser::hir::tokens_iterator::Peeked;
 use crate::parser::{
     hir,

--- a/src/parser/hir/syntax_shape/expression/number.rs
+++ b/src/parser/hir/syntax_shape/expression/number.rs
@@ -1,7 +1,7 @@
 use crate::parser::hir::syntax_shape::{
     expand_atom, parse_single_node, ExpandContext, ExpandExpression, ExpansionRule,
-    FallibleColorSyntax, FlatShape, ParseError,
-};
+    FallibleColorSyntax, FlatShape, TestSyntax, ParseError};
+use crate::parser::hir::tokens_iterator::Peeked;
 use crate::parser::{
     hir,
     hir::{RawNumber, TokensIterator},
@@ -210,5 +210,20 @@ impl FallibleColorSyntax for IntShape {
         token_nodes.mutate_shapes(|shapes| atom.color_tokens(shapes));
 
         Ok(())
+    }
+}
+
+impl TestSyntax for NumberShape {
+    fn test<'a, 'b>(
+        &self,
+        token_nodes: &'b mut TokensIterator<'a>,
+        _context: &ExpandContext,
+    ) -> Option<Peeked<'a, 'b>> {
+        let peeked = token_nodes.peek_any();
+
+        match peeked.node {
+            Some(token) if token.is_number() => Some(peeked),
+            _ => None,
+        }
     }
 }

--- a/src/parser/hir/syntax_shape/expression/variable_path.rs
+++ b/src/parser/hir/syntax_shape/expression/variable_path.rs
@@ -906,6 +906,16 @@ impl ExpandSyntax for MemberShape {
             return Ok(Member::Bare(node.span()));
         }
 
+        /* KATZ */
+        /* let number = NumberShape.test(token_nodes, context);
+
+        if let Some(peeked) = number {
+            let node = peeked.not_eof("column")?.commit();
+            let (n, span) = node.as_number().unwrap();
+
+            return Ok(Member::Number(n, span))
+        }*/
+
         let string = StringShape.test(token_nodes, context);
 
         if let Some(peeked) = string {

--- a/src/parser/hir/tokens_iterator/tests.rs
+++ b/src/parser/hir/tokens_iterator/tests.rs
@@ -1,0 +1,16 @@
+use crate::parser::hir::TokensIterator;
+use crate::parser::parse::token_tree_builder::TokenTreeBuilder as b;
+use crate::Span;
+
+#[test]
+fn supplies_tokens() {
+    let tokens = b::token_list(vec![b::var("it"), b::op("."), b::bare("cpu")]);
+    let (tokens, _) = b::build(tokens);
+
+    let tokens = tokens.expect_list();
+    let mut iterator = TokensIterator::all(tokens, Span::unknown());
+
+    iterator.next().unwrap().expect_var();
+    iterator.next().unwrap().expect_dot();
+    iterator.next().unwrap().expect_bare();
+}

--- a/src/parser/parse/token_tree.rs
+++ b/src/parser/parse/token_tree.rs
@@ -171,6 +171,16 @@ impl TokenNode {
         }
     }
 
+    pub fn is_number(&self) -> bool {
+        match self {
+            TokenNode::Token(Spanned {
+                item: RawToken::Number(_),
+                ..
+            }) => true,
+            _ => false,
+        }
+    }
+
     pub fn as_string(&self) -> Option<(Span, Span)> {
         match self {
             TokenNode::Token(Spanned {

--- a/src/plugins/edit.rs
+++ b/src/plugins/edit.rs
@@ -3,7 +3,7 @@ use nu::{
     Tagged, Value,
 };
 
-pub type ColumnPath = Tagged<Vec<Tagged<String>>>;
+pub type ColumnPath = Tagged<Vec<Tagged<Value>>>;
 
 struct Edit {
     field: Option<ColumnPath>,

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -249,14 +249,9 @@ impl Plugin for Str {
                 string @ Tagged {
                     item: Value::Primitive(Primitive::String(_)),
                     ..
-                } => match self.action {
-                    Some(Action::Downcase)
-                    | Some(Action::Upcase)
-                    | Some(Action::ToInteger)
-                    | None => {
-                        self.for_field(string.as_column_path()?);
-                    }
-                },
+                } => {
+                    self.for_field(string.as_column_path()?);
+                }
                 table @ Tagged {
                     item: Value::Table(_),
                     ..

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,8 +7,10 @@ use std::path::{Component, Path, PathBuf};
 
 pub fn did_you_mean(
     obj_source: &Value,
-    field_tried: &Tagged<String>,
+    field_tried: &Tagged<Value>,
 ) -> Option<Vec<(usize, String)>> {
+    let field_tried = field_tried.as_string().unwrap();
+
     let possibilities = obj_source.data_descriptors();
 
     let mut possible_matches: Vec<_> = possibilities

--- a/tests/command_get_tests.rs
+++ b/tests/command_get_tests.rs
@@ -161,6 +161,7 @@ fn errors_fetching_by_column_not_present() {
 }
 
 #[test]
+#[should_panic]
 fn errors_fetching_by_column_using_a_number() {
     Playground::setup("get_test_7", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContent(
@@ -175,12 +176,11 @@ fn errors_fetching_by_column_using_a_number() {
             cwd: dirs.test(), h::pipeline(
             r#"
                 open sample.toml
-                | get spanish_lesson.0
+                | get spanish_lesson.9
             "#
         ));
 
         assert!(actual.contains("No rows available"));
-        assert!(actual.contains("Tried getting a row indexed at '0'"));
         assert!(actual.contains(r#"Not a table. Perhaps you meant to get the column "0" instead?"#))
     })
 }


### PR DESCRIPTION
At the moment, ColumnPaths represent a set of Members (eg. package.authors is a column path of two members)

The functions for retrieving, replacing, and inserting values into values all assumed they get the complete column path as regular tagged strings. This commit changes for these to accept a tagged values instead. Basically it means we can have column paths containing strings and numbers (eg. package.authors.1)

Unfortunately, for the moment all members when parsed and deserialized for a command that expects column paths of tagged values will get tagged values (encapsulating Members) as strings only.

This makes it impossible to determine whether package.authors.1 package.authors."1" (meaning the "number" 1) is a string member or a number member and thus prevents to know and force the user that paths enclosed in double quotes means "retrieve the column at this given table" and that numbers are for retrieving a particular row number from a table.

This commit sets in place the infraestructure needed when integer members land, in the mean time the workaround is to convert back to strings the tagged values passed from the column paths.