### PR TITLE
Improve duration math and printing

### DIFF
--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -1,5 +1,6 @@
 use crate::commands::UnevaluatedCallInfo;
 use crate::commands::WholeStreamCommand;
+use crate::data::value::format_leaf;
 use crate::prelude::*;
 use nu_errors::ShellError;
 use nu_protocol::{hir, hir::Expression, hir::Literal, hir::SpannedExpression};
@@ -161,6 +162,19 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                 ..
                             } => {
                                 out!("{}", b);
+                            }
+                            Value {
+                                value: UntaggedValue::Primitive(Primitive::Duration(d)),
+                                ..
+                            } => {
+                                let output = format_leaf(&x).plain_string(100_000);
+                                out!("{}", output);
+                            }
+                            Value {
+                                value: UntaggedValue::Primitive(Primitive::Date(d)),
+                                ..
+                            } => {
+                                out!("{}", d);
                             }
 
                             Value { value: UntaggedValue::Primitive(Primitive::Binary(ref b)), .. } => {

--- a/crates/nu-cli/src/data/value.rs
+++ b/crates/nu-cli/src/data/value.rs
@@ -111,6 +111,15 @@ pub fn compute_values(
                 }?;
                 Ok(UntaggedValue::Primitive(Primitive::Date(result)))
             }
+            (Primitive::Duration(x), Primitive::Duration(y)) => {
+                let result = match operator {
+                    Operator::Plus => Ok(x + y),
+                    Operator::Minus => Ok(x - y),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+
+                Ok(UntaggedValue::Primitive(Primitive::Duration(result)))
+            }
             _ => Err((left.type_name(), right.type_name())),
         },
         _ => Err((left.type_name(), right.type_name())),

--- a/crates/nu-cli/tests/commands/math.rs
+++ b/crates/nu-cli/tests/commands/math.rs
@@ -97,6 +97,18 @@ fn parens_precedence() {
 }
 
 #[test]
+fn duration_math() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 1m + 1d
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
 fn compound_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-cli/tests/commands/math.rs
+++ b/crates/nu-cli/tests/commands/math.rs
@@ -101,11 +101,11 @@ fn duration_math() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            = 1m + 1d
+            = 1w + 1d
         "#
     ));
 
-    assert_eq!(actual.out, "true");
+    assert_eq!(actual.out, "8:00:00:00");
 }
 
 #[test]


### PR DESCRIPTION
This allows you to now add durations, like `= 1w + 1d`.  I've also cleaned up printing of duration values