### PR TITLE
WIP: Add `hir::path::expand_tilde` that expands ~user paths too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_yaml",
- "shellexpand",
  "starship",
  "strip-ansi-escapes",
  "subprocess",
@@ -2257,6 +2256,7 @@ dependencies = [
  "indexmap",
  "itertools 0.8.2",
  "language-reporting",
+ "libc",
  "log",
  "nom 5.0.1",
  "nom-tracable",
@@ -2272,7 +2272,6 @@ dependencies = [
  "pretty_env_logger",
  "ptree",
  "serde 1.0.104",
- "shellexpand",
  "termcolor",
  "unicode-xid",
 ]
@@ -3424,15 +3423,6 @@ checksum = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "shellexpand"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a23aed0018ea07316c7826ade41e551772031cf652805f93ebc922215a44d4a"
-dependencies = [
- "dirs 1.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ hex = "0.4"
 tempfile = "3.1.0"
 ichwh = "0.2"
 textwrap = {version = "0.11.0", features = ["term_size"]}
-shellexpand = "1.0.0"
 pin-utils = "0.1.0-alpha.4"
 num-bigint = { version = "0.2.3", features = ["serde"] }
 bigdecimal = { version = "0.1.0", features = ["serde"] }

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -30,12 +30,12 @@ derive-new = "0.5.8"
 getset = "0.0.9"
 cfg-if = "0.1"
 itertools = "0.8.1"
-shellexpand = "1.0.0"
 ansi_term = "0.12.1"
 ptree = {version = "0.2" }
 language-reporting = "0.4.0"
 unicode-xid = "0.2.0"
 enumflags2 = "0.6.2"
+libc = "0.2"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/crates/nu-parser/src/hir/path.rs
+++ b/crates/nu-parser/src/hir/path.rs
@@ -39,3 +39,105 @@ impl Path {
         (self.head, self.tail)
     }
 }
+
+// WIP: find a better place for these functions.
+
+use libc::getpwnam;
+use std::error::Error;
+use std::ffi::{CStr, CString, NulError};
+use std::fmt;
+use std::path::PathBuf;
+
+type HomedirResult = Result<Option<String>, UsernameError<NulError>>;
+
+/// Matches exising user names
+///
+/// Used to resolve `~username` syntax, may fail if the username contains a null with
+/// `NulError`. Otherwise will return a `String` with the user dir (not checked to be a
+/// valid path) or `None` if there is no matching username.
+pub(crate) fn username_homedir(name: &str) -> HomedirResult {
+    let cname = CString::new(name).map_err(|e| UsernameError {
+        username: name.into(),
+        cause: e,
+    })?;
+    fn get_dir_from_username(cname: CString) -> Option<String> {
+        let pwd = unsafe { getpwnam(cname.as_ptr()) };
+        if pwd.is_null() {
+            None
+        } else {
+            let dir = unsafe {
+                let pwd = *pwd; // already checked to be not null
+                CStr::from_ptr(pwd.pw_dir).to_string_lossy().into_owned()
+            };
+            Some(dir)
+        }
+    }
+    Ok(get_dir_from_username(cname))
+}
+
+/// Represents a username lookup error.
+///
+/// This error is returned by `username_homedir()` function. The original error is
+/// provided in the `cause` field, while `username` contains the name of a user whose
+/// lookup caused the error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UsernameError<E> {
+    /// The name of the problematic username.
+    pub username: String,
+    /// The original error returned by the lookup function.
+    pub cause: E,
+}
+
+impl<E: fmt::Display> fmt::Display for UsernameError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "error looking user '{}' up: {}",
+            self.username, self.cause
+        )
+    }
+}
+
+impl<E: Error> Error for UsernameError<E> {
+    fn description(&self) -> &str {
+        "Homedir lookup error"
+    }
+    fn cause(&self) -> Option<&dyn Error> {
+        Some(&self.cause)
+    }
+}
+
+pub(crate) fn expand_tilde_with_context<'home>(
+    path: &str,
+    homedir: &dyn Fn() -> Option<PathBuf>,
+    username_homedir: &dyn Fn(&str) -> Option<String>,
+) -> PathBuf {
+    if !path.starts_with("~") {
+        path.into()
+    } else {
+        let home = homedir();
+        match (path, home) {
+            ("~", Some(home)) => home.into(),
+            (path, Some(home)) if path.starts_with("~/") => {
+                path.replacen("~", &home.to_string_lossy(), 1).into()
+            }
+            (path, _) => {
+                let end = path.find("/").unwrap_or(path.len());
+                let name = &path[1..end];
+                if let Some(home) = &username_homedir(name) {
+                    path.replacen(&path[0..end], &home, 1).into()
+                } else {
+                    path.into()
+                }
+            }
+        }
+    }
+}
+
+pub fn expand_tilde<'home>(path: &str, homedir: &dyn Fn() -> Option<PathBuf>) -> PathBuf {
+    expand_tilde_with_context(path, homedir, &|name| {
+        dbg!(username_homedir(name).unwrap_or(None))
+    })
+}
+
+// </WIP>

