### PR TITLE
Add (near) automatic testing for command examples

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -376,9 +376,7 @@ pub fn create_default_context(
 
         #[cfg(feature = "clipboard")]
         {
-            context.add_commands(vec![whole_stream_command(
-                crate::commands::clip::clipboard::Clip,
-            )]);
+            context.add_commands(vec![whole_stream_command(crate::commands::clip::Clip)]);
         }
     }
 

--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -12,6 +12,7 @@ pub(crate) mod cal;
 pub(crate) mod calc;
 pub(crate) mod cd;
 pub(crate) mod classified;
+#[cfg(feature = "clipboard")]
 pub(crate) mod clip;
 pub(crate) mod command;
 pub(crate) mod compact;

--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -43,15 +43,17 @@ impl WholeStreamCommand for Alias {
         alias(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "An alias without parameters",
                 example: "alias say-hi [] { echo 'Hello!' }",
+                result: None,
             },
             Example {
                 description: "An alias with a single parameter",
                 example: "alias l [x] { ls $x }",
+                result: None,
             },
         ]
     }
@@ -73,4 +75,16 @@ pub fn alias(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Alias;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Alias {})
+    }
 }

--- a/crates/nu-cli/src/commands/append.rs
+++ b/crates/nu-cli/src/commands/append.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, Value};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 
 #[derive(Deserialize)]
 struct AppendArgs {
@@ -36,10 +36,16 @@ impl WholeStreamCommand for Append {
         append(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Add something to the end of a list or table",
             example: "echo [1 2 3] | append 4",
+            result: Some(vec![
+                UntaggedValue::int(1).into(),
+                UntaggedValue::int(2).into(),
+                UntaggedValue::int(3).into(),
+                UntaggedValue::int(4).into(),
+            ]),
         }]
     }
 }
@@ -57,4 +63,16 @@ fn append(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Append;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Append {})
+    }
 }

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -38,15 +38,17 @@ impl WholeStreamCommand for Autoview {
         })
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Automatically view the results",
                 example: "ls | autoview",
+                result: None,
             },
             Example {
                 description: "Autoview is also implied. The above can be written as",
                 example: "ls",
+                result: None,
             },
         ]
     }
@@ -330,5 +332,17 @@ fn create_default_command_args(context: &RunnableContextWithoutInput) -> RawComm
             name_tag: context.name.clone(),
             scope: Scope::empty(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Autoview;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Autoview {})
     }
 }

--- a/crates/nu-cli/src/commands/cal.rs
+++ b/crates/nu-cli/src/commands/cal.rs
@@ -44,15 +44,17 @@ impl WholeStreamCommand for Cal {
         cal(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "This month's calendar",
                 example: "cal",
+                result: None,
             },
             Example {
                 description: "The calendar for all of 2012",
                 example: "cal --full-year 2012",
+                result: None,
             },
         ]
     }
@@ -339,4 +341,16 @@ fn add_month_to_table(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cal;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Cal {})
+    }
 }

--- a/crates/nu-cli/src/commands/calc.rs
+++ b/crates/nu-cli/src/commands/calc.rs
@@ -22,10 +22,11 @@ impl WholeStreamCommand for Calc {
         calc(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Calculate math in the pipeline",
             example: "echo '10 / 4' | calc",
+            result: Some(vec![UntaggedValue::decimal(2.5).into()]),
         }]
     }
 }
@@ -68,5 +69,17 @@ pub fn parse(math_expression: &str, tag: impl Into<Tag>) -> Result<Value, String
             Ok(UntaggedValue::from(Primitive::from(num)).into_value(tag))
         }
         Err(error) => Err(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Calc;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Calc {})
     }
 }

--- a/crates/nu-cli/src/commands/cd.rs
+++ b/crates/nu-cli/src/commands/cd.rs
@@ -39,23 +39,27 @@ impl WholeStreamCommand for Cd {
         cd(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Change to a new directory called 'dirname'",
                 example: "cd dirname",
+                result: None,
             },
             Example {
                 description: "Change to your home directory",
                 example: "cd",
+                result: None,
             },
             Example {
                 description: "Change to your home directory (alternate version)",
                 example: "cd ~",
+                result: None,
             },
             Example {
                 description: "Change to the previous directory",
                 example: "cd -",
+                result: None,
             },
         ]
     }
@@ -75,4 +79,16 @@ fn cd(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, She
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cd;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Cd {})
+    }
 }

