### PR TITLE
Move to git rustyline to fix Ctrl-L

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ nu-macros = { version = "0.7.0", path = "./crates/nu-macros" }
 
 query_interface = "0.3.5"
 typetag = "0.1.4"
-rustyline = "5.0.4"
+rustyline = { git = "https://github.com/kkawakam/rustyline.git" }
 chrono = { version = "0.4.10", features = ["serde"] }
 derive-new = "0.5.8"
 prettytable-rs = "0.8.0"


### PR DESCRIPTION
This moves to the git version of rustyline, which has a fix for the crash issue when using Ctrl-L

Fixes #1050 