### PR TITLE
Make duration its own primitive

### DIFF
--- a/src/commands/to_bson.rs
+++ b/src/commands/to_bson.rs
@@ -41,6 +41,7 @@ pub fn value_to_bson_value(v: &Tagged<Value>) -> Result<Bson, ShellError> {
                 .to_f64()
                 .expect("Unimplemented BUG: What about big decimals?"),
         ),
+        Value::Primitive(Primitive::Duration(secs)) => Bson::I64(*secs as i64),
         Value::Primitive(Primitive::Date(d)) => Bson::UtcDatetime(*d),
         Value::Primitive(Primitive::EndOfStream) => Bson::Null,
         Value::Primitive(Primitive::BeginningOfStream) => Bson::Null,

--- a/src/commands/to_json.rs
+++ b/src/commands/to_json.rs
@@ -32,6 +32,9 @@ pub fn value_to_json_value(v: &Tagged<Value>) -> Result<serde_json::Value, Shell
         Value::Primitive(Primitive::Bytes(b)) => serde_json::Value::Number(
             serde_json::Number::from(b.to_u64().expect("What about really big numbers")),
         ),
+        Value::Primitive(Primitive::Duration(secs)) => {
+            serde_json::Value::Number(serde_json::Number::from(*secs))
+        }
         Value::Primitive(Primitive::Date(d)) => serde_json::Value::String(d.to_string()),
         Value::Primitive(Primitive::EndOfStream) => serde_json::Value::Null,
         Value::Primitive(Primitive::BeginningOfStream) => serde_json::Value::Null,

--- a/src/commands/to_sqlite.rs
+++ b/src/commands/to_sqlite.rs
@@ -88,6 +88,7 @@ fn nu_value_to_sqlite_string(v: Value) -> String {
         Value::Primitive(p) => match p {
             Primitive::Nothing => "NULL".into(),
             Primitive::Int(i) => format!("{}", i),
+            Primitive::Duration(u) => format!("{}", u),
             Primitive::Decimal(f) => format!("{}", f),
             Primitive::Bytes(u) => format!("{}", u),
             Primitive::Pattern(s) => format!("'{}'", s.replace("'", "''")),

--- a/src/commands/to_toml.rs
+++ b/src/commands/to_toml.rs
@@ -30,6 +30,7 @@ pub fn value_to_toml_value(v: &Tagged<Value>) -> Result<toml::Value, ShellError>
     Ok(match v.item() {
         Value::Primitive(Primitive::Boolean(b)) => toml::Value::Boolean(*b),
         Value::Primitive(Primitive::Bytes(b)) => toml::Value::Integer(*b as i64),
+        Value::Primitive(Primitive::Duration(d)) => toml::Value::Integer(*d as i64),
         Value::Primitive(Primitive::Date(d)) => toml::Value::String(d.to_string()),
         Value::Primitive(Primitive::EndOfStream) => {
             toml::Value::String("<End of Stream>".to_string())

--- a/src/commands/to_yaml.rs
+++ b/src/commands/to_yaml.rs
@@ -32,6 +32,9 @@ pub fn value_to_yaml_value(v: &Tagged<Value>) -> Result<serde_yaml::Value, Shell
         Value::Primitive(Primitive::Bytes(b)) => {
             serde_yaml::Value::Number(serde_yaml::Number::from(b.to_f64().unwrap()))
         }
+        Value::Primitive(Primitive::Duration(secs)) => {
+            serde_yaml::Value::Number(serde_yaml::Number::from(secs.to_f64().unwrap()))
+        }
         Value::Primitive(Primitive::Date(d)) => serde_yaml::Value::String(d.to_string()),
         Value::Primitive(Primitive::EndOfStream) => serde_yaml::Value::Null,
         Value::Primitive(Primitive::BeginningOfStream) => serde_yaml::Value::Null,

--- a/src/parser/parse/unit.rs
+++ b/src/parser/parse/unit.rs
@@ -3,8 +3,6 @@ use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
-use std::time::Duration;
-use std::time::SystemTime;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub enum Unit {
@@ -68,31 +66,13 @@ impl Unit {
             Unit::Gigabyte => Value::number(size * 1024 * 1024 * 1024),
             Unit::Terabyte => Value::number(size * 1024 * 1024 * 1024 * 1024),
             Unit::Petabyte => Value::number(size * 1024 * 1024 * 1024 * 1024 * 1024),
-            Unit::Second => Value::system_date(
-                SystemTime::now() - Duration::from_secs(convert_number_to_u64(&size)),
-            ),
-            Unit::Minute => Value::system_date(
-                SystemTime::now() - Duration::from_secs(60 * convert_number_to_u64(&size)),
-            ),
-            Unit::Hour => Value::system_date(
-                SystemTime::now() - Duration::from_secs(60 * 60 * convert_number_to_u64(&size)),
-            ),
-            Unit::Day => Value::system_date(
-                SystemTime::now()
-                    - Duration::from_secs(24 * 60 * 60 * convert_number_to_u64(&size)),
-            ),
-            Unit::Week => Value::system_date(
-                SystemTime::now()
-                    - Duration::from_secs(7 * 24 * 60 * 60 * convert_number_to_u64(&size)),
-            ),
-            Unit::Month => Value::system_date(
-                SystemTime::now()
-                    - Duration::from_secs(30 * 24 * 60 * 60 * convert_number_to_u64(&size)),
-            ),
-            Unit::Year => Value::system_date(
-                SystemTime::now()
-                    - Duration::from_secs(365 * 24 * 60 * 60 * convert_number_to_u64(&size)),
-            ),
+            Unit::Second => Value::duration(convert_number_to_u64(&size)),
+            Unit::Minute => Value::duration(60 * convert_number_to_u64(&size)),
+            Unit::Hour => Value::duration(60 * 60 * convert_number_to_u64(&size)),
+            Unit::Day => Value::duration(24 * 60 * 60 * convert_number_to_u64(&size)),
+            Unit::Week => Value::duration(7 * 24 * 60 * 60 * convert_number_to_u64(&size)),
+            Unit::Month => Value::duration(30 * 24 * 60 * 60 * convert_number_to_u64(&size)),
+            Unit::Year => Value::duration(365 * 24 * 60 * 60 * convert_number_to_u64(&size)),
         }
     }
 }


### PR DESCRIPTION
This adds duration as a primitive, making it a first-class value. the same `where accessed < 1d` currently works, but now over date-duration comparison.

You can also see a duration as a value, for example doing:

```
> echo 1d
━━━━━━━━━━━━
 <value> 
────────────
 86400 secs 
━━━━━━━━━━━━
```

Fixes #971 