--- a/crates/nu-cli/src/commands/clear.rs
+++ b/crates/nu-cli/src/commands/clear.rs
@@ -10,12 +10,15 @@ impl WholeStreamCommand for Clear {
     fn name(&self) -> &str {
         "clear"
     }
+
     fn signature(&self) -> Signature {
         Signature::build("clear")
     }
+
     fn usage(&self) -> &str {
         "clears the terminal"
     }
+
     fn run(
         &self,
         args: CommandArgs,
@@ -23,13 +26,16 @@ impl WholeStreamCommand for Clear {
     ) -> Result<OutputStream, ShellError> {
         clear(args, registry)
     }
-    fn examples(&self) -> &[Example] {
-        &[Example {
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Clear the screen",
             example: "clear",
+            result: None,
         }]
     }
 }
+
 fn clear(_args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     if cfg!(windows) {
         Command::new("cmd")
@@ -43,4 +49,16 @@ fn clear(_args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream
             .expect("failed to execute process");
     }
     Ok(OutputStream::empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Clear;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Clear {})
+    }
 }

--- a/crates/nu-cli/src/commands/clip.rs
+++ b/crates/nu-cli/src/commands/clip.rs
@@ -1,112 +1,119 @@
-#[cfg(feature = "clipboard")]
-pub mod clipboard {
-    use crate::commands::WholeStreamCommand;
-    use crate::context::CommandRegistry;
-    use crate::prelude::*;
-    use futures::stream::StreamExt;
-    use nu_errors::ShellError;
-    use nu_protocol::{ReturnValue, Signature, Value};
+use crate::commands::WholeStreamCommand;
+use crate::context::CommandRegistry;
+use crate::prelude::*;
+use futures::stream::StreamExt;
+use nu_errors::ShellError;
+use nu_protocol::{ReturnValue, Signature, Value};
 
-    use clipboard::{ClipboardContext, ClipboardProvider};
+use clipboard::{ClipboardContext, ClipboardProvider};
 
-    pub struct Clip;
+pub struct Clip;
 
-    impl WholeStreamCommand for Clip {
-        fn name(&self) -> &str {
-            "clip"
-        }
-
-        fn signature(&self) -> Signature {
-            Signature::build("clip")
-        }
-
-        fn usage(&self) -> &str {
-            "Copy the contents of the pipeline to the copy/paste buffer"
-        }
-
-        fn run(
-            &self,
-            args: CommandArgs,
-            registry: &CommandRegistry,
-        ) -> Result<OutputStream, ShellError> {
-            clip(args, registry)
-        }
-
-        fn examples(&self) -> &[Example] {
-            &[Example {
-                description: "Save text to the clipboard",
-                example: "echo 'secret value' | clip",
-            }]
-        }
+impl WholeStreamCommand for Clip {
+    fn name(&self) -> &str {
+        "clip"
     }
 
-    pub fn clip(
+    fn signature(&self) -> Signature {
+        Signature::build("clip")
+    }
+
+    fn usage(&self) -> &str {
+        "Copy the contents of the pipeline to the copy/paste buffer"
+    }
+
+    fn run(
+        &self,
         args: CommandArgs,
-        _registry: &CommandRegistry,
+        registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        let stream = async_stream! {
-            let mut input = args.input;
-            let name = args.call_info.name_tag.clone();
-            let values: Vec<Value> = input.collect().await;
-
-            let mut clip_stream = inner_clip(values, name).await;
-            while let Some(value) = clip_stream.next().await {
-                yield value;
-            }
-        };
-
-        let stream: BoxStream<'static, ReturnValue> = stream.boxed();
-
-        Ok(OutputStream::from(stream))
+        clip(args, registry)
     }
 
-    async fn inner_clip(input: Vec<Value>, name: Tag) -> OutputStream {
-        if let Ok(clip_context) = ClipboardProvider::new() {
-            let mut clip_context: ClipboardContext = clip_context;
-            let mut new_copy_data = String::new();
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Save text to the clipboard",
+            example: "echo 'secret value' | clip",
+            result: None,
+        }]
+    }
+}
 
-            if !input.is_empty() {
-                let mut first = true;
-                for i in input.iter() {
-                    if !first {
-                        new_copy_data.push_str("\n");
-                    } else {
-                        first = false;
-                    }
+pub fn clip(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+    let stream = async_stream! {
+        let mut input = args.input;
+        let name = args.call_info.name_tag.clone();
+        let values: Vec<Value> = input.collect().await;
 
-                    let string: String = match i.as_string() {
-                        Ok(string) => string.to_string(),
-                        Err(_) => {
-                            return OutputStream::one(Err(ShellError::labeled_error(
-                                "Given non-string data",
-                                "expected strings from pipeline",
-                                name,
-                            )))
-                        }
-                    };
-
-                    new_copy_data.push_str(&string);
-                }
-            }
-
-            match clip_context.set_contents(new_copy_data) {
-                Ok(_) => {}
-                Err(_) => {
-                    return OutputStream::one(Err(ShellError::labeled_error(
-                        "Could not set contents of clipboard",
-                        "could not set contents of clipboard",
-                        name,
-                    )));
-                }
-            }
-
-            OutputStream::empty()
-        } else {
-            OutputStream::one(Err(ShellError::labeled_error(
-                "Could not open clipboard",
-                "could not open clipboard",
-                name,
-            )))
+        let mut clip_stream = inner_clip(values, name).await;
+        while let Some(value) = clip_stream.next().await {
+            yield value;
         }
+    };
+
+    let stream: BoxStream<'static, ReturnValue> = stream.boxed();
+
+    Ok(OutputStream::from(stream))
+}
+
+async fn inner_clip(input: Vec<Value>, name: Tag) -> OutputStream {
+    if let Ok(clip_context) = ClipboardProvider::new() {
+        let mut clip_context: ClipboardContext = clip_context;
+        let mut new_copy_data = String::new();
+
+        if !input.is_empty() {
+            let mut first = true;
+            for i in input.iter() {
+                if !first {
+                    new_copy_data.push_str("\n");
+                } else {
+                    first = false;
+                }
+
+                let string: String = match i.as_string() {
+                    Ok(string) => string.to_string(),
+                    Err(_) => {
+                        return OutputStream::one(Err(ShellError::labeled_error(
+                            "Given non-string data",
+                            "expected strings from pipeline",
+                            name,
+                        )))
+                    }
+                };
+
+                new_copy_data.push_str(&string);
+            }
+        }
+
+        match clip_context.set_contents(new_copy_data) {
+            Ok(_) => {}
+            Err(_) => {
+                return OutputStream::one(Err(ShellError::labeled_error(
+                    "Could not set contents of clipboard",
+                    "could not set contents of clipboard",
+                    name,
+                )));
+            }
+        }
+
+        OutputStream::empty()
+    } else {
+        OutputStream::one(Err(ShellError::labeled_error(
+            "Could not open clipboard",
+            "could not open clipboard",
+            name,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Clip;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Clip {})
     }
 }

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -272,6 +272,7 @@ impl EvaluatedCommandArgs {
 pub struct Example {
     pub example: &'static str,
     pub description: &'static str,
+    pub result: Option<Vec<Value>>,
 }
 
 pub trait WholeStreamCommand: Send + Sync {
@@ -293,8 +294,8 @@ pub trait WholeStreamCommand: Send + Sync {
         false
     }
 
-    fn examples(&self) -> &[Example] {
-        &[]
+    fn examples(&self) -> Vec<Example> {
+        Vec::new()
     }
 }
 

--- a/crates/nu-cli/src/commands/compact.rs
+++ b/crates/nu-cli/src/commands/compact.rs
@@ -34,11 +34,23 @@ impl WholeStreamCommand for Compact {
         compact(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
-            description: "Remove all directory entries, except those with a 'target'",
-            example: "ls -af | compact target",
-        }]
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Filter out all null entries in a list",
+                example: "echo [1 2 $null 3 $null $null] | compact target",
+                result: Some(vec![
+                    UntaggedValue::int(1).into(),
+                    UntaggedValue::int(2).into(),
+                    UntaggedValue::int(3).into(),
+                ]),
+            },
+            Example {
+                description: "Filter out all directory entries having no 'target'",
+                example: "ls -af | compact target",
+                result: None,
+            },
+        ]
     }
 }
 
@@ -67,4 +79,16 @@ pub fn compact(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
         }
     };
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Compact;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Compact {})
+    }
 }

--- a/crates/nu-cli/src/commands/config.rs
+++ b/crates/nu-cli/src/commands/config.rs
@@ -73,35 +73,42 @@ impl WholeStreamCommand for Config {
         config(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "See all config values",
                 example: "config",
+                result: None,
             },
             Example {
                 description: "Set completion_mode to circular",
                 example: "config --set [completion_mode circular]",
+                result: None,
             },
             Example {
                 description: "Store the contents of the pipeline as a path",
                 example: "echo ['/usr/bin' '/bin'] | config --set_into path",
+                result: None,
             },
             Example {
                 description: "Get the current startup commands",
                 example: "config --get startup",
+                result: None,
             },
             Example {
                 description: "Remove the startup commands",
                 example: "config --remove startup",
+                result: None,
             },
             Example {
                 description: "Clear the config (be careful!)",
                 example: "config --clear",
+                result: None,
             },
             Example {
                 description: "Get the path to the current config file",
                 example: "config --path",
+                result: None,
             },
         ]
     }
@@ -219,4 +226,16 @@ pub fn config(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Config {})
+    }
 }

--- a/crates/nu-cli/src/commands/count.rs
+++ b/crates/nu-cli/src/commands/count.rs
@@ -28,10 +28,11 @@ impl WholeStreamCommand for Count {
         count(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
-            description: "Count the number of files/directories in the current directory",
-            example: "ls | count",
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Count the number of entries in a list",
+            example: "echo [1 2 3 4 5] | count",
+            result: Some(vec![UntaggedValue::int(5).into()]),
         }]
     }
 }
@@ -45,4 +46,16 @@ pub fn count(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStr
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Count;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Count {})
+    }
 }

--- a/crates/nu-cli/src/commands/cp.rs
+++ b/crates/nu-cli/src/commands/cp.rs
@@ -43,15 +43,17 @@ impl WholeStreamCommand for Cpy {
         cp(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Copy myfile to dir_b",
                 example: "cp myfile dir_b",
+                result: None,
             },
             Example {
                 description: "Recursively copy dir_a to dir_b",
                 example: "cp -r dir_a dir_b",
+                result: None,
             },
         ]
     }
@@ -71,4 +73,16 @@ pub fn cp(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cpy;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Cpy {})
+    }
 }

--- a/crates/nu-cli/src/commands/date.rs
+++ b/crates/nu-cli/src/commands/date.rs
@@ -34,15 +34,17 @@ impl WholeStreamCommand for Date {
         date(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Get the current local time and date",
                 example: "date",
+                result: None,
             },
             Example {
                 description: "Get the current UTC time and date",
                 example: "date --utc",
+                result: None,
             },
         ]
     }
@@ -107,4 +109,16 @@ pub fn date(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Date;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Date {})
+    }
 }

--- a/crates/nu-cli/src/commands/debug.rs
+++ b/crates/nu-cli/src/commands/debug.rs
@@ -49,3 +49,15 @@ fn debug_value(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Debug;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Debug {})
+    }
+}

--- a/crates/nu-cli/src/commands/default.rs
+++ b/crates/nu-cli/src/commands/default.rs
@@ -41,10 +41,11 @@ impl WholeStreamCommand for Default {
         default(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Give a default 'target' to all file entries",
             example: "ls -af | default target 'nothing'",
+            result: None,
         }]
     }
 }
@@ -75,4 +76,16 @@ fn default(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Default;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Default {})
+    }
 }

--- a/crates/nu-cli/src/commands/drop.rs
+++ b/crates/nu-cli/src/commands/drop.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, Value};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 
 pub struct Drop;
