### PR TITLE
Add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "1024"]
+#![feature(bind_by_move_pattern_guards)]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/1033