### PR TITLE
When the nushell repo is located in a path that has a space in it, these tests break, this fixes it

### DIFF
--- a/crates/nu-cli/tests/commands/cd.rs
+++ b/crates/nu-cli/tests/commands/cd.rs
@@ -24,7 +24,7 @@ fn filesystem_change_from_current_directory_using_absolute_path() {
         let actual = nu!(
             cwd: dirs.test(),
             r#"
-                cd {}
+                cd "{}"
                 pwd | echo $it
             "#,
             dirs.formats()
@@ -113,9 +113,9 @@ fn filesystem_change_current_directory_to_parent_directory_after_delete_cwd() {
         let actual = nu!(
             cwd: dirs.test().join("foo/bar"),
             r#"
-                rm {}/foo/bar 
+                rm {}/foo/bar
                 echo ","
-                cd .. 
+                cd ..
                 pwd | echo $it
             "#,
             dirs.test()

--- a/crates/nu-cli/tests/commands/cp.rs
+++ b/crates/nu-cli/tests/commands/cp.rs
@@ -8,7 +8,7 @@ fn copies_a_file() {
     Playground::setup("cp_test_1", |dirs, _| {
         nu!(
             cwd: dirs.root(),
-            "cp {} cp_test_1/sample.ini",
+            "cp \"{}\" cp_test_1/sample.ini",
             dirs.formats().join("sample.ini")
         );
 

--- a/crates/nu-cli/tests/commands/save.rs
+++ b/crates/nu-cli/tests/commands/save.rs
@@ -37,7 +37,7 @@ fn writes_out_csv() {
 
         nu!(
             cwd: dirs.root(),
-            "open {}/cargo_sample.toml | get package | save save_test_2/cargo_sample.csv",
+            "open \"{}/cargo_sample.toml\" | get package | save save_test_2/cargo_sample.csv",
             dirs.formats()
         );
 


### PR DESCRIPTION
These 3 tests have always been broken for me since I have nushell in a path that has a space in it.  Ideally, I could modify the `nu!` macro to just be able to always wrap test paths in quotes, but the way it is laid out, it will require changing the way all of the `nu!` invocations are done (probably splitting up the `path` input parameter such that it doesn't have any additional information tacked onto the end of it, so that `nu!` can be modified to wrap `cwd + path` in quotes), which may take some time.  For now, this is a quick fix for these tests specifically.

Before changes:

<img width="1338" alt="Screen Shot 2020-06-06 at 5 40 54 PM" src="https://user-images.githubusercontent.com/19867440/83955045-e56e8e80-a81c-11ea-9dc3-8dbddb2fc9dd.png">

After changes:

<img width="1338" alt="Screen Shot 2020-06-06 at 5 42 45 PM" src="https://user-images.githubusercontent.com/19867440/83955072-249cdf80-a81d-11ea-902d-1c3687c6bf9b.png">

With the maintainers permission, I wouldn't mind trying to look into modifying `nu!` so that it always wraps test commands in quotes and then the tests will never have to worry about it.

EDIT:

Actually, the more I look at it, it may not be possible to add a single fix into `nu!` to address all the tests, so it might have to just be updated per-test, as they come along.