### PR TITLE
doc: add headers command page

### DIFF
--- a/docs/commands/headers.md
+++ b/docs/commands/headers.md
@@ -1,0 +1,23 @@
+# headers
+
+Use `headers` to turn the first row of a table into meaningful column names.
+
+As demonstrated in the following example, it's particularly handy when working with spreadsheets.
+
+## Examples
+
+```shell
+❯ open sample_data.ods | get SalesOrders
+────┬────────────┬─────────┬──────────┬─────────┬─────────┬───────────┬───────────
+ #  │  Column0   │ Column1 │ Column2  │ Column3 │ Column4 │  Column5  │  Column6
+────┼────────────┼─────────┼──────────┼─────────┼─────────┼───────────┼───────────
+  0 │ OrderDate  │ Region  │ Rep      │ Item    │ Units   │ Unit Cost │ Total
+  1 │ 2018-01-06 │ East    │ Jones    │ Pencil  │ 95.0000 │    1.9900 │  189.0500
+
+❯ open sample_data.ods | get SalesOrders | headers
+────┬────────────┬─────────┬──────────┬─────────┬─────────┬───────────┬───────────
+ #  │ OrderDate  │ Region  │   Rep    │  Item   │  Units  │ Unit Cost │   Total
+────┼────────────┼─────────┼──────────┼─────────┼─────────┼───────────┼───────────
+  0 │ 2018-01-06 │ East    │ Jones    │ Pencil  │ 95.0000 │    1.9900 │  189.0500
+  1 │ 2018-01-23 │ Central │ Kivell   │ Binder  │ 50.0000 │   19.9900 │  999.4999
+```


### PR DESCRIPTION
Hi

This PR adds a short documentation page for the `headers` command introduced in https://github.com/nushell/nushell/pull/1530

The example is taken from the blog https://www.nushell.sh/blog/2020/03/31/nushell_0_12_0.html#headers-samhedin