### PR TITLE
Switch to using subprocess::shell

### DIFF
--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -14,6 +14,16 @@ pub fn pipeline(commands: &str) -> String {
         .to_string()
 }
 
+pub fn shell_os_paths() -> Vec<std::path::PathBuf> {
+    let mut original_paths = vec![];
+
+    if let Some(paths) = std::env::var_os("PATH") {
+        original_paths = std::env::split_paths(&paths).collect::<Vec<_>>();
+    }
+
+    original_paths
+}
+
 #[cfg(test)]
 mod tests {
     use super::pipeline;

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -28,18 +28,25 @@ macro_rules! nu {
             $crate::fs::DisplayPath::display_path(&$path)
         );
 
-        let dummies = $crate::fs::binaries();
-        let dummies = dunce::canonicalize(&dummies).unwrap_or_else(|e| {
+        let test_bins = $crate::fs::binaries();
+        let test_bins = dunce::canonicalize(&test_bins).unwrap_or_else(|e| {
             panic!(
                 "Couldn't canonicalize dummy binaries path {}: {:?}",
-                dummies.display(),
+                test_bins.display(),
                 e
             )
         });
 
+        let mut paths = $crate::shell_os_paths();
+        paths.push(test_bins);
+
+        let paths_joined = match std::env::join_paths(paths.iter()) {
+            Ok(all) => all,
+            Err(_) => panic!("Couldn't join paths for PATH var."),
+        };
+
         let mut process = match Command::new($crate::fs::executable_path())
-            // .env_clear()
-            .env("PATH", dummies)
+            .env("PATH", paths_joined)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()
@@ -103,18 +110,25 @@ macro_rules! nu_error {
             $crate::fs::DisplayPath::display_path(&$path)
         );
 
-        let dummies = $crate::fs::binaries();
-        let dummies = dunce::canonicalize(&dummies).unwrap_or_else(|e| {
+        let test_bins = $crate::fs::binaries();
+        let test_bins = dunce::canonicalize(&test_bins).unwrap_or_else(|e| {
             panic!(
                 "Couldn't canonicalize dummy binaries path {}: {:?}",
-                dummies.display(),
+                test_bins.display(),
                 e
             )
         });
 
+        let mut paths = $crate::shell_os_paths();
+        paths.push(test_bins);
+
+        let paths_joined = match std::env::join_paths(paths.iter()) {
+            Ok(all) => all,
+            Err(_) => panic!("Couldn't join paths for PATH var."),
+        };
+
         let mut process = Command::new($crate::fs::executable_path())
-            // .env_clear()
-            .env("PATH", dummies)
+            .env("PATH", paths_joined)
             .stdout(Stdio::piped())
             .stdin(Stdio::piped())
             .stderr(Stdio::piped())

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -248,13 +248,13 @@ async fn spawn(
     let command = command.clone();
     let name_tag = command.name_tag.clone();
 
-    let mut process = Exec::cmd(&command.name);
+    let mut process = Exec::shell(&command.name);
 
     for arg in args {
         process = process.arg(&arg);
     }
 
-    process = process.shell(path);
+    process = process.cwd(path);
     trace!(target: "nu::run::external", "cwd = {:?}", &path);
 
     // We want stdout regardless of what

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -264,23 +264,6 @@ async fn spawn(
 
     let mut process = Exec::shell(&cmd_with_args);
 
-    let paths = shell_os_paths();
-
-    let paths_joined = match std::env::join_paths(paths.iter()) {
-        Ok(all) => all,
-        Err(reason) => {
-            let message = format!("Unable to join paths (error = {})", reason);
-
-            return Err(ShellError::labeled_error(
-                message,
-                "Internal error: Couldn't join paths for PATH var.",
-                &name_tag,
-            ));
-        }
-    };
-
-    process = process.env("PATH", paths_joined);
-
     process = process.cwd(path);
     trace!(target: "nu::run::external", "cwd = {:?}", &path);
 
@@ -453,6 +436,7 @@ fn remove_quotes(argument: &str) -> Option<&str> {
     Some(&argument[1..size - 1])
 }
 
+#[allow(unused)]
 fn shell_os_paths() -> Vec<std::path::PathBuf> {
     let mut original_paths = vec![];
 

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -254,7 +254,7 @@ async fn spawn(
         process = process.arg(&arg);
     }
 
-    process = process.cwd(path);
+    process = process.shell(path);
     trace!(target: "nu::run::external", "cwd = {:?}", &path);
 
     // We want stdout regardless of what

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -217,7 +217,7 @@ async fn run_with_stdin(
 
             let process_args = args.iter().map(|arg| {
                 let arg = expand_tilde(arg.deref(), || home_dir.as_ref());
-                
+
                 #[cfg(not(windows))]
                 {
                     if argument_contains_whitespace(&arg) && argument_is_quoted(&arg) {
@@ -228,7 +228,7 @@ async fn run_with_stdin(
                         }
                     } else {
                         arg.as_ref().to_string()
-                    }    
+                    }
                 }
                 #[cfg(windows)]
                 {

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -17,7 +17,7 @@ fn shows_error_for_command_not_found() {
         "ferris_is_not_here.exe"
     );
 
-    assert!(actual.contains("Command not found"));
+    assert!(actual.contains("External command failed"));
 }
 
 mod it_evaluation {

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -101,7 +101,7 @@ mod tilde_expansion {
         let actual = nu!(
             cwd: ".",
             r#"
-                    cococo "1~1"
+                    cococo 1~1
                 "#
         );
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -101,7 +101,7 @@ mod tilde_expansion {
         let actual = nu!(
             cwd: ".",
             r#"
-                    cococo 1~1
+                    cococo "1~1"
                 "#
         );
 


### PR DESCRIPTION
Switch to using the shell for subprocess to enable more natural shelling out.  This should allow calling out to .cmd scripts, .sh scripts, and so on.