### PR TITLE
Improve error messages for save

### DIFF
--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -19,8 +19,8 @@ macro_rules! process_string {
                 }
                 _ => {
                     break $scope Err(ShellError::labeled_error(
-                        "Save could not successfully save",
-                        "unexpected data during save",
+                        "Save requires formatted data",
+                        "consider piping to a converter (see `help commands`)",
                         $name_tag,
                     ));
                 }
@@ -214,9 +214,9 @@ fn save(
         match content {
             Ok(save_data) => match std::fs::write(full_path, save_data) {
                 Ok(o) => o,
-                Err(e) => yield Err(ShellError::labeled_error(e.to_string(), "for command", name)),
+                Err(e) => yield Err(ShellError::labeled_error(e.to_string(), "IO error while saving", name)),
             },
-            Err(e) => yield Err(ShellError::labeled_error(e.to_string(), "for command", name)),
+            Err(e) => yield Err(e),
         }
 
     };

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -19,8 +19,8 @@ macro_rules! process_string {
                 }
                 _ => {
                     break $scope Err(ShellError::labeled_error(
-                        "Save requires formatted data",
-                        "consider piping to a converter (see `help commands`)",
+                        "Save requires string data",
+                        "consider converting data to string (see `help commands`)",
                         $name_tag,
                     ));
                 }


### PR DESCRIPTION
`save` attempts to convert input based on the target filename extension,
and expects a stream of text otherwise. However the error message is
unclear and provides little guidance, hopefully this is less confusing
to new users.

It might be worthwhile to also add a hint about adding an extension,
though I'm not sure if it's possible to emit multiple diagnostics.