### PR TITLE
Add support for primitive values to sort-by

### DIFF
--- a/src/commands/sort_by.rs
+++ b/src/commands/sort_by.rs
@@ -43,7 +43,7 @@ fn sort_by(
 
         let calc_key = |item: &Value| {
             rest.iter()
-                .map(|f| get_data_by_key(item, f.borrow_spanned()).map(|i| i.clone()))
+                .map(|f| get_data_by_key(item, f.borrow_spanned()))
                 .collect::<Vec<Option<Value>>>()
         };
         vec.sort_by_cached_key(calc_key);

--- a/tests/commands/sort_by.rs
+++ b/tests/commands/sort_by.rs
@@ -21,3 +21,21 @@ fn by_column() {
 
     assert_eq!(actual, "description");
 }
+
+#[test]
+fn sort_primitive_values() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open cargo_sample.toml --raw
+            | lines
+            | skip 1
+            | first 6
+            | sort-by
+            | first 1
+            | echo $it
+        "#
+    ));
+
+    assert_eq!(actual, "authors = [\"Yehuda Katz <wycats@gmail.com>\"]");
+}


### PR DESCRIPTION
Closes #1238.

`sort-by` now checks if the first element of its input is a `Primitive` and if so uses `vec.sort` directly instead of `vec.sort_by_cached_key`.

I am not a _huge_ fan of the current solution. I couldn't find a clean way to determine the type of the `Value`'s in `input`.
An alternative would be to move the `match` inside the `calc_key` fn. But I'm worried about `calc_key` returning different keys depending on the type of the element.

---

`sort-by` without arguments looks a bit weird. I guess this would make more sense if we rename it as `sort`, and provide column names using `sort --by <col1> <col2>`.

A check shows me doing `vec.sort` on `Row`'s also seems to work. So it might make sense to also fallback to `vec.sort` when no `--by` is set.