### PR TITLE
Display either dir metadata size or dir apparent size in `ls`

### DIFF
--- a/crates/nu-cli/src/commands/du.rs
+++ b/crates/nu-cli/src/commands/du.rs
@@ -143,7 +143,7 @@ fn du(args: DuArgs, ctx: RunnableContext) -> Result<OutputStream, ShellError> {
     Ok(stream.to_output_stream())
 }
 
-struct DirBuilder {
+pub struct DirBuilder {
     tag: Tag,
     min: Option<u64>,
     deref: bool,
@@ -151,7 +151,25 @@ struct DirBuilder {
     all: bool,
 }
 
-struct DirInfo {
+impl DirBuilder {
+    pub fn new(
+        tag: Tag,
+        min: Option<u64>,
+        deref: bool,
+        exclude: Option<Pattern>,
+        all: bool,
+    ) -> DirBuilder {
+        DirBuilder {
+            tag,
+            min,
+            deref,
+            exclude,
+            all,
+        }
+    }
+}
+
+pub struct DirInfo {
     dirs: Vec<DirInfo>,
     files: Vec<FileInfo>,
     errors: Vec<ShellError>,
@@ -194,7 +212,7 @@ impl FileInfo {
 }
 
 impl DirInfo {
-    fn new(path: impl Into<PathBuf>, params: &DirBuilder, depth: Option<u64>) -> Self {
+    pub fn new(path: impl Into<PathBuf>, params: &DirBuilder, depth: Option<u64>) -> Self {
         let path = path.into();
 
         let mut s = Self {
@@ -273,6 +291,10 @@ impl DirInfo {
     fn add_error(mut self, e: ShellError) -> Self {
         self.errors.push(e);
         self
+    }
+
+    pub fn get_size(&self) -> u64 {
+        self.size
     }
 }
 

--- a/crates/nu-cli/src/commands/ls.rs
+++ b/crates/nu-cli/src/commands/ls.rs
@@ -16,6 +16,8 @@ pub struct LsArgs {
     pub short_names: bool,
     #[serde(rename = "with-symlink-targets")]
     pub with_symlink_targets: bool,
+    #[serde(rename = "du")]
+    pub du: bool,
 }
 
 impl WholeStreamCommand for Ls {
@@ -45,6 +47,11 @@ impl WholeStreamCommand for Ls {
                 "with-symlink-targets",
                 "display the paths to the target files that symlinks point to",
                 Some('w'),
+            )
+            .switch(
+                "du",
+                "display the apparent directory size in place of the directory metadata size",
+                Some('d'),
             )
     }
 

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -130,7 +130,7 @@ pub(crate) fn dir_entry_dict(
     let mut size_untagged_value: UntaggedValue = UntaggedValue::nothing();
 
     if let Some(md) = metadata {
-        if md.is_file() {
+        if md.is_dir() || md.is_file() {
             size_untagged_value = UntaggedValue::bytes(md.len() as u64);
         } else if md.file_type().is_symlink() {
             if let Ok(symlink_md) = filename.symlink_metadata() {

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -107,6 +107,7 @@ impl Shell for FilesystemShell {
             full,
             short_names,
             with_symlink_targets,
+            du,
         }: LsArgs,
         context: &RunnableContext,
     ) -> Result<OutputStream, ShellError> {
@@ -170,7 +171,8 @@ impl Shell for FilesystemShell {
                     name_tag.clone(),
                     full,
                     short_names,
-                    with_symlink_targets
+                    with_symlink_targets,
+                    du,
                 )
                 .map(|entry| ReturnSuccess::Value(entry.into()))?;
 


### PR DESCRIPTION
Originally, I thought that the directory size would be the actual size of the folder, [but it seems that other shells do not show the actual directory size in an ls command, they show the size of the directory's metadata](https://unix.stackexchange.com/questions/55/what-does-size-of-a-directory-mean-in-output-of-ls-l-command), so this PR spits out the dir metadata when running `ls`.  Additionally, if you toss in the `--du` command, it will show the directory's apparent size; this relies on code in the `du.rs`.  I've mostly hardcoded in the values that are given in the `du` command if the `du` command is ran with no options.  Even on my brand new totally spec'ed out 16 inch 2019 MacBook Pro, this command can takes a few seconds to run in the directories I've tested it in.  As @jonathandturner put it, it is "expensive," but it feels great to see the actual directory size there in Nu, under an optional flag.  I had the decision to either make a bunch of fields in `du.rs` `pub` or make some `pub` methods, I chose the latter. 


Here is a side-by-side comparison of the sizes of some of my directories in both Nu and zsh, when running just the normal `ls` command (which just outputs the directory metadata size):

<img width="1159" alt="Screen Shot 2020-05-01 at 8 41 11 PM" src="https://user-images.githubusercontent.com/19867440/80851165-f3ae0700-8bed-11ea-8a26-2c480a33e685.png">

Here is `ls --du` being ran, followed by some individual `du` commands to verify the sizes are the same:

<img width="1114" alt="Screen Shot 2020-05-03 at 12 41 45 AM" src="https://user-images.githubusercontent.com/19867440/80898887-f173a780-8cd6-11ea-8725-35a3921a70b1.png">

Please let me know if there is anything I can do to improve it is this if this isn't acceptable.  

Also, I originally had the option called. `du-dir-size`, but it felt pretty long.  If plain ole `du` is not liked, I can change it.