### PR TITLE
Add 'every' command to select (or skip) every nth row

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -320,6 +320,7 @@ pub fn create_default_context(
             whole_stream_command(GroupByDate),
             whole_stream_command(First),
             whole_stream_command(Last),
+            whole_stream_command(Every),
             whole_stream_command(Nth),
             whole_stream_command(Drop),
             whole_stream_command(Format),

--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -30,6 +30,7 @@ pub(crate) mod echo;
 pub(crate) mod enter;
 #[allow(unused)]
 pub(crate) mod evaluate_by;
+pub(crate) mod every;
 pub(crate) mod exit;
 pub(crate) mod first;
 pub(crate) mod format;
@@ -160,6 +161,7 @@ pub(crate) mod touch;
 pub(crate) use enter::Enter;
 #[allow(unused_imports)]
 pub(crate) use evaluate_by::EvaluateBy;
+pub(crate) use every::Every;
 pub(crate) use exit::Exit;
 pub(crate) use first::First;
 pub(crate) use format::Format;

--- a/crates/nu-cli/src/commands/every.rs
+++ b/crates/nu-cli/src/commands/every.rs
@@ -1,0 +1,85 @@
+use crate::commands::WholeStreamCommand;
+use crate::context::CommandRegistry;
+use crate::prelude::*;
+use nu_errors::ShellError;
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
+use nu_source::Tagged;
+
+pub struct Every;
+
+#[derive(Deserialize)]
+pub struct EveryArgs {
+    stride: Tagged<u64>,
+}
+
+#[async_trait]
+impl WholeStreamCommand for Every {
+    fn name(&self) -> &str {
+        "every"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "stride",
+                SyntaxShape::Int,
+                "every which row to select",
+            )
+    }
+
+    fn usage(&self) -> &str {
+        "Show only every nth row, starting from the first."
+    }
+
+    async fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        every(args, registry).await
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Get every second row",
+                example: "echo [1 2 3 4 5] | every 2",
+                result: Some(vec![
+                    UntaggedValue::int(1).into(),
+                    UntaggedValue::int(3).into(),
+                    UntaggedValue::int(5).into(),
+                ]),
+            },
+        ]
+    }
+}
+
+async fn every(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
+    let registry = registry.clone();
+    let (EveryArgs { stride }, input) = args.process(&registry).await?;
+    let v: Vec<_> = input.into_vec().await;
+
+    let stride_desired = if stride.item < 1 { 1 } else { stride.item } as usize;
+
+    let mut values_vec_deque = VecDeque::new();
+
+    for (i, x) in v.iter().enumerate() {
+        if i % stride_desired == 0 {
+            values_vec_deque.push_back(ReturnSuccess::value(x.clone()));
+        }
+    }
+
+    Ok(futures::stream::iter(values_vec_deque).to_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Every;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(Every {})
+    }
+}

--- a/crates/nu-cli/src/commands/every.rs
+++ b/crates/nu-cli/src/commands/every.rs
@@ -24,17 +24,17 @@ impl WholeStreamCommand for Every {
             .required(
                 "stride",
                 SyntaxShape::Int,
-                "every which row to select",
+                "how many rows to skip between (and including) each row returned",
             )
             .switch(
                 "skip",
-                "skip the rows instead of selecting them",
-                Some('s')
+                "skip the rows that would be returned, instead of selecting them",
+                Some('s'),
             )
     }
 
     fn usage(&self) -> &str {
-        "Show (or skip) every nth row, starting from the first."
+        "Show (or skip) every n-th row, starting from the first one."
     }
 
     async fn run(

--- a/crates/nu-cli/tests/commands/every.rs
+++ b/crates/nu-cli/tests/commands/every.rs
@@ -1,0 +1,100 @@
+use nu_test_support::fs::Stub::EmptyFile;
+use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn gets_all_rows_by_every_zero() {
+    Playground::setup("every_test_1", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 0
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "4");
+    })
+}
+
+#[test]
+fn gets_all_rows_by_every_one() {
+    Playground::setup("every_test_2", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 1
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "4");
+    })
+}
+
+#[test]
+fn gets_first_row_by_every_too_much() {
+    Playground::setup("every_test_3", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 999
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "1");
+    })
+}
+
+#[test]
+fn gets_every_third_row() {
+    Playground::setup("every_test_4", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("quatro.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 3
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "2");
+    })
+}

--- a/crates/nu-cli/tests/commands/every.rs
+++ b/crates/nu-cli/tests/commands/every.rs
@@ -27,8 +27,32 @@ fn gets_all_rows_by_every_zero() {
 }
 
 #[test]
