### PR TITLE
Remove env var from starship

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -396,6 +396,7 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
         let colored_prompt = {
             #[cfg(feature = "starship-prompt")]
             {
+                std::env::set_var("STARSHIP_SHELL", "");
                 starship::print::get_prompt(starship::context::Context::new_with_dir(
                     clap::ArgMatches::default(),
                     cwd,


### PR DESCRIPTION
This removes the unused STARSHIP_SHELL environment variable right before we render the starship prompt. With it removed, starship will correctly render the prompt, even when run inside a shell/environment that's already running starship.

Should hopefully address #1005 