### PR TITLE
Have internal/external/pipelines taken an optional InputStream.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -607,8 +607,7 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
                 return LineResult::Error(line.to_string(), err);
             }
 
-            let input = InputStream::empty();
-            match run_pipeline(pipeline, ctx, input, line).await {
+            match run_pipeline(pipeline, ctx, None, line).await {
                 Ok(_) => LineResult::Success(line.to_string()),
                 Err(err) => LineResult::Error(line.to_string(), err),
             }

--- a/src/commands/classified/internal.rs
+++ b/src/commands/classified/internal.rs
@@ -8,16 +8,20 @@ use nu_protocol::{CommandAction, Primitive, ReturnSuccess, UntaggedValue, Value}
 pub(crate) async fn run_internal_command(
     command: InternalCommand,
     context: &mut Context,
-    input: InputStream,
+    input: Option<InputStream>,
     source: Text,
-) -> Result<InputStream, ShellError> {
+) -> Result<Option<InputStream>, ShellError> {
     if log_enabled!(log::Level::Trace) {
         trace!(target: "nu::run::internal", "->");
         trace!(target: "nu::run::internal", "{}", command.name);
         trace!(target: "nu::run::internal", "{}", command.args.debug(&source));
     }
 
-    let objects: InputStream = trace_stream!(target: "nu::trace_stream::internal", "input" = input);
+    let objects: InputStream = if let Some(input) = input {
+        trace_stream!(target: "nu::trace_stream::internal", "input" = input)
+    } else {
+        InputStream::empty()
+    };
 
     let internal_command = context.expect_command(&command.name);
 
@@ -167,5 +171,5 @@ pub(crate) async fn run_internal_command(
         }
     };
 
-    Ok(stream.to_input_stream())
+    Ok(Some(stream.to_input_stream()))
 }


### PR DESCRIPTION
Closes https://github.com/nushell/nushell/issues/1173

Stdin pipes are no longer opened for the first external command in a pipeline. I think it also makes far more sense than `InputStream::Empty` as the starting point for a pipeline.

I was trying to think of how I could write a test to capture this, but nothing came to mind.