### PR TITLE
Fix positional macro on crate nu-macros

### DIFF
--- a/crates/nu-macros/src/lib.rs
+++ b/crates/nu-macros/src/lib.rs
@@ -17,9 +17,9 @@ macro_rules! signature {
 #[macro_export]
 macro_rules! positional {
     ($ident:tt, $name:tt (optional $shape:tt) - $desc:tt) => {
-        let $ident = $ident.required(stringify!($name), SyntaxShape::$shape, $desc);
+        let $ident = $ident.optional(stringify!($name), SyntaxShape::$shape, $desc);
     };
     ($ident:tt, $name:tt ($shape:tt)- $desc:tt) => {
-        let $ident = $ident.optional(stringify!($name), SyntaxShape::$shape, $desc);
+        let $ident = $ident.required(stringify!($name), SyntaxShape::$shape, $desc);
     };
 }


### PR DESCRIPTION
A simple change, this introduced a bug on the command `cd` (#1117), and probably other commands.