### PR TITLE
Clean up expansion of external words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,9 +1346,9 @@ checksum = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 
 [[package]]
 name = "http"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2790658cddc82e82b08e25176c431d7015a0adeb1718498715cbd20138a0bf68"
+checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ binaryview = ["image", "crossterm"]
 sys = ["heim", "battery"]
 ps = ["heim"]
 starship-prompt = ["starship"]
-# trace = ["nom-tracable/trace"]
+#trace = ["nu-parser/trace"]
 
 [dependencies.rusqlite]
 version = "0.20.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -38,3 +38,6 @@ pretty_assertions = "0.6.1"
 
 [build-dependencies]
 nu-build = { version = "0.1.0", path = "../nu-build" }
+
+[features]
+trace = ["nom-tracable/trace"]

--- a/crates/nu-parser/src/hir/expand_external_tokens.rs
+++ b/crates/nu-parser/src/hir/expand_external_tokens.rs
@@ -86,7 +86,7 @@ impl ColorSyntax for ExternalTokensShape {
 
             // Process an external expression. External expressions are mostly words, with a
             // few exceptions (like $variables and path expansion rules)
-            match color_syntax(&ExternalExpression, token_nodes, context, shapes).1 {
+            match color_syntax(&ExternalExpressionShape, token_nodes, context, shapes).1 {
                 ExternalExpressionResult::Eof => break,
                 ExternalExpressionResult::Processed => continue,
             }
@@ -115,7 +115,7 @@ impl ColorSyntax for ExternalTokensShape {
 
             // Process an external expression. External expressions are mostly words, with a
             // few exceptions (like $variables and path expansion rules)
-            match color_syntax(&ExternalExpression, token_nodes, context).1 {
+            match color_syntax(&ExternalExpressionShape, token_nodes, context).1 {
                 ExternalExpressionResult::Eof => break,
                 ExternalExpressionResult::Processed => continue,
             }
@@ -144,7 +144,7 @@ impl ExpandSyntax for ExternalExpressionShape {
             token_nodes,
             "external command",
             context,
-            ExpansionRule::new().allow_external_command(),
+            ExpansionRule::new().allow_external_word(),
         )?
         .span;
 
@@ -152,40 +152,6 @@ impl ExpandSyntax for ExternalExpressionShape {
 
         loop {
             let continuation = expand_expr(&ExternalContinuationShape, token_nodes, context);
-
-            if let Ok(continuation) = continuation {
-                last = continuation.span;
-            } else {
-                break;
-            }
-        }
-
-        Ok(Some(first.until(last)))
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-struct ExternalExpression;
-
-impl ExpandSyntax for ExternalExpression {
-    type Output = Option<Span>;
-
-    fn name(&self) -> &'static str {
-        "external expression"
-    }
-
-    fn expand_syntax<'a, 'b>(
-        &self,
-        token_nodes: &'b mut TokensIterator<'a>,
-        context: &ExpandContext,
-    ) -> Result<Self::Output, ParseError> {
-        expand_syntax(&MaybeSpaceShape, token_nodes, context)?;
-
-        let first = expand_syntax(&ExternalHeadShape, token_nodes, context)?.span;
-        let mut last = first;
-
-        loop {
-            let continuation = expand_syntax(&ExternalContinuationShape, token_nodes, context);
 
             if let Ok(continuation) = continuation {
                 last = continuation.span;
@@ -311,12 +277,12 @@ impl ExpandExpression for ExternalContinuationShape {
 }
 
 #[cfg(coloring_in_tokens)]
-impl ColorSyntax for ExternalExpression {
+impl ColorSyntax for ExternalExpressionShape {
     type Info = ExternalExpressionResult;
     type Input = ();
 
     fn name(&self) -> &'static str {
-        "ExternalExpression"
+        "ExternalExpressionShape"
     }
 
     fn color_syntax<'a, 'b>(
@@ -345,13 +311,13 @@ impl ColorSyntax for ExternalExpression {
 }
 
 #[must_use]
-enum ExternalExpressionResult {
+pub enum ExternalExpressionResult {
     Eof,
     Processed,
 }
 
 #[cfg(not(coloring_in_tokens))]
-impl ColorSyntax for ExternalExpression {
+impl ColorSyntax for ExternalExpressionShape {
     type Info = ExternalExpressionResult;
     type Input = ();
 


### PR DESCRIPTION
Previously, external words accidentally used
ExpansionRule::new().allow_external_command(), when it should have been
ExpansionRule::new().allow_external_word().

External words are the broadest category in the parser, and are the
appropriate category for external arguments. This was just a mistake.