### PR TITLE
WIP: Switch the parser to using Strings instead of Spans

### DIFF
--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -212,6 +212,7 @@ fn create_default_command_args(context: &RunnableContextWithoutInput) -> RawComm
         call_info: UnevaluatedCallInfo {
             args: hir::Call {
                 head: Box::new(SpannedExpression::new(
+                    #[allow(deprecated)]
                     Expression::Literal(Literal::String(span)),
                     span,
                 )),

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -146,7 +146,9 @@ fn evaluate_literal(literal: &hir::Literal, span: Span, source: &Text) -> Value 
         hir::Literal::String(tag) => UntaggedValue::string(tag.slice(source)).into_value(span),
         hir::Literal::Str(s) => UntaggedValue::string(s).into_value(span),
         hir::Literal::GlobPattern(pattern) => UntaggedValue::pattern(pattern).into_value(span),
+        #[allow(deprecated)]
         hir::Literal::Bare => UntaggedValue::string(span.slice(source)).into_value(span),
+        hir::Literal::BareStr(s) => UntaggedValue::string(s).into_value(span),
     }
 }
 

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -142,7 +142,9 @@ fn evaluate_literal(literal: &hir::Literal, span: Span, source: &Text) -> Value 
             nu_parser::Number::Decimal(d) => UntaggedValue::decimal(d.clone()).into_value(span),
         },
         hir::Literal::Size(int, unit) => unit.compute(&int).into_value(span),
+        #[allow(deprecated)]
         hir::Literal::String(tag) => UntaggedValue::string(tag.slice(source)).into_value(span),
+        hir::Literal::Str(s) => UntaggedValue::string(s).into_value(span),
         hir::Literal::GlobPattern(pattern) => UntaggedValue::pattern(pattern).into_value(span),
         hir::Literal::Bare => UntaggedValue::string(span.slice(source)).into_value(span),
     }

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -380,6 +380,11 @@ impl Expression {
         Expression::List(list)
     }
 
+    pub fn bare_str() -> Expression {
+        Expression::Literal(Literal::Bare)
+    }
+
+    #[deprecated(note = "switch to `bare_str`")]
     pub fn bare() -> Expression {
         Expression::Literal(Literal::Bare)
     }
@@ -421,7 +426,9 @@ pub enum Literal {
     Str(String),
     GlobPattern(String),
     ColumnPath(Vec<Member>),
+    #[deprecated(note = "switch to `Literal::BareStr` instead")]
     Bare,
+    BareStr(String),
 }
 
 impl Literal {
@@ -448,7 +455,9 @@ impl ShellTypeName for Literal {
             Literal::String(..) => "string",
             Literal::Str(..) => "string",
             Literal::ColumnPath(..) => "column path",
+            #[allow(deprecated)]
             Literal::Bare => "string",
+            Literal::BareStr(_) => "string",
             Literal::GlobPattern(_) => "pattern",
         }
     }
@@ -463,12 +472,14 @@ impl PrettyDebugWithSource for SpannedLiteral {
                 Literal::Size(number, unit) => (number.pretty() + unit.pretty()).group(),
                 #[allow(deprecated)]
                 Literal::String(string) => b::primitive(format!("{:?}", string.slice(source))),
-                Literal::Str(string) => b::primitive(format!("{:?}", string)),
+                Literal::Str(s) => b::primitive(s),
                 Literal::GlobPattern(pattern) => b::primitive(pattern),
                 Literal::ColumnPath(path) => {
                     b::intersperse_with_source(path.iter(), b::space(), source)
                 }
+                #[allow(deprecated)]
                 Literal::Bare => b::delimit("b\"", b::primitive(self.span.slice(source)), "\""),
+                Literal::BareStr(s) => b::delimit("b\"", b::primitive(s), "\""),
             },
         }
     }
@@ -484,13 +495,15 @@ impl PrettyDebugWithSource for SpannedLiteral {
                 "string",
                 b::primitive(format!("{:?}", string.slice(source))),
             ),
-            Literal::Str(string) => b::typed("string", b::primitive(format!("{:?}", string))),
+            Literal::Str(s) => b::typed("string", b::primitive(s)),
             Literal::GlobPattern(pattern) => b::typed("pattern", b::primitive(pattern)),
             Literal::ColumnPath(path) => b::typed(
                 "column path",
                 b::intersperse_with_source(path.iter(), b::space(), source),
             ),
+            #[allow(deprecated)]
             Literal::Bare => b::typed("bare", b::primitive(self.span.slice(source))),
+            Literal::BareStr(s) => b::typed("bare", b::primitive(s)),
         }
     }
 }

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -321,7 +321,7 @@ impl Expression {
         Expression::Literal(Literal::Size(i.into(), unit.into()))
     }
 
