### PR TITLE
Don't emit a newline in autoview.

### DIFF
--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -112,14 +112,14 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     let result = text.run(command_args, &context.commands);
                                     result.collect::<Vec<_>>().await;
                                 } else {
-                                    outln!("{}", s);
+                                    out!("{}", s);
                                 }
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::String(s)),
                                 ..
                             } => {
-                                outln!("{}", s);
+                                out!("{}", s);
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Line(ref s)),
@@ -132,32 +132,32 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     let result = text.run(command_args, &context.commands);
                                     result.collect::<Vec<_>>().await;
                                 } else {
-                                    outln!("{}\n", s);
+                                    out!("{}\n", s);
                                 }
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Line(s)),
                                 ..
                             } => {
-                                outln!("{}\n", s);
+                                out!("{}\n", s);
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Path(s)),
                                 ..
                             } => {
-                                outln!("{}", s.display());
+                                out!("{}", s.display());
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Int(n)),
                                 ..
                             } => {
-                                outln!("{}", n);
+                                out!("{}", n);
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Decimal(n)),
                                 ..
                             } => {
-                                outln!("{}", n);
+                                out!("{}", n);
                             }
 
                             Value { value: UntaggedValue::Primitive(Primitive::Binary(ref b)), .. } => {
@@ -169,7 +169,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     result.collect::<Vec<_>>().await;
                                 } else {
                                     use pretty_hex::*;
-                                    outln!("{:?}", b.hex_dump());
+                                    out!("{:?}", b.hex_dump());
                                 }
                             }
 
@@ -184,7 +184,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     let result = table.run(command_args, &context.commands);
                                     result.collect::<Vec<_>>().await;
                                 } else {
-                                    outln!("{:?}", item);
+                                    out!("{:?}", item);
                                 }
                             }
                         }
@@ -192,7 +192,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                 }
             }
             _ => {
-                //outln!("<no results>");
+                //out!("<no results>");
             }
         }
 

--- a/crates/nu-cli/src/prelude.rs
+++ b/crates/nu-cli/src/prelude.rs
@@ -68,7 +68,7 @@ macro_rules! trace_out_stream {
     }};
 }
 
-pub(crate) use nu_protocol::{errln, outln};
+pub(crate) use nu_protocol::{errln, out, outln};
 use nu_source::HasFallibleSpan;
 
 pub(crate) use crate::commands::command::{

--- a/crates/nu-protocol/src/macros.rs
+++ b/crates/nu-protocol/src/macros.rs
@@ -3,6 +3,15 @@
 /// Note: this exists to differentiate between intentional writing to stdout
 /// and stray printlns left by accident
 #[macro_export]
+macro_rules! out {
+    ($($tokens:tt)*) => { print!($($tokens)*) }
+}
+
+/// Outputs to standard out with a newline added
+///
+/// Note: this exists to differentiate between intentional writing to stdout
+/// and stray printlns left by accident
+#[macro_export]
 macro_rules! outln {
     ($($tokens:tt)*) => { println!($($tokens)*) }
 }


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/1419

The extra newline character makes it hard to use nu as part of an external processing pipeline, since the extra character could taint the results. For example:

```
$ nu -c 'echo test | xxd'
00000000: 7465 7374                                test
```

versus

```
nu -c 'echo test' | xxd
00000000: 7465 7374 0a                             test.
```