### PR TITLE
Math operators

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -697,6 +697,7 @@ async fn process_line(
 
             let pipeline = nu_parser::classify_pipeline(&result, ctx.registry());
 
+            debug!("{:#?}", pipeline);
             //println!("{:#?}", pipeline);
 
             if let Some(failure) = pipeline.failed {

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -156,6 +156,12 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                             } => {
                                 out!("{}", n);
                             }
+                            Value {
+                                value: UntaggedValue::Primitive(Primitive::Boolean(b)),
+                                ..
+                            } => {
+                                out!("{}", b);
+                            }
 
                             Value { value: UntaggedValue::Primitive(Primitive::Binary(ref b)), .. } => {
                                 if let Some(binary) = binary {

--- a/crates/nu-cli/src/commands/skip_while.rs
+++ b/crates/nu-cli/src/commands/skip_while.rs
@@ -16,7 +16,7 @@ impl WholeStreamCommand for SkipWhile {
         Signature::build("skip-while")
             .required(
                 "condition",
-                SyntaxShape::Condition,
+                SyntaxShape::Math,
                 "the condition that must be met to continue skipping",
             )
             .filter()

--- a/crates/nu-cli/src/commands/where_.rs
+++ b/crates/nu-cli/src/commands/where_.rs
@@ -18,7 +18,7 @@ impl PerItemCommand for Where {
     fn signature(&self) -> Signature {
         Signature::build("where").required(
             "condition",
-            SyntaxShape::Condition,
+            SyntaxShape::Math,
             "the condition that must match",
         )
     }

--- a/crates/nu-cli/src/data/base.rs
+++ b/crates/nu-cli/src/data/base.rs
@@ -18,7 +18,7 @@ use std::time::SystemTime;
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, new, Serialize)]
 pub struct Operation {
     pub(crate) left: Value,
-    pub(crate) operator: hir::CompareOperator,
+    pub(crate) operator: hir::Operator,
     pub(crate) right: Value,
 }
 
@@ -87,7 +87,7 @@ pub(crate) enum CompareValues {
     Decimals(BigDecimal, BigDecimal),
     String(String, String),
     Date(DateTime<Utc>, DateTime<Utc>),
-    DateDuration(DateTime<Utc>, u64),
+    DateDuration(DateTime<Utc>, i64),
 }
 
 impl CompareValues {
@@ -101,7 +101,11 @@ impl CompareValues {
                 use std::time::Duration;
 
                 // Create the datetime we're comparing against, as duration is an offset from now
-                let right: DateTime<Utc> = (SystemTime::now() - Duration::from_secs(*right)).into();
+                let right: DateTime<Utc> = if *right < 0 {
+                    (SystemTime::now() + Duration::from_secs((*right * -1) as u64)).into()
+                } else {
+                    (SystemTime::now() - Duration::from_secs(*right as u64)).into()
+                };
                 right.cmp(left)
             }
         }

--- a/crates/nu-cli/src/data/base/shape.rs
+++ b/crates/nu-cli/src/data/base/shape.rs
@@ -27,7 +27,7 @@ pub enum InlineShape {
     Pattern(String),
     Boolean(bool),
     Date(DateTime<Utc>),
-    Duration(u64),
+    Duration(i64),
     Path(PathBuf),
     Binary,
 

--- a/crates/nu-cli/src/data/value.rs
+++ b/crates/nu-cli/src/data/value.rs
@@ -3,7 +3,8 @@ use crate::data::base::shape::{Column, InlineShape};
 use crate::data::primitive::style_primitive;
 use chrono::DateTime;
 use nu_errors::ShellError;
-use nu_protocol::hir::CompareOperator;
+use nu_protocol::hir::Operator;
+use nu_protocol::ShellTypeName;
 use nu_protocol::{Primitive, Type, UntaggedValue};
 use nu_source::{DebugDocBuilder, PrettyDebug, Tagged};
 
@@ -21,8 +22,91 @@ pub fn date_from_str(s: Tagged<&str>) -> Result<UntaggedValue, ShellError> {
     Ok(UntaggedValue::Primitive(Primitive::Date(date)))
 }
 
+pub fn compute_values(
+    operator: Operator,
+    left: &UntaggedValue,
+    right: &UntaggedValue,
+) -> Result<UntaggedValue, (&'static str, &'static str)> {
+    match (left, right) {
+        (UntaggedValue::Primitive(lhs), UntaggedValue::Primitive(rhs)) => match (lhs, rhs) {
+            (Primitive::Bytes(x), Primitive::Bytes(y)) => {
+                let result = match operator {
+                    Operator::Plus => Ok(x + y),
+                    Operator::Minus => Ok(x - y),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+                Ok(UntaggedValue::Primitive(Primitive::Bytes(result)))
+            }
+            (Primitive::Int(x), Primitive::Int(y)) => match operator {
+                Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
+                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
+                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
+                Operator::Divide => {
+                    if (x / y) == (y * (x / y)) {
+                        Ok(UntaggedValue::Primitive(Primitive::Int(x / y)))
+                    } else {
+                        Ok(UntaggedValue::Primitive(Primitive::Decimal(
+                            bigdecimal::BigDecimal::from(x.clone())
+                                / bigdecimal::BigDecimal::from(y.clone()),
+                        )))
+                    }
+                }
+                _ => Err((left.type_name(), right.type_name())),
+            },
+            (Primitive::Decimal(x), Primitive::Int(y)) => {
+                let result = match operator {
+                    Operator::Plus => Ok(x + bigdecimal::BigDecimal::from(y.clone())),
+                    Operator::Minus => Ok(x - bigdecimal::BigDecimal::from(y.clone())),
+                    Operator::Multiply => Ok(x * bigdecimal::BigDecimal::from(y.clone())),
+                    Operator::Divide => Ok(x / bigdecimal::BigDecimal::from(y.clone())),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+                Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))
+            }
+            (Primitive::Int(x), Primitive::Decimal(y)) => {
+                let result = match operator {
+                    Operator::Plus => Ok(bigdecimal::BigDecimal::from(x.clone()) + y),
+                    Operator::Minus => Ok(bigdecimal::BigDecimal::from(x.clone()) - y),
+                    Operator::Multiply => Ok(bigdecimal::BigDecimal::from(x.clone()) * y),
+                    Operator::Divide => Ok(bigdecimal::BigDecimal::from(x.clone()) / y),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+                Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))
+            }
+            (Primitive::Decimal(x), Primitive::Decimal(y)) => {
+                let result = match operator {
+                    Operator::Plus => Ok(x + y),
+                    Operator::Minus => Ok(x - y),
+                    Operator::Multiply => Ok(x * y),
+                    Operator::Divide => Ok(x / y),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+                Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))
+            }
+            (Primitive::Date(x), Primitive::Date(y)) => {
+                let result = match operator {
+                    Operator::Minus => Ok(x.signed_duration_since(*y).num_seconds()),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+                Ok(UntaggedValue::Primitive(Primitive::Duration(result)))
+            }
+            (Primitive::Date(x), Primitive::Duration(y)) => {
+                let result = match operator {
+                    Operator::Plus => Ok(x
+                        .checked_add_signed(chrono::Duration::seconds(*y as i64))
+                        .expect("Overflowing add of duration")),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+                Ok(UntaggedValue::Primitive(Primitive::Date(result)))
+            }
+            _ => Err((left.type_name(), right.type_name())),
+        },
+        _ => Err((left.type_name(), right.type_name())),
+    }
+}
+
 pub fn compare_values(
-    operator: CompareOperator,
+    operator: Operator,
     left: &UntaggedValue,
     right: &UntaggedValue,
 ) -> Result<bool, (&'static str, &'static str)> {
@@ -34,15 +118,16 @@ pub fn compare_values(
             use std::cmp::Ordering;
 
             let result = match (operator, ordering) {
-                (CompareOperator::Equal, Ordering::Equal) => true,
-                (CompareOperator::NotEqual, Ordering::Less)
-                | (CompareOperator::NotEqual, Ordering::Greater) => true,
-                (CompareOperator::LessThan, Ordering::Less) => true,
-                (CompareOperator::GreaterThan, Ordering::Greater) => true,
-                (CompareOperator::GreaterThanOrEqual, Ordering::Greater)
-                | (CompareOperator::GreaterThanOrEqual, Ordering::Equal) => true,
-                (CompareOperator::LessThanOrEqual, Ordering::Less)
-                | (CompareOperator::LessThanOrEqual, Ordering::Equal) => true,
+                (Operator::Equal, Ordering::Equal) => true,
+                (Operator::NotEqual, Ordering::Less) | (Operator::NotEqual, Ordering::Greater) => {
+                    true
+                }
+                (Operator::LessThan, Ordering::Less) => true,
+                (Operator::GreaterThan, Ordering::Greater) => true,
+                (Operator::GreaterThanOrEqual, Ordering::Greater)
+                | (Operator::GreaterThanOrEqual, Ordering::Equal) => true,
+                (Operator::LessThanOrEqual, Ordering::Less)
+                | (Operator::LessThanOrEqual, Ordering::Equal) => true,
                 _ => false,
             };
 

--- a/crates/nu-cli/src/data/value.rs
+++ b/crates/nu-cli/src/data/value.rs
@@ -42,7 +42,7 @@ pub fn compute_values(
                 Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Int(x - y))),
                 Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Int(x * y))),
                 Operator::Divide => {
-                    if (x / y) == (y * (x / y)) {
+                    if x - (y * (x / y)) == num_bigint::BigInt::from(0) {
                         Ok(UntaggedValue::Primitive(Primitive::Int(x / y)))
                     } else {
                         Ok(UntaggedValue::Primitive(Primitive::Decimal(

--- a/crates/nu-cli/src/data/value.rs
+++ b/crates/nu-cli/src/data/value.rs
@@ -39,8 +39,8 @@ pub fn compute_values(
             }
             (Primitive::Int(x), Primitive::Int(y)) => match operator {
                 Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
-                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
-                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
+                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Int(x - y))),
+                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Int(x * y))),
                 Operator::Divide => {
                     if (x / y) == (y * (x / y)) {
                         Ok(UntaggedValue::Primitive(Primitive::Int(x / y)))

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -31,6 +31,7 @@ pub(crate) fn evaluate_baseline_expr(
         Expression::Command(_) => evaluate_command(tag, scope),
         Expression::ExternalCommand(external) => evaluate_external(external, scope),
         Expression::Binary(binary) => {
+            // TODO: If we want to add short-circuiting, we'll need to move these down
             let left = evaluate_baseline_expr(&binary.left, registry, scope)?;
             let right = evaluate_baseline_expr(&binary.right, registry, scope)?;
 

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -103,7 +103,7 @@ pub(crate) fn evaluate_baseline_expr(
                                 return Err(ShellError::labeled_error(
                                     "Unknown column",
                                     format!("did you mean '{}'?", possible_matches[0].1),
-                                    &tag,
+                                    &member.span,
                                 ));
                             } else {
                                 return Err(err);

--- a/crates/nu-cli/src/evaluate/operator.rs
+++ b/crates/nu-cli/src/evaluate/operator.rs
@@ -17,18 +17,19 @@ pub fn apply_operator(
         | Operator::GreaterThanOrEqual => {
             value::compare_values(op, left, right).map(UntaggedValue::boolean)
         }
-        Operator::Contains => contains(left, right).map(UntaggedValue::boolean),
-        Operator::NotContains => contains(left, right)
+        Operator::Contains => string_contains(left, right).map(UntaggedValue::boolean),
+        Operator::NotContains => string_contains(left, right)
             .map(Not::not)
             .map(UntaggedValue::boolean),
         Operator::Plus => value::compute_values(op, left, right),
         Operator::Minus => value::compute_values(op, left, right),
         Operator::Multiply => value::compute_values(op, left, right),
         Operator::Divide => value::compute_values(op, left, right),
+        Operator::In => table_contains(left, right).map(UntaggedValue::boolean),
     }
 }
 
-fn contains(
+fn string_contains(
     left: &UntaggedValue,
     right: &UntaggedValue,
 ) -> Result<bool, (&'static str, &'static str)> {
@@ -49,6 +50,17 @@ fn contains(
             UntaggedValue::Primitive(Primitive::Line(l)),
             UntaggedValue::Primitive(Primitive::Line(r)),
         ) => Ok(l.contains(r)),
+        _ => Err((left.type_name(), right.type_name())),
+    }
+}
+
+fn table_contains(
+    left: &UntaggedValue,
+    right: &UntaggedValue,
+) -> Result<bool, (&'static str, &'static str)> {
+    let left = left.clone();
+    match right {
+        UntaggedValue::Table(values) => Ok(values.iter().any(|x| x.value == left)),
         _ => Err((left.type_name(), right.type_name())),
     }
 }

--- a/crates/nu-cli/src/evaluate/operator.rs
+++ b/crates/nu-cli/src/evaluate/operator.rs
@@ -26,6 +26,14 @@ pub fn apply_operator(
         Operator::Multiply => value::compute_values(op, left, right),
         Operator::Divide => value::compute_values(op, left, right),
         Operator::In => table_contains(left, right).map(UntaggedValue::boolean),
+        Operator::And => match (left.as_bool(), right.as_bool()) {
+            (Ok(left), Ok(right)) => Ok(UntaggedValue::boolean(left && right)),
+            _ => Err((left.type_name(), right.type_name())),
+        },
+        Operator::Or => match (left.as_bool(), right.as_bool()) {
+            (Ok(left), Ok(right)) => Ok(UntaggedValue::boolean(left || right)),
+            _ => Err((left.type_name(), right.type_name())),
+        },
     }
 }
 

--- a/crates/nu-cli/src/evaluate/operator.rs
+++ b/crates/nu-cli/src/evaluate/operator.rs
@@ -1,26 +1,30 @@
 use crate::data::value;
-use nu_protocol::hir::CompareOperator;
+use nu_protocol::hir::Operator;
 use nu_protocol::{Primitive, ShellTypeName, UntaggedValue, Value};
 use std::ops::Not;
 
 pub fn apply_operator(
-    op: CompareOperator,
+    op: Operator,
     left: &Value,
     right: &Value,
 ) -> Result<UntaggedValue, (&'static str, &'static str)> {
     match op {
-        CompareOperator::Equal
-        | CompareOperator::NotEqual
-        | CompareOperator::LessThan
-        | CompareOperator::GreaterThan
-        | CompareOperator::LessThanOrEqual
-        | CompareOperator::GreaterThanOrEqual => {
+        Operator::Equal
+        | Operator::NotEqual
+        | Operator::LessThan
+        | Operator::GreaterThan
+        | Operator::LessThanOrEqual
+        | Operator::GreaterThanOrEqual => {
             value::compare_values(op, left, right).map(UntaggedValue::boolean)
         }
-        CompareOperator::Contains => contains(left, right).map(UntaggedValue::boolean),
-        CompareOperator::NotContains => contains(left, right)
+        Operator::Contains => contains(left, right).map(UntaggedValue::boolean),
+        Operator::NotContains => contains(left, right)
             .map(Not::not)
             .map(UntaggedValue::boolean),
+        Operator::Plus => value::compute_values(op, left, right),
+        Operator::Minus => value::compute_values(op, left, right),
+        Operator::Multiply => value::compute_values(op, left, right),
+        Operator::Divide => value::compute_values(op, left, right),
     }
 }
 

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -120,7 +120,7 @@ impl Painter {
             FlatShape::ItVariable | FlatShape::Keyword => Color::Purple.bold(),
             FlatShape::Variable | FlatShape::Identifier => Color::Purple.normal(),
             FlatShape::Type => Color::Blue.bold(),
-            FlatShape::CompareOperator => Color::Yellow.normal(),
+            FlatShape::Operator => Color::Yellow.normal(),
             FlatShape::DotDot => Color::Yellow.bold(),
             FlatShape::Dot => Style::new().fg(Color::White),
             FlatShape::InternalCommand => Color::Cyan.bold(),

--- a/crates/nu-cli/src/utils/data_processing.rs
+++ b/crates/nu-cli/src/utils/data_processing.rs
@@ -2,7 +2,7 @@ use crate::data::value::compare_values;
 use crate::data::TaggedListBuilder;
 use chrono::{DateTime, NaiveDate, Utc};
 use nu_errors::ShellError;
-use nu_protocol::hir::CompareOperator;
+use nu_protocol::hir::Operator;
 use nu_protocol::{Primitive, TaggedDictBuilder, UntaggedValue, Value};
 use nu_source::{SpannedItem, Tag, Tagged, TaggedItem};
 use nu_value_ext::{get_data_by_key, ValueExt};
@@ -317,7 +317,7 @@ pub fn map_max(
                         let right = &acc.value;
 
                         if let Ok(is_greater_than) =
-                            compare_values(CompareOperator::GreaterThan, left, right)
+                            compare_values(Operator::GreaterThan, left, right)
                         {
                             if is_greater_than {
                                 value.clone()
@@ -336,9 +336,7 @@ pub fn map_max(
                 let left = &value.value;
                 let right = &max.value;
 
-                if let Ok(is_greater_than) =
-                    compare_values(CompareOperator::GreaterThan, left, right)
-                {
+                if let Ok(is_greater_than) = compare_values(Operator::GreaterThan, left, right) {
                     if is_greater_than {
                         value
                     } else {

--- a/crates/nu-cli/tests/commands/math.rs
+++ b/crates/nu-cli/tests/commands/math.rs
@@ -1,0 +1,133 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn one_arg() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 1
+        "#
+    ));
+
+    assert_eq!(actual, "1");
+}
+
+#[test]
+fn add() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 1 + 1
+        "#
+    ));
+
+    assert_eq!(actual, "2");
+}
+
+#[test]
+fn add_compount() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 1 + 2 + 2
+        "#
+    ));
+
+    assert_eq!(actual, "5");
+}
+
+#[test]
+fn precedence_of_operators() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 1 + 2 * 2
+        "#
+    ));
+
+    assert_eq!(actual, "5");
+}
+
+#[test]
+fn precedence_of_operators2() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 1 + 2 * 2 + 1
+        "#
+    ));
+
+    assert_eq!(actual, "6");
+}
+
+#[test]
+fn division_of_ints() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 4 / 2
+        "#
+    ));
+
+    assert_eq!(actual, "2");
+}
+
+#[test]
+fn division_of_ints2() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 1 / 4
+        "#
+    ));
+
+    assert_eq!(actual, "0.25");
+}
+
+#[test]
+fn parens_precedence() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 4 * (6 - 3)
+        "#
+    ));
+
+    assert_eq!(actual, "12");
+}
+
+#[test]
+fn compound_comparison() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 4 > 3 && 2 > 1
+        "#
+    ));
+
+    assert_eq!(actual, "true");
+}
+
+#[test]
+fn compound_comparison2() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 4 < 3 || 2 > 1
+        "#
+    ));
+
+    assert_eq!(actual, "true");
+}
+
+#[test]
+fn compound_where() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            echo '[{"a": 1, "b": 1}, {"a": 2, "b": 1}, {"a": 2, "b": 2}]' | from-json | where a == 2 && b == 1 | to-json
+        "#
+    ));
+
+    assert_eq!(actual, r#"{"a":2,"b":1}"#);
+}

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -18,6 +18,7 @@ mod insert;
 mod last;
 mod lines;
 mod ls;