@@ -37,15 +37,20 @@ impl WholeStreamCommand for Drop {
         drop(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Remove the last item of a list/table",
                 example: "echo [1 2 3] | drop",
+                result: Some(vec![
+                    UntaggedValue::int(1).into(),
+                    UntaggedValue::int(2).into(),
+                ]),
             },
             Example {
                 description: "Remove the last 2 items of a list/table",
                 example: "echo [1 2 3] | drop 2",
+                result: Some(vec![UntaggedValue::int(1).into()]),
             },
         ]
     }
@@ -72,4 +77,16 @@ fn drop(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, S
         }
     };
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Drop;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Drop {})
+    }
 }

--- a/crates/nu-cli/src/commands/du.rs
+++ b/crates/nu-cli/src/commands/du.rs
@@ -79,10 +79,11 @@ impl WholeStreamCommand for Du {
         du(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Disk usage of the current directory",
-            example: "du *",
+            example: "du",
+            result: None,
         }]
     }
 }
@@ -402,5 +403,17 @@ impl From<FileInfo> for Value {
         r.insert("files".to_string(), UntaggedValue::nothing().retag(&f.tag));
 
         UntaggedValue::row(r).retag(&f.tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Du;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Du {})
     }
 }

--- a/crates/nu-cli/src/commands/each.rs
+++ b/crates/nu-cli/src/commands/each.rs
@@ -7,7 +7,7 @@ use futures::stream::once;
 use nu_errors::ShellError;
 use nu_protocol::{
     hir::Block, hir::Expression, hir::SpannedExpression, hir::Synthetic, ReturnSuccess, Signature,
-    SyntaxShape,
+    SyntaxShape, UntaggedValue,
 };
 
 pub struct Each;
@@ -42,11 +42,26 @@ impl WholeStreamCommand for Each {
         each(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
-            description: "Print the name of each file",
-            example: "ls | each { echo $it.name }",
-        }]
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Echo the square of each integer",
+                example: "echo [1 2 3] | each { echo $(= $it * $it) }",
+                result: Some(vec![
+                    UntaggedValue::int(1).into(),
+                    UntaggedValue::int(4).into(),
+                    UntaggedValue::int(9).into(),
+                ]),
+            },
+            Example {
+                description: "Echo the sum of each row",
+                example: "echo [[1 2] [3 4]] | each { echo $it | sum }",
+                result: Some(vec![
+                    UntaggedValue::int(3).into(),
+                    UntaggedValue::int(7).into(),
+                ]),
+            },
+        ]
     }
 }
 
@@ -103,4 +118,16 @@ fn each(raw_args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Each;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Each {})
+    }
 }

--- a/crates/nu-cli/src/commands/echo.rs
+++ b/crates/nu-cli/src/commands/echo.rs
@@ -31,15 +31,17 @@ impl WholeStreamCommand for Echo {
         echo(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Put a hello message in the pipeline",
                 example: "echo 'hello'",
+                result: Some(vec![Value::from("hello")]),
             },
             Example {
                 description: "Print the value of the special '$nu' variable",
                 example: "echo $nu",
+                result: None,
             },
         ]
     }
@@ -75,4 +77,16 @@ fn echo(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, S
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Echo;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Echo {})
+    }
 }

--- a/crates/nu-cli/src/commands/enter.rs
+++ b/crates/nu-cli/src/commands/enter.rs
@@ -41,15 +41,17 @@ impl WholeStreamCommand for Enter {
         enter(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Enter a path as a new shell",
                 example: "enter ../projectB",
+                result: None,
             },
             Example {
                 description: "Enter a file as a new shell",
                 example: "enter package.json",
+                result: None,
             },
         ]
     }
@@ -164,4 +166,16 @@ fn enter(raw_args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Enter;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Enter {})
+    }
 }

--- a/crates/nu-cli/src/commands/evaluate_by.rs
+++ b/crates/nu-cli/src/commands/evaluate_by.rs
@@ -73,3 +73,15 @@ pub fn evaluate_by(
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EvaluateBy;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(EvaluateBy {})
+    }
+}

--- a/crates/nu-cli/src/commands/exit.rs
+++ b/crates/nu-cli/src/commands/exit.rs
@@ -27,15 +27,17 @@ impl WholeStreamCommand for Exit {
         exit(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Exit the current shell",
                 example: "exit",
+                result: None,
             },
             Example {
                 description: "Exit all shells (exiting Nu)",
                 example: "exit --now",
+                result: None,
             },
         ]
     }
@@ -54,4 +56,16 @@ pub fn exit(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Exit;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Exit {})
+    }
 }

--- a/crates/nu-cli/src/commands/first.rs
+++ b/crates/nu-cli/src/commands/first.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
 
 pub struct First;
@@ -37,15 +37,20 @@ impl WholeStreamCommand for First {
         first(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Return the first item of a list/table",
                 example: "echo [1 2 3] | first",
+                result: Some(vec![UntaggedValue::int(1).into()]),
             },
             Example {
                 description: "Return the first 2 items of a list/table",
                 example: "echo [1 2 3] | first 2",
+                result: Some(vec![
+                    UntaggedValue::int(1).into(),
+                    UntaggedValue::int(2).into(),
+                ]),
             },
         ]
     }
@@ -72,4 +77,16 @@ fn first(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::First;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(First {})
+    }
 }

--- a/crates/nu-cli/src/commands/format.rs
+++ b/crates/nu-cli/src/commands/format.rs
@@ -39,10 +39,11 @@ impl WholeStreamCommand for Format {
         format_command(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Print filenames with their sizes",
             example: "ls | format '{name}: {size}'",
+            result: None,
         }]
     }
 }
@@ -171,4 +172,16 @@ fn to_column_path(
         )
         .into_value(&tag),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Format;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Format {})
+    }
 }

--- a/crates/nu-cli/src/commands/from.rs
+++ b/crates/nu-cli/src/commands/from.rs
@@ -34,3 +34,15 @@ impl WholeStreamCommand for From {
         Ok(stream.to_output_stream())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::From;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(From {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_bson.rs
+++ b/crates/nu-cli/src/commands/from_bson.rs
@@ -29,10 +29,11 @@ impl WholeStreamCommand for FromBSON {
         from_bson(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Convert bson data to a table",
             example: "open file.bin | from bson",
+            result: None,
         }]
     }
 }
@@ -230,4 +231,16 @@ fn from_bson(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FromBSON;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromBSON {})
+    }
 }

--- a/crates/nu-cli/src/commands/from_csv.rs
+++ b/crates/nu-cli/src/commands/from_csv.rs
@@ -44,19 +44,22 @@ impl WholeStreamCommand for FromCSV {
         from_csv(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Convert comma-separated data to a table",
                 example: "open data.txt | from csv",
+                result: None,
             },
             Example {
                 description: "Convert comma-separated data to a table, ignoring headers",
                 example: "open data.txt | from csv --headerless",
+                result: None,
             },
             Example {
                 description: "Convert semicolon-separated data to a table",
                 example: "open data.txt | from csv --separator ';'",
+                result: None,
             },
         ]
     }
@@ -99,4 +102,16 @@ fn from_csv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FromCSV;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromCSV {})
+    }
 }

