### PR TITLE
Make --headerless treat first row as data

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 pub(crate) mod macros;
 
+mod from_structured_data;
+
 pub(crate) mod append;
 pub(crate) mod args;
 pub(crate) mod autoview;

--- a/src/commands/from_csv.rs
+++ b/src/commands/from_csv.rs
@@ -1,7 +1,7 @@
+use crate::commands::from_structured_data::from_structured_data;
 use crate::commands::WholeStreamCommand;
-use crate::data::{Primitive, TaggedDictBuilder, Value};
+use crate::data::{Primitive, Value};
 use crate::prelude::*;
-use csv::ReaderBuilder;
 
 pub struct FromCSV;
 
@@ -39,49 +39,13 @@ impl WholeStreamCommand for FromCSV {
     }
 }
 
-pub fn from_csv_string_to_value(
-    s: String,
-    headerless: bool,
-    separator: char,
-    tag: impl Into<Tag>,
-) -> Result<Tagged<Value>, csv::Error> {
-    let mut reader = ReaderBuilder::new()
-        .has_headers(!headerless)
-        .delimiter(separator as u8)
-        .from_reader(s.as_bytes());
-    let tag = tag.into();
-
-    let headers = if headerless {
-        (1..=reader.headers()?.len())
-            .map(|i| format!("Column{}", i))
-            .collect::<Vec<String>>()
-    } else {
-        reader.headers()?.iter().map(String::from).collect()
-    };
-
-    let mut rows = vec![];
-    for row in reader.records() {
-        let mut tagged_row = TaggedDictBuilder::new(&tag);
-        for (value, header) in row?.iter().zip(headers.iter()) {
-            tagged_row.insert_tagged(
-                header,
-                Value::Primitive(Primitive::String(String::from(value))).tagged(&tag),
-            )
-        }
-        rows.push(tagged_row.into_tagged_value());
-    }
-
-    Ok(Value::Table(rows).tagged(&tag))
-}
-
 fn from_csv(
     FromCSVArgs {
         headerless,
         separator,
     }: FromCSVArgs,
-    RunnableContext { input, name, .. }: RunnableContext,
+    runnable_context: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
-    let name_tag = name;
     let sep = match separator {
         Some(Tagged {
             item: Value::Primitive(Primitive::String(s)),
@@ -101,51 +65,5 @@ fn from_csv(
         _ => ',',
     };
 
-    let stream = async_stream! {
-        let values: Vec<Tagged<Value>> = input.values.collect().await;
-
-        let mut concat_string = String::new();
-        let mut latest_tag: Option<Tag> = None;
-
-        for value in values {
-            let value_tag = value.tag();
-            latest_tag = Some(value_tag.clone());
-            match value.item {
-                Value::Primitive(Primitive::String(s)) => {
-                    concat_string.push_str(&s);
-                    concat_string.push_str("\n");
-                }
-                _ => yield Err(ShellError::labeled_error_with_secondary(
-                    "Expected a string from pipeline",
-                    "requires string input",
-                    name_tag.clone(),
-                    "value originates from here",
-                    value_tag.clone(),
-                )),
-
-            }
-        }
-
-        match from_csv_string_to_value(concat_string, headerless, sep, name_tag.clone()) {
-            Ok(x) => match x {
-                Tagged { item: Value::Table(list), .. } => {
-                    for l in list {
-                        yield ReturnSuccess::value(l);
-                    }
-                }
-                x => yield ReturnSuccess::value(x),
-            },
-            Err(_) => if let Some(last_tag) = latest_tag {
-                yield Err(ShellError::labeled_error_with_secondary(
-                    "Could not parse as CSV",
-                    "input cannot be parsed as CSV",
-                    name_tag.clone(),
-                    "value originates from here",
-                    last_tag.clone(),
-                ))
-            } ,
-        }
-    };
-
-    Ok(stream.to_output_stream())
+    from_structured_data(headerless, sep, "CSV", runnable_context)
 }

--- a/src/commands/from_structured_data.rs
+++ b/src/commands/from_structured_data.rs
@@ -1,0 +1,97 @@
+use crate::data::{Primitive, TaggedDictBuilder, Value};
+use crate::prelude::*;
+use csv::ReaderBuilder;
+
+fn from_stuctured_string_to_value(
+    s: String,
+    headerless: bool,
+    separator: char,
+    tag: impl Into<Tag>,
+) -> Result<Tagged<Value>, csv::Error> {
+    let mut reader = ReaderBuilder::new()
+        .has_headers(!headerless)
+        .delimiter(separator as u8)
+        .from_reader(s.as_bytes());
+    let tag = tag.into();
+
+    let headers = if headerless {
+        (1..=reader.headers()?.len())
+            .map(|i| format!("Column{}", i))
+            .collect::<Vec<String>>()
+    } else {
+        reader.headers()?.iter().map(String::from).collect()
+    };
+
+    let mut rows = vec![];
+    for row in reader.records() {
+        let mut tagged_row = TaggedDictBuilder::new(&tag);
+        for (value, header) in row?.iter().zip(headers.iter()) {
+            tagged_row.insert_tagged(
+                header,
+                Value::Primitive(Primitive::String(String::from(value))).tagged(&tag),
+            )
+        }
+        rows.push(tagged_row.into_tagged_value());
+    }
+
+    Ok(Value::Table(rows).tagged(&tag))
+}
+
+pub fn from_structured_data(
+    headerless: bool,
+    sep: char,
+    format_name: &'static str,
+    RunnableContext { input, name, .. }: RunnableContext,
+) -> Result<OutputStream, ShellError> {
+    let name_tag = name;
+
+    let stream = async_stream! {
+        let values: Vec<Tagged<Value>> = input.values.collect().await;
+
+        let mut concat_string = String::new();
+        let mut latest_tag: Option<Tag> = None;
+
+        for value in values {
+            let value_tag = value.tag();
+            latest_tag = Some(value_tag.clone());
+            match value.item {
+                Value::Primitive(Primitive::String(s)) => {
+                    concat_string.push_str(&s);
+                    concat_string.push_str("\n");
+                }
+                _ => yield Err(ShellError::labeled_error_with_secondary(
+                    "Expected a string from pipeline",
+                    "requires string input",
+                    name_tag.clone(),
+                    "value originates from here",
+                    value_tag.clone(),
+                )),
+
+            }
+        }
+
+        match from_stuctured_string_to_value(concat_string, headerless, sep, name_tag.clone()) {
+            Ok(x) => match x {
+                Tagged { item: Value::Table(list), .. } => {
+                    for l in list {
+                        yield ReturnSuccess::value(l);
+                    }
+                }
+                x => yield ReturnSuccess::value(x),
+            },
+            Err(_) => if let Some(last_tag) = latest_tag {
+                let line_one = format!("Could not parse as {}", format_name);
+                let line_two = format!("input cannot be parsed as {}", format_name);
+                yield Err(ShellError::labeled_error_with_secondary(
+                    line_one,
+                    line_two,
+                    name_tag.clone(),
+                    "value originates from here",
+                    last_tag.clone(),
+                ))
+            } ,
+        }
+    };
+
+    Ok(stream.to_output_stream())
+}

--- a/src/commands/from_tsv.rs
+++ b/src/commands/from_tsv.rs
@@ -1,7 +1,6 @@
+use crate::commands::from_structured_data::from_structured_data;
 use crate::commands::WholeStreamCommand;
-use crate::data::{Primitive, TaggedDictBuilder, Value};
 use crate::prelude::*;
-use csv::ReaderBuilder;
 
 pub struct FromTSV;
 
@@ -33,91 +32,9 @@ impl WholeStreamCommand for FromTSV {
     }
 }
 
-pub fn from_tsv_string_to_value(
-    s: String,
-    headerless: bool,
-    tag: impl Into<Tag>,
-) -> Result<Tagged<Value>, csv::Error> {
-    let mut reader = ReaderBuilder::new()
-        .has_headers(!headerless)
-        .delimiter(b'\t')
-        .from_reader(s.as_bytes());
-    let tag = tag.into();
-
-    let headers = if headerless {
-        (1..=reader.headers()?.len())
-            .map(|i| format!("Column{}", i))
-            .collect::<Vec<String>>()
-    } else {
-        reader.headers()?.iter().map(String::from).collect()
-    };
-
-    let mut rows = vec![];
-    for row in reader.records() {
-        let mut tagged_row = TaggedDictBuilder::new(&tag);
-        for (value, header) in row?.iter().zip(headers.iter()) {
-            tagged_row.insert_tagged(
-                header,
-                Value::Primitive(Primitive::String(String::from(value))).tagged(&tag),
-            )
-        }
-        rows.push(tagged_row.into_tagged_value());
-    }
-
-    Ok(Value::Table(rows).tagged(&tag))
-}
-
 fn from_tsv(
     FromTSVArgs { headerless }: FromTSVArgs,
-    RunnableContext { input, name, .. }: RunnableContext,
+    runnable_context: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
-    let name_tag = name;
-
-    let stream = async_stream! {
-        let values: Vec<Tagged<Value>> = input.values.collect().await;
-
-        let mut concat_string = String::new();
-        let mut latest_tag: Option<Tag> = None;
-
-        for value in values {
-            let value_tag = value.tag();
-            latest_tag = Some(value_tag.clone());
-            match value.item {
-                Value::Primitive(Primitive::String(s)) => {
-                    concat_string.push_str(&s);
-                    concat_string.push_str("\n");
-                }
-                _ => yield Err(ShellError::labeled_error_with_secondary(
-                    "Expected a string from pipeline",
-                    "requires string input",
-                    &name_tag,
-                    "value originates from here",
-                    &value_tag,
-                )),
-
-            }
-        }
-
-        match from_tsv_string_to_value(concat_string, headerless, name_tag.clone()) {
-            Ok(x) => match x {
-                Tagged { item: Value::Table(list), .. } => {
-                    for l in list {
-                        yield ReturnSuccess::value(l);
-                    }
-                }
-                x => yield ReturnSuccess::value(x),
-            },
-            Err(_) => if let Some(last_tag) = latest_tag {
-                yield Err(ShellError::labeled_error_with_secondary(
-                    "Could not parse as TSV",
-                    "input cannot be parsed as TSV",
-                    &name_tag,
-                    "value originates from here",
-                    &last_tag,
-                ))
-            } ,
-        }
-    };
-
-    Ok(stream.to_output_stream())
+    from_structured_data(headerless, '\t', "TSV", runnable_context)
 }

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -135,7 +135,6 @@ fn converts_from_csv_text_skipping_headers_to_structured_table() {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "los_tres_amigos.txt",
             r#"
-                first_name,last_name,rusty_luck
                 Andrés,Robalino,1
                 Jonathan,Turner,1
                 Yehuda,Katz,1
@@ -361,7 +360,6 @@ fn converts_from_tsv_text_skipping_headers_to_structured_table() {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "los_tres_amigos.txt",
             r#"
-                first Name	Last Name	rusty_luck
                 Andrés	Robalino	1
                 Jonathan	Turner	1
                 Yehuda	Katz	1
@@ -441,12 +439,11 @@ fn converts_from_ssv_text_to_structured_table_with_separator_specified() {
 }
 
 #[test]
-fn converts_from_ssv_text_skipping_headers_to_structured_table() {
+fn converts_from_ssv_text_treating_first_line_as_data_with_flag() {
     Playground::setup("filter_from_ssv_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "oc_get_svc.txt",
             r#"
-                NAME              LABELS                                    SELECTOR                  IP              PORT(S)
                 docker-registry   docker-registry=default                   docker-registry=default   172.30.78.158   5000/TCP
                 kubernetes        component=apiserver,provider=kubernetes   <none>                    172.30.0.2      443/TCP
                 kubernetes-ro     component=apiserver,provider=kubernetes   <none>                    172.30.0.1      80/TCP
@@ -458,13 +455,13 @@ fn converts_from_ssv_text_skipping_headers_to_structured_table() {
             r#"
                 open oc_get_svc.txt
                 | from-ssv --headerless
-                | nth 2
-                | get Column2
+                | first
+                | get Column1
                 | echo $it
             "#
         ));
 
-        assert_eq!(actual, "component=apiserver,provider=kubernetes");
+        assert_eq!(actual, "docker-registry");
     })
 }
 

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -450,7 +450,18 @@ fn converts_from_ssv_text_treating_first_line_as_data_with_flag() {
             "#,
         )]);
 
-        let actual = nu!(
+        let aligned_columns = nu!(
+        cwd: dirs.test(), h::pipeline(
+            r#"
+                open oc_get_svc.txt
+                | from-ssv --headerless --aligned-columns
+                | first
+                | get Column1
+                | echo $it
+            "#
+        ));
+
+        let separator_based = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"
                 open oc_get_svc.txt
@@ -461,7 +472,8 @@ fn converts_from_ssv_text_treating_first_line_as_data_with_flag() {
             "#
         ));
 
-        assert_eq!(actual, "docker-registry");
+        assert_eq!(aligned_columns, separator_based);
+        assert_eq!(separator_based, "docker-registry");
     })
 }
 


### PR DESCRIPTION
As discussed in #875, this PR tracks the effort to make headerless treat the first row as data. 

At the time of opening this draft request, only tests have been updated to reflect the new way of operation.

# Update

This PR makes the commands `from-tsv`, `from-csv`, and `from-ssv` treat the first row as data when they're provided with the `--headerless` option.

In addition to this, I've also added some more tests to the `from-ssv` module and took this chance to split the parsing into separate functions to make it more manageable.


## Resolve before merge
### Refactored out common csv logic between `from-tsv` and `from-ssv`
The tsv and csv commands had quite a bit of overlapping logic, which rather duplicating, I extracted into a separate module.  Two questions:
- [ ] Is this 'okay'? There might have been a reason to keep them separate, so if we'd rather keep them that way, then I'll go ahead and revert that change.
- [ ] If we do decide to keep the refactoring: Where should the code go? What's a good name for the module? Right now it's in the `commands` directory because that's where it's being used, but it's not immediately obvious.
