### PR TITLE
Pub expose InterruptibleStream and InputStream.

### DIFF
--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -44,7 +44,7 @@ pub use crate::data::primitive;
 pub use crate::data::value;
 pub use crate::env::environment_syncer::EnvironmentSyncer;
 pub use crate::env::host::BasicHost;
-pub use crate::stream::OutputStream;
+pub use crate::stream::{InputStream, InterruptibleStream, OutputStream};
 pub use nu_value_ext::ValueExt;
 pub use num_traits::cast::ToPrimitive;
 


### PR DESCRIPTION
This allows crate users to make sure their long-running
streams can be interrupted with ctrl-c.