### PR TITLE
Fix and refactor cd for Filesystem Shell.

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -204,7 +204,8 @@ impl Shell for FilesystemShell {
                         ));
                     }
 
-                    if cfg!(unix) {
+                    #[cfg(unix)]
+                    {
                         let has_exec = path
                             .metadata()
                             .map(|m| {

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use trash as SendToTrash;
 
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 pub struct FilesystemShell {


### PR DESCRIPTION
Reorder check conditions, don't check existence twice.
If building for unix check exec bit on folder.
Should fix #1428 