### PR TITLE
Unified path expansion under new module and better canonicalize

### DIFF
--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -17,6 +17,7 @@ mod evaluate;
 mod format;
 mod futures;
 mod git;
+mod path;
 mod shell;
 mod stream;
 mod utils;

--- a/crates/nu-cli/src/path.rs
+++ b/crates/nu-cli/src/path.rs
@@ -1,0 +1,154 @@
+// Copyright (C) 2020 Kevin Dc
+//
+// This file is part of nushell.
+//
+// nushell is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// nushell is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with nushell.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+pub fn normalize(path: impl AsRef<Path>) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.as_ref().components() {
+        match component {
+            Component::Normal(normal) => {
+                if let Some(normal) = normal.to_str() {
+                    if normal.chars().all(|c| c == '.') {
+                        for _ in 0..(normal.len() - 1) {
+                            normalized.push("..");
+                        }
+                    } else {
+                        normalized.push(normal);
+                    }
+                } else {
+                    normalized.push(normal);
+                }
+            }
+            c => normalized.push(c.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
+pub struct AllowMissing(pub bool);
+
+pub fn canonicalize<P, Q>(
+    relative_to: P,
+    path: Q,
+    allow_missing: AllowMissing,
+) -> io::Result<PathBuf>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+{
+    let path = normalize(path);
+    let (relative_to, path) = if path.is_absolute() {
+        let components: Vec<_> = path.components().collect();
+        let separator = components
+            .iter()
+            .enumerate()
+            .find(|(_, c)| c == &&Component::CurDir || c == &&Component::ParentDir);
+
+        if let Some((index, _)) = separator {
+            let (absolute, relative) = components.split_at(index);
+            let absolute: PathBuf = absolute.iter().collect();
+            let relative: PathBuf = relative.iter().collect();
+
+            (absolute, relative)
+        } else {
+            (relative_to.as_ref().to_path_buf(), path)
+        }
+    } else {
+        (relative_to.as_ref().to_path_buf(), path)
+    };
+
+    let path = if path.is_relative() {
+        let mut result = relative_to;
+        path.components().for_each(|component| match component {
+            Component::ParentDir => {
+                result.pop();
+            }
+            Component::Normal(normal) => result.push(normal),
+            _ => {}
+        });
+
+        result
+    } else {
+        path
+    };
+
+    let path = if allow_missing.0 {
+        path
+    } else {
+        std::fs::read_link(path)?
+    };
+
+    Ok(dunce::simplified(&path).to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn normalize_three_dots() {
+        assert_eq!(PathBuf::from("../.."), normalize("..."));
+    }
+
+    #[test]
+    fn normalize_three_dots_with_redundant_dot() {
+        assert_eq!(PathBuf::from("./../.."), normalize("./..."));
+    }
+
+    #[test]
+    fn canonicalize_two_dots_and_allow_missing() -> io::Result<()> {
+        let relative_to = Path::new("/foo/bar"); // does not exists
+        let path = Path::new("..");
+
+        assert_eq!(
+            PathBuf::from("/foo"),
+            canonicalize(relative_to, path, AllowMissing(true))?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn canonicalize_three_dots_and_allow_missing() -> io::Result<()> {
+        let relative_to = Path::new("/foo/bar/baz"); // missing path
+        let path = Path::new("...");
+
+        assert_eq!(
+            PathBuf::from("/foo"),
+            canonicalize(relative_to, path, AllowMissing(true))?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn canonicalize_three_dots_with_redundant_dot_and_allow_missing() -> io::Result<()> {
+        let relative_to = Path::new("/foo/bar/baz"); // missing path
+        let path = Path::new("./...");
+
+        assert_eq!(
+            PathBuf::from("/foo"),
+            canonicalize(relative_to, path, AllowMissing(true))?
+        );
+
+        Ok(())
+    }
+}

--- a/crates/nu-cli/src/path.rs
+++ b/crates/nu-cli/src/path.rs
@@ -92,9 +92,10 @@ where
     let path = match std::fs::read_link(&path) {
         Ok(resolved) => resolved,
         Err(e) => {
-            // Fail if path doesn't exists or is not symlink
-            // Check if we allow missing paths or the path exists
+            // We are here if path doesn't exist or isn't a symlink
             if allow_missing.0 || path.exists() {
+                // Return if we allow missing paths or if the path
+                // actually exists, but wasn't a symlink
                 path
             } else {
                 return Err(e);


### PR DESCRIPTION
~This a work-in-progress~ that aims to close #1553, moving `normalize` and `canonicalize` to a separate module (introduced in #1547  and #1485  respectively). Along with some changes to `canonicalize` that allows it to imitate `realpath -m`, i.e. allow missing components in the resulting path. 