### PR TITLE
Update `ichwh` to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,6 @@ checksum = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1070,17 +1069,6 @@ name = "futures-core-preview"
 version = "0.3.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-executor-preview"
@@ -1605,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "ichwh"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee706a4af782acda5a05b7641867dd9c93d7f2884f214fbbad009e5752228d1"
+checksum = "ec27ed05786e59eb2e012b8693ab59abda5d76c7578ef1cde2eb5ff631c342ce"
 dependencies = [
  "async-std",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ subprocess = "0.1.18"
 pretty-hex = "0.1.1"
 hex = "0.4"
 tempfile = "3.1.0"
-ichwh = "0.2"
+ichwh = "0.3"
 textwrap = {version = "0.11.0", features = ["term_size"]}
 shellexpand = "1.1.1"
 pin-utils = "0.1.0-alpha.4"


### PR DESCRIPTION
The [newest update for ichwh][changes] introduced some breaking changes. It also drops one dependency and introduces some concurrency which may provide a speed boost. This PR bumps the version and refactors the `which` command to take these into account.

[changes]: https://gitlab.com/avandesa/ichwh-rs/blob/master/CHANGELOG.md#030-2020-01-22