--- a/crates/nu-cli/src/commands/from_eml.rs
+++ b/crates/nu-cli/src/commands/from_eml.rs
@@ -117,3 +117,15 @@ fn from_eml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromEML;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromEML {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_ics.rs
+++ b/crates/nu-cli/src/commands/from_ics.rs
@@ -239,3 +239,15 @@ fn params_to_value(params: Vec<(String, Vec<String>)>, tag: Tag) -> Value {
 
     row.into_value()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromIcs;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromIcs {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_ini.rs
+++ b/crates/nu-cli/src/commands/from_ini.rs
@@ -94,3 +94,15 @@ fn from_ini(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromINI;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromINI {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_json.rs
+++ b/crates/nu-cli/src/commands/from_json.rs
@@ -130,3 +130,15 @@ fn from_json(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromJSON;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromJSON {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_ods.rs
+++ b/crates/nu-cli/src/commands/from_ods.rs
@@ -92,3 +92,15 @@ fn from_ods(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromODS;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromODS {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_sqlite.rs
+++ b/crates/nu-cli/src/commands/from_sqlite.rs
@@ -164,3 +164,15 @@ fn from_sqlite(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromSQLite;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromSQLite {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_ssv.rs
+++ b/crates/nu-cli/src/commands/from_ssv.rs
@@ -485,4 +485,12 @@ mod tests {
         assert_eq!(aligned_columns_headerless, separator_headerless);
         assert_eq!(aligned_columns_with_headers, separator_with_headers);
     }
+
+    #[test]
+    fn examples_work_as_expected() {
+        use super::FromSSV;
+        use crate::examples::test as test_examples;
+
+        test_examples(FromSSV {})
+    }
 }

--- a/crates/nu-cli/src/commands/from_toml.rs
+++ b/crates/nu-cli/src/commands/from_toml.rs
@@ -97,3 +97,15 @@ pub fn from_toml(
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromTOML;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromTOML {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_tsv.rs
+++ b/crates/nu-cli/src/commands/from_tsv.rs
@@ -51,3 +51,15 @@ fn from_tsv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromTSV;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromTSV {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_url.rs
+++ b/crates/nu-cli/src/commands/from_url.rs
@@ -62,3 +62,15 @@ fn from_url(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromURL;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromURL {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_vcf.rs
+++ b/crates/nu-cli/src/commands/from_vcf.rs
@@ -101,3 +101,15 @@ fn params_to_value(params: Vec<(String, Vec<String>)>, tag: Tag) -> Value {
 
     row.into_value()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromVcf;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromVcf {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_xlsx.rs
+++ b/crates/nu-cli/src/commands/from_xlsx.rs
@@ -92,3 +92,15 @@ fn from_xlsx(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromXLSX;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromXLSX {})
+    }
+}

--- a/crates/nu-cli/src/commands/from_xml.rs
+++ b/crates/nu-cli/src/commands/from_xml.rs
@@ -301,4 +301,12 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn examples_work_as_expected() {
+        use super::FromXML;
+        use crate::examples::test as test_examples;
+
+        test_examples(FromXML {})
+    }
 }

--- a/crates/nu-cli/src/commands/from_yaml.rs
+++ b/crates/nu-cli/src/commands/from_yaml.rs
@@ -150,3 +150,15 @@ fn from_yaml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FromYAML;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(FromYAML {})
+    }
+}

--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -41,15 +41,17 @@ impl WholeStreamCommand for Get {
         get(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Extract the name of files as a list",
                 example: "ls | get name",
+                result: None,
             },
             Example {
                 description: "Extract the cpu list from the sys information",
                 example: "sys | get cpu",
+                result: None,
             },
         ]
     }
@@ -239,4 +241,16 @@ pub fn get(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
         }
     };
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Get;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Get {})
+    }
 }

--- a/crates/nu-cli/src/commands/group_by.rs
+++ b/crates/nu-cli/src/commands/group_by.rs
@@ -1,7 +1,8 @@
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
+use indexmap::indexmap;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, Value};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 
 pub struct GroupBy;
@@ -36,11 +37,36 @@ impl WholeStreamCommand for GroupBy {
         group_by(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
-            description: "Group files by type",
-            example: "ls | group-by type",
-        }]
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Group items by type",
+                example: r#"ls | group-by type"#,
+                result: None,
+            },
+            Example {
+                description: "Group items by their value",
+                example: "echo [1 3 1 3 2 1 1] | group-by",
+                result: Some(vec![UntaggedValue::row(indexmap! {
+                    "1".to_string() => UntaggedValue::Table(vec![
+                        UntaggedValue::int(1).into(),
+                        UntaggedValue::int(1).into(),
+                        UntaggedValue::int(1).into(),
+                        UntaggedValue::int(1).into(),
+                    ]).into(),
+
+                    "3".to_string() => UntaggedValue::Table(vec![
+                        UntaggedValue::int(3).into(),
+                        UntaggedValue::int(3).into(),
+                    ]).into(),
+
+                    "2".to_string() => UntaggedValue::Table(vec![
+                        UntaggedValue::int(2).into(),
+                    ]).into(),
+                })
+                .into()]),
+            },
+        ]
     }
 }
 
@@ -184,5 +210,13 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn examples_work_as_expected() {
+        use super::GroupBy;
+        use crate::examples::test as test_examples;
+
+        test_examples(GroupBy {})
     }
 }

--- a/crates/nu-cli/src/commands/group_by_date.rs
+++ b/crates/nu-cli/src/commands/group_by_date.rs
@@ -44,10 +44,11 @@ impl WholeStreamCommand for GroupByDate {
         group_by_date(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Group files by type",
-            example: "ls | group-by date --fmt '%d/%m/%Y'",
+            example: "ls | group-by date --format '%d/%m/%Y'",
+            result: None,
         }]
     }
 }
@@ -100,4 +101,16 @@ pub fn group_by_date(
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GroupByDate;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(GroupByDate {})
+    }
 }

--- a/crates/nu-cli/src/commands/headers.rs
+++ b/crates/nu-cli/src/commands/headers.rs
@@ -30,10 +30,11 @@ impl WholeStreamCommand for Headers {
         headers(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Create headers for a raw string",
-            example: "echo \"a b c|1 2 3\" | split-row \"|\" | split-column \" \" | headers",
+            example: r#"echo "a b c|1 2 3" | split-row "|" | split-column " " | headers"#,
+            result: None,
         }]
     }
 }
@@ -83,4 +84,16 @@ pub fn headers(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputS
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Headers;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Headers {})
+    }
 }

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -281,3 +281,15 @@ pub fn get_help(cmd: &dyn WholeStreamCommand, registry: &CommandRegistry) -> Str
 
     long_desc
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Help;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Help {})
+    }
+}

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -47,20 +47,23 @@ impl WholeStreamCommand for Histogram {
         histogram(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Get a histogram for the types of files",
                 example: "ls | histogram type",
+                result: None,
             },
             Example {
                 description:
                     "Get a histogram for the types of files, with frequency column named count",
                 example: "ls | histogram type count",
+                result: None,
             },
             Example {
                 description: "Get a histogram for a list of numbers",
-                example: "echo [1 2 3 1 2 3 1 1 1 1 3 2 1 1 3] | wrap | histogram Column",
+                example: "echo [1 2 3 1 1 1 2 2 1 1] | histogram",
+                result: None,
             },
         ]
     }
@@ -178,4 +181,16 @@ fn percentages(values: &Value, max: Value, tag: impl Into<Tag>) -> Result<Value,
     };
 
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Histogram;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Histogram {})
+    }
 }

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -48,3 +48,15 @@ fn history(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStrea
     };
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::History;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(History {})
+    }
+}

--- a/crates/nu-cli/src/commands/insert.rs
+++ b/crates/nu-cli/src/commands/insert.rs
@@ -74,3 +74,15 @@ fn insert(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
     };
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Insert;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Insert {})
+    }
+}

--- a/crates/nu-cli/src/commands/is_empty.rs
+++ b/crates/nu-cli/src/commands/is_empty.rs
@@ -196,3 +196,15 @@ fn is_empty(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
     };
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::IsEmpty;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(IsEmpty {})
+    }
+}

--- a/crates/nu-cli/src/commands/keep.rs
+++ b/crates/nu-cli/src/commands/keep.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
 
 pub struct Keep;
@@ -37,15 +37,22 @@ impl WholeStreamCommand for Keep {
         keep(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Keep the first row",
-                example: "ls | keep",
+                example: "echo [1 2 3] | keep",
+                result: Some(vec![UntaggedValue::int(1).into()]),
             },
             Example {
                 description: "Keep the first four rows",
-                example: "ls | keep 4",
+                example: "echo [1 2 3 4 5] | keep 4",
+                result: Some(vec![
+                    UntaggedValue::int(1).into(),
+                    UntaggedValue::int(2).into(),
+                    UntaggedValue::int(3).into(),
+                    UntaggedValue::int(4).into(),
+                ]),
             },
         ]
     }
@@ -72,4 +79,16 @@ fn keep(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, S
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Keep;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Keep {})
+    }
 }

