### PR TITLE
Add examples to commands

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -125,7 +125,9 @@ pub(crate) mod wrap;
 
 pub(crate) use autoview::Autoview;
 pub(crate) use cd::Cd;
-pub(crate) use command::{whole_stream_command, Command, UnevaluatedCallInfo, WholeStreamCommand};
+pub(crate) use command::{
+    whole_stream_command, Command, Example, UnevaluatedCallInfo, WholeStreamCommand,
+};
 
 pub(crate) use alias::Alias;
 pub(crate) use append::Append;

--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -1,4 +1,4 @@
-use crate::commands::WholeStreamCommand;
+use crate::commands::{Example, WholeStreamCommand};
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
@@ -40,6 +40,13 @@ impl WholeStreamCommand for Alias {
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
         args.process(registry, alias)?.run()
+    }
+
+    fn examples(&self) -> &[Example] {
+        &[Example {
+            description: "Some people prefer to write one letter instead of two",
+            example: "alias l [x] { ls $x }",
+        }]
     }
 }
 

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -407,7 +407,7 @@ impl Command {
 
     pub fn run(&self, args: CommandArgs, registry: &CommandRegistry) -> OutputStream {
         if args.call_info.switch_present("help") {
-            get_help(self.name(), self.usage(), self.signature(), registry).into()
+            get_help(&*self.0, registry).into()
         } else {
             match self.0.run(args, registry) {
                 Ok(stream) => stream,
@@ -418,6 +418,10 @@ impl Command {
 
     pub fn is_binary(&self) -> bool {
         self.0.is_binary()
+    }
+
+    pub fn stream_command(&self) -> &dyn WholeStreamCommand {
+        &*self.0
     }
 }
 

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -350,6 +350,11 @@ impl EvaluatedCommandArgs {
     }
 }
 
+pub struct Example {
+    pub example: &'static str,
+    pub description: &'static str,
+}
+
 pub trait WholeStreamCommand: Send + Sync {
     fn name(&self) -> &str;
 
@@ -369,8 +374,8 @@ pub trait WholeStreamCommand: Send + Sync {
         false
     }
 
-    fn example(&self) -> Option<&str> {
-        None
+    fn examples(&self) -> &[Example] {
+        &[]
     }
 }
 

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -368,6 +368,10 @@ pub trait WholeStreamCommand: Send + Sync {
     fn is_binary(&self) -> bool {
         false
     }
+
+    fn example(&self) -> Option<&str> {
+        None
+    }
 }
 
 #[derive(Clone)]

--- a/crates/nu-cli/src/commands/from.rs
+++ b/crates/nu-cli/src/commands/from.rs
@@ -23,9 +23,6 @@ impl WholeStreamCommand for From {
         _args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        Ok(
-            crate::commands::help::get_help(self.name(), self.usage(), self.signature(), registry)
-                .into(),
-        )
+        Ok(crate::commands::help::get_help(&*self, registry).into())
     }
 }

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -86,22 +86,10 @@ fn help(
             // Check for a subcommand
             let command_name = format!("{} {}", rest[0].item, rest[1].item);
             if let Some(command) = registry.get_command(&command_name) {
-                return Ok(get_help(
-                    &command.name(),
-                    &command.usage(),
-                    command.signature(),
-                    &registry,
-                )
-                .into());
+                return Ok(get_help(command.stream_command(), &registry).into());
             }
         } else if let Some(command) = registry.get_command(&document.item) {
-            return Ok(get_help(
-                &command.name(),
-                &command.usage(),
-                command.signature(),
-                &registry,
-            )
-            .into());
+            return Ok(get_help(command.stream_command(), &registry).into());
         } else {
             return Err(ShellError::labeled_error(
                 "Can't find command (use 'help commands' for full list)",
@@ -143,18 +131,17 @@ You can also learn more at https://www.nushell.sh/book/"#;
 }
 
 pub(crate) fn get_help(
-    cmd_name: &str,
-    cmd_usage: &str,
-    cmd_sig: Signature,
+    cmd: &dyn WholeStreamCommand,
     registry: &CommandRegistry,
 ) -> impl Into<OutputStream> {
+    let cmd_name = cmd.name();
+    let cmd_usage = cmd.usage();
+    let signature = cmd.signature();
     let mut help = VecDeque::new();
     let mut long_desc = String::new();
 
     long_desc.push_str(&cmd_usage);
     long_desc.push_str("\n");
-
-    let signature = cmd_sig;
 
     let mut subcommands = String::new();
     for name in registry.names() {

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -130,18 +130,17 @@ You can also learn more at https://www.nushell.sh/book/"#;
     }
 }
 
+#[allow(clippy::cognitive_complexity)]
 pub(crate) fn get_help(
     cmd: &dyn WholeStreamCommand,
     registry: &CommandRegistry,
 ) -> impl Into<OutputStream> {
     let cmd_name = cmd.name();
-    let cmd_usage = cmd.usage();
-    let cmd_example = cmd.example();
     let signature = cmd.signature();
     let mut help = VecDeque::new();
     let mut long_desc = String::new();
 
-    long_desc.push_str(&cmd_usage);
+    long_desc.push_str(&cmd.usage());
     long_desc.push_str("\n");
 
     let mut subcommands = String::new();
@@ -271,8 +270,14 @@ pub(crate) fn get_help(
         }
     }
 
-    if let Some(example) = cmd_example {
-        long_desc.push_str(&format!("\nExample:\n  > {}\n", example));
+    let examples = cmd.examples();
+    if !examples.is_empty() {
+        long_desc.push_str("\nExamples:\n");
+    }
+    for example in examples {
+        long_desc.push_str("  ");
+        long_desc.push_str(example.description);
+        long_desc.push_str(&format!("\n  > {}\n", example.example));
     }
 
     help.push_back(ReturnSuccess::value(

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -136,6 +136,7 @@ pub(crate) fn get_help(
 ) -> impl Into<OutputStream> {
     let cmd_name = cmd.name();
     let cmd_usage = cmd.usage();
+    let cmd_example = cmd.example();
     let signature = cmd.signature();
     let mut help = VecDeque::new();
     let mut long_desc = String::new();
@@ -268,6 +269,10 @@ pub(crate) fn get_help(
             };
             long_desc.push_str(&msg);
         }
+    }
+
+    if let Some(example) = cmd_example {
+        long_desc.push_str(&format!("\nExample:\n  > {}\n", example));
     }
 
     help.push_back(ReturnSuccess::value(

--- a/crates/nu-cli/src/commands/to.rs
+++ b/crates/nu-cli/src/commands/to.rs
@@ -23,9 +23,6 @@ impl WholeStreamCommand for To {
         _args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        Ok(
-            crate::commands::help::get_help(self.name(), self.usage(), self.signature(), registry)
-                .into(),
-        )
+        Ok(crate::commands::help::get_help(self, registry).into())
     }
 }


### PR DESCRIPTION
Hi,
I installed this terminal right now, and first of all it's pretty awesome! thanks for your work.
but, I tried porting some of my bash tricks here and had a very hard time figuring out how to use `alias` here, and figured out when I found this issue https://github.com/nushell/nushell/issues/1633
So I added the option to add examples to commands, it's optional so I/others can do it gradually.
I'll try to add examples to all the commands I'll find confusing.

I added a `pub fn stream_command(&self) -> &dyn WholeStreamCommand` to the `Command`, but another option would be to implement `WholeStreamCommand` directly on `Command` and delegate the calls to the inner Arc.

(the goal of using `WholeStreamCommand` in `get_help` was to decrease the number of arguments that function is getting)

A bunch of tests failed locally but they didn't seem related in any way