### PR TITLE
Allow cp to overwrite existing files

### DIFF
--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -252,7 +252,7 @@ impl Shell for FilesystemShell {
 
                 if entry.is_file() {
                     let strategy = |(source_file, _depth_level)| {
-                        if destination.exists() {
+                        if destination.is_dir() {
                             let mut new_dst = dunce::canonicalize(destination.clone())?;
                             if let Some(name) = entry.file_name() {
                                 new_dst.push(name);

--- a/tests/commands/cp.rs
+++ b/tests/commands/cp.rs
@@ -165,3 +165,22 @@ fn copies_using_a_glob() {
         ));
     });
 }
+
+#[test]
+fn copies_same_file_twice() {
+    Playground::setup("cp_test_8", |dirs, _| {
+        nu!(
+            cwd: dirs.root(),
+            "cp \"{}\" cp_test_8/sample.ini",
+            dirs.formats().join("sample.ini")
+        );
+
+        nu!(
+            cwd: dirs.root(),
+            "cp \"{}\" cp_test_8/sample.ini",
+            dirs.formats().join("sample.ini")
+        );
+
+        assert!(dirs.test().join("sample.ini").exists());
+    });
+}


### PR DESCRIPTION
This solves the #1245 issue.

The changed flow logic is,
1a. if destination exists and is directory -> updated destination is the file name appended to the directory
1b. if destination does not exist or it exists and is a file -> destination is unchanged
2. try to copy file to destination

The `1b` logic can later be changed to include a `-n` that prevents overwriting an existing file.
