### PR TITLE
Make `futures-timer` a non-optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ futures-util = "0.3.1"
 termcolor = "1.1.0"
 natural = "0.3.0"
 parking_lot = "0.10.0"
+futures-timer = "1.0.2"
 
 clipboard = {version = "0.5", optional = true }
 ptree = {version = "0.2" }
@@ -131,7 +132,6 @@ battery = {version = "0.7.5", optional = true}
 syntect = {version = "3.2.0", optional = true }
 onig_sys = {version = "=69.1.0", optional = true }
 crossterm = {version = "0.10.2", optional = true}
-futures-timer = {version = "1.0.2", optional = true}
 url = {version = "2.1.1", optional = true}
 semver = {version = "0.9.0", optional = true}
 
@@ -147,7 +147,7 @@ stable = ["default", "starship-prompt", "binaryview", "match", "tree", "average"
 
 # Default
 sys = ["heim", "battery"]
-ps = ["heim", "futures-timer"]
+ps = ["heim"]
 textview = ["crossterm", "syntect", "onig_sys", "url"]
 inc = ["nu_plugin_inc"]
 str = ["nu_plugin_str"]


### PR DESCRIPTION
Originally, it was only brought in with the `ps` feature enabled. However, #1231 made the crate used in `src/commands/classified/external.rs` unconditionally, causing the build to fail when built without the `ps` feature.

This commit fixes the problem by making it a non-optional dependency.