### PR TITLE
Add some nu_source docs for meta.rs

### DIFF
--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -160,7 +160,6 @@ impl<T> std::ops::Deref for Tagged<T> {
 }
 
 impl<T> Tagged<T> {
-
     pub fn map<U>(self, input: impl FnOnce(T) -> U) -> Tagged<U> {
         let tag = self.tag();
 
@@ -370,7 +369,7 @@ impl Tag {
         self.anchor.clone()
     }
 
-    // Merges the current `Tag` with the given `Tag`. 
+    // Merges the current `Tag` with the given `Tag`.
     ///
     /// Both Tags must share the same `AnchorLocation`.
     // The resulting `Tag` will have a `Span` that starts from the current `Tag` and ends at `Span` of the given `Tag`.
@@ -387,7 +386,7 @@ impl Tag {
         }
     }
 
-    /// Merges the current `Tag` with the given optional `Tag`. 
+    /// Merges the current `Tag` with the given optional `Tag`.
     ///
     /// Both `Tag`s must share the same `AnchorLocation`.
     /// The resulting `Tag` will have a `Span` that starts from the current `Tag` and ends at `Span` of the given `Tag`.
@@ -581,7 +580,7 @@ impl Span {
         Span::new(self.start, other.end)
     }
 
-    /// Returns a new Span by merging a later Span with the current Span. 
+    /// Returns a new Span by merging a later Span with the current Span.
     ///
     /// If the given Span is of the None variant,
     /// A Span with the same values as the current Span is returned.

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -608,17 +608,27 @@ impl Span {
         self.slice(source).to_string().spanned(*self)
     }
 
-    /// Returns the start value of the current Span.
+    /// Returns the start position of the current Span.
     pub fn start(&self) -> usize {
         self.start
     }
 
-    /// Returns the end value of the current Span.
+    /// Returns the end position of the current Span.
     pub fn end(&self) -> usize {
         self.end
     }
 
     /// Returns a bool if the current Span indicates an "unknown"  position.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let unknown_span = Span::unknown();
+    /// let known_span = Span::new(4, 6);
+    ///
+    /// assert_eq!(unknown_span.is_unknown(), true);
+    /// assert_eq!(known_span.is_unknown(), false);
+    /// ```
     pub fn is_unknown(&self) -> bool {
         self.start == 0 && self.end == 0
     }

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -519,6 +519,7 @@ impl Span {
     }
 
     // Returns a new Span by merging an earlier Span with the current Span.
+    // The resulting Span will have the same start position as the given Span and same end as the current Span.
     pub fn since(&self, other: impl Into<Span>) -> Span {
         let other = other.into();
 
@@ -526,6 +527,7 @@ impl Span {
     }
 
     // Returns a new Span by merging a later Span with the current Span.
+    // The resulting Span will have the same start position as the current Span and same end as the given Span.
     pub fn until(&self, other: impl Into<Span>) -> Span {
         let other = other.into();
 

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -135,9 +135,9 @@ pub trait TaggedItem: Sized {
         }
     }
 
-    /// For now, this is a temporary facility. In many cases, there are other useful spans that we
-    /// could be using, such as the original source spans of JSON or Toml files, but we don't yet
-    /// have the infrastructure to make that work.
+    // For now, this is a temporary facility. In many cases, there are other useful spans that we
+    // could be using, such as the original source spans of JSON or Toml files, but we don't yet
+    // have the infrastructure to make that work.
     fn tagged_unknown(self) -> Tagged<Self> {
         Tagged {
             item: self,

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -135,9 +135,9 @@ pub trait TaggedItem: Sized {
         }
     }
 
-    // For now, this is a temporary facility. In many cases, there are other useful spans that we
-    // could be using, such as the original source spans of JSON or Toml files, but we don't yet
-    // have the infrastructure to make that work.
+    /// For now, this is a temporary facility. In many cases, there are other useful spans that we
+    /// could be using, such as the original source spans of JSON or Toml files, but we don't yet
+    /// have the infrastructure to make that work.
     fn tagged_unknown(self) -> Tagged<Self> {
         Tagged {
             item: self,
@@ -186,22 +186,22 @@ impl<T> Tagged<T> {
         }
     }
 
-    // Creates a new tab from the current Tag
+    /// Creates a new `Tag` from the current `Tag`
     pub fn tag(&self) -> Tag {
         self.tag.clone()
     }
 
-    // Retrieve the Span for the current Tag.
+    /// Retrieve the `Span` for the current `Tag`.
     pub fn span(&self) -> Span {
         self.tag.span
     }
 
-    // Returns the AnchorLocation of the Tag if there is one.
+    /// Returns the `AnchorLocation` of the `Tag` if there is one.
     pub fn anchor(&self) -> Option<AnchorLocation> {
         self.tag.anchor.clone()
     }
 
-    // Returns the underlying AnchorLocation variant type as a string.
+    /// Returns the underlying `AnchorLocation` variant type as a string.
     pub fn anchor_name(&self) -> Option<String> {
         match self.tag.anchor {
             Some(AnchorLocation::File(ref file)) => Some(file.clone()),
@@ -210,12 +210,12 @@ impl<T> Tagged<T> {
         }
     }
 
-    // Returns a reference to the current Tag's item.
+    /// Returns a reference to the current `Tag`'s item.
     pub fn item(&self) -> &T {
         &self.item
     }
 
-    // Returns a tuple of the Tagged item and Tag.
+    /// Returns a tuple of the `Tagged` item and `Tag`.
     pub fn into_parts(self) -> (T, Tag) {
         (self.item, self.tag)
     }
@@ -336,12 +336,12 @@ impl From<&Tag> for Span {
 }
 
 impl Tag {
-    // Creates a Tag from the given Span with no AnchorLocation
+    /// Creates a `Tag` from the given `Span` with no `AnchorLocation`
     pub fn unknown_anchor(span: Span) -> Tag {
         Tag { anchor: None, span }
     }
 
-    // Creates a Tag from the given AnchorLocation for a span with a length of 1.
+    /// Creates a `Tag` from the given `AnchorLocation` for a span with a length of 1.
     pub fn for_char(pos: usize, anchor: AnchorLocation) -> Tag {
         Tag {
             anchor: Some(anchor),
@@ -349,7 +349,7 @@ impl Tag {
         }
     }
 
-    // Creates a Tag for the given AnchorLocatrion with unknown Span information.
+    /// Creates a `Tag` for the given `AnchorLocatrion` with unknown `Span` position.
     pub fn unknown_span(anchor: AnchorLocation) -> Tag {
         Tag {
             anchor: Some(anchor),
@@ -357,7 +357,7 @@ impl Tag {
         }
     }
 
-    // Creates a Tag with no AnchorLocation and an unknown Span.
+    /// Creates a `Tag` with no `AnchorLocation` and an unknown `Span` position.
     pub fn unknown() -> Tag {
         Tag {
             anchor: None,
@@ -365,13 +365,15 @@ impl Tag {
         }
     }
 
-    // Returns the AnchorLocation of the current Tag
+    /// Returns the `AnchorLocation` of the current `Tag`
     pub fn anchor(&self) -> Option<AnchorLocation> {
         self.anchor.clone()
     }
 
-    // Merges the current Tag with the given Tag. Both Tags must share the same AnchorLocation.
-    // The resulting Tag will have a Span that starts from the current Tag and ends at Span of the given Tag.
+    // Merges the current `Tag` with the given `Tag`. 
+    ///
+    /// Both Tags must share the same `AnchorLocation`.
+    // The resulting `Tag` will have a `Span` that starts from the current `Tag` and ends at `Span` of the given `Tag`.
     pub fn until(&self, other: impl Into<Tag>) -> Tag {
         let other = other.into();
         debug_assert!(
@@ -385,9 +387,11 @@ impl Tag {
         }
     }
 
-    // Merges the current Tag with the given optional Tag. Both Tags must share the same AnchorLocation.
-    // The resulting Tag will have a Span that starts from the current Tag and ends at Span of the given Tag.
-    // Should the None variant be passed in, a new Tag with the same Span and Anchorlocation will be returned.
+    /// Merges the current `Tag` with the given optional `Tag`. 
+    ///
+    /// Both `Tag`s must share the same `AnchorLocation`.
+    /// The resulting `Tag` will have a `Span` that starts from the current `Tag` and ends at `Span` of the given `Tag`.
+    /// Should the `None` variant be passed in, a new `Tag` with the same `Span` and `Anchorlocation` will be returned.
     pub fn until_option(&self, other: Option<impl Into<Tag>>) -> Tag {
         match other {
             Some(other) => {
@@ -463,9 +467,10 @@ pub fn span_for_spanned_list(mut iter: impl Iterator<Item = Span>) -> Span {
     }
 }
 
-// A Span is metadata which indicates the start and end positions.
-// Spans are combined with AnchorLocations to form another type of metadata, a Tag.
-// A Span's end position must be greater than or equal to its start position.
+/// A `Span` is metadata which indicates the start and end positions.
+///
+/// `Span`s are combined with `AnchorLocation`s to form another type of metadata, a `Tag`.
+/// A `Span`'s end position must be greater than or equal to its start position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct Span {
     start: usize,
@@ -488,12 +493,12 @@ impl From<Option<Span>> for Span {
 }
 
 impl Span {
-    // Creates a new span that has 0 start and 0 end.
+    /// Creates a new `Span` that has 0 start and 0 end.
     pub fn unknown() -> Span {
         Span::new(0, 0)
     }
 
-    // Creates a new span from start and end inputs. The end parameter must be greater than or equal to the start parameter.
+    /// Creates a new `Span` from start and end inputs. The end parameter must be greater than or equal to the start parameter.
     pub fn new(start: usize, end: usize) -> Span {
         assert!(
             end >= start,
@@ -505,7 +510,16 @@ impl Span {
         Span { start, end }
     }
 
-    // Creates a Span with a length of 1 from the given position.
+    /// Creates a `Span` with a length of 1 from the given position.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let char_span = Span::for_char(5);
+    ///
+    /// assert_eq!(char_span.start(), 5);
+    /// assert_eq!(char_span.end(), 6);
+    /// ```
     pub fn for_char(pos: usize) -> Span {
         Span {
             start: pos,
@@ -513,29 +527,64 @@ impl Span {
         }
     }
 
-    // Returns a bool indicating if the given position falls inside the current Span.
+    /// Returns a bool indicating if the given position falls inside the current `Span`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let span = Span::new(2, 8);
+    ///
+    /// assert_eq!(span.contains(5), true);
+    /// assert_eq!(span.contains(100), false);
+    /// ```
     pub fn contains(&self, pos: usize) -> bool {
         self.start <= pos && self.end >= pos
     }
 
-    // Returns a new Span by merging an earlier Span with the current Span.
-    // The resulting Span will have the same start position as the given Span and same end as the current Span.
+    /// Returns a new Span by merging an earlier Span with the current Span.
+    ///
+    /// The resulting Span will have the same start position as the given Span and same end as the current Span.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let original_span = Span::new(4, 6);
+    /// let earlier_span = Span::new(1, 3);
+    /// let merged_span = origin_span.since(earlier_span);
+    ///
+    /// assert_eq!(merged_span.start(), 1);
+    /// assert_eq!(merged_span.end(), 6);
+    /// ```
     pub fn since(&self, other: impl Into<Span>) -> Span {
         let other = other.into();
 
         Span::new(other.start, self.end)
     }
 
-    // Returns a new Span by merging a later Span with the current Span.
-    // The resulting Span will have the same start position as the current Span and same end as the given Span.
+    /// Returns a new Span by merging a later Span with the current Span.
+    ///
+    /// The resulting Span will have the same start position as the current Span and same end as the given Span.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let original_span = Span::new(4, 6);
+    /// let later_span = Span::new(9, 11);
+    /// let merged_span = origin_span.until(later_span);
+    ///
+    /// assert_eq!(merged_span.start(), 4);
+    /// assert_eq!(merged_span.end(), 11);
+    /// ```
     pub fn until(&self, other: impl Into<Span>) -> Span {
         let other = other.into();
 
         Span::new(self.start, other.end)
     }
 
-    // Returns a new Span by merging a later Span with the current Span. If the given Span is of the None variant,
-    // A Span with the same values as the current Span is returned.
+    /// Returns a new Span by merging a later Span with the current Span. 
+    ///
+    /// If the given Span is of the None variant,
+    /// A Span with the same values as the current Span is returned.
     pub fn until_option(&self, other: Option<impl Into<Span>>) -> Span {
         match other {
             Some(other) => {
@@ -559,22 +608,22 @@ impl Span {
         self.slice(source).to_string().spanned(*self)
     }
 
-    // Returns the start value of the current Span.
+    /// Returns the start value of the current Span.
     pub fn start(&self) -> usize {
         self.start
     }
 
-    // Returns the end value of the current Span.
+    /// Returns the end value of the current Span.
     pub fn end(&self) -> usize {
         self.end
     }
 
-    // Returns a bool if the current Span indicates an "unknown"  position.
+    /// Returns a bool if the current Span indicates an "unknown"  position.
     pub fn is_unknown(&self) -> bool {
         self.start == 0 && self.end == 0
     }
 
-    // Returns a slice of the input that covers the start and end of the current Span.
+    /// Returns a slice of the input that covers the start and end of the current Span.
     pub fn slice<'a>(&self, source: &'a str) -> &'a str {
         &source[self.start..self.end]
     }

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -160,6 +160,7 @@ impl<T> std::ops::Deref for Tagged<T> {
 }
 
 impl<T> Tagged<T> {
+
     pub fn map<U>(self, input: impl FnOnce(T) -> U) -> Tagged<U> {
         let tag = self.tag();
 
@@ -185,18 +186,22 @@ impl<T> Tagged<T> {
         }
     }
 
+    // Creates a new tab from the current Tag
     pub fn tag(&self) -> Tag {
         self.tag.clone()
     }
 
+    // Retrieve the Span for the current Tag.
     pub fn span(&self) -> Span {
         self.tag.span
     }
 
+    // Returns the AnchorLocation of the Tag if there is one.
     pub fn anchor(&self) -> Option<AnchorLocation> {
         self.tag.anchor.clone()
     }
 
+    // Returns the underlying AnchorLocation variant type as a string.
     pub fn anchor_name(&self) -> Option<String> {
         match self.tag.anchor {
             Some(AnchorLocation::File(ref file)) => Some(file.clone()),
@@ -205,10 +210,12 @@ impl<T> Tagged<T> {
         }
     }
 
+    // Returns a reference to the current Tag's item.
     pub fn item(&self) -> &T {
         &self.item
     }
 
+    // Returns a tuple of the Tagged item and Tag.
     pub fn into_parts(self) -> (T, Tag) {
         (self.item, self.tag)
     }
@@ -329,10 +336,12 @@ impl From<&Tag> for Span {
 }
 
 impl Tag {
+    // Creates a Tag from the given Span with no AnchorLocation
     pub fn unknown_anchor(span: Span) -> Tag {
         Tag { anchor: None, span }
     }
 
+    // Creates a Tag from the given AnchorLocation for a span with a length of 1.
     pub fn for_char(pos: usize, anchor: AnchorLocation) -> Tag {
         Tag {
             anchor: Some(anchor),
@@ -340,6 +349,7 @@ impl Tag {
         }
     }
 
+    // Creates a Tag for the given AnchorLocatrion with unknown Span information.
     pub fn unknown_span(anchor: AnchorLocation) -> Tag {
         Tag {
             anchor: Some(anchor),
@@ -347,6 +357,7 @@ impl Tag {
         }
     }
 
+    // Creates a Tag with no AnchorLocation and an unknown Span.
     pub fn unknown() -> Tag {
         Tag {
             anchor: None,
@@ -354,10 +365,13 @@ impl Tag {
         }
     }
 
+    // Returns the AnchorLocation of the current Tag
     pub fn anchor(&self) -> Option<AnchorLocation> {
         self.anchor.clone()
     }
 
+    // Merges the current Tag with the given Tag. Both Tags must share the same AnchorLocation.
+    // The resulting Tag will have a Span that starts from the current Tag and ends at Span of the given Tag.
     pub fn until(&self, other: impl Into<Tag>) -> Tag {
         let other = other.into();
         debug_assert!(
@@ -371,6 +385,9 @@ impl Tag {
         }
     }
 
+    // Merges the current Tag with the given optional Tag. Both Tags must share the same AnchorLocation.
+    // The resulting Tag will have a Span that starts from the current Tag and ends at Span of the given Tag.
+    // Should the None variant be passed in, a new Tag with the same Span and Anchorlocation will be returned.
     pub fn until_option(&self, other: Option<impl Into<Tag>>) -> Tag {
         match other {
             Some(other) => {
@@ -446,6 +463,9 @@ pub fn span_for_spanned_list(mut iter: impl Iterator<Item = Span>) -> Span {
     }
 }
 
+// A Span is metadata which indicates the start and end positions.
+// Spans are combined with AnchorLocations to form another type of metadata, a Tag.
+// A Span's end position must be greater than or equal to its start position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct Span {
     start: usize,
@@ -468,10 +488,12 @@ impl From<Option<Span>> for Span {
 }
 
 impl Span {
+    // Creates a new span that has 0 start and 0 end.
     pub fn unknown() -> Span {
         Span::new(0, 0)
     }
 
+    // Creates a new span from start and end inputs. The end parameter must be greater than or equal to the start parameter.
     pub fn new(start: usize, end: usize) -> Span {
         assert!(
             end >= start,
@@ -483,6 +505,7 @@ impl Span {
         Span { start, end }
     }
 
+    // Creates a Span with a length of 1 from the given position.
     pub fn for_char(pos: usize) -> Span {
         Span {
             start: pos,
@@ -490,22 +513,27 @@ impl Span {
         }
     }
 
+    // Returns a bool indicating if the given position falls inside the current Span.
     pub fn contains(&self, pos: usize) -> bool {
         self.start <= pos && self.end >= pos
     }
 
+    // Returns a new Span by merging an earlier Span with the current Span.
     pub fn since(&self, other: impl Into<Span>) -> Span {
         let other = other.into();
 
         Span::new(other.start, self.end)
     }
 
+    // Returns a new Span by merging a later Span with the current Span.
     pub fn until(&self, other: impl Into<Span>) -> Span {
         let other = other.into();
 
         Span::new(self.start, other.end)
     }
 
+    // Returns a new Span by merging a later Span with the current Span. If the given Span is of the None variant,
+    // A Span with the same values as the current Span is returned.
     pub fn until_option(&self, other: Option<impl Into<Span>>) -> Span {
         match other {
             Some(other) => {
@@ -529,18 +557,22 @@ impl Span {
         self.slice(source).to_string().spanned(*self)
     }
 
+    // Returns the start value of the current Span.
     pub fn start(&self) -> usize {
         self.start
     }
 
+    // Returns the end value of the current Span.
     pub fn end(&self) -> usize {
         self.end
     }
 
+    // Returns a bool if the current Span indicates an "unknown"  position.
     pub fn is_unknown(&self) -> bool {
         self.start == 0 && self.end == 0
     }
 
+    // Returns a slice of the input that covers the start and end of the current Span.
     pub fn slice<'a>(&self, source: &'a str) -> &'a str {
         &source[self.start..self.end]
     }


### PR DESCRIPTION
Started filling in some documentation for the rest of the types and impls in `nu_source` `meta.rs`.