### PR TITLE
Nu source overview

### DIFF
--- a/crates/nu-source/README.md
+++ b/crates/nu-source/README.md
@@ -5,3 +5,5 @@
 The `nu-source` crate contains types and traits that nu uses to keep track of the values it is processing. This type of data is referred to as "metadata" and there are several types of information that is tracked. Inside Nu, values are `Tagged`, which is a data structure that keeps track of the item and its metadata, which is also known as a `Tag`. A `Tag` is made up of location based information such as an `AnchorLocation` as well as a `Span`. An `AchorLocation` represents the location where a value originated from. This can be a `Url`, `File`, or `Source` text that a value was parsed from.
 The source `Text` is special in that it is a type similar to a `String` with the ability to be cheaply cloned.
 A `Span` is used to keep track of the position of a value with a `start` and `end`.
+
+In addition to metadata tracking, `nu-source` also contains types and traits related to debugging, tracing, and formatting the metadata and values it processes.

--- a/crates/nu-source/README.md
+++ b/crates/nu-source/README.md
@@ -1,0 +1,29 @@
+# nu-source
+
+## Overview
+
+Inside this crate, you will find the types and behaviors responsible for metadata inside `Nushell` with additional debugging features.
+
+Important Types
+
+### Text
+Represent the value of an input file. 
+Similar to a `String` in rust, but cheaply cloneable.
+
+### AnchorLocation
+An enum that represents the location where a value originated from. 
+ex. Url, File, or Source `Text`
+
+### Span
+A start point and end point
+
+### Spanned
+A _spanned_ value. This combines a `Span` with some value.
+
+### Tag
+Metadata that can be associated with some value.
+A tag is made from an `AnchorLocation` and `Span`.
+Tags can be made with unknown locations or spans.
+
+### Tagged
+A _tagged_ value. This combines a `Tag` with some value.

