### PR TITLE
Streamline plugin search path

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -102,20 +102,21 @@ fn search_paths() -> Vec<std::path::PathBuf> {
 
     let mut search_paths = Vec::new();
 
+    // First priority is the path that the user gives us
+    let config = crate::data::config::config(Tag::unknown());
+    if let Ok(config) = config {
+        if let Some(s) = config.get("plugin_path") {
+            if let Ok(s) = s.as_string() {
+                search_paths.push(PathBuf::from(s));
+                return search_paths;    
+            }
+        }    
+    }
+    
     // Automatically add path `nu` is in as a search path
     if let Ok(exe_path) = env::current_exe() {
         if let Some(exe_dir) = exe_path.parent() {
             search_paths.push(exe_dir.to_path_buf());
-        }
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-        match env::var_os("PATH") {
-            Some(paths) => {
-                search_paths.extend(env::split_paths(&paths).collect::<Vec<_>>());
-            }
-            None => println!("PATH is not defined in the environment."),
         }
     }
 

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -110,9 +110,9 @@ fn search_paths() -> Vec<std::path::PathBuf> {
                 search_paths.push(PathBuf::from(s));
                 return search_paths;    
             }
-        }    
+        }
     }
-    
+
     // Automatically add path `nu` is in as a search path
     if let Ok(exe_path) = env::current_exe() {
         if let Some(exe_dir) = exe_path.parent() {

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -108,7 +108,7 @@ fn search_paths() -> Vec<std::path::PathBuf> {
         if let Some(s) = config.get("plugin_path") {
             if let Ok(s) = s.as_string() {
                 search_paths.push(PathBuf::from(s));
-                return search_paths;    
+                return search_paths;
             }
         }
     }


### PR DESCRIPTION
Instead of looking through all the PATH for binaries on startup, streamline the search:

* First look in the config to see if they specified a `plugin_path` that we can use. If so, use it.
* If not, look at the current directory `nu` is running inside of