### PR TITLE
doc: fix prepend example definition

### DIFF
--- a/crates/nu-cli/src/commands/prepend.rs
+++ b/crates/nu-cli/src/commands/prepend.rs
@@ -38,8 +38,8 @@ impl WholeStreamCommand for Prepend {
 
     fn examples(&self) -> &[Example] {
         &[Example {
-            description: "Add something to the end of a list or table",
-            example: "echo [2 3 4] | prepend 4",
+            description: "Add something to the beginning of a list or table",
+            example: "echo [2 3 4] | prepend 1",
         }]
     }
 }


### PR DESCRIPTION
Hello

I just stumbled upon this while skimming through the latest commits.

It seems that the description was copy-pasted by mistake from the `append` command.