### PR TITLE
Fixed mv not moving files on Windows.

### DIFF
--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -720,6 +720,22 @@ impl Shell for FilesystemShell {
                                     }
                                     Ok(o) => o,
                                 }
+                            } else if src.is_file() {
+                                match std::fs::copy(src, dst) {
+                                    Err(e) => {
+                                        return Err(ShellError::labeled_error(
+                                            format!(
+                                                "Moving file {:?} to {:?} aborted. {:}",
+                                                src,
+                                                dst,
+                                                e.to_string(),
+                                            ),
+                                            e.to_string(),
+                                            name_tag,
+                                        ));
+                                    }
+                                    Ok(o) => (),
+                                }
                             }
                         }
 

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -734,7 +734,7 @@ impl Shell for FilesystemShell {
                                             name_tag,
                                         ));
                                     }
-                                    Ok(o) => (),
+                                    Ok(_o) => (),
                                 }
                             }
                         }

--- a/tests/commands/mv.rs
+++ b/tests/commands/mv.rs
@@ -188,8 +188,14 @@ fn moves_a_directory_with_files() {
         sandbox
             .mkdir("vehicles/car")
             .mkdir("vehicles/bicycle")
-            .with_files(vec![EmptyFile("vehicles/car/car1.txt"), EmptyFile("vehicles/car/car2.txt")])
-            .with_files(vec![EmptyFile("vehicles/bicycle/bicycle1.txt"), EmptyFile("vehicles/bicycle/bicycle2.txt")]);
+            .with_files(vec![
+                EmptyFile("vehicles/car/car1.txt"),
+                EmptyFile("vehicles/car/car2.txt"),
+            ])
+            .with_files(vec![
+                EmptyFile("vehicles/bicycle/bicycle1.txt"),
+                EmptyFile("vehicles/bicycle/bicycle2.txt"),
+            ]);
 
         let original_dir = dirs.test().join("vehicles");
         let expected_dir = dirs.test().join("expected");
@@ -201,6 +207,14 @@ fn moves_a_directory_with_files() {
 
         assert!(!original_dir.exists());
         assert!(expected_dir.exists());
-        assert!(files_exist_at(vec!["car/car1.txt", "car/car2.txt", "bicycle/bicycle1.txt", "bicycle/bicycle2.txt"], expected_dir))
+        assert!(files_exist_at(
+            vec![
+                "car/car1.txt",
+                "car/car2.txt",
+                "bicycle/bicycle1.txt",
+                "bicycle/bicycle2.txt"
+            ],
+            expected_dir
+        ));
     })
 }

--- a/tests/commands/mv.rs
+++ b/tests/commands/mv.rs
@@ -96,6 +96,7 @@ fn moves_the_directory_inside_directory_if_path_to_move_is_existing_directory() 
 
         assert!(!original_dir.exists());
         assert!(expected.exists());
+        assert!(files_exist_at(vec!["jonathan.txt"], expected))
     })
 }
 
@@ -178,5 +179,28 @@ fn moves_using_a_glob() {
             vec!["arepa.txt", "empanada.txt", "taquiza.txt",],
             expected
         ));
+    })
+}
+
+#[test]
+fn moves_a_directory_with_files() {
+    Playground::setup("mv_test_9", |dirs, sandbox| {
+        sandbox
+            .mkdir("vehicles/car")
+            .mkdir("vehicles/bicycle")
+            .with_files(vec![EmptyFile("vehicles/car/car1.txt"), EmptyFile("vehicles/car/car2.txt")])
+            .with_files(vec![EmptyFile("vehicles/bicycle/bicycle1.txt"), EmptyFile("vehicles/bicycle/bicycle2.txt")]);
+
+        let original_dir = dirs.test().join("vehicles");
+        let expected_dir = dirs.test().join("expected");
+
+        nu!(
+            cwd: dirs.test(),
+            "mv vehicles expected"
+        );
+
+        assert!(!original_dir.exists());
+        assert!(expected_dir.exists());
+        assert!(files_exist_at(vec!["car/car1.txt", "car/car2.txt", "bicycle/bicycle1.txt", "bicycle/bicycle2.txt"], expected_dir))
     })
 }


### PR DESCRIPTION
Fixes #1338 
The `mv` operation will correctly copy files from the source folder to the destination folder.
The `#[cfg(not(windows))]` part would use std::fs::rename which works completely fine but on `#[cfg(windows)]`, rename can't be used because the destination cannot be a directory.
So when iterating through the sources there wasn't any check if the src was a file so it can be copied.
I added this statement so it also copies the file (the correct behavior of a `mv` operation). 