### PR TITLE
Revert "Display rows in the same table regardless of their column order."

### DIFF
--- a/src/commands/table.rs
+++ b/src/commands/table.rs
@@ -72,21 +72,13 @@ fn table(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
                         Some(a) => {
                             if !new_input.is_empty() {
                                 if let Some(descs) = new_input.get(0) {
-
                                     let descs = descs.data_descriptors();
-                                    let descs_size = descs.len();
-
-                                    let a_descs = a.data_descriptors();
-
-                                    let mut compare = a_descs;
-                                    compare.extend(descs.into_iter());
-                                    compare.dedup();
-
-                                    if !compare.is_empty() {
-                                        new_input.push_back(a);
-                                    } else {
+                                    let compare = a.data_descriptors();
+                                    if descs != compare {
                                         delay_slot = Some(a);
                                         break;
+                                    } else {
+                                        new_input.push_back(a);
                                     }
                                 } else {
                                     new_input.push_back(a);

--- a/tests/shell/pipeline/mod.rs
+++ b/tests/shell/pipeline/mod.rs
@@ -1,40 +1,10 @@
 mod commands;
 
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::nu;
-use nu_test_support::playground::Playground;
 
 #[test]
 fn doesnt_break_on_utf8() {
     let actual = nu!(cwd: ".", "echo ö");
 
     assert_eq!(actual, "ö", "'{}' should contain ö", actual);
-}
-
-#[test]
-fn visualize_one_table_given_rows_with_same_columns_regardless_of_their_order_per_row() {
-    Playground::setup("visualize_table_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "unordered_columns.txt",
-            r#"
-                [
-                    {"name":"Andrés", "rusty_luck": 1         },
-                    {"rusty_luck": 1,       "name": "Jonathan"},
-                ]
-            "#,
-        )]);
-
-        let actual = nu!(
-            cwd: dirs.test(), "open unordered_columns.txt | from-json"
-        );
-
-        let name_column_indices: Vec<_> = actual.match_indices("name").collect();
-        let rusty_luck_column_indices: Vec<_> = actual.match_indices("rusty_luck").collect();
-
-        for (index, (name_index, _)) in name_column_indices.iter().enumerate() {
-            let (rusty_luck_index, _) = rusty_luck_column_indices[index];
-
-            assert!(name_index < &rusty_luck_index);
-        }
-    })
 }


### PR DESCRIPTION
Reverts nushell/nushell#1392

This had unintended consequences. Since we want to release tomorrow, we'll revert for now and look into a better fix later. 