### PR TITLE
Fix column bugs associated with previous refactoring

### DIFF
--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -65,9 +65,9 @@ pub(crate) fn dir_entry_dict(
         dict.insert_untagged("type", UntaggedValue::nothing());
     }
 
-    let mut symlink_target_untagged_value: UntaggedValue = UntaggedValue::nothing();
-
     if full || with_symlink_targets {
+        let mut symlink_target_untagged_value: UntaggedValue = UntaggedValue::nothing();
+
         if let Some(md) = metadata {
             if md.file_type().is_symlink() {
                 if let Ok(path_to_link) = filename.read_link() {
@@ -79,9 +79,9 @@ pub(crate) fn dir_entry_dict(
                 }
             }
         }
-    }
 
-    dict.insert_untagged("target", symlink_target_untagged_value);
+        dict.insert_untagged("target", symlink_target_untagged_value);
+    }
 
     if full {
         if let Some(md) = metadata {

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -124,9 +124,9 @@ pub(crate) fn dir_entry_dict(
         }
     }
 
-    let mut size_untagged_value: UntaggedValue = UntaggedValue::nothing();
-
     if let Some(md) = metadata {
+        let mut size_untagged_value: UntaggedValue = UntaggedValue::nothing();
+
         if md.is_dir() {
             let dir_size: u64 = if du {
                 let params = DirBuilder::new(
@@ -153,9 +153,9 @@ pub(crate) fn dir_entry_dict(
                 size_untagged_value = UntaggedValue::bytes(symlink_md.len() as u64);
             }
         }
-    }
 
-    dict.insert_untagged("size", size_untagged_value);
+        dict.insert_untagged("size", size_untagged_value);
+    }
 
     if let Some(md) = metadata {
         if full {

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -66,9 +66,9 @@ pub(crate) fn dir_entry_dict(
     }
 
     if full || with_symlink_targets {
-        let mut symlink_target_untagged_value: UntaggedValue = UntaggedValue::nothing();
-
         if let Some(md) = metadata {
+            let mut symlink_target_untagged_value: UntaggedValue = UntaggedValue::nothing();
+
             if md.file_type().is_symlink() {
                 if let Ok(path_to_link) = filename.read_link() {
                     symlink_target_untagged_value =
@@ -78,9 +78,9 @@ pub(crate) fn dir_entry_dict(
                         UntaggedValue::string("Could not obtain target file's path");
                 }
             }
-        }
 
-        dict.insert_untagged("target", symlink_target_untagged_value);
+            dict.insert_untagged("target", symlink_target_untagged_value);
+        }
     }
 
     if full {


### PR DESCRIPTION
Some of the small refactoring I did in https://github.com/nushell/nushell/commit/ef3049f5a116276633645a9a2c9aa587bf3af429 and https://github.com/nushell/nushell/commit/8d197e1b2f8e447e7dc1512829b4b1cb50886c4c caused a few side effects.  

For the symlink targets, the symlink target column didn't care if you specified `full` or `with-symlink-targets` or nothing at all, it would always show that column.  

For both the symlink target column and the size column, they were originally coded in a way where if all of the items had metadata that was `None`, then it wouldn't display the column, so that is now the case again.