### PR TITLE
Eliminate is_first_command by defaulting to Value::nothing()

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -588,9 +588,7 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
             }
 
             let mut input = ClassifiedInputStream::new();
-
             let mut iter = pipeline.commands.item.into_iter().peekable();
-            let mut is_first_command = true;
 
             // Check the config to see if we need to update the path
             // TODO: make sure config is cached so we don't path this load every call
@@ -628,20 +626,20 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
                     (
                         Some(ClassifiedCommand::Internal(left)),
                         Some(ClassifiedCommand::External(_)),
-                    ) => match left.run(ctx, input, Text::from(line), is_first_command) {
+                    ) => match left.run(ctx, input, Text::from(line)) {
                         Ok(val) => ClassifiedInputStream::from_input_stream(val),
                         Err(err) => return LineResult::Error(line.to_string(), err),
                     },
 
                     (Some(ClassifiedCommand::Internal(left)), Some(_)) => {
-                        match left.run(ctx, input, Text::from(line), is_first_command) {
+                        match left.run(ctx, input, Text::from(line)) {
                             Ok(val) => ClassifiedInputStream::from_input_stream(val),
                             Err(err) => return LineResult::Error(line.to_string(), err),
                         }
                     }
 
                     (Some(ClassifiedCommand::Internal(left)), None) => {
-                        match left.run(ctx, input, Text::from(line), is_first_command) {
+                        match left.run(ctx, input, Text::from(line)) {
                             Ok(val) => {
                                 use futures::stream::TryStreamExt;
 
@@ -693,8 +691,6 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
                         }
                     }
                 };
-
-                is_first_command = false;
             }
 
             LineResult::Success(line.to_string())

--- a/src/commands/autoview.rs
+++ b/src/commands/autoview.rs
@@ -96,7 +96,7 @@ pub fn autoview(
                                 named_args.insert_optional("start_number", Some(Expression::number(current_idx, Tag::unknown())));
                                 command_args.call_info.args.named = Some(named_args);
 
-                                let result = table.run(command_args, &context.commands, false);
+                                let result = table.run(command_args, &context.commands);
                                 result.collect::<Vec<_>>().await;
 
                                 if finished {
@@ -117,7 +117,7 @@ pub fn autoview(
                                     if let Some(text) = text {
                                         let mut stream = VecDeque::new();
                                         stream.push_back(Value::string(s).tagged(Tag { anchor, span }));
-                                        let result = text.run(raw.with_input(stream.into()), &context.commands, false);
+                                        let result = text.run(raw.with_input(stream.into()), &context.commands);
                                         result.collect::<Vec<_>>().await;
                                     } else {
                                         println!("{}", s);
@@ -134,7 +134,7 @@ pub fn autoview(
                                     if let Some(binary) = binary {
                                         let mut stream = VecDeque::new();
                                         stream.push_back(x.clone());
-                                        let result = binary.run(raw.with_input(stream.into()), &context.commands, false);
+                                        let result = binary.run(raw.with_input(stream.into()), &context.commands);
                                         result.collect::<Vec<_>>().await;
                                     } else {
                                         use pretty_hex::*;
@@ -149,7 +149,7 @@ pub fn autoview(
                                     if let Some(table) = table {
                                         let mut stream = VecDeque::new();
                                         stream.push_back(x.clone());
-                                        let result = table.run(raw.with_input(stream.into()), &context.commands, false);
+                                        let result = table.run(raw.with_input(stream.into()), &context.commands);
                                         result.collect::<Vec<_>>().await;
                                     } else {
                                         println!("{:?}", item);

--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -54,7 +54,7 @@ pub(crate) struct ClassifiedInputStream {
 impl ClassifiedInputStream {
     pub(crate) fn new() -> ClassifiedInputStream {
         ClassifiedInputStream {
-            objects: VecDeque::new().into(),
+            objects: vec![Value::nothing().tagged(Tag::unknown())].into(),
             stdin: None,
         }
     }
@@ -158,7 +158,6 @@ impl InternalCommand {
         context: &mut Context,
         input: ClassifiedInputStream,
         source: Text,
-        is_first_command: bool,
     ) -> Result<InputStream, ShellError> {
         if log_enabled!(log::Level::Trace) {
             trace!(target: "nu::run::internal", "->");
@@ -178,7 +177,6 @@ impl InternalCommand {
                 self.args.item,
                 &source,
                 objects,
-                is_first_command,
             )
         };
 

--- a/src/commands/enter.rs
+++ b/src/commands/enter.rs
@@ -105,7 +105,6 @@ impl PerItemCommand for Enter {
                                         let mut result = converter.run(
                                             new_args.with_input(vec![tagged_contents]),
                                             &registry,
-                                            false
                                         );
                                         let result_vec: Vec<Result<ReturnSuccess, ShellError>> =
                                             result.drain_vec().await;

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -100,7 +100,7 @@ fn run(
                         name_tag: raw_args.call_info.name_tag,
                     }
                 };
-                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry, false);
+                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry);
                 let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                 for res in result_vec {
                     match res {

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -101,7 +101,7 @@ fn run(
                         name_tag: raw_args.call_info.name_tag,
                     }
                 };
-                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry, false);
+                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry);
                 let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                 for res in result_vec {
                     match res {

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -124,7 +124,7 @@ fn run(
                         name_tag: raw_args.call_info.name_tag,
                     }
                 };
-                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry, false);
+                let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &registry);
                 let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                 for res in result_vec {
                     match res {
@@ -270,7 +270,6 @@ pub async fn post(
                     let mut result = converter.run(
                         new_args.with_input(vec![item.clone().tagged(tag.clone())]),
                         &registry,
-                        false,
                     );
                     let result_vec: Vec<Result<ReturnSuccess, ShellError>> =
                         result.drain_vec().await;

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -193,7 +193,7 @@ fn save(
                                 name_tag: raw_args.call_info.name_tag,
                             }
                         };
-                        let mut result = converter.run(new_args.with_input(input), &registry, false);
+                        let mut result = converter.run(new_args.with_input(input), &registry);
                         let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                         if converter.is_binary() {
                             process_binary_return_success!('scope, result_vec, name_tag)

--- a/src/context.rs
+++ b/src/context.rs
@@ -112,10 +112,9 @@ impl Context {
         args: hir::Call,
         source: &Text,
         input: InputStream,
-        is_first_command: bool,
     ) -> OutputStream {
         let command_args = self.command_args(args, input, source, name_tag);
-        command.run(command_args, self.registry(), is_first_command)
+        command.run(command_args, self.registry())
     }
 
     fn call_info(&self, args: hir::Call, source: &Text, name_tag: Tag) -> UnevaluatedCallInfo {


### PR DESCRIPTION
Instead of tracking the first command in a pipeline, we can simply have the input stream start in a state that mimics the previous behaviour.

I think this is a simpler model, and should hopefully help us in moving towards orchestrating more and more of the pipeline ourself (instead of using an external shell).

All tests are passing. Since I'm still fairly new to the codebase, definitely focus on how this could behaviourally be wrong.