### PR TITLE
Let `ls` ignore permission errors

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -10,4 +10,3 @@ pub mod value;
 pub(crate) use command::command_dict;
 pub(crate) use dict::TaggedListBuilder;
 pub(crate) use files::dir_entry_dict;
-pub(crate) use files::empty_dir_entry_dict;

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,3 +10,4 @@ pub mod value;
 pub(crate) use command::command_dict;
 pub(crate) use dict::TaggedListBuilder;
 pub(crate) use files::dir_entry_dict;
+pub(crate) use files::empty_dir_entry_dict;

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -32,7 +32,7 @@ pub(crate) fn empty_dir_entry_dict(
         dict.insert_untagged("target", UntaggedValue::nothing());
     }
 
-    if full {   
+    if full {
         dict.insert_untagged("readonly", UntaggedValue::nothing());
 
         #[cfg(unix)]
@@ -51,7 +51,7 @@ pub(crate) fn empty_dir_entry_dict(
     }
 
     dict.insert_untagged("modified", UntaggedValue::nothing());
-    
+
     Ok(dict.into_value())
 }
 

--- a/src/data/files.rs
+++ b/src/data/files.rs
@@ -2,62 +2,9 @@ use crate::prelude::*;
 use nu_errors::ShellError;
 use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
 
-pub(crate) fn empty_dir_entry_dict(
-    filename: &std::path::Path,
-    tag: impl Into<Tag>,
-    full: bool,
-    name_only: bool,
-    with_symlink_targets: bool,
-) -> Result<Value, ShellError> {
-    let tag = tag.into();
-    let mut dict = TaggedDictBuilder::new(&tag);
-
-    let name = if name_only {
-        filename.file_name().and_then(|s| s.to_str())
-    } else {
-        filename.to_str()
-    }
-    .ok_or_else(|| {
-        ShellError::labeled_error(
-            format!("Invalid file name: {:}", filename.to_string_lossy()),
-            "invalid file name",
-            tag,
-        )
-    })?;
-
-    dict.insert_untagged("name", UntaggedValue::string(name));
-    dict.insert_untagged("type", UntaggedValue::nothing());
-
-    if full || with_symlink_targets {
-        dict.insert_untagged("target", UntaggedValue::nothing());
-    }
-
-    if full {
-        dict.insert_untagged("readonly", UntaggedValue::nothing());
-
-        #[cfg(unix)]
-        {
-            dict.insert_untagged("mode", UntaggedValue::nothing());
-            dict.insert_untagged("uid", UntaggedValue::nothing());
-            dict.insert_untagged("group", UntaggedValue::nothing());
-        }
-    }
-
-    dict.insert_untagged("size", UntaggedValue::nothing());
-
-    if full {
-        dict.insert_untagged("created", UntaggedValue::nothing());
-        dict.insert_untagged("accessed", UntaggedValue::nothing());
-    }
-
-    dict.insert_untagged("modified", UntaggedValue::nothing());
-
-    Ok(dict.into_value())
-}
-
 pub(crate) fn dir_entry_dict(
     filename: &std::path::Path,
-    metadata: &std::fs::Metadata,
+    metadata: Option<&std::fs::Metadata>,
     tag: impl Into<Tag>,
     full: bool,
     name_only: bool,
@@ -81,77 +28,110 @@ pub(crate) fn dir_entry_dict(
 
     dict.insert_untagged("name", UntaggedValue::string(name));
 
-    if metadata.is_dir() {
-        dict.insert_untagged("type", UntaggedValue::string("Dir"));
-    } else if metadata.is_file() {
-        dict.insert_untagged("type", UntaggedValue::string("File"));
+    if let Some(md) = metadata {
+        if md.is_dir() {
+            dict.insert_untagged("type", UntaggedValue::string("Dir"));
+        } else if md.is_file() {
+            dict.insert_untagged("type", UntaggedValue::string("File"));
+        } else {
+            dict.insert_untagged("type", UntaggedValue::string("Symlink"));
+        }
     } else {
-        dict.insert_untagged("type", UntaggedValue::string("Symlink"));
-    };
+        dict.insert_untagged("type", UntaggedValue::nothing());
+    }
 
     if full || with_symlink_targets {
-        if metadata.is_dir() || metadata.is_file() {
-            dict.insert_untagged("target", UntaggedValue::nothing());
-        } else if let Ok(path_to_link) = filename.read_link() {
-            dict.insert_untagged(
-                "target",
-                UntaggedValue::string(path_to_link.to_string_lossy()),
-            );
+        if let Some(md) = metadata {
+            if md.is_dir() || md.is_file() {
+                dict.insert_untagged("target", UntaggedValue::nothing());
+            } else if let Ok(path_to_link) = filename.read_link() {
+                dict.insert_untagged(
+                    "target",
+                    UntaggedValue::string(path_to_link.to_string_lossy()),
+                );
+            } else {
+                dict.insert_untagged(
+                    "target",
+                    UntaggedValue::string("Could not obtain target file's path"),
+                );
+            }
         } else {
-            dict.insert_untagged(
-                "target",
-                UntaggedValue::string("Could not obtain target file's path"),
-            );
+            dict.insert_untagged("target", UntaggedValue::nothing());
         }
     }
 
     if full {
-        dict.insert_untagged(
-            "readonly",
-            UntaggedValue::boolean(metadata.permissions().readonly()),
-        );
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt;
-            use std::os::unix::fs::PermissionsExt;
-            let mode = metadata.permissions().mode();
+        if let Some(md) = metadata {
             dict.insert_untagged(
-                "mode",
-                UntaggedValue::string(umask::Mode::from(mode).to_string()),
+                "readonly",
+                UntaggedValue::boolean(md.permissions().readonly()),
             );
 
-            if let Some(user) = users::get_user_by_uid(metadata.uid()) {
-                dict.insert_untagged("uid", UntaggedValue::string(user.name().to_string_lossy()));
-            }
-
-            if let Some(group) = users::get_group_by_gid(metadata.gid()) {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::MetadataExt;
+                use std::os::unix::fs::PermissionsExt;
+                let mode = md.permissions().mode();
                 dict.insert_untagged(
-                    "group",
-                    UntaggedValue::string(group.name().to_string_lossy()),
+                    "mode",
+                    UntaggedValue::string(umask::Mode::from(mode).to_string()),
                 );
+
+                if let Some(user) = users::get_user_by_uid(md.uid()) {
+                    dict.insert_untagged(
+                        "uid",
+                        UntaggedValue::string(user.name().to_string_lossy()),
+                    );
+                }
+
+                if let Some(group) = users::get_group_by_gid(md.gid()) {
+                    dict.insert_untagged(
+                        "group",
+                        UntaggedValue::string(group.name().to_string_lossy()),
+                    );
+                }
+            }
+        } else {
+            dict.insert_untagged("readonly", UntaggedValue::nothing());
+
+            #[cfg(unix)]
+            {
+                dict.insert_untagged("mode", UntaggedValue::nothing());
             }
         }
     }
 
-    if metadata.is_file() {
-        dict.insert_untagged("size", UntaggedValue::bytes(metadata.len() as u64));
+    if let Some(md) = metadata {
+        if md.is_file() {
+            dict.insert_untagged("size", UntaggedValue::bytes(md.len() as u64));
+        } else {
+            dict.insert_untagged("size", UntaggedValue::nothing());
+        }
     } else {
         dict.insert_untagged("size", UntaggedValue::nothing());
     }
 
-    if full {
-        if let Ok(c) = metadata.created() {
-            dict.insert_untagged("created", UntaggedValue::system_date(c));
+    if let Some(md) = metadata {
+        if full {
+            if let Ok(c) = md.created() {
+                dict.insert_untagged("created", UntaggedValue::system_date(c));
+            }
+
+            if let Ok(a) = md.accessed() {
+                dict.insert_untagged("accessed", UntaggedValue::system_date(a));
+            }
         }
 
-        if let Ok(a) = metadata.accessed() {
-            dict.insert_untagged("accessed", UntaggedValue::system_date(a));
+        if let Ok(m) = md.modified() {
+            dict.insert_untagged("modified", UntaggedValue::system_date(m));
         }
-    }
+    } else {
+        if full {
+            dict.insert_untagged("created", UntaggedValue::nothing());
+            dict.insert_untagged("accessed", UntaggedValue::nothing());
+        }
 
-    if let Ok(m) = metadata.modified() {
-        dict.insert_untagged("modified", UntaggedValue::system_date(m));
+        dict.insert_untagged("modified", UntaggedValue::nothing());
     }
 
     Ok(dict.into_value())

--- a/src/shell/filesystem_shell.rs
+++ b/src/shell/filesystem_shell.rs
@@ -4,7 +4,7 @@ use crate::commands::ls::LsArgs;
 use crate::commands::mkdir::MkdirArgs;
 use crate::commands::mv::MoveArgs;
 use crate::commands::rm::RemoveArgs;
-use crate::data::{dir_entry_dict, empty_dir_entry_dict};
+use crate::data::dir_entry_dict;
 use crate::prelude::*;
 use crate::shell::completer::NuCompleter;
 use crate::shell::shell::Shell;
@@ -142,7 +142,7 @@ impl Shell for FilesystemShell {
                 match path {
                     Ok(p) => match std::fs::symlink_metadata(&p) {
                         Ok(m) => {
-                            match dir_entry_dict(&p, &m, name_tag.clone(), full, short_names, with_symlink_targets) {
+                            match dir_entry_dict(&p, Some(&m), name_tag.clone(), full, short_names, with_symlink_targets) {
                                 Ok(d) => yield ReturnSuccess::value(d),
                                 Err(e) => yield Err(e)
                             }
@@ -150,7 +150,7 @@ impl Shell for FilesystemShell {
                         Err(e) => {
                             match e.kind() {
                                 PermissionDenied => {
-                                    match empty_dir_entry_dict(&p, name_tag.clone(), full, short_names, with_symlink_targets) {
+                                    match dir_entry_dict(&p, None, name_tag.clone(), full, short_names, with_symlink_targets) {
                                         Ok(d) => yield ReturnSuccess::value(d),
                                         Err(e) => yield Err(e)
                                     }


### PR DESCRIPTION
On Windows, when `ls` tries to list a directory that contains files you don't have permission to open and/or read, it errors out instead of showing the rest of the files in the directory.

An example of this would be, in my case, running `ls` in the system root drive or in the Windows folder.

I'm not super fond of this solution (it prints just the filename, leaving the other columns empty), so I hope someone else can clean it up if needs be.

Creating a new function just for making "empty" entries also seemed a bit wrong, but I wasn't sure if editing the other function would be a nicer way of doing it. 😅