### PR TITLE
[docs/enter] Warn about `enter` opening multiple shells

### DIFF
--- a/docs/commands/enter.md
+++ b/docs/commands/enter.md
@@ -37,3 +37,23 @@ It also provides the ability to work with multiple directories at the same time.
 /> n
 /tmp>
 ```
+
+## Note
+
+If you `enter` a JSON file with multiple a top-level list, this will open one new shell for each list element. 
+
+```shell
+/private/tmp> printf "1\\n2\\n3\\n" | lines | save foo.json
+/private/tmp> enter foo.json
+/> shells
+───┬────────┬─────────────────────────┬──────────────
+ # │ active │ name                    │ path
+───┼────────┼─────────────────────────┼──────────────
+ 0 │        │ filesystem              │ /private/tmp
+ 1 │        │ {/private/tmp/foo.json} │ /
+ 2 │        │ {/private/tmp/foo.json} │ /
+ 3 │ X      │ {/private/tmp/foo.json} │ /
+───┴────────┴─────────────────────────┴──────────────
+/>
+```
+


### PR DESCRIPTION
Opening a JSON with a top-level list, opens one shell per list element. This can be extremely confusing to unexpected users.