-    #[deprecated(note = "please use `Expression::str` instead")]
+    #[deprecated(note = "switch to `Expression::str` instead")]
     pub fn string(inner: impl Into<Span>) -> Expression {
         #[allow(deprecated)]
         Expression::Literal(Literal::String(inner.into()))
@@ -416,7 +416,7 @@ impl From<Spanned<Path>> for SpannedExpression {
 pub enum Literal {
     Number(Number),
     Size(Number, Unit),
-    #[deprecated(note = "please use `Literal::Str` instead")]
+    #[deprecated(note = "switch to `Literal::Str` instead")]
     String(Span),
     Str(String),
     GlobPattern(String),

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -321,7 +321,7 @@ impl Expression {
         Expression::Literal(Literal::Size(i.into(), unit.into()))
     }
 
-    #[deprecated]
+    #[deprecated(note = "please use `Expression::str` instead")]
     pub fn string(inner: impl Into<Span>) -> Expression {
         #[allow(deprecated)]
         Expression::Literal(Literal::String(inner.into()))
@@ -416,7 +416,7 @@ impl From<Spanned<Path>> for SpannedExpression {
 pub enum Literal {
     Number(Number),
     Size(Number, Unit),
-    #[deprecated]
+    #[deprecated(note = "please use `Literal::Str` instead")]
     String(Span),
     Str(String),
     GlobPattern(String),

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -380,11 +380,12 @@ impl Expression {
         Expression::List(list)
     }
 
-    pub fn bare_str() -> Expression {
-        Expression::Literal(Literal::Bare)
+    pub fn bare_str(s: impl Into<String>) -> Expression {
+        Expression::Literal(Literal::BareStr(s.into()))
     }
 
     #[deprecated(note = "switch to `bare_str`")]
+    #[allow(deprecated)]
     pub fn bare() -> Expression {
         Expression::Literal(Literal::Bare)
     }

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -321,8 +321,14 @@ impl Expression {
         Expression::Literal(Literal::Size(i.into(), unit.into()))
     }
 
+    #[deprecated]
     pub fn string(inner: impl Into<Span>) -> Expression {
+        #[allow(deprecated)]
         Expression::Literal(Literal::String(inner.into()))
+    }
+
+    pub fn str(s: impl Into<String>) -> Expression {
+        Expression::Literal(Literal::Str(s.into()))
     }
 
     pub fn synthetic_string(string: impl Into<String>) -> Expression {
@@ -410,7 +416,9 @@ impl From<Spanned<Path>> for SpannedExpression {
 pub enum Literal {
     Number(Number),
     Size(Number, Unit),
+    #[deprecated]
     String(Span),
+    Str(String),
     GlobPattern(String),
     ColumnPath(Vec<Member>),
     Bare,
@@ -436,7 +444,9 @@ impl ShellTypeName for Literal {
         match &self {
             Literal::Number(..) => "number",
             Literal::Size(..) => "size",
+            #[allow(deprecated)]
             Literal::String(..) => "string",
+            Literal::Str(..) => "string",
             Literal::ColumnPath(..) => "column path",
             Literal::Bare => "string",
             Literal::GlobPattern(_) => "pattern",
@@ -451,7 +461,9 @@ impl PrettyDebugWithSource for SpannedLiteral {
             PrettyDebugRefineKind::WithContext => match &self.literal {
                 Literal::Number(number) => number.pretty(),
                 Literal::Size(number, unit) => (number.pretty() + unit.pretty()).group(),
+                #[allow(deprecated)]
                 Literal::String(string) => b::primitive(format!("{:?}", string.slice(source))),
+                Literal::Str(string) => b::primitive(format!("{:?}", string)),
                 Literal::GlobPattern(pattern) => b::primitive(pattern),
                 Literal::ColumnPath(path) => {
                     b::intersperse_with_source(path.iter(), b::space(), source)
@@ -467,10 +479,12 @@ impl PrettyDebugWithSource for SpannedLiteral {
             Literal::Size(number, unit) => {
                 b::typed("size", (number.pretty() + unit.pretty()).group())
             }
+            #[allow(deprecated)]
             Literal::String(string) => b::typed(
                 "string",
                 b::primitive(format!("{:?}", string.slice(source))),
             ),
+            Literal::Str(string) => b::typed("string", b::primitive(format!("{:?}", string))),
             Literal::GlobPattern(pattern) => b::typed("pattern", b::primitive(pattern)),
             Literal::ColumnPath(path) => b::typed(
                 "column path",

--- a/crates/nu-parser/src/hir/syntax_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape.rs
@@ -15,7 +15,8 @@ use crate::hir::tokens_iterator::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
 use crate::parse::operator::EvaluationOperator;
 use crate::parse::token_tree::{
-    BareStrType, ExternalCommandType, PipelineType, SpannedToken, Token, WhitespaceType, WordType,
+    BareStrType, ExternalCommandType, PipelineType, SpannedToken, Token, WhitespaceType,
+    WordStrType, WordType,
 };
 use crate::parse_command::parse_command_tail;
 use derive_new::new;
@@ -505,10 +506,9 @@ impl ExpandSyntax for CommandHeadShape {
                 ))
             })
             .or_else(|_| {
-                token_nodes.expand_token(WordType, |span| {
-                    let name = span.slice(&source);
-                    if registry.has(name) {
-                        let signature = registry.get(name).unwrap();
+                token_nodes.expand_token(WordStrType, |(span, name)| {
+                    if registry.has(&name) {
+                        let signature = registry.get(&name).unwrap();
                         Ok((
                             FlatShape::InternalCommand,
                             CommandSignature::Internal(signature.spanned(span)),

--- a/crates/nu-parser/src/hir/syntax_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape.rs
@@ -294,10 +294,6 @@ impl ExpandSyntax for BarePathShape {
 }
 
 #[derive(Debug, Copy, Clone)]
-#[deprecated(note = "switch to BareStrShape")]
-pub struct BareShape;
-
-#[derive(Debug, Copy, Clone)]
 pub struct BareStrShape;
 
 #[derive(Debug, Clone)]
@@ -331,31 +327,6 @@ impl ExpandSyntax for BareStrShape {
     ) -> Result<BareSyntax, ParseError> {
         token_nodes.expand_token(BareStrType, |(span, s)| {
             Ok((FlatShape::Word, BareSyntax { word: s, span }))
-        })
-    }
-}
-
-impl ExpandSyntax for BareShape {
-    type Output = Result<BareSyntax, ParseError>;
-
-    fn name(&self) -> &'static str {
-        "word"
-    }
-
-    fn expand<'a, 'b>(
-        &self,
-        token_nodes: &'b mut TokensIterator<'a>,
-    ) -> Result<BareSyntax, ParseError> {
-        let source = token_nodes.source();
-
-        token_nodes.expand_token(WordType, |span| {
-            Ok((
-                FlatShape::Word,
-                BareSyntax {
-                    word: span.string(&source),
-                    span,
-                },
-            ))
         })
     }
 }

--- a/crates/nu-parser/src/hir/syntax_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape.rs
@@ -15,7 +15,7 @@ use crate::hir::tokens_iterator::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
 use crate::parse::operator::EvaluationOperator;
 use crate::parse::token_tree::{
-    ExternalCommandType, PipelineType, SpannedToken, Token, WhitespaceType, WordType,
+    BareStrType, ExternalCommandType, PipelineType, SpannedToken, Token, WhitespaceType, WordType,
 };
 use crate::parse_command::parse_command_tail;
 use derive_new::new;
@@ -294,7 +294,11 @@ impl ExpandSyntax for BarePathShape {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[deprecated(note = "switch to BareStrShape")]
 pub struct BareShape;
+
+#[derive(Debug, Copy, Clone)]
+pub struct BareStrShape;
 
 #[derive(Debug, Clone)]
 pub struct BareSyntax {
@@ -311,6 +315,23 @@ impl HasSpan for BareSyntax {
 impl PrettyDebug for BareSyntax {
     fn pretty(&self) -> DebugDocBuilder {
         b::primitive(&self.word)
+    }
+}
+
+impl ExpandSyntax for BareStrShape {
+    type Output = Result<BareSyntax, ParseError>;
+
+    fn name(&self) -> &'static str {
+        "word"
+    }
+
+    fn expand<'a, 'b>(
+        &self,
+        token_nodes: &'b mut TokensIterator<'a>,
+    ) -> Result<BareSyntax, ParseError> {
+        token_nodes.expand_token(BareStrType, |(span, s)| {
+            Ok((FlatShape::Word, BareSyntax { word: s, span }))
+        })
     }
 }
 

--- a/crates/nu-parser/src/hir/syntax_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape.rs
@@ -255,9 +255,9 @@ pub fn expand_bare(
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct BareExpressionShape;
+pub struct BareExpressionStrShape;
 
-impl ExpandSyntax for BareExpressionShape {
+impl ExpandSyntax for BareExpressionStrShape {
     type Output = Result<SpannedExpression, ParseError>;
 
     fn name(&self) -> &'static str {
@@ -269,12 +269,13 @@ impl ExpandSyntax for BareExpressionShape {
         token_nodes: &'b mut TokensIterator<'a>,
     ) -> Result<SpannedExpression, ParseError> {
         token_nodes
-            .expand_syntax(BarePathShape)
-            .map(|span| Expression::bare().into_expr(span))
+            .expand_syntax(BarePathStrShape)
+            .map(|syntax| Expression::bare_str(syntax.word).into_expr(syntax.span))
     }
 }
 
 #[derive(Debug, Copy, Clone)]
+#[deprecated(note = "switch to BarePathStrShape")]
 pub struct BarePathShape;
 
 impl ExpandSyntax for BarePathShape {
@@ -292,6 +293,26 @@ impl ExpandSyntax for BarePathShape {
             | Token::BareStr(_) => true,
 
             _ => false,
+        })
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct BarePathStrShape;
+
+impl ExpandSyntax for BarePathStrShape {
+    type Output = Result<BareSyntax, ParseError>;
+
+    fn name(&self) -> &'static str {
+        "bare path"
+    }
+
+    fn expand<'a, 'b>(
+        &self,
+        token_nodes: &'b mut TokensIterator<'a>,
+    ) -> Result<BareSyntax, ParseError> {
+        token_nodes.expand_token(BareStrType, |(span, s)| {
+            Ok((FlatShape::BareMember, BareSyntax { word: s, span }))
         })
     }
 }

--- a/crates/nu-parser/src/hir/syntax_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape.rs
@@ -286,7 +286,10 @@ impl ExpandSyntax for BarePathShape {
 
     fn expand<'a, 'b>(&self, token_nodes: &'b mut TokensIterator<'a>) -> Result<Span, ParseError> {
         expand_bare(token_nodes, |token| match token.unspanned() {
-            Token::Bare | Token::EvaluationOperator(EvaluationOperator::Dot) => true,
+            #[allow(deprecated)]
+            Token::Bare
+            | Token::EvaluationOperator(EvaluationOperator::Dot)
+            | Token::BareStr(_) => true,
 
             _ => false,
         })

--- a/crates/nu-parser/src/hir/syntax_shape/expression.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression.rs
@@ -9,7 +9,7 @@ pub(crate) mod unit;
 pub(crate) mod variable_path;
 
 use crate::hir::syntax_shape::{
-    BareExpressionShape, DelimitedSquareShape, ExpandContext, ExpandSyntax,
+    BareExpressionStrShape, DelimitedSquareShape, ExpandContext, ExpandSyntax,
     ExpressionContinuationShape, NumberExpressionShape, PatternExpressionShape,
     StringExpressionShape, UnitExpressionShape, VariableShape,
 };
@@ -62,7 +62,7 @@ impl ExpandSyntax for AnyExpressionStartShape {
         token_nodes
             .expand_syntax(VariableShape)
             .or_else(|_| token_nodes.expand_syntax(UnitExpressionShape))
-            .or_else(|_| token_nodes.expand_syntax(BareExpressionShape))
+            .or_else(|_| token_nodes.expand_syntax(BareExpressionStrShape))
             .or_else(|_| token_nodes.expand_syntax(PatternExpressionShape))
             .or_else(|_| token_nodes.expand_syntax(NumberExpressionShape))
             .or_else(|_| token_nodes.expand_syntax(StringExpressionShape))

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -1,6 +1,6 @@
 use crate::hir::syntax_shape::{
-    expression::expand_file_path, BarePathShape, DecimalShape, ExpandContext, ExpandSyntax,
-    FlatShape, IntShape, StringShape,
+    expression::expand_file_path, BarePathShape, BarePathStrShape, DecimalShape, ExpandContext,
+    ExpandSyntax, FlatShape, IntShape, StringShape,
 };
 use crate::hir::{Expression, SpannedExpression, TokensIterator};
 use crate::parse::token_tree::ExternalWordType;
@@ -25,6 +25,11 @@ impl ExpandSyntax for FilePathShape {
             .expand_syntax(BarePathShape)
             .or_else(|_| token_nodes.expand_syntax(ExternalWordShape))
             .map(|span| file_path(span, token_nodes.context()).into_expr(span))
+            .or_else(|_| {
+                token_nodes.expand_syntax(BarePathStrShape).map(|syntax| {
+                    file_path_str(&syntax.word, token_nodes.context()).into_expr(syntax.span)
+                })
+            })
             .or_else(|_| {
                 token_nodes.expand_syntax(StringShape).map(|syntax| {
                     file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -27,7 +27,7 @@ impl ExpandSyntax for FilePathShape {
             .map(|span| file_path(span, token_nodes.context()).into_expr(span))
             .or_else(|_| {
                 token_nodes.expand_syntax(StringShape).map(|syntax| {
-                    file_path(syntax.inner, token_nodes.context()).into_expr(syntax.span)
+                    file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)
                 })
             })
             .or_else(|_| {
@@ -42,8 +42,13 @@ impl ExpandSyntax for FilePathShape {
     }
 }
 
+#[deprecated]
 fn file_path(text: Span, context: &ExpandContext) -> Expression {
     Expression::FilePath(expand_file_path(text.slice(context.source), context))
+}
+
+fn file_path_str(text: &str, context: &ExpandContext) -> Expression {
+    Expression::FilePath(expand_file_path(text, context))
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -42,7 +42,7 @@ impl ExpandSyntax for FilePathShape {
     }
 }
 
-#[deprecated]
+#[deprecated(note = "please use `file_path_str` instead")]
 fn file_path(text: Span, context: &ExpandContext) -> Expression {
     Expression::FilePath(expand_file_path(text.slice(context.source), context))
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -42,7 +42,7 @@ impl ExpandSyntax for FilePathShape {
     }
 }
 
-#[deprecated(note = "please use `file_path_str` instead")]
+#[deprecated(note = "switch to `file_path_str` instead")]
 fn file_path(text: Span, context: &ExpandContext) -> Expression {
     Expression::FilePath(expand_file_path(text.slice(context.source), context))
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -1,6 +1,6 @@
 use crate::hir::syntax_shape::{
-    expression::expand_file_path, BarePathShape, BarePathStrShape, DecimalShape, ExpandContext,
-    ExpandSyntax, FlatShape, IntShape, StringShape,
+    expression::expand_file_path, BarePathStrShape, DecimalShape, ExpandContext, ExpandSyntax,
+    FlatShape, IntShape, StringShape,
 };
 use crate::hir::{Expression, SpannedExpression, TokensIterator};
 use crate::parse::token_tree::ExternalWordType;
@@ -22,18 +22,19 @@ impl ExpandSyntax for FilePathShape {
         token_nodes: &mut TokensIterator<'_>,
     ) -> Result<SpannedExpression, ParseError> {
         token_nodes
-            .expand_syntax(BarePathShape)
-            .or_else(|_| token_nodes.expand_syntax(ExternalWordShape))
-            .map(|span| file_path(span, token_nodes.context()).into_expr(span))
+            .expand_syntax(StringShape)
+            .map(|syntax| {
+                file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)
+            })
             .or_else(|_| {
                 token_nodes.expand_syntax(BarePathStrShape).map(|syntax| {
                     file_path_str(&syntax.word, token_nodes.context()).into_expr(syntax.span)
                 })
             })
             .or_else(|_| {
-                token_nodes.expand_syntax(StringShape).map(|syntax| {
-                    file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)
-                })
+                token_nodes
+                    .expand_syntax(ExternalWordShape)
+                    .map(|span| file_path(span, token_nodes.context()).into_expr(span))
             })
             .or_else(|_| {
                 token_nodes

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -22,13 +22,11 @@ impl ExpandSyntax for FilePathShape {
         token_nodes: &mut TokensIterator<'_>,
     ) -> Result<SpannedExpression, ParseError> {
         token_nodes
-            .expand_syntax(StringShape)
-            .map(|syntax| {
-                file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)
-            })
+            .expand_syntax(BarePathStrShape)
+            .map(|syntax| file_path_str(&syntax.word, token_nodes.context()).into_expr(syntax.span))
             .or_else(|_| {
-                token_nodes.expand_syntax(BarePathStrShape).map(|syntax| {
-                    file_path_str(&syntax.word, token_nodes.context()).into_expr(syntax.span)
+                token_nodes.expand_syntax(StringShape).map(|syntax| {
+                    file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)
                 })
             })
             .or_else(|_| {

--- a/crates/nu-parser/src/hir/syntax_shape/expression/pattern.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/pattern.rs
@@ -88,9 +88,12 @@ impl ExpandSyntax for BarePatternShape {
 
     fn expand<'a, 'b>(&self, token_nodes: &'b mut TokensIterator<'a>) -> Result<Span, ParseError> {
         expand_bare(token_nodes, |token| match token.unspanned() {
+            #[allow(deprecated)]
             Token::Bare
+            | Token::BareStr(_)
             | Token::EvaluationOperator(EvaluationOperator::Dot)
-            | Token::GlobPattern => true,
+            | Token::GlobPattern
+            | Token::GlobPatternStr(_) => true,
 
             _ => false,
         })

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -24,11 +24,13 @@ impl ExpandSyntax for CoerceStringShape {
                 Ok((FlatShape::String, Expression::str(s).into_expr(outer)))
             })
             .or_else(|_| {
+                #[allow(deprecated)]
                 token_nodes.expand_token(BareType, |span| {
                     Ok((FlatShape::String, Expression::string(span).into_expr(span)))
                 })
             })
             .or_else(|_| {
+                #[allow(deprecated)]
                 token_nodes
                     .expand_syntax(NumberShape)
                     .map(|number| Expression::string(number.span()).into_expr(number.span()))

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -20,11 +20,8 @@ impl ExpandSyntax for CoerceStringShape {
         token_nodes: &'b mut TokensIterator<'a>,
     ) -> Result<SpannedExpression, ParseError> {
         token_nodes
-            .expand_token(StringType, |(inner, outer)| {
-                Ok((
-                    FlatShape::String,
-                    Expression::string(inner).into_expr(outer),
-                ))
+            .expand_token(StrType, |(s, outer)| {
+                Ok((FlatShape::String, Expression::str(s).into_expr(outer)))
             })
             .or_else(|_| {
                 token_nodes.expand_token(BareType, |span| {

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -1,7 +1,7 @@
 use crate::hir::syntax_shape::{ExpandSyntax, FlatShape, NumberShape, VariableShape};
 use crate::hir::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
-use crate::parse::token_tree::{BareType, StrType};
+use crate::parse::token_tree::{BareStrType, StrType};
 use nu_errors::ParseError;
 use nu_source::{b, DebugDocBuilder, HasSpan, PrettyDebugWithSource, Span};
 
@@ -25,8 +25,8 @@ impl ExpandSyntax for CoerceStringShape {
             })
             .or_else(|_| {
                 #[allow(deprecated)]
-                token_nodes.expand_token(BareType, |span| {
-                    Ok((FlatShape::String, Expression::string(span).into_expr(span)))
+                token_nodes.expand_token(BareStrType, |(span, s)| {
+                    Ok((FlatShape::String, Expression::str(s).into_expr(span)))
                 })
             })
             .or_else(|_| {

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -1,7 +1,7 @@
 use crate::hir::syntax_shape::{ExpandSyntax, FlatShape, NumberShape, VariableShape};
 use crate::hir::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
-use crate::parse::token_tree::{BareType, StringType};
+use crate::parse::token_tree::{BareType, StrType, StringType};
 use nu_errors::ParseError;
 use nu_source::{b, DebugDocBuilder, HasSpan, PrettyDebugWithSource, Span};
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -1,7 +1,7 @@
 use crate::hir::syntax_shape::{ExpandSyntax, FlatShape, NumberShape, VariableShape};
 use crate::hir::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
-use crate::parse::token_tree::{BareType, StrType, StringType};
+use crate::parse::token_tree::{BareType, StrType};
 use nu_errors::ParseError;
 use nu_source::{b, DebugDocBuilder, HasSpan, PrettyDebugWithSource, Span};
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -51,11 +51,8 @@ impl ExpandSyntax for StringExpressionShape {
         token_nodes: &'b mut TokensIterator<'a>,
     ) -> Result<SpannedExpression, ParseError> {
         token_nodes.expand_syntax(VariableShape).or_else(|_| {
-            token_nodes.expand_token(StringType, |(inner, outer)| {
-                Ok((
-                    FlatShape::String,
-                    Expression::string(inner).into_expr(outer),
-                ))
+            token_nodes.expand_token(StrType, |(s, outer)| {
+                Ok((FlatShape::String, Expression::str(s).into_expr(outer)))
             })
         })
     }
@@ -65,6 +62,24 @@ impl ExpandSyntax for StringExpressionShape {
 pub struct StringSyntax {
     pub inner: Span,
     pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct StrSyntax {
+    pub content: String,
+    pub span: Span,
+}
+
+impl HasSpan for StrSyntax {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl PrettyDebugWithSource for StrSyntax {
+    fn pretty_debug(&self, _: &str) -> DebugDocBuilder {
+        b::primitive(self.content.clone())
+    }
 }
 
 impl HasSpan for StringSyntax {
@@ -83,7 +98,7 @@ impl PrettyDebugWithSource for StringSyntax {
 pub struct StringShape;
 
 impl ExpandSyntax for StringShape {
-    type Output = Result<StringSyntax, ParseError>;
+    type Output = Result<StrSyntax, ParseError>;
 
     fn name(&self) -> &'static str {
         "string"
@@ -92,9 +107,15 @@ impl ExpandSyntax for StringShape {
     fn expand<'a, 'b>(
         &self,
         token_nodes: &'b mut TokensIterator<'a>,
-    ) -> Result<StringSyntax, ParseError> {
-        token_nodes.expand_token(StringType, |(inner, outer)| {
-            Ok((FlatShape::String, StringSyntax { inner, span: outer }))
+    ) -> Result<StrSyntax, ParseError> {
+        token_nodes.expand_token(StrType, |(s, outer)| {
+            Ok((
+                FlatShape::String,
+                StrSyntax {
+                    content: s,
+                    span: outer,
+                },
+            ))
         })
     }
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/unit.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/unit.rs
@@ -3,7 +3,7 @@ use crate::hir::syntax_shape::ExpandSyntax;
 use crate::hir::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
 use crate::parse::number::RawNumber;
-use crate::parse::token_tree::BareType;
+use crate::parse::token_tree::BareStrType;
 use crate::parse::unit::Unit;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -83,8 +83,8 @@ impl ExpandSyntax for UnitShape {
     ) -> Result<UnitSyntax, ParseError> {
         let source = token_nodes.source();
 
-        token_nodes.expand_token(BareType, |span| {
-            let unit = unit_size(span.slice(&source), span);
+        token_nodes.expand_token(BareStrType, |(span, s)| {
+            let unit = unit_size(&s, span);
 
             let (_, (number, unit)) = match unit {
                 Err(_) => return Err(ParseError::mismatch("unit", "word".spanned(span))),

--- a/crates/nu-parser/src/hir/syntax_shape/expression/unit.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/unit.rs
@@ -81,8 +81,6 @@ impl ExpandSyntax for UnitShape {
         &self,
         token_nodes: &'b mut TokensIterator<'a>,
     ) -> Result<UnitSyntax, ParseError> {
-        let source = token_nodes.source();
-
         token_nodes.expand_token(BareStrType, |(span, s)| {
             let unit = unit_size(&s, span);
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -265,16 +265,21 @@ pub enum Member {
     String(/* outer */ Span, /* inner */ Span),
     Str(/* outer */ Span, String),
     Int(BigInt, Span),
+    #[deprecated]
     Bare(Span),
+    BareStr(Span, String),
 }
 
 impl ShellTypeName for Member {
     fn type_name(&self) -> &'static str {
         match self {
+            #[allow(deprecated)]
             Member::String(_, _) => "string",
             Member::Str(_, _) => "string",
             Member::Int(_, _) => "integer",
             Member::Bare(_) => "word",
+            #[allow(deprecated)]
+            Member::BareStr(_, _) => "word",
         }
     }
 }
@@ -294,7 +299,9 @@ impl Member {
             Member::String(outer, inner) => PathMember::string(inner.slice(source), *outer),
             Member::Str(outer, s) => PathMember::string(s, *outer),
             Member::Int(int, span) => PathMember::int(int.clone(), *span),
+            #[allow(deprecated)]
             Member::Bare(span) => PathMember::string(span.slice(source), *span),
+            Member::BareStr(span, s) => PathMember::string(s, *span),
         }
     }
 }
@@ -306,7 +313,9 @@ impl PrettyDebugWithSource for Member {
             Member::String(outer, _) => b::value(outer.slice(source)),
             Member::Str(_, content) => b::value(&content),
             Member::Int(int, _) => b::value(format!("{}", int)),
+            #[allow(deprecated)]
             Member::Bare(span) => b::value(span.slice(source)),
+            Member::BareStr(_, s) => b::value(&s),
         }
     }
 }
@@ -318,7 +327,9 @@ impl HasSpan for Member {
             Member::String(outer, ..) => *outer,
             Member::Str(outer, ..) => *outer,
             Member::Int(_, int) => *int,
+            #[allow(deprecated)]
             Member::Bare(name) => *name,
+            Member::BareStr(span, ..) => *span,
         }
     }
 }
@@ -330,7 +341,9 @@ impl Member {
             Member::String(outer, inner) => Expression::string(*inner).into_expr(outer),
             Member::Str(outer, content) => Expression::str(content).into_expr(outer),
             Member::Int(number, span) => Expression::number(number.clone()).into_expr(span),
+            #[allow(deprecated)]
             Member::Bare(span) => Expression::string(*span).into_expr(span),
+            Member::BareStr(span, content) => Expression::str(content).into_expr(span),
         }
     }
 
@@ -340,7 +353,9 @@ impl Member {
             Member::String(outer, _inner) => *outer,
             Member::Str(outer, _) => *outer,
             Member::Int(_, span) => *span,
+            #[allow(deprecated)]
             Member::Bare(span) => *span,
+            Member::BareStr(span, _) => *span,
         }
     }
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -261,11 +261,11 @@ impl ExpandSyntax for VariableShape {
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Member {
-    #[deprecated]
+    #[deprecated(note = "please use `Member::Str` instead")]
     String(/* outer */ Span, /* inner */ Span),
     Str(/* outer */ Span, String),
     Int(BigInt, Span),
-    #[deprecated]
+    #[deprecated(note = "please use `Member::Str` instead")]
     Bare(Span),
     BareStr(Span, String),
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -265,7 +265,7 @@ pub enum Member {
     String(/* outer */ Span, /* inner */ Span),
     Str(/* outer */ Span, String),
     Int(BigInt, Span),
-    #[deprecated(note = "switch to `Member::Str` instead")]
+    #[deprecated(note = "switch to `Member::BareStr` instead")]
     Bare(Span),
     BareStr(Span, String),
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -1,6 +1,6 @@
 use crate::hir::syntax_shape::{
-    AnyExpressionShape, BareShape, ExpandSyntax, FlatShape, IntShape, ParseError, StringShape,
-    WhitespaceShape,
+    AnyExpressionShape, BareShape, BareStrShape, ExpandSyntax, FlatShape, IntShape, ParseError,
+    StringShape, WhitespaceShape,
 };
 use crate::hir::{Expression, SpannedExpression, TokensIterator};
 use crate::parse::token_tree::{CompareOperatorType, DotDotType, DotType, ItVarType, VarType};
@@ -497,6 +497,12 @@ impl ExpandSyntax for MemberShape {
     fn expand<'a, 'b>(&self, token_nodes: &mut TokensIterator<'_>) -> Result<Member, ParseError> {
         if let Ok(int) = token_nodes.expand_syntax(IntMemberShape) {
             return Ok(int);
+        }
+
+        let bare = token_nodes.expand_syntax(BareStrShape);
+
+        if let Ok(bare) = bare {
+            return Ok(Member::BareStr(bare.span(), bare.word));
         }
 
         let bare = token_nodes.expand_syntax(BareShape);

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -1,6 +1,6 @@
 use crate::hir::syntax_shape::{
-    AnyExpressionShape, BareShape, BareStrShape, ExpandSyntax, FlatShape, IntShape, ParseError,
-    StringShape, WhitespaceShape,
+    AnyExpressionShape, BareStrShape, ExpandSyntax, FlatShape, IntShape, ParseError, StringShape,
+    WhitespaceShape,
 };
 use crate::hir::{Expression, SpannedExpression, TokensIterator};
 use crate::parse::token_tree::{CompareOperatorType, DotDotType, DotType, ItVarType, VarType};
@@ -503,12 +503,6 @@ impl ExpandSyntax for MemberShape {
 
         if let Ok(bare) = bare {
             return Ok(Member::BareStr(bare.span(), bare.word));
-        }
-
-        let bare = token_nodes.expand_syntax(BareShape);
-
-        if let Ok(bare) = bare {
-            return Ok(Member::Bare(bare.span()));
         }
 
         let string = token_nodes.expand_syntax(StringShape);

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -261,11 +261,11 @@ impl ExpandSyntax for VariableShape {
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Member {
-    #[deprecated(note = "please use `Member::Str` instead")]
+    #[deprecated(note = "switch to `Member::Str` instead")]
     String(/* outer */ Span, /* inner */ Span),
     Str(/* outer */ Span, String),
     Int(BigInt, Span),
-    #[deprecated(note = "please use `Member::Str` instead")]
+    #[deprecated(note = "switch to `Member::Str` instead")]
     Bare(Span),
     BareStr(Span, String),
 }
@@ -277,8 +277,8 @@ impl ShellTypeName for Member {
             Member::String(_, _) => "string",
             Member::Str(_, _) => "string",
             Member::Int(_, _) => "integer",
-            Member::Bare(_) => "word",
             #[allow(deprecated)]
+            Member::Bare(_) => "word",
             Member::BareStr(_, _) => "word",
         }
     }

--- a/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
@@ -166,7 +166,7 @@ impl FlatShape {
             Token::GlobPatternStr(_) => shapes.push(FlatShape::GlobPattern.spanned(span)),
             #[allow(deprecated)]
             Token::Bare => shapes.push(FlatShape::Word.spanned(span)),
-            Token::BareStr(_) => shapes.push(FlatShape::GlobPattern.spanned(span)),
+            Token::BareStr(_) => shapes.push(FlatShape::Word.spanned(span)),
             Token::Call(_) => unimplemented!(),
             Token::Delimited(v) => {
                 shapes.push(FlatShape::OpenDelimiter(v.delimiter).spanned(v.spans.0));

--- a/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
@@ -161,8 +161,12 @@ impl FlatShape {
             Token::ItVariable(_) => shapes.push(FlatShape::ItVariable.spanned(span)),
             Token::ExternalCommand(_) => shapes.push(FlatShape::ExternalCommand.spanned(span)),
             Token::ExternalWord => shapes.push(FlatShape::ExternalWord.spanned(span)),
+            #[allow(deprecated)]
             Token::GlobPattern => shapes.push(FlatShape::GlobPattern.spanned(span)),
+            Token::GlobPatternStr(_) => shapes.push(FlatShape::GlobPattern.spanned(span)),
+            #[allow(deprecated)]
             Token::Bare => shapes.push(FlatShape::Word.spanned(span)),
+            Token::BareStr(_) => shapes.push(FlatShape::GlobPattern.spanned(span)),
             Token::Call(_) => unimplemented!(),
             Token::Delimited(v) => {
                 shapes.push(FlatShape::OpenDelimiter(v.delimiter).spanned(v.spans.0));

--- a/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
@@ -151,7 +151,9 @@ impl FlatShape {
                 shapes.push(FlatShape::DotDot.spanned(span))
             }
             Token::CompareOperator(_) => shapes.push(FlatShape::CompareOperator.spanned(span)),
+            #[allow(deprecated)]
             Token::String(_) => shapes.push(FlatShape::String.spanned(span)),
+            Token::Str(_) => shapes.push(FlatShape::String.spanned(span)),
             Token::Variable(v) if v.slice(source) == "it" => {
                 shapes.push(FlatShape::ItVariable.spanned(span))
             }

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -6,8 +6,8 @@ use crate::parse::{
 use nom;
 use nom::branch::*;
 use nom::bytes::complete::*;
-use nom::character::complete::*;
 use nom::character::complete;
+use nom::character::complete::*;
 use nom::combinator::*;
 use nom::multi::*;
 use nom::sequence::*;
@@ -317,7 +317,7 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
-    let (input, _) = escaped(none_of("\"\\"),'\\',complete::one_of("\"\\"))(input)?;
+    let (input, _) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
 
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -315,8 +315,10 @@ pub fn operator(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
 #[tracable_parser]
 pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     fn remove_escapes(s: &str) -> String {
+        /// This is required to remove the escape characters since the `escaped` nom function returns a
+        /// Span (since it uses one as input)
         let mut string = String::new();
-        let mut was_escape = false; //
+        let mut was_escape = false;
         for c in s.chars() {
             if c == '\\' && !was_escape {
                 was_escape = true;

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -380,6 +380,7 @@ pub fn external(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     ))
 }
 
+#[deprecated(note = "This needs to be updated to return a String instead of a span")]
 fn word<'a, T, U, V>(
     start_predicate: impl Fn(NomSpan<'a>) -> IResult<NomSpan<'a>, U>,
     next_predicate: impl Fn(NomSpan<'a>) -> IResult<NomSpan<'a>, V> + Copy,

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -314,17 +314,30 @@ pub fn operator(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
 
 #[tracable_parser]
 pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
+    fn remove_escapes(s: &str) -> String {
+        let mut string = String::new();
+        let mut was_escape = false; //
+        for c in s.chars() {
+            if c == '\\' && !was_escape {
+                was_escape = true;
+            } else {
+                string.push(c);
+                was_escape = false;
+            }
+        }
+        string
+    }
+
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
     let (input, result) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
-
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;
     let end = input.offset;
     Ok((
         input,
-        TokenTreeBuilder::spanned_str(result.fragment, Span::new(start, end)),
+        TokenTreeBuilder::spanned_str(remove_escapes(result.fragment), Span::new(start, end)),
     ))
 }
 

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -7,6 +7,7 @@ use nom;
 use nom::branch::*;
 use nom::bytes::complete::*;
 use nom::character::complete::*;
+use nom::character::complete;
 use nom::combinator::*;
 use nom::multi::*;
 use nom::sequence::*;
@@ -316,7 +317,7 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
-    let (input, _) = many0(none_of("\""))(input)?;
+    let (input, _) = escaped(none_of("\"\\"),'\\',complete::one_of("\"\\"))(input)?;
 
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -317,14 +317,14 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
-    let (input, _) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
+    let (input, result) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
 
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;
     let end = input.offset;
     Ok((
         input,
-        TokenTreeBuilder::spanned_string(Span::new(start1, end1), Span::new(start, end)),
+        TokenTreeBuilder::spanned_str(result.fragment, Span::new(start, end)),
     ))
 }
 
@@ -333,14 +333,17 @@ pub fn sq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('\'')(input)?;
     let start1 = input.offset;
-    let (input, _) = many0(none_of("\'"))(input)?;
+    let (input, result) = many0(none_of("\'"))(input)?;
     let end1 = input.offset;
     let (input, _) = char('\'')(input)?;
     let end = input.offset;
 
     Ok((
         input,
-        TokenTreeBuilder::spanned_string(Span::new(start1, end1), Span::new(start, end)),
+        TokenTreeBuilder::spanned_str(
+            result.into_iter().collect::<String>(),
+            Span::new(start, end),
+        ),
     ))
 }
 

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -485,12 +485,6 @@ pub fn pattern_str(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
 }
 
 #[tracable_parser]
-#[deprecated(note = "switch to `start_pattern_str`")]
-pub fn start_pattern(input: NomSpan) -> IResult<NomSpan, NomSpan> {
-    alt((take_while1(is_dot), matches(is_start_glob_char)))(input)
-}
-
-#[tracable_parser]
 pub fn start_pattern_str(input: NomSpan) -> IResult<NomSpan, char> {
     alt((matches_str(is_dot), matches_str(is_start_glob_char)))(input)
 }

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -493,13 +493,9 @@ pub fn start_pattern_str(input: NomSpan) -> IResult<NomSpan, char> {
 pub fn filename(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start_pos = input.offset;
 
-    let mut filename = String::new();
-    let (mut input, (mut saw_special)) = match start_file_char(input) {
+    let (mut input, mut saw_special, mut filename) = match start_file_char(input) {
         Err(err) => return Err(err),
-        Ok((input, (special, c))) => {
-            filename.push(c);
-            (input, special)
-        }
+        Ok((input, (special, c))) => (input, special, c.to_string()),
     };
 
     loop {
@@ -1156,7 +1152,6 @@ fn is_file_char(c: char) -> bool {
         '\\' => true,
         '/' => true,
         '_' => true,
-        '.' => true,
         '-' => true,
         '=' => true,
         '~' => true,

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -476,17 +476,6 @@ pub fn matches_str(cond: fn(char) -> bool) -> impl Fn(NomSpan) -> IResult<NomSpa
 }
 
 #[tracable_parser]
-#[deprecated(note = "switch to `pattern_str`")]
-#[allow(deprecated)]
-pub fn pattern(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
-    word(
-        start_pattern,
-        matches(is_glob_char),
-        TokenTreeBuilder::spanned_pattern,
-    )(input)
-}
-
-#[tracable_parser]
 pub fn pattern_str(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     word_str(
         start_pattern_str,
@@ -502,7 +491,6 @@ pub fn start_pattern(input: NomSpan) -> IResult<NomSpan, NomSpan> {
 }
 
 #[tracable_parser]
-#[deprecated(note = "switch to `start_pattern_str`")]
 pub fn start_pattern_str(input: NomSpan) -> IResult<NomSpan, char> {
     alt((matches_str(is_dot), matches_str(is_start_glob_char)))(input)
 }
@@ -623,10 +611,10 @@ pub fn start_filename(input: NomSpan) -> IResult<NomSpan, char> {
 
 #[tracable_parser]
 pub fn bare_member(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
-    word(
-        matches(is_start_member_char),
-        matches(is_member_char),
-        TokenTreeBuilder::spanned_bare,
+    word_str(
+        matches_str(is_start_member_char),
+        matches_str(is_member_char),
+        TokenTreeBuilder::spanned_bare_str,
     )(input)
 }
 
@@ -1025,7 +1013,7 @@ pub fn tight_node(input: NomSpan) -> IResult<NomSpan, Vec<SpannedToken>> {
     alt((
         tight(to_list(leaf)),
         tight(to_list(filename)),
-        tight(to_list(pattern)),
+        tight(to_list(pattern_str)),
         to_list(comment),
         to_list(external_word),
         tight(to_list(delimited_paren)),

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -22,9 +22,12 @@ pub enum Token {
     ItVariable(Span),
     ExternalCommand(Span),
     ExternalWord,
+    #[deprecated(note = "switch to `Token::GlobPatternStr` instead")]
     GlobPattern,
-    #[deprecated(note = "switch to `Token::String` instead")]
+    GlobPatternStr(String),
+    #[deprecated(note = "switch to `Token::BareStr` instead")]
     Bare,
+    BareStr(String),
     Garbage,
 
     Call(CallNode),
@@ -220,9 +223,12 @@ impl PrettyDebugWithSource for SpannedToken {
             Token::CompareOperator(operator) => operator.pretty_debug(source),
             Token::EvaluationOperator(operator) => operator.pretty_debug(source),
             #[allow(deprecated)]
-            Token::String(_) | Token::Str(_) | Token::GlobPattern | Token::Bare => {
-                b::primitive(self.span.slice(source))
-            }
+            Token::String(_)
+            | Token::Str(_)
+            | Token::GlobPattern
+            | Token::GlobPatternStr(_)
+            | Token::Bare
+            | Token::BareStr(_) => b::primitive(self.span.slice(source)),
             Token::Variable(_) => b::var(self.span.slice(source)),
             Token::ItVariable(_) => b::keyword(self.span.slice(source)),
             Token::ExternalCommand(_) => b::description(self.span.slice(source)),
@@ -261,8 +267,12 @@ impl ShellTypeName for Token {
             Token::ItVariable(_) => "it variable",
             Token::ExternalCommand(_) => "external command",
             Token::ExternalWord => "external word",
+            #[allow(deprecated)]
             Token::GlobPattern => "glob pattern",
+            Token::GlobPatternStr(_) => "glob pattern",
+            #[allow(deprecated)]
             Token::Bare => "word",
+            Token::BareStr(_) => "word",
             Token::Call(_) => "command",
             Token::Delimited(d) => d.type_name(),
             Token::Pipeline(_) => "pipeline",

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -108,9 +108,13 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
-#[deprecated(note = "switch to `StrType` instead")]
+#[deprecated(note = "switch to `BareStrType` instead")]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
+});
+
+token_type!(struct BareStrType (desc: "word") -> (Span,String) {
+    |span, Token::BareStr(s)| => (span,s.clone())
 });
 
 token_type!(struct DotType (desc: "dot") -> Span {
@@ -309,7 +313,9 @@ impl SpannedToken {
 
     pub fn is_bare(&self) -> bool {
         match self.unspanned() {
+            #[allow(deprecated)]
             Token::Bare => true,
+            Token::BareStr(_) => true,
             _ => false,
         }
     }
@@ -355,14 +361,18 @@ impl SpannedToken {
 
     pub fn is_pattern(&self) -> bool {
         match self.unspanned() {
+            #[allow(deprecated)]
             Token::GlobPattern => true,
+            Token::GlobPatternStr(_) => true,
             _ => false,
         }
     }
 
     pub fn is_word(&self) -> bool {
         match self.unspanned() {
+            #[allow(deprecated)]
             Token::Bare => true,
+            Token::BareStr(_) => true,
             _ => false,
         }
     }

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -15,7 +15,7 @@ pub enum Token {
     Number(RawNumber),
     CompareOperator(CompareOperator),
     EvaluationOperator(EvaluationOperator),
-    #[deprecated]
+    #[deprecated(note = "please use `Token::String` instead")]
     String(Span),
     Str(String),
     Variable(Span),
@@ -23,7 +23,7 @@ pub enum Token {
     ExternalCommand(Span),
     ExternalWord,
     GlobPattern,
-    #[deprecated]
+    #[deprecated(note = "please use `Token::String` instead")]
     Bare,
     Garbage,
 
@@ -96,7 +96,7 @@ token_type!(struct DecimalType (desc: "decimal") -> RawNumber {
     Token::Number(number @ RawNumber::Decimal(_)) => number
 });
 
-#[deprecated]
+#[deprecated(note = "please use `StrType` instead")]
 token_type!(struct StringType (desc: "string") -> (Span, Span) {
     |outer, Token::String(inner)| => (*inner, outer)
 });
@@ -105,7 +105,7 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
-#[deprecated]
+#[deprecated(note = "please use `StrType` instead")]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
 });
@@ -327,7 +327,7 @@ impl SpannedToken {
         }
     }
 
-    #[deprecated]
+    #[deprecated(note = "please use `SpannedToken::as_str` instead")]
     pub fn as_string(&self) -> Option<(Span, Span)> {
         match self.unspanned() {
             #[allow(deprecated)]

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -15,7 +15,7 @@ pub enum Token {
     Number(RawNumber),
     CompareOperator(CompareOperator),
     EvaluationOperator(EvaluationOperator),
-    #[deprecated(note = "please use `Token::String` instead")]
+    #[deprecated(note = "switch to `Token::String` instead")]
     String(Span),
     Str(String),
     Variable(Span),
@@ -23,7 +23,7 @@ pub enum Token {
     ExternalCommand(Span),
     ExternalWord,
     GlobPattern,
-    #[deprecated(note = "please use `Token::String` instead")]
+    #[deprecated(note = "switch to `Token::String` instead")]
     Bare,
     Garbage,
 
@@ -96,7 +96,7 @@ token_type!(struct DecimalType (desc: "decimal") -> RawNumber {
     Token::Number(number @ RawNumber::Decimal(_)) => number
 });
 
-#[deprecated(note = "please use `StrType` instead")]
+#[deprecated(note = "switch to `StrType` instead")]
 token_type!(struct StringType (desc: "string") -> (Span, Span) {
     |outer, Token::String(inner)| => (*inner, outer)
 });
@@ -105,7 +105,7 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
-#[deprecated(note = "please use `StrType` instead")]
+#[deprecated(note = "switch to `StrType` instead")]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
 });
@@ -327,7 +327,7 @@ impl SpannedToken {
         }
     }
 
-    #[deprecated(note = "please use `SpannedToken::as_str` instead")]
+    #[deprecated(note = "switch to `SpannedToken::as_str` instead")]
     pub fn as_string(&self) -> Option<(Span, Span)> {
         match self.unspanned() {
             #[allow(deprecated)]

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -23,6 +23,7 @@ pub enum Token {
     ExternalCommand(Span),
     ExternalWord,
     GlobPattern,
+    #[deprecated]
     Bare,
     Garbage,
 
@@ -104,6 +105,7 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
+#[deprecated]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
 });

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -144,8 +144,13 @@ token_type!(struct WhitespaceType (desc: "whitespace") -> Span {
     |span, Token::Whitespace| => span
 });
 
+#[deprecated(note = "switch to WordStrType")]
 token_type!(struct WordType (desc: "word") -> Span {
     |span, Token::Bare| => span
+});
+
+token_type!(struct WordStrType (desc: "word") -> (Span,String) {
+    |span, Token::BareStr(s)| => (span, s.clone())
 });
 
 token_type!(struct ItVarType (desc: "$it") -> (Span, Span) {

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -108,11 +108,6 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
-#[deprecated(note = "switch to `BareStrType` instead")]
-token_type!(struct BareType (desc: "word") -> Span {
-    |span, Token::Bare| => span
-});
-
 token_type!(struct BareStrType (desc: "word") -> (Span,String) {
     |span, Token::BareStr(s)| => (span,s.clone())
 });

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -174,7 +174,7 @@ impl TokenTreeBuilder {
         })
     }
 
-    #[deprecated]
+    #[deprecated(note = "please use `spanned_str` instead")]
     pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> SpannedToken {
         #[allow(deprecated)]
         Token::String(input.into()).into_spanned(span)

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -174,7 +174,7 @@ impl TokenTreeBuilder {
         })
     }
 
-    #[deprecated(note = "please use `spanned_str` instead")]
+    #[deprecated(note = "switch to `spanned_str` instead")]
     pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> SpannedToken {
         #[allow(deprecated)]
         Token::String(input.into()).into_spanned(span)
@@ -184,6 +184,8 @@ impl TokenTreeBuilder {
         Token::Str(input.into()).into_spanned(span)
     }
 
+    #[deprecated(note = "switch to `spanned_str`")]
+    #[allow(deprecated)]
     pub fn bare(input: impl Into<String>) -> CurriedToken {
         let input = input.into();
 
@@ -195,6 +197,7 @@ impl TokenTreeBuilder {
         })
     }
 
+    #[deprecated]
     pub fn spanned_bare(span: impl Into<Span>) -> SpannedToken {
         Token::Bare.into_spanned(span)
     }

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -211,6 +211,7 @@ impl TokenTreeBuilder {
             let (start, end) = b.consume(&input);
             b.pos = end;
 
+            #[allow(deprecated)]
             TokenTreeBuilder::spanned_pattern(Span::new(start, end))
         })
     }

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -166,19 +166,22 @@ impl TokenTreeBuilder {
 
         Box::new(move |b| {
             let (start, _) = b.consume("\"");
-            let (inner_start, inner_end) = b.consume(&input);
+            b.consume(&input);
             let (_, end) = b.consume("\"");
             b.pos = end;
 
-            TokenTreeBuilder::spanned_string(
-                Span::new(inner_start, inner_end),
-                Span::new(start, end),
-            )
+            TokenTreeBuilder::spanned_str(input, Span::new(start, end))
         })
     }
 
+    #[deprecated]
     pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> SpannedToken {
+        #[allow(deprecated)]
         Token::String(input.into()).into_spanned(span)
+    }
+
+    pub fn spanned_str(input: impl Into<String>, span: impl Into<Span>) -> SpannedToken {
+        Token::Str(input.into()).into_spanned(span)
     }
 
     pub fn bare(input: impl Into<String>) -> CurriedToken {

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -196,6 +196,7 @@ impl TokenTreeBuilder {
     }
 
     #[deprecated(note = "switch to `spanned_bare_str`")]
+    #[allow(deprecated)]
     pub fn spanned_bare(span: impl Into<Span>) -> SpannedToken {
         Token::Bare.into_spanned(span)
     }
@@ -217,6 +218,7 @@ impl TokenTreeBuilder {
     }
 
     #[deprecated(note = "switch to `spanned_bare_str`")]
+    #[allow(deprecated)]
     pub fn spanned_pattern(input: impl Into<Span>) -> SpannedToken {
         Token::GlobPattern.into_spanned(input)
     }

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -184,22 +184,24 @@ impl TokenTreeBuilder {
         Token::Str(input.into()).into_spanned(span)
     }
 
-    #[deprecated(note = "switch to `spanned_str`")]
+    #[deprecated(note = "it seems that this function is unused outside of tests")]
     #[allow(deprecated)]
     pub fn bare(input: impl Into<String>) -> CurriedToken {
         let input = input.into();
-
         Box::new(move |b| {
             let (start, end) = b.consume(&input);
             b.pos = end;
-
             TokenTreeBuilder::spanned_bare(Span::new(start, end))
         })
     }
 
-    #[deprecated]
+    #[deprecated(note = "switch to `spanned_bare_str`")]
     pub fn spanned_bare(span: impl Into<Span>) -> SpannedToken {
         Token::Bare.into_spanned(span)
+    }
+
+    pub fn spanned_bare_str(input: impl Into<String>, span: impl Into<Span>) -> SpannedToken {
+        Token::BareStr(input.into()).into_spanned(span)
     }
 
     pub fn pattern(input: impl Into<String>) -> CurriedToken {
@@ -213,8 +215,13 @@ impl TokenTreeBuilder {
         })
     }
 
+    #[deprecated(note = "switch to `spanned_bare_str`")]
     pub fn spanned_pattern(input: impl Into<Span>) -> SpannedToken {
         Token::GlobPattern.into_spanned(input)
+    }
+
+    pub fn spanned_pattern_str(input: impl Into<String>, span: impl Into<Span>) -> SpannedToken {
+        Token::GlobPatternStr(input.into()).into_spanned(span)
     }
 
     pub fn external_word(input: impl Into<String>) -> CurriedToken {

--- a/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
+++ b/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
@@ -38,7 +38,7 @@ impl ExpandSyntax for LineSeparatedShape {
                     .or_else(|_| {
                         token_nodes
                             .expand_syntax(StringShape)
-                            .map(|syntax| Expression::string(syntax.inner).into_expr(syntax.span))
+                            .map(|syntax| Expression::str(syntax.content).into_expr(syntax.span))
                     })
             };
 
@@ -50,6 +50,7 @@ impl ExpandSyntax for LineSeparatedShape {
                     Expression::Literal(hir::Literal::Number(crate::Number::Decimal(d))) => {
                         entries.push(UntaggedValue::decimal(d.clone()))
                     }
+                    #[allow(deprecated)]
                     Expression::Literal(hir::Literal::String(span)) => {
                         if span.is_closed() {
                             entries.push(UntaggedValue::nothing())

--- a/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
+++ b/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
@@ -57,6 +57,13 @@ impl ExpandSyntax for LineSeparatedShape {
                             entries.push(UntaggedValue::string(span.slice(&source)))
                         }
                     }
+                    Expression::Literal(hir::Literal::Str(s)) => {
+                        if s.is_empty() {
+                            entries.push(UntaggedValue::nothing())
+                        } else {
+                            entries.push(UntaggedValue::string(s))
+                        }
+                    }
                     _ => {}
                 }
             }


### PR DESCRIPTION
I've been trying to fix #1456.
However, the parser deals a lot with Spans instead of Strings. As a result, it isn't currently possible to implement escape sequences inside the parser since they need to de de-escaped much later at multiple places at the same time which would be a likely source of bugs since the same escaping needs to be implemented 3 or 4 times. 

Therefore I've done some work to refactor the parser to use String instead of spans where escape sequences can be useful, so they can be implemented easily.

This may have a slight impact on the overall performance of the parser but I don't think it would be significant since the Spans have to be converted to Strings later anyway.