### PR TITLE
Add exit code verification

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -878,20 +878,20 @@ async fn process_line(
 }
 
 pub fn print_err(err: ShellError, host: &dyn Host, source: &Text) {
-    let diag = err.into_diagnostic();
-
-    let writer = host.err_termcolor();
-    let mut source = source.to_string();
-    source.push_str(" ");
-    let files = nu_parser::Files::new(source);
-    let _ = std::panic::catch_unwind(move || {
-        let _ = language_reporting::emit(
-            &mut writer.lock(),
-            &files,
-            &diag,
-            &language_reporting::DefaultConfig,
-        );
-    });
+    if let Some(diag) = err.into_diagnostic() {
+        let writer = host.err_termcolor();
+        let mut source = source.to_string();
+        source.push_str(" ");
+        let files = nu_parser::Files::new(source);
+        let _ = std::panic::catch_unwind(move || {
+            let _ = language_reporting::emit(
+                &mut writer.lock(),
+                &files,
+                &diag,
+                &language_reporting::DefaultConfig,
+            );
+        });
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This adds a marker that we can use when an external doesn't return with a successful exit code.  As the user may not always wish to print an error in these cases, sometimes the expected behavior is to silently allow something to fail without any additional commentary.

With this PR, we have a ShellError that allows us to notice the failure without commenting on it. This then allows us to correctly shortcircuit the `;` in the cases where the notice of failure comes from the exit code.