### PR TITLE
Refactor streams out of nu-cli into a separate subcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,7 +2214,6 @@ dependencies = [
  "eml-parser",
  "filesize",
  "futures 0.3.5",
- "futures-util",
  "futures_codec",
  "getset",
  "git2",
@@ -2234,6 +2233,7 @@ dependencies = [
  "nu-plugin",
  "nu-protocol",
  "nu-source",
+ "nu-streams",
  "nu-test-support",
  "nu-value-ext",
  "num-bigint",
@@ -2371,6 +2371,17 @@ dependencies = [
  "pretty",
  "serde 1.0.110",
  "termcolor",
+]
+
+[[package]]
+name = "nu-streams"
+version = "0.14.1"
+dependencies = [
+ "futures 0.3.5",
+ "nu-build",
+ "nu-errors",
+ "nu-protocol",
+ "nu-source",
 ]
 
 [[package]]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -10,14 +10,14 @@ license = "MIT"
 doctest = false
 
 [dependencies]
-nu-source = { version = "0.14.1", path = "../nu-source" }
-nu-plugin = { version = "0.14.1", path = "../nu-plugin" }
-nu-protocol = { version = "0.14.1", path = "../nu-protocol" }
 nu-errors = { version = "0.14.1", path = "../nu-errors" }
 nu-parser = { version = "0.14.1", path = "../nu-parser" }
-nu-value-ext = { version = "0.14.1", path = "../nu-value-ext" }
+nu-plugin = { version = "0.14.1", path = "../nu-plugin" }
+nu-protocol = { version = "0.14.1", path = "../nu-protocol" }
+nu-source = { version = "0.14.1", path = "../nu-source" }
+nu-streams = { version = "0.14.1", path = "../nu-streams" }
 nu-test-support = { version = "0.14.1", path = "../nu-test-support" }
-
+nu-value-ext = { version = "0.14.1", path = "../nu-value-ext" }
 
 ansi_term = "0.12.1"
 app_dirs = "1.2.1"
@@ -41,7 +41,6 @@ dunce = "1.0.0"
 eml-parser = "0.1.0"
 filesize = "0.2.0"
 futures = { version = "0.3", features = ["compat", "io-compat"] }
-futures-util = "0.3.5"
 futures_codec = "0.4"
 getset = "0.1.1"
 git2 = { version = "0.13.5", default_features = false }

--- a/crates/nu-cli/src/commands/classified/block.rs
+++ b/crates/nu-cli/src/commands/classified/block.rs
@@ -2,7 +2,6 @@ use crate::commands::classified::expr::run_expression_block;
 use crate::commands::classified::internal::run_internal_command;
 use crate::context::Context;
 use crate::prelude::*;
-use crate::stream::InputStream;
 use futures::stream::TryStreamExt;
 use nu_errors::ShellError;
 use nu_protocol::hir::{Block, ClassifiedCommand, Commands};

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -412,7 +412,7 @@ impl WholeStreamCommand for FnFilterCommand {
                 match func(args) {
                     Err(err) => yield Err(err),
                     Ok(mut stream) => {
-                        while let Some(value) = stream.values.next().await {
+                        while let Some(value) = stream.next().await {
                             yield value;
                         }
                     }

--- a/crates/nu-cli/src/context.rs
+++ b/crates/nu-cli/src/context.rs
@@ -1,12 +1,12 @@
 use crate::commands::{command::CommandArgs, Command, UnevaluatedCallInfo};
 use crate::env::host::Host;
 use crate::shell::shell_manager::ShellManager;
-use crate::stream::{InputStream, OutputStream};
 use indexmap::IndexMap;
 use nu_errors::ShellError;
 use nu_parser::SignatureRegistry;
 use nu_protocol::{hir, Scope, Signature};
 use nu_source::{Tag, Text};
+use nu_streams::{InputStream, OutputStream};
 use parking_lot::Mutex;
 use std::error::Error;
 use std::sync::atomic::AtomicBool;

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -3,11 +3,11 @@ use futures::executor::block_on;
 use nu_errors::ShellError;
 use nu_protocol::hir::ClassifiedBlock;
 use nu_protocol::{Scope, ShellTypeName, Value};
+use nu_streams::InputStream;
 
 use crate::commands::classified::block::run_block;
 use crate::commands::{whole_stream_command, Echo};
 use crate::context::Context;
-use crate::stream::InputStream;
 use crate::WholeStreamCommand;
 
 pub fn test(cmd: impl WholeStreamCommand + 'static) {

--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -25,7 +25,6 @@ mod futures;
 mod git;
 mod path;
 mod shell;
-mod stream;
 pub mod utils;
 
 #[cfg(test)]
@@ -44,7 +43,7 @@ pub use crate::data::primitive;
 pub use crate::data::value;
 pub use crate::env::environment_syncer::EnvironmentSyncer;
 pub use crate::env::host::BasicHost;
-pub use crate::stream::OutputStream;
+pub use nu_streams::OutputStream;
 pub use nu_value_ext::ValueExt;
 pub use num_traits::cast::ToPrimitive;
 

--- a/crates/nu-cli/src/prelude.rs
+++ b/crates/nu-cli/src/prelude.rs
@@ -36,7 +36,7 @@ macro_rules! trace_stream {
                 );
             });
 
-            $crate::stream::InputStream::from_stream(objects.boxed())
+            nu_streams::InputStream::from_stream(objects.boxed())
         } else {
             $expr
         }
@@ -61,15 +61,12 @@ macro_rules! trace_out_stream {
                 );
             });
 
-            $crate::stream::OutputStream::new(objects)
+            nu_streams::OutputStream::new(objects)
         } else {
             $expr
         }
     }};
 }
