### PR TITLE
Add space to bottom of table in 'light' mode

### DIFF
--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -262,6 +262,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                         table.set_format(
                                             FormatBuilder::new()
                                                 .separator(LinePosition::Title, LineSeparator::new('─', '─', ' ', ' '))
+                                                .separator(LinePosition::Bottom, LineSeparator::new(' ', ' ', ' ', ' '))
                                                 .padding(1, 1)
                                                 .build(),
                                         );

--- a/crates/nu-cli/src/format/table.rs
+++ b/crates/nu-cli/src/format/table.rs
@@ -357,6 +357,7 @@ impl RenderView for TableView {
                 table.set_format(
                     FormatBuilder::new()
                         .separator(LinePosition::Title, LineSeparator::new('─', '─', ' ', ' '))
+                        .separator(LinePosition::Bottom, LineSeparator::new(' ', ' ', ' ', ' '))
                         .padding(1, 1)
                         .build(),
                 );


### PR DESCRIPTION
Adds an empty line to the end of tables in "light" mode for added readability between tables.

Closes #1806 