### PR TITLE
UTF8 fix for twitter-reported issue

### DIFF
--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -357,7 +357,10 @@ fn word<'a, T, U, V>(
 
 pub fn matches(cond: fn(char) -> bool) -> impl Fn(NomSpan) -> IResult<NomSpan, NomSpan> + Copy {
     move |input: NomSpan| match input.iter_elements().next() {
-        Option::Some(c) if cond(c) => Ok((input.slice(1..), input.slice(0..1))),
+        Option::Some(c) if cond(c) => {
+            let len_utf8 = c.len_utf8();
+            Ok((input.slice(len_utf8..), input.slice(0..len_utf8)))
+        }
         _ => Err(nom::Err::Error(nom::error::ParseError::from_error_kind(
             input,
             nom::error::ErrorKind::Many0,

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -32,11 +32,11 @@ mod pipeline {
     #[test]
     fn doesnt_break_on_utf8_command() {
         let actual = nu!(
-            cwd: std::path::PathBuf::from("."),
+            cwd: ".", pipeline(
             r#"
-                sh -c "echo ö"
+                echo ö
             "#
-        );
+        ));
 
         assert!(
             actual.contains("ö"),

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -30,6 +30,21 @@ mod pipeline {
     }
 
     #[test]
+    fn doesnt_break_on_utf8_command() {
+        let actual = nu!(
+            cwd: std::path::PathBuf::from("."),
+            r#"
+                sh -c "echo ö"
+            "#
+        );
+
+        assert!(
+            actual.contains("ö"),
+            format!("'{}' should contain ö", actual)
+        );
+    }
+
+    #[test]
     fn can_process_row_as_it_argument_to_an_external_command_given_the_it_data_is_one_string_line()
     {
         Playground::setup("it_argument_test_2", |dirs, sandbox| {


### PR DESCRIPTION
From twitter:

"love the idea of it, and that it is built in Rust! but also insta panicked after 20 sec of use when I hit the letter ‘ö’ on my (Swedish) keyboard, which doesn’t inspire confidence"

This adds back the ability to parse utf-8, which I believe we lost during the recent parser refactor. We should shore up our tests a bit more here for future refactors.
