### PR TITLE
Update more futures-preview to futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ dependencies = [
 name = "nu_plugin_fetch"
 version = "0.9.0"
 dependencies = [
- "futures-preview",
+ "futures 0.3.3",
  "nu-build",
  "nu-errors",
  "nu-plugin",
@@ -2462,7 +2462,7 @@ dependencies = [
 name = "nu_plugin_match"
 version = "0.9.0"
 dependencies = [
- "futures-preview",
+ "futures 0.3.3",
  "nu-build",
  "nu-errors",
  "nu-plugin",
@@ -2476,7 +2476,7 @@ name = "nu_plugin_post"
 version = "0.9.0"
 dependencies = [
  "base64 0.11.0",
- "futures-preview",
+ "futures 0.3.3",
  "nu-build",
  "nu-errors",
  "nu-plugin",

--- a/crates/nu_plugin_fetch/Cargo.toml
+++ b/crates/nu_plugin_fetch/Cargo.toml
@@ -11,9 +11,9 @@ nu-plugin = { path = "../nu-plugin", version = "0.9.0" }
 nu-protocol = { path = "../nu-protocol", version = "0.9.0" }
 nu-source = { path = "../nu-source", version = "0.9.0" }
 nu-errors = { path = "../nu-errors", version = "0.9.0" }
-futures-preview = { version = "=0.3.0-alpha.19", features = ["compat", "io-compat"] }
+futures = { version = "0.3", features = ["compat", "io-compat"] }
 surf = "1.0.3"
-url = "2.1.0"
+url = "2.1.1"
 
 [build-dependencies]
 nu-build = { version = "0.9.0", path = "../nu-build" }

--- a/crates/nu_plugin_match/Cargo.toml
+++ b/crates/nu_plugin_match/Cargo.toml
@@ -11,7 +11,7 @@ nu-plugin = { path = "../nu-plugin", version = "0.9.0" }
 nu-protocol = { path = "../nu-protocol", version = "0.9.0" }
 nu-source = { path = "../nu-source", version = "0.9.0" }
 nu-errors = { path = "../nu-errors", version = "0.9.0" }
-futures-preview = { version = "=0.3.0-alpha.19", features = ["compat", "io-compat"] }
+futures = { version = "0.3", features = ["compat", "io-compat"] }
 regex = "1"
 
 [build-dependencies]

--- a/crates/nu_plugin_post/Cargo.toml
+++ b/crates/nu_plugin_post/Cargo.toml
@@ -11,12 +11,12 @@ nu-plugin = { path = "../nu-plugin", version = "0.9.0" }
 nu-protocol = { path = "../nu-protocol", version = "0.9.0" }
 nu-source = { path = "../nu-source", version = "0.9.0" }
 nu-errors = { path = "../nu-errors", version = "0.9.0" }
-futures-preview = { version = "=0.3.0-alpha.19", features = ["compat", "io-compat"] }
+futures = { version = "0.3", features = ["compat", "io-compat"] }
 surf = "1.0.3"
-url = "2.1.0"
-serde_json = "1.0.44"
+url = "2.1.1"
+serde_json = "1.0.46"
 base64 = "0.11"
-num-traits = "0.2.10"
+num-traits = "0.2.11"
 
 [build-dependencies]
 nu-build = { version = "0.9.0", path = "../nu-build" }


### PR DESCRIPTION
This updates more crates to use the more recent `futures` crate.

The only dependency left is `surf` that still uses futures-preview. They have an updated version in the repo that removes it, but nothing published to crates.io