### PR TITLE
RM error on bad filename

### DIFF
--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -294,6 +294,19 @@ impl Value {
     }
 }
 
+impl Into<Value> for String {
+    fn into(self) -> Value {
+        let end = self.len();
+        Value {
+            value: self.into(),
+            tag: Tag {
+                anchor: None,
+                span: Span::new(0, end),
+            },
+        }
+    }
+}
+
 impl Into<UntaggedValue> for &str {
     /// Convert a string slice into an UntaggedValue
     fn into(self) -> UntaggedValue {

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -995,7 +995,7 @@ impl Shell for FilesystemShell {
         match glob::glob(&path.to_string_lossy()) {
             Ok(files) => {
                 let files: Vec<_> = files.collect();
-                if files.len() == 0 {
+                if files.is_empty() {
                     Err(ShellError::labeled_error(
                         "Remove aborted. Not a valid path",
                         "Remove aborted. Not a valid path",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -131,10 +131,12 @@ impl FileStructure {
         }
     }
 
+    #[allow(dead_code)]
     pub fn contains_more_than_one_file(&self) -> bool {
         self.resources.len() > 1
     }
 
+    #[allow(dead_code)]
     pub fn contains_files(&self) -> bool {
         !self.resources.is_empty()
     }

--- a/tests/commands/rm.rs
+++ b/tests/commands/rm.rs
@@ -132,7 +132,7 @@ fn errors_if_attempting_to_delete_a_directory_with_content_without_recursive_fla
         );
 
         assert!(dirs.test().exists());
-        assert!(actual.contains("is a directory"));
+        assert!(actual.contains("Cannot remove non-empty directory"));
     })
 }
 


### PR DESCRIPTION
Changed `rm` to give an error when it's given a bad filename. I also restructured the code a bit to make it a little easier to follow.