### PR TITLE
Custom canonicalize method on Filesystem Shell. 

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -14,7 +14,7 @@ use nu_parser::ExpandContext;
 use nu_protocol::{Primitive, ReturnSuccess, UntaggedValue};
 use rustyline::completion::FilenameCompleter;
 use rustyline::hint::{Hinter, HistoryHinter};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::Ordering;
 use trash as SendToTrash;
 
@@ -204,8 +204,7 @@ impl Shell for FilesystemShell {
                 if target == Path::new("-") {
                     PathBuf::from(&self.last_path)
                 } else {
-                    let path = PathBuf::from(self.path());
-                    let path = dunce::canonicalize(path.join(&target)).map_err(|_| {
+                    let path = self.canonicalize(target).map_err(|_| {
                         ShellError::labeled_error(
                             "Cannot change to directory",
                             "directory not found",

--- a/crates/nu-cli/tests/commands/cd.rs
+++ b/crates/nu-cli/tests/commands/cd.rs
@@ -86,6 +86,28 @@ fn filesystem_change_current_directory_to_parent_directory() {
 }
 
 #[test]
+fn filesystem_change_current_directory_to_parent_directory_after_delete_cwd() {
+    Playground::setup("cd_test_5_1", |dirs, sandbox| {
+        sandbox.within("foo").mkdir("bar");
+
+        let actual = nu!(
+            cwd: dirs.test().join("foo/bar"),
+            r#"
+                rm {}/foo/bar 
+                echo ","
+                cd .. 
+                pwd | echo $it
+            "#,
+            dirs.test()
+        );
+
+        let actual = actual.split(',').nth(1).unwrap();
+
+        assert_eq!(PathBuf::from(actual), *dirs.test().join("foo"));
+    })
+}
+
+#[test]
 fn filesystem_change_to_home_directory() {
     Playground::setup("cd_test_6", |dirs, _| {
         let actual = nu!(


### PR DESCRIPTION
Added a new canonicalize custom method for Filesystem Shell, this method prepares path for dunce::canonicalize. Fixes #1484 