### PR TITLE
Do not panic when failing to decode lines from external stdout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,11 @@ name = "cococo"
 path = "crates/nu-test-support/src/bins/cococo.rs"
 required-features = ["test-bins"]
 
+[[bin]]
+name = "nonu"
+path = "crates/nu-test-support/src/bins/nonu.rs"
+required-features = ["test-bins"]
+
 # Core plugins that ship with `cargo install nu` by default
 # Currently, Cargo limits us to installing only one binary
 # unless we use [[bin]], so we use this as a workaround

--- a/crates/nu-test-support/src/bins/nonu.rs
+++ b/crates/nu-test-support/src/bins/nonu.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::env::args().skip(1).for_each(|arg| print!("{}", arg));
+}

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -78,6 +78,24 @@ mod it_evaluation {
     }
 }
 
+mod stdin_evaluation {
+    use super::nu_error;
+    use nu_test_support::pipeline;
+
+    #[test]
+    fn does_not_panic_with_no_newline_in_stream() {
+        let stderr = nu_error!(
+            cwd: ".",
+            pipeline(r#"
+                nonu "where's the nuline?"
+                | count
+            "#
+        ));
+
+        assert_eq!(stderr, "");
+    }
+}
+
 mod external_words {
     use super::nu;
 


### PR DESCRIPTION
Part of an effort to reduce the number of panics, this will simply error with an informative message when we can't properly decode stdin. This only happens when an external's stdin doesn't put a newline at the end of the stream.

Related issue: https://github.com/nushell/nushell/issues/1355