### PR TITLE
Add configurations for table headers

### DIFF
--- a/crates/nu-cli/src/format/table.rs
+++ b/crates/nu-cli/src/format/table.rs
@@ -413,7 +413,7 @@ fn str_to_color(s: String) -> Option<Color> {
 fn to_style_vec(a: Vec<Value>) -> Vec<Attr> {
     let mut v: Vec<Attr> = Vec::new();
     for t in a {
-        if let Some(s) = t.as_string().ok() {
+        if let Ok(s) = t.as_string() {
             if let Some(r) = str_to_style(s) {
                 v.push(r);
             }

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -74,6 +74,16 @@ impl Primitive {
             )),
         }
     }
+
+    pub fn into_string(self, span: Span) -> Result<String, ShellError> {
+        match self {
+            Primitive::String(s) => Ok(s),
+            other => Err(ShellError::type_error(
+                "string",
+                other.type_name().spanned(span),
+            )),
+        }
+    }
 }
 
 impl num_traits::Zero for Primitive {


### PR DESCRIPTION
Added some config fields to allow the user to customize how the headers look

header_color: Available colors are from term::color module
header_align: Sets header alignment center/left/right
header_style: Sets style bold, underlined, italic. More than one can be used 