### PR TITLE
Bump `ichwh` minimum version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "ichwh"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710eee656faf1879c4af26a1b281147586b6f3327191e2b1e54e2dc10bf1142b"
+checksum = "ada08ff7272ae34697d0463565b7ad6831bff3a99329fc6c04839666ef5cd328"
 dependencies = [
  "async-std",
  "cfg-if",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -45,7 +45,7 @@ glob = "0.3.0"
 hex = "0.4"
 htmlescape = "0.3.1"
 ical = "0.6.*"
-ichwh = "0.3.2"
+ichwh = "0.3.3"
 indexmap = { version = "1.3.2", features = ["serde-1"] }
 itertools = "0.9.0"
 language-reporting = "0.4.0"


### PR DESCRIPTION
The new version includes a fix for [this issue]

[this issue]: https://gitlab.com/avandesa/ichwh-rs/-/issues/2