### PR TITLE
Fixes #1204 : `sys | get host.users` displays the same user account twice while only one exists (macOS)

### DIFF
--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -113,7 +113,8 @@ async fn host(tag: Tag) -> Value {
         dict.insert_value("uptime", uptime_dict);
     }
 
-    // Users
+    // Sessions
+    // note: the heim host module has nomenclature "users"
     let mut users = host::users();
     let mut user_vec = vec![];
     while let Some(user) = users.next().await {
@@ -125,7 +126,7 @@ async fn host(tag: Tag) -> Value {
         }
     }
     let user_list = UntaggedValue::Table(user_vec);
-    dict.insert_untagged("users", user_list);
+    dict.insert_untagged("sessions", user_list);
 
     dict.into_value()
 }

--- a/docs/commands/sys.md
+++ b/docs/commands/sys.md
@@ -1,6 +1,6 @@
 # sys
 
-This command gives information about the system where nu is running on.
+This command gives information about the system nu is running on.
 
 ## Examples
 
@@ -13,7 +13,7 @@ This command gives information about the system where nu is running on.
 ━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━
 > sys | get host
 ━━━━━━━━┯━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━┯━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━
- name   │ release │ hostname     │ arch   │ uptime         │ users
+ name   │ release │ hostname     │ arch   │ uptime         │ sessions
 ────────┼─────────┼──────────────┼────────┼────────────────┼──────────────────
  Darwin │ 18.7.0  │ C02Y437GJGH6 │ x86_64 │ [table: 1 row] │ [table: 17 rows]
 ━━━━━━━━┷━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
#1204
- renamed host.users to host.sessions