### PR TITLE
Allow user to specify the indentation setting on the pretty flag for the to json command

### DIFF
--- a/crates/nu-cli/src/commands/to_json.rs
+++ b/crates/nu-cli/src/commands/to_json.rs
@@ -23,13 +23,13 @@ impl WholeStreamCommand for ToJSON {
         Signature::build("to json").named(
             "pretty",
             SyntaxShape::Int,
-            "Formats the json text with the provided indentation setting",
+            "Formats the JSON text with the provided indentation setting",
             Some('p'),
         )
     }
 
     fn usage(&self) -> &str {
-        "Converts table data into json text."
+        "Converts table data into JSON text."
     }
 
     fn run(
@@ -44,12 +44,12 @@ impl WholeStreamCommand for ToJSON {
         &[
             Example {
                 description:
-                    "Outputs an unformatted json string representing the contents of this table",
+                    "Outputs an unformatted JSON string representing the contents of this table",
                 example: "to json",
             },
             Example {
                 description:
-                    "Outputs a formatted json string representing the contents of this table with an indentation setting of 4 spaces",
+                    "Outputs a formatted JSON string representing the contents of this table with an indentation setting of 4 spaces",
                 example: "to json --pretty 4",
             },
         ]

--- a/crates/nu-cli/src/commands/to_json.rs
+++ b/crates/nu-cli/src/commands/to_json.rs
@@ -1,7 +1,9 @@
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use nu_errors::{CoerceInto, ShellError};
-use nu_protocol::{Primitive, ReturnSuccess, Signature, UnspannedPathMember, UntaggedValue, Value};
+use nu_protocol::{
+    Primitive, ReturnSuccess, Signature, SyntaxShape, UnspannedPathMember, UntaggedValue, Value,
+};
 use serde::Serialize;
 use serde_json::json;
 
@@ -18,7 +20,12 @@ impl WholeStreamCommand for ToJSON {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("to json").switch("pretty", "Formats the json text", Some('p'))
+        Signature::build("to json").named(
+            "pretty",
+            SyntaxShape::Int,
+            "Formats the json text with the provided indentation setting",
+            Some('p'),
+        )
     }
 
     fn usage(&self) -> &str {
@@ -37,13 +44,13 @@ impl WholeStreamCommand for ToJSON {
         &[
             Example {
                 description:
-                    "Outputs an unformatted JSON string representing the contents of this table",
+                    "Outputs an unformatted json string representing the contents of this table",
                 example: "to json",
             },
             Example {
                 description:
-                    "Outputs a formatted JSON string representing the contents of this table",
-                example: "to json --pretty",
+                    "Outputs a formatted json string representing the contents of this table with an indentation setting of 4 spaces",
+                example: "to json --pretty 4",
             },
         ]
     }
@@ -180,17 +187,19 @@ fn to_json(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream
                             if let Some(pretty_value) = &pretty {
                                 let mut pretty_format_failed = true;
 
-                                if let Ok(serde_json_value) = serde_json::from_str::<serde_json::Value>(serde_json_string.as_str()) {
-                                    let indentation_string = std::iter::repeat(" ").take(4).collect::<String>();
-                                    let serde_formatter = serde_json::ser::PrettyFormatter::with_indent(indentation_string.as_bytes());
-                                    let serde_buffer = Vec::new();
-                                    let mut serde_serializer = serde_json::Serializer::with_formatter(serde_buffer, serde_formatter);
-                                    let serde_json_object = json!(serde_json_value);
+                                if let Ok(pretty_u64) = pretty_value.as_u64() {
+                                    if let Ok(serde_json_value) = serde_json::from_str::<serde_json::Value>(serde_json_string.as_str()) {
+                                        let indentation_string = std::iter::repeat(" ").take(pretty_u64 as usize).collect::<String>();
+                                        let serde_formatter = serde_json::ser::PrettyFormatter::with_indent(indentation_string.as_bytes());
+                                        let serde_buffer = Vec::new();
+                                        let mut serde_serializer = serde_json::Serializer::with_formatter(serde_buffer, serde_formatter);
+                                        let serde_json_object = json!(serde_json_value);
 
-                                    if let Ok(()) = serde_json_object.serialize(&mut serde_serializer) {
-                                        if let Ok(ser_json_string) = String::from_utf8(serde_serializer.into_inner()) {
-                                            pretty_format_failed = false;
-                                            serde_json_string = ser_json_string
+                                        if let Ok(()) = serde_json_object.serialize(&mut serde_serializer) {
+                                            if let Ok(ser_json_string) = String::from_utf8(serde_serializer.into_inner()) {
+                                                pretty_format_failed = false;
+                                                serde_json_string = ser_json_string
+                                            }
                                         }
                                     }
                                 }

--- a/docs/commands/to-json.md
+++ b/docs/commands/to-json.md
@@ -4,7 +4,7 @@ Converts table data into json text.
 
 ## Flags
 
-* `-p`, `--pretty`: Formats the json text
+* `-p`, `--pretty` \<integer>: Formats the json text with the provided indentation setting
 
 ## Example
 

--- a/docs/commands/to-json.md
+++ b/docs/commands/to-json.md
@@ -1,10 +1,10 @@
 # to json
 
-Converts table data into json text.
+Converts table data into JSON text.
 
 ## Flags
 
-* `-p`, `--pretty` \<integer>: Formats the json text with the provided indentation setting
+* `-p`, `--pretty` \<integer>: Formats the JSON text with the provided indentation setting
 
 ## Example
 


### PR DESCRIPTION
By default, the new `to json` `--pretty` flag would set the output indentation automatically to 4 spaces, but I feel that others may want another value for this, such as 2.  This PR changes the flag such that it requires an unsigned int, which allows the user to specify their preferred indentation setting.

```
> cal -ymq --month-names --full-year 2020 | where friday == 13 | to json --pretty 2
[
  {
    "year": 2020,
    "quarter": 1,
    "month": "march",
    "sunday": 8,
    "monday": 9,
    "tuesday": 10,
    "wednesday": 11,
    "thursday": 12,
    "friday": 13,
    "saturday": 14
  },
  {
    "year": 2020,
    "quarter": 4,
    "month": "november",
    "sunday": 8,
    "monday": 9,
    "tuesday": 10,
    "wednesday": 11,
    "thursday": 12,
    "friday": 13,
    "saturday": 14
  }
]
```

```
> cal -ymq --month-names --full-year 2020 | where friday == 13 | to json --pretty 4
[
    {
        "year": 2020,
        "quarter": 1,
        "month": "march",
        "sunday": 8,
        "monday": 9,
        "tuesday": 10,
        "wednesday": 11,
        "thursday": 12,
        "friday": 13,
        "saturday": 14
    },
    {
        "year": 2020,
        "quarter": 4,
        "month": "november",
        "sunday": 8,
        "monday": 9,
        "tuesday": 10,
        "wednesday": 11,
        "thursday": 12,
        "friday": 13,
        "saturday": 14
    }
]
```