### PR TITLE
Implement login for the fetch command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,7 @@ dependencies = [
 name = "nu_plugin_fetch"
 version = "0.14.1"
 dependencies = [
+ "base64 0.12.1",
  "futures 0.3.5",
  "nu-build",
  "nu-errors",

--- a/crates/nu_plugin_fetch/Cargo.toml
+++ b/crates/nu_plugin_fetch/Cargo.toml
@@ -17,6 +17,7 @@ nu-errors = { path = "../nu-errors", version = "0.14.1" }
 futures = { version = "0.3", features = ["compat", "io-compat"] }
 surf = "1.0.3"
 url = "2.1.1"
+base64 = "0.12.1"
 
 [build-dependencies]
 nu-build = { version = "0.14.1", path = "../nu-build" }

--- a/crates/nu_plugin_fetch/src/nu/mod.rs
+++ b/crates/nu_plugin_fetch/src/nu/mod.rs
@@ -15,6 +15,18 @@ impl Plugin for Fetch {
                 SyntaxShape::String,
                 "the URL to fetch the contents from",
             )
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
             .switch("raw", "fetch contents as text rather than a table", Some('r'))
             .filter())
     }
@@ -26,6 +38,8 @@ impl Plugin for Fetch {
                 ShellError::labeled_error("internal error: path not set", "path not set", &self.tag)
             })?,
             self.has_raw,
+            self.user.clone(),
+            self.password.clone(),
         ))])
     }
 }


### PR DESCRIPTION
Closes #1734 

Implemented user/password login for the fetch command.

Tested with:
`fetch https://jigsaw.w3.org/HTTP/Basic/ -u guest -p guest`
- See [HTTP/1.1 demos](https://jigsaw.w3.org/HTTP/)
