### PR TITLE
Respect CARGO_TARGET_DIR when set

### DIFF
--- a/crates/nu-test-support/src/fs.rs
+++ b/crates/nu-test-support/src/fs.rs
@@ -246,7 +246,10 @@ pub fn root() -> PathBuf {
 }
 
 pub fn binaries() -> PathBuf {
-    root().join("target/debug")
+    std::env::var("CARGO_TARGET_DIR")
+        .ok()
+        .map(|target_dir| PathBuf::from(target_dir).join("debug"))
+        .unwrap_or_else(|| root().join("target/debug"))
 }
 
 pub fn fixtures() -> PathBuf {


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/1521

This makes the `binaries` function respect the `CARGO_TARGET_DIR` environment variable when set. If it's not present it falls back to the regular target directory used by Cargo.