### PR TITLE
Csv errors

### DIFF
--- a/crates/nu-cli/src/commands/from_delimited_data.rs
+++ b/crates/nu-cli/src/commands/from_delimited_data.rs
@@ -58,8 +58,8 @@ pub fn from_delimited_data(
                 }
                 x => yield ReturnSuccess::value(x),
             },
-            Err(_) => {
-                let line_one = format!("Could not parse as {}", format_name);
+            Err(err) => {
+                let line_one = format!("Could not parse as {}\n{}", format_name,err);
                 let line_two = format!("input cannot be parsed as {}", format_name);
                 yield Err(ShellError::labeled_error_with_secondary(
                     line_one,

--- a/crates/nu-cli/src/commands/from_delimited_data.rs
+++ b/crates/nu-cli/src/commands/from_delimited_data.rs
@@ -87,7 +87,7 @@ fn pretty_csv_error(err: csv::Error) -> Option<String> {
         } => {
             if let Some(pos) = pos {
                 Some(format!(
-                    "Line {}, expected {} fields, found {}",
+                    "Line {}: expected {} fields, found {}",
                     pos.line(),
                     expected_len,
                     len

--- a/crates/nu-cli/src/commands/from_delimited_data.rs
+++ b/crates/nu-cli/src/commands/from_delimited_data.rs
@@ -60,7 +60,7 @@ pub fn from_delimited_data(
             },
             Err(err) => {
                 let line_one = match pretty_csv_error(err) {
-                    Some(pretty) => format!("Could not parse as {}\n{}", format_name,pretty),
+                    Some(pretty) => format!("Could not parse as {} ({})", format_name,pretty),
                     None => format!("Could not parse as {}", format_name),
                 };
                 let line_two = format!("input cannot be parsed as {}", format_name);

--- a/crates/nu-cli/src/commands/from_delimited_data.rs
+++ b/crates/nu-cli/src/commands/from_delimited_data.rs
@@ -96,7 +96,7 @@ fn pretty_csv_error(err: csv::Error) -> Option<String> {
                 Some(format!("Expected {} fields, found {}", expected_len, len))
             }
         }
-        ErrorKind::Seek => Some(format!("Internal error while parsing csv")),
+        ErrorKind::Seek => Some("Internal error while parsing csv".to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
This pull request adds an error message when opening an invalid csv file.
This deals with issue  #1426 when using `open file.txt | from-csv.` :

```
error: Could not parse as CSV
Line 2, expected 3 fields, found 2
- shell:1:24
1 | open test.txt | from-csv
  |                 ^^^^^^^^ input cannot be parsed as CSV
- shell:1:24
1 | open test.txt | from-csv
  |      -------- value originates from here
```

However I noticed that when opening a csv file with :
`open file.csv`

No error message is displayed at all. This pull request doesn't fix that