### PR TITLE
Add support for plugin names containing numbers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,7 +147,7 @@ fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
     for path in search_paths() {
         let mut pattern = path.to_path_buf();
 
-        pattern.push(std::path::Path::new("nu_plugin_[a-z]*"));
+        pattern.push(std::path::Path::new("nu_plugin_[a-z]?[a-z0-9]*"));
 
         match glob::glob_with(&pattern.to_string_lossy(), opts) {
             Err(_) => {}
@@ -173,14 +173,14 @@ fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
                         {
                             bin_name
                                 .chars()
-                                .all(|c| c.is_ascii_alphabetic() || c == '_' || c == '.')
+                                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
                         }
 
                         #[cfg(not(windows))]
                         {
                             bin_name
                                 .chars()
-                                .all(|c| c.is_ascii_alphabetic() || c == '_')
+                                .all(|c| c.is_ascii_alphanumeric() || c == '_')
                         }
                     };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,7 +147,7 @@ fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
     for path in search_paths() {
         let mut pattern = path.to_path_buf();
 
-        pattern.push(std::path::Path::new("nu_plugin_[a-z]?[a-z0-9]*"));
+        pattern.push(std::path::Path::new("nu_plugin_[a-z0-9]*"));
 
         match glob::glob_with(&pattern.to_string_lossy(), opts) {
             Err(_) => {}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,7 +147,7 @@ fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
     for path in search_paths() {
         let mut pattern = path.to_path_buf();
 
-        pattern.push(std::path::Path::new("nu_plugin_[a-z0-9]*"));
+        pattern.push(std::path::Path::new("nu_plugin_[a-z0-9]+"));
 
         match glob::glob_with(&pattern.to_string_lossy(), opts) {
             Err(_) => {}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,7 +147,7 @@ fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
     for path in search_paths() {
         let mut pattern = path.to_path_buf();
 
-        pattern.push(std::path::Path::new("nu_plugin_[a-z0-9]+"));
+        pattern.push(std::path::Path::new("nu_plugin_[a-z0-9][a-z0-9]*"));
 
         match glob::glob_with(&pattern.to_string_lossy(), opts) {
             Err(_) => {}


### PR DESCRIPTION
Fixes #1315 

The regex has been changed to support 0 or more alphanumeric characters.
A plugin name may...
- contain only numbers => `nu_plugin_8675309`
- contain a mixture of alphabetic characters and numbers => `nu_plugin_h264`
- contain only alphabetic characters => `nu_plugin_len`
- contain no extra characters (not sure why, but looks like this is already supported?) => `nu_plugin_`