### PR TITLE
Isolate environment state changes into Host.

### DIFF
--- a/src/env/host.rs
+++ b/src/env/host.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+#[cfg(test)]
+use indexmap::IndexMap;
 use nu_errors::ShellError;
 use std::ffi::OsString;
 use std::fmt::Debug;
@@ -13,7 +15,7 @@ pub trait Host: Debug + Send {
     fn stdout(&mut self, out: &str);
     fn stderr(&mut self, out: &str);
 
-    fn vars(&mut self) -> std::env::Vars;
+    fn vars(&mut self) -> Vec<(String, String)>;
     fn env_get(&mut self, key: OsString) -> Option<OsString>;
     fn env_set(&mut self, k: OsString, v: OsString);
     fn env_rm(&mut self, k: OsString);
@@ -38,7 +40,7 @@ impl Host for Box<dyn Host> {
         (**self).stderr(out)
     }
 
-    fn vars(&mut self) -> std::env::Vars {
+    fn vars(&mut self) -> Vec<(String, String)> {
         (**self).vars()
     }
 
@@ -93,8 +95,8 @@ impl Host for BasicHost {
         }
     }
 
-    fn vars(&mut self) -> std::env::Vars {
-        std::env::vars()
+    fn vars(&mut self) -> Vec<(String, String)> {
+        std::env::vars().collect::<Vec<_>>()
     }
 
     fn env_get(&mut self, key: OsString) -> Option<OsString> {
@@ -119,6 +121,82 @@ impl Host for BasicHost {
 
     fn width(&self) -> usize {
         std::cmp::max(textwrap::termwidth(), 20)
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub struct FakeHost {
+    line_written: String,
+    env_vars: IndexMap<String, String>,
+}
+
+#[cfg(test)]
+impl FakeHost {
+    pub fn new() -> FakeHost {
+        FakeHost {
+            line_written: String::from(""),
+            env_vars: IndexMap::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Host for FakeHost {
+    fn out_terminal(&self) -> Option<Box<term::StdoutTerminal>> {
+        None
+    }
+
+    fn err_terminal(&self) -> Option<Box<term::StderrTerminal>> {
+        None
+    }
+
+    fn stdout(&mut self, out: &str) {
+        self.line_written = out.to_string();
+    }
+
+    fn stderr(&mut self, out: &str) {
+        self.line_written = out.to_string();
+    }
+
+    fn vars(&mut self) -> Vec<(String, String)> {
+        self.env_vars
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect::<Vec<_>>()
+    }
+
+    fn env_get(&mut self, key: OsString) -> Option<OsString> {
+        let key = key.into_string().expect("Couldn't convert to string.");
+
+        match self.env_vars.get(&key) {
+            Some(env) => Some(OsString::from(env)),
+            None => None,
+        }
+    }
+
+    fn env_set(&mut self, key: OsString, value: OsString) {
+        self.env_vars.insert(
+            key.into_string().expect("Couldn't convert to string."),
+            value.into_string().expect("Couldn't convert to string."),
+        );
+    }
+
+    fn env_rm(&mut self, key: OsString) {
+        self.env_vars
+            .shift_remove(&key.into_string().expect("Couldn't convert to string."));
+    }
+
+    fn out_termcolor(&self) -> termcolor::StandardStream {
+        termcolor::StandardStream::stdout(termcolor::ColorChoice::Auto)
+    }
+
+    fn err_termcolor(&self) -> termcolor::StandardStream {
+        termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto)
+    }
+
+    fn width(&self) -> usize {
+        1
     }
 }
 


### PR DESCRIPTION
Moves the state changes for setting and removing environment variables
into the context's host as opposed to calling `std::env::*` directly
from anywhere else.

Introduced FakeHost to prevent environemnt state changes leaking
between unit tests and cause random test failures.