### PR TITLE
Fix invalid shorthand flag

### DIFF
--- a/src/commands/pivot.rs
+++ b/src/commands/pivot.rs
@@ -26,7 +26,7 @@ impl WholeStreamCommand for Pivot {
             .switch(
                 "header-row",
                 "treat the first row as column names",
-                Some('h'),
+                Some('r'),
             )
             .switch(
                 "ignore-titles",


### PR DESCRIPTION
I had accidentally assigned 'h' to a switch that wasn't help.