### PR TITLE
default history size to 100k

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -571,7 +571,7 @@ pub async fn cli(
         let max_history_size = config::config(Tag::unknown())?
             .get("history_size")
             .map(|i| i.value.expect_int())
-            .unwrap_or(100);
+            .unwrap_or(100_000);
 
         rl.set_max_history_size(max_history_size as usize);
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -37,7 +37,7 @@ Syntax: `config {flags}`
 | table_mode      | "light" or other       | enable lightweight or normal tables                            |
 | edit_mode       | "vi" or "emacs"        | changes line editing to "vi" or "emacs" mode                   |
 | key_timeout     | integer (milliseconds) | vi: the delay to wait for a longer key sequence after ESC      |
-| history_size    | integer                | maximum entries that will be stored in history (100 default)   |
+| history_size    | integer                | maximum entries that will be stored in history (100,000 default)   |
 | completion_mode | "circular" or "list"   | changes completion type to "circular" (default) or "list" mode |
 | no_auto_pivot   | boolean                | whether or not to automatically pivot single-row results       |
 


### PR DESCRIPTION
100k is ultimately an arbitrary number. This now raises the question of, do we need history size to be configurable at all?

https://github.com/fish-shell/fish-shell/issues/2674#issuecomment-171198612

> but the short answer is that fish uses a LRU list to manage history, that it's limited to 256k unique items, and that there's no configuration knob to control this