### PR TITLE
Allow moving in text with Ctrl+ArrowLeft, Ctrl+ArrowRight

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -350,6 +350,7 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
     let config = Config::builder().color_mode(ColorMode::Forced).build();
     let mut rl: Editor<_> = Editor::with_config(config);
 
+    // add key bindings to move over a whole word with Ctrl+ArrowLeft and Ctrl+ArrowRight
     rl.bind_sequence(KeyPress::ControlLeft, Cmd::Move(Movement::BackwardWord(1, Word::Vi)));
     rl.bind_sequence(KeyPress::ControlRight, Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)));
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,10 @@ use nu_protocol::{Signature, UntaggedValue, Value};
 
 use log::{debug, log_enabled, trace};
 use rustyline::error::ReadlineError;
-use rustyline::{self, config::Configurer, config::EditMode, ColorMode, Config, Editor, KeyPress, Cmd, Movement, Word, At};
+use rustyline::{
+    self, config::Configurer, config::EditMode, At, Cmd, ColorMode, Config, Editor, KeyPress,
+    Movement, Word,
+};
 use std::error::Error;
 use std::io::{BufRead, BufReader, Write};
 use std::iter::Iterator;
@@ -351,8 +354,14 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
     let mut rl: Editor<_> = Editor::with_config(config);
 
     // add key bindings to move over a whole word with Ctrl+ArrowLeft and Ctrl+ArrowRight
-    rl.bind_sequence(KeyPress::ControlLeft, Cmd::Move(Movement::BackwardWord(1, Word::Vi)));
-    rl.bind_sequence(KeyPress::ControlRight, Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)));
+    rl.bind_sequence(
+        KeyPress::ControlLeft,
+        Cmd::Move(Movement::BackwardWord(1, Word::Vi)),
+    );
+    rl.bind_sequence(
+        KeyPress::ControlRight,
+        Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)),
+    );
 
     #[cfg(windows)]
     {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ use nu_protocol::{Signature, UntaggedValue, Value};
 
 use log::{debug, log_enabled, trace};
 use rustyline::error::ReadlineError;
-use rustyline::{self, config::Configurer, config::EditMode, ColorMode, Config, Editor};
+use rustyline::{self, config::Configurer, config::EditMode, ColorMode, Config, Editor, KeyPress, Cmd, Movement, Word, At};
 use std::error::Error;
 use std::io::{BufRead, BufReader, Write};
 use std::iter::Iterator;
@@ -349,6 +349,9 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
 
     let config = Config::builder().color_mode(ColorMode::Forced).build();
     let mut rl: Editor<_> = Editor::with_config(config);
+
+    rl.bind_sequence(KeyPress::ControlLeft, Cmd::Move(Movement::BackwardWord(1, Word::Vi)));
+    rl.bind_sequence(KeyPress::ControlRight, Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)));
 
     #[cfg(windows)]
     {


### PR DESCRIPTION
Fixes #441 

Moving over whole words in text with <kbd>Ctrl+ArrowLeft</kbd>/<kbd>Ctrl+ArrowRight</kbd> is a basic feature of every text input on every platform I know. This PR adds these key shortcuts to nushell.