### PR TITLE
Add support for specifying max history size in config

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -568,6 +568,13 @@ pub async fn cli(
 
         rl.set_edit_mode(edit_mode);
 
+        let max_history_size = config::config(Tag::unknown())?
+            .get("history_size")
+            .map(|i| i.value.expect_int())
+            .unwrap_or(100);
+
+        rl.set_max_history_size(max_history_size as usize);
+
         let key_timeout = config::config(Tag::unknown())?
             .get("key_timeout")
             .map(|s| s.value.expect_int())

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -37,6 +37,7 @@ Syntax: `config {flags}`
 | table_mode      | "light" or other       | enable lightweight or normal tables                            |
 | edit_mode       | "vi" or "emacs"        | changes line editing to "vi" or "emacs" mode                   |
 | key_timeout     | integer (milliseconds) | vi: the delay to wait for a longer key sequence after ESC      |
+| history_size    | integer                | maximum entries that will be stored in history (100 default)   |
 | completion_mode | "circular" or "list"   | changes completion type to "circular" (default) or "list" mode |
 
 ## Examples


### PR DESCRIPTION
Closes #1829 

A few questions I have:

1. Where would tests for this live? Should this be tested?
2. Is casting to `usize` acceptable? I see it is done [here](https://github.com/nushell/nushell/blob/5f1136dcb07ef1c1a6adabe5ea332dcfd40a1301/crates/nu-cli/src/cli.rs#L576).
3. Is `history_size` acceptable as the parameter name?