### PR TITLE
docs/commands: add alias.md

### DIFF
--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -1,5 +1,5 @@
 # alias
-This command allows you to define shortcuts for common commands, equivalent to the same bash command.
+This command allows you to define shortcuts for other common commands.
 
 The command expects three parameters:
 * the name of alias

--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -1,0 +1,62 @@
+# alias
+This command allows you to define shortcuts for common commands, equivalent to the same bash command.
+
+The command expects three parameters:
+* the name of alias
+* the parameters as a space-separated list (`[a b ...]`), can be empty (`[]`)
+* the body of the alias as a `{...}` block
+
+## Examples
+
+Define a custom `myecho` command as an alias:
+```shell
+> alias myecho [msg] { echo $msg }
+> myecho "hello world"
+hello world
+```
+
+Since the parameters are well defined, calling the command with the wrong number of parameters will fail properly:
+```shell
+> myecho hello world
+error: myecho unexpected world
+- shell:1:18
+1 | myecho hello world
+  |              ^^^^^ unexpected argument (try myecho -h)
+```
+
+The suggested help command works!
+```shell
+> myecho -h
+
+Usage:
+  > myecho ($msg) {flags}
+
+parameters:
+  ($msg)
+
+flags:
+  -h, --help: Display this help message
+```
+
+## Persistent aliases
+
+Aliases are most useful when they are persistent. For that, add them to your startup config:
+```
+> config --set [startup ["alias myecho [msg] { echo $msg }"]]
+```
+This is fine for the first alias, but since it overwrites the startup config, you need a different approach for additional aliases.
+
+To add a 2nd alias:
+```
+config --get startup | append "alias s [] { git status -sb }" | config --set_into startup
+```
+This first reads the `startup` config (a table of strings), then appends another alias, then sets the `startup` config with the output of the pipeline.
+
+To make this process easier, you could define another alias:
+```
+> alias addalias [alias-string] { config --get startup | append $alias-string | config --set_into startup }
+```
+Then use that to add more aliases:
+```
+addalias "alias s [] { git status -sb }"
+```


### PR DESCRIPTION
Arguably this shows the need for better managing of alias commands.

Or tell people to edit the nu/config.toml directly. I didn't include that here since I had some trouble passing `config --path` to my editor: https://discordapp.com/channels/601130461678272522/614593951969574961/706131398783926284