### PR TITLE
Abbreviate ls by default, add --full flag

### DIFF
--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -8,6 +8,7 @@ pub struct LS;
 #[derive(Deserialize)]
 pub struct LsArgs {
     path: Option<Tagged<PathBuf>>,
+    full: bool,
 }
 
 impl WholeStreamCommand for LS {
@@ -16,11 +17,13 @@ impl WholeStreamCommand for LS {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("ls").optional(
-            "path",
-            SyntaxShape::Pattern,
-            "a path to get the directory contents from",
-        )
+        Signature::build("ls")
+            .optional(
+                "path",
+                SyntaxShape::Pattern,
+                "a path to get the directory contents from",
+            )
+            .switch("full", "list all available columns for each entry")
     }
 
     fn usage(&self) -> &str {
@@ -37,6 +40,6 @@ impl WholeStreamCommand for LS {
     }
 }
 
-fn ls(LsArgs { path }: LsArgs, context: RunnableContext) -> Result<OutputStream, ShellError> {
-    context.shell_manager.ls(path, &context)
+fn ls(LsArgs { path, full }: LsArgs, context: RunnableContext) -> Result<OutputStream, ShellError> {
+    context.shell_manager.ls(path, &context, full)
 }

--- a/src/parser/hir/baseline_parse/tests.rs
+++ b/src/parser/hir/baseline_parse/tests.rs
@@ -1,12 +1,13 @@
 use crate::commands::classified::InternalCommand;
 use crate::commands::ClassifiedCommand;
 use crate::env::host::BasicHost;
-use crate::parser::hir;
 use crate::parser::hir::syntax_shape::*;
 use crate::parser::hir::TokensIterator;
+use crate::parser::hir::{self, named::NamedValue, NamedArguments};
 use crate::parser::parse::token_tree_builder::{CurriedToken, TokenTreeBuilder as b};
 use crate::parser::TokenNode;
 use crate::{HasSpan, Span, SpannedItem, Tag, Text};
+use indexmap::IndexMap;
 use pretty_assertions::assert_eq;
 use std::fmt::Debug;
 
@@ -67,6 +68,9 @@ fn test_parse_command() {
 
             eprintln!("{:?} {:?} {:?}", bare, pat, bare.until(pat));
 
+            let mut map = IndexMap::new();
+            map.insert("full".to_string(), NamedValue::AbsentSwitch);
+
             ClassifiedCommand::Internal(InternalCommand::new(
                 "ls".to_string(),
                 Tag {
@@ -76,7 +80,7 @@ fn test_parse_command() {
                 hir::Call {
                     head: Box::new(hir::RawExpression::Command(bare).spanned(bare)),
                     positional: Some(vec![hir::Expression::pattern("*.txt", pat)]),
-                    named: None,
+                    named: Some(NamedArguments { named: map }),
                 }
                 .spanned(bare.until(pat)),
             ))

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -86,6 +86,7 @@ impl Shell for FilesystemShell {
         &self,
         pattern: Option<Tagged<PathBuf>>,
         context: &RunnableContext,
+        full: bool,
     ) -> Result<OutputStream, ShellError> {
         let cwd = self.path();
         let mut full_path = PathBuf::from(self.path());
@@ -136,7 +137,7 @@ impl Shell for FilesystemShell {
                                     Path::new(&filepath)
                                 };
 
-                                let value = dir_entry_dict(filename, &metadata, &name_tag)?;
+                                let value = dir_entry_dict(filename, &metadata, &name_tag, full)?;
                                 yield ReturnSuccess::value(value);
                             }
                         }
@@ -175,7 +176,7 @@ impl Shell for FilesystemShell {
                             Path::new(&entry)
                         };
 
-                        if let Ok(value) = dir_entry_dict(filename, &metadata, &name_tag) {
+                        if let Ok(value) = dir_entry_dict(filename, &metadata, &name_tag, full) {
                             yield ReturnSuccess::value(value);
                         }
                     }

--- a/src/shell/help_shell.rs
+++ b/src/shell/help_shell.rs
@@ -129,6 +129,7 @@ impl Shell for HelpShell {
         &self,
         _pattern: Option<Tagged<PathBuf>>,
         _context: &RunnableContext,
+        _full: bool,
     ) -> Result<OutputStream, ShellError> {
         Ok(self
             .commands()

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -16,6 +16,7 @@ pub trait Shell: std::fmt::Debug {
         &self,
         pattern: Option<Tagged<PathBuf>>,
         context: &RunnableContext,
+        full: bool,
     ) -> Result<OutputStream, ShellError>;
     fn cd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError>;
     fn cp(&self, args: CopyArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;

--- a/src/shell/shell_manager.rs
+++ b/src/shell/shell_manager.rs
@@ -127,10 +127,11 @@ impl ShellManager {
         &self,
         path: Option<Tagged<PathBuf>>,
         context: &RunnableContext,
+        full: bool,
     ) -> Result<OutputStream, ShellError> {
         let env = self.shells.lock().unwrap();
 
-        env[self.current_shell()].ls(path, context)
+        env[self.current_shell()].ls(path, context, full)
     }
 
     pub fn cd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {

--- a/src/shell/value_shell.rs
+++ b/src/shell/value_shell.rs
@@ -90,6 +90,7 @@ impl Shell for ValueShell {
         &self,
         target: Option<Tagged<PathBuf>>,
         context: &RunnableContext,
+        _full: bool,
     ) -> Result<OutputStream, ShellError> {
         let mut full_path = PathBuf::from(self.path());
         let name_tag = context.name.clone();


### PR DESCRIPTION
Currently, in 80x24 screens the current `ls` is a bit too big. Taking a first step by abbreviating `ls` and moving some of the columns behind a `--full` flag.

I also added platform-specific extension for permissions (though needs more work to be useful).