### PR TITLE
Pipeline sink refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
  "async-stream",
+ "atty",
  "base64 0.11.0",
  "bigdecimal",
  "bson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ termcolor = "1.1.0"
 natural = "0.3.0"
 parking_lot = "0.10.0"
 meval = "0.2"
+atty = "0.2"
 
 clipboard = {version = "0.5", optional = true }
 ptree = {version = "0.2" }

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -204,6 +204,12 @@ pub struct SpannedExpression {
     pub span: Span,
 }
 
+impl SpannedExpression {
+    pub fn new(expr: Expression, span: Span) -> SpannedExpression {
+        SpannedExpression { expr, span }
+    }
+}
+
 impl std::ops::Deref for SpannedExpression {
     type Target = Expression;
 

--- a/crates/nu_plugin_average/src/main.rs
+++ b/crates/nu_plugin_average/src/main.rs
@@ -102,7 +102,7 @@ impl Plugin for Average {
                 }
                 UntaggedValue::Primitive(Primitive::Bytes(bytes)) => {
                     let avg = *bytes as f64 / self.count as f64;
-                    let primitive_value: UntaggedValue = Primitive::from(avg).into();
+                    let primitive_value: UntaggedValue = UntaggedValue::bytes(avg as u64);
                     let tagged_value = primitive_value.into_value(inner.tag.clone());
                     Ok(vec![ReturnSuccess::value(tagged_value)])
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -401,7 +401,7 @@ pub async fn run_pipeline_standalone(pipeline: String) -> Result<(), Box<dyn Err
                 print_err(err, host, &Text::from(line.clone()));
             });
 
-            context.maybe_print_errors(Text::from(line.clone()));
+            context.maybe_print_errors(Text::from(line));
         }
 
         _ => {}
@@ -643,8 +643,8 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
                         source: Text::from(String::new()),
                     };
 
-                    match crate::commands::autoview::autoview(context) {
-                        Ok(mut output_stream) => loop {
+                    if let Ok(mut output_stream) = crate::commands::autoview::autoview(context) {
+                        loop {
                             match output_stream.try_next().await {
                                 Ok(Some(ReturnSuccess::Value(Value {
                                     value: UntaggedValue::Error(e),
@@ -659,8 +659,7 @@ async fn process_line(readline: Result<String, ReadlineError>, ctx: &mut Context
                                     break;
                                 }
                             }
-                        },
-                        _ => {}
+                        }
                     }
 
                     LineResult::Success(line.to_string())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -103,8 +103,8 @@ pub(crate) mod wrap;
 pub(crate) use autoview::Autoview;
 pub(crate) use cd::Cd;
 pub(crate) use command::{
-    per_item_command, whole_stream_command, Command, PerItemCommand,
-    UnevaluatedCallInfo, WholeStreamCommand,
+    per_item_command, whole_stream_command, Command, PerItemCommand, UnevaluatedCallInfo,
+    WholeStreamCommand,
 };
 
 pub(crate) use append::Append;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -103,7 +103,7 @@ pub(crate) mod wrap;
 pub(crate) use autoview::Autoview;
 pub(crate) use cd::Cd;
 pub(crate) use command::{
-    per_item_command, whole_stream_command, Command, PerItemCommand, RawCommandArgs,
+    per_item_command, whole_stream_command, Command, PerItemCommand,
     UnevaluatedCallInfo, WholeStreamCommand,
 };
 

--- a/src/commands/classified/internal.rs
+++ b/src/commands/classified/internal.rs
@@ -138,6 +138,14 @@ pub(crate) async fn run_internal_command(
                     }
                 },
 
+                Ok(ReturnSuccess::Value(Value {
+                    value: UntaggedValue::Error(err),
+                    ..
+                })) => {
+                    context.error(err);
+                    break;
+                }
+
                 Ok(ReturnSuccess::Value(v)) => {
                     yielded = true;
                     yield Ok(v);

--- a/src/commands/classified/pipeline.rs
+++ b/src/commands/classified/pipeline.rs
@@ -1,19 +1,17 @@
 use crate::commands::classified::external::run_external_command;
 use crate::commands::classified::internal::run_internal_command;
 use crate::context::Context;
-use crate::stream::{InputStream, OutputStream};
+use crate::stream::InputStream;
 use nu_errors::ShellError;
 use nu_parser::{ClassifiedCommand, ClassifiedPipeline};
-use nu_protocol::{ReturnSuccess, UntaggedValue, Value};
 use nu_source::Text;
-use std::sync::atomic::Ordering;
 
 pub(crate) async fn run_pipeline(
     pipeline: ClassifiedPipeline,
     ctx: &mut Context,
     mut input: Option<InputStream>,
     line: &str,
-) -> Result<(), ShellError> {
+) -> Result<Option<InputStream>, ShellError> {
     let mut iter = pipeline.commands.list.into_iter().peekable();
 
     loop {
@@ -48,26 +46,5 @@ pub(crate) async fn run_pipeline(
         };
     }
 
-    use futures::stream::TryStreamExt;
-    if let Some(input) = input {
-        let mut output_stream: OutputStream = input.into();
-        loop {
-            match output_stream.try_next().await {
-                Ok(Some(ReturnSuccess::Value(Value {
-                    value: UntaggedValue::Error(e),
-                    ..
-                }))) => return Err(e),
-                Ok(Some(_item)) => {
-                    if ctx.ctrl_c.load(Ordering::SeqCst) {
-                        break;
-                    }
-                }
-                _ => {
-                    break;
-                }
-            }
-        }
-    }
-
-    Ok(())
+    Ok(input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod shell;
 mod stream;
 mod utils;
 
-pub use crate::cli::cli;
+pub use crate::cli::{cli, run_pipeline_standalone};
 pub use crate::data::dict::TaggedListBuilder;
 pub use crate::data::primitive;
 pub use crate::data::value;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("commands")
+                .short("c")
+                .long("commands")
+                .multiple(false)
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("develop")
                 .long("develop")
                 .multiple(true)
@@ -60,6 +67,16 @@ fn main() -> Result<(), Box<dyn Error>> {
             for item in values {
                 builder.filter_module(&format!("nu::{}", item), LevelFilter::Debug);
             }
+        }
+    }
+
+    match matches.values_of("commands") {
+        None => {}
+        Some(values) => {
+            for item in values {
+                futures::executor::block_on(nu::run_pipeline_standalone(item.into()))?;
+            }
+            return Ok(());
         }
     }
 


### PR DESCRIPTION
This updates how we sink the pipeline and opens us up to some new features in the future:

* Moves where autoview is assumed out of `run_pipeline`. This means that `run_pipeline` will now output a stream that can be later consumed. In the future, this will allow blocks to hold a pipeline and evaluate it without viewing it.
* Adds a `-c` commandline flag to pass in a pipeline of commands via a string that is run to completions. Note: stdin redirection is not yet supported
