### PR TITLE
Testing fix to build matrix to define all variables

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,15 +52,15 @@ jobs:
         - glibc
         - musl
         include:
-        - { tag: alpine,           base-image: alpine,                     arch: x86_64-unknown-linux-musl, plugin: true    }
-        - { tag: slim,             base-image: 'debian:stable-slim',       arch: x86_64-unknown-linux-gnu,  plugin: true    }
-        - { tag: debian,           base-image: debian,                     arch: x86_64-unknown-linux-gnu,  plugin: true    }
-        - { tag: glibc-busybox,    base-image: 'busybox:glibc',            arch: x86_64-unknown-linux-gnu,  use-patch: true }
-        - { tag: musl-busybox,     base-image: 'busybox:musl',             arch: x86_64-unknown-linux-musl,                 }
-        - { tag: musl-distroless,  base-image: 'gcr.io/distroless/static', arch: x86_64-unknown-linux-musl,                 }
-        - { tag: glibc-distroless, base-image: 'gcr.io/distroless/cc',     arch: x86_64-unknown-linux-gnu,  use-patch: true }
-        - { tag: glibc,            base-image: scratch,                    arch: x86_64-unknown-linux-gnu,                  }
-        - { tag: musl,             base-image: scratch,                    arch: x86_64-unknown-linux-musl,                 }
+        - { tag: alpine,           base-image: alpine,                     arch: x86_64-unknown-linux-musl, plugin: true,  use-patch: false}
+        - { tag: slim,             base-image: 'debian:stable-slim',       arch: x86_64-unknown-linux-gnu,  plugin: true,  use-patch: false}
+        - { tag: debian,           base-image: debian,                     arch: x86_64-unknown-linux-gnu,  plugin: true,  use-patch: false}
+        - { tag: glibc-busybox,    base-image: 'busybox:glibc',            arch: x86_64-unknown-linux-gnu,  plugin: false, use-patch: true }
+        - { tag: musl-busybox,     base-image: 'busybox:musl',             arch: x86_64-unknown-linux-musl, plugin: false, use-patch: false}
+        - { tag: musl-distroless,  base-image: 'gcr.io/distroless/static', arch: x86_64-unknown-linux-musl, plugin: false, use-patch: false}
+        - { tag: glibc-distroless, base-image: 'gcr.io/distroless/cc',     arch: x86_64-unknown-linux-gnu,  plugin: false, use-patch: true }
+        - { tag: glibc,            base-image: scratch,                    arch: x86_64-unknown-linux-gnu,  plugin: false, use-patch: false}
+        - { tag: musl,             base-image: scratch,                    arch: x86_64-unknown-linux-musl, plugin: false, use-patch: false}
     steps:
     - uses: actions/checkout@v1
     - uses: actions/download-artifact@master


### PR DESCRIPTION
There is currently a bug with invalid syntax for some of the docker build steps, and I think this is because there are build variables in the matrix that are not defined. This PR will attempt to resolve this issue by defining all missing variables for each row in the matrix. For preservation, here is the slack discussion:

![image](https://user-images.githubusercontent.com/814322/77372574-83c57a80-6d2b-11ea-9750-e6ed4ae8eb15.png)


Signed-off-by: vsoch <vsochat@stanford.edu>