### PR TITLE
Fix broken ordering of args when parsing command with env vars.

### DIFF
--- a/crates/nu-cli/tests/commands/with_env.rs
+++ b/crates/nu-cli/tests/commands/with_env.rs
@@ -19,3 +19,13 @@ fn with_env_shorthand() {
 
     assert_eq!(actual.out, "BARRRR");
 }
+
+#[test]
+fn shorthand_doesnt_reorder_arguments() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "FOO=BARRRR nu --testbin cococo first second"
+    );
+
+    assert_eq!(actual.out, "firstsecond");
+}

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1200,7 +1200,7 @@ fn expand_shorthand_forms(
                 if !lite_pipeline.commands[0].args.is_empty() {
                     let new_lite_command_name = lite_pipeline.commands[0].args[0].clone();
                     let mut new_lite_command_args = lite_pipeline.commands[0].args.clone();
-                    new_lite_command_args.swap_remove(0);
+                    new_lite_command_args.remove(0);
 
                     lite_pipeline.commands[0].name = new_lite_command_name;
                     lite_pipeline.commands[0].args = new_lite_command_args;

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .help("the nu script to run")
                 .index(1),
         )
+        .arg(
+            Arg::with_name("args")
+                .help("positional args (used by --testbin)")
+                .index(2)
+                .multiple(true),
+        )
         .get_matches();
 
     if let Some(bin) = matches.value_of("testbin") {


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/1795

`swap_remove` removes the element by swapping it with the last item. This means the ordering of arguments change, which can be detrimental to a command which cares about this ordering.