### PR TITLE
Force a \n at the end of a stdout stream

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -635,7 +635,9 @@ async fn process_line(
             }
 
             let input_stream = if redirect_stdin {
-                let file = futures::io::AllowStdIo::new(std::io::stdin());
+                let file = futures::io::AllowStdIo::new(
+                    crate::commands::classified::external::StdoutWithNewline::new(std::io::stdin()),
+                );
                 let stream = FramedRead::new(file, LinesCodec).map(|line| {
                     if let Ok(line) = line {
                         Ok(Value {

--- a/src/commands/classified/external.rs
+++ b/src/commands/classified/external.rs
@@ -398,7 +398,7 @@ impl<T: std::io::Read> std::io::Read for StdoutWithNewline<T> {
         match self.stdout.read(buf) {
             Err(e) => Err(e),
             Ok(0) => {
-                if !self.ended_in_newline && buf.len() > 0 {
+                if !self.ended_in_newline && !buf.is_empty() {
                     self.ended_in_newline = true;
                     buf[0] = b'\n';
                     Ok(1)


### PR DESCRIPTION
Fixes #1355 