### PR TITLE
Revert some of the recent styled string changes

### DIFF
--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -30,13 +30,10 @@ impl WholeStreamCommand for Debug {
 
 fn debug_value(
     _args: DebugArgs,
-    RunnableContext { mut input, .. }: RunnableContext,
+    RunnableContext { input, .. }: RunnableContext,
 ) -> Result<impl ToOutputStream, ShellError> {
-    let stream = async_stream! {
-        while let Some(row) = input.values.next().await {
-            yield ReturnSuccess::debug_value(row.clone())
-        }
-    };
-
-    Ok(stream)
+    Ok(input
+        .values
+        .map(|v| ReturnSuccess::value(Value::string(format!("{:?}", v)).tagged_unknown()))
+        .to_output_stream())
 }

--- a/src/commands/what.rs
+++ b/src/commands/what.rs
@@ -34,14 +34,14 @@ impl WholeStreamCommand for What {
 
 pub fn what(
     WhatArgs {}: WhatArgs,
-    RunnableContext { input, host, .. }: RunnableContext,
+    RunnableContext { input, .. }: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
     let stream = async_stream! {
         let values = input.values;
         pin_mut!(values);
 
         while let Some(row) = values.next().await {
-            let name = row.format_type(host.clone().lock().unwrap().width());
+            let name = row.format_leaf().pretty_debug().plain_string(100000);
             yield ReturnSuccess::value(Value::string(name).tagged(Tag::unknown_anchor(row.tag.span)));
         }
     };

--- a/src/data/base.rs
+++ b/src/data/base.rs
@@ -3,7 +3,7 @@ mod property_get;
 pub(crate) mod shape;
 
 use crate::context::CommandRegistry;
-use crate::data::base::shape::{Column, InlineShape, TypeShape};
+use crate::data::base::shape::{InlineShape, TypeShape};
 use crate::data::TaggedDictBuilder;
 use crate::errors::ShellError;
 use crate::evaluate::{evaluate_baseline_expr, Scope};
@@ -439,6 +439,7 @@ impl Value {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn format_type(&self, width: usize) -> String {
         TypeShape::from_value(self).colored_string(width)
     }
@@ -447,11 +448,11 @@ impl Value {
         InlineShape::from_value(self).format().pretty_debug()
     }
 
-    pub(crate) fn format_for_column(&self, column: impl Into<Column>) -> DebugDocBuilder {
-        InlineShape::from_value(self)
-            .format_for_column(column)
-            .pretty_debug()
-    }
+    // pub(crate) fn format_for_column(&self, column: impl Into<Column>) -> DebugDocBuilder {
+    //     InlineShape::from_value(self)
+    //         .format_for_column(column)
+    //         .pretty_debug()
+    // }
 
     pub(crate) fn style_leaf(&self) -> &'static str {
         match self {

--- a/src/data/base/shape.rs
+++ b/src/data/base/shape.rs
@@ -22,6 +22,7 @@ use std::path::PathBuf;
   It also serves as the primary vehicle for pretty-printing.
 */
 
+#[allow(unused)]
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum TypeShape {
     Nothing,
@@ -281,12 +282,12 @@ impl InlineShape {
         }
     }
 
-    pub fn format_for_column(self, column: impl Into<Column>) -> FormatInlineShape {
-        FormatInlineShape {
-            shape: self,
-            column: Some(column.into()),
-        }
-    }
+    // pub fn format_for_column(self, column: impl Into<Column>) -> FormatInlineShape {
+    //     FormatInlineShape {
+    //         shape: self,
+    //         column: Some(column.into()),
+    //     }
+    // }
 
     pub fn format(self) -> FormatInlineShape {
         FormatInlineShape {

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -1,7 +1,7 @@
 use crate::data::Value;
 use crate::format::RenderView;
 use crate::prelude::*;
-use crate::traits::{DebugDocBuilder, DebugDocBuilder as b, PrettyDebug};
+use crate::traits::PrettyDebug;
 use derive_new::new;
 use textwrap::fill;
 
@@ -58,33 +58,56 @@ impl TableView {
         let mut entries = vec![];
 
         for (idx, value) in values.iter().enumerate() {
-            let mut row: Vec<(DebugDocBuilder, &'static str)> = match value {
-                Tagged {
-                    item: Value::Row(..),
-                    ..
-                } => headers
-                    .iter()
-                    .enumerate()
-                    .map(|(i, d)| {
-                        let data = value.get_data(d);
-                        return (
-                            data.borrow().format_for_column(&headers[i]),
-                            data.borrow().style_leaf(),
-                        );
-                    })
-                    .collect(),
-                x => vec![(x.format_leaf(), x.style_leaf())],
-            };
+            let mut row: Vec<(String, &'static str)> = headers
+                .iter()
+                .map(|d| {
+                    if d == "<value>" {
+                        match value {
+                            Tagged {
+                                item: Value::Row(..),
+                                ..
+                            } => (
+                                Value::nothing()
+                                    .format_leaf()
+                                    .pretty_debug()
+                                    .plain_string(100000),
+                                Value::nothing().style_leaf(),
+                            ),
+                            _ => (
+                                value.format_leaf().pretty_debug().plain_string(100000),
+                                value.style_leaf(),
+                            ),
+                        }
+                    } else {
+                        match value {
+                            Tagged {
+                                item: Value::Row(..),
+                                ..
+                            } => {
+                                let data = value.get_data(d);
+                                (
+                                    data.borrow()
+                                        .format_leaf()
+                                        .pretty_debug()
+                                        .plain_string(100000),
+                                    data.borrow().style_leaf(),
+                                )
+                            }
+                            _ => (
+                                Value::nothing()
+                                    .format_leaf()
+                                    .pretty_debug()
+                                    .plain_string(100000),
+                                Value::nothing().style_leaf(),
+                            ),
+                        }
+                    }
+                })
+                .collect();
 
             if values.len() > 1 {
                 // Indices are black, bold, right-aligned:
-                row.insert(
-                    0,
-                    (
-                        b::primitive(format!("{}", (starting_idx + idx).to_string())),
-                        "Fdbr",
-                    ),
-                );
+                row.insert(0, (format!("{}", (starting_idx + idx).to_string()), "Fdbr"));
             }
 
             entries.push(row);
@@ -96,13 +119,10 @@ impl TableView {
             headers.insert(0, format!("#"));
         }
 
-        // Different platforms want different amounts of buffer, not sure why
-        let termwidth = std::cmp::max(textwrap::termwidth(), 20);
-
         for head in 0..headers.len() {
             let mut current_col_max = 0;
             for row in 0..values.len() {
-                let value_length = entries[row][head].0.plain_string(termwidth).chars().count();
+                let value_length = entries[row][head].0.chars().count();
                 if value_length > current_col_max {
                     current_col_max = value_length;
                 }
@@ -113,6 +133,9 @@ impl TableView {
                 headers[head].chars().count(),
             ));
         }
+
+        // Different platforms want different amounts of buffer, not sure why
+        let termwidth = std::cmp::max(textwrap::termwidth(), 20);
 
         // Make sure we have enough space for the columns we have
         let max_num_of_columns = termwidth / 10;
@@ -126,7 +149,7 @@ impl TableView {
 
             headers.push("...".to_string());
             for row in 0..entries.len() {
-                entries[row].push((b::description("..."), "c")); // ellipsis is centred
+                entries[row].push(("...".to_string(), "c")); // ellipsis is centred
             }
         }
 
@@ -198,52 +221,18 @@ impl TableView {
             99999
         };
 
-        let mut out_entries: Vec<Vec<(String, &'static str)>> = Vec::with_capacity(entries.len());
-
-        for row in entries.iter() {
-            let mut out_row = Vec::with_capacity(row.len());
-
-            for _ in row {
-                out_row.push((String::new(), "Fdbr"));
-            }
-
-            out_entries.push(out_row);
-        }
-
         // Wrap cells as needed
         for head in 0..headers.len() {
             if max_per_column[head] > max_naive_column_width {
-                if true_width(&headers[head]) > max_column_width {
-                    headers[head] = fill(&headers[head], max_column_width);
-                }
-
-                for (i, row) in entries.iter().enumerate() {
-                    let column = &row[head].0;
-                    let column = column.plain_string(max_column_width);
-
-                    out_entries[i][head] = (column, row[head].1);
-                }
-            } else {
-                for (i, row) in entries.iter().enumerate() {
-                    let column = &row[head].0;
-                    let column = column.plain_string(max_column_width);
-
-                    out_entries[i][head] = (column, row[head].1);
+                headers[head] = fill(&headers[head], max_column_width);
+                for row in 0..entries.len() {
+                    entries[row][head].0 = fill(&entries[row][head].0, max_column_width);
                 }
             }
         }
 
-        Some(TableView {
-            headers,
-            entries: out_entries,
-        })
+        Some(TableView { headers, entries })
     }
-}
-
-fn true_width(string: &str) -> usize {
-    let stripped = console::strip_ansi_codes(string);
-
-    stripped.lines().map(|line| line.len()).max().unwrap_or(0)
 }
 
 impl RenderView for TableView {


### PR DESCRIPTION
This reverts some of the recent changes for `what?` and `debug` as well as updates to table printing. We'd like to implement these again in the future, but currently there are regressions in table printing we hope to address with this PR before the upcoming release.