### PR TITLE
Add support for compound shorthand flags

### DIFF
--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -1349,14 +1349,6 @@ mod tests {
     }
 
     #[test]
-    fn test_shorthand_flag() {
-        equal_tokens! {
-            <nodes>
-            "-katz" -> b::token_list(vec![b::shorthand("katz")])
-        }
-    }
-
-    #[test]
     fn test_variable() {
         equal_tokens! {
             <nodes>

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -685,7 +685,27 @@ pub fn token_list(input: NomSpan) -> IResult<NomSpan, Spanned<Vec<SpannedToken>>
 
                 break;
             }
-            Ok((after_node_input, next_node)) => (after_node_input, next_node),
+            Ok((after_node_input, next_node)) => {
+                let mut new_nodes = Vec::new();
+                for n in next_node {
+                    match n.unspanned() {
+                        Token::Flag(f) if f.kind == FlagKind::Shorthand && f.name > 1 => {
+                            new_nodes.push(TokenTreeBuilder::spanned_shorthand(
+                                Span::new(f.name.start(), f.name.start() + 1),
+                                Span::new(n.span().start(), f.name.start() + 1),
+                            ));
+                            for t in f.name.start() + 1..f.name.end() {
+                                new_nodes.push(TokenTreeBuilder::spanned_shorthand(
+                                    Span::for_char(t),
+                                    Span::for_char(t),
+                                ))
+                            }
+                        }
+                        _ => new_nodes.push(n),
+                    }
+                }
+                (after_node_input, new_nodes)
+            }
         };
 
         node_list.extend(next_nodes);

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -6,6 +6,7 @@ use derive_new::new;
 use getset::Getters;
 use serde::Deserialize;
 use serde::Serialize;
+use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 
 /// Anchors represent a location that a value originated from. The value may have been loaded from a file, fetched from a website, or parsed from some text
@@ -661,6 +662,18 @@ impl Span {
     /// Returns a slice of the input that covers the start and end of the current Span.
     pub fn slice<'a>(&self, source: &'a str) -> &'a str {
         &source[self.start..self.end]
+    }
+}
+
+impl PartialOrd<usize> for Span {
+    fn partial_cmp(&self, other: &usize) -> Option<Ordering> {
+        (self.end - self.start).partial_cmp(other)
+    }
+}
+
+impl PartialEq<usize> for Span {
+    fn eq(&self, other: &usize) -> bool {
+        (self.end - self.start) == *other
     }
 }
 


### PR DESCRIPTION
This will take a shorthand flag token from the tokenizer and break it up in to multiple shorthand flag tokens if the original token was longer than a single character.