### PR TITLE
Merge pivot options

### DIFF
--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -86,16 +86,14 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
         Auto,
         Always,
         Never,
-        ToFit,
     }
 
     let pivot_mode = crate::data::config::config(Tag::unknown());
     let pivot_mode = if let Some(v) = pivot_mode?.get("pivot_mode") {
         match v.as_string() {
-            Ok(m) if m.to_lowercase() == "auto" => AutoPivotMode::ToFit,
+            Ok(m) if m.to_lowercase() == "auto" => AutoPivotMode::Auto,
             Ok(m) if m.to_lowercase() == "always" => AutoPivotMode::Always,
             Ok(m) if m.to_lowercase() == "never" => AutoPivotMode::Never,
-            Ok(m) if m.to_lowercase() == "tofit" => AutoPivotMode::ToFit,
             _ => AutoPivotMode::Always,
         }
     } else {
@@ -249,8 +247,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
 
                             Value { value: UntaggedValue::Row(row), ..} 
                                 if pivot_mode == AutoPivotMode::Always || 
-                                ((pivot_mode == AutoPivotMode::ToFit || 
-                                    pivot_mode == AutoPivotMode::Auto) &&
+                                (pivot_mode == AutoPivotMode::Auto &&
                                 (row.entries.iter().map(|(k,v)| v.convert_to_string())
                                 .collect::<Vec<_>>().iter()
                                 .fold(0, |acc, len| acc + len.len())

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -245,8 +245,8 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                 yield Err(e);
                             }
 
-                            Value { value: UntaggedValue::Row(row), ..} 
-                                if pivot_mode == AutoPivotMode::Always || 
+                            Value { value: UntaggedValue::Row(row), ..}
+                                if pivot_mode == AutoPivotMode::Always ||
                                 (pivot_mode == AutoPivotMode::Auto &&
                                 (row.entries.iter().map(|(k,v)| v.convert_to_string())
                                 .collect::<Vec<_>>().iter()

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -39,7 +39,7 @@ Syntax: `config {flags}`
 | key_timeout        | integer (milliseconds) | vi: the delay to wait for a longer key sequence after ESC           |
 | history_size       | integer                | maximum entries that will be stored in history (100,000 default)    |
 | completion_mode    | "circular" or "list"   | changes completion type to "circular" (default) or "list" mode      |
-| no_auto_pivot      | boolean                | whether or not to automatically pivot single-row results            |
+| pivot_mode      | "auto" or "always" or "never"                | "auto" will only pivot single row tables if the output is greater than the terminal width. "always" will always pivot single row tables. "never" will never pivot single row tables.            |
 | complete_from_path | boolean                | whether or not to complete names of binaries on PATH (default true) |
 
 ## Examples


### PR DESCRIPTION
As per @thegedge suggestion on Discord, I merged the auto pivot options into an enum.
```rust
    enum AutoPivotMode {
        Auto,
        Always,
        Never,
        ToFit,
    }
```