### PR TITLE
Don't await streams from internals/externals in a pipeline.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,11 @@ name = "nonu"
 path = "crates/nu-test-support/src/bins/nonu.rs"
 required-features = ["test-bins"]
 
+[[bin]]
+name = "iecho"
+path = "crates/nu-test-support/src/bins/iecho.rs"
+required-features = ["test-bins"]
+
 # Core plugins that ship with `cargo install nu` by default
 # Currently, Cargo limits us to installing only one binary
 # unless we use [[bin]], so we use this as a workaround

--- a/crates/nu-test-support/src/bins/iecho.rs
+++ b/crates/nu-test-support/src/bins/iecho.rs
@@ -1,0 +1,13 @@
+use std::io::{self, Write};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    // println! panics if stdout gets closed, whereas writeln gives us an error
+    let mut stdout = io::stdout();
+    let _ = args
+        .iter()
+        .skip(1)
+        .cycle()
+        .try_for_each(|v| writeln!(stdout, "{}", v));
+}

--- a/src/commands/classified/internal.rs
+++ b/src/commands/classified/internal.rs
@@ -5,7 +5,7 @@ use nu_errors::ShellError;
 use nu_parser::InternalCommand;
 use nu_protocol::{CommandAction, Primitive, ReturnSuccess, UntaggedValue, Value};
 
-pub(crate) async fn run_internal_command(
+pub(crate) fn run_internal_command(
     command: InternalCommand,
     context: &mut Context,
     input: Option<InputStream>,

--- a/src/commands/classified/pipeline.rs
+++ b/src/commands/classified/pipeline.rs
@@ -31,15 +31,15 @@ pub(crate) async fn run_pipeline(
             (_, Some(ClassifiedCommand::Error(err))) => return Err(err.clone().into()),
 
             (Some(ClassifiedCommand::Internal(left)), _) => {
-                run_internal_command(left, ctx, input, Text::from(line)).await?
+                run_internal_command(left, ctx, input, Text::from(line))?
             }
 
             (Some(ClassifiedCommand::External(left)), None) => {
-                run_external_command(left, ctx, input, true).await?
+                run_external_command(left, ctx, input, true)?
             }
 
             (Some(ClassifiedCommand::External(left)), _) => {
-                run_external_command(left, ctx, input, false).await?
+                run_external_command(left, ctx, input, false)?
             }
 
             (None, _) => break,

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -1,0 +1,73 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{self, Poll, Waker};
+use std::thread;
+
+struct SharedState<T: Send + 'static> {
+    result: Option<T>,
+    waker: Option<Waker>,
+}
+
+pub struct ThreadedFuture<T: Send + 'static> {
+    shared_state: Arc<Mutex<SharedState<T>>>,
+}
+
+impl<T: Send + 'static> ThreadedFuture<T> {
+    pub fn new(f: impl FnOnce() -> T + Send + 'static) -> ThreadedFuture<T> {
+        let shared_state = Arc::new(Mutex::new(SharedState {
+            result: None,
+            waker: None,
+        }));
+
+        // Clone everything to avoid lifetimes
+        let thread_shared_state = shared_state.clone();
+        thread::spawn(move || {
+            let result = f();
+
+            let mut shared_state = thread_shared_state
+                .lock()
+                .expect("ThreadedFuture shared state shouldn't be poisoned");
+
+            shared_state.result = Some(result);
+            if let Some(waker) = shared_state.waker.take() {
+                waker.wake();
+            }
+        });
+
+        ThreadedFuture { shared_state }
+    }
+}
+
+impl<T: Send + 'static> Future for ThreadedFuture<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let mut shared_state = self
+            .shared_state
+            .lock()
+            .expect("ThreadedFuture shared state shouldn't be poisoned");
+
+        if let Some(result) = shared_state.result.take() {
+            Poll::Ready(result)
+        } else {
+            shared_state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod threaded_future {
+        use super::super::ThreadedFuture;
+        use futures::executor::block_on;
+
+        #[test]
+        fn returns_expected_result() {
+            let future = ThreadedFuture::new(|| 42);
+            let result = block_on(future);
+            assert_eq!(42, result);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod deserializer;
 mod env;
 mod evaluate;
 mod format;
+mod futures;
 mod git;
 mod shell;
 mod stream;

--- a/tests/commands/touch.rs
+++ b/tests/commands/touch.rs
@@ -1,15 +1,12 @@
-use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 
 #[test]
-fn adds_a_file() {
-    Playground::setup("add_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("i_will_be_created.txt")]);
-
+fn creates_a_file_when_it_doesnt_exist() {
+    Playground::setup("create_test_1", |dirs, _sandbox| {
         nu!(
-            cwd: dirs.root(),
-            "touch touch_test/i_will_be_created.txt"
+            cwd: dirs.test(),
+            "touch i_will_be_created.txt"
         );
 
         let path = dirs.test().join("i_will_be_created.txt");

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -117,6 +117,23 @@ mod stdin_evaluation {
 
         assert_eq!(stderr, "");
     }
+
+    /* Currently runs forever, but should not be the case
+    #[test]
+    fn does_not_block_indefinitely() {
+        let stdout = nu!(
+            cwd: ".",
+            pipeline(r#"
+                iecho yes
+                | chop
+                | chop
+                | first 1
+            "#
+        ));
+
+        assert_eq!(stdout, "ye");
+    }
+    */
 }
 
 mod external_words {


### PR DESCRIPTION
This is the first of a series of commits to improve pipelines. In particular, one thing that we can't (properly) do today is consume an infinite input stream. For example:

```
yes | grep y | head -n10
```

will give 10 "y"s in most shells, but blocks forever in nu.