### PR TITLE
Replace `ichwh` with `which` and some fixes for auto-cd (canonicalization)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-std"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
+dependencies = [
+ "async-attributes",
+ "async-task",
+ "crossbeam-channel 0.4.2",
+ "crossbeam-deque",
+ "crossbeam-utils 0.7.2",
+ "futures-core",
+ "futures-io",
+ "futures-timer 2.0.2",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "mio",
+ "mio-uds",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +127,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async-task"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac2c016b079e771204030951c366db398864f5026f84a44dafb0ff20f02085d"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -477,6 +523,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 dependencies = [
  "crossbeam-utils 0.6.6",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -1040,6 +1096,12 @@ checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
 
 [[package]]
 name = "futures-timer"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
+
+[[package]]
+name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
@@ -1405,6 +1467,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ichwh"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea685d38f1becb4f0a04e6cbff9256c6c2cd5e5905563b251401d1c13d12c654"
+dependencies = [
+ "async-std",
+ "cfg-if",
+ "futures 0.3.4",
+ "thiserror",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,7 +1560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b77027f12e53ae59a379f7074259d32eb10867e6183388020e922832d9c3fb"
 dependencies = [
  "bytes 0.4.12",
- "crossbeam-channel",
+ "crossbeam-channel 0.3.9",
  "crossbeam-utils 0.6.6",
  "curl",
  "curl-sys",
@@ -1570,6 +1644,15 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1842,6 +1925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-uds"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2148,7 @@ dependencies = [
  "hex 0.4.0",
  "htmlescape",
  "ical",
+ "ichwh",
  "indexmap",
  "itertools 0.9.0",
  "language-reporting",
@@ -2321,7 +2416,7 @@ name = "nu_plugin_ps"
 version = "0.13.0"
 dependencies = [
  "futures 0.3.4",
- "futures-timer",
+ "futures-timer 3.0.2",
  "heim",
  "nu-build",
  "nu-errors",
@@ -2638,6 +2733,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
@@ -3593,6 +3694,26 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "term_size",
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,7 @@ dependencies = [
  "umask",
  "unicode-xid",
  "users",
+ "which",
 ]
 
 [[package]]
@@ -4082,6 +4083,16 @@ checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "failure",
+ "libc",
 ]
 
 [[package]]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -47,7 +47,6 @@ glob = "0.3.0"
 hex = "0.4"
 htmlescape = "0.3.1"
 ical = "0.6.*"
-ichwh = "0.3.4"
 indexmap = { version = "1.3.2", features = ["serde-1"] }
 itertools = "0.9.0"
 language-reporting = "0.4.0"
@@ -84,6 +83,7 @@ toml = "0.5.6"
 typetag = "0.1.4"
 umask = "0.1"
 unicode-xid = "0.2.0"
+which = "3"
 
 trash = { version = "1.0.0", optional = true }
 clipboard = { version = "0.5", optional = true }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -47,6 +47,7 @@ glob = "0.3.0"
 hex = "0.4"
 htmlescape = "0.3.1"
 ical = "0.6.*"
+ichwh = "0.3.4"
 indexmap = { version = "1.3.2", features = ["serde-1"] }
 itertools = "0.9.0"
 language-reporting = "0.4.0"

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -6,6 +6,7 @@ use crate::commands::whole_stream_command;
 use crate::context::Context;
 #[cfg(not(feature = "starship-prompt"))]
 use crate::git::current_branch;
+use crate::path::canonicalize;
 use crate::prelude::*;
 use futures_codec::FramedRead;
 
@@ -22,7 +23,7 @@ use rustyline::{
 use std::error::Error;
 use std::io::{BufRead, BufReader, Write};
 use std::iter::Iterator;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 
 fn load_plugin(path: &std::path::Path, context: &mut Context) -> Result<(), ShellError> {
@@ -775,9 +776,9 @@ async fn process_line(
                             .as_ref()
                             .map(NamedArguments::is_empty)
                             .unwrap_or(true)
-                        && dunce::canonicalize(&name).is_ok()
-                        && PathBuf::from(&name).is_dir()
-                        && ichwh::which(&name).await.unwrap_or(None).is_none()
+                        && canonicalize(ctx.shell_manager.path(), name).is_ok()
+                        && Path::new(&name).is_dir()
+                        && which::which(&name).is_err()
                     {
                         // Here we work differently if we're in Windows because of the expected Windows behavior
                         #[cfg(windows)]

--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -467,12 +467,12 @@ fn spawn(
 async fn did_find_command(name: &str) -> bool {
     #[cfg(not(windows))]
     {
-        ichwh::which(name).await.unwrap_or(None).is_some()
+        which::which(name).is_ok()
     }
 
     #[cfg(windows)]
     {
-        if ichwh::which(name).await.unwrap_or(None).is_some() {
+        if which::which(name).is_ok() {
             true
         } else {
             let cmd_builtins = [

--- a/crates/nu-cli/src/commands/classified/internal.rs
+++ b/crates/nu-cli/src/commands/classified/internal.rs
@@ -117,7 +117,7 @@ pub(crate) fn run_internal_command(
                     }
                     CommandAction::EnterShell(location) => {
                         context.shell_manager.insert_at_current(Box::new(
-                            FilesystemShell::with_location(location, context.registry().clone()),
+                            FilesystemShell::with_location(location, context.registry().clone())?,
                         ));
                     }
                     CommandAction::AddAlias(name, args, block) => {

--- a/crates/nu-cli/src/commands/run_external.rs
+++ b/crates/nu-cli/src/commands/run_external.rs
@@ -181,7 +181,7 @@ async fn maybe_autocd_dir<'a>(cmd: &ExternalCommand, ctx: &mut Context) -> Optio
         || (cmd.args.is_empty()
             && PathBuf::from(name).is_dir()
             && dunce::canonicalize(name).is_ok()
-            && ichwh::which(&name).await.unwrap_or(None).is_none())
+            && which::which(&name).is_err())
     {
         Some(name)
     } else {

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -69,9 +69,15 @@ impl FilesystemShell {
         })
     }
 
-    pub fn with_location(path: String, commands: CommandRegistry) -> FilesystemShell {
+    pub fn with_location(
+        path: String,
+        commands: CommandRegistry,
+    ) -> Result<FilesystemShell, std::io::Error> {
+        let path = canonicalize(std::env::current_dir()?, &path)?;
+        let path = path.display().to_string();
         let last_path = path.clone();
-        FilesystemShell {
+
+        Ok(FilesystemShell {
             path,
             last_path,
             completer: NuCompleter {
@@ -80,7 +86,7 @@ impl FilesystemShell {
                 homedir: dirs::home_dir(),
             },
             hinter: HistoryHinter {},
-        }
+        })
     }
 }
 
@@ -978,7 +984,7 @@ impl Shell for FilesystemShell {
 
     fn set_path(&mut self, path: String) {
         let pathbuf = PathBuf::from(&path);
-        let path = match dunce::canonicalize(pathbuf.as_path()) {
+        let path = match canonicalize(self.path(), pathbuf.as_path()) {
             Ok(path) => {
                 let _ = std::env::set_current_dir(&path);
                 path


### PR DESCRIPTION
I've replaced for now `ichwh` with `which` and made some changes on FilesystemShell when building it with `with_location`, concretely this may fail because it needs to canonicalize the received path. 

Other changes include the replacement on `dunce::canonicalize` with nushell custom canonicalize, that successfully resolves more paths than normal canonicalize. 

The advanced fix for `auto-cd` specifically solves the same issue as presented in #1484 