### PR TITLE
embed as column when embedding a list

### DIFF
--- a/src/plugins/embed.rs
+++ b/src/plugins/embed.rs
@@ -11,18 +11,40 @@ use nu_source::Tag;
 
 struct Embed {
     field: Option<String>,
+    are_all_rows: bool,
     values: Vec<Value>,
 }
 impl Embed {
     fn new() -> Embed {
         Embed {
             field: None,
+            are_all_rows: true,
             values: Vec::new(),
         }
     }
 
     fn embed(&mut self, value: Value) -> Result<(), ShellError> {
-        self.values.push(value);
+        match &value {
+            Value {
+                value: UntaggedValue::Row(_),
+                ..
+            } => {
+                self.values.push(value);
+            }
+            _ => {
+                self.are_all_rows = false;
+
+                self.values.push(
+                    value::row(indexmap! {
+                        match &self.field {
+                            Some(key) => key.clone(),
+                            None => "Column".into()
+                        } => value
+                    })
+                    .into_value(Tag::unknown()),
+                );
+            }
+        }
         Ok(())
     }
 }
@@ -58,15 +80,23 @@ impl Plugin for Embed {
     }
 
     fn end_filter(&mut self) -> Result<Vec<ReturnValue>, ShellError> {
-        let row = value::row(indexmap! {
-            match &self.field {
-                Some(key) => key.clone(),
-                None => "root".into(),
-            } => value::table(&self.values).into_value(Tag::unknown()),
-        })
-        .into_untagged_value();
+        if self.are_all_rows {
+            let row = value::row(indexmap! {
+                match &self.field {
+                    Some(key) => key.clone(),
+                    None => "Column".into(),
+                } => value::table(&self.values).into_value(Tag::unknown()),
+            })
+            .into_untagged_value();
 
-        Ok(vec![ReturnSuccess::value(row)])
+            Ok(vec![ReturnSuccess::value(row)])
+        } else {
+            Ok(self
+                .values
+                .iter()
+                .map(|row| ReturnSuccess::value(row.clone()))
+                .collect::<Vec<_>>())
+        }
     }
 }
 

--- a/tests/filters_test.rs
+++ b/tests/filters_test.rs
@@ -727,8 +727,8 @@ fn can_get_reverse_first() {
 }
 
 #[test]
-fn embed() {
-    Playground::setup("embed_test", |dirs, sandbox| {
+fn embed_rows_into_a_row() {
+    Playground::setup("embed_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
@@ -753,6 +753,36 @@ fn embed() {
         ));
 
         assert_eq!(actual, "Robalino");
+    })
+}
+
+#[test]
+fn embed_rows_into_a_table() {
+    Playground::setup("embed_test_2", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name,last_name
+                Andrés,Robalino
+                Jonathan,Turner
+                Yehuda,Katz
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), h::pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from-csv
+                | get last_name
+                | embed caballero
+                | nth 2
+                | get caballero
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual, "Katz");
     })
 }
 


### PR DESCRIPTION
Given

```
ls | embed results

━━━━━━━━━━━━━━━━━
 results
─────────────────
 [table 28 rows]
━━━━━━━━━━━━━━━━━
```

Basically we enclose the table given by `ls` in a new table with `results` column. However, sometimes we may do `ls | get name | first 5` like so:

```
━━━┯━━━━━━━━━━━━━━━━━━━━
 # │ <value>
───┼────────────────────
 0 │ CODE_OF_CONDUCT.md
 1 │ Makefile.toml
 2 │ Cargo.toml
 3 │ crates
 4 │ docker
━━━┷━━━━━━━━━━━━━━━━━━━━
```

At times we may need a full fledged table with a column for the above output. With this PR we are able to do so:

```
ls | get name | embed column | first 5
━━━┯━━━━━━━━━━━━━━━━━━━━
 # │ column
───┼────────────────────
 0 │ CODE_OF_CONDUCT.md
 1 │ Makefile.toml
 2 │ Cargo.toml
 3 │ crates
 4 │ docker
━━━┷━━━━━━━━━━━━━━━━━━━━
```