### PR TITLE
Remove the old it-hacks from fetch and post

### DIFF
--- a/crates/nu-cli/src/commands/plugin.rs
+++ b/crates/nu-cli/src/commands/plugin.rs
@@ -72,11 +72,7 @@ pub fn filter_plugin(
     trace!("filter_plugin :: {}", path);
     let registry = registry.clone();
 
-    let scope = args
-        .call_info
-        .scope
-        .clone()
-        .set_it(UntaggedValue::string("$it").into_untagged_value());
+    let scope = args.call_info.scope.clone();
 
     let stream = async_stream! {
         let mut args = args.evaluate_once_with_scope(&registry, &scope).await?;

--- a/crates/nu_plugin_fetch/src/fetch.rs
+++ b/crates/nu_plugin_fetch/src/fetch.rs
@@ -9,6 +9,7 @@ use surf::mime;
 #[derive(Default)]
 pub struct Fetch {
     pub path: Option<Value>,
+    pub tag: Tag,
     pub has_raw: bool,
 }
 
@@ -16,6 +17,7 @@ impl Fetch {
     pub fn new() -> Fetch {
         Fetch {
             path: None,
+            tag: Tag::unknown(),
             has_raw: false,
         }
     }
@@ -31,6 +33,7 @@ impl Fetch {
             })?;
             file.clone()
         });
+        self.tag = call_info.name_tag.clone();
 
         self.has_raw = call_info.args.has("raw");
 
@@ -38,18 +41,8 @@ impl Fetch {
     }
 }
 
-pub async fn fetch_helper(path: &Value, has_raw: bool, row: Value) -> ReturnValue {
-    let path_buf = path.as_path()?;
-    let path_str = path_buf.display().to_string();
-
-    //FIXME: this is a workaround because plugins don't yet support per-item iteration
-    let path_str = if path_str == "$it" {
-        let path_buf = row.as_path()?;
-        path_buf.display().to_string()
-    } else {
-        path_str
-    };
-
+pub async fn fetch_helper(path: &Value, has_raw: bool) -> ReturnValue {
+    let path_str = path.as_string()?;
     let path_span = path.tag.span;
 
     let result = fetch(&path_str, path_span, has_raw).await;

--- a/crates/nu_plugin_fetch/src/nu/mod.rs
+++ b/crates/nu_plugin_fetch/src/nu/mod.rs
@@ -1,7 +1,7 @@
 use futures::executor::block_on;
 use nu_errors::ShellError;
 use nu_plugin::Plugin;
-use nu_protocol::{CallInfo, ReturnValue, Signature, SyntaxShape, Value};
+use nu_protocol::{CallInfo, ReturnValue, Signature, SyntaxShape};
 
 use crate::fetch::fetch_helper;
 use crate::Fetch;
@@ -11,8 +11,8 @@ impl Plugin for Fetch {
         Ok(Signature::build("fetch")
             .desc("Load from a URL into a cell, convert to table if possible (avoid by appending '--raw')")
             .required(
-                "path",
-                SyntaxShape::Path,
+                "URL",
+                SyntaxShape::String,
                 "the URL to fetch the contents from",
             )
             .switch("raw", "fetch contents as text rather than a table", Some('r'))
@@ -21,20 +21,11 @@ impl Plugin for Fetch {
 
     fn begin_filter(&mut self, callinfo: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
         self.setup(callinfo)?;
-        Ok(vec![])
-    }
-
-    fn filter(&mut self, value: Value) -> Result<Vec<ReturnValue>, ShellError> {
         Ok(vec![block_on(fetch_helper(
             &self.path.clone().ok_or_else(|| {
-                ShellError::labeled_error(
-                    "internal error: path not set",
-                    "path not set",
-                    &value.tag,
-                )
+                ShellError::labeled_error("internal error: path not set", "path not set", &self.tag)
             })?,
             self.has_raw,
-            value,
         ))])
     }
 }

--- a/crates/nu_plugin_post/src/nu/mod.rs
+++ b/crates/nu_plugin_post/src/nu/mod.rs
@@ -1,7 +1,7 @@
 use futures::executor::block_on;
 use nu_errors::ShellError;
 use nu_plugin::Plugin;
-use nu_protocol::{CallInfo, ReturnValue, Signature, SyntaxShape, Value};
+use nu_protocol::{CallInfo, ReturnValue, Signature, SyntaxShape};
 
 use crate::post::post_helper;
 use crate::Post;
@@ -46,10 +46,6 @@ impl Plugin for Post {
 
     fn begin_filter(&mut self, call_info: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
         self.setup(call_info)?;
-        Ok(vec![])
-    }
-
-    fn filter(&mut self, row: Value) -> Result<Vec<ReturnValue>, ShellError> {
         Ok(vec![block_on(post_helper(
             &self.path.clone().ok_or_else(|| {
                 ShellError::labeled_error("expected a 'path'", "expected a 'path'", &self.tag)
@@ -61,7 +57,6 @@ impl Plugin for Post {
             self.user.clone(),
             self.password.clone(),
             &self.headers.clone(),
-            row,
         ))])
     }
 }

--- a/crates/nu_plugin_post/src/post.rs
+++ b/crates/nu_plugin_post/src/post.rs
@@ -87,29 +87,9 @@ pub async fn post_helper(
     user: Option<String>,
     password: Option<String>,
     headers: &[HeaderKind],
-    row: Value,
 ) -> ReturnValue {
     let path_tag = path.tag.clone();
-    let path_str = path.as_string()?.to_string();
-
-    //FIXME: this is a workaround because plugins don't yet support per-item iteration
-    let path_str = if path_str == "$it" {
-        let path_buf = row.as_path()?;
-        path_buf.display().to_string()
-    } else {
-        path_str
-    };
-
-    //FIXME: this is a workaround because plugins don't yet support per-item iteration
-    let body = if let Ok(x) = body.as_string() {
-        if x == "$it" {
-            &row
-        } else {
-            body
-        }
-    } else {
-        body
-    };
+    let path_str = path.as_string()?;
 
     let (file_extension, contents, contents_tag) =
         post(&path_str, &body, user, password, &headers, path_tag.clone()).await?;


### PR DESCRIPTION
We add some old hacks in `fetch` and `post` that prevented them from using the full it-expansion.  This PR just removes those hacks so they don't interfere with the expansion pass