### PR TITLE
change the test to use the origin column

### DIFF
--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -22,7 +22,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
         cwd: dirs.test(), pipeline(
         r#"
             open nu_times.csv
-            | get name
+            | get origin
             | ^echo $it
             | nu --testbin chop
             | lines
@@ -31,7 +31,8 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
             "#
         ));
 
-        assert_eq!(actual.out, "AndKitKat");
+        // chop will remove the last escaped double quote from \"Estados Unidos\" 
+        assert_eq!(actual.out, "\"Estados Unidos");
     })
 }
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -31,7 +31,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
             "#
         ));
 
-        // chop will remove the last escaped double quote from \"Estados Unidos\" 
+        // chop will remove the last escaped double quote from \"Estados Unidos\"
         assert_eq!(actual.out, "\"Estados Unidos");
     })
 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -26,13 +26,13 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
             | ^echo $it
             | nu --testbin chop
             | lines
-            | nth 3
+            | nth 2
             | echo $it
             "#
         ));
 
         // chop will remove the last escaped double quote from \"Estados Unidos\"
-        assert_eq!(actual.out, "\"Estados Unidos");
+        assert_eq!(actual.out, "Ecuado");
     })
 }
 


### PR DESCRIPTION
Fixes #1877 

Rather than change Andrés name, I opted to use the `origin` column from the csv. The assertion is a little strange, because the string `\"Estados Unidos\" ` is passed to `chop`. The last escaped quote is chopped off, which looks awkward to me, but is correct.