### PR TITLE
Only spawn external once when no $it argument

### DIFF
--- a/crates/nu-test-support/src/bins/chop.rs
+++ b/crates/nu-test-support/src/bins/chop.rs
@@ -8,12 +8,9 @@ fn main() {
 
     // if no arguments given, chop from standard input and exit.
     let stdin = io::stdin();
-    let mut input = stdin.lock().lines();
-
-    if let Some(Ok(given)) = input.next() {
-        if !given.is_empty() {
+    for line in stdin.lock().lines() {
+        if let Ok(given) = line {
             println!("{}", chop(&given));
-            std::process::exit(0);
         }
     }
 
@@ -21,9 +18,12 @@ fn main() {
 }
 
 fn chop(word: &str) -> &str {
-    let to = word.len() - 1;
-
-    &word[..to]
+    if word.is_empty() {
+        word
+    } else {
+        let to = word.len() - 1;
+        &word[..to]
+    }
 }
 
 fn did_chop_arguments() -> bool {

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -21,8 +21,8 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
         r#"
             open nu_times.csv
             | get name
+            | ^echo $it
             | chop
-            | lines
             | nth 3
             | echo $it
             "#


### PR DESCRIPTION
Resolves https://github.com/nushell/nushell/issues/1309

This is more intuitive, and also ensures that certain externals that aggregate results will be possible (e.g., `wc`, `less`). Even if this is unneeded, this approach is far more performant since spawning a command is an expensive operation.

Note: Although the syntax is uncertain right now, we can find another way to spawn once per entry _and_ pipe that value into stdin. For example, `each { echo $it | ^external }` could work.

@jonathandturner I'll need you to verify I didn't break everything on Windows 😅 