### PR TITLE
Enable multiple dots on more commands, and use custom canonicalize method 

### DIFF
--- a/crates/nu-cli/src/path.rs
+++ b/crates/nu-cli/src/path.rs
@@ -1,20 +1,3 @@
-// Copyright (C) 2020 Kevin Dc
-//
-// This file is part of nushell.
-//
-// nushell is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// nushell is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with nushell.  If not, see <http://www.gnu.org/licenses/>.
-
 use std::io;
 use std::path::{Component, Path, PathBuf};
 


### PR DESCRIPTION
This aims to enable multiple dots for more commands apart from those in FilesystemShell, like `open`, also it'll replace the use of `dunce::canonicalize` with `canonicalize` introduced in #1571, possibly fixing some issues that will be referenced as they get eventually fixed in commits. 