-fn gets_all_rows_by_every_one() {
+fn gets_no_rows_by_every_skip_zero() {
     Playground::setup("every_test_2", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 0 --skip
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "0");
+    })
+}
+
+#[test]
+fn gets_all_rows_by_every_one() {
+    Playground::setup("every_test_3", |dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
@@ -51,8 +75,32 @@ fn gets_all_rows_by_every_one() {
 }
 
 #[test]
+fn gets_no_rows_by_every_skip_one() {
+    Playground::setup("every_test_4", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 1 --skip
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "0");
+    })
+}
+
+#[test]
 fn gets_first_row_by_every_too_much() {
-    Playground::setup("every_test_3", |dirs, sandbox| {
+    Playground::setup("every_test_5", |dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
@@ -75,8 +123,32 @@ fn gets_first_row_by_every_too_much() {
 }
 
 #[test]
+fn gets_all_rows_except_first_by_every_skip_too_much() {
+    Playground::setup("every_test_6", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 999 --skip
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "3");
+    })
+}
+
+#[test]
 fn gets_every_third_row() {
-    Playground::setup("every_test_4", |dirs, sandbox| {
+    Playground::setup("every_test_7", |dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
@@ -96,5 +168,30 @@ fn gets_every_third_row() {
         ));
 
         assert_eq!(actual.out, "2");
+    })
+}
+
+#[test]
+fn skips_every_third_row() {
+    Playground::setup("every_test_8", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("quatro.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls
+                | every 3 --skip
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "3");
     })
 }

--- a/crates/nu-cli/tests/commands/every.rs
+++ b/crates/nu-cli/tests/commands/every.rs
@@ -16,13 +16,19 @@ fn gets_all_rows_by_every_zero() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 0
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "4");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ amigos.txt arepas.clu los.txt tres.txt ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }
 
@@ -40,13 +46,19 @@ fn gets_no_rows_by_every_skip_zero() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 0 --skip
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "0");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }
 
@@ -64,13 +76,19 @@ fn gets_all_rows_by_every_one() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 1
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "4");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ amigos.txt arepas.clu los.txt tres.txt ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }
 
@@ -88,13 +106,19 @@ fn gets_no_rows_by_every_skip_one() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 1 --skip
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "0");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }
 
@@ -112,13 +136,19 @@ fn gets_first_row_by_every_too_much() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 999
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "1");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ amigos.txt ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }
 
@@ -136,13 +166,19 @@ fn gets_all_rows_except_first_by_every_skip_too_much() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 999 --skip
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "3");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ arepas.clu los.txt tres.txt ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }
 
@@ -161,13 +197,19 @@ fn gets_every_third_row() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 3
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "2");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ amigos.txt quatro.txt ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }
 
@@ -186,12 +228,18 @@ fn skips_every_third_row() {
             cwd: dirs.test(), pipeline(
             r#"
                 ls
+                | get name
                 | every 3 --skip
-                | count
-                | echo $it
             "#
         ));
 
-        assert_eq!(actual.out, "3");
+        let expected = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                echo [ arepas.clu los.txt tres.txt ]
+            "#
+        ));
+
+        assert_eq!(actual.out, expected.out);
     })
 }

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -10,6 +10,7 @@ mod default;
 mod drop;
 mod each;
 mod enter;
+mod every;
 mod first;
 mod format;
 mod get;

--- a/docs/commands/every.md
+++ b/docs/commands/every.md
@@ -1,0 +1,46 @@
+# every
+
+Selects every n-th row of a table, starting from the first one. With the `--skip` flag, every n-th row will be skipped, inverting the original functionality.
+
+Syntax: `> [input-command] | every <stride> {flags}`
+
+## Flags
+
+* `--skip`, `-s`: Skip the rows that would be returned, instead of selecting them
+
+
+## Examples
+
+```shell
+> open contacts.csv
+───┬─────────┬──────┬─────────────────
+ # │ first   │ last │ email
+───┼─────────┼──────┼─────────────────
+ 0 │ John    │ Doe  │ doe.1@email.com
+ 1 │ Jane    │ Doe  │ doe.2@email.com
+ 2 │ Chris   │ Doe  │ doe.3@email.com
+ 3 │ Francis │ Doe  │ doe.4@email.com
+ 4 │ Stella  │ Doe  │ doe.5@email.com
+───┴─────────┴──────┴─────────────────
+```
+
+```shell
+> open contacts.csv | every 2
+───┬─────────┬──────┬─────────────────
+ # │ first   │ last │ email
+───┼─────────┼──────┼─────────────────
+ 0 │ John    │ Doe  │ doe.1@email.com
+ 2 │ Chris   │ Doe  │ doe.3@email.com
+ 4 │ Stella  │ Doe  │ doe.5@email.com
+───┴─────────┴──────┴─────────────────
+```
+
+```shell
+> open contacts.csv | every 2 --skip
+───┬─────────┬──────┬─────────────────
+ # │ first   │ last │ email
+───┼─────────┼──────┼─────────────────
+ 1 │ Jane    │ Doe  │ doe.2@email.com
+ 3 │ Francis │ Doe  │ doe.4@email.com
+───┴─────────┴──────┴─────────────────
+```


### PR DESCRIPTION
Pretty self-explanatory. `echo [ 1 2 3 4 5 ] | every 2` selects every second row (result will be `[ 1 3 5 ]`). The `--skip` flag skips every nth row instead of selecting it (result will be `[ 2 4 ]`).

It needs a language review, especially the `<stride>` argument feels like broken English but I didn't know how to formulate it better.

- [ ]  check the language of the help messages