### PR TITLE
Switch the parser to stop using Strings instead of Spans to represent quoted strings

### DIFF
--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -212,8 +212,7 @@ fn create_default_command_args(context: &RunnableContextWithoutInput) -> RawComm
         call_info: UnevaluatedCallInfo {
             args: hir::Call {
                 head: Box::new(SpannedExpression::new(
-                    #[allow(deprecated)]
-                    Expression::Literal(Literal::String(span)),
+                    Expression::Literal(Literal::NoCopyString(span)),
                     span,
                 )),
                 positional: None,

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -212,6 +212,7 @@ fn create_default_command_args(context: &RunnableContextWithoutInput) -> RawComm
         call_info: UnevaluatedCallInfo {
             args: hir::Call {
                 head: Box::new(SpannedExpression::new(
+                    #[allow(deprecated)]
                     Expression::Literal(Literal::String(span)),
                     span,
                 )),

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -145,7 +145,7 @@ fn evaluate_literal(literal: &hir::Literal, span: Span, source: &Text) -> Value 
         hir::Literal::NoCopyString(tag) => {
             UntaggedValue::string(tag.slice(source)).into_value(span)
         }
-        hir::Literal::Str(s) => UntaggedValue::string(s).into_value(span),
+        hir::Literal::String(s) => UntaggedValue::string(s).into_value(span),
         hir::Literal::GlobPattern(pattern) => UntaggedValue::pattern(pattern).into_value(span),
         hir::Literal::Bare => UntaggedValue::string(span.slice(source)).into_value(span),
     }

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -142,7 +142,9 @@ fn evaluate_literal(literal: &hir::Literal, span: Span, source: &Text) -> Value 
             nu_parser::Number::Decimal(d) => UntaggedValue::decimal(d.clone()).into_value(span),
         },
         hir::Literal::Size(int, unit) => unit.compute(&int).into_value(span),
+        #[allow(deprecated)]
         hir::Literal::String(tag) => UntaggedValue::string(tag.slice(source)).into_value(span),
+        hir::Literal::Str(s) => UntaggedValue::string(s).into_value(span),
         hir::Literal::GlobPattern(pattern) => UntaggedValue::pattern(pattern).into_value(span),
         hir::Literal::Bare => UntaggedValue::string(span.slice(source)).into_value(span),
     }

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -142,8 +142,9 @@ fn evaluate_literal(literal: &hir::Literal, span: Span, source: &Text) -> Value 
             nu_parser::Number::Decimal(d) => UntaggedValue::decimal(d.clone()).into_value(span),
         },
         hir::Literal::Size(int, unit) => unit.compute(&int).into_value(span),
-        #[allow(deprecated)]
-        hir::Literal::String(tag) => UntaggedValue::string(tag.slice(source)).into_value(span),
+        hir::Literal::NoCopyString(tag) => {
+            UntaggedValue::string(tag.slice(source)).into_value(span)
+        }
         hir::Literal::Str(s) => UntaggedValue::string(s).into_value(span),
         hir::Literal::GlobPattern(pattern) => UntaggedValue::pattern(pattern).into_value(span),
         hir::Literal::Bare => UntaggedValue::string(span.slice(source)).into_value(span),

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -321,7 +321,7 @@ impl Expression {
         Expression::Literal(Literal::Size(i.into(), unit.into()))
     }
 
