### PR TITLE
Add quickstart option to Docker section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ cargo build --workspace --features=stable
 
 ## Docker
 
+### Quickstart
+
+Want to try Nu right away? Execute the following to get started.
+
+```bash
+docker run -it quay.io/nushell/nu:latest
+```
+
+### Guide
+
 If you want to pull a pre-built container, you can browse tags for the [nushell organization](https://quay.io/organization/nushell)
 on Quay.io. Pulling a container would come down to:
 


### PR DESCRIPTION
When wanting to show Nu to co-workers and friends, I've been sharing this one command that I've pieced together from the documentation.

Although very minor, I thought that I would offer the idea and contribute back.

Please let me know what you think.