### PR TITLE
$it: add conversion from Int for external commands

### DIFF
--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -81,6 +81,10 @@ async fn run_with_iterator_arg(
         .iter()
         .map(|i| match i {
             Value {
+                value: UntaggedValue::Primitive(Primitive::Int(i)),
+                ..
+            } => Ok(i.to_string()),
+            Value {
                 value: UntaggedValue::Primitive(Primitive::String(s)),
                 ..
             }


### PR DESCRIPTION
Today, I've encountered a very similar problem to #1203 when I wanted to pass the pid of a program to an external command:

```
❯ ps | where name == node | get pid | kill -9 $it
error: External $it needs string data
- shell:1:47
1 | ps | where name == node | get pid | kill -9 $it
  |                                             ^^^ given row instead of string data

```
pid is of type Int, which can not yet be converted to a string for external commands.
This PR adds support for the Int type, similar to #1210.

To test for yourself:

- run sleep (this program will be killed):
```
sleep 600
```
- run the following in another terminal:
```
ps | where name == sleep | get name | kill -9 $it
```
