### PR TITLE
removed the requirement on the 'regex' feature for the match plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ path = "src/plugins/skip.rs"
 [[bin]]
 name = "nu_plugin_match"
 path = "src/plugins/match.rs"
-required-features = ["regex"]
 
 [[bin]]
 name = "nu_plugin_sys"


### PR DESCRIPTION
The nu_plugin_match binary wasn't built anymore after the regex dependency was made non-optional in https://github.com/nushell/nushell/pull/889, causing the removal of the regex feature, which nu_plugin_match depended on.