### PR TITLE
Move alias arguments to optional arguments

### DIFF
--- a/crates/nu-cli/src/commands/run_alias.rs
+++ b/crates/nu-cli/src/commands/run_alias.rs
@@ -24,7 +24,7 @@ impl PerItemCommand for AliasCommand {
         let mut alias = Signature::build(&self.name);
 
         for arg in &self.args {
-            alias = alias.required(arg, SyntaxShape::Any, "");
+            alias = alias.optional(arg, SyntaxShape::Any, "");
         }
 
         alias


### PR DESCRIPTION
This will allow people to use more variables to capture more, if necessary, without having to implement required/optional/rest