### PR TITLE
Columnpath support when passing fields for formatting.

### DIFF
--- a/crates/nu-cli/tests/commands/format.rs
+++ b/crates/nu-cli/tests/commands/format.rs
@@ -14,3 +14,17 @@ fn creates_the_resulting_string_from_the_given_fields() {
 
     assert_eq!(actual, "nu has license ISC");
 }
+
+#[test]
+fn given_fields_can_be_column_paths() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        open cargo_sample.toml
+            | format "{package.name} is {package.description}"
+            | echo $it
+        "#
+    ));
+
+    assert_eq!(actual, "nu is a new type of shell");
+}

--- a/crates/nu-cli/tests/commands/save.rs
+++ b/crates/nu-cli/tests/commands/save.rs
@@ -42,6 +42,6 @@ fn writes_out_csv() {
         );
 
         let actual = file_contents(expected_file);
-        assert!(actual.contains("[Table],A shell for the GitHub era,2018,ISC,nu,0.1.1"));
+        assert!(actual.contains("[Table],a new type of shell,2018,ISC,nu,0.1.1"));
     })
 }

--- a/tests/fixtures/formats/cargo_sample.toml
+++ b/tests/fixtures/formats/cargo_sample.toml
@@ -2,7 +2,7 @@
 name = "nu"
 version = "0.1.1"
 authors = ["Yehuda Katz <wycats@gmail.com>"]
-description = "A shell for the GitHub era"
+description = "a new type of shell"
 license = "ISC"
 edition = "2018"
 


### PR DESCRIPTION
`open Cargo.toml | format "The package version is {package.version}"`