### PR TITLE
Fix deleting / showing `ls` named pipes and other fs objects not explicitly recognized by std::fs

### DIFF
--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -28,7 +28,7 @@ fn get_file_type(md: &std::fs::Metadata) -> &str {
             }
         }
     }
-    return file_type;
+    file_type
 }
 
 pub(crate) fn dir_entry_dict(

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -978,7 +978,7 @@ impl Shell for FilesystemShell {
                                     };
 
                                     let valid_target =
-                                        f.is_file() || (f.is_dir() && (is_empty || recursive.item));
+                                        f.exists() && (!f.is_dir() || (is_empty || recursive.item));
                                     if valid_target {
                                         if trash.item {
                                             match SendToTrash::remove(f) {


### PR DESCRIPTION
This fixes #1396 