### PR TITLE
Check capture group count

### DIFF
--- a/crates/nu_plugin_parse/src/nu/mod.rs
+++ b/crates/nu_plugin_parse/src/nu/mod.rs
@@ -61,9 +61,8 @@ impl Plugin for Parse {
                     if self.column_names.len() != group_count {
                         return Err(ShellError::labeled_error(
                             format!(
-                                "The are {} column(s) specified: [{}], but there are only {} regex match(es): [{}]",
+                                "There are {} column(s) specified in the pattern, but could only match the first {}: [{}]",
                                 self.column_names.len(),
-                                self.column_names.join(", "),
                                 group_count,
                                 caps.iter()
                                     .skip(1)
@@ -84,7 +83,7 @@ impl Plugin for Parse {
                                     .collect::<Vec<String>>()
                                     .join(", ")
                             ),
-                            "the number of regex matches does not equal the number of columns specified here",
+                            "could not match all columns in pattern",
                             &self.pattern_tag,
                         ));
                     }

--- a/crates/nu_plugin_parse/src/nu/mod.rs
+++ b/crates/nu_plugin_parse/src/nu/mod.rs
@@ -67,7 +67,7 @@ impl Plugin for Parse {
                                 group_count,
                                 caps.iter()
                                     .skip(1)
-                                    .map(|m| 
+                                    .map(|m| {
                                         if let Some(m) = m {
                                             let m = m.as_str();
                                             let mut m = m.replace(",","\\,");
@@ -79,7 +79,8 @@ impl Plugin for Parse {
                                             }
                                         } else {
                                             "<none>".to_string()
-                                        })
+                                        }
+                                    })
                                     .collect::<Vec<String>>()
                                     .join(", ")
                             ),

--- a/crates/nu_plugin_parse/src/nu/mod.rs
+++ b/crates/nu_plugin_parse/src/nu/mod.rs
@@ -61,18 +61,29 @@ impl Plugin for Parse {
                     if self.column_names.len() != group_count {
                         return Err(ShellError::labeled_error(
                             format!(
-                                "Found {} {} [{}], but expected {} for columns [{}]",
+                                "The are {} column(s) specified: [{}], but there are only {} regex match(es): [{}]",
+                                self.column_names.len(),
+                                self.column_names.join(", "),
                                 group_count,
-                                if group_count == 1 { "match" } else { "matches" },
                                 caps.iter()
                                     .skip(1)
-                                    .map(|g| g.map_or("<none>", |g| g.as_str()).to_string())
+                                    .map(|m| 
+                                        if let Some(m) = m {
+                                            let m = m.as_str();
+                                            let mut m = m.replace(",","\\,");
+                                            if m.len() > 20 {
+                                                m.truncate(17);
+                                                format!("{}...", m)
+                                            } else {
+                                                m
+                                            }
+                                        } else {
+                                            "<none>".to_string()
+                                        })
                                     .collect::<Vec<String>>()
-                                    .join(", "),
-                                self.column_names.len(),
-                                self.column_names.join(", ")
+                                    .join(", ")
                             ),
-                            "expected columns",
+                            "the number of regex matches does not equal the number of columns specified here",
                             &self.pattern_tag,
                         ));
                     }

--- a/crates/nu_plugin_parse/src/parse.rs
+++ b/crates/nu_plugin_parse/src/parse.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 pub struct Parse {
     pub regex: Regex,
     pub name: Tag,
+    pub pattern_tag: Tag,
     pub column_names: Vec<String>,
 }
 
@@ -13,6 +14,7 @@ impl Parse {
         Ok(Parse {
             regex: Regex::new("")?,
             name: Tag::unknown(),
+            pattern_tag: Tag::unknown(),
             column_names: vec![],
         })
     }


### PR DESCRIPTION
Addresses first part of #1797
>Prevent the panic from ever occurring. I'd recommend checking the number of capture groups against the number of column names.

Output for the input given in that bug:
```
     Running `target/debug/nu --commands 'echo "tests.html" | parse "{filename}[.{ext}]?"'`
error: The are 2 column(s) specified: [filename, ext], but there are only 1 regex match(es): [tests.html]
- shell:1:47
1 | echo "tests.html" | parse "{filename}[.{ext}]?"
  |                           ^^^^^^^^^^^^^^^^^^^^^ the number of regex matches does not equal the number of columns specified here
```

and I thought it would also be good to bound the length of the error spew
```
     Running `target/debug/nu --commands 'echo "reallylongnametests.html" | parse "{filename}[.{ext}]?"'`
error: The are 2 column(s) specified: [filename, ext], but there are only 1 regex match(es): [reallylongnametes...]
- shell:1:61
1 | echo "reallylongnametests.html" | parse "{filename}[.{ext}]?"
  |                                         ^^^^^^^^^^^^^^^^^^^^^ the number of regex matches does not equal the number of columns specified here
```

I am new to Nu so looking for feedback!