### PR TITLE
Simplify plugin directory scanning

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -110,13 +110,19 @@ fn search_paths() -> Vec<std::path::PathBuf> {
         }
     }
 
-    #[cfg(not(debug_assertions))]
-    {
-        match env::var_os("PATH") {
-            Some(paths) => {
-                search_paths.extend(env::split_paths(&paths).collect::<Vec<_>>());
+    if let Ok(config) = crate::data::config::config(Tag::unknown()) {
+        if let Some(plugin_dirs) = config.get("plugin_dirs") {
+            if let Value {
+                value: UntaggedValue::Table(pipelines),
+                ..
+            } = plugin_dirs
+            {
+                for pipeline in pipelines {
+                    if let Ok(plugin_dir) = pipeline.as_string() {
+                        search_paths.push(PathBuf::from(plugin_dir));
+                    }
+                }
             }
-            None => println!("PATH is not defined in the environment."),
         }
     }
 


### PR DESCRIPTION
This PR simplifies how we scan directories for plugins on startup.

Previous, we would scan all directories in the PATH for any file that matches `nu_plugin_*` and then attempt to load it. If we could run the exe, and get a correct configuration out of it, we added it to the list of commands. This scanning is very friendly for extending Nu, but it can be costly to scan the whole PATH for executables.

In this PR we only scan two sources: the path the "nu.exe" lives in and any additional directories the user specifies in the "plugin_dirs" config variable.