### PR TITLE
Fixed cp overwrite bug

### DIFF
--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -253,10 +253,7 @@ impl Shell for FilesystemShell {
                 if entry.is_file() {
                     let strategy = |(source_file, _depth_level)| {
                         if destination.exists() {
-                            let mut new_dst = dunce::canonicalize(destination.clone())?;
-                            if let Some(name) = entry.file_name() {
-                                new_dst.push(name);
-                            }
+                            let new_dst = dunce::canonicalize(destination.clone())?;
                             Ok((source_file, new_dst))
                         } else {
                             Ok((source_file, destination.clone()))


### PR DESCRIPTION
Fixes #1245 .
The result of the if condition was appending the name again creating a wrong destination path.
For example if you tried copying `test.txt` to `copy.txt` and `copy.txt` already existed.
The destination path would become `"E:\\copy.txt\\test.txt"` so the OS threw an error that the destination could not be found.