### PR TITLE
Add booleans and fix semicolon shortcircuit

### DIFF
--- a/crates/nu-cli/src/commands/classified/block.rs
+++ b/crates/nu-cli/src/commands/classified/block.rs
@@ -30,16 +30,23 @@ pub(crate) async fn run_block(
                             ..
                         }))) => return Err(e),
                         Ok(Some(_item)) => {
+                            if let Some(err) = ctx.get_errors().get(0) {
+                                ctx.clear_errors();
+                                return Err(err.clone());
+                            }
                             if ctx.ctrl_c.load(Ordering::SeqCst) {
                                 break;
                             }
                         }
-                        Ok(None) => break,
+                        Ok(None) => {
+                            if let Some(err) = ctx.get_errors().get(0) {
+                                ctx.clear_errors();
+                                return Err(err.clone());
+                            }
+                            break;
+                        }
                         Err(e) => return Err(e),
                     }
-                }
-                if !ctx.get_errors().is_empty() {
-                    return Ok(InputStream::empty());
                 }
             }
             Err(e) => {

--- a/crates/nu-cli/src/context.rs
+++ b/crates/nu-cli/src/context.rs
@@ -147,6 +147,10 @@ impl Context {
         self.with_errors(|errors| errors.push(error))
     }
 
+    pub(crate) fn clear_errors(&mut self) {
+        self.current_errors.lock().clear()
+    }
+
     pub(crate) fn get_errors(&self) -> Vec<ShellError> {
         self.current_errors.lock().clone()
     }

--- a/crates/nu-cli/src/data/base.rs
+++ b/crates/nu-cli/src/data/base.rs
@@ -88,6 +88,7 @@ pub(crate) enum CompareValues {
     String(String, String),
     Date(DateTime<Utc>, DateTime<Utc>),
     DateDuration(DateTime<Utc>, i64),
+    Booleans(bool, bool),
 }
 
 impl CompareValues {
@@ -108,6 +109,7 @@ impl CompareValues {
                 };
                 right.cmp(left)
             }
+            CompareValues::Booleans(left, right) => left.cmp(right),
         }
     }
 }
@@ -164,6 +166,7 @@ fn coerce_compare_primitive(
         (Line(left), Line(right)) => CompareValues::String(left.clone(), right.clone()),
         (Date(left), Date(right)) => CompareValues::Date(*left, *right),
         (Date(left), Duration(right)) => CompareValues::DateDuration(*left, *right),
+        (Boolean(left), Boolean(right)) => CompareValues::Booleans(*left, *right),
         _ => return Err((left.type_name(), right.type_name())),
     })
 }

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -152,6 +152,14 @@ fn evaluate_reference(name: &hir::Variable, scope: &Scope, tag: Tag) -> Result<V
         hir::Variable::It(_) => Ok(scope.it.value.clone().into_value(tag)),
         hir::Variable::Other(name, _) => match name {
             x if x == "$nu" => crate::evaluate::variables::nu(tag),
+            x if x == "$true" => Ok(Value {
+                value: UntaggedValue::boolean(true),
+                tag,
+            }),
+            x if x == "$false" => Ok(Value {
+                value: UntaggedValue::boolean(false),
+                tag,
+            }),
             x => Ok(scope
                 .vars
                 .get(x)


### PR DESCRIPTION
Two unrelated fixes: 
* Adds `$true` and `$false` to represent their boolean values
* Attempts to fix the semicolon shortcircuit, so that we stop evaluating when we hit an error rather than continuing to the right hand side of the `;`

Fixes #1619 
Fixes #1119 