--- a/crates/nu-source/README.md
+++ b/crates/nu-source/README.md
@@ -21,3 +21,10 @@ In the following example Nu is able to report to the user where the typo of a co
 ```
 
 In addition to metadata tracking, `nu-source` also contains types and traits related to debugging, tracing, and formatting the metadata and values it processes.
+
+## Other Resources
+- [Nushell Github Project](https://github.com/nushell): Contains all projects in the Nushell ecosystem such as the source code to Nushell as well as website and books.
+- [Nushell Git Repository](https://github.com/nushell/nushell): A direct link to the source git repository for Nushell
+- [Nushell Contributor Book](https://github.com/nushell/contributor-book): An overview of topics about Nushell to help you get started contributing to the project.
+- [Discord Channel](https://discordapp.com/invite/NtAbbGn)
+- [Twitter](https://twitter.com/nu_shell)

--- a/crates/nu-source/README.md
+++ b/crates/nu-source/README.md
@@ -2,7 +2,6 @@
 
 ## Overview
 
-Inside this crate you will find the types and traits responsible for keeping track
 The `nu-source` crate contains types and traits that nu uses to keep track of the values it is processing. This type of data is referred to as "metadata" and there are several types of information that is tracked. Inside Nu, values are `Tagged`, which is a data structure that keeps track of the item and its metadata, which is also known as a `Tag`. A `Tag` is made up of location based information such as an `AnchorLocation` as well as a `Span`. An `AchorLocation` represents the location where a value originated from. This can be a `Url`, `File`, or `Source` text that a value was parsed from.
 The source `Text` is special in that it is a type similar to a `String` with the ability to be cheaply cloned.
 A `Span` is used to keep track of the position of a value with a `start` and `end`.

--- a/crates/nu-source/README.md
+++ b/crates/nu-source/README.md
@@ -2,8 +2,13 @@
 
 ## Overview
 
-The `nu-source` crate contains types and traits that nu uses to keep track of the values it is processing. This type of data is referred to as "metadata" and there are several types of information that is tracked. Inside Nu, values are `Tagged`, which is a data structure that keeps track of the item and its metadata, which is also known as a `Tag`. A `Tag` is made up of location based information such as an `AnchorLocation` as well as a `Span`. An `AchorLocation` represents the location where a value originated from. This can be a `Url`, `File`, or `Source` text that a value was parsed from.
-The source `Text` is special in that it is a type similar to a `String` with the ability to be cheaply cloned.
-A `Span` is used to keep track of the position of a value with a `start` and `end`.
+The `nu-source` crate contains types and traits used for keeping track of _metadata_ about values being processed. 
+Nu uses `Tag`s to keep track of where a value came from, an `AnchorLocation`,
+as well as positional information about the value, a `Span`.
+An `AchorLocation` can be a `Url`, `File`, or `Source` text that a value was parsed from.
+The source `Text` is special in that it is a type similar to a `String` that comes with the ability to be cheaply cloned.
+A `Span` keeps track of a value's `start` and `end` positions.
+These types make up the metadata for a value and are wrapped up together in a `Tagged` struct,
+which holds everything needed to track and locate a value. 
 
 In addition to metadata tracking, `nu-source` also contains types and traits related to debugging, tracing, and formatting the metadata and values it processes.

--- a/crates/nu-source/README.md
+++ b/crates/nu-source/README.md
@@ -11,4 +11,13 @@ A `Span` keeps track of a value's `start` and `end` positions.
 These types make up the metadata for a value and are wrapped up together in a `Tagged` struct,
 which holds everything needed to track and locate a value. 
 
+
+Nu's metadata system can be seen when reporting errors.
+In the following example Nu is able to report to the user where the typo of a column originated from.
+
+```
+1 | ls | get typ
+  |          ^^^ did you mean 'type'?
+```
+
 In addition to metadata tracking, `nu-source` also contains types and traits related to debugging, tracing, and formatting the metadata and values it processes.

--- a/crates/nu-source/README.md
+++ b/crates/nu-source/README.md
@@ -2,28 +2,7 @@
 
 ## Overview
 
-Inside this crate, you will find the types and behaviors responsible for metadata inside `Nushell` with additional debugging features.
-
-Important Types
-
-### Text
-Represent the value of an input file. 
-Similar to a `String` in rust, but cheaply cloneable.
-
-### AnchorLocation
-An enum that represents the location where a value originated from. 
-ex. Url, File, or Source `Text`
-
-### Span
-A start point and end point
-
-### Spanned
-A _spanned_ value. This combines a `Span` with some value.
-
-### Tag
-Metadata that can be associated with some value.
-A tag is made from an `AnchorLocation` and `Span`.
-Tags can be made with unknown locations or spans.
-
-### Tagged
-A _tagged_ value. This combines a `Tag` with some value.
+Inside this crate you will find the types and traits responsible for keeping track
+The `nu-source` crate contains types and traits that nu uses to keep track of the values it is processing. This type of data is referred to as "metadata" and there are several types of information that is tracked. Inside Nu, values are `Tagged`, which is a data structure that keeps track of the item and its metadata, which is also known as a `Tag`. A `Tag` is made up of location based information such as an `AnchorLocation` as well as a `Span`. An `AchorLocation` represents the location where a value originated from. This can be a `Url`, `File`, or `Source` text that a value was parsed from.
+The source `Text` is special in that it is a type similar to a `String` with the ability to be cheaply cloned.
+A `Span` is used to keep track of the position of a value with a `start` and `end`.


### PR DESCRIPTION
First attempt at creating crate overview documentation and looking for some feedback. I'm not entirely sure how helpful this will be in the long-run or if this information should instead live somewhere like the [Contributor Book](https://www.nushell.sh/contributor-book/). While I am strongly in favor of documenting Nu internals to help onboard new contributors, I am concerned with this documentation getting out of sync with the project and being difficult to maintain.