### PR TITLE
Change `get` to remove blanks

### DIFF
--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -4,8 +4,8 @@ use indexmap::set::IndexSet;
 use log::trace;
 use nu_errors::ShellError;
 use nu_protocol::{
-    did_you_mean, ColumnPath, PathMember, ReturnSuccess, ReturnValue, Signature, SyntaxShape,
-    UnspannedPathMember, UntaggedValue, Value,
+    did_you_mean, ColumnPath, PathMember, Primitive, ReturnSuccess, ReturnValue, Signature,
+    SyntaxShape, UnspannedPathMember, UntaggedValue, Value,
 };
 use nu_source::span_for_spanned_list;
 use nu_value_ext::get_data_by_column_path;
@@ -221,6 +221,10 @@ pub fn get(
                                     result.push_back(ReturnSuccess::value(item.clone()));
                                 }
                             }
+                            Value {
+                                value: UntaggedValue::Primitive(Primitive::Nothing),
+                                ..
+                            } => {}
                             other => result.push_back(ReturnSuccess::value(other.clone())),
                         },
                         Err(reason) => result.push_back(ReturnSuccess::value(


### PR DESCRIPTION
Remove blank values when getting a column of values.

Before:

```
> ls | get size
────┬──────────
 #  │ <value>
────┼──────────
  0 │
  1 │
  2 │
  3 │      7 B
  4 │    223 B
  5 │
  6 │    193 B
  7 │    172 B
  8 │   1.2 KB
```

After: 

```
> ls | get size
────┬──────────
 #  │ <value>
────┼──────────
  0 │      7 B
  1 │    223 B
  2 │    193 B
  3 │    172 B
  4 │   1.2 KB
  5 │   3.4 KB
  6 │ 104.8 KB
```