### PR TITLE
make trim apply to strings contained in tables (also at deeper nesting

### DIFF
--- a/crates/nu-cli/src/commands/trim.rs
+++ b/crates/nu-cli/src/commands/trim.rs
@@ -66,7 +66,7 @@ fn trim(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
     Ok(args
         .input
         .map(|v| {
-            let mut trimmed = v.clone();
+            let mut trimmed = v;
             trim_value(&mut trimmed);
             ReturnSuccess::value(trimmed)
         })

--- a/crates/nu-cli/src/commands/trim.rs
+++ b/crates/nu-cli/src/commands/trim.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
+use nu_protocol::{Dictionary, Primitive, ReturnSuccess, Signature, UntaggedValue, Value};
 
 pub struct Trim;
 
@@ -28,12 +28,47 @@ impl WholeStreamCommand for Trim {
     }
 }
 
+fn trim_primitive(p: &mut Primitive) {
+    match p {
+        Primitive::String(s) | Primitive::Line(s) => *p = Primitive::String(s.trim().to_string()),
+        Primitive::Nothing
+        | Primitive::Int(_)
+        | Primitive::Decimal(_)
+        | Primitive::Bytes(_)
+        | Primitive::ColumnPath(_)
+        | Primitive::Pattern(_)
+        | Primitive::Boolean(_)
+        | Primitive::Date(_)
+        | Primitive::Duration(_)
+        | Primitive::Range(_)
+        | Primitive::Path(_)
+        | Primitive::Binary(_)
+        | Primitive::BeginningOfStream
+        | Primitive::EndOfStream => (),
+    }
+}
+
+fn trim_row(d: &mut Dictionary) {
+    for (_, mut value) in d.entries.iter_mut() {
+        trim_value(&mut value);
+    }
+}
+
+fn trim_value(v: &mut Value) {
+    match &mut v.value {
+        UntaggedValue::Primitive(p) => trim_primitive(p),
+        UntaggedValue::Row(row) => trim_row(row),
+        _ => (),
+    };
+}
+
 fn trim(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     Ok(args
         .input
-        .map(move |v| {
-            let string = String::extract(&v)?;
-            ReturnSuccess::value(UntaggedValue::string(string.trim()).into_value(v.tag()))
+        .map(|v| {
+            let mut trimmed = v.clone();
+            trim_value(&mut trimmed);
+            ReturnSuccess::value(trimmed)
         })
         .to_output_stream())
 }

--- a/crates/nu-cli/src/prelude.rs
+++ b/crates/nu-cli/src/prelude.rs
@@ -78,7 +78,6 @@ pub(crate) use crate::commands::command::{
 pub(crate) use crate::context::CommandRegistry;
 pub(crate) use crate::context::Context;
 pub(crate) use crate::data::config;
-pub(crate) use crate::data::types::ExtractType;
 pub(crate) use crate::data::value;
 pub(crate) use crate::env::host::handle_unexpected;
 pub(crate) use crate::env::Host;

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -37,6 +37,7 @@ mod split_by;
 mod split_column;
 mod sum;
 mod touch;
+mod trim;
 mod uniq;
 mod where_;
 mod wrap;

--- a/crates/nu-cli/tests/commands/trim.rs
+++ b/crates/nu-cli/tests/commands/trim.rs
@@ -1,0 +1,85 @@
+use nu_test_support::fs::Stub::FileWithContent;
+use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn string() {
+    Playground::setup("trim_test_1", |dirs, _sandbox| {
+        let test_strings = ["\n", " \n ", "\thi\n\n", "\u{2003}a"];
+        assert!(test_strings[3].chars().count() == 2);
+
+        for test_string in &test_strings {
+            let commandline = format!(
+                r#"
+                        echo {}
+                        | trim
+                    "#,
+                test_string
+            );
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(&commandline
+            ));
+            assert_eq!(actual, test_string.trim())
+        }
+    })
+}
+
+#[test]
+fn row() {
+    Playground::setup("trim_test_2", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            FileWithContent("lines.csv", "lines\n l0\n\tl1\n l2\t \n\n"),
+            FileWithContent("lines_trimmed.csv", "lines\nl0\nl1\nl2\n"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open lines.csv
+                | trim
+            "#
+        ));
+
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open lines_trimmed.csv
+            "#
+        ));
+
+        assert_eq!(actual, expected)
+    })
+}
+
+#[test]
+fn nested() {
+    Playground::setup("trim_test_3", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            FileWithContent(
+                "nested.json",
+                r#"{ "l0" : {"l1": {"l2" : {"a" : "  s0", "b" : "\t\ts1\n"} } } }"#,
+            ),
+            FileWithContent(
+                "nested_trimmed.json",
+                r#"{ "l0" : {"l1": {"l2" : {"a" : "s0", "b" : "s1"} } } }"#,
+            ),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open nested.json
+                | trim
+            "#
+        ));
+
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open nested_trimmed.json
+            "#
+        ));
+
+        assert_eq!(actual, expected)
+    })
+}


### PR DESCRIPTION
levels), not just top-level strings

addresses https://github.com/nushell/nushell/issues/1657

I actually didn't want to implement trimming further down into nested tables, but then I found out that it actually does it as it is written now. Of course I'm open to going back to making it only go one level deep.

Explicitly listing all the primitives here is a bit tedious, but I didn't really know of a better way to make sure that an added variant similar to Primitive::Line would be handled correctly once it's added.

I'm not sure whether the use of mutable references here is unidiomatic (it may be a C++-ism). My first experiment with making it work by moving stuff into functions everywhere failed (my understanding of the borrow checker is not complete).