### PR TITLE
Add a simplified list view

### DIFF
--- a/crates/nu-cli/src/commands/to_html.rs
+++ b/crates/nu-cli/src/commands/to_html.rs
@@ -39,7 +39,7 @@ fn to_html(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
         let headers = nu_protocol::merge_descriptors(&input);
         let mut output_string = "<html><body>".to_string();
 
-        if !headers.is_empty() && (headers.len() > 1 || headers[0] != "<value>") {
+        if !headers.is_empty() && (headers.len() > 1 || headers[0] != "") {
             output_string.push_str("<table>");
 
             output_string.push_str("<tr>");
@@ -109,7 +109,7 @@ fn to_html(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
             }
         }
 
-        if !headers.is_empty() && (headers.len() > 1 || headers[0] != "<value>") {
+        if !headers.is_empty() && (headers.len() > 1 || headers[0] != "") {
             output_string.push_str("</table>");
         }
         output_string.push_str("</body></html>");

--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -38,7 +38,7 @@ fn to_html(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
         let headers = nu_protocol::merge_descriptors(&input);
         let mut output_string = String::new();
 
-        if !headers.is_empty() && (headers.len() > 1 || headers[0] != "<value>") {
+        if !headers.is_empty() && (headers.len() > 1 || headers[0] != "") {
             output_string.push_str("|");
             for header in &headers {
                 output_string.push_str(&htmlescape::encode_minimal(&header));

--- a/crates/nu-cli/src/format/table.rs
+++ b/crates/nu-cli/src/format/table.rs
@@ -89,14 +89,14 @@ fn values_to_entries(values: &[Value], headers: &mut Vec<String>, starting_idx: 
     let mut entries = vec![];
 
     if headers.is_empty() {
-        headers.push("<value>".to_string());
+        headers.push("".to_string());
     }
 
     for (idx, value) in values.iter().enumerate() {
         let mut row: Vec<(String, &'static str)> = headers
             .iter()
             .map(|d: &String| {
-                if d == "<value>" {
+                if d == "" {
                     match value {
                         Value {
                             value: UntaggedValue::Row(..),
@@ -374,6 +374,8 @@ impl RenderView for TableView {
             }
         }
 
+        let skip_headers = self.headers.len() == 2 && self.headers[1] == "";
+
         let header: Vec<Cell> = self
             .headers
             .iter()
@@ -387,7 +389,9 @@ impl RenderView for TableView {
             })
             .collect();
 
-        table.set_titles(Row::new(header));
+        if !skip_headers {
+            table.set_titles(Row::new(header));
+        }
 
         for row in &self.entries {
             table.add_row(Row::new(

--- a/crates/nu-protocol/src/type_shape.rs
+++ b/crates/nu-protocol/src/type_shape.rs
@@ -239,7 +239,7 @@ impl PrettyDebug for Type {
                     row.map.iter().map(|(key, ty)| {
                         (b::key(match key {
                             Column::String(string) => string.clone(),
-                            Column::Value => "<value>".to_string(),
+                            Column::Value => "".to_string(),
                         }) + b::delimit("(", ty.pretty(), ")").into_kind())
                         .nest()
                     }),
@@ -303,7 +303,7 @@ impl<'a> PrettyDebug for DebugEntry<'a> {
     fn pretty(&self) -> DebugDocBuilder {
         b::key(match self.key {
             Column::String(string) => string.clone(),
-            Column::Value => "<value>".to_string(),
+            Column::Value => "".to_string(),
         }) + b::delimit("(", self.value.pretty(), ")").into_kind()
     }
 }

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -32,8 +32,10 @@ use std::time::SystemTime;
 pub enum UntaggedValue {
     /// A primitive (or fundamental) type of values
     Primitive(Primitive),
+
     /// A table row
     Row(Dictionary),
+
     /// A full inner (or embedded) table
     Table(Vec<Value>),
 
@@ -494,13 +496,13 @@ impl std::ops::Add for Value {
 
 pub fn merge_descriptors(values: &[Value]) -> Vec<String> {
     let mut ret: Vec<String> = vec![];
-    let value_column = "<value>".to_string();
+    let value_column = "".to_string();
     for value in values {
         let descs = value.data_descriptors();
 
         if descs.is_empty() {
             if !ret.contains(&value_column) {
-                ret.push("<value>".to_string());
+                ret.push("".to_string());
             }
         } else {
             for desc in value.data_descriptors() {


### PR DESCRIPTION
With this change, we simplify list printing so that it's less similar to tables, and no longer uses the confusing `<value>` column name.

Previously:

```
> ls | get size | first 5
───┬──────────
 # │ <value> 
───┼──────────
 0 │   3.4 KB 
 1 │    886 B 
 2 │ 100.4 KB 
 3 │   5.7 KB 
 4 │   1.1 KB 
───┴──────────
```

After PR:
```
> ls | get size | first 5
───┬──────────
 0 │   3.4 KB 
 1 │    886 B 
 2 │ 100.4 KB 
 3 │   5.7 KB 
 4 │   1.1 KB 
───┴──────────
```
