### PR TITLE
Fix completer handling of paths with spaces

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -83,7 +83,8 @@ impl NuCompleter {
         for completion in &mut completions {
             // If the cursor is at a double-quote, remove the double-quote in the replacement
             // This prevents duplicate quotes
-            if line.chars().nth(pos).unwrap_or(' ') == '"' && completion.replacement.ends_with('"') {
+            let cursor_char = line.chars().nth(pos);
+            if cursor_char.unwrap_or(' ') == '"' && completion.replacement.ends_with('"') {
                 completion.replacement.pop();
             }
         }


### PR DESCRIPTION
Closes #1850.

This uses the `lite_parse` components of `nu_parser` to perform a more accurate parsing of arguments for completions, which means that it gets the correct start position for paths in quotes containing spaces.

If the parser fails here for some reason, it will fall back to the old "look for the closest space" algorithm to determine the completion start point.