--- a/crates/nu-cli/src/commands/keep_until.rs
+++ b/crates/nu-cli/src/commands/keep_until.rs
@@ -109,3 +109,15 @@ impl WholeStreamCommand for KeepUntil {
         Ok(stream.to_output_stream())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::KeepUntil;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(KeepUntil {})
+    }
+}

--- a/crates/nu-cli/src/commands/keep_while.rs
+++ b/crates/nu-cli/src/commands/keep_while.rs
@@ -109,3 +109,15 @@ impl WholeStreamCommand for KeepWhile {
         Ok(stream.to_output_stream())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::KeepWhile;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(KeepWhile {})
+    }
+}

--- a/crates/nu-cli/src/commands/kill.rs
+++ b/crates/nu-cli/src/commands/kill.rs
@@ -45,15 +45,17 @@ impl WholeStreamCommand for Kill {
         kill(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Kill the pid using the most memory",
                 example: "ps | sort-by mem | last | kill $it.pid",
+                result: None,
             },
             Example {
                 description: "Force kill a given pid",
                 example: "kill --force 12345",
+                result: None,
             },
         ]
     }
@@ -116,4 +118,16 @@ fn kill(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, S
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Kill;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Kill {})
+    }
 }

--- a/crates/nu-cli/src/commands/last.rs
+++ b/crates/nu-cli/src/commands/last.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, Value};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 
 pub struct Last;
@@ -37,15 +37,21 @@ impl WholeStreamCommand for Last {
         last(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Get the last row",
-                example: "ls | last",
+                example: "echo [1 2 3] | last",
+                result: Some(vec![Value::from(UntaggedValue::from(BigInt::from(3)))]),
             },
             Example {
                 description: "Get the last three rows",
-                example: "ls | last 3",
+                example: "echo [1 2 3 4 5] | last 3",
+                result: Some(vec![
+                    UntaggedValue::int(3).into(),
+                    UntaggedValue::int(4).into(),
+                    UntaggedValue::int(5).into(),
+                ]),
             },
         ]
     }
@@ -73,4 +79,16 @@ fn last(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, S
         }
     };
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Last;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Last {})
+    }
 }

--- a/crates/nu-cli/src/commands/lines.rs
+++ b/crates/nu-cli/src/commands/lines.rs
@@ -26,10 +26,11 @@ impl WholeStreamCommand for Lines {
         lines(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
-            description: "Split output from an external command into lines",
-            example: "^ls -l | lines",
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Split multi-line string into lines",
+            example: r#"^echo "two\nlines" | lines"#,
+            result: None,
         }]
     }
 }
@@ -120,4 +121,16 @@ fn lines(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
     .flatten();
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Lines;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Lines {})
+    }
 }

--- a/crates/nu-cli/src/commands/ls.rs
+++ b/crates/nu-cli/src/commands/ls.rs
@@ -67,19 +67,22 @@ impl WholeStreamCommand for Ls {
         ls(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "List all files in the current directory",
                 example: "ls",
+                result: None,
             },
             Example {
                 description: "List all files in a subdirectory",
                 example: "ls subdir",
+                result: None,
             },
             Example {
                 description: "List all rust files",
                 example: "ls *.rs",
+                result: None,
             },
         ]
     }
@@ -100,4 +103,16 @@ fn ls(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, She
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Ls;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Ls {})
+    }
 }

--- a/crates/nu-cli/src/commands/map_max_by.rs
+++ b/crates/nu-cli/src/commands/map_max_by.rs
@@ -74,3 +74,15 @@ pub fn map_max_by(
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::MapMaxBy;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(MapMaxBy {})
+    }
+}

--- a/crates/nu-cli/src/commands/merge.rs
+++ b/crates/nu-cli/src/commands/merge.rs
@@ -39,10 +39,11 @@ impl WholeStreamCommand for Merge {
         merge(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Merge a 1-based index column with some ls output",
             example: "ls | select name | keep 3 | merge { echo [1 2 3] | wrap index }",
+            result: None,
         }]
     }
 }
@@ -96,4 +97,16 @@ fn merge(raw_args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Merge;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Merge {})
+    }
 }

--- a/crates/nu-cli/src/commands/mkdir.rs
+++ b/crates/nu-cli/src/commands/mkdir.rs
@@ -34,10 +34,11 @@ impl WholeStreamCommand for Mkdir {
         mkdir(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Make a directory named foo",
             example: "mkdir foo",
+            result: None,
         }]
     }
 }
@@ -56,4 +57,16 @@ fn mkdir(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Mkdir;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Mkdir {})
+    }
 }

--- a/crates/nu-cli/src/commands/mv.rs
+++ b/crates/nu-cli/src/commands/mv.rs
@@ -45,19 +45,22 @@ impl WholeStreamCommand for Move {
         mv(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Rename a file",
                 example: "mv before.txt after.txt",
+                result: None,
             },
             Example {
                 description: "Move a file into a directory",
                 example: "mv test.txt my/subdirectory",
+                result: None,
             },
             Example {
                 description: "Move many files into a directory",
                 example: "mv *.txt my/subdirectory",
+                result: None,
             },
         ]
     }
@@ -77,4 +80,16 @@ fn mv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, She
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Move;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Move {})
+    }
 }

--- a/crates/nu-cli/src/commands/next.rs
+++ b/crates/nu-cli/src/commands/next.rs
@@ -30,3 +30,15 @@ impl WholeStreamCommand for Next {
 fn next(_args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     Ok(vec![Ok(ReturnSuccess::Action(CommandAction::NextShell))].into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Next;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Next {})
+    }
+}

--- a/crates/nu-cli/src/commands/nth.rs
+++ b/crates/nu-cli/src/commands/nth.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, Value};
 use nu_source::Tagged;
 
 #[derive(Deserialize)]
@@ -40,15 +40,17 @@ impl WholeStreamCommand for Nth {
         nth(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Get the second row",
                 example: "echo [first second third] | nth 1",
+                result: Some(vec![Value::from("second")]),
             },
             Example {
                 description: "Get the first and third rows",
                 example: "echo [first second third] | nth 0 2",
+                result: Some(vec![Value::from("first"), Value::from("third")]),
             },
         ]
     }
@@ -78,4 +80,16 @@ fn nth(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, Sh
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Nth;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Nth {})
+    }
 }

--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -242,3 +242,15 @@ fn read_be_u16(input: &[u8]) -> Option<Vec<u16>> {
         Some(result)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Open;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Open {})
+    }
+}

--- a/crates/nu-cli/src/commands/pivot.rs
+++ b/crates/nu-cli/src/commands/pivot.rs
@@ -137,3 +137,15 @@ pub fn pivot(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(OutputStream::new(stream))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Pivot;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Pivot {})
+    }
+}

--- a/crates/nu-cli/src/commands/prepend.rs
+++ b/crates/nu-cli/src/commands/prepend.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, Value};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 
 #[derive(Deserialize)]
 struct PrependArgs {
@@ -36,10 +36,16 @@ impl WholeStreamCommand for Prepend {
         prepend(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Add something to the beginning of a list or table",
             example: "echo [2 3 4] | prepend 1",
+            result: Some(vec![
+                UntaggedValue::int(1).into(),
+                UntaggedValue::int(2).into(),
+                UntaggedValue::int(3).into(),
+                UntaggedValue::int(4).into(),
+            ]),
         }]
     }
 }
@@ -57,4 +63,16 @@ fn prepend(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Prepend;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Prepend {})
+    }
 }

--- a/crates/nu-cli/src/commands/prev.rs
+++ b/crates/nu-cli/src/commands/prev.rs
@@ -31,3 +31,15 @@ impl WholeStreamCommand for Previous {
 fn previous(_args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     Ok(vec![Ok(ReturnSuccess::Action(CommandAction::PreviousShell))].into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Previous;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Previous {})
+    }
+}

--- a/crates/nu-cli/src/commands/pwd.rs
+++ b/crates/nu-cli/src/commands/pwd.rs
@@ -26,10 +26,11 @@ impl WholeStreamCommand for Pwd {
         pwd(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Print the current working directory",
             example: "pwd",
+            result: None,
         }]
     }
 }
