### PR TITLE
Add `--regex` flag to `parse`

### DIFF
--- a/crates/nu-cli/tests/commands/parse.rs
+++ b/crates/nu-cli/tests/commands/parse.rs
@@ -1,11 +1,11 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::fs::Stub;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn extracts_fields_from_the_given_the_pattern() {
     Playground::setup("parse_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(vec![Stub::FileWithContentToBeTrimmed(
             "key_value_separated_arepa_ingredients.txt",
             r#"
                 VAR1=Cheese
@@ -27,4 +27,78 @@ fn extracts_fields_from_the_given_the_pattern() {
 
         assert_eq!(actual.out, "JonathanParsed");
     })
+}
+
+mod regex {
+    use super::*;
+
+    fn nushell_git_log_oneline<'a>() -> Vec<Stub<'a>> {
+        vec![Stub::FileWithContentToBeTrimmed(
+            "nushell_git_log_oneline.txt",
+            r#"
+                ae87582c Fix missing invocation errors (#1846)
+                b89976da let format access variables also (#1842)
+            "#,
+        )]
+    }
+
+    #[test]
+    fn extracts_fields_with_all_named_groups() {
+        Playground::setup("parse_test_regex_1", |dirs, sandbox| {
+            sandbox.with_files(nushell_git_log_oneline());
+
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                open nushell_git_log_oneline.txt
+                | parse --regex "(?P<Hash>\w+) (?P<Message>.+) \(#(?P<PR>\d+)\)"
+                | nth 1
+                | get PR
+                | echo $it
+            "#
+            ));
+
+            assert_eq!(actual.out, "1842");
+        })
+    }
+
+    #[test]
+    fn extracts_fields_with_all_unnamed_groups() {
+        Playground::setup("parse_test_regex_2", |dirs, sandbox| {
+            sandbox.with_files(nushell_git_log_oneline());
+
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                open nushell_git_log_oneline.txt
+                | parse --regex "(\w+) (.+) \(#(\d+)\)"
+                | nth 1
+                | get Capture1
+                | echo $it
+            "#
+            ));
+
+            assert_eq!(actual.out, "b89976da");
+        })
+    }
+
+    #[test]
+    fn extracts_fields_with_named_and_unnamed_groups() {
+        Playground::setup("parse_test_regex_3", |dirs, sandbox| {
+            sandbox.with_files(nushell_git_log_oneline());
+
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                open nushell_git_log_oneline.txt
+                | parse --regex "(?P<Hash>\w+) (.+) \(#(?P<PR>\d+)\)"
+                | nth 1
+                | get Capture2
+                | echo $it
+            "#
+            ));
+
+            assert_eq!(actual.out, "let format access variables also");
+        })
+    }
 }

--- a/crates/nu_plugin_parse/src/lib.rs
+++ b/crates/nu_plugin_parse/src/lib.rs
@@ -1,4 +1,4 @@
 mod nu;
 mod parse;
 
-pub use parse::Parse;
+pub use parse::{ColumnNames, Parse};

--- a/crates/nu_plugin_parse/src/parse.rs
+++ b/crates/nu_plugin_parse/src/parse.rs
@@ -5,8 +5,10 @@ pub struct Parse {
     pub regex: Regex,
     pub name: Tag,
     pub pattern_tag: Tag,
-    pub column_names: Vec<String>,
+    pub column_names: ColumnNames,
 }
+
+pub struct ColumnNames(pub Vec<String>);
 
 impl Parse {
     #[allow(clippy::trivial_regex)]
@@ -15,7 +17,7 @@ impl Parse {
             regex: Regex::new("")?,
             name: Tag::unknown(),
             pattern_tag: Tag::unknown(),
-            column_names: vec![],
+            column_names: ColumnNames(vec![]),
         })
     }
 }


### PR DESCRIPTION
Close #1831.

Not in this PR:
- proper escaping of patterns when `--regex` flag is not given

Things I'm not very happy about:

- `ColumnNames` is a nice abstraction for getting names both from `&[ParseCommand]` (by default) and `&Regex` (with `--regex`), but using `.0` everywhere is subpar
- `self.regex = Regex::new` lines are duplicated, because by default `self.column_names` are created before `self.regex`, and the other way around in case of `--regex`.

<details>
<summary>Testing logs</summary>

```
C:\Users\brigh\nushell(master)> git log --oneline | keep 2 | parse -r '(?P<hash>\w+) (?P<message>.+)'
───┬──────────┬──────────────────────────────────────────
 # │ hash     │ message 
───┼──────────┼──────────────────────────────────────────
 0 │ ae87582c │ Fix missing invocation errors (#1846)
 1 │ b89976da │ let format access variables also (#1842)
───┴──────────┴──────────────────────────────────────────

C:\Users\brigh\nushell(master)> git log --oneline | keep 2 | parse -r '(\w+) (?P<message>.+)'
───┬──────────┬──────────────────────────────────────────
 # │ Capture1 │ message
───┼──────────┼──────────────────────────────────────────
 0 │ ae87582c │ Fix missing invocation errors (#1846)
 1 │ b89976da │ let format access variables also (#1842)
───┴──────────┴──────────────────────────────────────────

C:\Users\brigh\nushell(master)> git log --oneline | keep 2 | parse -r '(?P<hash>\w+) (.+)'
───┬──────────┬──────────────────────────────────────────
 # │ hash     │ Capture2
───┼──────────┼──────────────────────────────────────────
 0 │ ae87582c │ Fix missing invocation errors (#1846)
 1 │ b89976da │ let format access variables also (#1842)
───┴──────────┴──────────────────────────────────────────
```

</details>