-    #[deprecated(note = "please use `Expression::str` instead")]
+    #[deprecated(note = "switch to `Expression::str` instead")]
     pub fn string(inner: impl Into<Span>) -> Expression {
         #[allow(deprecated)]
         Expression::Literal(Literal::String(inner.into()))
@@ -416,7 +416,7 @@ impl From<Spanned<Path>> for SpannedExpression {
 pub enum Literal {
     Number(Number),
     Size(Number, Unit),
-    #[deprecated(note = "please use `Literal::Str` instead")]
+    #[deprecated(note = "switch to `Literal::Str` instead")]
     String(Span),
     Str(String),
     GlobPattern(String),

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -321,10 +321,8 @@ impl Expression {
         Expression::Literal(Literal::Size(i.into(), unit.into()))
     }
 
-    #[deprecated(note = "switch to `Expression::str` instead")]
     pub fn string(inner: impl Into<Span>) -> Expression {
-        #[allow(deprecated)]
-        Expression::Literal(Literal::String(inner.into()))
+        Expression::Literal(Literal::NoCopyString(inner.into()))
     }
 
     pub fn str(s: impl Into<String>) -> Expression {
@@ -416,8 +414,7 @@ impl From<Spanned<Path>> for SpannedExpression {
 pub enum Literal {
     Number(Number),
     Size(Number, Unit),
-    #[deprecated(note = "switch to `Literal::Str` instead")]
-    String(Span),
+    NoCopyString(Span),
     Str(String),
     GlobPattern(String),
     ColumnPath(Vec<Member>),
@@ -444,8 +441,7 @@ impl ShellTypeName for Literal {
         match &self {
             Literal::Number(..) => "number",
             Literal::Size(..) => "size",
-            #[allow(deprecated)]
-            Literal::String(..) => "string",
+            Literal::NoCopyString(..) => "string",
             Literal::Str(..) => "string",
             Literal::ColumnPath(..) => "column path",
             Literal::Bare => "string",
@@ -461,8 +457,9 @@ impl PrettyDebugWithSource for SpannedLiteral {
             PrettyDebugRefineKind::WithContext => match &self.literal {
                 Literal::Number(number) => number.pretty(),
                 Literal::Size(number, unit) => (number.pretty() + unit.pretty()).group(),
-                #[allow(deprecated)]
-                Literal::String(string) => b::primitive(format!("{:?}", string.slice(source))),
+                Literal::NoCopyString(string) => {
+                    b::primitive(format!("{:?}", string.slice(source)))
+                }
                 Literal::Str(string) => b::primitive(format!("{:?}", string)),
                 Literal::GlobPattern(pattern) => b::primitive(pattern),
                 Literal::ColumnPath(path) => {
@@ -479,8 +476,7 @@ impl PrettyDebugWithSource for SpannedLiteral {
             Literal::Size(number, unit) => {
                 b::typed("size", (number.pretty() + unit.pretty()).group())
             }
-            #[allow(deprecated)]
-            Literal::String(string) => b::typed(
+            Literal::NoCopyString(string) => b::typed(
                 "string",
                 b::primitive(format!("{:?}", string.slice(source))),
             ),

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -321,7 +321,7 @@ impl Expression {
         Expression::Literal(Literal::Size(i.into(), unit.into()))
     }
 
-    #[deprecated]
+    #[deprecated(note = "please use `Expression::str` instead")]
     pub fn string(inner: impl Into<Span>) -> Expression {
         #[allow(deprecated)]
         Expression::Literal(Literal::String(inner.into()))
@@ -416,7 +416,7 @@ impl From<Spanned<Path>> for SpannedExpression {
 pub enum Literal {
     Number(Number),
     Size(Number, Unit),
-    #[deprecated]
+    #[deprecated(note = "please use `Literal::Str` instead")]
     String(Span),
     Str(String),
     GlobPattern(String),

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -326,7 +326,7 @@ impl Expression {
     }
 
     pub fn str(s: impl Into<String>) -> Expression {
-        Expression::Literal(Literal::Str(s.into()))
+        Expression::Literal(Literal::String(s.into()))
     }
 
     pub fn synthetic_string(string: impl Into<String>) -> Expression {
@@ -415,7 +415,7 @@ pub enum Literal {
     Number(Number),
     Size(Number, Unit),
     NoCopyString(Span),
-    Str(String),
+    String(String),
     GlobPattern(String),
     ColumnPath(Vec<Member>),
     Bare,
@@ -442,7 +442,7 @@ impl ShellTypeName for Literal {
             Literal::Number(..) => "number",
             Literal::Size(..) => "size",
             Literal::NoCopyString(..) => "string",
-            Literal::Str(..) => "string",
+            Literal::String(..) => "string",
             Literal::ColumnPath(..) => "column path",
             Literal::Bare => "string",
             Literal::GlobPattern(_) => "pattern",
@@ -460,7 +460,7 @@ impl PrettyDebugWithSource for SpannedLiteral {
                 Literal::NoCopyString(string) => {
                     b::primitive(format!("{:?}", string.slice(source)))
                 }
-                Literal::Str(string) => b::primitive(format!("{:?}", string)),
+                Literal::String(string) => b::primitive(format!("{:?}", string)),
                 Literal::GlobPattern(pattern) => b::primitive(pattern),
                 Literal::ColumnPath(path) => {
                     b::intersperse_with_source(path.iter(), b::space(), source)
@@ -480,7 +480,7 @@ impl PrettyDebugWithSource for SpannedLiteral {
                 "string",
                 b::primitive(format!("{:?}", string.slice(source))),
             ),
-            Literal::Str(string) => b::typed("string", b::primitive(format!("{:?}", string))),
+            Literal::String(string) => b::typed("string", b::primitive(format!("{:?}", string))),
             Literal::GlobPattern(pattern) => b::typed("pattern", b::primitive(pattern)),
             Literal::ColumnPath(path) => b::typed(
                 "column path",

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -321,8 +321,14 @@ impl Expression {
         Expression::Literal(Literal::Size(i.into(), unit.into()))
     }
 
+    #[deprecated]
     pub fn string(inner: impl Into<Span>) -> Expression {
+        #[allow(deprecated)]
         Expression::Literal(Literal::String(inner.into()))
+    }
+
+    pub fn str(s: impl Into<String>) -> Expression {
+        Expression::Literal(Literal::Str(s.into()))
     }
 
     pub fn synthetic_string(string: impl Into<String>) -> Expression {
@@ -410,7 +416,9 @@ impl From<Spanned<Path>> for SpannedExpression {
 pub enum Literal {
     Number(Number),
     Size(Number, Unit),
+    #[deprecated]
     String(Span),
+    Str(String),
     GlobPattern(String),
     ColumnPath(Vec<Member>),
     Bare,
@@ -436,7 +444,9 @@ impl ShellTypeName for Literal {
         match &self {
             Literal::Number(..) => "number",
             Literal::Size(..) => "size",
+            #[allow(deprecated)]
             Literal::String(..) => "string",
+            Literal::Str(..) => "string",
             Literal::ColumnPath(..) => "column path",
             Literal::Bare => "string",
             Literal::GlobPattern(_) => "pattern",
@@ -451,7 +461,9 @@ impl PrettyDebugWithSource for SpannedLiteral {
             PrettyDebugRefineKind::WithContext => match &self.literal {
                 Literal::Number(number) => number.pretty(),
                 Literal::Size(number, unit) => (number.pretty() + unit.pretty()).group(),
+                #[allow(deprecated)]
                 Literal::String(string) => b::primitive(format!("{:?}", string.slice(source))),
+                Literal::Str(string) => b::primitive(format!("{:?}", string)),
                 Literal::GlobPattern(pattern) => b::primitive(pattern),
                 Literal::ColumnPath(path) => {
                     b::intersperse_with_source(path.iter(), b::space(), source)
@@ -467,10 +479,12 @@ impl PrettyDebugWithSource for SpannedLiteral {
             Literal::Size(number, unit) => {
                 b::typed("size", (number.pretty() + unit.pretty()).group())
             }
+            #[allow(deprecated)]
             Literal::String(string) => b::typed(
                 "string",
                 b::primitive(format!("{:?}", string.slice(source))),
             ),
+            Literal::Str(string) => b::typed("string", b::primitive(format!("{:?}", string))),
             Literal::GlobPattern(pattern) => b::typed("pattern", b::primitive(pattern)),
             Literal::ColumnPath(path) => b::typed(
                 "column path",

--- a/crates/nu-parser/src/hir/baseline_parse/tests.rs
+++ b/crates/nu-parser/src/hir/baseline_parse/tests.rs
@@ -66,9 +66,7 @@ fn test_parse_string() {
         CoerceStringShape,
         r#""hello""#,
         vec![b::string("hello")],
-        |tokens| {
-            Expression::string(inner_string_span(tokens[0].span())).into_expr(tokens[0].span())
-        },
+        |tokens| Expression::str("hello").into_expr(tokens[0].span()),
     );
 }
 

--- a/crates/nu-parser/src/hir/baseline_parse/tests.rs
+++ b/crates/nu-parser/src/hir/baseline_parse/tests.rs
@@ -11,7 +11,7 @@ use derive_new::new;
 use indexmap::IndexMap;
 use nu_errors::{ParseError, ShellError};
 use nu_protocol::{outln, PathMember, Signature, SyntaxShape};
-use nu_source::{HasSpan, PrettyDebugWithSource, Span, SpannedItem, Tag, Text};
+use nu_source::{HasSpan, PrettyDebugWithSource, SpannedItem, Tag, Text};
 use pretty_assertions::assert_eq;
 use std::fmt::Debug;
 
@@ -284,10 +284,6 @@ fn parse_expr(
             assert_eq!(expr, expected);
         }
     })
-}
-
-fn inner_string_span(span: Span) -> Span {
-    Span::new(span.start() + 1, span.end() - 1)
 }
 
 pub fn print_err(err: ShellError, source: &Text) {

--- a/crates/nu-parser/src/hir/baseline_parse/tests.rs
+++ b/crates/nu-parser/src/hir/baseline_parse/tests.rs
@@ -102,7 +102,7 @@ fn test_parse_path() {
         |tokens| {
             let (outer_var, inner_var) = tokens[0].expect_var();
             let amount = tokens[2].expect_bare();
-            let (outer_max_ghz, _) = tokens[4].expect_string();
+            let outer_max_ghz = tokens[4].expect_string("max ghz");
 
             Expression::path(
                 Expression::variable(inner_var).into_expr(outer_var),

--- a/crates/nu-parser/src/hir/baseline_parse/tests.rs
+++ b/crates/nu-parser/src/hir/baseline_parse/tests.rs
@@ -68,6 +68,13 @@ fn test_parse_string() {
         vec![b::string("hello")],
         |tokens| Expression::str("hello").into_expr(tokens[0].span()),
     );
+
+    parse_tokens(
+        CoerceStringShape,
+        r#""escaped\"quote""#,
+        vec![b::string(r#"escaped\"quote"#)],
+        |tokens| Expression::str(r#"escaped\"quote"#).into_expr(tokens[0].span()),
+    );
 }
 
 #[test]

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -27,7 +27,7 @@ impl ExpandSyntax for FilePathShape {
             .map(|span| file_path(span, token_nodes.context()).into_expr(span))
             .or_else(|_| {
                 token_nodes.expand_syntax(StringShape).map(|syntax| {
-                    file_path(syntax.inner, token_nodes.context()).into_expr(syntax.span)
+                    file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)
                 })
             })
             .or_else(|_| {
@@ -42,8 +42,13 @@ impl ExpandSyntax for FilePathShape {
     }
 }
 
+#[deprecated]
 fn file_path(text: Span, context: &ExpandContext) -> Expression {
     Expression::FilePath(expand_file_path(text.slice(context.source), context))
+}
+
+fn file_path_str(text: &str, context: &ExpandContext) -> Expression {
+    Expression::FilePath(expand_file_path(text, context))
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -24,7 +24,7 @@ impl ExpandSyntax for FilePathShape {
         token_nodes
             .expand_syntax(BarePathShape)
             .or_else(|_| token_nodes.expand_syntax(ExternalWordShape))
-            .map(|span| file_path(span, token_nodes.context()).into_expr(span))
+            .map(|span| no_copy_file_path(span, token_nodes.context()).into_expr(span))
             .or_else(|_| {
                 token_nodes.expand_syntax(StringShape).map(|syntax| {
                     file_path_str(&syntax.content, token_nodes.context()).into_expr(syntax.span)
@@ -35,15 +35,15 @@ impl ExpandSyntax for FilePathShape {
                     .expand_syntax(IntShape)
                     .or_else(|_| token_nodes.expand_syntax(DecimalShape))
                     .map(|number| {
-                        file_path(number.span(), token_nodes.context()).into_expr(number.span())
+                        no_copy_file_path(number.span(), token_nodes.context())
+                            .into_expr(number.span())
                     })
             })
             .map_err(|_| token_nodes.err_next_token("file path"))
     }
 }
 
-#[deprecated(note = "switch to `file_path_str` instead")]
-fn file_path(text: Span, context: &ExpandContext) -> Expression {
+fn no_copy_file_path(text: Span, context: &ExpandContext) -> Expression {
     Expression::FilePath(expand_file_path(text.slice(context.source), context))
 }
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -42,7 +42,7 @@ impl ExpandSyntax for FilePathShape {
     }
 }
 
-#[deprecated]
+#[deprecated(note = "please use `file_path_str` instead")]
 fn file_path(text: Span, context: &ExpandContext) -> Expression {
     Expression::FilePath(expand_file_path(text.slice(context.source), context))
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/file_path.rs
@@ -42,7 +42,7 @@ impl ExpandSyntax for FilePathShape {
     }
 }
 
-#[deprecated(note = "please use `file_path_str` instead")]
+#[deprecated(note = "switch to `file_path_str` instead")]
 fn file_path(text: Span, context: &ExpandContext) -> Expression {
     Expression::FilePath(expand_file_path(text.slice(context.source), context))
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -24,11 +24,13 @@ impl ExpandSyntax for CoerceStringShape {
                 Ok((FlatShape::String, Expression::str(s).into_expr(outer)))
             })
             .or_else(|_| {
+                #[allow(deprecated)]
                 token_nodes.expand_token(BareType, |span| {
                     Ok((FlatShape::String, Expression::string(span).into_expr(span)))
                 })
             })
             .or_else(|_| {
+                #[allow(deprecated)]
                 token_nodes
                     .expand_syntax(NumberShape)
                     .map(|number| Expression::string(number.span()).into_expr(number.span()))

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -28,6 +28,12 @@ impl ExpandSyntax for CoerceStringShape {
                     Ok((FlatShape::String, Expression::string(span).into_expr(span)))
                 })
             })
+            .or_else(|_| {
+                #[allow(deprecated)]
+                token_nodes
+                    .expand_syntax(NumberShape)
+                    .map(|number| Expression::string(number.span()).into_expr(number.span()))
+            })
     }
 }
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -20,11 +20,8 @@ impl ExpandSyntax for CoerceStringShape {
         token_nodes: &'b mut TokensIterator<'a>,
     ) -> Result<SpannedExpression, ParseError> {
         token_nodes
-            .expand_token(StringType, |(inner, outer)| {
-                Ok((
-                    FlatShape::String,
-                    Expression::string(inner).into_expr(outer),
-                ))
+            .expand_token(StrType, |(s, outer)| {
+                Ok((FlatShape::String, Expression::str(s).into_expr(outer)))
             })
             .or_else(|_| {
                 token_nodes.expand_token(BareType, |span| {

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -29,12 +29,6 @@ impl ExpandSyntax for CoerceStringShape {
                     Ok((FlatShape::String, Expression::string(span).into_expr(span)))
                 })
             })
-            .or_else(|_| {
-                #[allow(deprecated)]
-                token_nodes
-                    .expand_syntax(NumberShape)
-                    .map(|number| Expression::string(number.span()).into_expr(number.span()))
-            })
     }
 }
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -1,7 +1,7 @@
 use crate::hir::syntax_shape::{ExpandSyntax, FlatShape, NumberShape, VariableShape};
 use crate::hir::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
-use crate::parse::token_tree::{BareType, StringType};
+use crate::parse::token_tree::{BareType, StrType, StringType};
 use nu_errors::ParseError;
 use nu_source::{b, DebugDocBuilder, HasSpan, PrettyDebugWithSource, Span};
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -29,7 +29,6 @@ impl ExpandSyntax for CoerceStringShape {
                 })
             })
             .or_else(|_| {
-                #[allow(deprecated)]
                 token_nodes
                     .expand_syntax(NumberShape)
                     .map(|number| Expression::string(number.span()).into_expr(number.span()))

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -1,7 +1,7 @@
 use crate::hir::syntax_shape::{ExpandSyntax, FlatShape, NumberShape, VariableShape};
 use crate::hir::TokensIterator;
 use crate::hir::{Expression, SpannedExpression};
-use crate::parse::token_tree::{BareType, StrType, StringType};
+use crate::parse::token_tree::{BareType, StrType};
 use nu_errors::ParseError;
 use nu_source::{b, DebugDocBuilder, HasSpan, PrettyDebugWithSource, Span};
 

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -24,7 +24,6 @@ impl ExpandSyntax for CoerceStringShape {
                 Ok((FlatShape::String, Expression::str(s).into_expr(outer)))
             })
             .or_else(|_| {
-                #[allow(deprecated)]
                 token_nodes.expand_token(BareType, |span| {
                     Ok((FlatShape::String, Expression::string(span).into_expr(span)))
                 })

--- a/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/string.rs
@@ -51,11 +51,8 @@ impl ExpandSyntax for StringExpressionShape {
         token_nodes: &'b mut TokensIterator<'a>,
     ) -> Result<SpannedExpression, ParseError> {
         token_nodes.expand_syntax(VariableShape).or_else(|_| {
-            token_nodes.expand_token(StringType, |(inner, outer)| {
-                Ok((
-                    FlatShape::String,
-                    Expression::string(inner).into_expr(outer),
-                ))
+            token_nodes.expand_token(StrType, |(s, outer)| {
+                Ok((FlatShape::String, Expression::str(s).into_expr(outer)))
             })
         })
     }
@@ -65,6 +62,24 @@ impl ExpandSyntax for StringExpressionShape {
 pub struct StringSyntax {
     pub inner: Span,
     pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct StrSyntax {
+    pub content: String,
+    pub span: Span,
+}
+
+impl HasSpan for StrSyntax {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl PrettyDebugWithSource for StrSyntax {
+    fn pretty_debug(&self, _: &str) -> DebugDocBuilder {
+        b::primitive(self.content.clone())
+    }
 }
 
 impl HasSpan for StringSyntax {
@@ -83,7 +98,7 @@ impl PrettyDebugWithSource for StringSyntax {
 pub struct StringShape;
 
 impl ExpandSyntax for StringShape {
-    type Output = Result<StringSyntax, ParseError>;
+    type Output = Result<StrSyntax, ParseError>;
 
     fn name(&self) -> &'static str {
         "string"
@@ -92,9 +107,15 @@ impl ExpandSyntax for StringShape {
     fn expand<'a, 'b>(
         &self,
         token_nodes: &'b mut TokensIterator<'a>,
-    ) -> Result<StringSyntax, ParseError> {
-        token_nodes.expand_token(StringType, |(inner, outer)| {
-            Ok((FlatShape::String, StringSyntax { inner, span: outer }))
+    ) -> Result<StrSyntax, ParseError> {
+        token_nodes.expand_token(StrType, |(s, outer)| {
+            Ok((
+                FlatShape::String,
+                StrSyntax {
+                    content: s,
+                    span: outer,
+                },
+            ))
         })
     }
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -265,16 +265,21 @@ pub enum Member {
     String(/* outer */ Span, /* inner */ Span),
     Str(/* outer */ Span, String),
     Int(BigInt, Span),
+    #[deprecated]
     Bare(Span),
+    BareStr(Span, String),
 }
 
 impl ShellTypeName for Member {
     fn type_name(&self) -> &'static str {
         match self {
+            #[allow(deprecated)]
             Member::String(_, _) => "string",
             Member::Str(_, _) => "string",
             Member::Int(_, _) => "integer",
             Member::Bare(_) => "word",
+            #[allow(deprecated)]
+            Member::BareStr(_, _) => "word",
         }
     }
 }
@@ -294,7 +299,9 @@ impl Member {
             Member::String(outer, inner) => PathMember::string(inner.slice(source), *outer),
             Member::Str(outer, s) => PathMember::string(s, *outer),
             Member::Int(int, span) => PathMember::int(int.clone(), *span),
+            #[allow(deprecated)]
             Member::Bare(span) => PathMember::string(span.slice(source), *span),
+            Member::BareStr(span, s) => PathMember::string(s, *span),
         }
     }
 }
@@ -306,7 +313,9 @@ impl PrettyDebugWithSource for Member {
             Member::String(outer, _) => b::value(outer.slice(source)),
             Member::Str(_, content) => b::value(&content),
             Member::Int(int, _) => b::value(format!("{}", int)),
+            #[allow(deprecated)]
             Member::Bare(span) => b::value(span.slice(source)),
+            Member::BareStr(_, s) => b::value(&s),
         }
     }
 }
@@ -318,7 +327,9 @@ impl HasSpan for Member {
             Member::String(outer, ..) => *outer,
             Member::Str(outer, ..) => *outer,
             Member::Int(_, int) => *int,
+            #[allow(deprecated)]
             Member::Bare(name) => *name,
+            Member::BareStr(span, ..) => *span,
         }
     }
 }
@@ -330,7 +341,9 @@ impl Member {
             Member::String(outer, inner) => Expression::string(*inner).into_expr(outer),
             Member::Str(outer, content) => Expression::str(content).into_expr(outer),
             Member::Int(number, span) => Expression::number(number.clone()).into_expr(span),
+            #[allow(deprecated)]
             Member::Bare(span) => Expression::string(*span).into_expr(span),
+            Member::BareStr(span, content) => Expression::str(content).into_expr(span),
         }
     }
 
@@ -340,7 +353,9 @@ impl Member {
             Member::String(outer, _inner) => *outer,
             Member::Str(outer, _) => *outer,
             Member::Int(_, span) => *span,
+            #[allow(deprecated)]
             Member::Bare(span) => *span,
+            Member::BareStr(span, _) => *span,
         }
     }
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -261,11 +261,11 @@ impl ExpandSyntax for VariableShape {
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Member {
-    #[deprecated]
+    #[deprecated(note = "please use `Member::Str` instead")]
     String(/* outer */ Span, /* inner */ Span),
     Str(/* outer */ Span, String),
     Int(BigInt, Span),
-    #[deprecated]
+    #[deprecated(note = "please use `Member::Str` instead")]
     Bare(Span),
     BareStr(Span, String),
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -263,9 +263,7 @@ impl ExpandSyntax for VariableShape {
 pub enum Member {
     String(/* outer */ Span, String),
     Int(BigInt, Span),
-    #[deprecated(note = "switch to `Member::Str` instead")]
     Bare(Span),
-    BareStr(Span, String),
 }
 
 impl ShellTypeName for Member {
@@ -273,9 +271,7 @@ impl ShellTypeName for Member {
         match self {
             Member::String(_, _) => "string",
             Member::Int(_, _) => "integer",
-            #[allow(deprecated)]
             Member::Bare(_) => "word",
-            Member::BareStr(_, _) => "word",
         }
     }
 }
@@ -293,9 +289,7 @@ impl Member {
         match self {
             Member::String(outer, s) => PathMember::string(s, *outer),
             Member::Int(int, span) => PathMember::int(int.clone(), *span),
-            #[allow(deprecated)]
             Member::Bare(span) => PathMember::string(span.slice(source), *span),
-            Member::BareStr(span, s) => PathMember::string(s, *span),
         }
     }
 }
@@ -305,9 +299,7 @@ impl PrettyDebugWithSource for Member {
         match self {
             Member::String(_, content) => b::value(&content),
             Member::Int(int, _) => b::value(format!("{}", int)),
-            #[allow(deprecated)]
             Member::Bare(span) => b::value(span.slice(source)),
-            Member::BareStr(_, s) => b::value(&s),
         }
     }
 }
@@ -317,9 +309,7 @@ impl HasSpan for Member {
         match self {
             Member::String(outer, ..) => *outer,
             Member::Int(_, int) => *int,
-            #[allow(deprecated)]
             Member::Bare(name) => *name,
-            Member::BareStr(span, ..) => *span,
         }
     }
 }
@@ -329,9 +319,7 @@ impl Member {
         match self {
             Member::String(outer, content) => Expression::str(content).into_expr(outer),
             Member::Int(number, span) => Expression::number(number.clone()).into_expr(span),
-            #[allow(deprecated)]
             Member::Bare(span) => Expression::string(*span).into_expr(span),
-            Member::BareStr(span, content) => Expression::str(content).into_expr(span),
         }
     }
 
@@ -339,9 +327,7 @@ impl Member {
         match self {
             Member::String(outer, _) => *outer,
             Member::Int(_, span) => *span,
-            #[allow(deprecated)]
             Member::Bare(span) => *span,
-            Member::BareStr(span, _) => *span,
         }
     }
 }

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -261,9 +261,7 @@ impl ExpandSyntax for VariableShape {
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Member {
-    #[deprecated(note = "switch to `Member::Str` instead")]
-    String(/* outer */ Span, /* inner */ Span),
-    Str(/* outer */ Span, String),
+    String(/* outer */ Span, String),
     Int(BigInt, Span),
     #[deprecated(note = "switch to `Member::Str` instead")]
     Bare(Span),
@@ -273,9 +271,7 @@ pub enum Member {
 impl ShellTypeName for Member {
     fn type_name(&self) -> &'static str {
         match self {
-            #[allow(deprecated)]
             Member::String(_, _) => "string",
-            Member::Str(_, _) => "string",
             Member::Int(_, _) => "integer",
             #[allow(deprecated)]
             Member::Bare(_) => "word",
@@ -295,9 +291,7 @@ impl Member {
 
     pub fn to_path_member(&self, source: &Text) -> PathMember {
         match self {
-            #[allow(deprecated)]
-            Member::String(outer, inner) => PathMember::string(inner.slice(source), *outer),
-            Member::Str(outer, s) => PathMember::string(s, *outer),
+            Member::String(outer, s) => PathMember::string(s, *outer),
             Member::Int(int, span) => PathMember::int(int.clone(), *span),
             #[allow(deprecated)]
             Member::Bare(span) => PathMember::string(span.slice(source), *span),
@@ -309,9 +303,7 @@ impl Member {
 impl PrettyDebugWithSource for Member {
     fn pretty_debug(&self, source: &str) -> DebugDocBuilder {
         match self {
-            #[allow(deprecated)]
-            Member::String(outer, _) => b::value(outer.slice(source)),
-            Member::Str(_, content) => b::value(&content),
+            Member::String(_, content) => b::value(&content),
             Member::Int(int, _) => b::value(format!("{}", int)),
             #[allow(deprecated)]
             Member::Bare(span) => b::value(span.slice(source)),
@@ -323,9 +315,7 @@ impl PrettyDebugWithSource for Member {
 impl HasSpan for Member {
     fn span(&self) -> Span {
         match self {
-            #[allow(deprecated)]
             Member::String(outer, ..) => *outer,
-            Member::Str(outer, ..) => *outer,
             Member::Int(_, int) => *int,
             #[allow(deprecated)]
             Member::Bare(name) => *name,
@@ -337,9 +327,7 @@ impl HasSpan for Member {
 impl Member {
     pub fn to_expr(&self) -> hir::SpannedExpression {
         match self {
-            #[allow(deprecated)]
-            Member::String(outer, inner) => Expression::string(*inner).into_expr(outer),
-            Member::Str(outer, content) => Expression::str(content).into_expr(outer),
+            Member::String(outer, content) => Expression::str(content).into_expr(outer),
             Member::Int(number, span) => Expression::number(number.clone()).into_expr(span),
             #[allow(deprecated)]
             Member::Bare(span) => Expression::string(*span).into_expr(span),
@@ -349,9 +337,7 @@ impl Member {
 
     pub(crate) fn span(&self) -> Span {
         match self {
-            #[allow(deprecated)]
-            Member::String(outer, _inner) => *outer,
-            Member::Str(outer, _) => *outer,
+            Member::String(outer, _) => *outer,
             Member::Int(_, span) => *span,
             #[allow(deprecated)]
             Member::Bare(span) => *span,
@@ -508,7 +494,7 @@ impl ExpandSyntax for MemberShape {
         let string = token_nodes.expand_syntax(StringShape);
 
         if let Ok(syntax) = string {
-            return Ok(Member::Str(syntax.span, syntax.content));
+            return Ok(Member::String(syntax.span, syntax.content));
         }
 
         Err(token_nodes.peek().type_error("column"))

--- a/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/expression/variable_path.rs
@@ -261,11 +261,11 @@ impl ExpandSyntax for VariableShape {
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Member {
-    #[deprecated(note = "please use `Member::Str` instead")]
+    #[deprecated(note = "switch to `Member::Str` instead")]
     String(/* outer */ Span, /* inner */ Span),
     Str(/* outer */ Span, String),
     Int(BigInt, Span),
-    #[deprecated(note = "please use `Member::Str` instead")]
+    #[deprecated(note = "switch to `Member::Str` instead")]
     Bare(Span),
     BareStr(Span, String),
 }
@@ -277,8 +277,8 @@ impl ShellTypeName for Member {
             Member::String(_, _) => "string",
             Member::Str(_, _) => "string",
             Member::Int(_, _) => "integer",
-            Member::Bare(_) => "word",
             #[allow(deprecated)]
+            Member::Bare(_) => "word",
             Member::BareStr(_, _) => "word",
         }
     }

--- a/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
@@ -151,7 +151,9 @@ impl FlatShape {
                 shapes.push(FlatShape::DotDot.spanned(span))
             }
             Token::CompareOperator(_) => shapes.push(FlatShape::CompareOperator.spanned(span)),
+            #[allow(deprecated)]
             Token::String(_) => shapes.push(FlatShape::String.spanned(span)),
+            Token::Str(_) => shapes.push(FlatShape::String.spanned(span)),
             Token::Variable(v) if v.slice(source) == "it" => {
                 shapes.push(FlatShape::ItVariable.spanned(span))
             }

--- a/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
+++ b/crates/nu-parser/src/hir/syntax_shape/flat_shape.rs
@@ -151,9 +151,7 @@ impl FlatShape {
                 shapes.push(FlatShape::DotDot.spanned(span))
             }
             Token::CompareOperator(_) => shapes.push(FlatShape::CompareOperator.spanned(span)),
-            #[allow(deprecated)]
             Token::String(_) => shapes.push(FlatShape::String.spanned(span)),
-            Token::Str(_) => shapes.push(FlatShape::String.spanned(span)),
             Token::Variable(v) if v.slice(source) == "it" => {
                 shapes.push(FlatShape::ItVariable.spanned(span))
             }

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -6,8 +6,8 @@ use crate::parse::{
 use nom;
 use nom::branch::*;
 use nom::bytes::complete::*;
-use nom::character::complete::*;
 use nom::character::complete;
+use nom::character::complete::*;
 use nom::combinator::*;
 use nom::multi::*;
 use nom::sequence::*;
@@ -317,7 +317,7 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
-    let (input, _) = escaped(none_of("\"\\"),'\\',complete::one_of("\"\\"))(input)?;
+    let (input, _) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
 
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -315,8 +315,10 @@ pub fn operator(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
 #[tracable_parser]
 pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     fn remove_escapes(s: &str) -> String {
+        /// This is required to remove the escape characters since the `escaped` nom function returns a
+        /// Span (since it uses one as input)
         let mut string = String::new();
-        let mut was_escape = false; //
+        let mut was_escape = false;
         for c in s.chars() {
             if c == '\\' && !was_escape {
                 was_escape = true;

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -380,6 +380,7 @@ pub fn external(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     ))
 }
 
+#[deprecated(note = "This needs to be updated to return a String instead of a span")]
 fn word<'a, T, U, V>(
     start_predicate: impl Fn(NomSpan<'a>) -> IResult<NomSpan<'a>, U>,
     next_predicate: impl Fn(NomSpan<'a>) -> IResult<NomSpan<'a>, V> + Copy,

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -314,17 +314,30 @@ pub fn operator(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
 
 #[tracable_parser]
 pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
+    fn remove_escapes(s: &str) -> String {
+        let mut string = String::new();
+        let mut was_escape = false; //
+        for c in s.chars() {
+            if c == '\\' && !was_escape {
+                was_escape = true;
+            } else {
+                string.push(c);
+                was_escape = false;
+            }
+        }
+        string
+    }
+
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
     let (input, result) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
-
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;
     let end = input.offset;
     Ok((
         input,
-        TokenTreeBuilder::spanned_str(result.fragment, Span::new(start, end)),
+        TokenTreeBuilder::spanned_str(remove_escapes(result.fragment), Span::new(start, end)),
     ))
 }
 

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -339,7 +339,7 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let end = input.offset;
     Ok((
         input,
-        TokenTreeBuilder::spanned_str(remove_escapes(result.fragment), Span::new(start, end)),
+        TokenTreeBuilder::spanned_string(remove_escapes(result.fragment), Span::new(start, end)),
     ))
 }
 
@@ -355,7 +355,7 @@ pub fn sq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
 
     Ok((
         input,
-        TokenTreeBuilder::spanned_str(
+        TokenTreeBuilder::spanned_string(
             result.into_iter().collect::<String>(),
             Span::new(start, end),
         ),

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -7,6 +7,7 @@ use nom;
 use nom::branch::*;
 use nom::bytes::complete::*;
 use nom::character::complete::*;
+use nom::character::complete;
 use nom::combinator::*;
 use nom::multi::*;
 use nom::sequence::*;
@@ -316,7 +317,7 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
-    let (input, _) = many0(none_of("\""))(input)?;
+    let (input, _) = escaped(none_of("\"\\"),'\\',complete::one_of("\"\\"))(input)?;
 
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -317,14 +317,14 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
-    let (input, _) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
+    let (input, result) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
 
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;
     let end = input.offset;
     Ok((
         input,
-        TokenTreeBuilder::spanned_string(Span::new(start1, end1), Span::new(start, end)),
+        TokenTreeBuilder::spanned_str(result.fragment, Span::new(start, end)),
     ))
 }
 
@@ -333,14 +333,17 @@ pub fn sq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('\'')(input)?;
     let start1 = input.offset;
-    let (input, _) = many0(none_of("\'"))(input)?;
+    let (input, result) = many0(none_of("\'"))(input)?;
     let end1 = input.offset;
     let (input, _) = char('\'')(input)?;
     let end = input.offset;
 
     Ok((
         input,
-        TokenTreeBuilder::spanned_string(Span::new(start1, end1), Span::new(start, end)),
+        TokenTreeBuilder::spanned_str(
+            result.into_iter().collect::<String>(),
+            Span::new(start, end),
+        ),
     ))
 }
 

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -380,7 +380,6 @@ pub fn external(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     ))
 }
 
-#[deprecated(note = "This needs to be updated to return a String instead of a span")]
 fn word<'a, T, U, V>(
     start_predicate: impl Fn(NomSpan<'a>) -> IResult<NomSpan<'a>, U>,
     next_predicate: impl Fn(NomSpan<'a>) -> IResult<NomSpan<'a>, V> + Copy,

--- a/crates/nu-parser/src/parse/parser.rs
+++ b/crates/nu-parser/src/parse/parser.rs
@@ -323,6 +323,9 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
             if c == '\\' && !was_escape {
                 was_escape = true;
             } else {
+                if was_escape && (c != '\\' && c != '"') {
+                    string.push('\\');
+                }
                 string.push(c);
                 was_escape = false;
             }
@@ -333,7 +336,7 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let start = input.offset;
     let (input, _) = char('"')(input)?;
     let start1 = input.offset;
-    let (input, result) = escaped(none_of("\"\\"), '\\', complete::one_of("\"\\"))(input)?;
+    let (input, result) = escaped(none_of("\"\\"), '\\', take(1usize))(input)?;
     let end1 = input.offset;
     let (input, _) = char('"')(input)?;
     let end = input.offset;

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -15,9 +15,7 @@ pub enum Token {
     Number(RawNumber),
     CompareOperator(CompareOperator),
     EvaluationOperator(EvaluationOperator),
-    #[deprecated(note = "switch to `Token::String` instead")]
-    String(Span),
-    Str(String),
+    String(String),
     Variable(Span),
     ItVariable(Span),
     ExternalCommand(Span),
@@ -95,13 +93,8 @@ token_type!(struct DecimalType (desc: "decimal") -> RawNumber {
     Token::Number(number @ RawNumber::Decimal(_)) => number
 });
 
-#[deprecated(note = "switch to `StrType` instead")]
-token_type!(struct StringType (desc: "string") -> (Span, Span) {
-    |outer, Token::String(inner)| => (*inner, outer)
-});
-
 token_type!(struct StrType(desc: "string") -> (String, Span) {
-    |outer, Token::Str(s)| => (s.clone(), outer)
+    |outer, Token::String(s)| => (s.clone(), outer)
 });
 
 token_type!(struct BareType (desc: "word") -> Span {
@@ -217,8 +210,7 @@ impl PrettyDebugWithSource for SpannedToken {
             Token::Number(number) => number.pretty_debug(source),
             Token::CompareOperator(operator) => operator.pretty_debug(source),
             Token::EvaluationOperator(operator) => operator.pretty_debug(source),
-            #[allow(deprecated)]
-            Token::String(_) | Token::Str(_) | Token::GlobPattern | Token::Bare => {
+            Token::String(_) | Token::GlobPattern | Token::Bare => {
                 b::primitive(self.span.slice(source))
             }
             Token::Variable(_) => b::var(self.span.slice(source)),
@@ -252,9 +244,7 @@ impl ShellTypeName for Token {
             Token::CompareOperator(_) => "comparison operator",
             Token::EvaluationOperator(EvaluationOperator::Dot) => "dot",
             Token::EvaluationOperator(EvaluationOperator::DotDot) => "dot dot",
-            #[allow(deprecated)]
             Token::String(_) => "string",
-            Token::Str(_) => "string",
             Token::Variable(_) => "variable",
             Token::ItVariable(_) => "it variable",
             Token::ExternalCommand(_) => "external command",
@@ -304,9 +294,7 @@ impl SpannedToken {
 
     pub fn is_string(&self) -> bool {
         match self.unspanned() {
-            #[allow(deprecated)]
             Token::String(_) => true,
-            Token::Str(_) => true,
             _ => false,
         }
     }
@@ -325,18 +313,9 @@ impl SpannedToken {
         }
     }
 
-    #[deprecated(note = "switch to `SpannedToken::as_str` instead")]
-    pub fn as_string(&self) -> Option<(Span, Span)> {
-        match self.unspanned() {
-            #[allow(deprecated)]
-            Token::String(inner_span) => Some((self.span(), *inner_span)),
-            _ => None,
-        }
-    }
-
     pub fn as_str<'tree>(&'tree self) -> Option<(Span, &'tree str)> {
         match self.unspanned() {
-            Token::Str(s) => Some((self.span(), s)),
+            Token::String(s) => Some((self.span(), s)),
             _ => None,
         }
     }
@@ -516,7 +495,7 @@ impl SpannedToken {
 
     pub fn expect_string(&self, value: impl Into<String>) -> Span {
         match self.unspanned() {
-            Token::Str(s) if *s == value.into() => self.span(),
+            Token::String(s) if *s == value.into() => self.span(),
             other => panic!("Expected string, found {:?}", other),
         }
     }

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -15,7 +15,7 @@ pub enum Token {
     Number(RawNumber),
     CompareOperator(CompareOperator),
     EvaluationOperator(EvaluationOperator),
-    #[deprecated]
+    #[deprecated(note = "please use `Token::String` instead")]
     String(Span),
     Str(String),
     Variable(Span),
@@ -23,7 +23,7 @@ pub enum Token {
     ExternalCommand(Span),
     ExternalWord,
     GlobPattern,
-    #[deprecated]
+    #[deprecated(note = "please use `Token::String` instead")]
     Bare,
     Garbage,
 
@@ -96,7 +96,7 @@ token_type!(struct DecimalType (desc: "decimal") -> RawNumber {
     Token::Number(number @ RawNumber::Decimal(_)) => number
 });
 
-#[deprecated]
+#[deprecated(note = "please use `StrType` instead")]
 token_type!(struct StringType (desc: "string") -> (Span, Span) {
     |outer, Token::String(inner)| => (*inner, outer)
 });
@@ -105,7 +105,7 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
-#[deprecated]
+#[deprecated(note = "please use `StrType` instead")]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
 });
@@ -327,7 +327,7 @@ impl SpannedToken {
         }
     }
 
-    #[deprecated]
+    #[deprecated(note = "please use `SpannedToken::as_str` instead")]
     pub fn as_string(&self) -> Option<(Span, Span)> {
         match self.unspanned() {
             #[allow(deprecated)]

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -15,7 +15,7 @@ pub enum Token {
     Number(RawNumber),
     CompareOperator(CompareOperator),
     EvaluationOperator(EvaluationOperator),
-    #[deprecated(note = "please use `Token::String` instead")]
+    #[deprecated(note = "switch to `Token::String` instead")]
     String(Span),
     Str(String),
     Variable(Span),
@@ -23,7 +23,7 @@ pub enum Token {
     ExternalCommand(Span),
     ExternalWord,
     GlobPattern,
-    #[deprecated(note = "please use `Token::String` instead")]
+    #[deprecated(note = "switch to `Token::String` instead")]
     Bare,
     Garbage,
 
@@ -96,7 +96,7 @@ token_type!(struct DecimalType (desc: "decimal") -> RawNumber {
     Token::Number(number @ RawNumber::Decimal(_)) => number
 });
 
-#[deprecated(note = "please use `StrType` instead")]
+#[deprecated(note = "switch to `StrType` instead")]
 token_type!(struct StringType (desc: "string") -> (Span, Span) {
     |outer, Token::String(inner)| => (*inner, outer)
 });
@@ -105,7 +105,7 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
-#[deprecated(note = "please use `StrType` instead")]
+#[deprecated(note = "switch to `StrType` instead")]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
 });
@@ -327,7 +327,7 @@ impl SpannedToken {
         }
     }
 
-    #[deprecated(note = "please use `SpannedToken::as_str` instead")]
+    #[deprecated(note = "switch to `SpannedToken::as_str` instead")]
     pub fn as_string(&self) -> Option<(Span, Span)> {
         match self.unspanned() {
             #[allow(deprecated)]

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -516,9 +516,9 @@ impl SpannedToken {
         }
     }
 
-    pub fn expect_string(&self) -> (Span, Span) {
+    pub fn expect_string(&self, value: impl Into<String>) -> Span {
         match self.unspanned() {
-            Token::String(inner_span) => (self.span(), *inner_span),
+            Token::Str(s) if *s == value.into() => self.span(),
             other => panic!("Expected string, found {:?}", other),
         }
     }

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -23,7 +23,6 @@ pub enum Token {
     ExternalCommand(Span),
     ExternalWord,
     GlobPattern,
-    #[deprecated(note = "switch to `Token::String` instead")]
     Bare,
     Garbage,
 

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -23,6 +23,7 @@ pub enum Token {
     ExternalCommand(Span),
     ExternalWord,
     GlobPattern,
+    #[deprecated]
     Bare,
     Garbage,
 
@@ -104,6 +105,7 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
+#[deprecated]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
 });

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -313,7 +313,7 @@ impl SpannedToken {
         }
     }
 
-    pub fn as_str<'tree>(&'tree self) -> Option<(Span, &'tree str)> {
+    pub fn as_str(&self) -> Option<(Span, &str)> {
         match self.unspanned() {
             Token::String(s) => Some((self.span(), s)),
             _ => None,

--- a/crates/nu-parser/src/parse/token_tree.rs
+++ b/crates/nu-parser/src/parse/token_tree.rs
@@ -105,7 +105,6 @@ token_type!(struct StrType(desc: "string") -> (String, Span) {
     |outer, Token::Str(s)| => (s.clone(), outer)
 });
 
-#[deprecated(note = "switch to `StrType` instead")]
 token_type!(struct BareType (desc: "word") -> Span {
     |span, Token::Bare| => span
 });

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -178,8 +178,6 @@ impl TokenTreeBuilder {
         Token::String(input.into()).into_spanned(span)
     }
 
-    #[deprecated(note = "switch to `spanned_string`")]
-    #[allow(deprecated)]
     pub fn bare(input: impl Into<String>) -> CurriedToken {
         let input = input.into();
 
@@ -191,7 +189,6 @@ impl TokenTreeBuilder {
         })
     }
 
-    #[deprecated]
     pub fn spanned_bare(span: impl Into<Span>) -> SpannedToken {
         Token::Bare.into_spanned(span)
     }

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -174,7 +174,7 @@ impl TokenTreeBuilder {
         })
     }
 
-    #[deprecated]
+    #[deprecated(note = "please use `spanned_str` instead")]
     pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> SpannedToken {
         #[allow(deprecated)]
         Token::String(input.into()).into_spanned(span)

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -174,7 +174,7 @@ impl TokenTreeBuilder {
         })
     }
 
-    #[deprecated(note = "please use `spanned_str` instead")]
+    #[deprecated(note = "switch to `spanned_str` instead")]
     pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> SpannedToken {
         #[allow(deprecated)]
         Token::String(input.into()).into_spanned(span)
@@ -184,6 +184,8 @@ impl TokenTreeBuilder {
         Token::Str(input.into()).into_spanned(span)
     }
 
+    #[deprecated(note = "switch to `spanned_str`")]
+    #[allow(deprecated)]
     pub fn bare(input: impl Into<String>) -> CurriedToken {
         let input = input.into();
 
@@ -195,6 +197,7 @@ impl TokenTreeBuilder {
         })
     }
 
+    #[deprecated]
     pub fn spanned_bare(span: impl Into<Span>) -> SpannedToken {
         Token::Bare.into_spanned(span)
     }

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -170,21 +170,15 @@ impl TokenTreeBuilder {
             let (_, end) = b.consume("\"");
             b.pos = end;
 
-            TokenTreeBuilder::spanned_str(input, Span::new(start, end))
+            TokenTreeBuilder::spanned_string(input, Span::new(start, end))
         })
     }
 
-    #[deprecated(note = "switch to `spanned_str` instead")]
-    pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> SpannedToken {
-        #[allow(deprecated)]
+    pub fn spanned_string(input: impl Into<String>, span: impl Into<Span>) -> SpannedToken {
         Token::String(input.into()).into_spanned(span)
     }
 
-    pub fn spanned_str(input: impl Into<String>, span: impl Into<Span>) -> SpannedToken {
-        Token::Str(input.into()).into_spanned(span)
-    }
-
-    #[deprecated(note = "switch to `spanned_str`")]
+    #[deprecated(note = "switch to `spanned_string`")]
     #[allow(deprecated)]
     pub fn bare(input: impl Into<String>) -> CurriedToken {
         let input = input.into();

--- a/crates/nu-parser/src/parse/token_tree_builder.rs
+++ b/crates/nu-parser/src/parse/token_tree_builder.rs
@@ -166,19 +166,22 @@ impl TokenTreeBuilder {
 
         Box::new(move |b| {
             let (start, _) = b.consume("\"");
-            let (inner_start, inner_end) = b.consume(&input);
+            b.consume(&input);
             let (_, end) = b.consume("\"");
             b.pos = end;
 
-            TokenTreeBuilder::spanned_string(
-                Span::new(inner_start, inner_end),
-                Span::new(start, end),
-            )
+            TokenTreeBuilder::spanned_str(input, Span::new(start, end))
         })
     }
 
+    #[deprecated]
     pub fn spanned_string(input: impl Into<Span>, span: impl Into<Span>) -> SpannedToken {
+        #[allow(deprecated)]
         Token::String(input.into()).into_spanned(span)
+    }
+
+    pub fn spanned_str(input: impl Into<String>, span: impl Into<Span>) -> SpannedToken {
+        Token::Str(input.into()).into_spanned(span)
     }
 
     pub fn bare(input: impl Into<String>) -> CurriedToken {

--- a/crates/nu-parser/src/parse/util/line_delimited_parser/parser.rs
+++ b/crates/nu-parser/src/parse/util/line_delimited_parser/parser.rs
@@ -159,7 +159,7 @@ pub fn dq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
     let end = input.offset;
     Ok((
         input,
-        TokenTreeBuilder::spanned_str(result.fragment, Span::new(start, end)),
+        TokenTreeBuilder::spanned_string(result.fragment, Span::new(start, end)),
     ))
 }
 
@@ -173,7 +173,7 @@ pub fn sq_string(input: NomSpan) -> IResult<NomSpan, SpannedToken> {
 
     Ok((
         input,
-        TokenTreeBuilder::spanned_str(
+        TokenTreeBuilder::spanned_string(
             result.into_iter().collect::<String>(),
             Span::new(start, end),
         ),
@@ -194,7 +194,7 @@ pub fn fallback_string_without(c: &str) -> impl Fn(NomSpan) -> IResult<NomSpan, 
 
         Ok((
             input,
-            TokenTreeBuilder::spanned_str(
+            TokenTreeBuilder::spanned_string(
                 result.into_iter().collect::<String>(),
                 Span::new(start, end),
             ),

--- a/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
+++ b/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
@@ -38,7 +38,7 @@ impl ExpandSyntax for LineSeparatedShape {
                     .or_else(|_| {
                         token_nodes
                             .expand_syntax(StringShape)
-                            .map(|syntax| Expression::string(syntax.inner).into_expr(syntax.span))
+                            .map(|syntax| Expression::str(syntax.content).into_expr(syntax.span))
                     })
             };
 
@@ -50,6 +50,7 @@ impl ExpandSyntax for LineSeparatedShape {
                     Expression::Literal(hir::Literal::Number(crate::Number::Decimal(d))) => {
                         entries.push(UntaggedValue::decimal(d.clone()))
                     }
+                    #[allow(deprecated)]
                     Expression::Literal(hir::Literal::String(span)) => {
                         if span.is_closed() {
                             entries.push(UntaggedValue::nothing())

--- a/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
+++ b/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
@@ -57,7 +57,7 @@ impl ExpandSyntax for LineSeparatedShape {
                             entries.push(UntaggedValue::string(span.slice(&source)))
                         }
                     }
-                    Expression::Literal(hir::Literal::Str(s)) => {
+                    Expression::Literal(hir::Literal::String(s)) => {
                         if s.is_empty() {
                             entries.push(UntaggedValue::nothing())
                         } else {

--- a/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
+++ b/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
@@ -50,8 +50,7 @@ impl ExpandSyntax for LineSeparatedShape {
                     Expression::Literal(hir::Literal::Number(crate::Number::Decimal(d))) => {
                         entries.push(UntaggedValue::decimal(d.clone()))
                     }
-                    #[allow(deprecated)]
-                    Expression::Literal(hir::Literal::String(span)) => {
+                    Expression::Literal(hir::Literal::NoCopyString(span)) => {
                         if span.is_closed() {
                             entries.push(UntaggedValue::nothing())
                         } else {

--- a/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
+++ b/crates/nu-parser/src/parse/util/line_delimited_parser/shape.rs
@@ -57,6 +57,13 @@ impl ExpandSyntax for LineSeparatedShape {
                             entries.push(UntaggedValue::string(span.slice(&source)))
                         }
                     }
+                    Expression::Literal(hir::Literal::Str(s)) => {
+                        if s.is_empty() {
+                            entries.push(UntaggedValue::nothing())
+                        } else {
+                            entries.push(UntaggedValue::string(s))
+                        }
+                    }
                     _ => {}
                 }
             }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -137,3 +137,27 @@ mod tilde_expansion {
         assert_eq!(actual, "1~1");
     }
 }
+
+mod escape_sequences {
+    use super::nu;
+
+    #[test]
+    fn support_escaped_quotes() {
+        let actual = nu!(
+            cwd: ".",
+            r#"echo "string \"with escaped quotes""#
+        );
+
+        assert_eq!(actual, r#"string "with escaped quotes"#);
+    }
+
+    #[test]
+    fn support_escaping_escapes() {
+        let actual = nu!(
+            cwd: ".",
+            r#"echo "\\""#
+        );
+
+        assert_eq!(actual, r#"\"#);
+    }
+}


### PR DESCRIPTION
This replaces the PR #1520.
Since the first PR was way too big, this one is smaller and only deals with double quoted strings.

This PR changes the parser to use copied strings from the original input instead of a span. This allows the implementation of escaping in double quoted strings. This fixes #1456. Now `echo "fo\"o"` doesn't fail and displays `fo"o`. Slashes can also be escaped `echo "foo\\"` displays `foo\`.

This fix applies to any command using double quoted string.