### PR TITLE
Extend to/from usage text to indicate subcommands

### DIFF
--- a/crates/nu-cli/src/commands/from.rs
+++ b/crates/nu-cli/src/commands/from.rs
@@ -15,7 +15,7 @@ impl WholeStreamCommand for From {
     }
 
     fn usage(&self) -> &str {
-        "Parse content (string or binary) as a table."
+        "Parse content (string or binary) as a table (input format based on subcommand, like csv, ini, json, toml)"
     }
 
     fn run(

--- a/crates/nu-cli/src/commands/to.rs
+++ b/crates/nu-cli/src/commands/to.rs
@@ -15,7 +15,7 @@ impl WholeStreamCommand for To {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into an output format."
+        "Convert table into an output format (based on subcommand, like csv, html, json, yaml)."
     }
 
     fn run(


### PR DESCRIPTION
Both to and from without a subcommand only print the helptext. Expand the usage line a bit, so a glance at `help commands` indicates the existance of the subcommands and mentions some common formats.

Ref a9968046ede45827dfa1986f00059179e40b2c18
Ref #1708