### PR TITLE
Bump `ichwh` to version 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "ichwh"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada08ff7272ae34697d0463565b7ad6831bff3a99329fc6c04839666ef5cd328"
+checksum = "ea685d38f1becb4f0a04e6cbff9256c6c2cd5e5905563b251401d1c13d12c654"
 dependencies = [
  "async-std",
  "cfg-if",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -45,7 +45,7 @@ glob = "0.3.0"
 hex = "0.4"
 htmlescape = "0.3.1"
 ical = "0.6.*"
-ichwh = "0.3.3"
+ichwh = "0.3.4"
 indexmap = { version = "1.3.2", features = ["serde-1"] }
 itertools = "0.9.0"
 language-reporting = "0.4.0"


### PR DESCRIPTION
Fixes #1626 and [this ichwh issue](https://gitlab.com/avandesa/ichwh-rs/-/issues/3).