### PR TITLE
Allow external binary to register custom commands.

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -8,6 +8,7 @@ use crate::context::Context;
 use crate::git::current_branch;
 use crate::path::canonicalize;
 use crate::prelude::*;
+use crate::EnvironmentSyncer;
 use futures_codec::FramedRead;
 
 use nu_errors::ShellError;
@@ -482,14 +483,14 @@ pub async fn run_pipeline_standalone(
 }
 
 /// The entry point for the CLI. Will register all known internal commands, load experimental commands, load plugins, then prepare the prompt and line reader for input.
-pub async fn cli() -> Result<(), Box<dyn Error>> {
+pub async fn cli(
+    mut syncer: EnvironmentSyncer,
+    mut context: Context,
+) -> Result<(), Box<dyn Error>> {
     #[cfg(windows)]
     const DEFAULT_COMPLETION_MODE: CompletionType = CompletionType::Circular;
     #[cfg(not(windows))]
     const DEFAULT_COMPLETION_MODE: CompletionType = CompletionType::List;
-
-    let mut syncer = crate::EnvironmentSyncer::new();
-    let mut context = create_default_context(&mut syncer, true)?;
 
     let _ = load_plugins(&mut context);
 

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -131,7 +131,7 @@ You can also learn more at https://www.nushell.sh/book/"#;
 }
 
 #[allow(clippy::cognitive_complexity)]
-pub(crate) fn get_help(
+pub fn get_help(
     cmd: &dyn WholeStreamCommand,
     registry: &CommandRegistry,
 ) -> impl Into<OutputStream> {

--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -31,11 +31,17 @@ mod utils;
 pub use crate::cli::{
     cli, create_default_context, load_plugins, run_pipeline_standalone, run_vec_of_pipelines,
 };
+pub use crate::commands::command::{
+    whole_stream_command, CommandArgs, EvaluatedWholeStreamCommandArgs, WholeStreamCommand,
+};
+pub use crate::commands::help::get_help;
+pub use crate::context::CommandRegistry;
 pub use crate::data::dict::TaggedListBuilder;
 pub use crate::data::primitive;
 pub use crate::data::value;
 pub use crate::env::environment_syncer::EnvironmentSyncer;
 pub use crate::env::host::BasicHost;
+pub use crate::stream::OutputStream;
 pub use nu_value_ext::ValueExt;
 pub use num_traits::cast::ToPrimitive;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{App, Arg};
 use log::LevelFilter;
+use nu_cli::{create_default_context, EnvironmentSyncer};
 use std::error::Error;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
@@ -128,7 +129,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                 "Welcome to Nushell {} (type 'help' for more info)",
                 clap::crate_version!()
             );
-            futures::executor::block_on(nu_cli::cli())?;
+
+            let mut syncer = EnvironmentSyncer::new();
+            let context = create_default_context(&mut syncer, true)?;
+            futures::executor::block_on(nu_cli::cli(syncer, context))?;
         }
     }
 


### PR DESCRIPTION
This changeset contains everything that a separate binary needs to
register its own commands (including the new help function). It is
very possible that this commit misses other pub use exports, but
the contained ones work for our use cases so far.