### PR TITLE
Make it-expansion work when in a list

### DIFF
--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -567,6 +567,14 @@ impl SpannedExpression {
             }
             Expression::Variable(Variable::It(_)) => true,
             Expression::Path(path) => path.head.has_shallow_it_usage(),
+            Expression::List(list) => {
+                for l in list {
+                    if l.has_shallow_it_usage() {
+                        return true;
+                    }
+                }
+                false
+            }
             Expression::Invocation(block) => {
                 for commands in block.block.iter() {
                     for command in commands.list.iter() {

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -61,6 +61,18 @@ fn proper_it_expansion() {
 }
 
 #[test]
+fn it_expansion_of_list() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo "foo" | echo [bar $it] | to json
+        "#
+    );
+
+    assert_eq!(actual.out, "[\"bar\",\"foo\"]");
+}
+
+#[test]
 fn argument_invocation() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
Previously, you weren't able to it-expand when the $it variable was in a list

```
> ls | echo [$it.name "bob"]
```

With this PR, that is now possible