+mod math;
 mod mkdir;
 mod mv;
 mod open;

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -78,6 +78,12 @@ fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseErr
             if let Some('{') = block_level.last() {
                 let _ = block_level.pop();
             }
+        } else if c == '(' {
+            block_level.push(c);
+        } else if c == ')' {
+            if let Some('(') = block_level.last() {
+                let _ = block_level.pop();
+            }
         } else if block_level.is_empty() && c.is_whitespace() {
             break;
         }

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -168,9 +168,21 @@ fn pipeline(src: &mut Input, span_offset: usize) -> Result<LitePipeline, ParseEr
                 // The first character tells us a lot about each argument
                 match c {
                     '|' => {
-                        // this is the end of this command
                         let _ = src.next();
-                        break;
+                        if let Some((pos, next_c)) = src.peek() {
+                            if *next_c == '|' {
+                                // this isn't actually a pipeline but a comparison
+                                let span = Span::new(pos - 1 + span_offset, pos + 1 + span_offset);
+                                cmd.args.push("||".to_string().spanned(span));
+                                let _ = src.next();
+                            } else {
+                                // this is the end of this command
+                                break;
+                            }
+                        } else {
+                            // this is the end of this command
+                            break;
+                        }
                     }
                     '"' | '\'' => {
                         let c = *c;

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -609,7 +609,7 @@ fn parse_math_expression(
 
         if idx < lite_args.len() {
             trace!(
-                "idx: {} working_exprs: {:?} prec: {:?}",
+                "idx: {} working_exprs: {:#?} prec: {:?}",
                 idx,
                 working_exprs,
                 prec
@@ -639,14 +639,8 @@ fn parse_math_expression(
                     });
                     prec.pop();
                 }
-                let lhs = working_exprs.pop().expect("This shouldn't be possible");
-                let span = Span::new(lhs.span.start(), rhs.span.end());
-                let binary = SpannedExpression::new(
-                    Expression::Binary(Box::new(Binary::new(lhs, op, rhs))),
-                    span,
-                );
-                working_exprs.push(binary);
-                prec.pop();
+                working_exprs.push(op);
+                working_exprs.push(rhs);
             }
 
             idx += 1;

--- a/crates/nu-parser/src/shapes.rs
+++ b/crates/nu-parser/src/shapes.rs
@@ -32,9 +32,7 @@ pub fn expression_to_flat_shape(e: &SpannedExpression) -> Vec<Spanned<FlatShape>
             vec![FlatShape::GlobPattern.spanned(e.span)]
         }
         Expression::Literal(Literal::Number(_)) => vec![FlatShape::Int.spanned(e.span)],
-        Expression::Literal(Literal::Operator(_)) => {
-            vec![FlatShape::CompareOperator.spanned(e.span)]
-        }
+        Expression::Literal(Literal::Operator(_)) => vec![FlatShape::Operator.spanned(e.span)],
         Expression::Literal(Literal::Size(number, unit)) => vec![FlatShape::Size {
             number: number.span,
             unit: unit.span,
@@ -48,7 +46,7 @@ pub fn expression_to_flat_shape(e: &SpannedExpression) -> Vec<Spanned<FlatShape>
         Expression::Binary(binary) => {
             let mut output = vec![];
             output.append(&mut expression_to_flat_shape(&binary.left));
-            output.push(FlatShape::CompareOperator.spanned(binary.op.span));
+            output.push(FlatShape::Operator.spanned(binary.op.span));
             output.append(&mut expression_to_flat_shape(&binary.right));
             output
         }

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -463,6 +463,8 @@ impl SpannedExpression {
                     | Operator::Equal
                     | Operator::NotEqual
                     | Operator::In => 80,
+                    Operator::And => 50,
+                    Operator::Or => 40, // TODO: should we have And and Or be different precedence?
                 }
             }
             _ => 0,
@@ -599,6 +601,8 @@ pub enum Operator {
     Multiply,
     Divide,
     In,
+    And,
+    Or,
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize, new)]

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -575,6 +575,7 @@ pub enum Operator {
     Minus,
     Multiply,
     Divide,
+    In,
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize, new)]

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -445,6 +445,29 @@ impl SpannedExpression {
     pub fn new(expr: Expression, span: Span) -> SpannedExpression {
         SpannedExpression { expr, span }
     }
+
+    pub fn precedence(&self) -> usize {
+        match self.expr {
+            Expression::Literal(Literal::Operator(operator)) => {
+                // Higher precedence binds tighter
+
+                match operator {
+                    Operator::Multiply | Operator::Divide => 100,
+                    Operator::Plus | Operator::Minus => 90,
+                    Operator::NotContains
+                    | Operator::Contains
+                    | Operator::LessThan
+                    | Operator::LessThanOrEqual
+                    | Operator::GreaterThan
+                    | Operator::GreaterThanOrEqual
+                    | Operator::Equal
+                    | Operator::NotEqual
+                    | Operator::In => 80,
+                }
+            }
+            _ => 0,
+        }
+    }
 }
 
 impl std::ops::Deref for SpannedExpression {

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -30,6 +30,8 @@ pub enum SyntaxShape {
     Unit,
     /// An operator
     Operator,
+    /// A parenthesized math expression, eg `(1 + 3)`
+    Parenthesized,
     /// A math expression, eg `foo > 1`
     Math,
 }
@@ -51,6 +53,7 @@ impl PrettyDebug for SyntaxShape {
             SyntaxShape::Table => "table",
             SyntaxShape::Unit => "unit",
             SyntaxShape::Operator => "operator",
+            SyntaxShape::Parenthesized => "math with parentheses",
             SyntaxShape::Math => "condition",
         })
     }

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -30,8 +30,8 @@ pub enum SyntaxShape {
     Unit,
     /// An operator
     Operator,
-    /// A condition, eg `foo > 1`
-    Condition,
+    /// A math expression, eg `foo > 1`
+    Math,
 }
 
 impl PrettyDebug for SyntaxShape {
@@ -51,7 +51,7 @@ impl PrettyDebug for SyntaxShape {
             SyntaxShape::Table => "table",
             SyntaxShape::Unit => "unit",
             SyntaxShape::Operator => "operator",
-            SyntaxShape::Condition => "condition",
+            SyntaxShape::Math => "condition",
         })
     }
 }

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -193,7 +193,7 @@ impl UntaggedValue {
     }
 
     /// Helper for creating date duration values
