### PR TITLE
Interpret trailing slash in head position as an auto-cd.

### DIFF
--- a/crates/nu-cli/src/commands/cd.rs
+++ b/crates/nu-cli/src/commands/cd.rs
@@ -1,7 +1,16 @@
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
+
+use std::path::PathBuf;
+
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape};
+use nu_source::Tagged;
+
+#[derive(Deserialize)]
+pub struct CdArgs {
+    pub(crate) path: Option<Tagged<PathBuf>>,
+}
 
 pub struct Cd;
 
@@ -27,12 +36,10 @@ impl WholeStreamCommand for Cd {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        cd(args, registry)
+        args.process(registry, cd)?.run()
     }
 }
 
-fn cd(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
-    let shell_manager = args.shell_manager.clone();
-    let args = args.evaluate_once(registry)?;
-    shell_manager.cd(args)
+fn cd(args: CdArgs, context: RunnableContext) -> Result<OutputStream, ShellError> {
+    context.shell_manager.cd(args, &context)
 }

--- a/crates/nu-cli/src/commands/run_external.rs
+++ b/crates/nu-cli/src/commands/run_external.rs
@@ -1,29 +1,39 @@
+use crate::commands::cd::CdArgs;
 use crate::commands::classified::external;
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 
 use derive_new::new;
 use parking_lot::Mutex;
+use std::path::PathBuf;
 
 use nu_errors::ShellError;
 use nu_protocol::hir::{Expression, ExternalArgs, ExternalCommand, Literal, SpannedExpression};
 use nu_protocol::{ReturnSuccess, Signature, SyntaxShape};
+use nu_source::Tagged;
 
 #[derive(Deserialize)]
 pub struct RunExternalArgs {}
 
 #[derive(new)]
-pub struct RunExternalCommand;
+pub struct RunExternalCommand {
+    /// Whether or not nushell is being used in an interactive context
+    pub(crate) interactive: bool,
+}
 
-fn spanned_expression_to_string(expr: SpannedExpression) -> String {
+fn spanned_expression_to_string(expr: SpannedExpression) -> Result<String, ShellError> {
     if let SpannedExpression {
         expr: Expression::Literal(Literal::String(s)),
         ..
     } = expr
     {
-        s
+        Ok(s)
     } else {
-        "notacommand!!!".to_string()
+        Err(ShellError::labeled_error(
+            "Expected string for command name",
+            "expected string",
+            expr.span,
+        ))
     }
 }
 
@@ -45,7 +55,7 @@ impl WholeStreamCommand for RunExternalCommand {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        let positionals = args.call_info.args.positional.ok_or_else(|| {
+        let positionals = args.call_info.args.positional.clone().ok_or_else(|| {
             ShellError::untagged_runtime_error("positional arguments unexpectedly empty")
         })?;
 
@@ -53,49 +63,89 @@ impl WholeStreamCommand for RunExternalCommand {
 
         let name = positionals
             .next()
-            .map(spanned_expression_to_string)
             .ok_or_else(|| {
-                ShellError::untagged_runtime_error(
-                    "run_external unexpectedly missing external name positional arg",
-                )
-            })?;
+                ShellError::untagged_runtime_error("run_external called with no arguments")
+            })
+            .and_then(spanned_expression_to_string)?;
 
-        let command = ExternalCommand {
-            name,
-            name_tag: args.call_info.name_tag.clone(),
-            args: ExternalArgs {
-                list: positionals.collect(),
-                span: args.call_info.args.span,
-            },
+        let mut external_context = {
+            #[cfg(windows)]
+            {
+                Context {
+                    registry: registry.clone(),
+                    host: args.host.clone(),
+                    shell_manager: args.shell_manager.clone(),
+                    ctrl_c: args.ctrl_c.clone(),
+                    current_errors: Arc::new(Mutex::new(vec![])),
+                    windows_drives_previous_cwd: Arc::new(Mutex::new(
+                        std::collections::HashMap::new(),
+                    )),
+                }
+            }
+            #[cfg(not(windows))]
+            {
+                Context {
+                    registry: registry.clone(),
+                    host: args.host.clone(),
+                    shell_manager: args.shell_manager.clone(),
+                    ctrl_c: args.ctrl_c.clone(),
+                    current_errors: Arc::new(Mutex::new(vec![])),
+                }
+            }
         };
 
-        let mut external_context;
-        #[cfg(windows)]
-        {
-            external_context = Context {
-                registry: registry.clone(),
-                host: args.host.clone(),
-                shell_manager: args.shell_manager.clone(),
-                ctrl_c: args.ctrl_c.clone(),
-                current_errors: Arc::new(Mutex::new(vec![])),
-                windows_drives_previous_cwd: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            };
-        }
-        #[cfg(not(windows))]
-        {
-            external_context = Context {
-                registry: registry.clone(),
-                host: args.host.clone(),
-                shell_manager: args.shell_manager.clone(),
-                ctrl_c: args.ctrl_c.clone(),
-                current_errors: Arc::new(Mutex::new(vec![])),
-            };
-        }
-        let scope = args.call_info.scope.clone();
+        let is_interactive = self.interactive;
 
-        let is_last = args.call_info.args.is_last;
-        let input = args.input;
         let stream = async_stream! {
+            let command = ExternalCommand {
+                name,
+                name_tag: args.call_info.name_tag.clone(),
+                args: ExternalArgs {
+                    list: positionals.collect(),
+                    span: args.call_info.args.span,
+                },
+            };
+
+            // If we're in interactive mode, we will "auto cd". That is, instead of interpreting
+            // this as an external command, we will see it as a path and `cd` into it.
+            if is_interactive {
+                if let Some(path) = maybe_autocd_dir(&command, &mut external_context).await {
+                    let cd_args = CdArgs {
+                        path: Some(Tagged {
+                            item: PathBuf::from(path),
+                            tag: args.call_info.name_tag.clone(),
+                        })
+                    };
+
+                    let context = RunnableContext {
+                        input: InputStream::empty(),
+                        shell_manager: external_context.shell_manager.clone(),
+                        host: external_context.host.clone(),
+                        ctrl_c: external_context.ctrl_c.clone(),
+                        registry: external_context.registry.clone(),
+                        name: args.call_info.name_tag.clone(),
+                    };
+
+                    let result = external_context.shell_manager.cd(cd_args, &context);
+                    match result {
+                        Ok(mut stream) => {
+                            while let Some(value) = stream.next().await {
+                                yield value;
+                            }
+                        },
+                        Err(e) => {
+                            yield Err(e);
+                        },
+                        _ => {}
+                    }
+
+                    return;
+                }
+            }
+
+            let scope = args.call_info.scope.clone();
+            let is_last = args.call_info.args.is_last;
+            let input = args.input;
             let result = external::run_external_command(
                 command,
                 &mut external_context,
@@ -119,4 +169,55 @@ impl WholeStreamCommand for RunExternalCommand {
 
         Ok(stream.to_output_stream())
     }
+}
+
+#[allow(unused_variables)]
+async fn maybe_autocd_dir<'a>(cmd: &ExternalCommand, ctx: &mut Context) -> Option<String> {
+    // We will "auto cd" if
+    //   - the command name ends in a path separator, or
+    //   - it's not a command on the path and no arguments were given.
+    let name = &cmd.name;
+    let path_name = if name.ends_with(std::path::MAIN_SEPARATOR)
+        || (cmd.args.is_empty()
+            && PathBuf::from(name).is_dir()
+            && dunce::canonicalize(name).is_ok()
+            && ichwh::which(&name).await.unwrap_or(None).is_none())
+    {
+        Some(name)
+    } else {
+        None
+    };
+
+    path_name.map(|name| {
+        #[cfg(windows)]
+        {
+            if name.ends_with(':') {
+                // This looks like a drive shortcut. We need to a) switch drives and b) go back to the previous directory we were viewing on that drive
+                // But first, we need to save where we are now
+                let current_path = ctx.shell_manager.path();
+
+                let split_path: Vec<_> = current_path.split(':').collect();
+                if split_path.len() > 1 {
+                    ctx.windows_drives_previous_cwd
+                        .lock()
+                        .insert(split_path[0].to_string(), current_path);
+                }
+
+                let name = name.to_uppercase();
+                let new_drive: Vec<_> = name.split(':').collect();
+
+                if let Some(val) = ctx.windows_drives_previous_cwd.lock().get(new_drive[0]) {
+                    val.to_string()
+                } else {
+                    name
+                }
+            } else {
+                name.to_string()
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            name.to_string()
+        }
+    })
 }

--- a/crates/nu-cli/src/shell/help_shell.rs
+++ b/crates/nu-cli/src/shell/help_shell.rs
@@ -1,3 +1,4 @@
+use crate::commands::cd::CdArgs;
 use crate::commands::command::EvaluatedWholeStreamCommandArgs;
 use crate::commands::cp::CopyArgs;
 use crate::commands::ls::LsArgs;
@@ -7,12 +8,15 @@ use crate::commands::rm::RemoveArgs;
 use crate::data::command_dict;
 use crate::prelude::*;
 use crate::shell::shell::Shell;
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
 use nu_errors::ShellError;
 use nu_protocol::{
     Primitive, ReturnSuccess, ShellTypeName, TaggedDictBuilder, UntaggedValue, Value,
 };
-use std::ffi::OsStr;
-use std::path::PathBuf;
+use nu_source::Tagged;
 
 #[derive(Clone, Debug)]
 pub struct HelpShell {
@@ -149,12 +153,11 @@ impl Shell for HelpShell {
         Ok(output.into())
     }
 
-    fn cd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {
-        let path = match args.nth(0) {
+    fn cd(&self, args: CdArgs, _name: Tag) -> Result<OutputStream, ShellError> {
+        let path = match args.path {
             None => "/".to_string(),
             Some(v) => {
-                let target = v.as_path()?;
-
+                let Tagged { item: target, .. } = v;
                 let mut cwd = PathBuf::from(&self.path);
 
                 if target == PathBuf::from("..") {

--- a/crates/nu-cli/src/shell/shell.rs
+++ b/crates/nu-cli/src/shell/shell.rs
@@ -1,3 +1,4 @@
+use crate::commands::cd::CdArgs;
 use crate::commands::command::EvaluatedWholeStreamCommandArgs;
 use crate::commands::cp::CopyArgs;
 use crate::commands::ls::LsArgs;
@@ -18,7 +19,7 @@ pub trait Shell: std::fmt::Debug {
         args: LsArgs,
         context: &RunnablePerItemContext,
     ) -> Result<OutputStream, ShellError>;
-    fn cd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError>;
+    fn cd(&self, args: CdArgs, name: Tag) -> Result<OutputStream, ShellError>;
     fn cp(&self, args: CopyArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;
     fn mkdir(&self, args: MkdirArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;
     fn mv(&self, args: MoveArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;

--- a/crates/nu-cli/src/shell/shell_manager.rs
+++ b/crates/nu-cli/src/shell/shell_manager.rs
@@ -1,3 +1,4 @@
+use crate::commands::cd::CdArgs;
 use crate::commands::command::{EvaluatedWholeStreamCommandArgs, RunnablePerItemContext};
 use crate::commands::cp::CopyArgs;
 use crate::commands::ls::LsArgs;
@@ -141,10 +142,10 @@ impl ShellManager {
         env[self.current_shell()].ls(args, context)
     }
 
-    pub fn cd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {
+    pub fn cd(&self, args: CdArgs, context: &RunnableContext) -> Result<OutputStream, ShellError> {
         let env = self.shells.lock();
 
-        env[self.current_shell()].cd(args)
+        env[self.current_shell()].cd(args, context.name.clone())
     }
 
     pub fn cp(

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -25,7 +25,7 @@ fn automatically_change_directory() {
     use nu_test_support::playground::Playground;
 
     Playground::setup("cd_test_5_1", |dirs, sandbox| {
-        sandbox.within("autodir").mkdir("bar");
+        sandbox.mkdir("autodir");
 
         let actual = nu!(
             cwd: dirs.test(),
@@ -36,6 +36,25 @@ fn automatically_change_directory() {
         );
 
         assert!(actual.ends_with("autodir"));
+    })
+}
+
+#[test]
+fn automatically_change_directory_with_trailing_slash_and_same_name_as_command() {
+    use nu_test_support::playground::Playground;
+
+    Playground::setup("cd_test_5_1", |dirs, sandbox| {
+        sandbox.mkdir("cd");
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"
+                cd/
+                pwd | echo $it
+            "#
+        );
+
+        assert!(actual.ends_with("cd"));
     })
 }
 


### PR DESCRIPTION
Resolves https://github.com/nushell/nushell/issues/1658

For example, when running the following:

    crates/nu-cli/src

nushell currently parses this as an external command. Before running the command, we check to see if it's a directory. If it is, we "auto cd" into that directory, otherwise we go through normal external processing.

If we put a trailing slash on it though, shells typically interpret that as "user is explicitly referencing directory". So

    crates/nu-cli/src/

should not be interpreted as "run an external command". We intercept a trailing slash in the head position of a command in a pipeline as such, and inject a `cd` internal command.