### PR TITLE
Add `--with-symlink-targets` option for the `ls` command that displays a new column for the target files of symlinks

### DIFF
--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -13,6 +13,8 @@ pub struct LsArgs {
     pub full: bool,
     #[serde(rename = "short-names")]
     pub short_names: bool,
+    #[serde(rename = "with-symlink-targets")]
+    pub with_symlink_targets: bool,
 }
 
 impl PerItemCommand for Ls {
@@ -29,6 +31,10 @@ impl PerItemCommand for Ls {
             )
             .switch("full", "list all available columns for each entry")
             .switch("short-names", "only print the file names and not the path")
+            .switch(
+                "with-symlink-targets",
+                "display the paths to the target files that symlinks point to",
+            )
     }
 
     fn usage(&self) -> &str {

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -7,6 +7,7 @@ pub(crate) fn dir_entry_dict(
     metadata: &std::fs::Metadata,
     tag: impl Into<Tag>,
     full: bool,
+    with_symlink_targets: bool,
 ) -> Result<Value, ShellError> {
     let mut dict = TaggedDictBuilder::new(tag);
     dict.insert_untagged("name", UntaggedValue::string(filename.to_string_lossy()));
@@ -18,6 +19,24 @@ pub(crate) fn dir_entry_dict(
     } else {
         dict.insert_untagged("type", UntaggedValue::string("Symlink"));
     };
+
+    if full || with_symlink_targets {
+        if metadata.is_dir() || metadata.is_file() {
+            dict.insert_untagged("target", UntaggedValue::bytes(0u64));
+        } else {
+            if let Ok(path_to_link) = filename.read_link() {
+                dict.insert_untagged(
+                    "target",
+                    UntaggedValue::string(path_to_link.to_string_lossy()),
+                );
+            } else {
+                dict.insert_untagged(
+                    "target",
+                    UntaggedValue::string("Could not obtain target file's path"),
+                );
+            }
+        }
+    }
 
     if full {
         dict.insert_untagged(

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -23,18 +23,16 @@ pub(crate) fn dir_entry_dict(
     if full || with_symlink_targets {
         if metadata.is_dir() || metadata.is_file() {
             dict.insert_untagged("target", UntaggedValue::bytes(0u64));
+        } else if let Ok(path_to_link) = filename.read_link() {
+            dict.insert_untagged(
+                "target",
+                UntaggedValue::string(path_to_link.to_string_lossy()),
+            );
         } else {
-            if let Ok(path_to_link) = filename.read_link() {
-                dict.insert_untagged(
-                    "target",
-                    UntaggedValue::string(path_to_link.to_string_lossy()),
-                );
-            } else {
-                dict.insert_untagged(
-                    "target",
-                    UntaggedValue::string("Could not obtain target file's path"),
-                );
-            }
+            dict.insert_untagged(
+                "target",
+                UntaggedValue::string("Could not obtain target file's path"),
+            );
         }
     }
 

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -92,6 +92,7 @@ impl Shell for FilesystemShell {
             path,
             full,
             short_names,
+            with_symlink_targets,
         }: LsArgs,
         context: &RunnablePerItemContext,
     ) -> Result<OutputStream, ShellError> {
@@ -166,7 +167,7 @@ impl Shell for FilesystemShell {
                                     }
                                 }
 
-                                let value = dir_entry_dict(filename, &metadata, &name_tag, full)?;
+                                let value = dir_entry_dict(filename, &metadata, &name_tag, full, with_symlink_targets)?;
                                 yield ReturnSuccess::value(value);
                             }
                         }
@@ -217,7 +218,7 @@ impl Shell for FilesystemShell {
                             }
                         }
 
-                        if let Ok(value) = dir_entry_dict(filename, &metadata, &name_tag, full) {
+                        if let Ok(value) = dir_entry_dict(filename, &metadata, &name_tag, full, with_symlink_targets) {
                             yield ReturnSuccess::value(value);
                         }
                     }


### PR DESCRIPTION
I'm not entirely sure I'm doing everything correctly, but I figured I can get some feedback here if anything is incorrect.

1.  I'm not sure how to handle errors that may arise from using the Rust method `read_link()`; currently, I'm just adding a message where the symlink target path would go that states: "Could not obtain target file's path".  I'm not sure if this is a correct way to handle this or not.
2.  It looks like you are using rustfmt, I went ahead and formatted my code with it (hopefully that is correct)
3.  I'm unable to test on Windows and Linux; I am using a built-in Rust method for retrieving the symlink's target path, but I'm not sure if I've done anything that may break on other systems.

I would also appreciate any other feedback I could use in order to get this feature merged in.

Thank you!