### PR TITLE
ISSUE-1744-Glob support for start command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,7 +2519,6 @@ name = "nu_plugin_start"
 version = "0.1.0"
 dependencies = [
  "glob",
- "log",
  "nu-build",
  "nu-errors",
  "nu-plugin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,8 @@ dependencies = [
 name = "nu_plugin_start"
 version = "0.1.0"
 dependencies = [
+ "glob",
+ "log",
  "nu-build",
  "nu-errors",
  "nu-plugin",

--- a/crates/nu_plugin_start/Cargo.toml
+++ b/crates/nu_plugin_start/Cargo.toml
@@ -16,6 +16,8 @@ nu-source = { path = "../nu-source", version = "0.14.1" }
 nu-errors = { path = "../nu-errors", version = "0.14.1" }
 url = "2.1.1"
 open = "1.4.0"
+log = "*"
+glob = "*"
 
 [build-dependencies]
 nu-build = { version = "0.14.1", path = "../nu-build" }

--- a/crates/nu_plugin_start/Cargo.toml
+++ b/crates/nu_plugin_start/Cargo.toml
@@ -16,7 +16,6 @@ nu-source = { path = "../nu-source", version = "0.14.1" }
 nu-errors = { path = "../nu-errors", version = "0.14.1" }
 url = "2.1.1"
 open = "1.4.0"
-log = "*"
 glob = "*"
 
 [build-dependencies]

--- a/crates/nu_plugin_start/Cargo.toml
+++ b/crates/nu_plugin_start/Cargo.toml
@@ -16,7 +16,7 @@ nu-source = { path = "../nu-source", version = "0.14.1" }
 nu-errors = { path = "../nu-errors", version = "0.14.1" }
 url = "2.1.1"
 open = "1.4.0"
-glob = "*"
+glob = "0.3.0"
 
 [build-dependencies]
 nu-build = { version = "0.14.1", path = "../nu-build" }

--- a/crates/nu_plugin_start/src/start.rs
+++ b/crates/nu_plugin_start/src/start.rs
@@ -1,4 +1,3 @@
-use glob;
 use nu_errors::ShellError;
 use nu_protocol::{CallInfo, Value};
 use nu_source::{Tag, Tagged, TaggedItem};
@@ -50,11 +49,8 @@ impl Start {
             Ok(paths) => {
                 for path_result in paths {
                     match path_result {
-                        Ok(path) => result.push(
-                            path.to_string_lossy()
-                                .to_string()
-                                .tagged(value.tag.clone()),
-                        ),
+                        Ok(path) => result
+                            .push(path.to_string_lossy().to_string().tagged(value.tag.clone())),
                         // TODO-arash: Figure out error type
                         Err(glob_error) => {
                             return Err(ShellError::unimplemented(format!("{:?}", glob_error)));

--- a/crates/nu_plugin_start/src/start.rs
+++ b/crates/nu_plugin_start/src/start.rs
@@ -51,16 +51,22 @@ impl Start {
                     match path_result {
                         Ok(path) => result
                             .push(path.to_string_lossy().to_string().tagged(value.tag.clone())),
-                        // TODO-arash: Figure out error type
                         Err(glob_error) => {
-                            return Err(ShellError::unimplemented(format!("{:?}", glob_error)));
+                            return Err(ShellError::labeled_error(
+                                format!("{}", glob_error),
+                                "glob error",
+                                value.tag.clone(),
+                            ));
                         }
                     }
                 }
             }
-            // TODO-arash: Figure out error type
             Err(pattern_error) => {
-                return Err(ShellError::unimplemented(format!("{:?}", pattern_error)))
+                return Err(ShellError::labeled_error(
+                    format!("{}", pattern_error),
+                    "invalid pattern",
+                    value.tag.clone(),
+                ))
             }
         }
 
@@ -73,11 +79,8 @@ impl Start {
                 let mut result = vec![];
 
                 for value in values.iter() {
-                    match self.glob_to_values(value) {
-                        Ok(res) => result.extend(res),
-                        // TODO-arash: I think there was a better pattern for this but I forget it
-                        Err(se) => return Err(se),
-                    }
+                    let res = self.glob_to_values(value)?;
+                    result.extend(res);
                 }
 
                 if result.is_empty() {

--- a/crates/nu_plugin_start/src/start.rs
+++ b/crates/nu_plugin_start/src/start.rs
@@ -29,12 +29,7 @@ impl Start {
         trace!("{:?}", call_info);
         self.parse_filenames(&call_info)?;
         self.parse_application(&call_info);
-        Err(ShellError::labeled_error(
-            format!("{:?}", self.filenames),
-            "the filenames",
-            self.tag.clone(),
-        ))
-        // Ok(())
+        Ok(())
     }
 
     fn add_filename(&mut self, filename: Tagged<String>) -> Result<(), ShellError> {

--- a/crates/nu_plugin_start/src/start.rs
+++ b/crates/nu_plugin_start/src/start.rs
@@ -44,7 +44,6 @@ impl Start {
 
     fn glob_to_values(&self, value: &Value) -> Result<Vec<Tagged<String>>, ShellError> {
         let mut result = vec![];
-        // TODO-arash: Avoid nested callback hell?
         match glob::glob(&value.as_string()?) {
             Ok(paths) => {
                 for path_result in paths {

--- a/crates/nu_plugin_start/src/start.rs
+++ b/crates/nu_plugin_start/src/start.rs
@@ -1,5 +1,4 @@
 use glob;
-use log::{debug, trace};
 use nu_errors::ShellError;
 use nu_protocol::{CallInfo, Value};
 use nu_source::{Tag, Tagged, TaggedItem};
@@ -26,7 +25,6 @@ impl Start {
 
     pub fn parse(&mut self, call_info: CallInfo) -> Result<(), ShellError> {
         self.tag = call_info.name_tag.clone();
-        trace!("{:?}", call_info);
         self.parse_filenames(&call_info)?;
         self.parse_application(&call_info);
         Ok(())
@@ -53,9 +51,8 @@ impl Start {
                 for path_result in paths {
                     match path_result {
                         Ok(path) => result.push(
-                            path.into_os_string()
-                                .into_string()
-                                .expect("could not convert to string")
+                            path.to_string_lossy()
+                                .to_string()
                                 .tagged(value.tag.clone()),
                         ),
                         // TODO-arash: Figure out error type
@@ -80,7 +77,6 @@ impl Start {
                 let mut result = vec![];
 
                 for value in values.iter() {
-                    debug!("{:?}", value);
                     match self.glob_to_values(value) {
                         Ok(res) => result.extend(res),
                         // TODO-arash: I think there was a better pattern for this but I forget it


### PR DESCRIPTION
https://github.com/nushell/nushell/issues/1744

Summary:
- Use the glob library to take an passed arguments and expand them into a list of filenames
- Supports passing multiple globs

TODO:
- [x] What types of shell errors should I be returning?
   - I don't know if the Shell Errors I returned are any good, but it's something 🤷 
- [ ] Figure out how to write tests... (Still not sure where to look for these)

Usage:
```bash
> start *.md
``` 
Results in opening up:
```
CODE_OF_CONDUCT.md
CONTRIBUTING.md
README.md
TODO.md
```