### PR TITLE
Refactor struct names for old commands (ls, cd, pwd)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -232,9 +232,9 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
 
         context.add_commands(vec![
             // System/file operations
-            whole_stream_command(PWD),
-            whole_stream_command(LS),
-            whole_stream_command(CD),
+            whole_stream_command(Pwd),
+            whole_stream_command(Ls),
+            whole_stream_command(Cd),
             whole_stream_command(Env),
             per_item_command(Remove),
             per_item_command(Open),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -97,7 +97,7 @@ pub(crate) mod which_;
 pub(crate) mod wrap;
 
 pub(crate) use autoview::Autoview;
-pub(crate) use cd::CD;
+pub(crate) use cd::Cd;
 pub(crate) use command::{
     per_item_command, whole_stream_command, Command, PerItemCommand, RawCommandArgs,
     UnevaluatedCallInfo, WholeStreamCommand,
@@ -142,7 +142,7 @@ pub(crate) use history::History;
 pub(crate) use insert::Insert;
 pub(crate) use last::Last;
 pub(crate) use lines::Lines;
-pub(crate) use ls::LS;
+pub(crate) use ls::Ls;
 #[allow(unused)]
 pub(crate) use map_max_by::MapMaxBy;
 pub(crate) use mkdir::Mkdir;
@@ -155,7 +155,7 @@ pub(crate) use pick::Pick;
 pub(crate) use pivot::Pivot;
 pub(crate) use prepend::Prepend;
 pub(crate) use prev::Previous;
-pub(crate) use pwd::PWD;
+pub(crate) use pwd::Pwd;
 pub(crate) use range::Range;
 #[allow(unused)]
 pub(crate) use reduce_by::ReduceBy;

--- a/src/commands/cd.rs
+++ b/src/commands/cd.rs
@@ -4,9 +4,9 @@ use nu_errors::ShellError;
 use nu_macros::signature;
 use nu_protocol::{Signature, SyntaxShape};
 
-pub struct CD;
+pub struct Cd;
 
-impl WholeStreamCommand for CD {
+impl WholeStreamCommand for Cd {
     fn name(&self) -> &str {
         "cd"
     }

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -5,7 +5,7 @@ use nu_protocol::{Signature, SyntaxShape};
 use nu_source::Tagged;
 use std::path::PathBuf;
 
-pub struct LS;
+pub struct Ls;
 
 #[derive(Deserialize)]
 pub struct LsArgs {
@@ -13,7 +13,7 @@ pub struct LsArgs {
     full: bool,
 }
 
-impl WholeStreamCommand for LS {
+impl WholeStreamCommand for Ls {
     fn name(&self) -> &str {
         "ls"
     }

--- a/src/commands/pwd.rs
+++ b/src/commands/pwd.rs
@@ -3,9 +3,9 @@ use crate::prelude::*;
 use nu_errors::ShellError;
 use nu_protocol::Signature;
 
-pub struct PWD;
+pub struct Pwd;
 
-impl WholeStreamCommand for PWD {
+impl WholeStreamCommand for Pwd {
     fn name(&self) -> &str {
         "pwd"
     }


### PR DESCRIPTION
This commit fixes #1131.