--- a/crates/nu-parser/src/hir/path.rs
+++ b/crates/nu-parser/src/hir/path.rs
@@ -107,22 +107,22 @@ impl<E: Error> Error for UsernameError<E> {
     }
 }
 
-pub(crate) fn expand_tilde_with_context<'home>(
+pub(crate) fn expand_tilde_with_context(
     path: &str,
     homedir: &dyn Fn() -> Option<PathBuf>,
     username_homedir: &dyn Fn(&str) -> Option<String>,
 ) -> PathBuf {
-    if !path.starts_with("~") {
+    if !path.starts_with('~') {
         path.into()
     } else {
         let home = homedir();
         match (path, home) {
-            ("~", Some(home)) => home.into(),
+            ("~", Some(home)) => home,
             (path, Some(home)) if path.starts_with("~/") => {
                 path.replacen("~", &home.to_string_lossy(), 1).into()
             }
             (path, _) => {
-                let end = path.find("/").unwrap_or(path.len());
+                let end = path.find('/').unwrap_or_else(|| path.len());
                 let name = &path[1..end];
                 if let Some(home) = &username_homedir(name) {
                     path.replacen(&path[0..end], &home, 1).into()
@@ -134,7 +134,7 @@ pub(crate) fn expand_tilde_with_context<'home>(
     }
 }
 
-pub fn expand_tilde<'home>(path: &str, homedir: &dyn Fn() -> Option<PathBuf>) -> PathBuf {
+pub fn expand_tilde(path: &str, homedir: &dyn Fn() -> Option<PathBuf>) -> PathBuf {
     expand_tilde_with_context(path, homedir, &|name| {
         dbg!(username_homedir(name).unwrap_or(None))
     })

--- a/crates/nu-parser/src/hir/syntax_shape/expression.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression.rs
@@ -9,6 +9,7 @@ pub(crate) mod string;
 pub(crate) mod unit;
 pub(crate) mod variable_path;
 
+use crate::hir::path::expand_tilde;
 use crate::hir::syntax_shape::{
     color_delimited_square, color_fallible_syntax, color_fallible_syntax_with, expand_atom,
     expand_delimited_square, expand_expr, expand_syntax, BareShape, ColorableDotShape, DotShape,
@@ -319,7 +320,7 @@ impl ExpandSyntax for BareTailShape {
 }
 
 pub fn expand_file_path(string: &str, context: &ExpandContext) -> PathBuf {
-    let expanded = shellexpand::tilde_with_context(string, || context.homedir());
-
-    PathBuf::from(expanded.as_ref())
+    dbg!(expand_tilde(string, &|| context
+        .homedir()
+        .map(|p| p.to_owned())))
 }

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -8,6 +8,7 @@ pub mod parse_command;
 pub use crate::commands::classified::{
     external::ExternalCommand, internal::InternalCommand, ClassifiedCommand, ClassifiedPipeline,
 };
+pub use crate::hir::path::expand_tilde;
 pub use crate::hir::syntax_shape::flat_shape::FlatShape;
 pub use crate::hir::syntax_shape::{
     expand_syntax, ExpandContext, ExpandSyntax, PipelineShape, SignatureRegistry,


### PR DESCRIPTION
- only posix supported (uses `getpwnam`)