### PR TITLE
Allow echo to iterate ranges

### DIFF
--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -72,7 +72,7 @@ pub(crate) async fn evaluate_baseline_expr(
             );
             let right = (
                 right.as_primitive()?.spanned(right_span),
-                RangeInclusion::Exclusive,
+                RangeInclusion::Inclusive,
             );
 
             Ok(UntaggedValue::range(left, right).into_value(tag))

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -193,6 +193,18 @@ fn can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external() {
     assert_eq!(actual.out, "nushell");
 }
 
+#[test]
+fn echoing_ranges() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo 1..3 | sum
+        "#
+    );
+
+    assert_eq!(actual.out, "6");
+}
+
 mod parse {
     use nu_test_support::nu;
 


### PR DESCRIPTION
This allows `echo` to iterate a range, much the same way it iterates a list now:

```
> echo 1..3
───┬───
 0 │ 1 
 1 │ 2 
 2 │ 3 
───┴───
```
