### PR TITLE
Convert if expression to match

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -221,43 +221,29 @@ fn parse_range(lite_arg: &Spanned<String>) -> (SpannedExpression, Option<ParseEr
 
 /// Parse any allowed operator, including word-based operators
 fn parse_operator(lite_arg: &Spanned<String>) -> (SpannedExpression, Option<ParseError>) {
-    let operator = if lite_arg.item == "==" {
-        Operator::Equal
-    } else if lite_arg.item == "!=" {
-        Operator::NotEqual
-    } else if lite_arg.item == "<" {
-        Operator::LessThan
-    } else if lite_arg.item == "<=" {
-        Operator::LessThanOrEqual
-    } else if lite_arg.item == ">" {
-        Operator::GreaterThan
-    } else if lite_arg.item == ">=" {
-        Operator::GreaterThanOrEqual
-    } else if lite_arg.item == "=~" {
-        Operator::Contains
-    } else if lite_arg.item == "!~" {
-        Operator::NotContains
-    } else if lite_arg.item == "+" {
-        Operator::Plus
-    } else if lite_arg.item == "-" {
-        Operator::Minus
-    } else if lite_arg.item == "*" {
-        Operator::Multiply
-    } else if lite_arg.item == "/" {
-        Operator::Divide
-    } else if lite_arg.item == "in:" {
-        Operator::In
-    } else if lite_arg.item == "not-in:" {
-        Operator::NotIn
-    } else if lite_arg.item == "&&" {
-        Operator::And
-    } else if lite_arg.item == "||" {
-        Operator::Or
-    } else {
-        return (
-            garbage(lite_arg.span),
-            Some(ParseError::mismatch("operator", lite_arg.clone())),
-        );
+    let operator = match &lite_arg.item[..] {
+        "==" => Operator::Equal,
+        "!=" => Operator::NotEqual,
+        "<" => Operator::LessThan,
+        "<=" => Operator::LessThanOrEqual,
+        ">" => Operator::GreaterThan,
+        ">=" => Operator::GreaterThanOrEqual,
+        "=~" => Operator::Contains,
+        "!~" => Operator::NotContains,
+        "+" => Operator::Plus,
+        "-" => Operator::Minus,
+        "*" => Operator::Multiply,
+        "/" => Operator::Divide,
+        "in:" => Operator::In,
+        "not-in:" => Operator::NotIn,
+        "&&" => Operator::And,
+        "||" => Operator::Or,
+        _ => {
+            return (
+                garbage(lite_arg.span),
+                Some(ParseError::mismatch("operator", lite_arg.clone())),
+            );
+        }
     };
 
     (


### PR DESCRIPTION
This is my first contribution to a Rust project. I just started learning Rust a few days ago, so please correct me if there is a difference in behavior between the old and new code.

Some questions:
- On my machine, the `target` directory is 2.4 GB large. Is this normal, and is there a way to reduce the size?
- When running `cargo test`, some tests are failing, even on `master`. Here's the output:
  ```
  running 40 tests
  test plugins::core_inc::can_only_apply_one ... ok
  test plugins::core_inc::by_one_with_no_field_passed ... ok
  test plugins::core_inc::semversion_major_inc ... ok
  test plugins::core_inc::by_one_with_field_passed ... ok
  test plugins::core_inc::semversion_patch_inc ... ok
  test plugins::core_inc::semversion_minor_inc ... ok
  test plugins::core_inc::semversion_without_passing_field ... ok
  test plugins::core_str::acts_without_passing_field ... ok
  test plugins::core_str::can_only_apply_one ... ok
  test plugins::core_str::capitalizes ... ok
  test plugins::core_str::downcases ... ok
  test plugins::core_str::converts_to_int ... ok
  test plugins::core_str::find_and_replaces ... ok
  test plugins::core_str::replaces ... ok
  test plugins::core_str::find_an_replaces_without_passing_field ... ok
  test plugins::core_str::trims ... ok
  test shell::pipeline::commands::external::automatically_change_directory_with_trailing_slash_and_same_name_as_command ... ok
  test shell::pipeline::commands::external::automatically_change_directory ... ok
  test plugins::core_str::upcases ... ok
  error: Command not found
  - shell:1:35
  1 |         cococo joturner@foo.bar.baz
    |         ^^^^^^ command not found
  test shell::pipeline::commands::external::external_words::relaxed_external_words ... FAILED
  test shell::pipeline::commands::external::it_evaluation::supports_fetching_given_a_column_path_to_it ... FAILED
  test shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings ... FAILED
  test shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines ... FAILED
  test shell::pipeline::commands::external::nu_commands::echo_internally_externally ... ok
  test shell::pipeline::commands::external::shows_error_for_command_not_found ... ok
  test shell::pipeline::commands::external::nu_script::run_nu_script_multiline ... ok
  test shell::pipeline::commands::external::nu_script::run_nu_script ... ok
  error: Command not found
  - shell:1:69
  1 |                             iecho yes | chop | chop | lines | first 1
    |                                                ^^^^ command not found
  test shell::pipeline::commands::external::stdin_evaluation::does_not_panic_with_no_newline_in_stream ... FAILED
  test shell::pipeline::commands::external::stdin_evaluation::does_not_block_indefinitely ... FAILED
  error: Command not found
  - shell:1:32
  1error |                     : cococoCommand not found
   "1~1"
  - shell : | 1                    :^^^^^^20
   1command not found |
              cococo ~
    |             ^^^^^^ command not found
  test shell::pipeline::commands::external::tilde_expansion::as_home_directory_when_passed_as_argument_and_begins_with_tilde ... ok
  test shell::pipeline::commands::external::tilde_expansion::does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde ... FAILED
  error: Command not found
  - shell:1:50
  1 |                             echo "nushelll" | chop
    |                                               ^^^^ command not found
  test shell::pipeline::commands::internal::parse::errors_if_flag_is_not_supported ... ok
  test shell::pipeline::commands::internal::can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external ... FAILED
  test shell::pipeline::commands::internal::parse::errors_if_passed_an_unexpected_argument ... ok
  error: Command not found
  - shell:1:94
  1 |                             open nu_times.csv | get name | ^echo $it | chop | nth 3 | echo $it
    |                                                                        ^^^^ command not found
  test shell::pipeline::commands::internal::tilde_expansion::as_home_directory_when_passed_as_argument_and_begins_with_tilde ... ok
  test shell::pipeline::commands::internal::takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external ... FAILED
  test shell::pipeline::commands::internal::tilde_expansion::does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde ... ok
  test shell::pipeline::commands::internal::parse::errors_if_flag_passed_is_not_exact ... ok
  test shell::pipeline::doesnt_break_on_utf8 ... ok
  test shell::pipeline::commands::internal::tilde_expansion::proper_it_expansion ... ok

  failures:

  ---- shell::pipeline::commands::external::external_words::relaxed_external_words stdout ----
  === stderr

  thread 'shell::pipeline::commands::external::external_words::relaxed_external_words' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"joturner@foo.bar.baz"`', tests/shell/pipeline/commands/external.rs:175:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

  ---- shell::pipeline::commands::external::it_evaluation::supports_fetching_given_a_column_path_to_it stdout ----
  === stderr

  thread 'shell::pipeline::commands::external::it_evaluation::supports_fetching_given_a_column_path_to_it' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"zion"`', tests/shell/pipeline/commands/external.rs:127:13

  ---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings stdout ----
  === stderr

  thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"jonathan_likes_cake.txt"`', tests/shell/pipeline/commands/external.rs:77:13

  ---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines stdout ----
  === stderr

  thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"Andr√°sWithKitKat"`', tests/shell/pipeline/commands/external.rs:104:13

  ---- shell::pipeline::commands::external::stdin_evaluation::does_not_panic_with_no_newline_in_stream stdout ----
  thread 'shell::pipeline::commands::external::stdin_evaluation::does_not_panic_with_no_newline_in_stream' panicked at 'assertion failed: `(left == right)`
    left: `"\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[38;5;9merror\u{1b}[0m\u{1b}[1m: \u{1b}[0m\u{1b}[1mCommand not found\u{1b}[0m\n\u{1b}[0m- \u{1b}[0mshell\u{1b}[0m:\u{1b}[0m1\u{1b}[0m:\u{1b}[0m62\u{1b}[0m\n\u{1b}[0m\u{1b}[34m1\u{1b}[0m\u{1b}[34m | \u{1b}[0m                            \u{1b}[0m\u{1b}[31mnonu\u{1b}[0m \"where\'s the nuline?\" | count\u{1b}[0m\n\u{1b}[0m\u{1b}[34m \u{1b}[0m\u{1b}[34m | \u{1b}[0m                            \u{1b}[0m\u{1b}[31m^^^^\u{1b}[0m\u{1b}[31m \u{1b}[0m\u{1b}[31mcommand not found\u{1b}[0m\n"`,
   right: `""`', tests/shell/pipeline/commands/external.rs:146:9

  ---- shell::pipeline::commands::external::stdin_evaluation::does_not_block_indefinitely stdout ----
  === stderr

  thread 'shell::pipeline::commands::external::stdin_evaluation::does_not_block_indefinitely' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"y"`', tests/shell/pipeline/commands/external.rs:162:9

  ---- shell::pipeline::commands::external::tilde_expansion::does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde stdout ----
  === stderr

  thread 'shell::pipeline::commands::external::tilde_expansion::does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"1~1"`', tests/shell/pipeline/commands/external.rs:241:9

  ---- shell::pipeline::commands::internal::can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external stdout ----
  === stderr

  thread 'shell::pipeline::commands::internal::can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"nushell"`', tests/shell/pipeline/commands/internal.rs:42:5

  ---- shell::pipeline::commands::internal::takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external stdout ----
  === stderr

  thread 'shell::pipeline::commands::internal::takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external' panicked at 'assertion failed: `(left == right)`
    left: `""`,
   right: `"AndKitKat"`', tests/shell/pipeline/commands/internal.rs:31:9


  failures:
      shell::pipeline::commands::external::external_words::relaxed_external_words
      shell::pipeline::commands::external::it_evaluation::supports_fetching_given_a_column_path_to_it
      shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines
      shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings
      shell::pipeline::commands::external::stdin_evaluation::does_not_block_indefinitely
      shell::pipeline::commands::external::stdin_evaluation::does_not_panic_with_no_newline_in_stream
      shell::pipeline::commands::external::tilde_expansion::does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde
      shell::pipeline::commands::internal::can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external
      shell::pipeline::commands::internal::takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external

  test result: FAILED. 31 passed; 9 failed; 0 ignored; 0 measured; 0 filtered out

  error: test failed, to rerun pass '--test main'd
  ```
  Am I doing something wrong here?

**Edit**: I just noticed that I was supposed to run `cargo test --all --features=stable,test-bins`, not `cargo test` 🙂. Now all the tests are passing. Also, now the `target` directory ballooned up to 4 GB. Any advice? 