### PR TITLE
create Palette trait

### DIFF
--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -263,7 +263,7 @@ pub fn get_help(cmd: &dyn WholeStreamCommand, registry: &CommandRegistry) -> Str
         }
     }
 
-    let pallet = crate::shell::helper::DefaultPallet {};
+    let palette = crate::shell::helper::DefaultPalette {};
     let examples = cmd.examples();
     if !examples.is_empty() {
         long_desc.push_str("\nExamples:");
@@ -273,7 +273,7 @@ pub fn get_help(cmd: &dyn WholeStreamCommand, registry: &CommandRegistry) -> Str
         long_desc.push_str("  ");
         long_desc.push_str(example.description);
         let colored_example =
-            crate::shell::helper::Painter::paint_string(example.example, registry, &pallet);
+            crate::shell::helper::Painter::paint_string(example.example, registry, &palette);
         long_desc.push_str(&format!("\n  > {}\n", colored_example));
     }
 

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -263,7 +263,7 @@ pub fn get_help(cmd: &dyn WholeStreamCommand, registry: &CommandRegistry) -> Str
         }
     }
 
-    let palette = crate::shell::helper::DefaultPalette {};
+    let palette = crate::shell::palette::DefaultPalette {};
     let examples = cmd.examples();
     if !examples.is_empty() {
         long_desc.push_str("\nExamples:");

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -263,6 +263,7 @@ pub fn get_help(cmd: &dyn WholeStreamCommand, registry: &CommandRegistry) -> Str
         }
     }
 
+    let pallet = crate::shell::helper::DefaultPallet {};
     let examples = cmd.examples();
     if !examples.is_empty() {
         long_desc.push_str("\nExamples:");
@@ -272,7 +273,7 @@ pub fn get_help(cmd: &dyn WholeStreamCommand, registry: &CommandRegistry) -> Str
         long_desc.push_str("  ");
         long_desc.push_str(example.description);
         let colored_example =
-            crate::shell::helper::Painter::paint_string(example.example, registry);
+            crate::shell::helper::Painter::paint_string(example.example, registry, &pallet);
         long_desc.push_str(&format!("\n  > {}\n", colored_example));
     }
 

--- a/crates/nu-cli/src/shell.rs
+++ b/crates/nu-cli/src/shell.rs
@@ -4,6 +4,7 @@ pub(crate) mod completer;
 pub(crate) mod filesystem_shell;
 pub(crate) mod help_shell;
 pub(crate) mod helper;
+pub(crate) mod palette;
 pub(crate) mod shell;
 pub(crate) mod shell_manager;
 pub(crate) mod value_shell;

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -64,7 +64,7 @@ impl Highlighter for Helper {
         Painter::paint_string(
             line,
             &self.context.registry().clone_box(),
-            &DefaultPallet {},
+            &DefaultPalette {},
         )
     }
 
@@ -100,10 +100,10 @@ impl Painter {
         }
     }
 
-    pub fn paint_string<'l, P: Pallet>(
+    pub fn paint_string<'l, P: Palette>(
         line: &'l str,
         registry: &dyn SignatureRegistry,
-        pallet: &P,
+        palette: &P,
     ) -> Cow<'l, str> {
         let lite_block = nu_parser::lite_parse(line, 0);
 
@@ -116,7 +116,7 @@ impl Painter {
                 let mut painter = Painter::new(line);
 
                 for shape in shapes {
-                    painter.paint_shape(&shape, pallet);
+                    painter.paint_shape(&shape, palette);
                 }
 
                 Cow::Owned(painter.into_string())
@@ -124,8 +124,8 @@ impl Painter {
         }
     }
 
