### PR TITLE
docs/commands: add to.md, update subcommands

### DIFF
--- a/docs/commands/from.md
+++ b/docs/commands/from.md
@@ -1,20 +1,29 @@
 # from-csv
 
-Converts content (string or binary) into a table. The format is specified as a subcommand, like `from csv` or `from json`.
+Converts content (string or binary) into a table. The source format is specified as a subcommand, like `from csv` or `from json`.
 
 Use this when nushell cannot determine the input file extension.
 
 ## Available Subcommands
 
+* from bson
 * [from csv](from-csv.md)
+* from eml
 * [from ics](from-ics.md)
+* from ini
 * [from json](from-json.md)
 * [from ods](from-ods.md)
+* from sqlite
+* from ssv
 * [from toml](from-toml.md)
 * [from tsv](from-tsv.md)
+* from url
 * [from vcf](from-vcf.md)
-* [from xlsx](from-csv.md)
+* [from xlsx](from-xlsx.md)
+* from xml
 * [from yaml](from-yaml.md)
+
+*Subcommands without links are currently missing their documentation.*
 
 ## Example for `from csv`
 

--- a/docs/commands/to-csv.md
+++ b/docs/commands/to-csv.md
@@ -1,4 +1,4 @@
-# to-csv
+# to csv
 
 Converts table data into csv text.
 
@@ -13,7 +13,7 @@ Converts table data into csv text.
  1 │   │ filesystem │ /home/shaurya/Pictures
  2 │   │ filesystem │ /home/shaurya/Desktop
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
-> shells | to-csv
+> shells | to csv
  ,name,path
 X,filesystem,/home/shaurya
  ,filesystem,/home/shaurya/Pictures
@@ -66,7 +66,7 @@ X,filesystem,/home/shaurya
    │              │              │             │ OMYACARB 1T  │          │            │            │            │           │           │
    │              │              │             │ CG BPA 25 NO │          │            │            │            │           │           │
 ━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━━━
-> open caco3_plastics.csv | to-csv
+> open caco3_plastics.csv | to csv
 importer,shipper,tariff_item,name,origin,shipped_at,arrived_at,net_weight,fob_price,cif_price,cif_per_net_weight
 PLASTICOS RIVAL CIA LTDA,S A REVERTE,2509000000,CARBONATO DE CALCIO TIPO CALCIPORE 160 T AL,SPAIN,18/03/2016,17/04/2016,"81,000.00","14,417.58","18,252.34",0.23
 MEXICHEM ECUADOR S.A.,OMYA ANDINA S A,2836500000,CARBONATO,COLOMBIA,07/07/2016,10/07/2016,"26,000.00","7,072.00","8,127.18",0.31
@@ -90,7 +90,7 @@ To use a character other than ',' to separate records, use `--separator` :
  1 │   │ filesystem │ /home/shaurya/Pictures
  2 │   │ filesystem │ /home/shaurya/Desktop
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
-> shells | to-csv --separator ';'
+> shells | to csv --separator ';'
  ;name,path
 X;filesystem;/home/shaurya
  ;filesystem;/home/shaurya/Pictures

--- a/docs/commands/to-json.md
+++ b/docs/commands/to-json.md
@@ -1,4 +1,4 @@
-# to-json
+# to json
 
 Converts table data into json text.
 
@@ -13,7 +13,7 @@ Converts table data into json text.
  1 │   │ filesystem │ /home/shaurya/Pictures
  2 │   │ filesystem │ /home/shaurya/Desktop
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
-> shells | to-json
+> shells | to json
 [{" ":"X","name":"filesystem","path":"/home/shaurya"},{" ":" ","name":"filesystem","path":"/home/shaurya/Pictures"},{" ":" ","name":"filesystem","path":"/home/shaurya/Desktop"}]
 ```
 
@@ -24,7 +24,7 @@ Converts table data into json text.
 ────────────────
  [table: 1 row]
 ━━━━━━━━━━━━━━━━
-> open sgml_description.json | to-json
+> open sgml_description.json | to json
 {"glossary":{"title":"example glossary","GlossDiv":{"title":"S","GlossList":{"GlossEntry":{"ID":"SGML","SortAs":"SGML","GlossTerm":"Standard Generalized Markup Language","Acronym":"SGML","Abbrev":"ISO 8879:1986","Height":10,"GlossDef":{"para":"A meta-markup language, used to create markup languages such as DocBook.","GlossSeeAlso":["GML","XML"]},"Sections":[101,102],"GlossSee":"markup"}}}}}
 ```
 We can also convert formats !
@@ -35,6 +35,6 @@ We can also convert formats !
 ────────────────
  [table: 1 row]
 ━━━━━━━━━━━━━━━━
