### PR TITLE
Update minimum Rust version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Try it in Gitpod.
 
 Up-to-date installation instructions can be found in the [installation chapter of the book](https://www.nushell.sh/book/en/installation.html).  **Windows users**: please note that Nu works on Windows 10 and does not currently have Windows 7/8.1 support.
 
-To build Nu, you will need to use the **latest stable (1.39 or later)** version of the compiler.
+To build Nu, you will need to use the **latest stable (1.41 or later)** version of the compiler.
 
 Required dependencies:
 


### PR DESCRIPTION
Commit a4c1b092baa86bb9c113ed3d85a96236a00eeb49 introduced uses of `map_or` on `Result`, which was [only stabilised in Rust 1.41](https://doc.rust-lang.org/nightly/src/core/result.rs.html#545).

Trying to build nushell on earlier versions of Rust fails:

```rust
error[E0599]: no method named `map_or` found for type `std::result::Result<std::string::String, nu_errors::ShellError>` in the current scope
   --> crates/nu-cli/src/format/table.rs:322:18
    |
322 |                 .map_or(Alignment::LEFT, |a| match a.to_lowercase().as_str() {
    |                  ^^^^^^ help: there is a method with a similar name: `map_err`

error[E0599]: no method named `map_or` found for type `std::result::Result<std::string::String, nu_errors::ShellError>` in the current scope
   --> crates/nu-cli/src/format/table.rs:330:27
    |
330 |             c.as_string().map_or(color::GREEN, |c| {
    |                           ^^^^^^ help: there is a method with a similar name: `map_err`

error[E0599]: no method named `map_or` found for type `std::result::Result<std::string::String, nu_errors::ShellError>` in the current scope
   --> crates/nu-cli/src/format/table.rs:342:26
    |
342 |                         .map_or(Attr::Bold, |s| str_to_style(s).unwrap_or(Attr::Bold))],
    |                          ^^^^^^ help: there is a method with a similar name: `map_err`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0599`.
error: failed to compile `nu v0.14.0 (/home/aaron/.cache/yay/nushell-stable/src/nushell-0.14.0)`, intermediate artifacts can be found at `/home/aaron/.cache/yay/nushell-stable/src/nushell-0.14.0/target`

Caused by:
  could not compile `nu-cli`.
```

This PR updates the README to reflect this new minimum version requirement.