-    fn paint_shape<P: Pallet>(&mut self, shape: &Spanned<FlatShape>, pallet: &P) {
-        pallet
+    fn paint_shape<P: Palette>(&mut self, shape: &Spanned<FlatShape>, palette: &P) {
+        palette
             .styles_for_shape(shape)
             .iter()
             .for_each(|x| self.paint(x));
@@ -177,13 +177,13 @@ impl rustyline::Helper for Helper {}
 // In the future we can implement this for custom multi-line support
 impl rustyline::validate::Validator for Helper {}
 
-pub trait Pallet {
+pub trait Palette {
     fn styles_for_shape(&self, shape: &Spanned<FlatShape>) -> Vec<Spanned<Style>>;
 }
 
-pub struct DefaultPallet {}
+pub struct DefaultPalette {}
 
-impl Pallet for DefaultPallet {
+impl Palette for DefaultPalette {
     fn styles_for_shape(&self, shape: &Spanned<FlatShape>) -> Vec<Spanned<Style>> {
         match &shape.item {
             FlatShape::OpenDelimiter(_) => single_style_span(Color::White.normal(), shape.span),

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -1,8 +1,9 @@
 use crate::context::Context;
+use crate::shell::palette::{DefaultPalette, Palette};
 use ansi_term::{Color, Style};
 use nu_parser::SignatureRegistry;
 use nu_protocol::hir::FlatShape;
-use nu_source::{Span, Spanned, Tag, Tagged};
+use nu_source::{Spanned, Tag, Tagged};
 use rustyline::completion::Completer;
 use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
@@ -176,63 +177,3 @@ impl rustyline::Helper for Helper {}
 // Use default validator for normal single line behaviour
 // In the future we can implement this for custom multi-line support
 impl rustyline::validate::Validator for Helper {}
-
-pub trait Palette {
-    fn styles_for_shape(&self, shape: &Spanned<FlatShape>) -> Vec<Spanned<Style>>;
-}
-
-pub struct DefaultPalette {}
-
-impl Palette for DefaultPalette {
-    fn styles_for_shape(&self, shape: &Spanned<FlatShape>) -> Vec<Spanned<Style>> {
-        match &shape.item {
-            FlatShape::OpenDelimiter(_) => single_style_span(Color::White.normal(), shape.span),
-            FlatShape::CloseDelimiter(_) => single_style_span(Color::White.normal(), shape.span),
-            FlatShape::ItVariable | FlatShape::Keyword => {
-                single_style_span(Color::Purple.bold(), shape.span)
-            }
-            FlatShape::Variable | FlatShape::Identifier => {
-                single_style_span(Color::Purple.normal(), shape.span)
-            }
-            FlatShape::Type => single_style_span(Color::Blue.bold(), shape.span),
-            FlatShape::Operator => single_style_span(Color::Yellow.normal(), shape.span),
-            FlatShape::DotDot => single_style_span(Color::Yellow.bold(), shape.span),
-            FlatShape::Dot => single_style_span(Style::new().fg(Color::White), shape.span),
-            FlatShape::InternalCommand => single_style_span(Color::Cyan.bold(), shape.span),
-            FlatShape::ExternalCommand => single_style_span(Color::Cyan.normal(), shape.span),
-            FlatShape::ExternalWord => single_style_span(Color::Green.bold(), shape.span),
-            FlatShape::BareMember => single_style_span(Color::Yellow.bold(), shape.span),
-            FlatShape::StringMember => single_style_span(Color::Yellow.bold(), shape.span),
-            FlatShape::String => single_style_span(Color::Green.normal(), shape.span),
-            FlatShape::Path => single_style_span(Color::Cyan.normal(), shape.span),
-            FlatShape::GlobPattern => single_style_span(Color::Cyan.bold(), shape.span),
-            FlatShape::Word => single_style_span(Color::Green.normal(), shape.span),
-            FlatShape::Pipe => single_style_span(Color::Purple.bold(), shape.span),
-            FlatShape::Flag => single_style_span(Color::Blue.bold(), shape.span),
-            FlatShape::ShorthandFlag => single_style_span(Color::Blue.bold(), shape.span),
-            FlatShape::Int => single_style_span(Color::Purple.bold(), shape.span),
-            FlatShape::Decimal => single_style_span(Color::Purple.bold(), shape.span),
-            FlatShape::Whitespace | FlatShape::Separator => {
-                single_style_span(Color::White.normal(), shape.span)
-            }
-            FlatShape::Comment => single_style_span(Color::Green.bold(), shape.span),
-            FlatShape::Garbage => {
-                single_style_span(Style::new().fg(Color::White).on(Color::Red), shape.span)
-            }
-            FlatShape::Size { number, unit } => vec![
-                Spanned::<Style> {
-                    span: *number,
-                    item: Color::Purple.bold(),
-                },
-                Spanned::<Style> {
-                    span: *unit,
-                    item: Color::Cyan.bold(),
-                },
-            ],
-        }
-    }
-}
-
-fn single_style_span(style: Style, span: Span) -> Vec<Spanned<Style>> {
-    vec![Spanned::<Style> { span, item: style }]
-}

--- a/crates/nu-cli/src/shell/palette.rs
+++ b/crates/nu-cli/src/shell/palette.rs
@@ -1,0 +1,63 @@
+use ansi_term::{Color, Style};
+use nu_protocol::hir::FlatShape;
+use nu_source::{Span, Spanned};
+
+pub trait Palette {
+    fn styles_for_shape(&self, shape: &Spanned<FlatShape>) -> Vec<Spanned<Style>>;
+}
+
+pub struct DefaultPalette {}
+
+impl Palette for DefaultPalette {
+    fn styles_for_shape(&self, shape: &Spanned<FlatShape>) -> Vec<Spanned<Style>> {
+        match &shape.item {
+            FlatShape::OpenDelimiter(_) => single_style_span(Color::White.normal(), shape.span),
+            FlatShape::CloseDelimiter(_) => single_style_span(Color::White.normal(), shape.span),
+            FlatShape::ItVariable | FlatShape::Keyword => {
+                single_style_span(Color::Purple.bold(), shape.span)
+            }
+            FlatShape::Variable | FlatShape::Identifier => {
+                single_style_span(Color::Purple.normal(), shape.span)
+            }
+            FlatShape::Type => single_style_span(Color::Blue.bold(), shape.span),
+            FlatShape::Operator => single_style_span(Color::Yellow.normal(), shape.span),
+            FlatShape::DotDot => single_style_span(Color::Yellow.bold(), shape.span),
+            FlatShape::Dot => single_style_span(Style::new().fg(Color::White), shape.span),
+            FlatShape::InternalCommand => single_style_span(Color::Cyan.bold(), shape.span),
+            FlatShape::ExternalCommand => single_style_span(Color::Cyan.normal(), shape.span),
+            FlatShape::ExternalWord => single_style_span(Color::Green.bold(), shape.span),
+            FlatShape::BareMember => single_style_span(Color::Yellow.bold(), shape.span),
+            FlatShape::StringMember => single_style_span(Color::Yellow.bold(), shape.span),
+            FlatShape::String => single_style_span(Color::Green.normal(), shape.span),
+            FlatShape::Path => single_style_span(Color::Cyan.normal(), shape.span),
+            FlatShape::GlobPattern => single_style_span(Color::Cyan.bold(), shape.span),
+            FlatShape::Word => single_style_span(Color::Green.normal(), shape.span),
+            FlatShape::Pipe => single_style_span(Color::Purple.bold(), shape.span),
+            FlatShape::Flag => single_style_span(Color::Blue.bold(), shape.span),
+            FlatShape::ShorthandFlag => single_style_span(Color::Blue.bold(), shape.span),
+            FlatShape::Int => single_style_span(Color::Purple.bold(), shape.span),
+            FlatShape::Decimal => single_style_span(Color::Purple.bold(), shape.span),
+            FlatShape::Whitespace | FlatShape::Separator => {
+                single_style_span(Color::White.normal(), shape.span)
+            }
+            FlatShape::Comment => single_style_span(Color::Green.bold(), shape.span),
+            FlatShape::Garbage => {
+                single_style_span(Style::new().fg(Color::White).on(Color::Red), shape.span)
+            }
+            FlatShape::Size { number, unit } => vec![
+                Spanned::<Style> {
+                    span: *number,
+                    item: Color::Purple.bold(),
+                },
+                Spanned::<Style> {
+                    span: *unit,
+                    item: Color::Cyan.bold(),
+                },
+            ],
+        }
+    }
+}
+
+fn single_style_span(style: Style, span: Span) -> Vec<Spanned<Style>> {
+    vec![Spanned::<Style> { span, item: style }]
+}


### PR DESCRIPTION
As stated in #1798, we'd like to be able to support user defined color schemes. The first step in this process seems to be abstracting out the ability to style spans. In this PR, we introduce the `Pallet` trait. The only implementor at the moment is the `DefaultPallet`, however, as stated in #1798 we aim to eventually be able to define our own base16 file format and then create a Pallet that can use those files.

I'd like to actually put the Pallet code in it's own file, but I kept getting compile errors like
```
103 |     pub fn paint_string<'l, P: Pallet>(
    |                                ^^^^^^ not found in this scope
```

I think this is due to my lack of knowledge on the Rust module system. Any guidance here would be much appreciated.

Also, we should probably discuss whether or not `paint_string` should remain a static function. It's starting to take in several parameters now and it might just be worth making it a method.