### PR TITLE
Thin-lines for tables for better rendering

### DIFF
--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -350,9 +350,9 @@ impl RenderView for TableView {
                 table.set_format(
                     FormatBuilder::new()
                         .column_separator('│')
-                        .separator(LinePosition::Top, LineSeparator::new('━', '┯', ' ', ' '))
+                        .separator(LinePosition::Top, LineSeparator::new('─', '┬', ' ', ' '))
                         .separator(LinePosition::Title, LineSeparator::new('─', '┼', ' ', ' '))
-                        .separator(LinePosition::Bottom, LineSeparator::new('━', '┷', ' ', ' '))
+                        .separator(LinePosition::Bottom, LineSeparator::new('─', '┴', ' ', ' '))
                         .padding(1, 1)
                         .build(),
                 );


### PR DESCRIPTION
The thick lines are pretty subtle and some fonts have issues with it. Seems keeping the lines consistent works better across fonts.