### PR TITLE
update readme to reflect >= 0.7.2 $nu variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To set one of these variables, you can use `config --set`. For example:
 
 ```
 > config --set [edit_mode "vi"]
-> config --set [path $nu:path]
+> config --set [path $nu.path]
 ```
 
 ## Shells


### PR DESCRIPTION
Update README to reflect `$nu.path` change in `0.7.2` as documented in the [0.5.0 blog post](https://www.nushell.sh/blog/2019/11/05/nushell-0_5_0.html#nu-as-a-login-shell-jonathandturner)