### PR TITLE
Properly deserialize history args

### DIFF
--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -9,7 +9,7 @@ use std::io::{BufRead, BufReader};
 pub struct History;
 
 #[derive(Deserialize)]
-pub struct HistoryArgs;
+pub struct HistoryArgs {}
 
 impl WholeStreamCommand for History {
     fn name(&self) -> &str {


### PR DESCRIPTION
The args deserializer needs `{}` instead of an empty struct for some reason. I looked and this is the only case I found.