### PR TITLE
Fix for inconsistency when quoted strings are used with with_env shorthand

### DIFF
--- a/crates/nu-cli/tests/commands/with_env.rs
+++ b/crates/nu-cli/tests/commands/with_env.rs
@@ -30,7 +30,6 @@ fn shorthand_doesnt_reorder_arguments() {
     assert_eq!(actual.out, "firstsecond");
 }
 
-
 #[test]
 fn with_env_shorthand_trimes_quotes() {
     let actual = nu!(

--- a/crates/nu-cli/tests/commands/with_env.rs
+++ b/crates/nu-cli/tests/commands/with_env.rs
@@ -29,3 +29,39 @@ fn shorthand_doesnt_reorder_arguments() {
 
     assert_eq!(actual.out, "firstsecond");
 }
+
+
+#[test]
+fn with_env_shorthand_trimes_quotes() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "FOO='BARRRR' echo $nu.env | get FOO"
+    );
+
+    assert_eq!(actual.out, "BARRRR");
+}
+
+#[test]
+fn with_env_and_shorthand_same_result() {
+    let actual_shorthand = nu!(
+        cwd: "tests/fixtures/formats",
+        "FOO='BARRRR' echo $nu.env | get FOO"
+    );
+
+    let actual_normal = nu!(
+        cwd: "tests/fixtures/formats",
+        "with-env [FOO BARRRR] {echo $nu.env} | get FOO"
+    );
+
+    assert_eq!(actual_shorthand.out, actual_normal.out);
+}
+
+#[test]
+fn with_env_shorthand_nested_quotes() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "FOO='-arg \"hello world\"' echo $nu.env | get FOO"
+    );
+
+    assert_eq!(actual.out, "-arg \"hello world\"");
+}

--- a/crates/nu-cli/tests/commands/with_env.rs
+++ b/crates/nu-cli/tests/commands/with_env.rs
@@ -31,7 +31,7 @@ fn shorthand_doesnt_reorder_arguments() {
 }
 
 #[test]
-fn with_env_shorthand_trimes_quotes() {
+fn with_env_shorthand_trims_quotes() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
         "FOO='BARRRR' echo $nu.env | get FOO"

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1379,7 +1379,7 @@ fn expand_shorthand_forms(
                         lite_pipeline,
                         Some((
                             variable_name.to_string().spanned(original_span),
-                            value.to_string().spanned(original_span),
+                            value.spanned(original_span),
                         )),
                         None,
                     )

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1362,7 +1362,9 @@ fn expand_shorthand_forms(
                 )
             } else {
                 let original_span = lite_pipeline.commands[0].name.span;
-                let (variable_name, value) = (assignment[0], assignment[1]);
+                let env_value = trim_quotes(assignment[1]);
+
+                let (variable_name, value) = (assignment[0], env_value);
                 let mut lite_pipeline = lite_pipeline.clone();
 
                 if !lite_pipeline.commands[0].args.is_empty() {


### PR DESCRIPTION
Now with_env and shorthand version returns same result when quotes are in use.

Fixes #1764 