### PR TITLE
Remove no_auto_pivot

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -39,7 +39,6 @@ Syntax: `config {flags}`
 | key_timeout        | integer (milliseconds) | vi: the delay to wait for a longer key sequence after ESC                 |
 | history_size       | integer                | maximum entries that will be stored in history (100,000 default)          |
 | completion_mode    | "circular" or "list"   | changes completion type to "circular" (default) or "list" mode            |
-| no_auto_pivot      | boolean                | whether or not to automatically pivot single-row results                  |
 | complete_from_path | boolean                | whether or not to complete names of binaries on PATH (default true)       |
 | rm_always_trash    | boolean                | whether or not to always use system trash when no flags are given to `rm` |
 | pivot_mode         | "auto" or "always" or "never"                | "auto" will only pivot single row tables if the output is greater than the terminal width. "always" will always pivot single row tables. "never" will never pivot single row tables.            |


### PR DESCRIPTION
no_auto_pivot does not exist any longer. It was rolled into pivot_mode.