### PR TITLE
$it: add conversion from Path for external commands

### DIFF
--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -88,6 +88,10 @@ async fn run_with_iterator_arg(
                 value: UntaggedValue::Primitive(Primitive::Line(s)),
                 ..
             } => Ok(s.clone()),
+            Value {
+                value: UntaggedValue::Primitive(Primitive::Path(p)),
+                ..
+            } => Ok(p.to_str().unwrap().to_owned()),
             _ => {
                 let arg = args.iter().find(|arg| arg.contains("$it"));
                 if let Some(arg) = arg {

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -91,7 +91,7 @@ async fn run_with_iterator_arg(
             Value {
                 value: UntaggedValue::Primitive(Primitive::Path(p)),
                 ..
-            } => Ok(p.to_str().unwrap().to_owned()),
+            } => Ok(p.to_string_lossy().to_string()),
             _ => {
                 let arg = args.iter().find(|arg| arg.contains("$it"));
                 if let Some(arg) = arg {


### PR DESCRIPTION
This should fix #1203.

This PR adds a conversion from `Primitive::Path` to string for external commands.

To test you can run the following:
```
> env | get history | ^echo $it
/Users/koenraad/Library/Application Support/nu/history.txt
```

---

`to_str()` on `PathBuf` returns an `Option`, which I simply unwrap (I assume Path always contains a valid path)
- is it indeed safe to unwrap?
- do you mind the naked unwrap? I could also make it an `.expect("<explanation why it is safe>")` or return an `Err`.

---

I noticed that if the path contains a space, this might cause some weird issues:
```
> env | get history | bat $it
[bat error]: '/Users/koenraad/Library/Application': No such file or directory (os error 2)
[bat error]: 'Support/nu/history.txt': No such file or directory (os error 2)
```
This can be avoided by adding quote's around $it:
```
> env | get history | bat '$it'
```
But nu could also try to do this automatically when it detects spaces in the path. I can add this as well, but I'm not sure if this is the responsibility of nu. It would also cause even more issues if the user adds their own set of quotes around $it...