### PR TITLE
Implement ctrl+c for the du command

### DIFF
--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -40,6 +40,7 @@ pub(crate) fn dir_entry_dict(
     short_name: bool,
     with_symlink_targets: bool,
     du: bool,
+    ctrl_c: Arc<AtomicBool>,
 ) -> Result<Value, ShellError> {
     let tag = tag.into();
     let mut dict = TaggedDictBuilder::new(&tag);
@@ -140,7 +141,7 @@ pub(crate) fn dir_entry_dict(
                     false,
                 );
 
-                DirInfo::new(filename, &params, None).get_size()
+                DirInfo::new(filename, &params, None, ctrl_c).get_size()
             } else {
                 md.len()
             };

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -32,6 +32,7 @@ fn get_file_type(md: &std::fs::Metadata) -> &str {
     file_type
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn dir_entry_dict(
     filename: &std::path::Path,
     metadata: Option<&std::fs::Metadata>,

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -112,6 +112,7 @@ impl Shell for FilesystemShell {
         name_tag: Tag,
         ctrl_c: Arc<AtomicBool>,
     ) -> Result<OutputStream, ShellError> {
+        let ctrl_c_copy = ctrl_c.clone();
         let (path, p_tag) = match path {
             Some(p) => {
                 let p_tag = p.tag;
@@ -171,6 +172,7 @@ impl Shell for FilesystemShell {
                     short_names,
                     with_symlink_targets,
                     du,
+                    ctrl_c.clone()
                 )
                 .map(|entry| ReturnSuccess::Value(entry.into()))?;
 
@@ -178,7 +180,7 @@ impl Shell for FilesystemShell {
             }
         };
 
-        Ok(stream.interruptible(ctrl_c).to_output_stream())
+        Ok(stream.interruptible(ctrl_c_copy).to_output_stream())
     }
 
     fn cd(&self, args: CdArgs, name: Tag) -> Result<OutputStream, ShellError> {


### PR DESCRIPTION
This implements the ctrl+c kill signal for `du`.  It should work when running `du` directly, or when running `ls --du`

If all is well, this should close: https://github.com/nushell/nushell/issues/1844

Let me know if this needs any additional work, I'll be happy to add to it.