### PR TITLE
Soften restrictions for external parameters

### DIFF
--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -1008,8 +1008,7 @@ fn is_boundary(c: Option<char>) -> bool {
 
 fn is_external_word_char(c: char) -> bool {
     match c {
-        ';' | '|' | '#' | '-' | '"' | '\'' | '$' | '(' | ')' | '[' | ']' | '{' | '}' | '`'
-        | '.' => false,
+        ';' | '|' | '"' | '\'' | '$' | '(' | ')' | '[' | ']' | '{' | '}' | '`' => false,
         other if other.is_whitespace() => false,
         _ => true,
     }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -78,6 +78,19 @@ mod it_evaluation {
     }
 }
 
+mod external_words {
+    use super::nu;
+
+    #[test]
+    fn relaxed_external_words() {
+        let actual = nu!(cwd: ".", r#"
+        cococo joturner@foo.bar.baz
+        "#);
+
+        assert_eq!(actual, "joturner@foo.bar.baz");
+    }
+}
+
 mod tilde_expansion {
     use super::nu;
 


### PR DESCRIPTION
We currently restrict some characters that can be in external arguments, though they are part of valid filenames and directories.  This PR softens those restrictions to allow more filenames to be passed to external commands.

Fixes #1224 
Fixes #1140 
