### PR TITLE
Simplify cp command and allow multiple recursive copying 

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -129,8 +129,8 @@ impl Shell for FilesystemShell {
 
         if paths.peek().is_none() {
             return Err(ShellError::labeled_error(
-                "Invalid File or Pattern",
-                "invalid file or pattern",
+                "Not matches found",
+                "not matches found",
                 &p_tag,
             ));
         }

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -129,8 +129,8 @@ impl Shell for FilesystemShell {
 
         if paths.peek().is_none() {
             return Err(ShellError::labeled_error(
-                "Not matches found",
-                "not matches found",
+                "No matches found",
+                "no matches found",
                 &p_tag,
             ));
         }
@@ -271,8 +271,8 @@ impl Shell for FilesystemShell {
 
         if sources.is_empty() {
             return Err(ShellError::labeled_error(
-                "Not matches found",
-                "not matches found",
+                "No matches found",
+                "no matches found",
                 src.tag,
             ));
         }

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -256,7 +256,7 @@ impl Shell for FilesystemShell {
 
         let path = Path::new(path);
         let source = path.join(&src.item);
-        let mut destination = path.join(&dst.item);
+        let destination = path.join(&dst.item);
 
         let sources: Vec<_> = match glob::glob(&source.to_string_lossy()) {
             Ok(files) => files.collect(),
@@ -306,7 +306,7 @@ impl Shell for FilesystemShell {
                 if entry.is_file() {
                     let sources = sources.paths_applying_with(|(source_file, _depth_level)| {
                         if destination.is_dir() {
-                            let mut dest = canonicalize_existing(&path, &dst.item)?;
+                            let mut dest = canonicalize(&path, &dst.item)?;
                             if let Some(name) = entry.file_name() {
                                 dest.push(name);
                             }
@@ -345,7 +345,7 @@ impl Shell for FilesystemShell {
 
                     let sources = sources.paths_applying_with(|(source_file, depth_level)| {
                         let mut dest = destination.clone();
-                        let path = canonicalize_existing(&path, &source_file)?;
+                        let path = canonicalize(&path, &source_file)?;
 
                         let comps: Vec<_> = path
                             .components()

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -269,6 +269,14 @@ impl Shell for FilesystemShell {
             }
         };
 
+        if sources.is_empty() {
+            return Err(ShellError::labeled_error(
+                "Not matches found",
+                "not matches found",
+                src.tag,
+            ));
+        }
+
         if sources.len() > 1 && !destination.is_dir() {
             return Err(ShellError::labeled_error(
                 "Destination must be a directory when copying multiple files",

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -124,7 +124,7 @@ impl Shell for FilesystemShell {
         };
 
         let mut paths = glob::glob(&path.to_string_lossy())
-            .map_err(|e| ShellError::labeled_error("Glob error", e.to_string(), &p_tag))?
+            .map_err(|e| ShellError::labeled_error(e.to_string(), "invalid pattern", &p_tag))?
             .peekable();
 
         if paths.peek().is_none() {

--- a/crates/nu-cli/src/utils.rs
+++ b/crates/nu-cli/src/utils.rs
@@ -1,6 +1,6 @@
 pub mod data_processing;
 
-use crate::path::canonicalize_existing;
+use crate::path::canonicalize;
 use nu_errors::ShellError;
 use nu_protocol::{UntaggedValue, Value};
 use std::path::{Component, Path, PathBuf};
@@ -139,7 +139,7 @@ impl FileStructure {
     }
 
     fn build(&mut self, src: &Path, lvl: usize) -> Result<(), ShellError> {
-        let source = canonicalize_existing(std::env::current_dir()?, src)?;
+        let source = canonicalize(std::env::current_dir()?, src)?;
 
         if source.is_dir() {
             for entry in std::fs::read_dir(src)? {

--- a/crates/nu-cli/src/utils.rs
+++ b/crates/nu-cli/src/utils.rs
@@ -1,5 +1,6 @@
 pub mod data_processing;
 
+use crate::path::canonicalize_existing;
 use nu_errors::ShellError;
 use nu_protocol::{UntaggedValue, Value};
 use std::path::{Component, Path, PathBuf};
@@ -138,7 +139,7 @@ impl FileStructure {
     }
 
     fn build(&mut self, src: &Path, lvl: usize) -> Result<(), ShellError> {
-        let source = dunce::canonicalize(src)?;
+        let source = canonicalize_existing(std::env::current_dir()?, src)?;
 
         if source.is_dir() {
             for entry in std::fs::read_dir(src)? {

--- a/crates/nu-cli/tests/commands/cp.rs
+++ b/crates/nu-cli/tests/commands/cp.rs
@@ -40,7 +40,7 @@ fn error_if_attempting_to_copy_a_directory_to_another_directory() {
         );
 
         assert!(actual.contains("../formats"));
-        assert!(actual.contains("is a directory (not copied)"));
+        assert!(actual.contains("resolves to a directory (not copied)"));
     });
 }
 

--- a/crates/nu-cli/tests/commands/cp.rs
+++ b/crates/nu-cli/tests/commands/cp.rs
@@ -209,7 +209,7 @@ fn copy_files_using_glob_two_parents_up_using_multiple_dots() {
                 "jonathan.json",
                 "andres.xml",
                 "kevin.txt",
-                "many_more.ppl"
+                "many_more.ppl",
             ],
             dirs.test()
         ));
@@ -217,20 +217,21 @@ fn copy_files_using_glob_two_parents_up_using_multiple_dots() {
 }
 
 #[test]
-fn copy_file_from_two_parents_up_using_multiple_dots_to_current_dir() {
+fn copy_file_and_dir_from_two_parents_up_using_multiple_dots_to_current_dir_recursive() {
     Playground::setup("cp_test_10", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("hello_there")]);
+        sandbox.mkdir("hello_again");
         sandbox.within("foo").mkdir("bar");
 
         nu!(
             cwd: dirs.test().join("foo/bar"),
             r#"
-                cp .../hello_there .
+                cp -r .../hello* .
             "#
         );
 
-        let expected = dirs.test().join("foo/bar/hello_there");
+        let expected = dirs.test().join("foo/bar");
 
-        assert!(expected.exists());
+        assert!(files_exist_at(vec!["hello_there", "hello_again"], expected));
     })
 }

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -128,7 +128,7 @@ fn fails_when_glob_doesnt_match() {
             "ls root3*"
         );
 
-        assert!(actual.contains("invalid file or pattern"));
+        assert!(actual.contains("not matches found"));
     })
 }
 

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -128,7 +128,7 @@ fn fails_when_glob_doesnt_match() {
             "ls root3*"
         );
 
-        assert!(actual.contains("not matches found"));
+        assert!(actual.contains("no matches found"));
     })
 }
 


### PR DESCRIPTION
~This aims to enable multiple dots for more commands apart from those in FilesystemShell, like `open`, also it'll replace the use of `dunce::canonicalize` with `canonicalize` introduced in #1571, possibly fixing some issues that will be referenced as they get eventually fixed in commits.
Copy of #1575 which lost track from the forked repository.~

Additionally, code refactoring and feature adding may be done in the way, noted here:
- [x] Remove duplicate code in `cp`
- [x] Allow recursive copying when using patterns that resolve to dirs in `cp` 

I decided to keep this PR tiny and stay with the fixes to `cp` and the added feature. 

@jonathandturner  ready for review.