### PR TITLE
Remove interpretation of `Primitive::Nothing` as the number 0.

### DIFF
--- a/crates/nu-cli/src/data/base.rs
+++ b/crates/nu-cli/src/data/base.rs
@@ -153,13 +153,7 @@ fn coerce_compare_primitive(
         (Bytes(left), Decimal(right)) => {
             CompareValues::Decimals(BigDecimal::from(*left), right.clone())
         }
-        (Bytes(left), Nothing) => CompareValues::Ints(BigInt::from(*left), BigInt::from(0)),
-        (Nothing, Nothing) => CompareValues::Ints(BigInt::from(0), BigInt::from(0)),
-        (Nothing, Bytes(right)) => CompareValues::Ints(BigInt::from(0), BigInt::from(*right)),
-        (Int(left), Nothing) => CompareValues::Ints(left.clone(), BigInt::from(0)),
-        (Nothing, Int(right)) => CompareValues::Ints(BigInt::from(0), right.clone()),
-        (Decimal(left), Nothing) => CompareValues::Decimals(left.clone(), BigDecimal::from(0.0)),
-        (Nothing, Decimal(right)) => CompareValues::Decimals(BigDecimal::from(0.0), right.clone()),
+        (Nothing, Nothing) => CompareValues::Booleans(true, true),
         (String(left), String(right)) => CompareValues::String(left.clone(), right.clone()),
         (Line(left), String(right)) => CompareValues::String(left.clone(), right.clone()),
         (String(left), Line(right)) => CompareValues::String(left.clone(), right.clone()),

--- a/crates/nu-cli/src/data/types.rs
+++ b/crates/nu-cli/src/data/types.rs
@@ -26,10 +26,6 @@ impl ExtractType for bool {
                 value: UntaggedValue::Primitive(Primitive::Boolean(b)),
                 ..
             } => Ok(*b),
-            Value {
-                value: UntaggedValue::Primitive(Primitive::Nothing),
-                ..
-            } => Ok(false),
             other => Err(ShellError::type_error("Boolean", other.spanned_type_name())),
         }
     }

--- a/crates/nu-cli/tests/commands/cal.rs
+++ b/crates/nu-cli/tests/commands/cal.rs
@@ -33,7 +33,7 @@ fn cal_friday_the_thirteenths_in_2015() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        cal --full-year 2015 | where friday == 13 | count
+        cal --full-year 2015 | get friday | compact | where $it == 13 | count
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/where_.rs
+++ b/crates/nu-cli/tests/commands/where_.rs
@@ -14,7 +14,7 @@ fn filters_by_unit_size_comparison() {
 fn filters_with_nothing_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from json | where foo > 1 | get foo | sum | echo $it"#
+        r#"echo '[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from json | get foo | compact | where $it > 1 | sum | echo $it"#
     );
 
     assert_eq!(actual.out, "7");

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -105,7 +105,6 @@ impl num_traits::Zero for Primitive {
             Primitive::Int(int) => int.is_zero(),
             Primitive::Decimal(decimal) => decimal.is_zero(),
             Primitive::Bytes(size) => size.is_zero(),
-            Primitive::Nothing => true,
             _ => false,
         }
     }

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! nu {
         });
 
         let mut paths = $crate::shell_os_paths();
-        paths.push(test_bins);
+        paths.insert(0, test_bins);
 
         let paths_joined = match std::env::join_paths(paths.iter()) {
             Ok(all) => all,

--- a/crates/nu_plugin_average/src/average.rs
+++ b/crates/nu_plugin_average/src/average.rs
@@ -17,7 +17,6 @@ impl Average {
 
     pub fn average(&mut self, value: Value) -> Result<(), ShellError> {
         match &value.value {
-            UntaggedValue::Primitive(Primitive::Nothing) => Ok(()),
             UntaggedValue::Primitive(Primitive::Int(i)) => match &self.total {
                 Some(Value {
                     value: UntaggedValue::Primitive(Primitive::Int(j)),

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -25,6 +25,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
             | get name
             | ^echo $it
             | nu --testbin chop
+            | lines
             | nth 3
             | echo $it
             "#
@@ -89,8 +90,7 @@ fn invocation_handles_dot() {
         r#"
             echo $(open nu_times.csv)
             | get name
-            | ^echo $it
-            | nu --testbin chop
+            | nu --testbin chop $it
             | nth 3
             | echo $it
             "#


### PR DESCRIPTION
Closes https://github.com/nushell/nushell/issues/1833
Fixes https://github.com/nushell/nushell/issues/1783

`Nothing` should be regarded as an "absence of value". Use of it in any mathematical context should be regarded as an error, which we should propagate upwards. This PR doesn't deal with propagating errors, but does prevent it from behaving like zero in some contexts.