### PR TITLE
Removing async_stream! from some commands

### DIFF
--- a/crates/nu-cli/src/commands/first.rs
+++ b/crates/nu-cli/src/commands/first.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for First {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        first(args, registry)
+        first(args, registry).await
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -57,27 +57,27 @@ impl WholeStreamCommand for First {
     }
 }
 
-fn first(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+async fn first(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
-    let stream = async_stream! {
-        let (FirstArgs { rows }, mut input) = args.process(&registry).await?;
-        let mut rows_desired = if let Some(quantity) = rows {
-            *quantity
-        } else {
-            1
-        };
-
-        while let Some(input) = input.next().await {
-            if rows_desired > 0 {
-                yield ReturnSuccess::value(input);
-                rows_desired -= 1;
-            } else {
-                break;
-            }
-        }
+    let (FirstArgs { rows }, mut input) = args.process(&registry).await?;
+    let mut rows_desired = if let Some(quantity) = rows {
+        *quantity
+    } else {
+        1
     };
 
-    Ok(stream.to_output_stream())
+    let mut values_vec_deque = VecDeque::new();
+
+    while let Some(input) = input.next().await {
+        if rows_desired > 0 {
+            values_vec_deque.push_back(ReturnSuccess::value(input));
+            rows_desired -= 1;
+        } else {
+            break;
+        }
+    }
+
+    Ok(futures::stream::iter(values_vec_deque).to_output_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-cli/src/commands/from_url.rs
+++ b/crates/nu-cli/src/commands/from_url.rs
@@ -24,44 +24,41 @@ impl WholeStreamCommand for FromURL {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        from_url(args, registry)
+        from_url(args, registry).await
     }
 }
 
-fn from_url(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+async fn from_url(
+    args: CommandArgs,
+    registry: &CommandRegistry,
+) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
-    let stream = async_stream! {
-        let args = args.evaluate_once(&registry).await?;
-        let tag = args.name_tag();
-        let input = args.input;
+    let args = args.evaluate_once(&registry).await?;
+    let tag = args.name_tag();
+    let input = args.input;
 
-        let concat_string = input.collect_string(tag.clone()).await?;
+    let concat_string = input.collect_string(tag.clone()).await?;
 
-        let result = serde_urlencoded::from_str::<Vec<(String, String)>>(&concat_string.item);
+    let result = serde_urlencoded::from_str::<Vec<(String, String)>>(&concat_string.item);
 
-        match result {
-            Ok(result) => {
-                let mut row = TaggedDictBuilder::new(tag);
+    match result {
+        Ok(result) => {
+            let mut row = TaggedDictBuilder::new(tag);
 
-                for (k,v) in result {
-                    row.insert_untagged(k, UntaggedValue::string(v));
-                }
-
-                yield ReturnSuccess::value(row.into_value());
+            for (k, v) in result {
+                row.insert_untagged(k, UntaggedValue::string(v));
             }
-            _ => {
-                yield Err(ShellError::labeled_error_with_secondary(
-                    "String not compatible with url-encoding",
-                    "input not url-encoded",
-                    tag,
-                    "value originates from here",
-                    concat_string.tag,
-                ));
-            }
+
+            Ok(OutputStream::one(ReturnSuccess::value(row.into_value())))
         }
-    };
-
-    Ok(stream.to_output_stream())
+        _ => Err(ShellError::labeled_error_with_secondary(
+            "String not compatible with url-encoding",
+            "input not url-encoded",
+            tag,
+            "value originates from here",
+            concat_string.tag,
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/crates/nu-cli/src/commands/skip.rs
+++ b/crates/nu-cli/src/commands/skip.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
 
 pub struct Skip;
@@ -48,25 +48,14 @@ impl WholeStreamCommand for Skip {
 
 async fn skip(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
-    let (SkipArgs { rows }, mut input) = args.process(&registry).await?;
-    let mut rows_desired = if let Some(quantity) = rows {
+    let (SkipArgs { rows }, input) = args.process(&registry).await?;
+    let rows_desired = if let Some(quantity) = rows {
         *quantity
     } else {
         1
     };
 
-    let mut values_vec_deque = VecDeque::new();
-
-    while let Some(input) = input.next().await {
-        if rows_desired == 0 {
-            values_vec_deque.push_back(ReturnSuccess::value(input));
-        }
-        if rows_desired > 0 {
-            rows_desired -= 1;
-        }
-    }
-
-    Ok(futures::stream::iter(values_vec_deque).to_output_stream())
+    Ok(input.skip(rows_desired).to_output_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-cli/src/commands/split/row.rs
+++ b/crates/nu-cli/src/commands/split/row.rs
@@ -2,7 +2,7 @@ use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use log::trace;
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue};
+use nu_protocol::{Primitive, ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
 
 #[derive(Deserialize)]
@@ -35,45 +35,41 @@ impl WholeStreamCommand for SubCommand {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        split_row(args, registry).await
+        split_row(args, registry)
     }
 }
 
-async fn split_row(
-    args: CommandArgs,
-    registry: &CommandRegistry,
-) -> Result<OutputStream, ShellError> {
+fn split_row(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
-    let name = args.call_info.name_tag.clone();
-    let (SplitRowArgs { separator }, mut input) = args.process(&registry).await?;
+    let stream = async_stream! {
+        let name = args.call_info.name_tag.clone();
+        let (SplitRowArgs { separator }, mut input) = args.process(&registry).await?;
+        while let Some(v) = input.next().await {
+            if let Ok(s) = v.as_string() {
+                let splitter = separator.item.replace("\\n", "\n");
+                trace!("splitting with {:?}", splitter);
+                let split_result: Vec<_> = s.split(&splitter).filter(|s| s.trim() != "").collect();
 
-    let mut values_vec_deque = VecDeque::new();
+                trace!("split result = {:?}", split_result);
 
-    while let Some(v) = input.next().await {
-        if let Ok(s) = v.as_string() {
-            let splitter = separator.item.replace("\\n", "\n");
-            trace!("splitting with {:?}", splitter);
-            let split_result: Vec<_> = s.split(&splitter).filter(|s| s.trim() != "").collect();
-
-            trace!("split result = {:?}", split_result);
-
-            for s in split_result {
-                values_vec_deque.push_back(
-                    UntaggedValue::Primitive(Primitive::String(s.into())).into_value(&v.tag),
-                );
+                for s in split_result {
+                    yield ReturnSuccess::value(
+                        UntaggedValue::Primitive(Primitive::String(s.into())).into_value(&v.tag),
+                    );
+                }
+            } else {
+                yield Err(ShellError::labeled_error_with_secondary(
+                    "Expected a string from pipeline",
+                    "requires string input",
+                    name.span,
+                    "value originates from here",
+                    v.tag.span,
+                ));
             }
-        } else {
-            return Err(ShellError::labeled_error_with_secondary(
-                "Expected a string from pipeline",
-                "requires string input",
-                name.span,
-                "value originates from here",
-                v.tag.span,
-            ));
         }
-    }
+    };
 
-    Ok(futures::stream::iter(values_vec_deque).to_output_stream())
+    Ok(stream.to_output_stream())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I tried to not use the method of stuffing Values into a VecDeque and then returning that if I could, but there were a few places I didn't know how to get around it (such as places that were inside nested loops).  Let me know if something looks weird or should be fixed, I'll gladly change it.