### PR TITLE
Fix '/' and '..' not being valid mv targets

### DIFF
--- a/crates/nu-cli/tests/commands/mv.rs
+++ b/crates/nu-cli/tests/commands/mv.rs
@@ -230,3 +230,23 @@ fn errors_if_source_doesnt_exist() {
         assert!(actual.contains("Invalid File or Pattern"));
     })
 }
+
+#[test]
+fn does_not_error_on_relative_parent_path() {
+    Playground::setup("mv_test_11", |dirs, sandbox| {
+        sandbox
+            .mkdir("first")
+            .with_files(vec![EmptyFile("first/william_hartnell.txt")]);
+
+        let original = dirs.test().join("first/william_hartnell.txt");
+        let expected = dirs.test().join("william_hartnell.txt");
+
+        nu!(
+            cwd: dirs.test().join("first"),
+            "mv william_hartnell.txt ./.."
+        );
+
+        assert!(!original.exists());
+        assert!(expected.exists());
+    })
+}


### PR DESCRIPTION
If `/` or `../` is specified as the destination for `mv`, it will fail with an error message saying it's not a valid destination. This fixes it to account for the fact that `Path::file_name` return `None` when the file name evaluates to `/` or `..`. It will only take the slow(er) path if `Path::file_name` returns `None` in its initial check.

Fixes #1291