-
-pub(crate) use nu_protocol::{errln, out, outln};
-use nu_source::HasFallibleSpan;
 
 pub(crate) use crate::commands::command::{CommandArgs, RawCommandArgs, RunnableContext};
 pub(crate) use crate::commands::Example;
@@ -83,87 +80,25 @@ pub(crate) use crate::shell::filesystem_shell::FilesystemShell;
 pub(crate) use crate::shell::help_shell::HelpShell;
 pub(crate) use crate::shell::shell_manager::ShellManager;
 pub(crate) use crate::shell::value_shell::ValueShell;
-pub(crate) use crate::stream::{InputStream, InterruptibleStream, OutputStream};
-pub(crate) use async_stream::stream as async_stream;
-pub(crate) use bigdecimal::BigDecimal;
-pub(crate) use futures::stream::BoxStream;
-pub(crate) use futures::{Stream, StreamExt};
-pub(crate) use nu_protocol::MaybeOwned;
+
+pub(crate) use nu_protocol::{errln, out, outln, MaybeOwned};
 pub(crate) use nu_source::{
     b, AnchorLocation, DebugDocBuilder, PrettyDebug, PrettyDebugWithSource, Span, SpannedItem, Tag,
     TaggedItem, Text,
 };
+pub(crate) use nu_streams::{
+    InputStream, Interruptible, OutputStream, ToInputStream, ToOutputStream,
+};
 pub(crate) use nu_value_ext::ValueExt;
+
+pub(crate) use async_stream::stream as async_stream;
+pub(crate) use bigdecimal::BigDecimal;
+pub(crate) use futures::stream::BoxStream;
+pub(crate) use futures::StreamExt;
+pub(crate) use itertools::Itertools;
 pub(crate) use num_bigint::BigInt;
 pub(crate) use num_traits::cast::ToPrimitive;
 pub(crate) use serde::Deserialize;
 pub(crate) use std::collections::VecDeque;
-pub(crate) use std::future::Future;
 pub(crate) use std::sync::atomic::AtomicBool;
 pub(crate) use std::sync::Arc;