@@ -48,4 +49,16 @@ pub fn pwd(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Pwd;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Pwd {})
+    }
 }

--- a/crates/nu-cli/src/commands/range.rs
+++ b/crates/nu-cli/src/commands/range.rs
@@ -58,3 +58,15 @@ fn range(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Range;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Range {})
+    }
+}

--- a/crates/nu-cli/src/commands/reduce_by.rs
+++ b/crates/nu-cli/src/commands/reduce_by.rs
@@ -73,3 +73,15 @@ pub fn reduce_by(
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ReduceBy;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ReduceBy {})
+    }
+}

--- a/crates/nu-cli/src/commands/reject.rs
+++ b/crates/nu-cli/src/commands/reject.rs
@@ -57,3 +57,15 @@ fn reject(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Reject;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Reject {})
+    }
+}

--- a/crates/nu-cli/src/commands/rename.rs
+++ b/crates/nu-cli/src/commands/rename.rs
@@ -40,15 +40,17 @@ impl WholeStreamCommand for Rename {
         rename(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Rename a column",
-                example: "ls | rename my_name",
+                example: r#"echo "{a: 1, b: 2, c: 3}" | from json | rename my_column"#,
+                result: None,
             },
             Example {
                 description: "Rename many columns",
-                example: "echo \"{a: 1, b: 2, c: 3}\" | from json | rename spam eggs cars",
+                example: r#"echo "{a: 1, b: 2, c: 3}" | from json | rename spam eggs cars"#,
+                result: None,
             },
         ]
     }
@@ -99,4 +101,16 @@ pub fn rename(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Rename;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Rename {})
+    }
 }

--- a/crates/nu-cli/src/commands/reverse.rs
+++ b/crates/nu-cli/src/commands/reverse.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature};
+use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
 
 pub struct Reverse;
 
@@ -27,10 +27,17 @@ impl WholeStreamCommand for Reverse {
         reverse(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
-            description: "Sort files in descending file size",
-            example: "ls | sort-by size | reverse",
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Sort list of numbers in descending file size",
+            example: "echo [3 1 2 19 0] | reverse",
+            result: Some(vec![
+                UntaggedValue::int(0).into(),
+                UntaggedValue::int(19).into(),
+                UntaggedValue::int(2).into(),
+                UntaggedValue::int(1).into(),
+                UntaggedValue::int(3).into(),
+            ]),
         }]
     }
 }
@@ -48,4 +55,16 @@ fn reverse(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Reverse;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Reverse {})
+    }
 }

--- a/crates/nu-cli/src/commands/rm.rs
+++ b/crates/nu-cli/src/commands/rm.rs
@@ -44,15 +44,17 @@ impl WholeStreamCommand for Remove {
         rm(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Delete a file",
                 example: "rm file.txt",
+                result: None,
             },
             Example {
                 description: "Move a file to the system trash",
                 example: "rm --trash file.txt",
+                result: None,
             },
         ]
     }
@@ -71,4 +73,16 @@ fn rm(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, She
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Remove;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Remove {})
+    }
 }

--- a/crates/nu-cli/src/commands/save.rs
+++ b/crates/nu-cli/src/commands/save.rs
@@ -282,3 +282,15 @@ fn string_from(input: &[Value]) -> String {
 
     save_data
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Save;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Save {})
+    }
+}

--- a/crates/nu-cli/src/commands/select.rs
+++ b/crates/nu-cli/src/commands/select.rs
@@ -40,15 +40,17 @@ impl WholeStreamCommand for Select {
         select(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Select just the name column",
                 example: "ls | select name",
+                result: None,
             },
             Example {
                 description: "Select the name and size columns",
                 example: "ls | select name size",
+                result: None,
             },
         ]
     }
@@ -171,4 +173,16 @@ fn select(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Select;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Select {})
+    }
 }

--- a/crates/nu-cli/src/commands/shells.rs
+++ b/crates/nu-cli/src/commands/shells.rs
@@ -48,3 +48,15 @@ fn shells(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream
 
     Ok(shells_out.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Shells;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Shells {})
+    }
+}

--- a/crates/nu-cli/src/commands/shuffle.rs
+++ b/crates/nu-cli/src/commands/shuffle.rs
@@ -66,3 +66,15 @@ fn shuffle(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Shuffle;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Shuffle {})
+    }
+}

--- a/crates/nu-cli/src/commands/size.rs
+++ b/crates/nu-cli/src/commands/size.rs
@@ -1,5 +1,6 @@
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
+use indexmap::indexmap;
 use nu_errors::ShellError;
 use nu_protocol::{ReturnSuccess, Signature, TaggedDictBuilder, UntaggedValue, Value};
 
@@ -26,10 +27,17 @@ impl WholeStreamCommand for Size {
         size(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Count the number of words in a string",
             example: r#"echo "There are seven words in this sentence" | size"#,
+            result: Some(vec![UntaggedValue::row(indexmap! {
+                "lines".to_string() => UntaggedValue::int(0).into(),
+                "words".to_string() => UntaggedValue::int(7).into(),
+                "chars".to_string() => UntaggedValue::int(38).into(),
+                "max length".to_string() => UntaggedValue::int(38).into(),
+            })
+            .into()]),
         }]
     }
 }
@@ -90,4 +98,16 @@ fn count(contents: &str, tag: impl Into<Tag>) -> Value {
     dict.insert_untagged("max length", UntaggedValue::int(bytes));
 
     dict.into_value()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Size;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Size {})
+    }
 }

--- a/crates/nu-cli/src/commands/skip.rs
+++ b/crates/nu-cli/src/commands/skip.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
 
 pub struct Skip;
@@ -33,10 +33,14 @@ impl WholeStreamCommand for Skip {
         skip(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Skip the first 5 rows",
-            example: "ls | skip 5",
+            example: "echo [1 2 3 4 5 6 7] | skip 5",
+            result: Some(vec![
+                UntaggedValue::int(6).into(),
+                UntaggedValue::int(7).into(),
+            ]),
         }]
     }
 }
@@ -62,4 +66,16 @@ fn skip(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, S
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Skip;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Skip {})
+    }
 }

--- a/crates/nu-cli/src/commands/skip_until.rs
+++ b/crates/nu-cli/src/commands/skip_until.rs
@@ -112,3 +112,15 @@ impl WholeStreamCommand for SkipUntil {
         Ok(stream.to_output_stream())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SkipUntil;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(SkipUntil {})
+    }
+}

--- a/crates/nu-cli/src/commands/skip_while.rs
+++ b/crates/nu-cli/src/commands/skip_while.rs
@@ -112,3 +112,15 @@ impl WholeStreamCommand for SkipWhile {
         Ok(stream.to_output_stream())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SkipWhile;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(SkipWhile {})
+    }
+}

--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -33,15 +33,27 @@ impl WholeStreamCommand for SortBy {
         sort_by(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Sort list by increasing value",
+                example: "echo [4 2 3 1] | sort-by",
+                result: Some(vec![
+                    UntaggedValue::int(1).into(),
+                    UntaggedValue::int(2).into(),
+                    UntaggedValue::int(3).into(),
+                    UntaggedValue::int(4).into(),
+                ]),
+            },
             Example {
                 description: "Sort output by increasing file size",
                 example: "ls | sort-by size",
+                result: None,
             },
             Example {
                 description: "Sort output by type, and then by file size for each type",
                 example: "ls | sort-by type size",
+                result: None,
             },
         ]
     }
@@ -80,4 +92,16 @@ fn sort_by(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SortBy;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(SortBy {})
+    }
 }

--- a/crates/nu-cli/src/commands/split_by.rs
+++ b/crates/nu-cli/src/commands/split_by.rs
@@ -273,4 +273,12 @@ mod tests {
 
         assert!(split(&for_key, &nu_releases, Tag::from(Span::new(5, 10))).is_err());
     }
+
+    #[test]
+    fn examples_work_as_expected() {
+        use super::SplitBy;
+        use crate::examples::test as test_examples;
+
+        test_examples(SplitBy {})
+    }
 }

--- a/crates/nu-cli/src/commands/split_column.rs
+++ b/crates/nu-cli/src/commands/split_column.rs
@@ -103,3 +103,15 @@ fn split_column(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SplitColumn;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(SplitColumn {})
+    }
+}

