### PR TITLE
Remove bin.is_file() because it's expensive

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -136,10 +136,6 @@ pub fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
             Err(_) => {}
             Ok(binaries) => {
                 for bin in binaries.filter_map(Result::ok) {
-                    if !bin.is_file() {
-                        continue;
-                    }
-
                     let bin_name = {
                         if let Some(name) = bin.file_name() {
                             match name.to_str() {


### PR DESCRIPTION
This one change takes the startup time from 2.8 seconds to 1.2 seconds in my testing on Windows.