-
-pub(crate) use itertools::Itertools;
-
-pub trait FromInputStream {
-    fn from_input_stream(self) -> OutputStream;
-}
-
-impl<T> FromInputStream for T
-where
-    T: Stream<Item = nu_protocol::Value> + Send + 'static,
-{
-    fn from_input_stream(self) -> OutputStream {
-        OutputStream {
-            values: self.map(nu_protocol::ReturnSuccess::value).boxed(),
-        }
-    }
-}
-
-pub trait ToInputStream {
-    fn to_input_stream(self) -> InputStream;
-}
-
-impl<T, U> ToInputStream for T
-where
-    T: Stream<Item = U> + Send + 'static,
-    U: Into<Result<nu_protocol::Value, nu_errors::ShellError>>,
-{
-    fn to_input_stream(self) -> InputStream {
-        InputStream::from_stream(self.map(|item| match item.into() {
-            Ok(result) => result,
-            Err(err) => match HasFallibleSpan::maybe_span(&err) {
-                Some(span) => nu_protocol::UntaggedValue::Error(err).into_value(span),
-                None => nu_protocol::UntaggedValue::Error(err).into_untagged_value(),
-            },
-        }))
-    }
-}
-
-pub trait ToOutputStream {
-    fn to_output_stream(self) -> OutputStream;
-}
-
-impl<T, U> ToOutputStream for T
-where
-    T: Stream<Item = U> + Send + 'static,
-    U: Into<nu_protocol::ReturnValue>,
-{
-    fn to_output_stream(self) -> OutputStream {
-        OutputStream {
-            values: self.map(|item| item.into()).boxed(),
-        }
-    }
-}
-
-pub trait Interruptible<V> {
-    fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V>;
-}
-
-impl<S, V> Interruptible<V> for S
-where
-    S: Stream<Item = V> + Send + 'static,
-{
-    fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V> {
-        InterruptibleStream::new(self, ctrl_c)
-    }
-}

--- a/crates/nu-cli/src/shell/shell.rs
+++ b/crates/nu-cli/src/shell/shell.rs
@@ -6,7 +6,6 @@ use crate::commands::mkdir::MkdirArgs;
 use crate::commands::mv::MoveArgs;
 use crate::commands::rm::RemoveArgs;
 use crate::prelude::*;
-use crate::stream::OutputStream;
 use nu_errors::ShellError;
 use std::path::PathBuf;
 

--- a/crates/nu-cli/src/shell/shell_manager.rs
+++ b/crates/nu-cli/src/shell/shell_manager.rs
@@ -8,7 +8,6 @@ use crate::commands::rm::RemoveArgs;
 use crate::prelude::*;
 use crate::shell::filesystem_shell::FilesystemShell;
 use crate::shell::shell::Shell;
-use crate::stream::OutputStream;
 use nu_errors::ShellError;
 use parking_lot::Mutex;
 use std::error::Error;

--- a/crates/nu-streams/Cargo.toml
+++ b/crates/nu-streams/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nu-streams"
+version = "0.14.1"
+authors = ["The Nu Project Contributors"]
+description = "I/O streams for internal communication"
+edition = "2018"
+license = "MIT"
+
+[lib]
+doctest = false
+
+[dependencies]
+nu-errors = { version = "0.14.1", path = "../nu-errors" }
+nu-source = { version = "0.14.1", path = "../nu-source" }
+nu-protocol = { version = "0.14.1", path = "../nu-protocol" }
+
+futures = { version = "0.3", features = ["compat", "io-compat"] }
+
+[build-dependencies]
+nu-build = { version = "0.14.1", path = "../nu-build" }
+
+[features]
+stable = []

--- a/crates/nu-streams/src/input.rs
+++ b/crates/nu-streams/src/input.rs
@@ -1,8 +1,10 @@
-use crate::prelude::*;
-use futures::stream::{iter, once};
+use futures::stream::{iter, once, BoxStream, Stream, StreamExt};
+use std::collections::VecDeque;
+use std::future::Future;
+
 use nu_errors::ShellError;
 use nu_protocol::{Primitive, UntaggedValue, Value};
