### PR TITLE
Remove async_stream! from some commands

### DIFF
--- a/crates/nu-cli/src/commands/group_by_date.rs
+++ b/crates/nu-cli/src/commands/group_by_date.rs
@@ -42,7 +42,7 @@ impl WholeStreamCommand for GroupByDate {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        group_by_date(args, registry)
+        group_by_date(args, registry).await
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -58,50 +58,59 @@ enum Grouper {
     ByDate(Option<String>),
 }
 
-pub fn group_by_date(
+pub async fn group_by_date(
     args: CommandArgs,
     registry: &CommandRegistry,
 ) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
     let name = args.call_info.name_tag.clone();
-    let stream = async_stream! {
-        let (GroupByDateArgs { column_name, format }, mut input) = args.process(&registry).await?;
-        let values: Vec<Value> = input.collect().await;
+    let (
+        GroupByDateArgs {
+            column_name,
+            format,
+        },
+        input,
+    ) = args.process(&registry).await?;
+    let values: Vec<Value> = input.collect().await;
 
-        if values.is_empty() {
-            yield Err(ShellError::labeled_error(
-                    "Expected table from pipeline",
-                    "requires a table input",
-                    name
-                ))
+    if values.is_empty() {
+        Err(ShellError::labeled_error(
+            "Expected table from pipeline",
+            "requires a table input",
+            name,
+        ))
+    } else {
+        let grouper = if let Some(Tagged { item: fmt, tag: _ }) = format {
+            Grouper::ByDate(Some(fmt))
         } else {
+            Grouper::ByDate(None)
+        };
 
-            let grouper = if let Some(Tagged { item: fmt, tag }) = format {
-                    Grouper::ByDate(Some(fmt))
-                } else {
-                    Grouper::ByDate(None)
-                };
-
-            match grouper {
-                Grouper::ByDate(None) => {
-                    match crate::utils::data::group(column_name, &values, Some(Box::new(|row: &Value| row.format("%Y-%b-%d"))), &name) {
-                        Ok(grouped) => yield ReturnSuccess::value(grouped),
-                        Err(err) => yield Err(err),
-                    }
+        match grouper {
+            Grouper::ByDate(None) => {
+                match crate::utils::data::group(
+                    column_name,
+                    &values,
+                    Some(Box::new(|row: &Value| row.format("%Y-%b-%d"))),
+                    &name,
+                ) {
+                    Ok(grouped) => Ok(OutputStream::one(ReturnSuccess::value(grouped))),
+                    Err(err) => Err(err),
                 }
-                Grouper::ByDate(Some(fmt)) => {
-                    match crate::utils::data::group(column_name, &values, Some(Box::new(move |row: &Value| {
-                        row.format(&fmt)
-                    })), &name) {
-                        Ok(grouped) => yield ReturnSuccess::value(grouped),
-                        Err(err) => yield Err(err),
-                    }
+            }
+            Grouper::ByDate(Some(fmt)) => {
+                match crate::utils::data::group(
+                    column_name,
+                    &values,
+                    Some(Box::new(move |row: &Value| row.format(&fmt))),
+                    &name,
+                ) {
+                    Ok(grouped) => Ok(OutputStream::one(ReturnSuccess::value(grouped))),
+                    Err(err) => Err(err),
                 }
             }
         }
-    };
-
-    Ok(stream.to_output_stream())
+    }
 }
 
 #[cfg(test)]

--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -1,9 +1,7 @@
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{
-    CommandAction, ReturnSuccess, Signature, SyntaxShape, UntaggedValue,
-};
+use nu_protocol::{CommandAction, ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
 use nu_source::{AnchorLocation, Span, Tagged};
 use std::path::{Path, PathBuf};
 
@@ -77,7 +75,9 @@ async fn open(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     let tagged_contents = contents.into_value(&contents_tag);
 
     if let Some(extension) = file_extension {
-        Ok(OutputStream::one(ReturnSuccess::action(CommandAction::AutoConvert(tagged_contents, extension))))
+        Ok(OutputStream::one(ReturnSuccess::action(
+            CommandAction::AutoConvert(tagged_contents, extension),
+        )))
     } else {
         Ok(OutputStream::one(ReturnSuccess::value(tagged_contents)))
     }

--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -1,7 +1,9 @@
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{CommandAction, ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
+use nu_protocol::{
+    CommandAction, ReturnSuccess, Signature, SyntaxShape, UntaggedValue,
+};
 use nu_source::{AnchorLocation, Span, Tagged};
 use std::path::{Path, PathBuf};
 
@@ -42,7 +44,7 @@ impl WholeStreamCommand for Open {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        open(args, registry)
+        open(args, registry).await
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -54,39 +56,31 @@ impl WholeStreamCommand for Open {
     }
 }
 
-fn open(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+async fn open(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     let cwd = PathBuf::from(args.shell_manager.path());
     let full_path = cwd;
     let registry = registry.clone();
 
-    let stream = async_stream! {
-        let (OpenArgs { path, raw }, _) = args.process(&registry).await?;
-        let result = fetch(&full_path, &path.item, path.tag.span).await;
+    let (OpenArgs { path, raw }, _) = args.process(&registry).await?;
+    let result = fetch(&full_path, &path.item, path.tag.span).await;
 
-        if let Err(e) = result {
-            yield Err(e);
-            return;
-        }
-        let (file_extension, contents, contents_tag) = result?;
+    let (file_extension, contents, contents_tag) = result?;
 
-        let file_extension = if raw.item {
-            None
-        } else {
-            // If the extension could not be determined via mimetype, try to use the path
-            // extension. Some file types do not declare their mimetypes (such as bson files).
-            file_extension.or(path.extension().map(|x| x.to_string_lossy().to_string()))
-        };
-
-        let tagged_contents = contents.into_value(&contents_tag);
-
-        if let Some(extension) = file_extension {
-            yield Ok(ReturnSuccess::Action(CommandAction::AutoConvert(tagged_contents, extension)))
-        } else {
-            yield ReturnSuccess::value(tagged_contents);
-        }
+    let file_extension = if raw.item {
+        None
+    } else {
+        // If the extension could not be determined via mimetype, try to use the path
+        // extension. Some file types do not declare their mimetypes (such as bson files).
+        file_extension.or(path.extension().map(|x| x.to_string_lossy().to_string()))
     };
 
-    Ok(stream.to_output_stream())
+    let tagged_contents = contents.into_value(&contents_tag);
+
+    if let Some(extension) = file_extension {
+        Ok(OutputStream::one(ReturnSuccess::action(CommandAction::AutoConvert(tagged_contents, extension))))
+    } else {
+        Ok(OutputStream::one(ReturnSuccess::value(tagged_contents)))
+    }
 }
 
 pub async fn fetch(

--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -69,7 +69,7 @@ async fn open(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     } else {
         // If the extension could not be determined via mimetype, try to use the path
         // extension. Some file types do not declare their mimetypes (such as bson files).
-        file_extension.or(path.extension().map(|x| x.to_string_lossy().to_string()))
+        file_extension.or_else(|| path.extension().map(|x| x.to_string_lossy().to_string()))
     };
 
     let tagged_contents = contents.into_value(&contents_tag);

--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -26,55 +26,58 @@ impl WholeStreamCommand for ToMarkdown {
         args: CommandArgs,
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
-        to_html(args, registry)
+        to_html(args, registry).await
     }
 }
 
-fn to_html(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+async fn to_html(
+    args: CommandArgs,
+    registry: &CommandRegistry,
+) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
-    let stream = async_stream! {
-        let args = args.evaluate_once(&registry).await?;
-        let name_tag = args.name_tag();
-        let input: Vec<Value> = args.input.collect().await;
-        let headers = nu_protocol::merge_descriptors(&input);
-        let mut output_string = String::new();
+    let args = args.evaluate_once(&registry).await?;
+    let name_tag = args.name_tag();
+    let input: Vec<Value> = args.input.collect().await;
+    let headers = nu_protocol::merge_descriptors(&input);
+    let mut output_string = String::new();
 
-        if !headers.is_empty() && (headers.len() > 1 || headers[0] != "") {
+    if !headers.is_empty() && (headers.len() > 1 || headers[0] != "") {
+        output_string.push_str("|");
+        for header in &headers {
+            output_string.push_str(&htmlescape::encode_minimal(&header));
             output_string.push_str("|");
-            for header in &headers {
-                output_string.push_str(&htmlescape::encode_minimal(&header));
-                output_string.push_str("|");
-            }
-            output_string.push_str("\n|");
-            for _ in &headers {
-                output_string.push_str("-");
-                output_string.push_str("|");
-            }
-            output_string.push_str("\n");
         }
+        output_string.push_str("\n|");
+        for _ in &headers {
+            output_string.push_str("-");
+            output_string.push_str("|");
+        }
+        output_string.push_str("\n");
+    }
 
-        for row in input {
-            match row.value {
-                UntaggedValue::Row(row) => {
+    for row in input {
+        match row.value {
+            UntaggedValue::Row(row) => {
+                output_string.push_str("|");
+                for header in &headers {
+                    let data = row.get_data(header);
+                    output_string.push_str(&format_leaf(data.borrow()).plain_string(100_000));
                     output_string.push_str("|");
-                    for header in &headers {
-                        let data = row.get_data(header);
-                        output_string.push_str(&format_leaf(data.borrow()).plain_string(100_000));
-                        output_string.push_str("|");
-                    }
-                    output_string.push_str("\n");
                 }
-                p => {
-                    output_string.push_str(&(htmlescape::encode_minimal(&format_leaf(&p).plain_string(100_000))));
-                    output_string.push_str("\n");
-                }
+                output_string.push_str("\n");
+            }
+            p => {
+                output_string.push_str(
+                    &(htmlescape::encode_minimal(&format_leaf(&p).plain_string(100_000))),
+                );
+                output_string.push_str("\n");
             }
         }
+    }
 
-        yield ReturnSuccess::value(UntaggedValue::string(output_string).into_value(name_tag));
-    };
-
-    Ok(stream.to_output_stream())
+    Ok(OutputStream::one(ReturnSuccess::value(
+        UntaggedValue::string(output_string).into_value(name_tag),
+    )))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I'm only focusing on the simple-to-convert commands here... totally skipping anything too hairy (I.E. yields within loops)