### PR TITLE
Make grouping more flexible.

### DIFF
--- a/crates/nu-cli/src/utils.rs
+++ b/crates/nu-cli/src/utils.rs
@@ -1,3 +1,4 @@
+pub mod data;
 pub mod data_processing;
 
 use crate::path::canonicalize;

--- a/crates/nu-cli/src/utils/data/group.rs
+++ b/crates/nu-cli/src/utils/data/group.rs
@@ -1,0 +1,62 @@
+use indexmap::IndexMap;
+use nu_errors::ShellError;
+use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
+use nu_source::{Tag, Tagged};
+use nu_value_ext::{as_string, get_data_by_key};
+
+#[allow(clippy::type_complexity)]
+pub fn group(
+    column_name: Tagged<String>,
+    values: &[Value],
+    grouper: Option<Box<dyn Fn(&Value) -> Result<String, ShellError> + Send>>,
+    tag: impl Into<Tag>,
+) -> Result<Value, ShellError> {
+    let tag = tag.into();
+
+    let mut groups: IndexMap<String, Vec<Value>> = IndexMap::new();
+
+    for value in values {
+        let group_key = get_data_by_key(&value, column_name.borrow_spanned());
+
+        if let Some(group_key) = group_key {
+            let group_key = if let Some(ref grouper) = grouper {
+                grouper(&group_key)
+            } else {
+                as_string(&group_key)
+            };
+            let group = groups.entry(group_key?).or_insert(vec![]);
+            group.push((*value).clone());
+        } else {
+            let possibilities = value.data_descriptors();
+
+            let mut possible_matches: Vec<_> = possibilities
+                .iter()
+                .map(|x| (natural::distance::levenshtein_distance(x, &column_name), x))
+                .collect();
+
+            possible_matches.sort();
+
+            if !possible_matches.is_empty() {
+                return Err(ShellError::labeled_error(
+                    "Unknown column",
+                    format!("did you mean '{}'?", possible_matches[0].1),
+                    column_name.tag(),
+                ));
+            } else {
+                return Err(ShellError::labeled_error(
+                    "Unknown column",
+                    "row does not contain this column",
+                    column_name.tag(),
+                ));
+            }
+        }
+    }
+
+    let mut out = TaggedDictBuilder::new(&tag);
+
+    for (k, v) in groups.iter() {
+        out.insert_untagged(k, UntaggedValue::table(v));
+    }
+
+    Ok(out.into_value())
+}

--- a/crates/nu-cli/src/utils/data/mod.rs
+++ b/crates/nu-cli/src/utils/data/mod.rs
@@ -1,0 +1,3 @@
+pub mod group;
+
+pub use crate::utils::data::group::group;

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -272,6 +272,13 @@ impl Value {
         }
     }
 
+    pub fn format(&self, fmt: &str) -> Result<String, ShellError> {
+        match &self.value {
+            UntaggedValue::Primitive(Primitive::Date(dt)) => Ok(dt.format(fmt).to_string()),
+            _ => Err(ShellError::type_error("date", self.spanned_type_name())),
+        }
+    }
+
     /// View into the borrowed string contents of a Value, if possible
     pub fn as_forgiving_string(&self) -> Result<&str, ShellError> {
         match &self.value {


### PR DESCRIPTION
Baseline work. To start, we introduce a `date` flag such that `group-by` can `group` rows where a column is a datetime value type.

Examples:

```
ls | group-by --date modified
──────────┬─────────────────
 Apr-2020 │ [table 63 rows]
 Mar-2020 │ [table 14 rows]
 May-2020 │ [table 43 rows]
──────────┴─────────────────
```

We can also tell Nu to group our dates in the format of our own choosing with the `--format` (shorthand `-f`) flag.

```
ls | group-by --date modified -f "%b-%Y"
──────────┬─────────────────
 Apr-2020 │ [table 63 rows]
 Mar-2020 │ [table 14 rows]
 May-2020 │ [table 43 rows]
──────────┴─────────────────
```

```
ls | group-by --date modified -f "%d-%b-%Y"
─────────────┬─────────────────
 27-Apr-2020 │ [table 19 rows]
 23-Apr-2020 │ [table 35 rows]
 16-Mar-2020 │ [table 14 rows]
 07-May-2020 │ [table 42 rows]
 26-Apr-2020 │ [table 1 rows]
 28-Apr-2020 │ [table 2 rows]
 17-Apr-2020 │ [table 2 rows]
 09-May-2020 │ [table 1 rows]
 30-Apr-2020 │ [table 4 rows]
─────────────┴─────────────────
```