### PR TITLE
Fix most Clippy performance warnings

### DIFF
--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -38,7 +38,7 @@ impl Spanned<String> {
     pub fn items<'a, U>(
         items: impl Iterator<Item = &'a Spanned<String>>,
     ) -> impl Iterator<Item = &'a str> {
-        items.into_iter().map(|item| &item.item[..])
+        items.map(|item| &item.item[..])
     }
 }
 
@@ -156,7 +156,7 @@ impl<T> Tagged<T> {
 
         Tagged {
             item: self.item,
-            tag: tag,
+            tag,
         }
     }
 

--- a/crates/nu-source/src/pretty.rs
+++ b/crates/nu-source/src/pretty.rs
@@ -316,7 +316,7 @@ impl DebugDocBuilder {
             result = result + item;
         }
 
-        result.into()
+        result
     }
 
     fn styled(string: impl std::fmt::Display, style: ShellStyle) -> DebugDocBuilder {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ fn load_plugin(path: &std::path::Path, context: &mut Context) -> Result<(), Shel
 
     let request = JsonRpc::new("config", Vec::<Value>::new());
     let request_raw = serde_json::to_string(&request)?;
-    stdin.write(format!("{}\n", request_raw).as_bytes())?;
+    stdin.write_all(format!("{}\n", request_raw).as_bytes())?;
     let path = dunce::canonicalize(path)?;
 
     let mut input = String::new();
@@ -58,7 +58,7 @@ fn load_plugin(path: &std::path::Path, context: &mut Context) -> Result<(), Shel
                         let name = params.name.clone();
                         let fname = fname.to_string();
 
-                        if let Some(_) = context.get_command(&name) {
+                        if context.get_command(&name).is_some() {
                             trace!("plugin {:?} already loaded.", &name);
                         } else {
                             if params.is_filter {
@@ -222,7 +222,7 @@ impl History {
                 p.push(FNAME);
                 p
             })
-            .unwrap_or(PathBuf::from(FNAME))
+            .unwrap_or_else(|_| PathBuf::from(FNAME))
     }
 }
 
@@ -609,8 +609,8 @@ fn classify_pipeline(
     context: &Context,
     source: &Text,
 ) -> Result<ClassifiedPipeline, ShellError> {
-    let mut pipeline_list = vec![pipeline.clone()];
-    let mut iterator = TokensIterator::all(&mut pipeline_list, source.clone(), pipeline.span());
+    let pipeline_list = vec![pipeline.clone()];
+    let mut iterator = TokensIterator::all(&pipeline_list, source.clone(), pipeline.span());
 
     let result = expand_syntax(
         &PipelineShape,

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -566,7 +566,7 @@ impl WholeStreamCommand for FnFilterCommand {
             );
 
             match func(args) {
-                Err(err) => return OutputStream::from(vec![Err(err)]).values,
+                Err(err) => OutputStream::from(vec![Err(err)]).values,
                 Ok(stream) => stream.values,
             }
         });

--- a/src/commands/enter.rs
+++ b/src/commands/enter.rs
@@ -47,7 +47,7 @@ impl PerItemCommand for Enter {
                 let tag_clone = tag.clone();
 
                 if location.starts_with("help") {
-                    let spec = location_string.split(":").collect::<Vec<&str>>();
+                    let spec = location_string.split(':').collect::<Vec<&str>>();
 
                     let (_, command) = (spec[0], spec[1]);
 

--- a/src/commands/evaluate_by.rs
+++ b/src/commands/evaluate_by.rs
@@ -94,7 +94,7 @@ pub fn evaluate(
             ..
         } => {
             let datasets: Vec<_> = datasets
-                .into_iter()
+                .iter()
                 .map(|subsets| match subsets {
                     Value {
                         value: UntaggedValue::Table(subsets),

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -129,7 +129,7 @@ pub async fn fetch(
     location: &str,
     span: Span,
 ) -> Result<(Option<String>, UntaggedValue, Tag), ShellError> {
-    if let Err(_) = url::Url::parse(location) {
+    if url::Url::parse(location).is_err() {
         return Err(ShellError::labeled_error(
             "Incomplete or incorrect url",
             "expected a full url",
@@ -275,19 +275,17 @@ pub async fn fetch(
             }
             None => Ok((
                 None,
-                UntaggedValue::string(format!("No content type found")),
+                UntaggedValue::string("No content type found".to_owned()),
                 Tag {
                     span,
                     anchor: Some(AnchorLocation::Url(location.to_string())),
                 },
             )),
         },
-        Err(_) => {
-            return Err(ShellError::labeled_error(
-                "URL could not be opened",
-                "url not found",
-                span,
-            ));
-        }
+        Err(_) => Err(ShellError::labeled_error(
+            "URL could not be opened",
+            "url not found",
+            span,
+        )),
     }
 }

--- a/src/commands/from_bson.rs
+++ b/src/commands/from_bson.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for FromBSON {
     }
 }
 
-fn bson_array(input: &Vec<Bson>, tag: Tag) -> Result<Vec<Value>, ShellError> {
+fn bson_array(input: &[Bson], tag: Tag) -> Result<Vec<Value>, ShellError> {
     let mut out = vec![];
 
     for value in input {
@@ -81,7 +81,7 @@ fn convert_bson_value_to_nu_value(v: &Bson, tag: impl Into<Tag>) -> Result<Value
                 ShellError::range_error(
                     ExpectedRange::BigDecimal,
                     &n.spanned(span),
-                    format!("converting BSON Decimal128 to BigDecimal"),
+                    "converting BSON Decimal128 to BigDecimal".to_owned(),
                 )
             })?;
             UntaggedValue::Primitive(Primitive::Decimal(decimal)).into_value(&tag)

--- a/src/commands/from_ini.rs
+++ b/src/commands/from_ini.rs
@@ -31,7 +31,7 @@ impl WholeStreamCommand for FromINI {
 fn convert_ini_second_to_nu_value(v: &HashMap<String, String>, tag: impl Into<Tag>) -> Value {
     let mut second = TaggedDictBuilder::new(tag);
 
-    for (key, value) in v.into_iter() {
+    for (key, value) in v.iter() {
         second.insert_untagged(key.clone(), Primitive::String(value.clone()));
     }
 

--- a/src/commands/from_sqlite.rs
+++ b/src/commands/from_sqlite.rs
@@ -97,7 +97,7 @@ fn convert_sqlite_row_to_nu_value(
             convert_sqlite_value_to_nu_value(row.get_raw(i), tag.clone()),
         );
     }
-    return Ok(collected.into_value());
+    Ok(collected.into_value())
 }
 
 fn convert_sqlite_value_to_nu_value(value: ValueRef, tag: impl Into<Tag> + Clone) -> Value {

--- a/src/commands/from_xml.rs
+++ b/src/commands/from_xml.rs
@@ -45,11 +45,7 @@ fn from_node_to_value<'a, 'd>(n: &roxmltree::Node<'a, 'd>, tag: impl Into<Tag>) 
                     value: UntaggedValue::Primitive(Primitive::String(f)),
                     ..
                 } => {
-                    if f.trim() == "" {
-                        false
-                    } else {
-                        true
-                    }
+                    !f.trim().is_empty() // non-whitespace characters?
                 }
                 _ => true,
             })

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -70,7 +70,7 @@ pub fn get_column_path(path: &ColumnPath, obj: &Value) -> Result<Value, ShellErr
                         ),
                         column_path_tried.span,
                         if total == 1 {
-                            format!("The table only has 1 row")
+                            "The table only has 1 row".to_owned()
                         } else {
                             format!("The table only has {} rows (0 to {})", total, total - 1)
                         },
@@ -91,7 +91,7 @@ pub fn get_column_path(path: &ColumnPath, obj: &Value) -> Result<Value, ShellErr
                 None => {}
             }
 
-            return error;
+            error
         }),
     )
 }
@@ -100,7 +100,7 @@ pub fn get(
     GetArgs { rest: mut fields }: GetArgs,
     RunnableContext { input, .. }: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
-    if fields.len() == 0 {
+    if fields.is_empty() {
         let stream = async_stream! {
             let values = input.values;
             pin_mut!(values);

--- a/src/commands/group_by.rs
+++ b/src/commands/group_by.rs
@@ -84,7 +84,7 @@ pub fn group(
 
             possible_matches.sort();
 
-            if possible_matches.len() > 0 {
+            if !possible_matches.is_empty() {
                 return Err(ShellError::labeled_error(
                     "Unknown column",
                     format!("did you mean '{}'?", possible_matches[0].1),

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -82,16 +82,16 @@ impl PerItemCommand for Help {
                         }
 
                         if signature.rest_positional.is_some() {
-                            one_liner.push_str(&format!(" ...args",));
+                            one_liner.push_str(" ...args");
                         }
 
-                        if signature.named.len() > 0 {
+                        if !signature.named.is_empty() {
                             one_liner.push_str("{flags} ");
                         }
 
                         long_desc.push_str(&format!("\nUsage:\n  > {}\n", one_liner));
 
-                        if signature.positional.len() > 0 || signature.rest_positional.is_some() {
+                        if !signature.positional.is_empty() || signature.rest_positional.is_some() {
                             long_desc.push_str("\nparameters:\n");
                             for positional in signature.positional {
                                 match positional.0 {
@@ -117,7 +117,7 @@ impl PerItemCommand for Help {
                                 ));
                             }
                         }
-                        if signature.named.len() > 0 {
+                        if !signature.named.is_empty() {
                             long_desc.push_str("\nflags:\n");
                             for (flag, ty) in signature.named {
                                 match ty.0 {
@@ -125,7 +125,7 @@ impl PerItemCommand for Help {
                                         long_desc.push_str(&format!(
                                             "  --{}{} {}\n",
                                             flag,
-                                            if ty.1.len() > 0 { ":" } else { "" },
+                                            if !ty.1.is_empty() { ":" } else { "" },
                                             ty.1
                                         ));
                                     }
@@ -134,7 +134,7 @@ impl PerItemCommand for Help {
                                             "  --{} <{}> (required parameter){} {}\n",
                                             flag,
                                             m.display(),
-                                            if ty.1.len() > 0 { ":" } else { "" },
+                                            if !ty.1.is_empty() { ":" } else { "" },
                                             ty.1
                                         ));
                                     }
@@ -143,7 +143,7 @@ impl PerItemCommand for Help {
                                             "  --{} <{}>{} {}\n",
                                             flag,
                                             o.display(),
-                                            if ty.1.len() > 0 { ":" } else { "" },
+                                            if !ty.1.is_empty() { ":" } else { "" },
                                             ty.1
                                         ));
                                     }

--- a/src/commands/histogram.rs
+++ b/src/commands/histogram.rs
@@ -88,7 +88,7 @@ pub fn histogram(
                 let column = (*column_name).clone();
 
                 if let Value { value: UntaggedValue::Table(start), .. } = datasets.get(0).unwrap() {
-                    for percentage in start.into_iter() {
+                    for percentage in start.iter() {
 
                         let mut fact = TaggedDictBuilder::new(&name);
                         let value: Tagged<String> = group_labels.get(idx).unwrap().clone();
@@ -99,7 +99,7 @@ pub fn histogram(
                             fact.insert_untagged(&frequency_column_name, UntaggedValue::string(string));
                         }
 
-                        idx = idx + 1;
+                        idx += 1;
 
                         yield ReturnSuccess::value(fact.into_value());
                     }
@@ -121,14 +121,14 @@ fn percentages(values: &Value, max: Value, tag: impl Into<Tag>) -> Result<Value,
             ..
         } => {
             let datasets: Vec<_> = datasets
-                .into_iter()
+                .iter()
                 .map(|subsets| match subsets {
                     Value {
                         value: UntaggedValue::Table(data),
                         ..
                     } => {
                         let data =
-                                data.into_iter()
+                                data.iter()
                                     .map(|d| match d {
                                         Value {
                                             value: UntaggedValue::Primitive(Primitive::Int(n)),

--- a/src/commands/map_max_by.rs
+++ b/src/commands/map_max_by.rs
@@ -84,13 +84,13 @@ pub fn map_max(
             ..
         } => {
             let datasets: Vec<_> = datasets
-                .into_iter()
+                .iter()
                 .map(|subsets| match subsets {
                     Value {
                         value: UntaggedValue::Table(data),
                         ..
                     } => {
-                        let data = data.into_iter().fold(0, |acc, value| match value {
+                        let data = data.iter().fold(0, |acc, value| match value {
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Int(n)),
                                 ..

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -44,7 +44,7 @@ fn run(
 ) -> Result<OutputStream, ShellError> {
     let shell_manager = &raw_args.shell_manager;
     let cwd = PathBuf::from(shell_manager.path());
-    let full_path = PathBuf::from(cwd);
+    let full_path = cwd;
 
     let path = call_info.args.nth(0).ok_or_else(|| {
         ShellError::labeled_error(
@@ -243,20 +243,18 @@ pub async fn fetch(
                     }
                 }
             },
-            Err(_) => {
-                return Err(ShellError::labeled_error(
-                    "File could not be opened",
-                    "file not found",
-                    span,
-                ));
-            }
+            Err(_) => Err(ShellError::labeled_error(
+                "File could not be opened",
+                "file not found",
+                span,
+            )),
         }
     } else {
-        return Err(ShellError::labeled_error(
+        Err(ShellError::labeled_error(
             "File could not be opened",
             "file not found",
             span,
-        ));
+        ))
     }
 }
 

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -39,7 +39,7 @@ fn pick(
     PickArgs { rest: fields }: PickArgs,
     RunnableContext { input, name, .. }: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
-    if fields.len() == 0 {
+    if fields.is_empty() {
         return Err(ShellError::labeled_error(
             "Pick requires columns to pick",
             "needs parameter",

--- a/src/commands/pivot.rs
+++ b/src/commands/pivot.rs
@@ -92,7 +92,7 @@ pub fn pivot(args: PivotArgs, context: RunnableContext) -> Result<OutputStream, 
                 }
             }
         } else {
-            for i in 0..input.len()+1 {
+            for i in 0..=input.len() {
                 if let Some(name) = args.rest.get(i) {
                     headers.push(name.to_string())
                 } else {

--- a/src/commands/post.rs
+++ b/src/commands/post.rs
@@ -214,7 +214,7 @@ pub async fn post(
     body: &Value,
     user: Option<String>,
     password: Option<String>,
-    headers: &Vec<HeaderKind>,
+    headers: &[HeaderKind],
     tag: Tag,
     registry: &CommandRegistry,
     raw_args: &RawCommandArgs,
@@ -435,20 +435,18 @@ pub async fn post(
                 }
                 None => Ok((
                     None,
-                    UntaggedValue::string(format!("No content type found")),
+                    UntaggedValue::string("No content type found".to_owned()),
                     Tag {
                         anchor: Some(AnchorLocation::Url(location.to_string())),
                         span: tag.span,
                     },
                 )),
             },
-            Err(_) => {
-                return Err(ShellError::labeled_error(
-                    "URL could not be opened",
-                    "url not found",
-                    tag,
-                ));
-            }
+            Err(_) => Err(ShellError::labeled_error(
+                "URL could not be opened",
+                "url not found",
+                tag,
+            )),
         }
     } else {
         Err(ShellError::labeled_error(

--- a/src/commands/range.rs
+++ b/src/commands/range.rs
@@ -42,7 +42,7 @@ fn range(
     RangeArgs { area: rows }: RangeArgs,
     RunnableContext { input, name, .. }: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
-    match rows.item.find(".") {
+    match rows.item.find('.') {
         Some(value) => {
             let (first, last) = rows.item.split_at(value);
             let first = match first.parse::<u64>() {
@@ -59,7 +59,7 @@ fn range(
                     }
                 }
             };
-            let last = match last.trim_start_matches(".").parse::<u64>() {
+            let last = match last.trim_start_matches('.').parse::<u64>() {
                 Ok(postion) => postion,
                 Err(_) => {
                     if last == ".." {
@@ -73,16 +73,14 @@ fn range(
                     }
                 }
             };
-            return Ok(OutputStream::from_input(
+            Ok(OutputStream::from_input(
                 input.values.skip(first).take(last - first + 1),
-            ));
+            ))
         }
-        None => {
-            return Err(ShellError::labeled_error(
-                "No correct formatted range found",
-                "format: <from>..<to>",
-                name,
-            ));
-        }
+        None => Err(ShellError::labeled_error(
+            "No correct formatted range found",
+            "format: <from>..<to>",
+            name,
+        )),
     }
 }

--- a/src/commands/reduce_by.rs
+++ b/src/commands/reduce_by.rs
@@ -118,7 +118,7 @@ pub fn reduce(
             ..
         } => {
             let datasets: Vec<_> = datasets
-                .into_iter()
+                .iter()
                 .map(|subsets| {
                     let mut acc = 0;
                     match subsets {
@@ -127,7 +127,7 @@ pub fn reduce(
                             ..
                         } => {
                             let data = data
-                                .into_iter()
+                                .iter()
                                 .map(|d| {
                                     if let Value {
                                         value: UntaggedValue::Table(x),

--- a/src/commands/reject.rs
+++ b/src/commands/reject.rs
@@ -38,7 +38,7 @@ fn reject(
     RejectArgs { rest: fields }: RejectArgs,
     RunnableContext { input, name, .. }: RunnableContext,
 ) -> Result<OutputStream, ShellError> {
-    if fields.len() == 0 {
+    if fields.is_empty() {
         return Err(ShellError::labeled_error(
             "Reject requires fields",
             "needs parameter",

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -226,10 +226,10 @@ fn save(
     Ok(OutputStream::new(stream))
 }
 
-fn string_from(input: &Vec<Value>) -> String {
+fn string_from(input: &[Value]) -> String {
     let mut save_data = String::new();
 
-    if input.len() > 0 {
+    if !input.is_empty() {
         let mut first = true;
         for i in input.iter() {
             if !first {

--- a/src/commands/split_column.rs
+++ b/src/commands/split_column.rs
@@ -74,7 +74,7 @@ fn split_column(
                 let positional: Vec<_> = rest.iter().map(|f| f.item.clone()).collect();
 
                 // If they didn't provide column names, make up our own
-                if positional.len() == 0 {
+                if positional.is_empty() {
                     let mut gen_columns = vec![];
                     for i in 0..split_result.len() {
                         gen_columns.push(format!("Column{}", i + 1));
@@ -85,15 +85,6 @@ fn split_column(
                         dict.insert_untagged(v.clone(), Primitive::String(k.into()));
                     }
 
-                    ReturnSuccess::value(dict.into_value())
-                } else if split_result.len() == positional.len() {
-                    let mut dict = TaggedDictBuilder::new(&v.tag);
-                    for (&k, v) in split_result.iter().zip(positional.iter()) {
-                        dict.insert_untagged(
-                            v,
-                            UntaggedValue::Primitive(Primitive::String(k.into())),
-                        );
-                    }
                     ReturnSuccess::value(dict.into_value())
                 } else {
                     let mut dict = TaggedDictBuilder::new(&v.tag);

--- a/src/commands/t_sort_by.rs
+++ b/src/commands/t_sort_by.rs
@@ -128,7 +128,7 @@ pub fn columns_sorted(
 
             keys.into_iter().map(|k| k.tagged(&origin_tag)).collect()
         }
-        _ => vec![format!("default").tagged(&origin_tag)],
+        _ => vec!["default".to_owned().tagged(&origin_tag)],
     }
 }
 
@@ -197,12 +197,12 @@ pub fn t_sort(
                         outer.push_value(UntaggedValue::Table(i).into_value(&origin_tag));
                     }
 
-                    return Ok(UntaggedValue::Table(outer.list).into_value(&origin_tag));
+                    Ok(UntaggedValue::Table(outer.list).into_value(&origin_tag))
                 }
-                Some(_) => return Ok(UntaggedValue::nothing().into_value(&origin_tag)),
+                Some(_) => Ok(UntaggedValue::nothing().into_value(&origin_tag)),
             }
         }
-        None => return Ok(UntaggedValue::nothing().into_value(&origin_tag)),
+        None => Ok(UntaggedValue::nothing().into_value(&origin_tag)),
     }
 }
 #[cfg(test)]

--- a/src/commands/to_json.rs
+++ b/src/commands/to_json.rs
@@ -94,7 +94,7 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
     })
 }
 
-fn json_list(input: &Vec<Value>) -> Result<Vec<serde_json::Value>, ShellError> {
+fn json_list(input: &[Value]) -> Result<Vec<serde_json::Value>, ShellError> {
     let mut out = vec![];
 
     for value in input {

--- a/src/commands/to_sqlite.rs
+++ b/src/commands/to_sqlite.rs
@@ -70,7 +70,7 @@ fn comma_concat(acc: String, current: String) -> String {
     }
 }
 
-fn get_columns(rows: &Vec<Value>) -> Result<String, std::io::Error> {
+fn get_columns(rows: &[Value]) -> Result<String, std::io::Error> {
     match &rows[0].value {
         UntaggedValue::Row(d) => Ok(d
             .entries

--- a/src/commands/to_toml.rs
+++ b/src/commands/to_toml.rs
@@ -82,7 +82,7 @@ pub fn value_to_toml_value(v: &Value) -> Result<toml::Value, ShellError> {
     })
 }
 
-fn collect_values(input: &Vec<Value>) -> Result<Vec<toml::Value>, ShellError> {
+fn collect_values(input: &[Value]) -> Result<Vec<toml::Value>, ShellError> {
     let mut out = vec![];
 
     for value in input {

--- a/src/commands/which_.rs
+++ b/src/commands/which_.rs
@@ -38,7 +38,7 @@ pub fn which(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
     let tag = args.call_info.name_tag.clone();
 
     if let Some(v) = &args.call_info.args.positional {
-        if v.len() > 0 {
+        if !v.is_empty() {
             match &v[0] {
                 Value {
                     value: UntaggedValue::Primitive(Primitive::String(s)),

--- a/src/context.rs
+++ b/src/context.rs
@@ -45,7 +45,7 @@ impl CommandRegistry {
     pub(crate) fn get_command(&self, name: &str) -> Option<Arc<Command>> {
         let registry = self.registry.lock().unwrap();
 
-        registry.get(name).map(|c| c.clone())
+        registry.get(name).cloned()
     }
 
     pub(crate) fn expect_command(&self, name: &str) -> Arc<Command> {
@@ -175,7 +175,7 @@ impl Context {
         self.registry.expect_command(name)
     }
 
-    pub(crate) fn run_command<'a>(
+    pub(crate) fn run_command(
         &mut self,
         command: Arc<Command>,
         name_tag: Tag,

--- a/src/data/base.rs
+++ b/src/data/base.rs
@@ -40,7 +40,7 @@ interfaces!(Block: dyn ObjectHash);
 #[typetag::serde]
 impl EvaluateTrait for Block {
     fn invoke(&self, scope: &Scope) -> Result<Value, ShellError> {
-        if self.expressions.len() == 0 {
+        if self.expressions.is_empty() {
             return Ok(UntaggedValue::nothing().into_value(&self.tag));
         }
 
@@ -189,8 +189,8 @@ fn coerce_compare_primitive(
         (Line(left), String(right)) => CompareValues::String(left.clone(), right.clone()),
         (String(left), Line(right)) => CompareValues::String(left.clone(), right.clone()),
         (Line(left), Line(right)) => CompareValues::String(left.clone(), right.clone()),
-        (Date(left), Date(right)) => CompareValues::Date(left.clone(), right.clone()),
-        (Date(left), Duration(right)) => CompareValues::DateDuration(left.clone(), right.clone()),
+        (Date(left), Date(right)) => CompareValues::Date(*left, *right),
+        (Date(left), Duration(right)) => CompareValues::DateDuration(*left, *right),
         _ => return Err((left.type_name(), right.type_name())),
     })
 }

--- a/src/data/base/property_get.rs
+++ b/src/data/base/property_get.rs
@@ -144,7 +144,7 @@ pub(crate) fn get_data_by_member(value: &Value, name: &PathMember) -> Result<Val
                         }
                     }
 
-                    if out.len() == 0 {
+                    if out.is_empty() {
                         Err(ShellError::missing_property(
                             "table".spanned(value.tag.span),
                             string.spanned(name.span),
@@ -203,7 +203,7 @@ pub fn get_data_by_column_path(
 pub fn insert_data_at_path(value: &Value, path: &str, new_value: Value) -> Option<Value> {
     let mut new_obj = value.clone();
 
-    let split_path: Vec<_> = path.split(".").collect();
+    let split_path: Vec<_> = path.split('.').collect();
 
     if let UntaggedValue::Row(ref mut o) = new_obj.value {
         let mut current = o;
@@ -256,9 +256,10 @@ pub fn insert_data_at_member(
 ) -> Result<(), ShellError> {
     match &mut value.value {
         UntaggedValue::Row(dict) => match &member.unspanned {
-            UnspannedPathMember::String(key) => Ok({
+            UnspannedPathMember::String(key) => {
                 dict.insert_data_at_key(key, new_value);
-            }),
+                Ok(())
+            }
             UnspannedPathMember::Int(_) => Err(ShellError::type_error(
                 "column name",
                 "integer".spanned(member.span),
@@ -269,7 +270,7 @@ pub fn insert_data_at_member(
                 "list index",
                 "string".spanned(member.span),
             )),
-            UnspannedPathMember::Int(int) => Ok({
+            UnspannedPathMember::Int(int) => {
                 let int = int.to_usize().ok_or_else(|| {
                     ShellError::range_error(
                         ExpectedRange::Usize,
@@ -279,7 +280,8 @@ pub fn insert_data_at_member(
                 })?;
 
                 insert_data_at_index(array, int.tagged(member.span), new_value.clone())?;
-            }),
+                Ok(())
+            }
         },
         other => match &member.unspanned {
             UnspannedPathMember::String(_) => Err(ShellError::type_error(
@@ -473,7 +475,7 @@ pub(crate) fn get_data_by_key(value: &Value, name: Spanned<&str>) -> Option<Valu
                 }
             }
 
-            if out.len() > 0 {
+            if !out.is_empty() {
                 Some(UntaggedValue::Table(out).into_value(name.span))
             } else {
                 None

--- a/src/data/command.rs
+++ b/src/data/command.rs
@@ -53,7 +53,7 @@ fn signature_dict(signature: Signature, tag: impl Into<Tag>) -> Value {
         sig.push_value(for_spec(arg.0.name(), "argument", is_required, &tag));
     }
 
-    if let Some(_) = signature.rest_positional {
+    if signature.rest_positional.is_some() {
         let is_required = false;
         sig.push_value(for_spec("rest", "argument", is_required, &tag));
     }

--- a/src/data/dict.rs
+++ b/src/data/dict.rs
@@ -16,7 +16,7 @@ impl<'a> PrettyDebug for DebugEntry<'a> {
 }
 
 pub trait DictionaryExt {
-    fn get_data(&self, desc: &String) -> MaybeOwned<'_, Value>;
+    fn get_data(&self, desc: &str) -> MaybeOwned<'_, Value>;
 
     fn keys(&self) -> indexmap::map::Keys<String, Value>;
     fn get_data_by_key(&self, name: Spanned<&str>) -> Option<Value>;
@@ -25,7 +25,7 @@ pub trait DictionaryExt {
 }
 
 impl DictionaryExt for Dictionary {
-    fn get_data(&self, desc: &String) -> MaybeOwned<'_, Value> {
+    fn get_data(&self, desc: &str) -> MaybeOwned<'_, Value> {
         match self.entries.get(desc) {
             Some(v) => MaybeOwned::Borrowed(v),
             None => MaybeOwned::Owned(

--- a/src/data/primitive.rs
+++ b/src/data/primitive.rs
@@ -29,15 +29,15 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
 
             match byte.get_unit() {
                 byte_unit::ByteUnit::B => format!("{} B ", byte.get_value()),
-                _ => format!("{}", byte.format(1)),
+                _ => byte.format(1).to_string(),
             }
         }
         Primitive::Duration(sec) => format_duration(*sec),
-        Primitive::Int(i) => format!("{}", i),
-        Primitive::Decimal(decimal) => format!("{}", decimal),
-        Primitive::Pattern(s) => format!("{}", s),
-        Primitive::String(s) => format!("{}", s),
-        Primitive::Line(s) => format!("{}", s),
+        Primitive::Int(i) => i.to_string(),
+        Primitive::Decimal(decimal) => decimal.to_string(),
+        Primitive::Pattern(s) => s.to_string(),
+        Primitive::String(s) => s.to_owned(),
+        Primitive::Line(s) => s.to_owned(),
         Primitive::ColumnPath(p) => {
             let mut members = p.iter();
             let mut f = String::new();
@@ -57,15 +57,16 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
             f
         }
         Primitive::Boolean(b) => match (b, field_name) {
-            (true, None) => format!("Yes"),
-            (false, None) => format!("No"),
-            (true, Some(s)) if !s.is_empty() => format!("{}", s),
-            (false, Some(s)) if !s.is_empty() => format!(""),
-            (true, Some(_)) => format!("Yes"),
-            (false, Some(_)) => format!("No"),
-        },
-        Primitive::Binary(_) => format!("<binary>"),
-        Primitive::Date(d) => format!("{}", d.humanize()),
+            (true, None) => "Yes",
+            (false, None) => "No",
+            (true, Some(s)) if !s.is_empty() => s,
+            (false, Some(s)) if !s.is_empty() => "",
+            (true, Some(_)) => "Yes",
+            (false, Some(_)) => "No",
+        }
+        .to_owned(),
+        Primitive::Binary(_) => "<binary>".to_owned(),
+        Primitive::Date(d) => d.humanize().to_string(),
     }
 }
 
@@ -83,7 +84,7 @@ fn format_duration(sec: u64) -> String {
     let (days, hours) = (hours / 24, hours % 24);
 
     match (days, hours, minutes, seconds) {
-        (0, 0, 0, 1) => format!("1 sec"),
+        (0, 0, 0, 1) => "1 sec".to_owned(),
         (0, 0, 0, s) => format!("{} secs", s),
         (0, 0, m, s) => format!("{}:{:02}", m, s),
         (0, h, m, s) => format!("{}:{:02}:{:02}", h, m, s),

--- a/src/data/value.rs
+++ b/src/data/value.rs
@@ -22,7 +22,7 @@ pub fn date_from_str(s: Tagged<&str>) -> Result<UntaggedValue, ShellError> {
 }
 
 pub fn compare_values(
-    operator: &Operator,
+    operator: Operator,
     left: &UntaggedValue,
     right: &UntaggedValue,
 ) -> Result<bool, (&'static str, &'static str)> {

--- a/src/evaluate/evaluator.rs
+++ b/src/evaluate/evaluator.rs
@@ -40,7 +40,7 @@ pub(crate) fn evaluate_baseline_expr(
 
             trace!("left={:?} right={:?}", left.value, right.value);
 
-            match apply_operator(binary.op(), &left, &right) {
+            match apply_operator(**binary.op(), &left, &right) {
                 Ok(result) => Ok(result.into_value(tag)),
                 Err((left_type, right_type)) => Err(ShellError::coerce_error(
                     left_type.spanned(binary.left().span),
@@ -83,7 +83,7 @@ pub(crate) fn evaluate_baseline_expr(
 
                             possible_matches.sort();
 
-                            if possible_matches.len() > 0 {
+                            if !possible_matches.is_empty() {
                                 return Err(ShellError::labeled_error(
                                     "Unknown column",
                                     format!("did you mean '{}'?", possible_matches[0].1),
@@ -174,7 +174,7 @@ fn evaluate_reference(
             x => Ok(scope
                 .vars
                 .get(x)
-                .map(|v| v.clone())
+                .cloned()
                 .unwrap_or_else(|| UntaggedValue::nothing().into_value(tag))),
         },
     }

--- a/src/evaluate/operator.rs
+++ b/src/evaluate/operator.rs
@@ -4,11 +4,11 @@ use nu_protocol::{Primitive, ShellTypeName, UntaggedValue, Value};
 use std::ops::Not;
 
 pub fn apply_operator(
-    op: &Operator,
+    op: Operator,
     left: &Value,
     right: &Value,
 ) -> Result<UntaggedValue, (&'static str, &'static str)> {
-    match *op {
+    match op {
         Operator::Equal
         | Operator::NotEqual
         | Operator::LessThan

--- a/src/format/entries.rs
+++ b/src/format/entries.rs
@@ -35,7 +35,7 @@ impl EntriesView {
 
 impl RenderView for EntriesView {
     fn render_view(&self, _host: &mut dyn Host) -> Result<(), ShellError> {
-        if self.entries.len() == 0 {
+        if self.entries.is_empty() {
             return Ok(());
         }
 

--- a/src/format/generic.rs
+++ b/src/format/generic.rs
@@ -16,7 +16,10 @@ impl RenderView for GenericView<'_> {
     fn render_view(&self, host: &mut dyn Host) -> Result<(), ShellError> {
         let tag = &self.value.tag;
         match &self.value.value {
-            UntaggedValue::Primitive(p) => Ok(host.stdout(&format_primitive(p, None))),
+            UntaggedValue::Primitive(p) => {
+                host.stdout(&format_primitive(p, None));
+                Ok(())
+            }
             UntaggedValue::Table(l) => {
                 let view = TableView::from_list(l, 0);
 

--- a/src/plugins/format.rs
+++ b/src/plugins/format.rs
@@ -21,7 +21,7 @@ fn format(input: &str) -> IResult<&str, Vec<FormatCommand>> {
     let mut loop_input = input;
     loop {
         let (input, before) = take_while(|c| c != '{')(loop_input)?;
-        if before.len() > 0 {
+        if !before.is_empty() {
             output.push(FormatCommand::Text(before.to_string()));
         }
         if input != "" {

--- a/src/plugins/inc.rs
+++ b/src/plugins/inc.rs
@@ -90,13 +90,13 @@ impl Inc {
             }
             UntaggedValue::Table(values) => {
                 if values.len() == 1 {
-                    return Ok(UntaggedValue::Table(vec![self.inc(values[0].clone())?])
-                        .into_value(value.tag()));
+                    Ok(UntaggedValue::Table(vec![self.inc(values[0].clone())?])
+                        .into_value(value.tag()))
                 } else {
-                    return Err(ShellError::type_error(
+                    Err(ShellError::type_error(
                         "incrementable value",
                         value.type_name().spanned(value.span()),
-                    ));
+                    ))
                 }
             }
 
@@ -108,20 +108,16 @@ impl Inc {
                         &f,
                         Box::new(move |(obj_source, column_path_tried, _)| {
                             match did_you_mean(&obj_source, &column_path_tried) {
-                                Some(suggestions) => {
-                                    return ShellError::labeled_error(
-                                        "Unknown column",
-                                        format!("did you mean '{}'?", suggestions[0].1),
-                                        span_for_spanned_list(fields.iter().map(|p| p.span)),
-                                    )
-                                }
-                                None => {
-                                    return ShellError::labeled_error(
-                                        "Unknown column",
-                                        "row does not contain this column",
-                                        span_for_spanned_list(fields.iter().map(|p| p.span)),
-                                    )
-                                }
+                                Some(suggestions) => ShellError::labeled_error(
+                                    "Unknown column",
+                                    format!("did you mean '{}'?", suggestions[0].1),
+                                    span_for_spanned_list(fields.iter().map(|p| p.span)),
+                                ),
+                                None => ShellError::labeled_error(
+                                    "Unknown column",
+                                    "row does not contain this column",
+                                    span_for_spanned_list(fields.iter().map(|p| p.span)),
+                                ),
                             }
                         }),
                     );
@@ -133,14 +129,12 @@ impl Inc {
                         &f,
                         replacement.value.clone().into_untagged_value(),
                     ) {
-                        Some(v) => return Ok(v),
-                        None => {
-                            return Err(ShellError::labeled_error(
-                                "inc could not find field to replace",
-                                "column name",
-                                value.tag(),
-                            ))
-                        }
+                        Some(v) => Ok(v),
+                        None => Err(ShellError::labeled_error(
+                            "inc could not find field to replace",
+                            "column name",
+                            value.tag(),
+                        )),
                     }
                 }
                 None => Err(ShellError::untagged_runtime_error(
@@ -201,13 +195,11 @@ impl Plugin for Inc {
         }
 
         match &self.error {
-            Some(reason) => {
-                return Err(ShellError::untagged_runtime_error(format!(
-                    "{}: {}",
-                    reason,
-                    Inc::usage()
-                )))
-            }
+            Some(reason) => Err(ShellError::untagged_runtime_error(format!(
+                "{}: {}",
+                reason,
+                Inc::usage()
+            ))),
             None => Ok(vec![]),
         }
     }

--- a/src/plugins/parse.rs
+++ b/src/plugins/parse.rs
@@ -22,7 +22,7 @@ fn parse(input: &str) -> IResult<&str, Vec<ParseCommand>> {
     let mut loop_input = input;
     loop {
         let (input, before) = take_while(|c| c != '{')(loop_input)?;
-        if before.len() > 0 {
+        if !before.is_empty() {
             output.push(ParseCommand::Text(before.to_string()));
         }
         if input != "" {
@@ -73,7 +73,7 @@ fn build_regex(commands: &[ParseCommand]) -> String {
         }
     }
 
-    return output;
+    output
 }
 struct Parse {
     regex: Regex,

--- a/src/plugins/str.rs
+++ b/src/plugins/str.rs
@@ -126,7 +126,7 @@ impl Str {
             _ => v[0].trim().parse().unwrap(),
         };
         let end: usize = match v[1] {
-            "" => usize::max_value().clone(),
+            "" => usize::max_value(),
             _ => v[1].trim().parse().unwrap(),
         };
         if start > end {
@@ -169,14 +169,12 @@ impl Str {
                             &f,
                             Box::new(move |(obj_source, column_path_tried, error)| {
                                 match did_you_mean(&obj_source, &column_path_tried) {
-                                    Some(suggestions) => {
-                                        return ShellError::labeled_error(
-                                            "Unknown column",
-                                            format!("did you mean '{}'?", suggestions[0].1),
-                                            span_for_spanned_list(fields.iter().map(|p| p.span)),
-                                        )
-                                    }
-                                    None => return error,
+                                    Some(suggestions) => ShellError::labeled_error(
+                                        "Unknown column",
+                                        format!("did you mean '{}'?", suggestions[0].1),
+                                        span_for_spanned_list(fields.iter().map(|p| p.span)),
+                                    ),
+                                    None => error,
                                 }
                             }),
                         );
@@ -188,7 +186,7 @@ impl Str {
                         &f,
                         replacement.value.clone().into_untagged_value(),
                     ) {
-                        Some(v) => return Ok(v),
+                        Some(v) => Ok(v),
                         None => Err(ShellError::labeled_error(
                             "str could not find field to replace",
                             "column name",
@@ -293,13 +291,11 @@ impl Plugin for Str {
         }
 
         match &self.error {
-            Some(reason) => {
-                return Err(ShellError::untagged_runtime_error(format!(
-                    "{}: {}",
-                    reason,
-                    Str::usage()
-                )))
-            }
+            Some(reason) => Err(ShellError::untagged_runtime_error(format!(
+                "{}: {}",
+                reason,
+                Str::usage()
+            ))),
             None => Ok(vec![]),
         }
     }

--- a/src/shell/completer.rs
+++ b/src/shell/completer.rs
@@ -28,11 +28,11 @@ impl NuCompleter {
                 completion.replacement = completion.replacement.replace("\\(", "(");
             }
 
-            if completion.replacement.contains(" ") || completion.replacement.contains("(") {
-                if !completion.replacement.starts_with("\"") {
+            if completion.replacement.contains(' ') || completion.replacement.contains('(') {
+                if !completion.replacement.starts_with('\"') {
                     completion.replacement = format!("\"{}", completion.replacement);
                 }
-                if !completion.replacement.ends_with("\"") {
+                if !completion.replacement.ends_with('\"') {
                     completion.replacement = format!("{}\"", completion.replacement);
                 }
             }

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -104,7 +104,7 @@ impl Shell for FilesystemShell {
 
         //If it's not a glob, try to display the contents of the entry if it's a directory
         let lossy_path = full_path.to_string_lossy();
-        if !lossy_path.contains("*") && !lossy_path.contains("?") {
+        if !lossy_path.contains('*') && !lossy_path.contains('?') {
             let entry = Path::new(&full_path);
             if entry.is_dir() {
                 let entries = std::fs::read_dir(&entry);
@@ -344,7 +344,7 @@ impl Shell for FilesystemShell {
                                 new_dst.push(fragment);
                             }
 
-                            Ok((PathBuf::from(&source_file), PathBuf::from(new_dst)))
+                            Ok((PathBuf::from(&source_file), new_dst))
                         };
 
                         let sources = sources.paths_applying_with(strategy)?;
@@ -418,7 +418,7 @@ impl Shell for FilesystemShell {
                                 new_dst.push(fragment);
                             }
 
-                            Ok((PathBuf::from(&source_file), PathBuf::from(new_dst)))
+                            Ok((PathBuf::from(&source_file), new_dst))
                         };
 
                         let sources = sources.paths_applying_with(strategy)?;
@@ -530,7 +530,7 @@ impl Shell for FilesystemShell {
     ) -> Result<OutputStream, ShellError> {
         let full_path = PathBuf::from(path);
 
-        if directories.len() == 0 {
+        if directories.is_empty() {
             return Err(ShellError::labeled_error(
                 "mkdir requires directory paths",
                 "needs parameter",
@@ -861,13 +861,11 @@ impl Shell for FilesystemShell {
             }
         } else {
             if destination.exists() {
-                if !sources.iter().all(|x| {
-                    if let Ok(entry) = x.as_ref() {
-                        entry.is_file()
-                    } else {
-                        false
-                    }
-                }) {
+                let is_file = |x: &Result<PathBuf, _>| {
+                    x.as_ref().map(|entry| entry.is_file()).unwrap_or_default()
+                };
+
+                if !sources.iter().all(is_file) {
                     return Err(ShellError::labeled_error(
                     "Rename aborted (directories found). Renaming in patterns not supported yet (try moving the directory directly)",
                     "Rename aborted (directories found). Renaming in patterns not supported yet (try moving the directory directly)",

--- a/src/shell/help_shell.rs
+++ b/src/shell/help_shell.rs
@@ -108,13 +108,11 @@ impl HelpShell {
 impl Shell for HelpShell {
     fn name(&self) -> String {
         let anchor_name = self.value.anchor_name();
-        format!(
-            "{}",
-            match anchor_name {
-                Some(x) => format!("{{{}}}", x),
-                None => format!("<{}>", self.value.type_name()),
-            }
-        )
+
+        match anchor_name {
+            Some(x) => format!("{{{}}}", x),
+            None => format!("<{}>", self.value.type_name()),
+        }
     }
 
     fn homedir(&self) -> Option<PathBuf> {
@@ -140,10 +138,7 @@ impl Shell for HelpShell {
         _context: &RunnableContext,
         _full: bool,
     ) -> Result<OutputStream, ShellError> {
-        Ok(self
-            .commands()
-            .map(|x| ReturnSuccess::value(x))
-            .to_output_stream())
+        Ok(self.commands().map(ReturnSuccess::value).to_output_stream())
     }
 
     fn cd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {

--- a/src/shell/value_shell.rs
+++ b/src/shell/value_shell.rs
@@ -76,13 +76,11 @@ impl ValueShell {
 impl Shell for ValueShell {
     fn name(&self) -> String {
         let anchor_name = self.value.anchor_name();
-        format!(
-            "{}",
-            match anchor_name {
-                Some(x) => format!("{{{}}}", x),
-                None => format!("<{}>", self.value.type_name()),
-            }
-        )
+
+        match anchor_name {
+            Some(x) => format!("{{{}}}", x),
+            None => format!("<{}>", self.value.type_name()),
+        }
     }
 
     fn homedir(&self) -> Option<PathBuf> {
@@ -124,7 +122,7 @@ impl Shell for ValueShell {
 
         Ok(self
             .members_under(full_path.as_path())
-            .map(|x| ReturnSuccess::value(x))
+            .map(ReturnSuccess::value)
             .to_output_stream())
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -142,7 +142,7 @@ impl From<VecDeque<Value>> for OutputStream {
         OutputStream {
             values: input
                 .into_iter()
-                .map(|i| ReturnSuccess::value(i))
+                .map(ReturnSuccess::value)
                 .collect::<VecDeque<ReturnValue>>()
                 .boxed(),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,7 @@ pub fn did_you_mean(obj_source: &Value, field_tried: &PathMember) -> Option<Vec<
         })
         .collect();
 
-    if possible_matches.len() > 0 {
+    if !possible_matches.is_empty() {
         possible_matches.sort();
         Some(possible_matches)
     } else {
@@ -96,7 +96,7 @@ impl Div<&str> for &AbsolutePath {
     type Output = AbsolutePath;
 
     fn div(self, rhs: &str) -> Self::Output {
-        let parts = rhs.split("/");
+        let parts = rhs.split('/');
         let mut result = self.inner.clone();
 
         for part in parts {
@@ -133,7 +133,7 @@ impl<T: AsRef<str>> Div<T> for &RelativePath {
     type Output = RelativePath;
 
     fn div(self, rhs: T) -> Self::Output {
-        let parts = rhs.as_ref().split("/");
+        let parts = rhs.as_ref().split('/');
         let mut result = self.inner.clone();
 
         for part in parts {
@@ -276,7 +276,7 @@ impl FileStructure {
     }
 
     pub fn contains_files(&self) -> bool {
-        self.resources.len() > 0
+        !self.resources.is_empty()
     }
 
     pub fn paths_applying_with<F>(


### PR DESCRIPTION
This commit resolves most of Clippy's performance warnings in Nu Shell.

command: `cargo clippy -- -W clippy::perf`

Some of the lint warnings I fixed:

- [len_zero](https://rust-lang.github.io/rust-clippy/master/index.html#len_zero)
- [redundant_closure](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure)
- [needless_return](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return)
- [needless_range_loop](https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop)