### PR TITLE
Introduce interruptible stream

### DIFF
--- a/crates/nu-cli/src/stream/input.rs
+++ b/crates/nu-cli/src/stream/input.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use futures::stream::iter;
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, ReturnSuccess, ReturnValue, UntaggedValue, Value};
+use nu_protocol::{Primitive, UntaggedValue, Value};
 use nu_source::{Tagged, TaggedItem};
 
 pub struct InputStream {
@@ -145,109 +145,6 @@ impl From<Vec<Value>> for InputStream {
     fn from(input: Vec<Value>) -> InputStream {
         InputStream {
             values: futures::stream::iter(input).boxed(),
-        }
-    }
-}
-
-pub struct OutputStream {
-    pub(crate) values: BoxStream<'static, ReturnValue>,
-}
-
-impl OutputStream {
-    pub fn new(values: impl Stream<Item = ReturnValue> + Send + 'static) -> OutputStream {
-        OutputStream {
-            values: values.boxed(),
-        }
-    }
-
-    pub fn empty() -> OutputStream {
-        let v: VecDeque<ReturnValue> = VecDeque::new();
-        v.into()
-    }
-
-    pub fn one(item: impl Into<ReturnValue>) -> OutputStream {
-        let mut v: VecDeque<ReturnValue> = VecDeque::new();
-        v.push_back(item.into());
-        v.into()
-    }
-
-    pub fn from_input(input: impl Stream<Item = Value> + Send + 'static) -> OutputStream {
-        OutputStream {
-            values: input.map(ReturnSuccess::value).boxed(),
-        }
-    }
-
-    pub fn drain_vec(&mut self) -> impl Future<Output = Vec<ReturnValue>> {
-        let mut values: BoxStream<'static, ReturnValue> = iter(VecDeque::new()).boxed();
-        std::mem::swap(&mut values, &mut self.values);
-
-        values.collect()
-    }
-}
-
-impl Stream for OutputStream {
-    type Item = ReturnValue;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> core::task::Poll<Option<Self::Item>> {
-        Stream::poll_next(std::pin::Pin::new(&mut self.values), cx)
-    }
-}
-
-impl From<InputStream> for OutputStream {
-    fn from(input: InputStream) -> OutputStream {
-        OutputStream {
-            values: input.values.map(ReturnSuccess::value).boxed(),
-        }
-    }
-}
-
-impl From<BoxStream<'static, Value>> for OutputStream {
-    fn from(input: BoxStream<'static, Value>) -> OutputStream {
-        OutputStream {
-            values: input.map(ReturnSuccess::value).boxed(),
-        }
-    }
-}
-
-impl From<BoxStream<'static, ReturnValue>> for OutputStream {
-    fn from(input: BoxStream<'static, ReturnValue>) -> OutputStream {
-        OutputStream { values: input }
-    }
-}
-
-impl From<VecDeque<ReturnValue>> for OutputStream {
-    fn from(input: VecDeque<ReturnValue>) -> OutputStream {
-        OutputStream {
-            values: futures::stream::iter(input).boxed(),
-        }
-    }
-}
-
-impl From<VecDeque<Value>> for OutputStream {
-    fn from(input: VecDeque<Value>) -> OutputStream {
-        let stream = input.into_iter().map(ReturnSuccess::value);
-        OutputStream {
-            values: futures::stream::iter(stream).boxed(),
-        }
-    }
-}
-
-impl From<Vec<ReturnValue>> for OutputStream {
-    fn from(input: Vec<ReturnValue>) -> OutputStream {
-        OutputStream {
-            values: futures::stream::iter(input).boxed(),
-        }
-    }
-}
-
-impl From<Vec<Value>> for OutputStream {
-    fn from(input: Vec<Value>) -> OutputStream {
-        let stream = input.into_iter().map(ReturnSuccess::value);
-        OutputStream {
-            values: futures::stream::iter(stream).boxed(),
         }
     }
 }

--- a/crates/nu-cli/src/stream/interruptible.rs
+++ b/crates/nu-cli/src/stream/interruptible.rs
@@ -1,0 +1,35 @@
+use crate::prelude::*;
+use futures::task::Poll;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct InterruptibleStream<V> {
+    inner: BoxStream<'static, V>,
+    ctrl_c: Arc<AtomicBool>,
+}
+
+impl<V> InterruptibleStream<V> {
+    pub fn new<S>(inner: S, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V>
+    where
+        S: Stream<Item = V> + Send + 'static,
+    {
+        InterruptibleStream {
+            inner: inner.boxed(),
+            ctrl_c,
+        }
+    }
+}
+
+impl<V> Stream for InterruptibleStream<V> {
+    type Item = V;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> core::task::Poll<Option<Self::Item>> {
+        if self.ctrl_c.load(Ordering::SeqCst) {
+            Poll::Ready(None)
+        } else {
+            Stream::poll_next(std::pin::Pin::new(&mut self.inner), cx)
+        }
+    }
+}

--- a/crates/nu-cli/src/stream/mod.rs
+++ b/crates/nu-cli/src/stream/mod.rs
@@ -1,0 +1,5 @@
+mod input;
+mod output;
+
+pub use input::*;
+pub use output::*;

--- a/crates/nu-cli/src/stream/mod.rs
+++ b/crates/nu-cli/src/stream/mod.rs
@@ -1,5 +1,7 @@
 mod input;
+mod interruptible;
 mod output;
 
 pub use input::*;
+pub use interruptible::*;
 pub use output::*;

--- a/crates/nu-cli/src/stream/output.rs
+++ b/crates/nu-cli/src/stream/output.rs
@@ -1,0 +1,106 @@
+use crate::prelude::*;
+use futures::stream::iter;
+use nu_protocol::{ReturnSuccess, ReturnValue, Value};
+
+pub struct OutputStream {
+    pub(crate) values: BoxStream<'static, ReturnValue>,
+}
+
+impl OutputStream {
+    pub fn new(values: impl Stream<Item = ReturnValue> + Send + 'static) -> OutputStream {
+        OutputStream {
+            values: values.boxed(),
+        }
+    }
+
+    pub fn empty() -> OutputStream {
+        let v: VecDeque<ReturnValue> = VecDeque::new();
+        v.into()
+    }
+
+    pub fn one(item: impl Into<ReturnValue>) -> OutputStream {
+        let mut v: VecDeque<ReturnValue> = VecDeque::new();
+        v.push_back(item.into());
+        v.into()
+    }
+
+    pub fn from_input(input: impl Stream<Item = Value> + Send + 'static) -> OutputStream {
+        OutputStream {
+            values: input.map(ReturnSuccess::value).boxed(),
+        }
+    }
+
+    pub fn drain_vec(&mut self) -> impl Future<Output = Vec<ReturnValue>> {
+        let mut values: BoxStream<'static, ReturnValue> = iter(VecDeque::new()).boxed();
+        std::mem::swap(&mut values, &mut self.values);
+
+        values.collect()
+    }
+}
+
+impl Stream for OutputStream {
+    type Item = ReturnValue;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> core::task::Poll<Option<Self::Item>> {
+        Stream::poll_next(std::pin::Pin::new(&mut self.values), cx)
+    }
+}
+
+impl From<InputStream> for OutputStream {
+    fn from(input: InputStream) -> OutputStream {
+        OutputStream {
+            values: input.values.map(ReturnSuccess::value).boxed(),
+        }
+    }
+}
+
+impl From<BoxStream<'static, Value>> for OutputStream {
+    fn from(input: BoxStream<'static, Value>) -> OutputStream {
+        OutputStream {
+            values: input.map(ReturnSuccess::value).boxed(),
+        }
+    }
+}
+
+impl From<BoxStream<'static, ReturnValue>> for OutputStream {
+    fn from(input: BoxStream<'static, ReturnValue>) -> OutputStream {
+        OutputStream { values: input }
+    }
+}
+
+impl From<VecDeque<ReturnValue>> for OutputStream {
+    fn from(input: VecDeque<ReturnValue>) -> OutputStream {
+        OutputStream {
+            values: futures::stream::iter(input).boxed(),
+        }
+    }
+}
+
+impl From<VecDeque<Value>> for OutputStream {
+    fn from(input: VecDeque<Value>) -> OutputStream {
+        let stream = input.into_iter().map(ReturnSuccess::value);
+        OutputStream {
+            values: futures::stream::iter(stream).boxed(),
+        }
+    }
+}
+
+impl From<Vec<ReturnValue>> for OutputStream {
+    fn from(input: Vec<ReturnValue>) -> OutputStream {
+        OutputStream {
+            values: futures::stream::iter(input).boxed(),
+        }
+    }
+}
+
+impl From<Vec<Value>> for OutputStream {
+    fn from(input: Vec<Value>) -> OutputStream {
+        let stream = input.into_iter().map(ReturnSuccess::value);
+        OutputStream {
+            values: futures::stream::iter(stream).boxed(),
+        }
+    }
+}


### PR DESCRIPTION
This should simplify checks for Ctrl-C when constructing streams, which we aren't doing a lot of right now. Could be premature 🙂

Also decided to split `stream.rs` into one file per type of stream (input, output, interruptible).