### PR TITLE
Use threads to avoid blocking reads/writes in externals.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,11 @@ name = "nonu"
 path = "crates/nu-test-support/src/bins/nonu.rs"
 required-features = ["test-bins"]
 
+[[bin]]
+name = "iecho"
+path = "crates/nu-test-support/src/bins/iecho.rs"
+required-features = ["test-bins"]
+
 # Core plugins that ship with `cargo install nu` by default
 # Currently, Cargo limits us to installing only one binary
 # unless we use [[bin]], so we use this as a workaround

--- a/crates/nu-test-support/src/bins/chop.rs
+++ b/crates/nu-test-support/src/bins/chop.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Write};
 
 fn main() {
     if did_chop_arguments() {
@@ -8,9 +8,12 @@ fn main() {
 
     // if no arguments given, chop from standard input and exit.
     let stdin = io::stdin();
+    let mut stdout = io::stdout();
     for line in stdin.lock().lines() {
         if let Ok(given) = line {
-            println!("{}", chop(&given));
+            if let Err(_e) = writeln!(stdout, "{}", chop(&given)) {
+                break;
+            }
         }
     }
 

--- a/crates/nu-test-support/src/bins/iecho.rs
+++ b/crates/nu-test-support/src/bins/iecho.rs
@@ -1,0 +1,13 @@
+use std::io::{self, Write};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    // println! panics if stdout gets closed, whereas writeln gives us an error
+    let mut stdout = io::stdout();
+    let _ = args
+        .iter()
+        .skip(1)
+        .cycle()
+        .try_for_each(|v| writeln!(stdout, "{}", v));
+}

--- a/src/commands/classified/internal.rs
+++ b/src/commands/classified/internal.rs
@@ -5,7 +5,7 @@ use nu_errors::ShellError;
 use nu_parser::InternalCommand;
 use nu_protocol::{CommandAction, Primitive, ReturnSuccess, UntaggedValue, Value};
 
-pub(crate) async fn run_internal_command(
+pub(crate) fn run_internal_command(
     command: InternalCommand,
     context: &mut Context,
     input: Option<InputStream>,

--- a/src/commands/classified/pipeline.rs
+++ b/src/commands/classified/pipeline.rs
@@ -31,15 +31,15 @@ pub(crate) async fn run_pipeline(
             (_, Some(ClassifiedCommand::Error(err))) => return Err(err.clone().into()),
 
             (Some(ClassifiedCommand::Internal(left)), _) => {
-                run_internal_command(left, ctx, input, Text::from(line)).await?
+                run_internal_command(left, ctx, input, Text::from(line))?
             }
 
             (Some(ClassifiedCommand::External(left)), None) => {
-                run_external_command(left, ctx, input, true).await?
+                run_external_command(left, ctx, input, true)?
             }
 
             (Some(ClassifiedCommand::External(left)), _) => {
-                run_external_command(left, ctx, input, false).await?
+                run_external_command(left, ctx, input, false)?
             }
 
             (None, _) => break,

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -1,0 +1,149 @@
+use futures::stream::Stream;
+use std::pin::Pin;
+use std::sync::{mpsc, Arc, Mutex};
+use std::task::{self, Poll, Waker};
+use std::thread;
+
+#[allow(clippy::option_option)]
+struct SharedState<T: Send + 'static> {
+    result: Option<Option<T>>,
+    kill: bool,
+    waker: Option<Waker>,
+}
+
+pub struct ThreadedReceiver<T: Send + 'static> {
+    shared_state: Arc<Mutex<SharedState<T>>>,
+}
+
+impl<T: Send + 'static> ThreadedReceiver<T> {
+    pub fn new(recv: mpsc::Receiver<T>) -> ThreadedReceiver<T> {
+        let shared_state = Arc::new(Mutex::new(SharedState {
+            result: None,
+            kill: false,
+            waker: None,
+        }));
+
+        // Clone everything to avoid lifetimes
+        let thread_shared_state = shared_state.clone();
+        thread::spawn(move || {
+            loop {
+                let result = recv.recv();
+
+                {
+                    let mut shared_state = thread_shared_state
+                        .lock()
+                        .expect("ThreadedFuture shared state shouldn't be poisoned");
+
+                    if let Ok(result) = result {
+                        shared_state.result = Some(Some(result));
+                    } else {
+                        break;
+                    }
+                }
+
+                // Don't attempt to recv anything else until consumed
+                loop {
+                    let mut shared_state = thread_shared_state
+                        .lock()
+                        .expect("ThreadedFuture shared state shouldn't be poisoned");
+
+                    if shared_state.kill {
+                        return;
+                    }
+
+                    if shared_state.result.is_some() {
+                        if let Some(waker) = shared_state.waker.take() {
+                            waker.wake();
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // Let the Stream implementation know that we're done
+            let mut shared_state = thread_shared_state
+                .lock()
+                .expect("ThreadedFuture shared state shouldn't be poisoned");
+
+            shared_state.result = Some(None);
+            if let Some(waker) = shared_state.waker.take() {
+                waker.wake();
+            }
+        });
+
+        ThreadedReceiver { shared_state }
+    }
+}
+
+impl<T: Send + 'static> Stream for ThreadedReceiver<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut shared_state = self
+            .shared_state
+            .lock()
+            .expect("ThreadedFuture shared state shouldn't be poisoned");
+
+        if let Some(result) = shared_state.result.take() {
+            Poll::Ready(result)
+        } else {
+            shared_state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl<T: Send + 'static> Drop for ThreadedReceiver<T> {
+    fn drop(&mut self) {
+        // Setting the kill flag to true will cause the thread spawned in `new` to exit, which
+        // will cause the `Receiver` argument to get dropped. This can allow senders to
+        // potentially clean up.
+        match self.shared_state.lock() {
+            Ok(mut state) => state.kill = true,
+            Err(mut poisoned_err) => poisoned_err.get_mut().kill = true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod threaded_receiver {
+        use super::super::ThreadedReceiver;
+        use futures::executor::block_on_stream;
+        use std::sync::mpsc;
+
+        #[test]
+        fn returns_expected_result() {
+            let (tx, rx) = mpsc::sync_channel(0);
+            std::thread::spawn(move || {
+                let _ = tx.send(1);
+                let _ = tx.send(2);
+                let _ = tx.send(3);
+            });
+
+            let stream = ThreadedReceiver::new(rx);
+            let mut result = block_on_stream(stream);
+            assert_eq!(Some(1), result.next());
+            assert_eq!(Some(2), result.next());
+            assert_eq!(Some(3), result.next());
+            assert_eq!(None, result.next());
+        }
+
+        #[test]
+        fn drops_receiver_when_stream_dropped() {
+            let (tx, rx) = mpsc::sync_channel(0);
+            let th = std::thread::spawn(move || {
+                tx.send(1).and_then(|_| tx.send(2)).and_then(|_| tx.send(3))
+            });
+
+            {
+                let stream = ThreadedReceiver::new(rx);
+                let mut result = block_on_stream(stream);
+                assert_eq!(Some(1), result.next());
+            }
+            let result = th.join();
+            assert_eq!(true, result.unwrap().is_err());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod deserializer;
 mod env;
 mod evaluate;
 mod format;
+mod futures;
 mod git;
 mod shell;
 mod stream;

--- a/tests/commands/touch.rs
+++ b/tests/commands/touch.rs
@@ -1,15 +1,12 @@
-use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 
 #[test]
-fn adds_a_file() {
-    Playground::setup("add_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("i_will_be_created.txt")]);
-
+fn creates_a_file_when_it_doesnt_exist() {
+    Playground::setup("create_test_1", |dirs, _sandbox| {
         nu!(
-            cwd: dirs.root(),
-            "touch touch_test/i_will_be_created.txt"
+            cwd: dirs.test(),
+            "touch i_will_be_created.txt"
         );
 
         let path = dirs.test().join("i_will_be_created.txt");

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -102,7 +102,7 @@ mod it_evaluation {
 }
 
 mod stdin_evaluation {
-    use super::nu_error;
+    use super::{nu, nu_error};
     use nu_test_support::pipeline;
 
     #[test]
@@ -116,6 +116,21 @@ mod stdin_evaluation {
         ));
 
         assert_eq!(stderr, "");
+    }
+
+    #[test]
+    fn does_not_block_indefinitely() {
+        let stdout = nu!(
+            cwd: ".",
+            pipeline(r#"
+                iecho yes
+                | chop
+                | chop
+                | first 1
+            "#
+        ));
+
+        assert_eq!(stdout, "y");
     }
 }
 


### PR DESCRIPTION
In particular, one thing that we can't (properly) do before this commit is consuming an infinite input stream. For example:

```
yes | grep y | head -n10
```

will give 10 "y"s in most shells, but blocks indefinitely in nu. This PR resolves that by doing blocking I/O in threads, and reducing the `await` calls we currently have in our pipeline code.

## For reviewers to focus on

- `ThreadedReceiver` is a bit complex. Is there a better alternative? I wasn't sure how to use `futures::mpsc::channel` in a nice way.
- I've tested a lot of different pipelines and everything appears to be working. My biggest concern is the complexity of `ThreadedReceiver` having some subtle edge cases. Encourage reviewers to give this branch a try locally.
- Other comments I'll scatter about.