### PR TITLE
External commands: wrap values that contain spaces in quotes (#1214)

### DIFF
--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -116,10 +116,14 @@ async fn run_with_iterator_arg(
         .map(|result| {
             result.map(|value| {
                 if argument_contains_whitespace(&value) {
-                    add_quotes(&value)
-                } else {
-                    value
+                    let arg = args.iter().find(|arg| arg.contains("$it"));
+                    if let Some(arg) = arg {
+                        if !argument_is_quoted(&arg) {
+                            return add_quotes(&value);
+                        }
+                    }
                 }
+                value
             })
         })
         .collect::<Result<Vec<String>, ShellError>>()?;

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -355,7 +355,10 @@ async fn run_with_stdin(
 
 #[cfg(test)]
 mod tests {
-    use super::{argument_is_quoted, argument_contains_whitespace, add_quotes, remove_quotes, run_external_command, Context, OutputStream};
+    use super::{
+        add_quotes, argument_contains_whitespace, argument_is_quoted, remove_quotes,
+        run_external_command, Context, OutputStream,
+    };
     use futures::executor::block_on;
     use futures::stream::TryStreamExt;
     use nu_errors::ShellError;

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -113,6 +113,15 @@ async fn run_with_iterator_arg(
                 }
             }
         })
+        .map(|result| {
+            result.map(|value| {
+                if value.chars().any(|c| c.is_whitespace()) {
+                    format!("'{}'", value)
+                } else {
+                    value
+                }
+            })
+        })
         .collect::<Result<Vec<String>, ShellError>>()?;
 
     let home_dir = dirs::home_dir();


### PR DESCRIPTION
This _should_ fix #1214: when passing values to an external command, if the value contains a whitespace, wrap the value within quotes (`'...'`).

Test case: `env | get config` is a path that contains a space on my system (macOS):

```
 env | get config
/Users/koenraad/Library/Application Support/nu/config.toml
```

I want to test what happens when I pass this path to external commands. I would expect the external command to interprate the value (`$it`) as a single argument.

### Behaviour before this PR:

```
❯ env | format "{config}" | bat $it
[bat error]: '/Users/koenraad/Library/Application': No such file or directory (os error 2)
[bat error]: 'Support/nu/config.toml': No such file or directory (os error 2)

❯ env | format "{config}" | bat '$it'
───────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /Users/koenraad/Library/Application Support/nu/config.toml   <EMPTY>
───────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

In this case, not wrapping `$it` results in the external command `bat` to receive 2 arguments. This can be avoided by manually quoting `$it`.

Notes
- I use `format` since a path can not be passed to an external command, this is fixed with #1210 

### Behaviour after this PR:

```
> env | get config | bat $it
───────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /Users/koenraad/Library/Application Support/nu/config.toml   <EMPTY>
───────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────

> env | get config | bat '$it'
[bat error]: '/Users/koenraad/Library/Application': No such file or directory (os error 2)
[bat error]: 'Support/nu/config.toml': No such file or directory (os error 2)
```

In this case `$it` is quoted when it contains a whitespace, so `bat $it` always works.

_But_, when $it is quoted again by the user, the quotes cancel each other out 😱 
- `bat ''some value''` ==> `bat some value`

### Discussion

So, this is kind of weird...
- before this PR, only `'$it'` works reliably, after this PR only `$it`
- if we want to make both cases work, we would have to detect whether `$it` is wrapped in quotes or not. I'm not sure if that is possible?

I'm not sure if this can be considered an improvement as is. In fact, passing values to external commands might feel more inconsistent now because values sometimes get wrapped in quotes.