### PR TITLE
doc: add more from command pages

### DIFF
--- a/docs/commands/from-ini.md
+++ b/docs/commands/from-ini.md
@@ -1,0 +1,26 @@
+# from ini
+
+Converts ini data into table. Use this when nushell cannot determine the input file extension.
+
+## Example
+
+Let's say we have the following `.txt` file :
+```shell
+> open sample.txt
+[SectionOne]
+
+key = value
+integer = 1234
+string1 = 'Case 1'
+```
+
+This file is actually a ini file, but the file extension isn't `.ini`. That's okay, we can use the `from ini` command :
+
+```shell
+> open sample.txt | from ini | get SectionOne
+━━━━━━━┯━━━━━━━━━┯━━━━━━━━━━
+ key   │ integer │ string1
+───────┼─────────┼──────────
+ value │ 1234    │ 'Case 1'
+━━━━━━━┷━━━━━━━━━┷━━━━━━━━━━
+```

--- a/docs/commands/from-toml.md
+++ b/docs/commands/from-toml.md
@@ -1,5 +1,5 @@
 # from toml
-Converts toml data into table. Use this when nushell cannot dertermine the input file extension.
+Converts toml data into table. Use this when nushell cannot determine the input file extension.
 
 ## Example
 Let's say we have the following Rust .lock file :

--- a/docs/commands/from-url.md
+++ b/docs/commands/from-url.md
@@ -1,0 +1,14 @@
+# from url
+
+Parse [url-encoded string](https://url.spec.whatwg.org/#application/x-www-form-urlencoded) as a table.
+
+## Example
+
+```shell
+> echo 'bread=baguette&cheese=comt%C3%A9&meat=ham&fat=butter' | from url
+━━━━━━━━━━┯━━━━━━━━┯━━━━━━┯━━━━━━━━
+ bread    │ cheese │ meat │ fat
+──────────┼────────┼──────┼────────
+ baguette │ comté  │ ham  │ butter
+━━━━━━━━━━┷━━━━━━━━┷━━━━━━┷━━━━━━━━
+```

--- a/docs/commands/from.md
+++ b/docs/commands/from.md
@@ -20,7 +20,7 @@ Use this when nushell cannot determine the input file extension.
 * [from url](from-url.md)
 * [from vcf](from-vcf.md)
 * [from xlsx](from-xlsx.md)
-* from xml
+* [from xml](from-xml.md)
 * [from yaml](from-yaml.md)
 
 *Subcommands without links are currently missing their documentation.*

--- a/docs/commands/from.md
+++ b/docs/commands/from.md
@@ -10,7 +10,7 @@ Use this when nushell cannot determine the input file extension.
 * [from csv](from-csv.md)
 * from eml
 * [from ics](from-ics.md)
-* from ini
+* [from ini](from-ini.md)
 * [from json](from-json.md)
 * [from ods](from-ods.md)
 * from sqlite

--- a/docs/commands/from.md
+++ b/docs/commands/from.md
@@ -17,7 +17,7 @@ Use this when nushell cannot determine the input file extension.
 * from ssv
 * [from toml](from-toml.md)
 * [from tsv](from-tsv.md)
-* from url
+* [from url](from-url.md)
 * [from vcf](from-vcf.md)
 * [from xlsx](from-xlsx.md)
 * from xml

--- a/docs/commands/to-url.md
+++ b/docs/commands/to-url.md
@@ -1,6 +1,6 @@
 # to url
 
-Converts table data into url-formatted text.
+Converts table data into [url-encoded text](https://url.spec.whatwg.org/#application/x-www-form-urlencoded).
 
 ## Example
 


### PR DESCRIPTION
Hi

This PR add basic document pages for `from ini` and `from url` commands.

I've also added links to the url spec to clearly define the format used by `serde`: https://url.spec.whatwg.org/#application/x-www-form-urlencoded