### PR TITLE
Remove source text where not needed

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -711,7 +711,7 @@ async fn process_line(
                 None
             };
 
-            match run_pipeline(pipeline, ctx, input_stream, line).await {
+            match run_pipeline(pipeline, ctx, input_stream).await {
                 Ok(Some(input)) => {
                     // Running a pipeline gives us back a stream that we can then
                     // work through. At the top level, we just want to pull on the
@@ -725,7 +725,6 @@ async fn process_line(
                         ctrl_c: ctx.ctrl_c.clone(),
                         commands: ctx.registry.clone(),
                         name: Tag::unknown(),
-                        source: Text::from(String::new()),
                     };
 
                     if let Ok(mut output_stream) = crate::commands::autoview::autoview(context) {

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -32,7 +32,6 @@ impl WholeStreamCommand for Autoview {
             commands: registry.clone(),
             shell_manager: args.shell_manager,
             host: args.host,
-            source: args.call_info.source,
             ctrl_c: args.ctrl_c,
             name: args.call_info.name_tag,
         })
@@ -42,7 +41,6 @@ impl WholeStreamCommand for Autoview {
 pub struct RunnableContextWithoutInput {
     pub shell_manager: ShellManager,
     pub host: Arc<parking_lot::Mutex<Box<dyn Host>>>,
-    pub source: Text,
     pub ctrl_c: Arc<AtomicBool>,
     pub commands: CommandRegistry,
     pub name: Tag,
@@ -53,7 +51,6 @@ impl RunnableContextWithoutInput {
         let new_context = RunnableContextWithoutInput {
             shell_manager: context.shell_manager,
             host: context.host,
-            source: context.source,
             ctrl_c: context.ctrl_c,
             commands: context.commands,
             name: context.name,
@@ -289,7 +286,6 @@ fn create_default_command_args(context: &RunnableContextWithoutInput) -> RawComm
                 named: None,
                 span,
             },
-            source: context.source.clone(),
             name_tag: context.name.clone(),
         },
     }

--- a/crates/nu-cli/src/commands/classified/internal.rs
+++ b/crates/nu-cli/src/commands/classified/internal.rs
@@ -9,12 +9,10 @@ pub(crate) fn run_internal_command(
     command: InternalCommand,
     context: &mut Context,
     input: Option<InputStream>,
-    source: Text,
 ) -> Result<Option<InputStream>, ShellError> {
     if log_enabled!(log::Level::Trace) {
         trace!(target: "nu::run::internal", "->");
         trace!(target: "nu::run::internal", "{}", command.name);
-        trace!(target: "nu::run::internal", "{}", command.args.debug(&source));
     }
 
     let objects: InputStream = if let Some(input) = input {
@@ -30,7 +28,6 @@ pub(crate) fn run_internal_command(
             internal_command?,
             Tag::unknown_anchor(command.name_span),
             command.args.clone(),
-            &source,
             objects,
         )
     };
@@ -70,7 +67,6 @@ pub(crate) fn run_internal_command(
                                         named: None,
                                         span: Span::unknown()
                                     },
-                                    source: source.clone(),
                                     name_tag: Tag::unknown_anchor(command.name_span),
                                 }
                             };

--- a/crates/nu-cli/src/commands/classified/pipeline.rs
+++ b/crates/nu-cli/src/commands/classified/pipeline.rs
@@ -4,13 +4,11 @@ use crate::context::Context;
 use crate::stream::InputStream;
 use nu_errors::ShellError;
 use nu_parser::{ClassifiedCommand, ClassifiedPipeline};
-use nu_source::Text;
 
 pub(crate) async fn run_pipeline(
     pipeline: ClassifiedPipeline,
     ctx: &mut Context,
     mut input: Option<InputStream>,
-    line: &str,
 ) -> Result<Option<InputStream>, ShellError> {
     let mut iter = pipeline.commands.list.into_iter().peekable();
 
@@ -29,9 +27,7 @@ pub(crate) async fn run_pipeline(
             (Some(ClassifiedCommand::Error(err)), _) => return Err(err.into()),
             (_, Some(ClassifiedCommand::Error(err))) => return Err(err.clone().into()),
 
-            (Some(ClassifiedCommand::Internal(left)), _) => {
-                run_internal_command(left, ctx, input, Text::from(line))?
-            }
+            (Some(ClassifiedCommand::Internal(left)), _) => run_internal_command(left, ctx, input)?,
 
             (Some(ClassifiedCommand::External(left)), None) => {
                 run_external_command(left, ctx, input, true).await?

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -15,7 +15,6 @@ use std::sync::atomic::AtomicBool;
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct UnevaluatedCallInfo {
     pub args: hir::Call,
-    pub source: Text,
     pub name_tag: Tag,
 }
 
@@ -25,7 +24,7 @@ impl UnevaluatedCallInfo {
         registry: &CommandRegistry,
         scope: &Scope,
     ) -> Result<CallInfo, ShellError> {
-        let args = evaluate_args(&self.args, registry, scope, &self.source)?;
+        let args = evaluate_args(&self.args, registry, scope)?;
 
         Ok(CallInfo {
             args,
@@ -145,10 +144,6 @@ impl CommandArgs {
         ))
     }
 
-    pub fn source(&self) -> Text {
-        self.call_info.source.clone()
-    }
-
     pub fn process<'de, T: Deserialize<'de>, O: ToOutputStream>(
         self,
         registry: &CommandRegistry,
@@ -156,7 +151,6 @@ impl CommandArgs {
     ) -> Result<RunnableArgs<T, O>, ShellError> {
         let shell_manager = self.shell_manager.clone();
         let host = self.host.clone();
-        let source = self.source();
         let ctrl_c = self.ctrl_c.clone();
         let args = self.evaluate_once(registry)?;
         let call_info = args.call_info.clone();
@@ -169,7 +163,6 @@ impl CommandArgs {
             context: RunnableContext {
                 input,
                 commands: registry.clone(),
-                source,
                 shell_manager,
                 name: name_tag,
                 host,
@@ -193,7 +186,6 @@ impl CommandArgs {
 
         let shell_manager = self.shell_manager.clone();
         let host = self.host.clone();
-        let source = self.source();
         let ctrl_c = self.ctrl_c.clone();
         let args = self.evaluate_once(registry)?;
         let call_info = args.call_info.clone();
@@ -207,7 +199,6 @@ impl CommandArgs {
             context: RunnableContext {
                 input,
                 commands: registry.clone(),
-                source,
                 shell_manager,
                 name: name_tag,
                 host,
@@ -229,7 +220,6 @@ pub struct RunnableContext {
     pub input: InputStream,
     pub shell_manager: ShellManager,
     pub host: Arc<parking_lot::Mutex<Box<dyn Host>>>,
-    pub source: Text,
     pub ctrl_c: Arc<AtomicBool>,
     pub commands: CommandRegistry,
     pub name: Tag,

--- a/crates/nu-cli/src/commands/enter.rs
+++ b/crates/nu-cli/src/commands/enter.rs
@@ -103,7 +103,6 @@ impl PerItemCommand for Enter {
                                                     named: None,
                                                     span: Span::unknown()
                                                 },
-                                                source: raw_args.call_info.source,
                                                 name_tag: raw_args.call_info.name_tag,
                                             },
                                         };

--- a/crates/nu-cli/src/commands/save.rs
+++ b/crates/nu-cli/src/commands/save.rs
@@ -234,7 +234,6 @@ fn save(
                                     named: None,
                                     span: Span::unknown()
                                 },
-                                source: raw_args.call_info.source,
                                 name_tag: raw_args.call_info.name_tag,
                             }
                         };

--- a/crates/nu-cli/src/commands/sum.rs
+++ b/crates/nu-cli/src/commands/sum.rs
@@ -30,7 +30,6 @@ impl WholeStreamCommand for Sum {
             commands: registry.clone(),
             shell_manager: args.shell_manager,
             host: args.host,
-            source: args.call_info.source,
             ctrl_c: args.ctrl_c,
             name: args.call_info.name_tag,
         })

--- a/crates/nu-cli/src/context.rs
+++ b/crates/nu-cli/src/context.rs
@@ -176,33 +176,22 @@ impl Context {
         command: Arc<Command>,
         name_tag: Tag,
         args: hir::Call,
-        source: &Text,
         input: InputStream,
     ) -> OutputStream {
-        let command_args = self.command_args(args, input, source, name_tag);
+        let command_args = self.command_args(args, input, name_tag);
         command.run(command_args, self.registry())
     }
 
-    fn call_info(&self, args: hir::Call, source: &Text, name_tag: Tag) -> UnevaluatedCallInfo {
-        UnevaluatedCallInfo {
-            args,
-            source: source.clone(),
-            name_tag,
-        }
+    fn call_info(&self, args: hir::Call, name_tag: Tag) -> UnevaluatedCallInfo {
+        UnevaluatedCallInfo { args, name_tag }
     }
 
-    fn command_args(
-        &self,
-        args: hir::Call,
-        input: InputStream,
-        source: &Text,
-        name_tag: Tag,
-    ) -> CommandArgs {
+    fn command_args(&self, args: hir::Call, input: InputStream, name_tag: Tag) -> CommandArgs {
         CommandArgs {
             host: self.host.clone(),
             ctrl_c: self.ctrl_c.clone(),
             shell_manager: self.shell_manager.clone(),
-            call_info: self.call_info(args, source, name_tag),
+            call_info: self.call_info(args, name_tag),
             input,
         }
     }

--- a/crates/nu-cli/src/data/base.rs
+++ b/crates/nu-cli/src/data/base.rs
@@ -12,7 +12,7 @@ use nu_protocol::{
     Evaluate, EvaluateTrait, Primitive, Scope, ShellTypeName, SpannedTypeName, TaggedDictBuilder,
     UntaggedValue, Value,
 };
-use nu_source::{Tag, Text};
+use nu_source::Tag;
 use nu_value_ext::ValueExt;
 use num_bigint::BigInt;
 use num_traits::Zero;
@@ -30,7 +30,6 @@ pub struct Operation {
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, new)]
 pub struct Block {
     pub(crate) expressions: Vec<hir::SpannedExpression>,
-    pub(crate) source: Text,
     pub(crate) tag: Tag,
 }
 
@@ -54,7 +53,7 @@ impl EvaluateTrait for Block {
         );
 
         for expr in self.expressions.iter() {
-            last = evaluate_baseline_expr(&expr, &CommandRegistry::empty(), &scope, &self.source)
+            last = evaluate_baseline_expr(&expr, &CommandRegistry::empty(), &scope)
         }
 
         last

--- a/crates/nu-cli/src/evaluate/evaluate_args.rs
+++ b/crates/nu-cli/src/evaluate/evaluate_args.rs
@@ -5,20 +5,18 @@ use indexmap::IndexMap;
 use nu_errors::ShellError;
 use nu_parser::hir;
 use nu_protocol::{EvaluatedArgs, Scope, UntaggedValue, Value};
-use nu_source::Text;
 
 pub(crate) fn evaluate_args(
     call: &hir::Call,
     registry: &CommandRegistry,
     scope: &Scope,
-    source: &Text,
 ) -> Result<EvaluatedArgs, ShellError> {
     let positional: Result<Option<Vec<_>>, _> = call
         .positional
         .as_ref()
         .map(|p| {
             p.iter()
-                .map(|e| evaluate_baseline_expr(e, registry, scope, source))
+                .map(|e| evaluate_baseline_expr(e, registry, scope))
                 .collect()
         })
         .transpose();
@@ -37,10 +35,8 @@ pub(crate) fn evaluate_args(
                         results.insert(name.clone(), UntaggedValue::boolean(true).into_value(tag));
                     }
                     hir::NamedValue::Value(_, expr) => {
-                        results.insert(
-                            name.clone(),
-                            evaluate_baseline_expr(expr, registry, scope, source)?,
-                        );
+                        results
+                            .insert(name.clone(), evaluate_baseline_expr(expr, registry, scope)?);
                     }
 
                     _ => {}

--- a/crates/nu-parser/src/hir.rs
+++ b/crates/nu-parser/src/hir.rs
@@ -462,7 +462,7 @@ pub enum Literal {
     String(String),
     GlobPattern(String),
     ColumnPath(Vec<Member>),
-    Bare,
+    Bare(String),
 }
 
 impl Literal {
@@ -488,7 +488,7 @@ impl ShellTypeName for Literal {
             Literal::Size(..) => "size",
             Literal::String(..) => "string",
             Literal::ColumnPath(..) => "column path",
-            Literal::Bare => "string",
+            Literal::Bare(_) => "string",
             Literal::GlobPattern(_) => "pattern",
             Literal::Operator(_) => "operator",
         }
@@ -507,7 +507,7 @@ impl PrettyDebugWithSource for SpannedLiteral {
                 Literal::ColumnPath(path) => {
                     b::intersperse_with_source(path.iter(), b::space(), source)
                 }
-                Literal::Bare => b::delimit("b\"", b::primitive(self.span.slice(source)), "\""),
+                Literal::Bare(bare) => b::delimit("b\"", b::primitive(bare), "\""),
                 Literal::Operator(operator) => b::primitive(format!("{:?}", operator)),
             },
         }
@@ -528,7 +528,7 @@ impl PrettyDebugWithSource for SpannedLiteral {
                 "column path",
                 b::intersperse_with_source(path.iter(), b::space(), source),
             ),
-            Literal::Bare => b::typed("bare", b::primitive(self.span.slice(source))),
+            Literal::Bare(bare) => b::typed("bare", b::primitive(bare)),
             Literal::Operator(operator) => {
                 b::typed("operator", b::primitive(format!("{:?}", operator)))
             }

--- a/crates/nu-parser/src/shapes.rs
+++ b/crates/nu-parser/src/shapes.rs
@@ -33,7 +33,7 @@ pub fn expression_to_flat_shape(e: &SpannedExpression) -> Vec<Spanned<FlatShape>
             output
         }
         Expression::Command(command) => vec![FlatShape::InternalCommand.spanned(*command)],
-        Expression::Literal(Literal::Bare) => vec![FlatShape::BareMember.spanned(e.span)],
+        Expression::Literal(Literal::Bare(_)) => vec![FlatShape::BareMember.spanned(e.span)],
         Expression::Literal(Literal::ColumnPath(_)) => vec![FlatShape::Path.spanned(e.span)],
         Expression::Literal(Literal::GlobPattern(_)) => {
             vec![FlatShape::GlobPattern.spanned(e.span)]


### PR DESCRIPTION
Because more of the original source is reified into the ClassifiedPipeline, we don't need to carry around the original source quite so much.  Removing where it's not needed.