### PR TITLE
Add completion for binaries on PATH

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -3,10 +3,13 @@ use crate::context::CommandRegistry;
 use crate::data::config;
 use crate::prelude::*;
 use derive_new::new;
+#[cfg(windows)]
+use ichwh::utils::pathext;
 use ichwh::IchwhResult;
 use rustyline::completion::{Completer, FilenameCompleter};
 use std::collections::HashSet;
 use std::fs::{read_dir, DirEntry};
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -40,6 +40,7 @@ Syntax: `config {flags}`
 | history_size    | integer                | maximum entries that will be stored in history (100,000 default)   |
 | completion_mode | "circular" or "list"   | changes completion type to "circular" (default) or "list" mode |
 | no_auto_pivot   | boolean                | whether or not to automatically pivot single-row results       |
+| no_bin_complete | boolean                | whether or not to complete names of binaries on PATH           |
 
 ## Examples
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -29,18 +29,18 @@ Syntax: `config {flags}`
 
 ### Variables
 
-| Variable        | Type                   | Description                                                    |
-| --------------- | ---------------------- | -------------------------------------------------------------- |
-| path            | table of strings       | PATH to use to find binaries                                   |
-| env             | row                    | the environment variables to pass to external commands         |
-| ctrlc_exit      | boolean                | whether or not to exit Nu after multiple ctrl-c presses        |
-| table_mode      | "light" or other       | enable lightweight or normal tables                            |
-| edit_mode       | "vi" or "emacs"        | changes line editing to "vi" or "emacs" mode                   |
-| key_timeout     | integer (milliseconds) | vi: the delay to wait for a longer key sequence after ESC      |
-| history_size    | integer                | maximum entries that will be stored in history (100,000 default)   |
-| completion_mode | "circular" or "list"   | changes completion type to "circular" (default) or "list" mode |
-| no_auto_pivot   | boolean                | whether or not to automatically pivot single-row results       |
-| no_bin_complete | boolean                | whether or not to complete names of binaries on PATH           |
+| Variable           | Type                   | Description                                                         |
+| ------------------ | ---------------------- | ------------------------------------------------------------------- |
+| path               | table of strings       | PATH to use to find binaries                                        |
+| env                | row                    | the environment variables to pass to external commands              |
+| ctrlc_exit         | boolean                | whether or not to exit Nu after multiple ctrl-c presses             |
+| table_mode         | "light" or other       | enable lightweight or normal tables                                 |
+| edit_mode          | "vi" or "emacs"        | changes line editing to "vi" or "emacs" mode                        |
+| key_timeout        | integer (milliseconds) | vi: the delay to wait for a longer key sequence after ESC           |
+| history_size       | integer                | maximum entries that will be stored in history (100,000 default)    |
+| completion_mode    | "circular" or "list"   | changes completion type to "circular" (default) or "list" mode      |
+| no_auto_pivot      | boolean                | whether or not to automatically pivot single-row results            |
+| complete_from_path | boolean                | whether or not to complete names of binaries on PATH (default true) |
 
 ## Examples
 


### PR DESCRIPTION
This PR adds completion for executables found on the user's PATH, just like how built-in commands such as `ls` and `version` are currently completed.

The `no_bin_complete` config option can be set to `$true` to disable this behaviour.

This also alters the behaviour of where certain autocompletion options are available, making commands and executables only appear as autocompletion options when the user is typing a command, and not when they are typing its arguments. For example, `echo ver<tab>` used to complete to `echo version` because of the existence of the `version` command, which isn't ideal; this kind of completion no longer occurs.