### PR TITLE
Move run to be async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "attohttpc"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2204,7 @@ dependencies = [
  "app_dirs",
  "async-recursion",
  "async-stream",
+ "async-trait",
  "base64 0.12.1",
  "bigdecimal",
  "bson",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -18,10 +18,10 @@ nu-parser = { version = "0.14.1", path = "../nu-parser" }
 nu-value-ext = { version = "0.14.1", path = "../nu-value-ext" }
 nu-test-support = { version = "0.14.1", path = "../nu-test-support" }
 
-
 ansi_term = "0.12.1"
 app_dirs = "1.2.1"
 async-recursion = "0.3.1"
+async-trait = "0.1.31"
 directories = "2.0.2"
 async-stream = "0.2"
 base64 = "0.12.1"

--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -18,6 +18,7 @@ pub struct AliasArgs {
     pub save: Option<bool>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Alias {
     fn name(&self) -> &str {
         "alias"
@@ -39,7 +40,7 @@ impl WholeStreamCommand for Alias {
         "Define a shortcut for another command."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/append.rs
+++ b/crates/nu-cli/src/commands/append.rs
@@ -11,6 +11,7 @@ struct AppendArgs {
 
 pub struct Append;
 
+#[async_trait]
 impl WholeStreamCommand for Append {
     fn name(&self) -> &str {
         "append"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for Append {
         "Append the given row to the table"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::Ordering;
 
 pub struct Autoview;
 
+#[async_trait]
 impl WholeStreamCommand for Autoview {
     fn name(&self) -> &str {
         "autoview"
@@ -23,7 +24,7 @@ impl WholeStreamCommand for Autoview {
         "View the contents of the pipeline as a table or list."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -128,7 +129,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
 
                         if let Some(table) = table {
                             let command_args = create_default_command_args(&context).with_input(stream);
-                            let result = table.run(command_args, &context.registry);
+                            let result = table.run(command_args, &context.registry).await;
                             result.collect::<Vec<_>>().await;
                         }
                     }
@@ -142,7 +143,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     let mut stream = VecDeque::new();
                                     stream.push_back(UntaggedValue::string(s).into_value(Tag { anchor, span }));
                                     let command_args = create_default_command_args(&context).with_input(stream);
-                                    let result = text.run(command_args, &context.registry);
+                                    let result = text.run(command_args, &context.registry).await;
                                     result.collect::<Vec<_>>().await;
                                 } else {
                                     out!("{}", s);
@@ -162,7 +163,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     let mut stream = VecDeque::new();
                                     stream.push_back(UntaggedValue::string(s).into_value(Tag { anchor, span }));
                                     let command_args = create_default_command_args(&context).with_input(stream);
-                                    let result = text.run(command_args, &context.registry);
+                                    let result = text.run(command_args, &context.registry).await;
                                     result.collect::<Vec<_>>().await;
                                 } else {
                                     out!("{}\n", s);
@@ -233,7 +234,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     let mut stream = VecDeque::new();
                                     stream.push_back(x);
                                     let command_args = create_default_command_args(&context).with_input(stream);
-                                    let result = binary.run(command_args, &context.registry);
+                                    let result = binary.run(command_args, &context.registry).await;
                                     result.collect::<Vec<_>>().await;
                                 } else {
                                     use pretty_hex::*;
@@ -328,7 +329,7 @@ pub fn autoview(context: RunnableContext) -> Result<OutputStream, ShellError> {
                                     let mut stream = VecDeque::new();
                                     stream.push_back(x);
                                     let command_args = create_default_command_args(&context).with_input(stream);
-                                    let result = table.run(command_args, &context.registry);
+                                    let result = table.run(command_args, &context.registry).await;
                                     result.collect::<Vec<_>>().await;
                                 } else {
                                     out!("{:?}", item);

--- a/crates/nu-cli/src/commands/build_string.rs
+++ b/crates/nu-cli/src/commands/build_string.rs
@@ -12,6 +12,7 @@ pub struct BuildStringArgs {
 
 pub struct BuildString;
 
+#[async_trait]
 impl WholeStreamCommand for BuildString {
     fn name(&self) -> &str {
         "build-string"
@@ -26,7 +27,7 @@ impl WholeStreamCommand for BuildString {
         "Builds a string from the arguments"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/cal.rs
+++ b/crates/nu-cli/src/commands/cal.rs
@@ -9,6 +9,7 @@ use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 
 pub struct Cal;
 
+#[async_trait]
 impl WholeStreamCommand for Cal {
     fn name(&self) -> &str {
         "cal"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for Cal {
         "Display a calendar."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/calc.rs
+++ b/crates/nu-cli/src/commands/calc.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Primitive, ReturnSuccess, UntaggedValue, Value};
 
 pub struct Calc;
 
+#[async_trait]
 impl WholeStreamCommand for Calc {
     fn name(&self) -> &str {
         "calc"
@@ -14,7 +15,7 @@ impl WholeStreamCommand for Calc {
         "Parse a math expression into a number"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/cd.rs
+++ b/crates/nu-cli/src/commands/cd.rs
@@ -14,6 +14,7 @@ pub struct CdArgs {
 
 pub struct Cd;
 
+#[async_trait]
 impl WholeStreamCommand for Cd {
     fn name(&self) -> &str {
         "cd"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for Cd {
         "Change to a new path."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/classified/block.rs
+++ b/crates/nu-cli/src/commands/classified/block.rs
@@ -87,7 +87,7 @@ async fn run_pipeline(
             (_, Some(ClassifiedCommand::Error(err))) => return Err(err.clone().into()),
 
             (Some(ClassifiedCommand::Internal(left)), _) => {
-                run_internal_command(left, ctx, input, it, vars, env)?
+                run_internal_command(left, ctx, input, it, vars, env).await?
             }
 
             (None, _) => break,

--- a/crates/nu-cli/src/commands/classified/internal.rs
+++ b/crates/nu-cli/src/commands/classified/internal.rs
@@ -7,7 +7,7 @@ use nu_errors::ShellError;
 use nu_protocol::hir::InternalCommand;
 use nu_protocol::{CommandAction, Primitive, ReturnSuccess, Scope, UntaggedValue, Value};
 
-pub(crate) fn run_internal_command(
+pub(crate) async fn run_internal_command(
     command: InternalCommand,
     context: &mut Context,
     input: InputStream,
@@ -28,17 +28,18 @@ pub(crate) fn run_internal_command(
     let objects: InputStream = trace_stream!(target: "nu::trace_stream::internal", "input" = input);
     let internal_command = context.expect_command(&command.name);
 
-    let result = {
-        context.run_command(
-            internal_command?,
-            Tag::unknown_anchor(command.name_span),
-            command.args.clone(),
-            &scope,
-            objects,
-        )
+    let mut result = {
+        context
+            .run_command(
+                internal_command?,
+                Tag::unknown_anchor(command.name_span),
+                command.args.clone(),
+                &scope,
+                objects,
+            )
+            .await
     };
 
-    let mut result = trace_out_stream!(target: "nu::trace_stream::internal", "output" = result);
     let mut context = context.clone();
     // let scope = scope.clone();
 
@@ -78,7 +79,7 @@ pub(crate) fn run_internal_command(
                                     scope: scope.clone(),
                                 }
                             };
-                            let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &context.registry);
+                            let mut result = converter.run(new_args.with_input(vec![tagged_contents]), &context.registry).await;
                             let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                             for res in result_vec {
                                 match res {

--- a/crates/nu-cli/src/commands/clear.rs
+++ b/crates/nu-cli/src/commands/clear.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 
 pub struct Clear;
 
+#[async_trait]
 impl WholeStreamCommand for Clear {
     fn name(&self) -> &str {
         "clear"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Clear {
         "clears the terminal"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/clip.rs
+++ b/crates/nu-cli/src/commands/clip.rs
@@ -9,6 +9,7 @@ use clipboard::{ClipboardContext, ClipboardProvider};
 
 pub struct Clip;
 
+#[async_trait]
 impl WholeStreamCommand for Clip {
     fn name(&self) -> &str {
         "clip"
@@ -22,7 +23,7 @@ impl WholeStreamCommand for Clip {
         "Copy the contents of the pipeline to the copy/paste buffer"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -278,6 +278,7 @@ pub struct Example {
     pub result: Option<Vec<Value>>,
 }
 
+#[async_trait]
 pub trait WholeStreamCommand: Send + Sync {
     fn name(&self) -> &str;
 
@@ -287,7 +288,7 @@ pub trait WholeStreamCommand: Send + Sync {
 
     fn usage(&self) -> &str;
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -337,7 +338,7 @@ impl Command {
         self.0.usage()
     }
 
-    pub fn run(&self, args: CommandArgs, registry: &CommandRegistry) -> OutputStream {
+    pub async fn run(&self, args: CommandArgs, registry: &CommandRegistry) -> OutputStream {
         if args.call_info.switch_present("help") {
             let cl = self.0.clone();
             let registry = registry.clone();
@@ -346,7 +347,7 @@ impl Command {
             };
             stream.to_output_stream()
         } else {
-            match self.0.run(args, registry) {
+            match self.0.run(args, registry).await {
                 Ok(stream) => stream,
                 Err(err) => OutputStream::one(Err(err)),
             }
@@ -367,6 +368,7 @@ pub struct FnFilterCommand {
     func: fn(EvaluatedFilterCommandArgs) -> Result<OutputStream, ShellError>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for FnFilterCommand {
     fn name(&self) -> &str {
         &self.name
@@ -376,7 +378,7 @@ impl WholeStreamCommand for FnFilterCommand {
         "usage"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/compact.rs
+++ b/crates/nu-cli/src/commands/compact.rs
@@ -13,6 +13,7 @@ pub struct CompactArgs {
     rest: Vec<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Compact {
     fn name(&self) -> &str {
         "compact"
@@ -26,7 +27,7 @@ impl WholeStreamCommand for Compact {
         "Creates a table with non-empty rows"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/config.rs
+++ b/crates/nu-cli/src/commands/config.rs
@@ -20,6 +20,7 @@ pub struct ConfigArgs {
     path: Tagged<bool>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Config {
     fn name(&self) -> &str {
         "config"
@@ -65,7 +66,7 @@ impl WholeStreamCommand for Config {
         "Configuration management."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/count.rs
+++ b/crates/nu-cli/src/commands/count.rs
@@ -7,6 +7,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue, Value};
 
 pub struct Count;
 
+#[async_trait]
 impl WholeStreamCommand for Count {
     fn name(&self) -> &str {
         "count"
@@ -20,7 +21,7 @@ impl WholeStreamCommand for Count {
         "Show the total number of rows or items."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/cp.rs
+++ b/crates/nu-cli/src/commands/cp.rs
@@ -15,6 +15,7 @@ pub struct CopyArgs {
     pub recursive: Tagged<bool>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Cpy {
     fn name(&self) -> &str {
         "cp"
@@ -35,7 +36,7 @@ impl WholeStreamCommand for Cpy {
         "Copy files."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/date.rs
+++ b/crates/nu-cli/src/commands/date.rs
@@ -11,6 +11,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
 
 pub struct Date;
 
+#[async_trait]
 impl WholeStreamCommand for Date {
     fn name(&self) -> &str {
         "date"
@@ -26,7 +27,7 @@ impl WholeStreamCommand for Date {
         "Get the current datetime."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/debug.rs
+++ b/crates/nu-cli/src/commands/debug.rs
@@ -10,6 +10,7 @@ pub struct DebugArgs {
     raw: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Debug {
     fn name(&self) -> &str {
         "debug"
@@ -23,7 +24,7 @@ impl WholeStreamCommand for Debug {
         "Print the Rust debug representation of the values"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/default.rs
+++ b/crates/nu-cli/src/commands/default.rs
@@ -14,6 +14,7 @@ struct DefaultArgs {
 
 pub struct Default;
 
+#[async_trait]
 impl WholeStreamCommand for Default {
     fn name(&self) -> &str {
         "default"
@@ -33,7 +34,7 @@ impl WholeStreamCommand for Default {
         "Sets a default row's column if missing."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/drop.rs
+++ b/crates/nu-cli/src/commands/drop.rs
@@ -12,6 +12,7 @@ pub struct DropArgs {
     rows: Option<Tagged<u64>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Drop {
     fn name(&self) -> &str {
         "drop"
@@ -29,7 +30,7 @@ impl WholeStreamCommand for Drop {
         "Drop the last number of rows."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/du.rs
+++ b/crates/nu-cli/src/commands/du.rs
@@ -30,6 +30,7 @@ pub struct DuArgs {
     min_size: Option<Tagged<u64>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Du {
     fn name(&self) -> &str {
         NAME
@@ -72,7 +73,7 @@ impl WholeStreamCommand for Du {
         "Find disk usage sizes of specified items"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/each.rs
+++ b/crates/nu-cli/src/commands/each.rs
@@ -17,6 +17,7 @@ pub struct EachArgs {
     block: Block,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Each {
     fn name(&self) -> &str {
         "each"
@@ -34,7 +35,7 @@ impl WholeStreamCommand for Each {
         "Run a block on each row of the table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/echo.rs
+++ b/crates/nu-cli/src/commands/echo.rs
@@ -13,6 +13,7 @@ pub struct EchoArgs {
     pub rest: Vec<Value>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Echo {
     fn name(&self) -> &str {
         "echo"
@@ -26,7 +27,7 @@ impl WholeStreamCommand for Echo {
         "Echo the arguments back to the user."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/enter.rs
+++ b/crates/nu-cli/src/commands/enter.rs
@@ -16,6 +16,7 @@ pub struct EnterArgs {
     location: Tagged<PathBuf>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Enter {
     fn name(&self) -> &str {
         "enter"
@@ -33,7 +34,7 @@ impl WholeStreamCommand for Enter {
         "Create a new shell and begin at this path."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -131,7 +132,7 @@ fn enter(raw_args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
                             let mut result = converter.run(
                                 new_args.with_input(vec![tagged_contents]),
                                 &registry,
-                            );
+                            ).await;
                             let result_vec: Vec<Result<ReturnSuccess, ShellError>> =
                                 result.drain_vec().await;
                             for res in result_vec {

--- a/crates/nu-cli/src/commands/evaluate_by.rs
+++ b/crates/nu-cli/src/commands/evaluate_by.rs
@@ -13,6 +13,7 @@ pub struct EvaluateByArgs {
     evaluate_with: Option<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for EvaluateBy {
     fn name(&self) -> &str {
         "evaluate-by"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for EvaluateBy {
         "Creates a new table with the data from the tables rows evaluated by the column given."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/exit.rs
+++ b/crates/nu-cli/src/commands/exit.rs
@@ -6,6 +6,7 @@ use nu_protocol::{CommandAction, ReturnSuccess, Signature};
 
 pub struct Exit;
 
+#[async_trait]
 impl WholeStreamCommand for Exit {
     fn name(&self) -> &str {
         "exit"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Exit {
         "Exit the current shell (or all shells)"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/first.rs
+++ b/crates/nu-cli/src/commands/first.rs
@@ -12,6 +12,7 @@ pub struct FirstArgs {
     rows: Option<Tagged<usize>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for First {
     fn name(&self) -> &str {
         "first"
@@ -29,7 +30,7 @@ impl WholeStreamCommand for First {
         "Show only the first number of rows."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/format.rs
+++ b/crates/nu-cli/src/commands/format.rs
@@ -14,6 +14,7 @@ pub struct FormatArgs {
     pattern: Tagged<String>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Format {
     fn name(&self) -> &str {
         "format"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for Format {
         "Format columns into a string using a simple pattern."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from.rs
+++ b/crates/nu-cli/src/commands/from.rs
@@ -5,6 +5,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
 
 pub struct From;
 
+#[async_trait]
 impl WholeStreamCommand for From {
     fn name(&self) -> &str {
         "from"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for From {
         "Parse content (string or binary) as a table (input format based on subcommand, like csv, ini, json, toml)"
     }
 
-    fn run(
+    async fn run(
         &self,
         _args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_bson.rs
+++ b/crates/nu-cli/src/commands/from_bson.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 
 pub struct FromBSON;
 
+#[async_trait]
 impl WholeStreamCommand for FromBSON {
     fn name(&self) -> &str {
         "from bson"
@@ -21,7 +22,7 @@ impl WholeStreamCommand for FromBSON {
         "Parse binary as .bson and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_csv.rs
+++ b/crates/nu-cli/src/commands/from_csv.rs
@@ -12,6 +12,7 @@ pub struct FromCSVArgs {
     separator: Option<Value>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for FromCSV {
     fn name(&self) -> &str {
         "from csv"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for FromCSV {
         "Parse text as .csv and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_eml.rs
+++ b/crates/nu-cli/src/commands/from_eml.rs
@@ -16,6 +16,7 @@ pub struct FromEMLArgs {
     preview_body: Option<Tagged<usize>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for FromEML {
     fn name(&self) -> &str {
         "from eml"
@@ -34,7 +35,7 @@ impl WholeStreamCommand for FromEML {
         "Parse text as .eml and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_ics.rs
+++ b/crates/nu-cli/src/commands/from_ics.rs
@@ -9,6 +9,7 @@ use std::io::BufReader;
 
 pub struct FromIcs;
 
+#[async_trait]
 impl WholeStreamCommand for FromIcs {
     fn name(&self) -> &str {
         "from ics"
@@ -22,7 +23,7 @@ impl WholeStreamCommand for FromIcs {
         "Parse text as .ics and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_ini.rs
+++ b/crates/nu-cli/src/commands/from_ini.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 pub struct FromINI;
 
+#[async_trait]
 impl WholeStreamCommand for FromINI {
     fn name(&self) -> &str {
         "from ini"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for FromINI {
         "Parse text as .ini and create table"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_json.rs
+++ b/crates/nu-cli/src/commands/from_json.rs
@@ -10,6 +10,7 @@ pub struct FromJSONArgs {
     objects: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for FromJSON {
     fn name(&self) -> &str {
         "from json"
@@ -27,7 +28,7 @@ impl WholeStreamCommand for FromJSON {
         "Parse text as .json and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_ods.rs
+++ b/crates/nu-cli/src/commands/from_ods.rs
@@ -13,6 +13,7 @@ pub struct FromODSArgs {
     headerless: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for FromODS {
     fn name(&self) -> &str {
         "from ods"
@@ -30,7 +31,7 @@ impl WholeStreamCommand for FromODS {
         "Parse OpenDocument Spreadsheet(.ods) data and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_sqlite.rs
+++ b/crates/nu-cli/src/commands/from_sqlite.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 pub struct FromSQLite;
 
+#[async_trait]
 impl WholeStreamCommand for FromSQLite {
     fn name(&self) -> &str {
         "from sqlite"
@@ -21,7 +22,7 @@ impl WholeStreamCommand for FromSQLite {
         "Parse binary data as sqlite .db and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -32,6 +33,7 @@ impl WholeStreamCommand for FromSQLite {
 
 pub struct FromDB;
 
+#[async_trait]
 impl WholeStreamCommand for FromDB {
     fn name(&self) -> &str {
         "from db"
@@ -45,7 +47,7 @@ impl WholeStreamCommand for FromDB {
         "Parse binary data as db and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_ssv.rs
+++ b/crates/nu-cli/src/commands/from_ssv.rs
@@ -20,6 +20,7 @@ pub struct FromSSVArgs {
 const STRING_REPRESENTATION: &str = "from ssv";
 const DEFAULT_MINIMUM_SPACES: usize = 2;
 
+#[async_trait]
 impl WholeStreamCommand for FromSSV {
     fn name(&self) -> &str {
         STRING_REPRESENTATION
@@ -45,7 +46,7 @@ impl WholeStreamCommand for FromSSV {
         "Parse text as space-separated values and create a table. The default minimum number of spaces counted as a separator is 2."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_toml.rs
+++ b/crates/nu-cli/src/commands/from_toml.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Primitive, ReturnSuccess, Signature, TaggedDictBuilder, Untagg
 
 pub struct FromTOML;
 
+#[async_trait]
 impl WholeStreamCommand for FromTOML {
     fn name(&self) -> &str {
         "from toml"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for FromTOML {
         "Parse text as .toml and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_tsv.rs
+++ b/crates/nu-cli/src/commands/from_tsv.rs
@@ -11,6 +11,7 @@ pub struct FromTSVArgs {
     headerless: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for FromTSV {
     fn name(&self) -> &str {
         "from tsv"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for FromTSV {
         "Parse text as .tsv and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_url.rs
+++ b/crates/nu-cli/src/commands/from_url.rs
@@ -5,6 +5,7 @@ use nu_protocol::{ReturnSuccess, Signature, TaggedDictBuilder, UntaggedValue};
 
 pub struct FromURL;
 
+#[async_trait]
 impl WholeStreamCommand for FromURL {
     fn name(&self) -> &str {
         "from url"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for FromURL {
         "Parse url-encoded string as a table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_vcf.rs
+++ b/crates/nu-cli/src/commands/from_vcf.rs
@@ -9,6 +9,7 @@ use std::io::BufReader;
 
 pub struct FromVcf;
 
+#[async_trait]
 impl WholeStreamCommand for FromVcf {
     fn name(&self) -> &str {
         "from vcf"
@@ -22,7 +23,7 @@ impl WholeStreamCommand for FromVcf {
         "Parse text as .vcf and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_xlsx.rs
+++ b/crates/nu-cli/src/commands/from_xlsx.rs
@@ -13,6 +13,7 @@ pub struct FromXLSXArgs {
     headerless: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for FromXLSX {
     fn name(&self) -> &str {
         "from xlsx"
@@ -30,7 +31,7 @@ impl WholeStreamCommand for FromXLSX {
         "Parse binary Excel(.xlsx) data and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_xml.rs
+++ b/crates/nu-cli/src/commands/from_xml.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Primitive, ReturnSuccess, Signature, TaggedDictBuilder, Untagg
 
 pub struct FromXML;
 
+#[async_trait]
 impl WholeStreamCommand for FromXML {
     fn name(&self) -> &str {
         "from xml"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for FromXML {
         "Parse text as .xml and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/from_yaml.rs
+++ b/crates/nu-cli/src/commands/from_yaml.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Primitive, ReturnSuccess, Signature, TaggedDictBuilder, Untagg
 
 pub struct FromYAML;
 
+#[async_trait]
 impl WholeStreamCommand for FromYAML {
     fn name(&self) -> &str {
         "from yaml"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for FromYAML {
         "Parse text as .yaml/.yml and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -29,6 +30,7 @@ impl WholeStreamCommand for FromYAML {
 
 pub struct FromYML;
 
+#[async_trait]
 impl WholeStreamCommand for FromYML {
     fn name(&self) -> &str {
         "from yml"
@@ -42,7 +44,7 @@ impl WholeStreamCommand for FromYML {
         "Parse text as .yaml/.yml and create table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -17,6 +17,7 @@ pub struct GetArgs {
     rest: Vec<ColumnPath>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Get {
     fn name(&self) -> &str {
         "get"
@@ -33,7 +34,7 @@ impl WholeStreamCommand for Get {
         "Open given cells as text."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/group_by.rs
+++ b/crates/nu-cli/src/commands/group_by.rs
@@ -12,6 +12,7 @@ pub struct GroupByArgs {
     column_name: Option<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for GroupBy {
     fn name(&self) -> &str {
         "group-by"
@@ -29,7 +30,7 @@ impl WholeStreamCommand for GroupBy {
         "Creates a new table with the data from the table rows grouped by the column given."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/group_by_date.rs
+++ b/crates/nu-cli/src/commands/group_by_date.rs
@@ -12,6 +12,7 @@ pub struct GroupByDateArgs {
     format: Option<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for GroupByDate {
     fn name(&self) -> &str {
         "group-by date"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for GroupByDate {
         "Creates a new table with the data from the table rows grouped by the column given."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/headers.rs
+++ b/crates/nu-cli/src/commands/headers.rs
@@ -9,6 +9,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue, Value};
 
 pub struct Headers;
 
+#[async_trait]
 impl WholeStreamCommand for Headers {
     fn name(&self) -> &str {
         "headers"
@@ -22,7 +23,7 @@ impl WholeStreamCommand for Headers {
         "Use the first row of the table as column names"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -17,6 +17,7 @@ pub struct HelpArgs {
     rest: Vec<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Help {
     fn name(&self) -> &str {
         "help"
@@ -30,7 +31,7 @@ impl WholeStreamCommand for Help {
         "Display help information about commands."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -17,6 +17,7 @@ pub struct HistogramArgs {
     rest: Vec<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Histogram {
     fn name(&self) -> &str {
         "histogram"
@@ -39,7 +40,7 @@ impl WholeStreamCommand for Histogram {
         "Creates a new table with a histogram based on the column name passed in."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -8,6 +8,7 @@ use std::io::{BufRead, BufReader};
 
 pub struct History;
 
+#[async_trait]
 impl WholeStreamCommand for History {
     fn name(&self) -> &str {
         "history"
@@ -21,7 +22,7 @@ impl WholeStreamCommand for History {
         "Display command history."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/insert.rs
+++ b/crates/nu-cli/src/commands/insert.rs
@@ -13,6 +13,7 @@ pub struct InsertArgs {
     value: Value,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Insert {
     fn name(&self) -> &str {
         "insert"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for Insert {
         "Insert a new column with a given value."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/is_empty.rs
+++ b/crates/nu-cli/src/commands/is_empty.rs
@@ -20,6 +20,7 @@ pub struct IsEmptyArgs {
     rest: Vec<Value>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for IsEmpty {
     fn name(&self) -> &str {
         "empty?"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for IsEmpty {
         "Checks emptiness. The last value is the replacement value for any empty column(s) given to check against the table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/keep.rs
+++ b/crates/nu-cli/src/commands/keep.rs
@@ -12,6 +12,7 @@ pub struct KeepArgs {
     rows: Option<Tagged<usize>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Keep {
     fn name(&self) -> &str {
         "keep"
@@ -29,7 +30,7 @@ impl WholeStreamCommand for Keep {
         "Keep the number of rows only"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/keep_until.rs
+++ b/crates/nu-cli/src/commands/keep_until.rs
@@ -9,6 +9,7 @@ use nu_protocol::{
 
 pub struct KeepUntil;
 
+#[async_trait]
 impl WholeStreamCommand for KeepUntil {
     fn name(&self) -> &str {
         "keep-until"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for KeepUntil {
         "Keeps rows until the condition matches."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/keep_while.rs
+++ b/crates/nu-cli/src/commands/keep_while.rs
@@ -9,6 +9,7 @@ use nu_protocol::{
 
 pub struct KeepWhile;
 
+#[async_trait]
 impl WholeStreamCommand for KeepWhile {
     fn name(&self) -> &str {
         "keep-while"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for KeepWhile {
         "Keeps rows while the condition matches."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/kill.rs
+++ b/crates/nu-cli/src/commands/kill.rs
@@ -16,6 +16,7 @@ pub struct KillArgs {
     pub quiet: Tagged<bool>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Kill {
     fn name(&self) -> &str {
         "kill"
@@ -37,7 +38,7 @@ impl WholeStreamCommand for Kill {
         "Kill a process using the process id."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/last.rs
+++ b/crates/nu-cli/src/commands/last.rs
@@ -12,6 +12,7 @@ pub struct LastArgs {
     rows: Option<Tagged<u64>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Last {
     fn name(&self) -> &str {
         "last"
@@ -29,7 +30,7 @@ impl WholeStreamCommand for Last {
         "Show only the last number of rows."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/lines.rs
+++ b/crates/nu-cli/src/commands/lines.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Primitive, ReturnSuccess, Signature, UntaggedValue, Value};
 
 pub struct Lines;
 
+#[async_trait]
 impl WholeStreamCommand for Lines {
     fn name(&self) -> &str {
         "lines"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for Lines {
         "Split single string into rows, one per line."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/ls.rs
+++ b/crates/nu-cli/src/commands/ls.rs
@@ -20,6 +20,7 @@ pub struct LsArgs {
     pub du: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Ls {
     fn name(&self) -> &str {
         "ls"
@@ -59,7 +60,7 @@ impl WholeStreamCommand for Ls {
         "View the contents of the current or given path."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/map_max_by.rs
+++ b/crates/nu-cli/src/commands/map_max_by.rs
@@ -14,6 +14,7 @@ pub struct MapMaxByArgs {
     column_name: Option<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for MapMaxBy {
     fn name(&self) -> &str {
         "map-max-by"
@@ -32,7 +33,7 @@ impl WholeStreamCommand for MapMaxBy {
         "Creates a new table with the data from the tables rows maxed by the column given."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/merge.rs
+++ b/crates/nu-cli/src/commands/merge.rs
@@ -14,6 +14,7 @@ pub struct MergeArgs {
     block: Block,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Merge {
     fn name(&self) -> &str {
         "merge"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for Merge {
         "Merge a table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/mkdir.rs
+++ b/crates/nu-cli/src/commands/mkdir.rs
@@ -13,6 +13,7 @@ pub struct MkdirArgs {
     pub rest: Vec<Tagged<PathBuf>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Mkdir {
     fn name(&self) -> &str {
         "mkdir"
@@ -26,7 +27,7 @@ impl WholeStreamCommand for Mkdir {
         "Make directories, creates intermediary directories as required."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/mv.rs
+++ b/crates/nu-cli/src/commands/mv.rs
@@ -14,6 +14,7 @@ pub struct MoveArgs {
     pub dst: Tagged<PathBuf>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Move {
     fn name(&self) -> &str {
         "mv"
@@ -37,7 +38,7 @@ impl WholeStreamCommand for Move {
         "Move files or directories."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/next.rs
+++ b/crates/nu-cli/src/commands/next.rs
@@ -5,6 +5,7 @@ use nu_protocol::{CommandAction, ReturnSuccess, Signature};
 
 pub struct Next;
 
+#[async_trait]
 impl WholeStreamCommand for Next {
     fn name(&self) -> &str {
         "n"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for Next {
         "Go to next shell."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/nth.rs
+++ b/crates/nu-cli/src/commands/nth.rs
@@ -13,6 +13,7 @@ struct NthArgs {
 
 pub struct Nth;
 
+#[async_trait]
 impl WholeStreamCommand for Nth {
     fn name(&self) -> &str {
         "nth"
@@ -32,7 +33,7 @@ impl WholeStreamCommand for Nth {
         "Return only the selected rows"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -13,6 +13,7 @@ pub struct OpenArgs {
     raw: Tagged<bool>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Open {
     fn name(&self) -> &str {
         "open"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for Open {
         "Load a file into a cell, convert to table if possible (avoid by appending '--raw')"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/pivot.rs
+++ b/crates/nu-cli/src/commands/pivot.rs
@@ -18,6 +18,7 @@ pub struct PivotArgs {
     ignore_titles: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Pivot {
     fn name(&self) -> &str {
         "pivot"
@@ -45,7 +46,7 @@ impl WholeStreamCommand for Pivot {
         "Pivots the table contents so rows become columns and columns become rows."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/plugin.rs
+++ b/crates/nu-cli/src/commands/plugin.rs
@@ -42,6 +42,7 @@ pub struct PluginCommand {
     config: Signature,
 }
 
+#[async_trait]
 impl WholeStreamCommand for PluginCommand {
     fn name(&self) -> &str {
         &self.name
@@ -55,7 +56,7 @@ impl WholeStreamCommand for PluginCommand {
         &self.config.usage
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -271,6 +272,7 @@ pub struct PluginSink {
     config: Signature,
 }
 
+#[async_trait]
 impl WholeStreamCommand for PluginSink {
     fn name(&self) -> &str {
         &self.name
@@ -284,7 +286,7 @@ impl WholeStreamCommand for PluginSink {
         &self.config.usage
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/prepend.rs
+++ b/crates/nu-cli/src/commands/prepend.rs
@@ -11,6 +11,7 @@ struct PrependArgs {
 
 pub struct Prepend;
 
+#[async_trait]
 impl WholeStreamCommand for Prepend {
     fn name(&self) -> &str {
         "prepend"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for Prepend {
         "Prepend the given row to the front of the table"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/prev.rs
+++ b/crates/nu-cli/src/commands/prev.rs
@@ -6,6 +6,7 @@ use crate::commands::WholeStreamCommand;
 
 pub struct Previous;
 
+#[async_trait]
 impl WholeStreamCommand for Previous {
     fn name(&self) -> &str {
         "p"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Previous {
         "Go to previous shell."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/pwd.rs
+++ b/crates/nu-cli/src/commands/pwd.rs
@@ -5,6 +5,7 @@ use nu_protocol::Signature;
 
 pub struct Pwd;
 
+#[async_trait]
 impl WholeStreamCommand for Pwd {
     fn name(&self) -> &str {
         "pwd"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for Pwd {
         "Output the current working directory."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/range.rs
+++ b/crates/nu-cli/src/commands/range.rs
@@ -13,6 +13,7 @@ struct RangeArgs {
 
 pub struct Range;
 
+#[async_trait]
 impl WholeStreamCommand for Range {
     fn name(&self) -> &str {
         "range"
@@ -30,7 +31,7 @@ impl WholeStreamCommand for Range {
         "Return only the selected rows"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/reduce_by.rs
+++ b/crates/nu-cli/src/commands/reduce_by.rs
@@ -13,6 +13,7 @@ pub struct ReduceByArgs {
     reduce_with: Option<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for ReduceBy {
     fn name(&self) -> &str {
         "reduce-by"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for ReduceBy {
         "Creates a new table with the data from the tables rows reduced by the command given."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/reject.rs
+++ b/crates/nu-cli/src/commands/reject.rs
@@ -12,6 +12,7 @@ pub struct RejectArgs {
 
 pub struct Reject;
 
+#[async_trait]
 impl WholeStreamCommand for Reject {
     fn name(&self) -> &str {
         "reject"
@@ -25,7 +26,7 @@ impl WholeStreamCommand for Reject {
         "Remove the given columns from the table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/rename.rs
+++ b/crates/nu-cli/src/commands/rename.rs
@@ -13,6 +13,7 @@ pub struct Arguments {
     rest: Vec<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Rename {
     fn name(&self) -> &str {
         "rename"
@@ -32,7 +33,7 @@ impl WholeStreamCommand for Rename {
         "Creates a new table with columns renamed."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/reverse.rs
+++ b/crates/nu-cli/src/commands/reverse.rs
@@ -6,6 +6,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
 
 pub struct Reverse;
 
+#[async_trait]
 impl WholeStreamCommand for Reverse {
     fn name(&self) -> &str {
         "reverse"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Reverse {
         "Reverses the table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/rm.rs
+++ b/crates/nu-cli/src/commands/rm.rs
@@ -16,6 +16,7 @@ pub struct RemoveArgs {
     pub trash: Tagged<bool>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Remove {
     fn name(&self) -> &str {
         "rm"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for Remove {
         "Remove file(s)"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/run_alias.rs
+++ b/crates/nu-cli/src/commands/run_alias.rs
@@ -13,6 +13,7 @@ pub struct AliasCommand {
     block: Block,
 }
 
+#[async_trait]
 impl WholeStreamCommand for AliasCommand {
     fn name(&self) -> &str {
         &self.name
@@ -32,7 +33,7 @@ impl WholeStreamCommand for AliasCommand {
         ""
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/run_external.rs
+++ b/crates/nu-cli/src/commands/run_external.rs
@@ -37,6 +37,7 @@ fn spanned_expression_to_string(expr: SpannedExpression) -> Result<String, Shell
     }
 }
 
+#[async_trait]
 impl WholeStreamCommand for RunExternalCommand {
     fn name(&self) -> &str {
         "run_external"
@@ -50,7 +51,7 @@ impl WholeStreamCommand for RunExternalCommand {
         ""
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/save.rs
+++ b/crates/nu-cli/src/commands/save.rs
@@ -129,6 +129,7 @@ pub struct SaveArgs {
     raw: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Save {
     fn name(&self) -> &str {
         "save"
@@ -148,7 +149,7 @@ impl WholeStreamCommand for Save {
         "Save the contents of the pipeline to a file."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -232,7 +233,7 @@ fn save(raw_args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
                                 scope,
                             }
                         };
-                        let mut result = converter.run(new_args.with_input(input), &registry);
+                        let mut result = converter.run(new_args.with_input(input), &registry).await;
                         let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec().await;
                         if converter.is_binary() {
                             process_binary_return_success!('scope, result_vec, name_tag)

--- a/crates/nu-cli/src/commands/select.rs
+++ b/crates/nu-cli/src/commands/select.rs
@@ -16,6 +16,7 @@ struct SelectArgs {
 
 pub struct Select;
 
+#[async_trait]
 impl WholeStreamCommand for Select {
     fn name(&self) -> &str {
         "select"
@@ -32,7 +33,7 @@ impl WholeStreamCommand for Select {
         "Down-select table to only these columns."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/shells.rs
+++ b/crates/nu-cli/src/commands/shells.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::Ordering;
 
 pub struct Shells;
 
+#[async_trait]
 impl WholeStreamCommand for Shells {
     fn name(&self) -> &str {
         "shells"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Shells {
         "Display the list of current shells."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/shuffle.rs
+++ b/crates/nu-cli/src/commands/shuffle.rs
@@ -9,6 +9,7 @@ use rand::thread_rng;
 
 pub struct Shuffle;
 
+#[async_trait]
 impl WholeStreamCommand for Shuffle {
     fn name(&self) -> &str {
         "shuffle"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for Shuffle {
         "Shuffle rows randomly."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/size.rs
+++ b/crates/nu-cli/src/commands/size.rs
@@ -6,6 +6,7 @@ use nu_protocol::{ReturnSuccess, Signature, TaggedDictBuilder, UntaggedValue, Va
 
 pub struct Size;
 
+#[async_trait]
 impl WholeStreamCommand for Size {
     fn name(&self) -> &str {
         "size"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Size {
         "Gather word count statistics on the text."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/skip.rs
+++ b/crates/nu-cli/src/commands/skip.rs
@@ -12,6 +12,7 @@ pub struct SkipArgs {
     rows: Option<Tagged<usize>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Skip {
     fn name(&self) -> &str {
         "skip"
@@ -25,7 +26,7 @@ impl WholeStreamCommand for Skip {
         "Skip some number of rows."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/skip_until.rs
+++ b/crates/nu-cli/src/commands/skip_until.rs
@@ -9,6 +9,7 @@ use nu_protocol::{
 
 pub struct SkipUntil;
 
+#[async_trait]
 impl WholeStreamCommand for SkipUntil {
     fn name(&self) -> &str {
         "skip-until"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for SkipUntil {
         "Skips rows until the condition matches."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/skip_while.rs
+++ b/crates/nu-cli/src/commands/skip_while.rs
@@ -9,6 +9,7 @@ use nu_protocol::{
 
 pub struct SkipWhile;
 
+#[async_trait]
 impl WholeStreamCommand for SkipWhile {
     fn name(&self) -> &str {
         "skip-while"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for SkipWhile {
         "Skips rows while the condition matches."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -12,6 +12,7 @@ pub struct SortByArgs {
     rest: Vec<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for SortBy {
     fn name(&self) -> &str {
         "sort-by"
@@ -25,7 +26,7 @@ impl WholeStreamCommand for SortBy {
         "Sort by the given columns, in increasing order."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/split/column.rs
+++ b/crates/nu-cli/src/commands/split/column.rs
@@ -17,6 +17,7 @@ struct SplitColumnArgs {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "split column"
@@ -37,7 +38,7 @@ impl WholeStreamCommand for SubCommand {
         "splits contents across multiple columns via the separator."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/split/command.rs
+++ b/crates/nu-cli/src/commands/split/command.rs
@@ -6,6 +6,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
 #[derive(Clone)]
 pub struct Command;
 
+#[async_trait]
 impl WholeStreamCommand for Command {
     fn name(&self) -> &str {
         "split"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Command {
         "split contents across desired subcommand (like row, column) via the separator."
     }
 
-    fn run(
+    async fn run(
         &self,
         _args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/split/row.rs
+++ b/crates/nu-cli/src/commands/split/row.rs
@@ -12,6 +12,7 @@ struct SplitRowArgs {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "split row"
@@ -29,7 +30,7 @@ impl WholeStreamCommand for SubCommand {
         "splits contents over multiple rows via the separator."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/split_by.rs
+++ b/crates/nu-cli/src/commands/split_by.rs
@@ -13,6 +13,7 @@ pub struct SplitByArgs {
     column_name: Tagged<String>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for SplitBy {
     fn name(&self) -> &str {
         "split-by"
@@ -30,7 +31,7 @@ impl WholeStreamCommand for SplitBy {
         "Creates a new table with the data from the inner tables split by the column given."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/capitalize.rs
+++ b/crates/nu-cli/src/commands/str_/capitalize.rs
@@ -15,6 +15,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str capitalize"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for SubCommand {
         "capitalizes text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/command.rs
+++ b/crates/nu-cli/src/commands/str_/command.rs
@@ -5,6 +5,7 @@ use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
 
 pub struct Command;
 
+#[async_trait]
 impl WholeStreamCommand for Command {
     fn name(&self) -> &str {
         "str"
@@ -21,7 +22,7 @@ impl WholeStreamCommand for Command {
         "Apply string function."
     }
 
-    fn run(
+    async fn run(
         &self,
         _args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/downcase.rs
+++ b/crates/nu-cli/src/commands/str_/downcase.rs
@@ -15,6 +15,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str downcase"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for SubCommand {
         "downcases text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/find_replace.rs
+++ b/crates/nu-cli/src/commands/str_/find_replace.rs
@@ -19,6 +19,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str find-replace"
@@ -38,7 +39,7 @@ impl WholeStreamCommand for SubCommand {
         "finds and replaces text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/set.rs
+++ b/crates/nu-cli/src/commands/str_/set.rs
@@ -13,6 +13,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str set"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for SubCommand {
         "sets text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -18,6 +18,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str substring"
@@ -40,7 +41,7 @@ impl WholeStreamCommand for SubCommand {
         "substrings text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/to_datetime.rs
+++ b/crates/nu-cli/src/commands/str_/to_datetime.rs
@@ -18,6 +18,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str to-datetime"
@@ -41,7 +42,7 @@ impl WholeStreamCommand for SubCommand {
         "converts text into datetime"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/to_float.rs
+++ b/crates/nu-cli/src/commands/str_/to_float.rs
@@ -18,6 +18,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str to-float"
@@ -34,7 +35,7 @@ impl WholeStreamCommand for SubCommand {
         "converts text into float"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/to_integer.rs
+++ b/crates/nu-cli/src/commands/str_/to_integer.rs
@@ -18,6 +18,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str to-int"
@@ -34,7 +35,7 @@ impl WholeStreamCommand for SubCommand {
         "converts text into integer"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/trim.rs
+++ b/crates/nu-cli/src/commands/str_/trim.rs
@@ -15,6 +15,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str trim"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for SubCommand {
         "trims text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/str_/upcase.rs
+++ b/crates/nu-cli/src/commands/str_/upcase.rs
@@ -15,6 +15,7 @@ struct Arguments {
 
 pub struct SubCommand;
 
+#[async_trait]
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
         "str upcase"
@@ -31,7 +32,7 @@ impl WholeStreamCommand for SubCommand {
         "upcases text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/sum.rs
+++ b/crates/nu-cli/src/commands/sum.rs
@@ -9,6 +9,7 @@ use indexmap::map::IndexMap;
 
 pub struct Sum;
 
+#[async_trait]
 impl WholeStreamCommand for Sum {
     fn name(&self) -> &str {
         "sum"
@@ -22,7 +23,7 @@ impl WholeStreamCommand for Sum {
         "Sums the values."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/t_sort_by.rs
+++ b/crates/nu-cli/src/commands/t_sort_by.rs
@@ -21,6 +21,7 @@ pub struct TSortByArgs {
     split_by: Option<String>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for TSortBy {
     fn name(&self) -> &str {
         "t-sort-by"
@@ -51,7 +52,7 @@ impl WholeStreamCommand for TSortBy {
         "Sort by the given columns."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/table.rs
+++ b/crates/nu-cli/src/commands/table.rs
@@ -10,6 +10,7 @@ const STREAM_TIMEOUT_CHECK_INTERVAL: usize = 100;
 
 pub struct Table;
 
+#[async_trait]
 impl WholeStreamCommand for Table {
     fn name(&self) -> &str {
         "table"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for Table {
         "View the contents of the pipeline as a table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/tags.rs
+++ b/crates/nu-cli/src/commands/tags.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Signature, TaggedDictBuilder, UntaggedValue};
 
 pub struct Tags;
 
+#[async_trait]
 impl WholeStreamCommand for Tags {
     fn name(&self) -> &str {
         "tags"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for Tags {
         "Read the tags (metadata) for values."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to.rs
+++ b/crates/nu-cli/src/commands/to.rs
@@ -6,6 +6,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
 #[derive(Clone)]
 pub struct To;
 
+#[async_trait]
 impl WholeStreamCommand for To {
     fn name(&self) -> &str {
         "to"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for To {
         "Convert table into an output format (based on subcommand, like csv, html, json, yaml)."
     }
 
-    fn run(
+    async fn run(
         &self,
         _args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_bson.rs
+++ b/crates/nu-cli/src/commands/to_bson.rs
@@ -10,6 +10,7 @@ use std::convert::TryInto;
 
 pub struct ToBSON;
 
+#[async_trait]
 impl WholeStreamCommand for ToBSON {
     fn name(&self) -> &str {
         "to bson"
@@ -23,7 +24,7 @@ impl WholeStreamCommand for ToBSON {
         "Convert table into .bson text."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_csv.rs
+++ b/crates/nu-cli/src/commands/to_csv.rs
@@ -12,6 +12,7 @@ pub struct ToCSVArgs {
     separator: Option<Value>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for ToCSV {
     fn name(&self) -> &str {
         "to csv"
@@ -36,7 +37,7 @@ impl WholeStreamCommand for ToCSV {
         "Convert table into .csv text "
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_html.rs
+++ b/crates/nu-cli/src/commands/to_html.rs
@@ -8,6 +8,7 @@ use nu_source::AnchorLocation;
 
 pub struct ToHTML;
 
+#[async_trait]
 impl WholeStreamCommand for ToHTML {
     fn name(&self) -> &str {
         "to html"
@@ -21,7 +22,7 @@ impl WholeStreamCommand for ToHTML {
         "Convert table into simple HTML"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_json.rs
+++ b/crates/nu-cli/src/commands/to_json.rs
@@ -14,6 +14,7 @@ pub struct ToJSONArgs {
     pretty: Option<Value>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for ToJSON {
     fn name(&self) -> &str {
         "to json"
@@ -32,7 +33,7 @@ impl WholeStreamCommand for ToJSON {
         "Converts table data into JSON text."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -7,6 +7,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue, Value};
 
 pub struct ToMarkdown;
 
+#[async_trait]
 impl WholeStreamCommand for ToMarkdown {
     fn name(&self) -> &str {
         "to md"
@@ -20,7 +21,7 @@ impl WholeStreamCommand for ToMarkdown {
         "Convert table into simple Markdown"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_sqlite.rs
+++ b/crates/nu-cli/src/commands/to_sqlite.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 
 pub struct ToSQLite;
 
+#[async_trait]
 impl WholeStreamCommand for ToSQLite {
     fn name(&self) -> &str {
         "to sqlite"
@@ -21,7 +22,7 @@ impl WholeStreamCommand for ToSQLite {
         "Convert table to sqlite .db binary data"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,
@@ -36,6 +37,7 @@ impl WholeStreamCommand for ToSQLite {
 
 pub struct ToDB;
 
+#[async_trait]
 impl WholeStreamCommand for ToDB {
     fn name(&self) -> &str {
         "to db"
@@ -49,7 +51,7 @@ impl WholeStreamCommand for ToDB {
         "Convert table to db data"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_toml.rs
+++ b/crates/nu-cli/src/commands/to_toml.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Primitive, ReturnSuccess, Signature, UnspannedPathMember, Unta
 
 pub struct ToTOML;
 
+#[async_trait]
 impl WholeStreamCommand for ToTOML {
     fn name(&self) -> &str {
         "to toml"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for ToTOML {
         "Convert table into .toml text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_tsv.rs
+++ b/crates/nu-cli/src/commands/to_tsv.rs
@@ -11,6 +11,7 @@ pub struct ToTSVArgs {
     headerless: bool,
 }
 
+#[async_trait]
 impl WholeStreamCommand for ToTSV {
     fn name(&self) -> &str {
         "to tsv"
@@ -28,7 +29,7 @@ impl WholeStreamCommand for ToTSV {
         "Convert table into .tsv text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_url.rs
+++ b/crates/nu-cli/src/commands/to_url.rs
@@ -5,6 +5,7 @@ use nu_protocol::{ReturnSuccess, Signature, UntaggedValue, Value};
 
 pub struct ToURL;
 
+#[async_trait]
 impl WholeStreamCommand for ToURL {
     fn name(&self) -> &str {
         "to url"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for ToURL {
         "Convert table into url-encoded text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/to_yaml.rs
+++ b/crates/nu-cli/src/commands/to_yaml.rs
@@ -5,6 +5,7 @@ use nu_protocol::{Primitive, ReturnSuccess, Signature, UnspannedPathMember, Unta
 
 pub struct ToYAML;
 
+#[async_trait]
 impl WholeStreamCommand for ToYAML {
     fn name(&self) -> &str {
         "to yaml"
@@ -18,7 +19,7 @@ impl WholeStreamCommand for ToYAML {
         "Convert table into .yaml/.yml text"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/touch.rs
+++ b/crates/nu-cli/src/commands/touch.rs
@@ -13,6 +13,7 @@ pub struct TouchArgs {
     pub target: Tagged<PathBuf>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Touch {
     fn name(&self) -> &str {
         "touch"
@@ -27,7 +28,7 @@ impl WholeStreamCommand for Touch {
     fn usage(&self) -> &str {
         "creates a file"
     }
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/trim.rs
+++ b/crates/nu-cli/src/commands/trim.rs
@@ -6,6 +6,7 @@ use nu_protocol::{Dictionary, Primitive, ReturnSuccess, Signature, UntaggedValue
 
 pub struct Trim;
 
+#[async_trait]
 impl WholeStreamCommand for Trim {
     fn name(&self) -> &str {
         "trim"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Trim {
         "Trim leading and following whitespace from text data."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -7,6 +7,7 @@ use nu_protocol::{ReturnSuccess, Signature};
 
 pub struct Uniq;
 
+#[async_trait]
 impl WholeStreamCommand for Uniq {
     fn name(&self) -> &str {
         "uniq"
@@ -20,7 +21,7 @@ impl WholeStreamCommand for Uniq {
         "Return the unique rows"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/update.rs
+++ b/crates/nu-cli/src/commands/update.rs
@@ -15,6 +15,7 @@ pub struct UpdateArgs {
     replacement: Value,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Update {
     fn name(&self) -> &str {
         "update"
@@ -38,7 +39,7 @@ impl WholeStreamCommand for Update {
         "Update an existing column to have a new value."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/version.rs
+++ b/crates/nu-cli/src/commands/version.rs
@@ -6,6 +6,7 @@ use nu_protocol::{Dictionary, Signature, UntaggedValue};
 
 pub struct Version;
 
+#[async_trait]
 impl WholeStreamCommand for Version {
     fn name(&self) -> &str {
         "version"
@@ -19,7 +20,7 @@ impl WholeStreamCommand for Version {
         "Display Nu version"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/what.rs
+++ b/crates/nu-cli/src/commands/what.rs
@@ -9,6 +9,7 @@ pub struct What;
 #[derive(Deserialize)]
 pub struct WhatArgs {}
 
+#[async_trait]
 impl WholeStreamCommand for What {
     fn name(&self) -> &str {
         "describe"
@@ -22,7 +23,7 @@ impl WholeStreamCommand for What {
         "Describes the objects in the stream."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/where_.rs
+++ b/crates/nu-cli/src/commands/where_.rs
@@ -12,6 +12,7 @@ pub struct WhereArgs {
     block: Block,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Where {
     fn name(&self) -> &str {
         "where"
@@ -29,7 +30,7 @@ impl WholeStreamCommand for Where {
         "Filter table to match the condition."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/which_.rs
+++ b/crates/nu-cli/src/commands/which_.rs
@@ -7,6 +7,7 @@ use nu_source::Tagged;
 
 pub struct Which;
 
+#[async_trait]
 impl WholeStreamCommand for Which {
     fn name(&self) -> &str {
         "which"
@@ -22,7 +23,7 @@ impl WholeStreamCommand for Which {
         "Finds a program file."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -12,6 +12,8 @@ struct WithEnvArgs {
     variable: (Tagged<String>, Tagged<String>),
     block: Block,
 }
+
+#[async_trait]
 impl WholeStreamCommand for WithEnv {
     fn name(&self) -> &str {
         "with-env"
@@ -35,7 +37,7 @@ impl WholeStreamCommand for WithEnv {
         "Runs a block with an environment set. Eg) with-env [NAME 'foo'] { echo $nu.env.NAME }"
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/commands/wrap.rs
+++ b/crates/nu-cli/src/commands/wrap.rs
@@ -15,6 +15,7 @@ struct WrapArgs {
     column: Option<Tagged<String>>,
 }
 
+#[async_trait]
 impl WholeStreamCommand for Wrap {
     fn name(&self) -> &str {
         "wrap"
@@ -32,7 +33,7 @@ impl WholeStreamCommand for Wrap {
         "Wraps the given data in a table."
     }
 
-    fn run(
+    async fn run(
         &self,
         args: CommandArgs,
         registry: &CommandRegistry,

--- a/crates/nu-cli/src/context.rs
+++ b/crates/nu-cli/src/context.rs
@@ -225,7 +225,7 @@ impl Context {
         self.registry.expect_command(name)
     }
 
-    pub(crate) fn run_command(
+    pub(crate) async fn run_command(
         &mut self,
         command: Command,
         name_tag: Tag,
@@ -234,7 +234,7 @@ impl Context {
         input: InputStream,
     ) -> OutputStream {
         let command_args = self.command_args(args, input, name_tag, scope);
-        command.run(command_args, self.registry())
+        command.run(command_args, self.registry()).await
     }
 
     fn call_info(&self, args: hir::Call, name_tag: Tag, scope: &Scope) -> UnevaluatedCallInfo {

--- a/crates/nu-cli/src/prelude.rs
+++ b/crates/nu-cli/src/prelude.rs
@@ -102,6 +102,7 @@ pub(crate) use std::future::Future;
 pub(crate) use std::sync::atomic::AtomicBool;
 pub(crate) use std::sync::Arc;
 
+pub(crate) use async_trait::async_trait;
 pub(crate) use indexmap::IndexMap;
 pub(crate) use itertools::Itertools;
 


### PR DESCRIPTION
This is (hopefully!) the first step in simplifying commands. In this step, we move to an async `.run()` on each command, which will allow us to more async processing before the `async_stream!` step.