### PR TITLE
Eliminate some compiler warnings

### DIFF
--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -680,8 +680,8 @@ fn argument_is_quoted(argument: &str) -> bool {
         return false;
     }
 
-    ((argument.starts_with('"') && argument.ends_with('"'))
-        || (argument.starts_with('\'') && argument.ends_with('\'')))
+    (argument.starts_with('"') && argument.ends_with('"'))
+        || (argument.starts_with('\'') && argument.ends_with('\''))
 }
 
 #[allow(unused)]

--- a/crates/nu-cli/src/commands/touch.rs
+++ b/crates/nu-cli/src/commands/touch.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use nu_errors::ShellError;
 use nu_protocol::{CallInfo, Signature, SyntaxShape, Value};
 use nu_source::Tagged;
-use std::error::Error;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 
@@ -48,7 +47,7 @@ fn touch(args: TouchArgs, _context: &RunnablePerItemContext) -> Result<OutputStr
         Ok(_) => Ok(OutputStream::empty()),
         Err(err) => Err(ShellError::labeled_error(
             "File Error",
-            err.description(),
+            err.to_string(),
             &args.target.tag,
         )),
     }

--- a/crates/nu-protocol/src/type_shape.rs
+++ b/crates/nu-protocol/src/type_shape.rs
@@ -301,10 +301,10 @@ struct DebugEntry<'a> {
 impl<'a> PrettyDebug for DebugEntry<'a> {
     /// Prepare debug entries for pretty-printing
     fn pretty(&self) -> DebugDocBuilder {
-        (b::key(match self.key {
+        b::key(match self.key {
             Column::String(string) => string.clone(),
             Column::Value => "<value>".to_string(),
-        }) + b::delimit("(", self.value.pretty(), ")").into_kind())
+        }) + b::delimit("(", self.value.pretty(), ")").into_kind()
     }
 }
 


### PR DESCRIPTION
- Unnecessary parentheses
- Deprecated `description()` method