### PR TITLE
Simplify execution of external commands.

### DIFF
--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -358,26 +358,24 @@ fn save_figures_out_intelligently_where_to_write_out_with_metadata() {
 
 #[test]
 fn it_arg_works_with_many_inputs_to_external_command() {
-    Playground::setup("it_arg_works_with_many_inputs", |dirs, sandbox| {
-        sandbox.with_files(vec![
-            FileWithContent("file1", "text"),
-            FileWithContent("file2", " and more text"),
-        ]);
+    Playground::setup("it_arg_works_with_many_inputs", |dirs, _| {
+        let expected_file = dirs.test().join("results.txt");
 
-        let (stdout, stderr) = nu_combined!(
+        let (_, stderr) = nu_combined!(
             cwd: dirs.test(), h::pipeline(
             r#"
                 echo hello world
                 | split-row " "
                 | ^echo $it
+                | save results.txt
             "#
         ));
 
-        #[cfg(windows)]
-        assert_eq!("hello world", stdout);
-
-        #[cfg(not(windows))]
-        assert_eq!("helloworld", stdout);
+        let actual = h::file_contents(expected_file);
+        assert_eq!(
+            vec!["hello", "world"],
+            actual.lines().map(str::trim).collect::<Vec<_>>()
+        );
 
         assert!(!stderr.contains("No such file or directory"));
     })


### PR DESCRIPTION
## What is this PR doing?

Simplifying external command by removing the need for it to know what kind of thing is next in the pipeline.

## How have you achieved that?

First, eliminates `StreamNext` in favour of `OutputDecoding` to determine how `ExternalCommand#run` should behave. With this, there is no concept of "last item in stream". A detached process is now assumed to have finished execution when stdout has been consumed/closed.

Second, all pipelines now end in "autoview", so external commands become a stream of lines.

Example output from `git status`:
```
~/src/github.com/nushell/nushell(simplify-external-commands)> git st
━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # │ <value>
───┼───────────────────────────────────────────────────────────────────
 0 │ On branch simplify-external-commands
 1 │ Your branch is up to date with 'fork/simplify-external-commands'.
 2 │
 3 │ nothing to commit, working tree clean
━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

## What should reviewers focus on?

Is the assumption that "a process is done when stdout is consumed/closed" a good one? I feel like perhaps it's possible for that pipe to be closed early by a process, but in the context of executing a pipeline, maybe that's okay? (given there's nothing more to pipe to the next command)

Do we want all externals commands at the end of a pipeline always be `autoview`ed as lines? It feels natural in nushell, but maybe it's undesirable.

## Other thoughts

By simplifying `ExternalCommand` in this way, I'm hoping it'll be even simpler for me to manually orchestrate the spawning of all the processes when we have `... | ^cmd $it ...`.