### PR TITLE
Open fails silently, fix #1493

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -675,9 +675,8 @@ async fn process_line(
                                         break;
                                     }
                                 }
-                                _ => {
-                                    break;
-                                }
+                                Ok(None) => break,
+                                Err(e) => return LineResult::Error(line.to_string(),e),
                             }
                         }
                     }

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -676,7 +676,7 @@ async fn process_line(
                                     }
                                 }
                                 Ok(None) => break,
-                                Err(e) => return LineResult::Error(line.to_string(),e),
+                                Err(e) => return LineResult::Error(line.to_string(), e),
                             }
                         }
                     }


### PR DESCRIPTION
This fixes #1493.

Some errors that could occur in `autoview` were discarded. This led to the behavior seen in issue #1493.
This PR adds simple handling of the error and fixes the bug.

The bug originates from commit 5f4fae5b if that matters to someone.