### PR TITLE
Compact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | command | description |
 | ------------- | ------------- |
 | append row-data | Append a row to the end of the table |
+| compact ...columns | Remove rows where given columns are empty |
 | count | Show the total number of rows |
 | edit column-or-column-path value | Edit an existing column to have a new value |
 | embed column | Creates a new table of one column with the given name, and places the current table inside of it |
@@ -286,7 +287,7 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 | reject ...columns | Remove the given columns from the table |
 | reverse | Reverses the table. |
 | skip amount | Skip a number of rows |
-| skip-while condition | Skips rows while the condition matches. |
+| skip-while condition | Skips rows while the condition matches |
 | split-by column | Creates a new table with the data from the inner tables splitted by the column given |
 | sort-by ...columns | Sort by the given columns |
 | str (column) | Apply string function. Optionally use the column of a table |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -309,6 +309,7 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
             per_item_command(Where),
             per_item_command(Echo),
             whole_stream_command(Config),
+            whole_stream_command(Compact),
             whole_stream_command(SkipWhile),
             per_item_command(Enter),
             per_item_command(Help),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,6 +11,7 @@ pub(crate) mod cd;
 pub(crate) mod classified;
 pub(crate) mod clip;
 pub(crate) mod command;
+pub(crate) mod compact;
 pub(crate) mod config;
 pub(crate) mod count;
 pub(crate) mod cp;
@@ -98,6 +99,7 @@ pub(crate) use command::{
 
 pub(crate) use append::Append;
 pub(crate) use classified::ClassifiedCommand;
+pub(crate) use compact::Compact;
 pub(crate) use config::Config;
 pub(crate) use count::Count;
 pub(crate) use cp::Cpy;

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -1,0 +1,53 @@
+use crate::commands::WholeStreamCommand;
+use crate::errors::ShellError;
+use crate::parser::registry::{CommandRegistry, Signature};
+use crate::prelude::*;
+use futures::stream::StreamExt;
+
+pub struct Compact;
+
+#[derive(Deserialize)]
+pub struct CompactArgs {
+    rest: Vec<Tagged<String>>,
+}
+
+impl WholeStreamCommand for Compact {
+    fn name(&self) -> &str {
+        "compact"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("compact").rest(SyntaxShape::Any, "the columns to compact from the table")
+    }
+
+    fn usage(&self) -> &str {
+        "Creates a table with non-empty rows"
+    }
+
+    fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        args.process(registry, compact)?.run()
+    }
+}
+
+pub fn compact(
+    CompactArgs { rest: columns }: CompactArgs,
+    RunnableContext { input, .. }: RunnableContext,
+) -> Result<OutputStream, ShellError> {
+    let objects = input.values.take_while(move |item| {
+        let keep = if columns.is_empty() {
+            item.is_some()
+        } else {
+            columns
+                .iter()
+                .all(|field| item.get_data(field).borrow().is_some())
+        };
+
+        futures::future::ready(keep)
+    });
+
+    Ok(objects.from_input_stream())
+}

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -36,7 +36,7 @@ fn debug_value(
 ) -> Result<OutputStream, ShellError> {
     let stream = async_stream! {
         while let Some(row) = input.values.next().await {
-            if let Tagged { item: true, .. } = raw {      
+            if let Tagged { item: true, .. } = raw {
                 println!("{:?}", row);
                 yield ReturnSuccess::value(row)
             } else {

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -4,9 +4,7 @@ use crate::prelude::*;
 pub struct Debug;
 
 #[derive(Deserialize)]
-pub struct DebugArgs {
-    raw: Tagged<bool>,
-}
+pub struct DebugArgs {}
 
 impl WholeStreamCommand for Debug {
     fn name(&self) -> &str {
@@ -14,7 +12,7 @@ impl WholeStreamCommand for Debug {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("debug").switch("raw", "print raw data")
+        Signature::build("debug")
     }
 
     fn usage(&self) -> &str {
@@ -31,19 +29,14 @@ impl WholeStreamCommand for Debug {
 }
 
 fn debug_value(
-    DebugArgs { raw }: DebugArgs,
+    _args: DebugArgs,
     RunnableContext { mut input, .. }: RunnableContext,
-) -> Result<OutputStream, ShellError> {
+) -> Result<impl ToOutputStream, ShellError> {
     let stream = async_stream! {
         while let Some(row) = input.values.next().await {
-            if let Tagged { item: true, .. } = raw {
-                println!("{:?}", row);
-                yield ReturnSuccess::value(row)
-            } else {
-                yield ReturnSuccess::debug_value(row.clone())
-            }
+            yield ReturnSuccess::debug_value(row.clone())
         }
     };
 
-    Ok(stream.to_output_stream())
+    Ok(stream)
 }

--- a/src/data/base.rs
+++ b/src/data/base.rs
@@ -497,6 +497,17 @@ impl Value {
         }
     }
 
+    pub(crate) fn is_some(&self) -> bool {
+        !self.is_none()
+    }
+
+    pub(crate) fn is_none(&self) -> bool {
+        match self {
+            Value::Primitive(Primitive::Nothing) => true,
+            _ => false,
+        }
+    }
+
     pub(crate) fn is_error(&self) -> bool {
         match self {
             Value::Error(_err) => true,

--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -36,7 +36,7 @@ fn compact_rows_where_given_column_is_empty() {
 }
 #[test]
 fn compact_empty_rows_by_default() {
-    Playground::setup("compact_test_2", |dirs, sandbox| {
+    Playground::setup("compact_test_2", |dirs, _| {
         let actual = nu!(
             cwd: dirs.test(), h::pipeline(
             r#"

--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -4,6 +4,54 @@ use helpers as h;
 use helpers::{Playground, Stub::*};
 
 #[test]
+fn compact_rows_where_given_column_is_empty() {
+    Playground::setup("compact_test_1", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_amigos.json",
+            r#"
+                {
+                    "amigos": [
+                        {"name":   "Yehuda", "rusty_luck": 1},
+                        {"name": "Jonathan", "rusty_luck": 1},
+                        {"name":   "Andres", "rusty_luck": 1},
+                        {"name":"GorbyPuff"}
+                    ]
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), h::pipeline(
+            r#"
+                open los_tres_amigos.json
+                | get amigos
+                | compact rusty_luck
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual, "3");
+    });
+}
+#[test]
+fn compact_empty_rows_by_default() {
+    Playground::setup("compact_test_2", |dirs, sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(), h::pipeline(
+            r#"
+                echo "[1,2,3,14,null]"
+                | from-json
+                | compact
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual, "4");
+    });
+}
+#[test]
 fn group_by() {
     Playground::setup("group_by_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(


### PR DESCRIPTION
There may be cases where we may have tables and one particular column in a row might be empty, like so:

```shells
> open amigos.json | get amigos
━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━
 # │ name      │ rusty_luck
───┼───────────┼────────────
 0 │ Yehuda    │          1
 1 │ Jonathan  │          1
 2 │ Andres    │          1
 3 │ GorbyPuff │
━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━
```

We can compact the table like this:

`> open amigos.json | get amigos | compact rusty_luck` giving:

```shells
━━━┯━━━━━━━━━━┯━━━━━━━━━━━━
 # │ name     │ rusty_luck
───┼──────────┼────────────
 0 │ Yehuda   │          1
 1 │ Jonathan │          1
 2 │ Andres   │          1
━━━┷━━━━━━━━━━┷━━━━━━━━━━━━
```