### PR TITLE
Implement an option to show paths made of mkdir.

### DIFF
--- a/crates/nu-cli/src/commands/mkdir.rs
+++ b/crates/nu-cli/src/commands/mkdir.rs
@@ -11,6 +11,8 @@ pub struct Mkdir;
 #[derive(Deserialize)]
 pub struct MkdirArgs {
     pub rest: Vec<Tagged<PathBuf>>,
+    #[serde(rename = "verbose")]
+    pub verbose: bool,
 }
 
 #[async_trait]
@@ -20,7 +22,9 @@ impl WholeStreamCommand for Mkdir {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("mkdir").rest(SyntaxShape::Path, "the name(s) of the path(s) to create")
+        Signature::build("mkdir")
+            .rest(SyntaxShape::Path, "the name(s) of the path(s) to create")
+            .switch("verbose", "print the path(s) created.", Some('v'))
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cli/src/commands/mkdir.rs
+++ b/crates/nu-cli/src/commands/mkdir.rs
@@ -11,8 +11,8 @@ pub struct Mkdir;
 #[derive(Deserialize)]
 pub struct MkdirArgs {
     pub rest: Vec<Tagged<PathBuf>>,
-    #[serde(rename = "verbose")]
-    pub verbose: bool,
+    #[serde(rename = "show-created-paths")]
+    pub show_created_paths: bool,
 }
 
 #[async_trait]
@@ -24,7 +24,7 @@ impl WholeStreamCommand for Mkdir {
     fn signature(&self) -> Signature {
         Signature::build("mkdir")
             .rest(SyntaxShape::Path, "the name(s) of the path(s) to create")
-            .switch("verbose", "print the path(s) created.", Some('v'))
+            .switch("show-created-paths", "show the path(s) created.", Some('s'))
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -396,11 +396,15 @@ impl Shell for FilesystemShell {
 
     fn mkdir(
         &self,
-        MkdirArgs { rest: directories }: MkdirArgs,
+        MkdirArgs {
+            rest: directories,
+            verbose,
+        }: MkdirArgs,
         name: Tag,
         path: &str,
     ) -> Result<OutputStream, ShellError> {
         let path = Path::new(path);
+        let mut stream = VecDeque::new();
 
         if directories.is_empty() {
             return Err(ShellError::labeled_error(
@@ -421,9 +425,13 @@ impl Shell for FilesystemShell {
                     dir.tag(),
                 ));
             }
+            if verbose {
+                let val = format!("mkdir: created directory {:?}", dir.item).into();
+                stream.push_back(Ok(ReturnSuccess::Value(val)));
+            }
         }
 
-        Ok(OutputStream::empty())
+        Ok(stream.into())
     }
 
     fn mv(

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -398,7 +398,7 @@ impl Shell for FilesystemShell {
         &self,
         MkdirArgs {
             rest: directories,
-            verbose,
+            show_created_paths,
         }: MkdirArgs,
         name: Tag,
         path: &str,
@@ -417,7 +417,7 @@ impl Shell for FilesystemShell {
         for dir in directories.iter() {
             let create_at = path.join(&dir.item);
 
-            let dir_res = std::fs::create_dir_all(create_at);
+            let dir_res = std::fs::create_dir_all(&create_at);
             if let Err(reason) = dir_res {
                 return Err(ShellError::labeled_error(
                     reason.to_string(),
@@ -425,8 +425,8 @@ impl Shell for FilesystemShell {
                     dir.tag(),
                 ));
             }
-            if verbose {
-                let val = format!("mkdir: created directory {:?}", dir.item).into();
+            if show_created_paths {
+                let val = format!("{:}", create_at.to_string_lossy()).into();
                 stream.push_back(Ok(ReturnSuccess::Value(val)));
             }
         }

--- a/crates/nu-cli/tests/commands/mkdir.rs
+++ b/crates/nu-cli/tests/commands/mkdir.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::files_exist_at;
-use nu_test_support::nu;
 use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
 use std::path::Path;
 
 #[test]
@@ -59,5 +59,27 @@ fn create_directory_two_parents_up_using_multiple_dots() {
         let expected = dirs.test().join("boo");
 
         assert!(expected.exists());
+    })
+}
+
+#[test]
+fn show_created_paths() {
+    Playground::setup("mkdir_test_2", |dirs, _| {
+        let actual = nu!(
+         cwd: dirs.test(),
+         pipeline(
+             r#"
+                 mkdir -s dir_1 dir_2 dir_3
+                 | count
+                 | echo $it
+             "#
+        ));
+
+        assert!(files_exist_at(
+            vec![Path::new("dir_1"), Path::new("dir_2"), Path::new("dir_3")],
+            dirs.test()
+        ));
+
+        assert_eq!(actual.out, "3");
     })
 }


### PR DESCRIPTION
I tried to Implement the verbose option of mkdir command.
I references other commands, but I'm not sure if I'm right.

```
/home/utam0k/nushell(mkdir-verbose)> mkdir -v a/b/c d/e/f
───┬──────────────────────────────────
 0 │ mkdir: created directory "a/b/c" 
 1 │ mkdir: created directory "d/e/f" 
───┴──────────────────────────────────
```