### PR TITLE
Show symlink sizes in ls

### DIFF
--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -130,6 +130,12 @@ pub(crate) fn dir_entry_dict(
     if let Some(md) = metadata {
         if md.is_file() {
             dict.insert_untagged("size", UntaggedValue::bytes(md.len() as u64));
+        } else if md.file_type().is_symlink() {
+            if let Ok(symlink_md) = filename.symlink_metadata() {
+                dict.insert_untagged("size", UntaggedValue::bytes(symlink_md.len() as u64));
+            } else {
+                dict.insert_untagged("size", UntaggedValue::nothing());
+            }
         } else {
             dict.insert_untagged("size", UntaggedValue::nothing());
         }

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -127,21 +127,19 @@ pub(crate) fn dir_entry_dict(
         }
     }
 
+    let mut size_untagged_value: UntaggedValue = UntaggedValue::nothing();
+
     if let Some(md) = metadata {
         if md.is_file() {
-            dict.insert_untagged("size", UntaggedValue::bytes(md.len() as u64));
+            size_untagged_value = UntaggedValue::bytes(md.len() as u64);
         } else if md.file_type().is_symlink() {
             if let Ok(symlink_md) = filename.symlink_metadata() {
-                dict.insert_untagged("size", UntaggedValue::bytes(symlink_md.len() as u64));
-            } else {
-                dict.insert_untagged("size", UntaggedValue::nothing());
+                size_untagged_value = UntaggedValue::bytes(symlink_md.len() as u64);
             }
-        } else {
-            dict.insert_untagged("size", UntaggedValue::nothing());
         }
-    } else {
-        dict.insert_untagged("size", UntaggedValue::nothing());
     }
+
+    dict.insert_untagged("size", size_untagged_value);
 
     if let Some(md) = metadata {
         if full {


### PR DESCRIPTION
In the `files.rs` file, there is a method called `dir_entry_dict()`.  It gets sent a `Metadata` object in the form of an `Option`.  This can't be used for the size of the symlink, as this version of the `Metadata` will follow the symlink to the target and get the target's size.  You have to call `symlink_metadata()` on the `File` object itself, which isn't accessible in this function, or call it on the `Path` object.  In the first case, the function signature would need to be re-written to have the `File` itself passed to the function, then the function could choose which `Metadata` version to use, so I chose the second option of just getting the symlink `Metadata` from the `Path` that is already being sent in.  I don't necessarily think it is the cleanest way, it simply called for less code changes, so I rolled with that.

I'm only able to test on macOS, but it seems to be reporting the same values as `zsh` in Terminal.

<img width="1536" alt="Screen Shot 2020-04-29 at 1 46 01 AM" src="https://user-images.githubusercontent.com/19867440/80564542-1953ca00-89bc-11ea-9c5e-4aa03ec1620a.png">
<img width="1029" alt="Screen Shot 2020-04-29 at 1 48 43 AM" src="https://user-images.githubusercontent.com/19867440/80564549-1bb62400-89bc-11ea-9dbf-3a508f0b3779.png">