-use nu_source::{Tagged, TaggedItem};
+use nu_source::{Tag, Tagged, TaggedItem};
 
 pub struct InputStream {
     values: BoxStream<'static, Value>,

--- a/crates/nu-streams/src/interruptible.rs
+++ b/crates/nu-streams/src/interruptible.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
+use futures::stream::{BoxStream, Stream, StreamExt};
 use futures::task::Poll;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 pub struct InterruptibleStream<V> {
     inner: BoxStream<'static, V>,

--- a/crates/nu-streams/src/lib.rs
+++ b/crates/nu-streams/src/lib.rs
@@ -1,7 +1,9 @@
 mod input;
 mod interruptible;
 mod output;
+mod traits;
 
 pub use input::*;
 pub use interruptible::*;
 pub use output::*;
+pub use traits::*;

--- a/crates/nu-streams/src/output.rs
+++ b/crates/nu-streams/src/output.rs
@@ -1,6 +1,10 @@
-use crate::prelude::*;
-use futures::stream::iter;
+use futures::stream::{iter, BoxStream, Stream, StreamExt};
+use std::collections::VecDeque;
+use std::future::Future;
+
 use nu_protocol::{ReturnSuccess, ReturnValue, Value};
+
+use crate::InputStream;
 
 pub struct OutputStream {
     pub(crate) values: BoxStream<'static, ReturnValue>,

--- a/crates/nu-streams/src/traits.rs
+++ b/crates/nu-streams/src/traits.rs
@@ -1,0 +1,71 @@
+use futures::stream::{Stream, StreamExt};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use crate::input::InputStream;
+use crate::interruptible::InterruptibleStream;
+use crate::output::OutputStream;
+
+pub trait FromInputStream {
+    fn from_input_stream(self) -> OutputStream;
+}
+
+impl<T> FromInputStream for T
+where
+    T: Stream<Item = nu_protocol::Value> + Send + 'static,
+{
+    fn from_input_stream(self) -> OutputStream {
+        OutputStream {
+            values: self.map(nu_protocol::ReturnSuccess::value).boxed(),
+        }
+    }
+}
+
+pub trait ToInputStream {
+    fn to_input_stream(self) -> InputStream;
+}
+
+impl<T, U> ToInputStream for T
+where
+    T: Stream<Item = U> + Send + 'static,
+    U: Into<Result<nu_protocol::Value, nu_errors::ShellError>>,
+{
+    fn to_input_stream(self) -> InputStream {
+        InputStream::from_stream(self.map(|item| match item.into() {
+            Ok(result) => result,
+            Err(err) => match nu_source::HasFallibleSpan::maybe_span(&err) {
+                Some(span) => nu_protocol::UntaggedValue::Error(err).into_value(span),
+                None => nu_protocol::UntaggedValue::Error(err).into_untagged_value(),
+            },
+        }))
+    }
+}
+
+pub trait ToOutputStream {
+    fn to_output_stream(self) -> OutputStream;
+}
+
+impl<T, U> ToOutputStream for T
+where
+    T: Stream<Item = U> + Send + 'static,
+    U: Into<nu_protocol::ReturnValue>,
+{
+    fn to_output_stream(self) -> OutputStream {
+        OutputStream {
+            values: self.map(|item| item.into()).boxed(),
+        }
+    }
+}
+
+pub trait Interruptible<V> {
+    fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V>;
+}
+
+impl<S, V> Interruptible<V> for S
+where
+    S: Stream<Item = V> + Send + 'static,
+{
+    fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V> {
+        InterruptibleStream::new(self, ctrl_c)
+    }
+}


### PR DESCRIPTION
Part of https://github.com/nushell/nushell/issues/1896

Breaking down `nu-cli` into smaller subcrates. This PR factors out the streams (`InputStream`, `OutputStream`, and so on) into a subcrate.