### PR TITLE
`ls` will return error if no files/folders match path/pattern

### DIFF
--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -1,42 +1,21 @@
 use crate::prelude::*;
 use nu_errors::ShellError;
 use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
-use std::path::PathBuf;
 
 pub(crate) fn dir_entry_dict(
-    path: &PathBuf,
+    filename: &std::path::Path,
+    metadata: &std::fs::Metadata,
     tag: impl Into<Tag>,
     full: bool,
     with_symlink_targets: bool,
     short_name: bool,
 ) -> Result<Value, ShellError> {
-    let tag = tag.into();
-    let metadata = match std::fs::metadata(path) {
-        Ok(m) => Ok(m),
-        Err(e) => Err(ShellError::from(e)),
-    }?;
-    let file_type = metadata.file_type();
+    let mut dict = TaggedDictBuilder::new(tag);
+    dict.insert_untagged("name", UntaggedValue::string(filename.to_string_lossy()));
 
-    let mut dict = TaggedDictBuilder::new(&tag);
-
-    let name = if short_name {
-        match path.file_name() {
-            Some(n) => Ok(n.to_str().expect("This path was not properly encoded.")),
-            None => Err(ShellError::labeled_error(
-                format!("Invalid File name: {:}", path.to_string_lossy()),
-                "Invalid File Name",
-                tag,
-            )),
-        }
-    } else {
-        Ok(path.to_str().expect("This path was not properly encoded."))
-    }?;
-
-    dict.insert_untagged("name", UntaggedValue::string(name));
-
-    if file_type.is_dir() {
+    if metadata.is_dir() {
         dict.insert_untagged("type", UntaggedValue::string("Dir"));
-    } else if file_type.is_file() {
+    } else if metadata.is_file() {
         dict.insert_untagged("type", UntaggedValue::string("File"));
     } else {
         dict.insert_untagged("type", UntaggedValue::string("Symlink"));
@@ -87,7 +66,7 @@ pub(crate) fn dir_entry_dict(
         }
     }
 
-    if file_type.is_file() {
+    if metadata.is_file() {
         dict.insert_untagged("size", UntaggedValue::bytes(metadata.len() as u64));
     } else {
         dict.insert_untagged("size", UntaggedValue::bytes(0u64));

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -8,10 +8,23 @@ pub(crate) fn dir_entry_dict(
     tag: impl Into<Tag>,
     full: bool,
     with_symlink_targets: bool,
-    short_name: bool,
+    name_only: bool,
 ) -> Result<Value, ShellError> {
-    let mut dict = TaggedDictBuilder::new(tag);
-    dict.insert_untagged("name", UntaggedValue::string(filename.to_string_lossy()));
+    let tag = tag.into();
+    let mut dict = TaggedDictBuilder::new(&tag);
+
+    let name = if name_only {
+        filename.file_name().and_then(|s| s.to_str())
+    } else {
+        filename.to_str()
+    }
+    .ok_or(ShellError::labeled_error(
+        format!("Invalid File name: {:}", filename.to_string_lossy()),
+        "Invalid File Name",
+        tag,
+    ))?;
+
+    dict.insert_untagged("name", UntaggedValue::string(name));
 
     if metadata.is_dir() {
         dict.insert_untagged("type", UntaggedValue::string("Dir"));

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -18,11 +18,13 @@ pub(crate) fn dir_entry_dict(
     } else {
         filename.to_str()
     }
-    .ok_or(ShellError::labeled_error(
-        format!("Invalid file name: {:}", filename.to_string_lossy()),
-        "invalid file name",
-        tag,
-    ))?;
+    .ok_or_else(|| {
+        ShellError::labeled_error(
+            format!("Invalid file name: {:}", filename.to_string_lossy()),
+            "invalid file name",
+            tag,
+        )
+    })?;
 
     dict.insert_untagged("name", UntaggedValue::string(name));
 

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -19,8 +19,8 @@ pub(crate) fn dir_entry_dict(
         filename.to_str()
     }
     .ok_or(ShellError::labeled_error(
-        format!("Invalid File name: {:}", filename.to_string_lossy()),
-        "Invalid File Name",
+        format!("Invalid file name: {:}", filename.to_string_lossy()),
+        "invalid file name",
         tag,
     ))?;
 

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -37,7 +37,7 @@ pub(crate) fn dir_entry_dict(
     if full || with_symlink_targets {
         if metadata.is_dir() || metadata.is_file() {
             dict.insert_untagged("target", UntaggedValue::bytes(0u64));
-        } else if let Ok(path_to_link) = path.read_link() {
+        } else if let Ok(path_to_link) = filename.read_link() {
             dict.insert_untagged(
                 "target",
                 UntaggedValue::string(path_to_link.to_string_lossy()),

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -140,13 +140,9 @@ impl Shell for FilesystemShell {
                     break;
                 }
                 match path {
-                    Ok(p) => match dir_entry_dict(&p, name_tag.clone(), full, short_names, with_symlink_targets) {
-                        Ok(d) => yield ReturnSuccess::value(d),
-                        Err(e) => yield Err(e),
-                    },
                     Ok(p) => match std::fs::symlink_metadata(&p) {
                         Ok(m) => {
-                            match dir_entry_dict(&p, &m, name_tag.clone(), full, short_names) {
+                            match dir_entry_dict(&p, &m, name_tag.clone(), full, short_names, with_symlink_targets) {
                                 Ok(d) => yield ReturnSuccess::value(d),
                                 Err(e) => yield Err(e)
                             }


### PR DESCRIPTION
This will make `ls` return an error on an invalid file/folder name, or if the pattern in the `path` option doesn't match any files.