### PR TITLE
Fix precedence parsing of parens. Limit use

### DIFF
--- a/crates/nu-cli/tests/commands/math.rs
+++ b/crates/nu-cli/tests/commands/math.rs
@@ -131,3 +131,15 @@ fn compound_where() {
 
     assert_eq!(actual, r#"{"a":2,"b":1}"#);
 }
+
+#[test]
+fn compound_where_paren() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            echo '[{"a": 1, "b": 1}, {"a": 2, "b": 1}, {"a": 2, "b": 2}]' | from-json | where (a == 2 && b == 1) || b == 2 | to-json
+        "#
+    ));
+
+    assert_eq!(actual, r#"[{"a":2,"b":1},{"a":2,"b":2}]"#);
+}

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -30,8 +30,6 @@ pub enum SyntaxShape {
     Unit,
     /// An operator
     Operator,
-    /// A parenthesized math expression, eg `(1 + 3)`
-    Parenthesized,
     /// A math expression, eg `foo > 1`
     Math,
 }
@@ -53,7 +51,6 @@ impl PrettyDebug for SyntaxShape {
             SyntaxShape::Table => "table",
             SyntaxShape::Unit => "unit",
             SyntaxShape::Operator => "operator",
-            SyntaxShape::Parenthesized => "math with parentheses",
             SyntaxShape::Math => "condition",
         })
     }


### PR DESCRIPTION
This PR does a couple things:

* first, it more correctly adds parens to precedence parsing for math. this allows you to more naturally use parens to wrap expressions to put them into higher precedence
* second, it removes the general parens from the argument parsing.  We may add this back later, but before added we wanted to get a better understanding of how parens would work as arguments.

fixes #1605 