### PR TITLE
Fix poor message for executable that user doesn't have permissions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,6 @@ dependencies = [
  "umask",
  "unicode-xid",
  "users",
- "which",
 ]
 
 [[package]]
@@ -4286,16 +4285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 dependencies = [
  "nom 4.2.3",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "failure",
- "libc",
 ]
 
 [[package]]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -87,7 +87,6 @@ trash = "1.0.0"
 typetag = "0.1.4"
 umask = "0.1"
 unicode-xid = "0.2.0"
-which = "3.1.1"
 
 clipboard = { version = "0.5", optional = true }
 starship = { version = "0.38.0", optional = true }

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -644,7 +644,7 @@ async fn process_line(
                 {
                     if dunce::canonicalize(name).is_ok()
                         && PathBuf::from(name).is_dir()
-                        && which::which(name).is_err()
+                        && ichwh::which(name).await.unwrap_or(None).is_none()
                         && args.list.is_empty()
                     {
                         // Here we work differently if we're in Windows because of the expected Windows behavior

--- a/crates/nu-cli/src/commands/classified/pipeline.rs
+++ b/crates/nu-cli/src/commands/classified/pipeline.rs
@@ -35,11 +35,11 @@ pub(crate) async fn run_pipeline(
             }
 
             (Some(ClassifiedCommand::External(left)), None) => {
-                run_external_command(left, ctx, input, true)?
+                run_external_command(left, ctx, input, true).await?
             }
 
             (Some(ClassifiedCommand::External(left)), _) => {
-                run_external_command(left, ctx, input, false)?
+                run_external_command(left, ctx, input, false).await?
             }
 
             (None, _) => break,


### PR DESCRIPTION
Resolves https://github.com/nushell/nushell/issues/1488

Previously, if the user didn't have the appropriate permissions to execute the binary/script, they would see "command not found", which is confusing.

This commit eliminates the `which` crate in favour of `ichwh`, which deals better with permissions by not dealing with them at all! This is closer to the behaviour of `which` in many shells. Permission checks are then left up to the caller to deal with.