### PR TITLE
extend it-expansion to externals

### DIFF
--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -116,7 +116,7 @@ fn run_with_stdin(
     let mut command_args = vec![];
     for arg in command.args.iter() {
         let value = evaluate_baseline_expr(arg, &context.registry, scope)?;
-        command_args.push(value.as_string()?);
+        command_args.push(value.as_string()?.trim_end_matches('\n').to_string());
     }
 
     let process_args = command_args

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -81,16 +81,6 @@ impl ClassifiedCommand {
     pub fn has_it_iteration(&self) -> bool {
         match self {
             ClassifiedCommand::Internal(command) => {
-                if let SpannedExpression {
-                    expr: Expression::Literal(Literal::String(s)),
-                    ..
-                } = &*command.args.head
-                {
-                    if s == "run_external" {
-                        // For now, don't it-expand externals
-                        return false;
-                    }
-                }
                 let mut result = command.args.head.has_shallow_it_usage();
 
                 if let Some(positionals) = &command.args.positional {
@@ -109,17 +99,6 @@ impl ClassifiedCommand {
     pub fn expand_it_usage(&mut self) {
         match self {
             ClassifiedCommand::Internal(command) => {
-                if let SpannedExpression {
-                    expr: Expression::Literal(Literal::String(s)),
-                    ..
-                } = &*command.args.head
-                {
-                    if s == "run_external" {
-                        // For now, don't it-expand externals
-                        return;
-                    }
-                }
-
                 if let Some(positionals) = &mut command.args.positional {
                     for arg in positionals {
                         if let SpannedExpression {
@@ -179,7 +158,9 @@ impl Commands {
                     name_span: self.span,
                     args: hir::Call {
                         head: Box::new(SpannedExpression {
-                            expr: Expression::Synthetic(Synthetic::String("each".to_string())),
+                            expr: Expression::Synthetic(Synthetic::String(
+                                "expanded-each".to_string(),
+                            )),
                             span: self.span,
                         }),
                         named: None,

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -101,7 +101,7 @@ mod it_evaluation {
                 "#
             ));
 
-            assert_eq!(actual, "AndrásWithKitKatz");
+            assert_eq!(actual, "AndrásWithKitKat");
         })
     }
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,15 +1,5 @@
 use nu_test_support::{nu, nu_error};
 
-// #[test]
-// fn shows_error_for_command_that_fails() {
-//     let actual = nu_error!(
-//         cwd: ".",
-//         "fail"
-//     );
-
-//     assert!(actual.contains("External command failed"));
-// }
-
 #[test]
 fn shows_error_for_command_not_found() {
     let actual = nu_error!(
@@ -111,7 +101,7 @@ mod it_evaluation {
                 "#
             ));
 
-            assert_eq!(actual, "AndrásWithKitKat");
+            assert_eq!(actual, "AndrásWithKitKatz");
         })
     }
 


### PR DESCRIPTION
Extends it-expansion so that it also expands external commands, which makes expansion now uniform across all command forms. This lets us remove a fair bit of the manual it-expansion for externals. 