### PR TITLE
Exclude images to reduce crate by 3MB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ default-run = "nu"
 repository = "https://github.com/nushell/nushell"
 homepage = "https://www.nushell.sh"
 documentation = "https://www.nushell.sh/book/"
+exclude = ["images"]
 
 [workspace]
 


### PR DESCRIPTION
Maybe there are more candidates for exclusion, but 'images/'
seemed obviously unnecessary.

Something I started realizing lately is that cargo puts most
of the root directory into the crate archive, causing huge
crates to appear on crates.io.

Now that I am in China, I do seem to notice every kilobyte.