### PR TITLE
No textview autoview

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -394,7 +394,19 @@ pub async fn run_pipeline_standalone(pipeline: String) -> Result<(), Box<dyn Err
 
     match line {
         LineResult::Success(line) => {
+            let error_code = {
+                let errors = context.current_errors.clone();
+                let errors = errors.lock();
+
+                if errors.len() > 0 {
+                    1
+                } else {
+                    0
+                }
+            };
+
             context.maybe_print_errors(Text::from(line));
+            std::process::exit(error_code);
         }
 
         LineResult::Error(line, err) => {
@@ -403,6 +415,7 @@ pub async fn run_pipeline_standalone(pipeline: String) -> Result<(), Box<dyn Err
             });
 
             context.maybe_print_errors(Text::from(line));
+            std::process::exit(1);
         }
 
         _ => {}

--- a/src/commands/autoview.rs
+++ b/src/commands/autoview.rs
@@ -64,7 +64,7 @@ impl RunnableContextWithoutInput {
 
 pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
     let binary = context.get_command("binaryview");
-    let text = context.get_command("textview");
+    //let text = context.get_command("textview");
     let table = context.get_command("table");
 
     Ok(OutputStream::new(async_stream! {
@@ -101,38 +101,10 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                     _ => {
                         match x {
                             Value {
-                                value: UntaggedValue::Primitive(Primitive::String(ref s)),
-                                tag: Tag { anchor, span },
-                            } if anchor.is_some() => {
-                                if let Some(text) = text {
-                                    let mut stream = VecDeque::new();
-                                    stream.push_back(UntaggedValue::string(s).into_value(Tag { anchor, span }));
-                                    let command_args = create_default_command_args(&context).with_input(stream);
-                                    let result = text.run(command_args, &context.commands);
-                                    result.collect::<Vec<_>>().await;
-                                } else {
-                                    outln!("{}", s);
-                                }
-                            }
-                            Value {
                                 value: UntaggedValue::Primitive(Primitive::String(s)),
                                 ..
                             } => {
                                 outln!("{}", s);
-                            }
-                            Value {
-                                value: UntaggedValue::Primitive(Primitive::Line(ref s)),
-                                tag: Tag { anchor, span },
-                            } if anchor.is_some() => {
-                                if let Some(text) = text {
-                                    let mut stream = VecDeque::new();
-                                    stream.push_back(UntaggedValue::string(s).into_value(Tag { anchor, span }));
-                                    let command_args = create_default_command_args(&context).with_input(stream);
-                                    let result = text.run(command_args, &context.commands);
-                                    result.collect::<Vec<_>>().await;
-                                } else {
-                                    outln!("{}\n", s);
-                                }
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Line(s)),


### PR DESCRIPTION
This removes the automatic `textview` from `autoview`. It would use this in cases where the anchor told the file type. Unfortunately, in practice this would trip up usage as it would take time to colorize and sometimes it would colorize text you didn't want to colorize.

It's easy enough to open `textview` manually at the end of a pipeline or open a file in an editor. This seems like a good idea that didn't quite pan out.