### PR TITLE
Fix typo in config flag description

### DIFF
--- a/crates/nu-cli/src/commands/config.rs
+++ b/crates/nu-cli/src/commands/config.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for Config {
             .named(
                 "load",
                 SyntaxShape::Path,
-                "load the config from the path give",
+                "load the config from the path given",
                 Some('l'),
             )
             .named(


### PR DESCRIPTION
Ironically, the commit fixes a typo, but has a typo in its description.