### PR TITLE
Fix incorrect display for zero-size files

### DIFF
--- a/src/data/base/shape.rs
+++ b/src/data/base/shape.rs
@@ -156,10 +156,6 @@ impl PrettyDebug for FormatInlineShape {
             InlineShape::Bytesize(bytesize) => {
                 let byte = byte_unit::Byte::from_bytes(*bytesize as u128);
 
-                if byte.get_bytes() == 0u128 {
-                    return b::description("—".to_string());
-                }
-
                 let byte = byte.get_appropriate_unit(false);
 
                 match byte.get_unit() {

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -38,7 +38,7 @@ pub(crate) fn dir_entry_dict(
 
     if full || with_symlink_targets {
         if metadata.is_dir() || metadata.is_file() {
-            dict.insert_untagged("target", UntaggedValue::bytes(0u64));
+            dict.insert_untagged("target", UntaggedValue::nothing());
         } else if let Ok(path_to_link) = filename.read_link() {
             dict.insert_untagged(
                 "target",
@@ -84,7 +84,7 @@ pub(crate) fn dir_entry_dict(
     if metadata.is_file() {
         dict.insert_untagged("size", UntaggedValue::bytes(metadata.len() as u64));
     } else {
-        dict.insert_untagged("size", UntaggedValue::bytes(0u64));
+        dict.insert_untagged("size", UntaggedValue::nothing());
     }
 
     if full {

--- a/src/data/primitive.rs
+++ b/src/data/primitive.rs
@@ -12,7 +12,6 @@ pub fn number(number: impl Into<Number>) -> Primitive {
 
 pub fn style_primitive(primitive: &Primitive) -> &'static str {
     match primitive {
-        Primitive::Bytes(0) => "c", // centre 'missing' indicator
         Primitive::Int(_) | Primitive::Bytes(_) | Primitive::Decimal(_) => "r",
         _ => "",
     }


### PR DESCRIPTION
Fix #1410.

---

`Primitive::Bytes(0u64)` was used to express "Not Applicable", but `Primitive::Nothing` should be used instead.