-> open jonathan.xml | to-json
+> open jonathan.xml | to json
 {"rss":[{"channel":[{"title":["Jonathan Turner"]},{"link":["http://www.jonathanturner.org"]},{"link":[]},{"item":[{"title":["Creating crossplatform Rust terminal apps"]},{"description":["<p><img src=\"/images/pikachu.jpg\" alt=\"Pikachu animation in Windows\" /></p>\n\n<p><em>Look Mom, Pikachu running in Windows CMD!</em></p>\n\n<p>Part of the adventure is not seeing the way ahead and going anyway.</p>\n"]},{"pubDate":["Mon, 05 Oct 2015 00:00:00 +0000"]},{"link":["http://www.jonathanturner.org/2015/10/off-to-new-adventures.html"]},{"guid":["http://www.jonathanturner.org/2015/10/off-to-new-adventures.html"]}]}]}]}
 ```

--- a/docs/commands/to-toml.md
+++ b/docs/commands/to-toml.md
@@ -1,4 +1,4 @@
-# to-toml
+# to toml
 
 Converts table data into toml text.
 
@@ -13,7 +13,7 @@ Converts table data into toml text.
  1 │   │ filesystem │ /home/shaurya/Pictures
  2 │   │ filesystem │ /home/shaurya/Desktop
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
-> shells | to-toml
+> shells | to toml
 [[]]
 " " = "X"
 name = "filesystem"
@@ -38,7 +38,7 @@ path = "/home/shaurya/Desktop"
 ────────────────┼──────────────────┼────────────────
  [table: 1 row] │ [table: 1 row]   │ [table: 1 row]
 ━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━
-> open cargo_sample.toml | to-toml
+> open cargo_sample.toml | to toml
 [dependencies]
 ansi_term = "0.11.0"
 app_dirs = "1.2.1"

--- a/docs/commands/to-tsv.md
+++ b/docs/commands/to-tsv.md
@@ -1,4 +1,4 @@
-# to-tsv
+# to tsv
 
 Converts table data into tsv text.
 
@@ -13,7 +13,7 @@ Converts table data into tsv text.
  1 │   │ filesystem │ /home/shaurya/Pictures
  2 │   │ filesystem │ /home/shaurya/Desktop
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
-> shells |to-tsv
+> shells | to tsv
  	name	path
 X	filesystem	/home/shaurya
 
@@ -65,7 +65,7 @@ X	filesystem	/home/shaurya
    │              │              │             │ OMYACARB 1T  │          │            │            │            │           │           │
    │              │              │             │ CG BPA 25 NO │          │            │            │            │           │           │
 ━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━━━
-> open caco3_plastics.tsv | to-tsv
+> open caco3_plastics.tsv | to tsv
 importer        shipper tariff_item     name    origin  shipped_at      arrived_at      net_weight      fob_price       cif_price       cif_per_net_weight
 PLASTICOS RIVAL CIA LTDA        S A REVERTE     2509000000      CARBONATO DE CALCIO TIPO CALCIPORE 160 T AL     SPAIN   18/03/2016      17/04/2016    81,000.00        14,417.58       18,252.34       0.23
 MEXICHEM ECUADOR S.A.   OMYA ANDINA S A 2836500000      CARBONATO       COLOMBIA        07/07/2016      10/07/2016      26,000.00       7,072.00      8,127.18 0.31

--- a/docs/commands/to-yaml.md
+++ b/docs/commands/to-yaml.md
@@ -1,4 +1,4 @@
-# to-yaml
+# to yaml
 
 Converts table data into yaml text.
 
@@ -13,7 +13,7 @@ Converts table data into yaml text.
  1 │   │ filesystem │ /home/shaurya/Pictures
  2 │   │ filesystem │ /home/shaurya/Desktop
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
-> shells | to-yaml
+> shells | to yaml
 ---
 - " ": X
   name: filesystem
@@ -33,7 +33,7 @@ Converts table data into yaml text.
 ────────────────────┼────────────────┼─────────────────┼───────┼─────────────────┼─────────────────
  Visual Studio 2017 │ [table: 1 row] │ [table: 5 rows] │       │ [table: 2 rows] │ [table: 2 rows]
 ━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━┷━━━━━━━┷━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━
-> open appveyor.yml | to-yaml
+> open appveyor.yml | to yaml
 ---
 image: Visual Studio 2017
 environment:

--- a/docs/commands/to.md
+++ b/docs/commands/to.md
@@ -1,6 +1,21 @@
-# to url
+# to
 
-Converts table data into url-formatted text.
+Converts table data into a string or binary. The target format is specified as a subcommand, like `to csv` or `to json`.
+
+## Available Subcommands
+
+* to bson
+* [to csv](to-csv.md)
+* to html
+* [to json](to-json.md)
+* to md
+* to sqlite
+* [to toml](to-toml.md)
+* [to tsv](to-tsv.md)
+* [to url](to-url.md)
+* [to yaml](to-yaml.md)
+
+*Subcommands without links are currently missing their documentation.*
 
 ## Example
 
@@ -13,14 +28,11 @@ Converts table data into url-formatted text.
  1 │   │ filesystem │ /home/shaurya/Pictures
  2 │   │ filesystem │ /home/shaurya/Desktop
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━
-> shells | to url
-━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- # │ value
-───┼───────────────────────────────────────────────────────
- 0 │ +=X&name=filesystem&path=%2Fhome%2Fshaurya
- 1 │ +=+&name=filesystem&path=%2Fhome%2Fshaurya%2FPictures
- 2 │ +=+&name=filesystem&path=%2Fhome%2Fshaurya%2FDesktop
-━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+> shells | to csv
+ ,name,path
+X,filesystem,/home/shaurya
+ ,filesystem,/home/shaurya/Pictures
+ ,filesystem,/home/shaurya/Desktop
 ```
 
 ```shell


### PR DESCRIPTION
This adds a top-level document for the new `to` command, with a list (of links) of all the subcommands.

All the to-* subcommands keep their filename, but the content is updated to use the new subcommand syntax.

Since not all subcommands have documentation, some items in the list are just text without a link. Also filled the list for the undocumented from* commands in the same style.

Fixes #1709