### PR TITLE
Add --to-float to str plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,6 +2319,7 @@ dependencies = [
 name = "nu-plugin"
 version = "0.14.1"
 dependencies = [
+ "bigdecimal",
  "indexmap",
  "nu-build",
  "nu-errors",
@@ -2531,6 +2532,7 @@ dependencies = [
 name = "nu_plugin_str"
 version = "0.14.1"
 dependencies = [
+ "bigdecimal",
  "chrono",
  "nu-build",
  "nu-errors",

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -179,7 +179,13 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                 value: UntaggedValue::Primitive(Primitive::Decimal(n)),
                                 ..
                             } => {
-                                out!("{}", n);
+                                // TODO: normalize decimal to remove trailing zeros.
+                                // normalization will be available in next release of bigdecimal crate
+                                let mut output = n.to_string().trim_end_matches('0').to_owned();
+                                if(output.ends_with('.')) {
+                                    output.push('0');
+                                }
+                                out!("{}", output);
                             }
                             Value {
                                 value: UntaggedValue::Primitive(Primitive::Boolean(b)),

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -181,8 +181,11 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                             } => {
                                 // TODO: normalize decimal to remove trailing zeros.
                                 // normalization will be available in next release of bigdecimal crate
-                                let mut output = n.to_string().trim_end_matches('0').to_owned();
-                                if(output.ends_with('.')) {
+                                let mut output = n.to_string();
+                                if output.contains('.') {
+                                    output = output.trim_end_matches('0').to_owned();
+                                }
+                                if output.ends_with('.') {
                                     output.push('0');
                                 }
                                 out!("{}", output);

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -19,6 +19,7 @@ indexmap = { version = "1.3.2", features = ["serde-1"] }
 serde = { version = "1.0.110", features = ["derive"] }
 num-bigint = { version = "0.2.6", features = ["serde"] }
 serde_json = "1.0.53"
+bigdecimal = { version = "0.1.2", features = ["serde"] }
 
 [build-dependencies]
 nu-build = { version = "0.14.1", path = "../nu-build" }

--- a/crates/nu-plugin/src/test_helpers.rs
+++ b/crates/nu-plugin/src/test_helpers.rs
@@ -172,12 +172,12 @@ pub fn expect_return_value_at(
 }
 
 pub mod value {
+    use bigdecimal::BigDecimal;
     use nu_errors::ShellError;
     use nu_protocol::{Primitive, TaggedDictBuilder, UntaggedValue, Value};
     use nu_source::Tag;
     use nu_value_ext::ValueExt;
     use num_bigint::BigInt;
-    use bigdecimal::BigDecimal;
 
     pub fn get_data(for_value: Value, key: &str) -> Value {
         for_value.get_data(&key.to_string()).borrow().clone()
@@ -187,7 +187,7 @@ pub mod value {
         UntaggedValue::Primitive(Primitive::Int(i.into())).into_untagged_value()
     }
 
-    pub fn decimal(f: impl Into<BigDecimal>) -> Value  {
+    pub fn decimal(f: impl Into<BigDecimal>) -> Value {
         UntaggedValue::Primitive(Primitive::Decimal(f.into())).into_untagged_value()
     }
 

--- a/crates/nu-plugin/src/test_helpers.rs
+++ b/crates/nu-plugin/src/test_helpers.rs
@@ -177,6 +177,7 @@ pub mod value {
     use nu_source::Tag;
     use nu_value_ext::ValueExt;
     use num_bigint::BigInt;
+    use bigdecimal::BigDecimal;
 
     pub fn get_data(for_value: Value, key: &str) -> Value {
         for_value.get_data(&key.to_string()).borrow().clone()
@@ -184,6 +185,10 @@ pub mod value {
 
     pub fn int(i: impl Into<BigInt>) -> Value {
         UntaggedValue::Primitive(Primitive::Int(i.into())).into_untagged_value()
+    }
+
+    pub fn decimal(f: impl Into<BigDecimal>) -> Value  {
+        UntaggedValue::Primitive(Primitive::Decimal(f.into())).into_untagged_value()
     }
 
     pub fn string(input: impl Into<String>) -> Value {

--- a/crates/nu_plugin_str/Cargo.toml
+++ b/crates/nu_plugin_str/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.11", features = ["serde"] }
 
 regex = "1"
 num-bigint = "0.2.6"
+bigdecimal = { version = "0.1.2", features = ["serde"] }
 
 [build-dependencies]
 nu-build = { version = "0.14.1", path = "../nu-build" }

--- a/crates/nu_plugin_str/src/nu/mod.rs
+++ b/crates/nu_plugin_str/src/nu/mod.rs
@@ -19,6 +19,7 @@ impl Plugin for Str {
             .switch("downcase", "convert string to lowercase", Some('d'))
             .switch("upcase", "convert string to uppercase", Some('U'))
             .switch("to-int", "convert string to integer", Some('i'))
+            .switch("to-float", "convert string to float", Some('F'))
             .switch("trim", "trims the string", Some('t'))
             .named(
                 "replace",
@@ -65,6 +66,9 @@ impl Plugin for Str {
         }
         if args.has("to-int") {
             self.for_to_int();
+        }
+        if args.has("to-float") {
+            self.for_to_float();
         }
         if args.has("substring") {
             if let Some(start_end) = args.get("substring") {

--- a/crates/nu_plugin_str/src/nu/tests.rs
+++ b/crates/nu_plugin_str/src/nu/tests.rs
@@ -3,7 +3,7 @@ mod integration {
     use crate::Str;
     use nu_errors::ShellError;
     use nu_plugin::test_helpers::value::{
-        column_path, get_data, int, string, structured_sample_record, table,
+        column_path, get_data, int, decimal, string, structured_sample_record, table,
         unstructured_sample_record,
     };
     use nu_plugin::test_helpers::{expect_return_value_at, plugin, CallStub};
@@ -89,6 +89,13 @@ mod integration {
         plugin(&mut Str::new())
             .args(CallStub::new().with_long_flag("to-int").create())
             .setup(|plugin, _| plugin.expect_action(Action::ToInteger));
+    }
+
+    #[test]
+    fn picks_up_to_float_flag() {
+        plugin(&mut Str::new())
+            .args(CallStub::new().with_long_flag("to-float").create())
+            .setup(|plugin, _| plugin.expect_action(Action::ToFloat));
     }
 
     #[test]
@@ -257,6 +264,25 @@ mod integration {
         let actual = expect_return_value_at(run, 0);
 
         assert_eq!(get_data(actual, "Nu_birthday"), int(10));
+        Ok(())
+    }
+    #[test]
+    fn converts_the_input_to_float_using_the_field_passed_as_parameter() -> Result<(), ShellError>
+    {
+        let run = plugin(&mut Str::new())
+            .args(
+                CallStub::new()
+                    .with_long_flag("to-float")
+                    .with_parameter("PI")?
+                    .create(),
+            )
+            .input(structured_sample_record("PI", "3.1415"))
+            .setup(|_, _| {})
+            .test();
+
+        let actual = expect_return_value_at(run, 0);
+
+        assert_eq!(get_data(actual, "PI"), decimal(3.1415));
         Ok(())
     }
 

--- a/crates/nu_plugin_str/src/nu/tests.rs
+++ b/crates/nu_plugin_str/src/nu/tests.rs
@@ -3,7 +3,7 @@ mod integration {
     use crate::Str;
     use nu_errors::ShellError;
     use nu_plugin::test_helpers::value::{
-        column_path, get_data, int, decimal, string, structured_sample_record, table,
+        column_path, decimal, get_data, int, string, structured_sample_record, table,
         unstructured_sample_record,
     };
     use nu_plugin::test_helpers::{expect_return_value_at, plugin, CallStub};
@@ -267,8 +267,7 @@ mod integration {
         Ok(())
     }
     #[test]
-    fn converts_the_input_to_float_using_the_field_passed_as_parameter() -> Result<(), ShellError>
-    {
+    fn converts_the_input_to_float_using_the_field_passed_as_parameter() -> Result<(), ShellError> {
         let run = plugin(&mut Str::new())
             .args(
                 CallStub::new()

--- a/crates/nu_plugin_str/src/strutils.rs
+++ b/crates/nu_plugin_str/src/strutils.rs
@@ -1,5 +1,6 @@
 extern crate chrono;
 
+use bigdecimal::BigDecimal;
 use chrono::DateTime;
 use nu_errors::ShellError;
 use nu_protocol::{did_you_mean, ColumnPath, Primitive, ShellTypeName, UntaggedValue, Value};
@@ -7,7 +8,6 @@ use nu_source::{span_for_spanned_list, Tagged};
 use nu_value_ext::ValueExt;
 use regex::Regex;
 use std::cmp;
-use bigdecimal::BigDecimal;
 use std::str::FromStr;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -95,12 +95,10 @@ impl Str {
                     Ok(v) => UntaggedValue::int(v),
                     Err(_) => UntaggedValue::string(input),
                 }
-            },
-            Some(Action::ToFloat) => {
-                match BigDecimal::from_str(input.trim()) {
-                    Ok(v) => UntaggedValue::decimal(v),
-                    Err(_) => UntaggedValue::string(input),
-                }
+            }
+            Some(Action::ToFloat) => match BigDecimal::from_str(input.trim()) {
+                Ok(v) => UntaggedValue::decimal(v),
+                Err(_) => UntaggedValue::string(input),
             },
             Some(Action::ToDateTime(dt)) => match DateTime::parse_from_str(input, dt) {
                 Ok(d) => UntaggedValue::date(d),
@@ -253,7 +251,7 @@ impl Str {
 pub mod tests {
     use super::ReplaceAction;
     use super::Str;
-    use nu_plugin::test_helpers::value::{int, decimal, string};
+    use nu_plugin::test_helpers::value::{decimal, int, string};
 
     #[test]
     fn trim() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/plugins/core_str.rs
+++ b/tests/plugins/core_str.rs
@@ -9,7 +9,7 @@ fn can_only_apply_one() {
         "open caco3_plastics.csv | first 1 | str origin --downcase --upcase"
     );
 
-    assert!(actual.err.contains(r#"--capitalize|--downcase|--upcase|--to-int|--substring "start,end"|--replace|--find-replace [pattern replacement]|to-date-time|--trim]"#));
+    assert!(actual.err.contains(r#"--capitalize|--downcase|--upcase|--to-int|--to-float|--substring "start,end"|--replace|--find-replace [pattern replacement]|to-date-time|--trim]"#));
 }
 
 #[test]
@@ -129,6 +129,21 @@ fn converts_to_int() {
     ));
 
     assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn converts_to_float() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            echo "3.1, 0.0415"
+            | split-row ","
+            | str --to-float
+            | sum
+        "#
+    ));
+
+    assert_eq!(actual.out, "3.1415");
 }
 
 #[test]

--- a/tests/plugins/core_str.rs
+++ b/tests/plugins/core_str.rs
@@ -137,7 +137,7 @@ fn converts_to_float() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             echo "3.1, 0.0415"
-            | split-row ","
+            | split row ","
             | str --to-float
             | sum
         "#


### PR DESCRIPTION
Hello, 

I thought I will give a try and implement this ( #1354 )  while I'm in process of learning rust. At current stage it works but I do have small problem with float representation after conversion - final result has too many trailing zeros and [one my test](https://github.com/nushell/nushell/pull/1872/files#diff-f6135a125bc0a55b9b470fca0e4223e0) [tests/plugins/core_str.rs] fails because of it (Should be visible on CI). For example If I pass to CLI `echo "3.1415" | str --to-float` I do get `3.141500000000000`. 

I did track it down to the following place: https://github.com/nushell/nushell/blob/9e6ab33fd76a1e5e1cbe5f75b693165b56982bf6/crates/nu-cli/src/commands/autoview.rs#L178-L183 It looks like final format before it is pushed to screen but I can't get this right. Is this right direction, or I'm trying to change something that I shouldn't touch?

Closes #1354 