--- a/crates/nu-cli/src/commands/split_row.rs
+++ b/crates/nu-cli/src/commands/split_row.rs
@@ -70,3 +70,15 @@ fn split_row(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SplitRow;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(SplitRow {})
+    }
+}

--- a/crates/nu-cli/src/commands/sum.rs
+++ b/crates/nu-cli/src/commands/sum.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use crate::utils::data_processing::{reducer_for, Reduce};
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, ReturnValue, Signature, Value};
+use nu_protocol::{ReturnSuccess, ReturnValue, Signature, UntaggedValue, Value};
 use num_traits::identities::Zero;
 
 pub struct Sum;
@@ -35,15 +35,17 @@ impl WholeStreamCommand for Sum {
         })
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description: "Sum a list of numbers",
                 example: "echo [1 2 3] | sum",
+                result: Some(vec![UntaggedValue::int(6).into()]),
             },
             Example {
                 description: "Get the disk usage for the current directory",
                 example: "ls --all --du | get size | sum",
+                result: None,
             },
         ]
     }
@@ -64,4 +66,16 @@ fn sum(RunnableContext { mut input, .. }: RunnableContext) -> Result<OutputStrea
     let stream: BoxStream<'static, ReturnValue> = stream.boxed();
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Sum;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Sum {})
+    }
 }

--- a/crates/nu-cli/src/commands/t_sort_by.rs
+++ b/crates/nu-cli/src/commands/t_sort_by.rs
@@ -87,3 +87,15 @@ fn t_sort_by(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TSortBy;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(TSortBy {})
+    }
+}

--- a/crates/nu-cli/src/commands/table.rs
+++ b/crates/nu-cli/src/commands/table.rs
@@ -128,3 +128,15 @@ fn table(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
 
     Ok(OutputStream::new(stream))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Table;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Table {})
+    }
+}

--- a/crates/nu-cli/src/commands/tags.rs
+++ b/crates/nu-cli/src/commands/tags.rs
@@ -55,3 +55,15 @@ fn tags(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
         })
         .to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Tags;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Tags {})
+    }
+}

--- a/crates/nu-cli/src/commands/to.rs
+++ b/crates/nu-cli/src/commands/to.rs
@@ -35,3 +35,15 @@ impl WholeStreamCommand for To {
         Ok(stream.to_output_stream())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::To;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(To {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_bson.rs
+++ b/crates/nu-cli/src/commands/to_bson.rs
@@ -306,3 +306,15 @@ fn to_bson(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToBSON;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToBSON {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_csv.rs
+++ b/crates/nu-cli/src/commands/to_csv.rs
@@ -83,3 +83,15 @@ fn to_csv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToCSV;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToCSV {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_html.rs
+++ b/crates/nu-cli/src/commands/to_html.rs
@@ -119,3 +119,15 @@ fn to_html(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToHTML;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToHTML {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_json.rs
+++ b/crates/nu-cli/src/commands/to_json.rs
@@ -40,17 +40,19 @@ impl WholeStreamCommand for ToJSON {
         to_json(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[
+    fn examples(&self) -> Vec<Example> {
+        vec![
             Example {
                 description:
                     "Outputs an unformatted JSON string representing the contents of this table",
-                example: "to json",
+                example: "echo [1 2 3] | to json",
+                result: Some(vec![Value::from("[1,2,3]")]),
             },
             Example {
                 description:
-                    "Outputs a formatted JSON string representing the contents of this table with an indentation setting of 4 spaces",
-                example: "to json --pretty 4",
+                    "Outputs a formatted JSON string representing the contents of this table with an indentation setting of 2 spaces",
+                example: "echo [1 2 3] | to json --pretty 2",
+                result: Some(vec![Value::from("[\n  1,\n  2,\n  3\n]")]),
             },
         ]
     }
@@ -232,4 +234,16 @@ fn to_json(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ToJSON;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToJSON {})
+    }
 }

--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -75,3 +75,15 @@ fn to_html(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToMarkdown;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToMarkdown {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_sqlite.rs
+++ b/crates/nu-cli/src/commands/to_sqlite.rs
@@ -222,3 +222,15 @@ fn to_sqlite(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToSQLite;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToSQLite {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_toml.rs
+++ b/crates/nu-cli/src/commands/to_toml.rs
@@ -137,3 +137,15 @@ fn to_toml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToTOML;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToTOML {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_tsv.rs
+++ b/crates/nu-cli/src/commands/to_tsv.rs
@@ -57,3 +57,15 @@ fn to_tsv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToTSV;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToTSV {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_url.rs
+++ b/crates/nu-cli/src/commands/to_url.rs
@@ -85,3 +85,15 @@ fn to_url(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream,
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToURL;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToURL {})
+    }
+}

--- a/crates/nu-cli/src/commands/to_yaml.rs
+++ b/crates/nu-cli/src/commands/to_yaml.rs
@@ -170,3 +170,15 @@ fn to_yaml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ToYAML;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(ToYAML {})
+    }
+}

--- a/crates/nu-cli/src/commands/touch.rs
+++ b/crates/nu-cli/src/commands/touch.rs
@@ -51,3 +51,15 @@ fn touch(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Touch;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Touch {})
+    }
+}

--- a/crates/nu-cli/src/commands/trim.rs
+++ b/crates/nu-cli/src/commands/trim.rs
@@ -72,3 +72,15 @@ fn trim(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
         })
         .to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Trim;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Trim {})
+    }
+}

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -41,3 +41,15 @@ fn uniq(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Uniq;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Uniq {})
+    }
+}

--- a/crates/nu-cli/src/commands/update.rs
+++ b/crates/nu-cli/src/commands/update.rs
@@ -142,3 +142,15 @@ fn update(raw_args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Update;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Update {})
+    }
+}

--- a/crates/nu-cli/src/commands/version.rs
+++ b/crates/nu-cli/src/commands/version.rs
@@ -40,3 +40,15 @@ pub fn version(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputS
     let value = UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag);
     Ok(OutputStream::one(value))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Version;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Version {})
+    }
+}

--- a/crates/nu-cli/src/commands/what.rs
+++ b/crates/nu-cli/src/commands/what.rs
@@ -45,3 +45,15 @@ pub fn what(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStre
 
     Ok(OutputStream::from(stream))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::What;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(What {})
+    }
+}

--- a/crates/nu-cli/src/commands/where_.rs
+++ b/crates/nu-cli/src/commands/where_.rs
@@ -98,3 +98,15 @@ fn where_command(
 
     Ok(stream.to_output_stream())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Where;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Where {})
+    }
+}

--- a/crates/nu-cli/src/commands/which_.rs
+++ b/crates/nu-cli/src/commands/which_.rs
@@ -108,3 +108,15 @@ fn which(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, 
         Ok(stream.take(1).to_output_stream())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Which;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Which {})
+    }
+}

--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -2,7 +2,7 @@ use crate::commands::classified::block::run_block;
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{hir::Block, ReturnSuccess, Signature, SyntaxShape};
+use nu_protocol::{hir::Block, ReturnSuccess, Signature, SyntaxShape, Value};
 use nu_source::Tagged;
 
 pub struct WithEnv;
@@ -43,10 +43,11 @@ impl WholeStreamCommand for WithEnv {
         with_env(args, registry)
     }
 
-    fn examples(&self) -> &[Example] {
-        &[Example {
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
             description: "Set the MYENV environment variable",
             example: r#"with-env [MYENV "my env value"] { echo $nu.env.MYENV }"#,
+            result: Some(vec![Value::from("my env value")]),
         }]
     }
 }
