### PR TITLE
Fixes #1427: Prints help message with -h switch

### DIFF
--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -74,11 +74,7 @@ impl Call {
     pub fn switch_preset(&self, switch: &str) -> bool {
         self.named
             .as_ref()
-            .and_then(|n| n.get(switch))
-            .map(|t| match t {
-                NamedValue::PresentSwitch(_) => true,
-                _ => false,
-            })
+            .map(|n| n.switch_present(switch))
             .unwrap_or(false)
     }
 }

--- a/crates/nu-parser/src/hir/named.rs
+++ b/crates/nu-parser/src/hir/named.rs
@@ -82,6 +82,16 @@ impl NamedArguments {
     pub fn insert_mandatory(&mut self, name: impl Into<String>, expr: SpannedExpression) {
         self.named.insert(name.into(), NamedValue::Value(expr));
     }
+
+    pub fn switch_present(&self, switch: &str) -> bool {
+        self.named
+            .get(switch)
+            .map(|t| match t {
+                NamedValue::PresentSwitch(_) => true,
+                _ => false,
+            })
+            .unwrap_or(false)
+    }
 }
 
 impl PrettyDebugWithSource for NamedArguments {

--- a/crates/nu-parser/src/parse_command.rs
+++ b/crates/nu-parser/src/parse_command.rs
@@ -114,7 +114,7 @@ pub fn parse_command_tail(
             positional = positionals;
         }
         Err(reason) => {
-            if found_error.is_none() && !tail.source().contains("help") {
+            if found_error.is_none() && !named.switch_present("help") {
                 found_error = Some(reason);
             }
         }


### PR DESCRIPTION
For some commands like `which` -h flag would trigger an error asking for
missing required parameters instead of printing the help message as it
does with --help. This commit adds a check in the command parser to
avoid that.