### PR TITLE
Parse file size (byte) units in all mixes of case

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -5,7 +5,6 @@ use crate::path::expand_path;
 use crate::signature::SignatureRegistry;
 use log::trace;
 use nu_errors::{ArgumentError, ParseError};
-use nu_protocol::hir::Unit::{Gigabyte, Kilobyte, Megabyte, Petabyte, Terabyte};
 use nu_protocol::hir::{
     self, Binary, Block, ClassifiedBlock, ClassifiedCommand, ClassifiedPipeline, Commands,
     Expression, Flag, FlagKind, InternalCommand, Member, NamedArguments, Operator,
@@ -1133,62 +1132,62 @@ fn unit_parse_byte_units() -> Result<(), ParseError> {
         TestCase {
             string: String::from("10kb"),
             value: 10i64,
-            unit: Kilobyte,
+            unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("16KB"),
             value: 16i64,
-            unit: Kilobyte,
+            unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("99kB"),
             value: 99i64,
-            unit: Kilobyte,
+            unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("27Kb"),
             value: 27i64,
-            unit: Kilobyte,
+            unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("11Mb"),
             value: 11i64,
-            unit: Megabyte,
+            unit: Unit::Megabyte,
         },
         TestCase {
             string: String::from("27mB"),
             value: 27i64,
-            unit: Megabyte,
+            unit: Unit::Megabyte,
         },
         TestCase {
             string: String::from("11Gb"),
             value: 11i64,
-            unit: Gigabyte,
+            unit: Unit::Gigabyte,
         },
         TestCase {
             string: String::from("27gB"),
             value: 27i64,
-            unit: Gigabyte,
+            unit: Unit::Gigabyte,
         },
         TestCase {
             string: String::from("11Tb"),
             value: 11i64,
-            unit: Terabyte,
+            unit: Unit::Terabyte,
         },
         TestCase {
             string: String::from("27tB"),
             value: 27i64,
-            unit: Terabyte,
+            unit: Unit::Terabyte,
         },
         TestCase {
             string: String::from("11Pb"),
             value: 11i64,
-            unit: Petabyte,
+            unit: Unit::Petabyte,
         },
         TestCase {
             string: String::from("27pB"),
             value: 27i64,
-            unit: Petabyte,
+            unit: Unit::Petabyte,
         },
     ];
 

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -5,6 +5,7 @@ use crate::path::expand_path;
 use crate::signature::SignatureRegistry;
 use log::trace;
 use nu_errors::{ArgumentError, ParseError};
+use nu_protocol::hir::Unit::{Gigabyte, Kilobyte, Megabyte, Petabyte, Terabyte};
 use nu_protocol::hir::{
     self, Binary, Block, ClassifiedBlock, ClassifiedCommand, ClassifiedPipeline, Commands,
     Expression, Flag, FlagKind, InternalCommand, Member, NamedArguments, Operator,
@@ -13,7 +14,6 @@ use nu_protocol::hir::{
 use nu_protocol::{NamedType, PositionalType, Signature, SyntaxShape, UnspannedPathMember};
 use nu_source::{Span, Spanned, SpannedItem};
 use num_bigint::BigInt;
-use nu_protocol::hir::Unit::{Kilobyte, Megabyte, Gigabyte, Terabyte, Petabyte};
 
 /// Parses a simple column path, one without a variable (implied or explicit) at the head
 fn parse_simple_column_path(lite_arg: &Spanned<String>) -> (SpannedExpression, Option<ParseError>) {
@@ -1123,34 +1123,92 @@ pub fn garbage(span: Span) -> SpannedExpression {
 
 #[test]
 fn unit_parse_byte_units() -> Result<(), ParseError> {
-
-    struct TestCase { string: String, value: i64, unit: Unit};
+    struct TestCase {
+        string: String,
+        value: i64,
+        unit: Unit,
+    };
 
     let cases = [
-        TestCase{string: String::from("10kb"), value: 10i64, unit: Kilobyte},
-        TestCase{string: String::from("16KB"), value: 16i64, unit: Kilobyte},
-        TestCase{string: String::from("99kB"), value: 99i64, unit: Kilobyte},
-        TestCase{string: String::from("27Kb"), value: 27i64, unit: Kilobyte},
-
-        TestCase{string: String::from("11Mb"), value: 11i64, unit: Megabyte},
-        TestCase{string: String::from("27mB"), value: 27i64, unit: Megabyte},
-
-        TestCase{string: String::from("11Gb"), value: 11i64, unit: Gigabyte},
-        TestCase{string: String::from("27gB"), value: 27i64, unit: Gigabyte},
-
-        TestCase{string: String::from("11Tb"), value: 11i64, unit: Terabyte},
-        TestCase{string: String::from("27tB"), value: 27i64, unit: Terabyte},
-
-        TestCase{string: String::from("11Pb"), value: 11i64, unit: Petabyte},
-        TestCase{string: String::from("27pB"), value: 27i64, unit: Petabyte},
-
+        TestCase {
+            string: String::from("10kb"),
+            value: 10i64,
+            unit: Kilobyte,
+        },
+        TestCase {
+            string: String::from("16KB"),
+            value: 16i64,
+            unit: Kilobyte,
+        },
+        TestCase {
+            string: String::from("99kB"),
+            value: 99i64,
+            unit: Kilobyte,
+        },
+        TestCase {
+            string: String::from("27Kb"),
+            value: 27i64,
+            unit: Kilobyte,
+        },
+        TestCase {
+            string: String::from("11Mb"),
+            value: 11i64,
+            unit: Megabyte,
+        },
+        TestCase {
+            string: String::from("27mB"),
+            value: 27i64,
+            unit: Megabyte,
+        },
+        TestCase {
+            string: String::from("11Gb"),
+            value: 11i64,
+            unit: Gigabyte,
+        },
+        TestCase {
+            string: String::from("27gB"),
+            value: 27i64,
+            unit: Gigabyte,
+        },
+        TestCase {
+            string: String::from("11Tb"),
+            value: 11i64,
+            unit: Terabyte,
+        },
+        TestCase {
+            string: String::from("27tB"),
+            value: 27i64,
+            unit: Terabyte,
+        },
+        TestCase {
+            string: String::from("11Pb"),
+            value: 11i64,
+            unit: Petabyte,
+        },
+        TestCase {
+            string: String::from("27pB"),
+            value: 27i64,
+            unit: Petabyte,
+        },
     ];
 
     for case in cases.iter() {
         let input = case.string.clone().spanned(Span::new(0, 3));
         let result = parse_unit(&input);
         assert_eq!(result.1, None);
-        assert_eq!(result.0.expr, Expression::unit(Spanned { span: Span::new(0, 2), item: case.value }, Spanned { span: Span::new(2, 3), item: case.unit }));
+        assert_eq!(
+            result.0.expr,
+            Expression::unit(
+                Spanned {
+                    span: Span::new(0, 2),
+                    item: case.value
+                },
+                Spanned {
+                    span: Span::new(2, 3),
+                    item: case.unit
+                }
+            )
+        );
     }
     Ok(())
 }

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1130,80 +1130,92 @@ fn unit_parse_byte_units() -> Result<(), ParseError> {
 
     let cases = [
         TestCase {
+            string: String::from("108b"),
+            value: 108,
+            unit: Unit::Byte,
+        },
+        TestCase {
+            string: String::from("0B"),
+            value: 0,
+            unit: Unit::Byte,
+        },
+        TestCase {
             string: String::from("10kb"),
-            value: 10i64,
+            value: 10,
             unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("16KB"),
-            value: 16i64,
+            value: 16,
             unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("99kB"),
-            value: 99i64,
+            value: 99,
             unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("27Kb"),
-            value: 27i64,
+            value: 27,
             unit: Unit::Kilobyte,
         },
         TestCase {
             string: String::from("11Mb"),
-            value: 11i64,
+            value: 11,
             unit: Unit::Megabyte,
         },
         TestCase {
             string: String::from("27mB"),
-            value: 27i64,
+            value: 27,
             unit: Unit::Megabyte,
         },
         TestCase {
-            string: String::from("11Gb"),
-            value: 11i64,
+            string: String::from("811Gb"),
+            value: 811,
             unit: Unit::Gigabyte,
         },
         TestCase {
             string: String::from("27gB"),
-            value: 27i64,
+            value: 27,
             unit: Unit::Gigabyte,
         },
         TestCase {
             string: String::from("11Tb"),
-            value: 11i64,
+            value: 11,
             unit: Unit::Terabyte,
         },
         TestCase {
-            string: String::from("27tB"),
-            value: 27i64,
+            string: String::from("1027tB"),
+            value: 1027,
             unit: Unit::Terabyte,
         },
         TestCase {
             string: String::from("11Pb"),
-            value: 11i64,
+            value: 11,
             unit: Unit::Petabyte,
         },
         TestCase {
             string: String::from("27pB"),
-            value: 27i64,
+            value: 27,
             unit: Unit::Petabyte,
         },
     ];
 
     for case in cases.iter() {
-        let input = case.string.clone().spanned(Span::new(0, 3));
+        let input_len = case.string.len();
+        let value_len = case.value.to_string().len();
+        let input = case.string.clone().spanned(Span::new(0, input_len));
         let result = parse_unit(&input);
         assert_eq!(result.1, None);
         assert_eq!(
             result.0.expr,
             Expression::unit(
                 Spanned {
-                    span: Span::new(0, 2),
+                    span: Span::new(0, value_len),
                     item: case.value
                 },
                 Spanned {
-                    span: Span::new(2, 3),
+                    span: Span::new(value_len, input_len),
                     item: case.unit
                 }
             )

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -256,7 +256,7 @@ fn parse_operator(lite_arg: &Spanned<String>) -> (SpannedExpression, Option<Pars
 fn parse_unit(lite_arg: &Spanned<String>) -> (SpannedExpression, Option<ParseError>) {
     let unit_groups = [
         (Unit::Byte, vec!["b", "B"]),
-        (Unit::Kilobyte, vec!["kb", "KB", "Kb"]),
+        (Unit::Kilobyte, vec!["kb", "KB", "Kb", "kB"]),
         (Unit::Megabyte, vec!["mb", "MB", "Mb"]),
         (Unit::Gigabyte, vec!["gb", "GB", "Gb"]),
         (Unit::Terabyte, vec!["tb", "TB", "Tb"]),
@@ -1118,4 +1118,15 @@ pub fn classify_block(lite_block: &LiteBlock, registry: &dyn SignatureRegistry) 
 /// Easy shorthand function to create a garbage expression at the given span
 pub fn garbage(span: Span) -> SpannedExpression {
     SpannedExpression::new(Expression::Garbage, span)
+}
+
+#[test]
+fn unit_parse_kb() -> Result<(), ParseError> {
+    for string in ["10kb", "10KB", "10Kb", "10kB"].iter() {
+        let input = String::from(*string).spanned(Span::new(0, 3));
+        let result = parse_unit(&input);
+        assert_eq!(result.1, None);
+        assert_eq!(result.0.expr, Expression::unit(Spanned { span: Span::new(0, 2), item: 10i64 }, Spanned { span: Span::new(2, 3), item: Unit::Kilobyte }));
+    }
+    Ok(())
 }


### PR DESCRIPTION
I had a go at a fix for #1678. I am an experienced dev, but not at Rust, so I'd be interested in seeing if my test can be expressed in a less clumsy way.