@@ -88,4 +89,16 @@ fn with_env(raw_args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
     };
 
     Ok(stream.to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WithEnv;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(WithEnv {})
+    }
 }

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -1,0 +1,89 @@
+use futures::executor::block_on;
+
+use nu_errors::ShellError;
+use nu_protocol::hir::ClassifiedBlock;
+use nu_protocol::{Scope, ShellTypeName, Value};
+
+use crate::commands::classified::block::run_block;
+use crate::commands::{whole_stream_command, Echo};
+use crate::context::Context;
+use crate::stream::InputStream;
+use crate::WholeStreamCommand;
+
+pub fn test(cmd: impl WholeStreamCommand + 'static) {
+    let examples = cmd.examples();
+    let mut base_context = Context::basic().expect("could not create basic context");
+    base_context.add_commands(vec![
+        whole_stream_command(Echo {}),
+        whole_stream_command(cmd),
+    ]);
+
+    for example in examples {
+        let mut ctx = base_context.clone();
+        let block = parse_line(example.example, &mut ctx).expect("failed to parse example");
+        if let Some(expected) = example.result {
+            let result = block_on(evaluate_block(block, &mut ctx)).expect("failed to run example");
+            assert!(
+                expected
+                    .iter()
+                    .zip(result.iter())
+                    .all(|(e, a)| values_equal(e, a)),
+                "example produced unexpected result: {}",
+                example.example,
+            );
+        }
+    }
+}
+
+/// Parse and run a nushell pipeline
+fn parse_line(line: &'static str, ctx: &mut Context) -> Result<ClassifiedBlock, ShellError> {
+    let line = if line.ends_with('\n') {
+        &line[..line.len() - 1]
+    } else {
+        line
+    };
+
+    let lite_result = nu_parser::lite_parse(&line, 0)?;
+
+    // TODO ensure the command whose examples we're testing is actually in the pipeline
+    let mut classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
+    classified_block.block.expand_it_usage();
+    Ok(classified_block)
+}
+
+async fn evaluate_block(
+    block: ClassifiedBlock,
+    ctx: &mut Context,
+) -> Result<Vec<Value>, ShellError> {
+    let input_stream = InputStream::empty();
+    let env = ctx.get_env();
+
+    Ok(run_block(&block.block, ctx, input_stream, &Scope::env(env))
+        .await?
+        .into_vec()
+        .await)
+}
+
+// TODO probably something already available to do this
+// TODO perhaps better panic messages when things don't compare
+
+// Deep value comparisons that ignore tags
+fn values_equal(expected: &Value, actual: &Value) -> bool {
+    use nu_protocol::UntaggedValue::*;
+
+    match (&expected.value, &actual.value) {
+        (Primitive(e), Primitive(a)) => e == a,
+        (Row(e), Row(a)) => {
+            if e.entries.len() != a.entries.len() {
+                return false;
+            }
+
+            e.entries
+                .iter()
+                .zip(a.entries.iter())
+                .all(|((ek, ev), (ak, av))| ek == ak && values_equal(ev, av))
+        }
+        (Table(e), Table(a)) => e.iter().zip(a.iter()).all(|(e, a)| values_equal(e, a)),
+        (e, a) => unimplemented!("{} {}", e.type_name(), a.type_name()),
+    }
+}

--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -28,6 +28,9 @@ mod shell;
 mod stream;
 mod utils;
 
+#[cfg(test)]
+mod examples;
+
 pub use crate::cli::{
     cli, create_default_context, load_plugins, run_pipeline_standalone, run_vec_of_pipelines,
 };

--- a/crates/nu-cli/tests/main.rs
+++ b/crates/nu-cli/tests/main.rs
@@ -1,3 +1,4 @@
+extern crate nu_cli;
 extern crate nu_test_support;
 
 mod commands;

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -359,11 +359,11 @@ impl Value {
     }
 }
 
-impl Into<Value> for String {
-    fn into(self) -> Value {
-        let end = self.len();
+impl From<String> for Value {
+    fn from(s: String) -> Value {
+        let end = s.len();
         Value {
-            value: self.into(),
+            value: s.into(),
             tag: Tag {
                 anchor: None,
                 span: Span::new(0, end),
@@ -372,17 +372,49 @@ impl Into<Value> for String {
     }
 }
 
-impl Into<UntaggedValue> for &str {
-    /// Convert a string slice into an UntaggedValue
-    fn into(self) -> UntaggedValue {
-        UntaggedValue::Primitive(Primitive::String(self.to_string()))
+impl From<&str> for Value {
+    fn from(s: &str) -> Value {
+        let end = s.len();
+        Value {
+            value: s.into(),
+            tag: Tag {
+                anchor: None,
+                span: Span::new(0, end),
+            },
+        }
     }
 }
 
-impl Into<UntaggedValue> for Value {
+impl<T> From<T> for UntaggedValue
+where
+    T: Into<Primitive>,
+{
+    /// Convert a Primitive to an UntaggedValue
+    fn from(input: T) -> UntaggedValue {
+        UntaggedValue::Primitive(input.into())
+    }
+}
+
+impl From<ShellError> for UntaggedValue {
+    fn from(e: ShellError) -> Self {
+        UntaggedValue::Error(e)
+    }
+}
+
+impl From<UntaggedValue> for Value {
+    /// Convert an UntaggedValue into a Value with a default tag
+    fn from(value: UntaggedValue) -> Value {
+        Value {
+            value,
+            tag: Tag::default(),
+        }
+    }
+}
+
+impl From<Value> for UntaggedValue {
     /// Convert a Value into an UntaggedValue
-    fn into(self) -> UntaggedValue {
-        self.value
+    fn from(v: Value) -> UntaggedValue {
+        v.value
     }
 }
 
@@ -417,26 +449,6 @@ impl ShellTypeName for UntaggedValue {
             UntaggedValue::Error(_) => "error",
             UntaggedValue::Block(_) => "block",
         }
-    }
-}
-
-impl From<Primitive> for UntaggedValue {
-    /// Convert a Primitive to an UntaggedValue
-    fn from(input: Primitive) -> UntaggedValue {
-        UntaggedValue::Primitive(input)
-    }
-}
-
-impl From<String> for UntaggedValue {
-    /// Convert a String to an UntaggedValue
-    fn from(input: String) -> UntaggedValue {
-        UntaggedValue::Primitive(Primitive::String(input))
-    }
-}
-
-impl From<ShellError> for UntaggedValue {
-    fn from(e: ShellError) -> Self {
-        UntaggedValue::Error(e)
     }
 }
 

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -171,6 +171,20 @@ impl std::ops::Mul for Primitive {
     }
 }
 
+impl From<&str> for Primitive {
+    /// Helper to convert from string slices to a primitive
+    fn from(s: &str) -> Primitive {
+        Primitive::String(s.to_string())
+    }
+}
+
+impl From<String> for Primitive {
+    /// Helper to convert from Strings to a primitive
+    fn from(s: String) -> Primitive {
+        Primitive::String(s)
+    }
+}
+
 impl From<BigDecimal> for Primitive {
     /// Helper to convert from decimals to a Primitive value
     fn from(decimal: BigDecimal) -> Primitive {


### PR DESCRIPTION
## Draft PR

Looking for a quick first pass to validate this approach before working on more examples. Some will be tougher (e.g., things that integrate with a shell), but I think a mock shell could easily be injected into the context for the purposes of testing.

Some questions:
- One thing I'm not a fan of: `result` is not scoped to tests, so technically it will be wasted memory when running in debug/release mode. Should we scope this attribute to `#[cfg(test)]`?
- Should we have the results include the anchors/spans too? It's a little more work to set up the expected result of an example, and I'm not sure it adds a ton of value over having great tests for anchors/tags/spans in the parser itself.

Other thoughts:
- `examples::compare_values` could perhaps be a `CompareIgnoringMetadata` trait, or something along those lines (just noticed `coerce_compare` while writing this, which is close to what I want).
- I feel like more blanket trait implementations on `Value` and `UntaggedValue` will dramatically reduce the amount of typing necessary for writing these results. Similarly, some more `From` impls on `Primitive`. Happy to do that work here.
- We could perhaps have one single test for all commands, by making use of the default context / registry that `cli` exposes.

## PR Description

Automatic testing is done by simply calling the new `examples::test` method with an instantiated command. It will run the example and compare it against a manually instantiated result (ignoring tags/anchors/spans for now).

All one needs to do is add this

```rust
#[cfg(test)]
mod tests {
    use super::Last;

    #[test]
    fn examples_work_as_expected() {
        use crate::examples::test as test_examples;

        test_examples(Last {})
    }
}
```