### PR TITLE
Fix help text for alias command.

### DIFF
--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -23,11 +23,11 @@ impl WholeStreamCommand for Alias {
         Signature::build("alias")
             .required("name", SyntaxShape::String, "the name of the alias")
             .required("args", SyntaxShape::Table, "the arguments to the alias")
-            .required("block", SyntaxShape::Block, "the block to run on each row")
+            .required("block", SyntaxShape::Block, "the block to run as the body of the alias")
     }
 
     fn usage(&self) -> &str {
-        "Run a block on each row of the table."
+        "Define a shortcut for another command."
     }
 
     fn run(

--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -23,7 +23,11 @@ impl WholeStreamCommand for Alias {
         Signature::build("alias")
             .required("name", SyntaxShape::String, "the name of the alias")
             .required("args", SyntaxShape::Table, "the arguments to the alias")
-            .required("block", SyntaxShape::Block, "the block to run as the body of the alias")
+            .required(
+                "block",
+                SyntaxShape::Block,
+                "the block to run as the body of the alias",
+            )
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION
It looks like a copy-paste error from the `each` command.