### PR TITLE
suppress the parser error for an insufficient number of required argu…

### DIFF
--- a/crates/nu-cli/tests/commands/histogram.rs
+++ b/crates/nu-cli/tests/commands/histogram.rs
@@ -30,3 +30,32 @@ fn summarizes() {
         // 50%
     })
 }
+
+#[test]
+fn help() {
+    Playground::setup("histogram_test_help", |dirs, _sandbox| {
+        let help_command = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+                help histogram
+            "#
+        ));
+
+        let help_short = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+                histogram -h
+            "#
+        ));
+
+        let help_long = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+                histogram --help
+            "#
+        ));
+
+        assert_eq!(help_short, help_command);
+        assert_eq!(help_long, help_command);
+    })
+}

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -976,11 +976,14 @@ fn parse_internal_command(
         }
     }
     if positional.len() < required_arg_count && error.is_none() {
-        let (_, name) = &signature.positional[positional.len()];
-        error = Some(ParseError::argument_error(
-            lite_cmd.name.clone(),
-            ArgumentError::MissingMandatoryPositional(name.to_owned()),
-        ));
+        // to make "command -h" work even if required arguments are missing
+        if !named.named.contains_key("help") {
+            let (_, name) = &signature.positional[positional.len()];
+            error = Some(ParseError::argument_error(
+                lite_cmd.name.clone(),
+                ArgumentError::MissingMandatoryPositional(name.to_owned()),
+            ));
+        }
     }
 
     if !named.is_empty() {


### PR DESCRIPTION
…ments if the named keyword argument 'help' is given

Should I be worried that there will now be arguments which have been successfully parsed but don't meet the requirements?

From a very purist point of view, it seems that arguments should either parse to a "normal" list of arguments with requirements or to "help" in which case one could even decide to throw away the rest of the arguments since they won't be used anyway. I haven't looked at it in detail but on first sight it seems like a rather big change for such a small feature.