### PR TITLE
Make a `calc` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "meval"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9"
+dependencies = [
+ "fnv",
+ "nom 1.2.4",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2149,12 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
+
+[[package]]
+name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
@@ -2237,6 +2253,7 @@ dependencies = [
  "itertools 0.8.2",
  "language-reporting",
  "log",
+ "meval",
  "natural",
  "nom 5.1.0",
  "nom-tracable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ termcolor = "1.1.0"
 natural = "0.3.0"
 parking_lot = "0.10.0"
 futures-timer = "1.0.2"
+meval = "0.2"
 
 clipboard = {version = "0.5", optional = true }
 ptree = {version = "0.2" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,7 +264,7 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
             whole_stream_command(Save),
             per_item_command(Cpy),
             whole_stream_command(Date),
-            whole_stream_command(Calc),
+            per_item_command(Calc),
             per_item_command(Mkdir),
             per_item_command(Move),
             whole_stream_command(Version),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,6 +264,7 @@ pub async fn cli() -> Result<(), Box<dyn Error>> {
             whole_stream_command(Save),
             per_item_command(Cpy),
             whole_stream_command(Date),
+            whole_stream_command(Calc),
             per_item_command(Mkdir),
             per_item_command(Move),
             whole_stream_command(Version),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -7,6 +7,7 @@ mod to_delimited_data;
 pub(crate) mod append;
 pub(crate) mod args;
 pub(crate) mod autoview;
+pub(crate) mod calc;
 pub(crate) mod cd;
 pub(crate) mod classified;
 pub(crate) mod clip;
@@ -106,6 +107,7 @@ pub(crate) use command::{
 };
 
 pub(crate) use append::Append;
+pub(crate) use calc::Calc;
 pub(crate) use compact::Compact;
 pub(crate) use config::Config;
 pub(crate) use count::Count;

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -1,0 +1,48 @@
+use crate::commands::WholeStreamCommand;
+use crate::prelude::*;
+use nu_errors::ShellError;
+use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue};
+
+pub struct Calc;
+
+impl WholeStreamCommand for Calc {
+    fn name(&self) -> &str {
+        "calc"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("calc").required(
+            "math-expression",
+            SyntaxShape::String,
+            "the expression to parse into a number",
+        )
+    }
+
+    fn usage(&self) -> &str {
+        "Parse a math expression into a number"
+    }
+
+    fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        calc(args, registry)
+    }
+}
+
+pub fn calc(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+    let args = args.evaluate_once(registry)?;
+    let arg = &args.parts().1.positional.unwrap_or_else(|| {
+        vec![UntaggedValue::from(Primitive::String("0".to_string())).into_untagged_value()]
+    })[0];
+
+    let math_expression = arg.as_string().unwrap_or_else(|_| "0".to_string());
+    let value = UntaggedValue::from(Primitive::from(
+        meval::eval_str(&math_expression).unwrap_or_default(),
+    ))
+    .into_untagged_value();
+    let output = vec![value];
+
+    Ok(OutputStream::from(output))
+}

--- a/src/commands/calc.rs
+++ b/src/commands/calc.rs
@@ -49,9 +49,9 @@ fn calc(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, S
         match parse(&string, &input.tag) {
             Ok(value) => ReturnSuccess::value(value),
             Err(err) => Err(ShellError::labeled_error(
-                format!("Cannot calculate expression: {}", err),
-                format!("error while calculating: {}", err),
-                name_span,
+                "Calulation error",
+                err,
+                &input.tag.span,
             )),
         }
     } else {

--- a/tests/commands/calc.rs
+++ b/tests/commands/calc.rs
@@ -1,0 +1,49 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn calculates_two_plus_two() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "2 + 2" | calc
+        "#
+    ));
+
+    assert!(actual.contains("4.0"));
+}
+
+#[test]
+fn calculates_two_to_the_power_six() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "2 ^ 6" | calc
+        "#
+    ));
+
+    assert!(actual.contains("64.0"));
+}
+
+#[test]
+fn calculates_three_multiplied_by_five() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "3 * 5" | calc
+        "#
+    ));
+
+    assert!(actual.contains("15.0"));
+}
+
+#[test]
+fn calculates_twenty_four_divided_by_two() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "24 / 2" | calc
+        "#
+    ));
+
+    assert!(actual.contains("12.0"));
+}

--- a/tests/commands/mod.rs
+++ b/tests/commands/mod.rs
@@ -1,4 +1,5 @@
 mod append;
+mod calc;
 mod cd;
 mod compact;
 mod cp;


### PR DESCRIPTION
Fixes #168 .

Used the `meval` crate to parse math expressions into a number.