### PR TITLE
Fix access to columns with quoted names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
+name = "eml-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e30d14e24cd200f2351837a02feacf8f043410f2a56441868c93ef33f90239"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2137,7 @@ dependencies = [
  "derive-new",
  "dirs 2.0.2",
  "dunce",
+ "eml-parser",
  "filesize",
  "futures 0.3.4",
  "futures-util",

--- a/crates/nu-cli/tests/commands/get.rs
+++ b/crates/nu-cli/tests/commands/get.rs
@@ -235,3 +235,13 @@ fn errors_fetching_by_index_out_of_bounds() {
         )
     })
 }
+
+#[test]
+fn quoted_column_access() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        r#"echo '[{"foo bar": {"baz": 4}}]' | from-json | get "foo bar".baz | echo $it"#
+    );
+
+    assert_eq!(actual, "4");
+}

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -104,45 +104,6 @@ fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseErr
     Ok(bare.spanned(span))
 }
 
-fn quoted(
-    src: &mut Input,
-    delimiter: char,
-    span_offset: usize,
-) -> Result<Spanned<String>, ParseError> {
-    skip_whitespace(src);
-
-    let mut quoted_string = String::new();
-    let start_offset = if let Some((pos, _)) = src.peek() {
-        *pos
-    } else {
-        0
-    };
-
-    let _ = src.next();
-
-    let mut found_end = false;
-
-    for (_, c) in src {
-        if c != delimiter {
-            quoted_string.push(c);
-        } else {
-            found_end = true;
-            break;
-        }
-    }
-
-    quoted_string.insert(0, delimiter);
-    if found_end {
-        quoted_string.push(delimiter);
-    }
-
-    let span = Span::new(
-        start_offset + span_offset,
-        start_offset + span_offset + quoted_string.len(),
-    );
-    Ok(quoted_string.spanned(span))
-}
-
 fn command(src: &mut Input, span_offset: usize) -> Result<LiteCommand, ParseError> {
     let command = bare(src, span_offset)?;
     if command.item.is_empty() {
@@ -193,12 +154,12 @@ fn pipeline(src: &mut Input, span_offset: usize) -> Result<LiteBlock, ParseError
                             break;
                         }
                     }
-                    '"' | '\'' => {
-                        let c = *c;
-                        // quoted string
-                        let arg = quoted(src, c, span_offset)?;
-                        cmd.args.push(arg);
-                    }
+                    // '"' | '\'' => {
+                    //     let c = *c;
+                    //     // quoted string
+                    //     let arg = quoted(src, c, span_offset)?;
+                    //     cmd.args.push(arg);
+                    // }
                     _ => {
                         // basic argument
                         let arg = bare(src, span_offset)?;


### PR DESCRIPTION
This fixes the issue where you can't access columns with quoted names.

Example:

`| get "foo bar".baz`