### PR TITLE
Fix numeric comparison with nothing

### DIFF
--- a/crates/nu-cli/src/data/base.rs
+++ b/crates/nu-cli/src/data/base.rs
@@ -180,6 +180,12 @@ fn coerce_compare_primitive(
         (Bytes(left), Decimal(right)) => {
             CompareValues::Decimals(BigDecimal::from(*left), right.clone())
         }
+        (Bytes(left), Nothing) => CompareValues::Ints(BigInt::from(*left), BigInt::from(0)),
+        (Nothing, Bytes(right)) => CompareValues::Ints(BigInt::from(0), BigInt::from(*right)),
+        (Int(left), Nothing) => CompareValues::Ints(left.clone(), BigInt::from(0)),
+        (Nothing, Int(right)) => CompareValues::Ints(BigInt::from(0), right.clone()),
+        (Decimal(left), Nothing) => CompareValues::Decimals(left.clone(), BigDecimal::from(0.0)),
+        (Nothing, Decimal(right)) => CompareValues::Decimals(BigDecimal::from(0.0), right.clone()),
         (String(left), String(right)) => CompareValues::String(left.clone(), right.clone()),
         (Line(left), String(right)) => CompareValues::String(left.clone(), right.clone()),
         (String(left), Line(right)) => CompareValues::String(left.clone(), right.clone()),

--- a/crates/nu-cli/tests/commands/where_.rs
+++ b/crates/nu-cli/tests/commands/where_.rs
@@ -11,6 +11,16 @@ fn filters_by_unit_size_comparison() {
 }
 
 #[test]
+fn filters_with_nothing_comparison() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        r#"echo '[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from-json | where foo > 1 | get foo | sum | echo $it"#
+    );
+
+    assert_eq!(actual, "7");
+}
+
+#[test]
 fn binary_operator_comparisons() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(


### PR DESCRIPTION
Fixes #1505 by continuing to show nothing, and extending numerical comparison to account for the nothing value (treating it as 0).

Not this doesn't add the value if none is there (ie if the column is completely missing), only if the specified value is UntaggedValue::Nothing. This should allow us to continue erroring in the cases where the field is missing.