-    pub fn duration(secs: u64) -> UntaggedValue {
+    pub fn duration(secs: i64) -> UntaggedValue {
         UntaggedValue::Primitive(Primitive::Duration(secs))
     }
 

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -41,7 +41,7 @@ pub enum Primitive {
     /// A date value, in UTC
     Date(DateTime<Utc>),
     /// A count in the number of seconds
-    Duration(u64),
+    Duration(i64),
     /// A range of values
     Range(Box<Range>),
     /// A file path
@@ -276,7 +276,7 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
 }
 
 /// Format a duration in seconds into a string
-pub fn format_duration(sec: u64) -> String {
+pub fn format_duration(sec: i64) -> String {
     let (minutes, seconds) = (sec / 60, sec % 60);
     let (hours, minutes) = (minutes / 60, minutes % 60);
     let (days, hours) = (hours / 24, hours % 24);
@@ -290,13 +290,73 @@ pub fn format_duration(sec: u64) -> String {
     }
 }
 
+#[allow(clippy::cognitive_complexity)]
 /// Format a UTC date value into a humanized string (eg "1 week ago" instead of a formal date string)
 pub fn format_date(d: &DateTime<Utc>) -> String {
     let utc: DateTime<Utc> = Utc::now();
 
     let duration = utc.signed_duration_since(*d);
 
-    if duration.num_weeks() >= 52 {
+    if duration.num_seconds() < 0 {
+        // Our duration is negative, so we need to speak about the future
+        if -duration.num_weeks() >= 52 {
+            let num_years = -duration.num_weeks() / 52;
+
+            format!(
+                "{} year{} from now",
+                num_years,
+                if num_years == 1 { "" } else { "s" }
+            )
+        } else if -duration.num_weeks() >= 4 {
+            let num_months = -duration.num_weeks() / 4;
+
+            format!(
+                "{} month{} from now",
+                num_months,
+                if num_months == 1 { "" } else { "s" }
+            )
+        } else if -duration.num_weeks() >= 1 {
+            let num_weeks = -duration.num_weeks();
+
+            format!(
+                "{} week{} from now",
+                num_weeks,
+                if num_weeks == 1 { "" } else { "s" }
+            )
+        } else if -duration.num_days() >= 1 {
+            let num_days = -duration.num_days();
+
+            format!(
+                "{} day{} from now",
+                num_days,
+                if num_days == 1 { "" } else { "s" }
+            )
+        } else if -duration.num_hours() >= 1 {
+            let num_hours = -duration.num_hours();
+
+            format!(
+                "{} hour{} from now",
+                num_hours,
+                if num_hours == 1 { "" } else { "s" }
+            )
+        } else if -duration.num_minutes() >= 1 {
+            let num_minutes = -duration.num_minutes();
+
+            format!(
+                "{} min{} from now",
+                num_minutes,
+                if num_minutes == 1 { "" } else { "s" }
+            )
+        } else {
+            let num_seconds = -duration.num_seconds();
+
+            format!(
+                "{} sec{} from now",
+                num_seconds,
+                if num_seconds == 1 { "" } else { "s" }
+            )
+        }
+    } else if duration.num_weeks() >= 52 {
         let num_years = duration.num_weeks() / 52;
 
         format!(

--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -97,7 +97,7 @@ async fn host(tag: Tag) -> Value {
 
     // Uptime
     if let Ok(uptime) = uptime_result {
-        let uptime = uptime.get::<time::second>().round() as u64;
+        let uptime = uptime.get::<time::second>().round() as i64;
 
         dict.insert_untagged("uptime", UntaggedValue::duration(uptime));
     }


### PR DESCRIPTION
Adds math operations to math blocks.  This includes:

* some default coersions between value types
* compound expressions, eg `1 + 2 + 3`
* operator precedence
* parenthesized math expressions
* compound comparisons, eg `where name =~ foo && size > 1kb`