### PR TITLE
Fix regression. skip-until 'skips' until condition is met.

### DIFF
--- a/crates/nu-cli/src/commands/skip_until.rs
+++ b/crates/nu-cli/src/commands/skip_until.rs
@@ -100,8 +100,8 @@ impl WholeStreamCommand for SkipUntil {
                     trace!("RESULT = {:?}", result);
 
                     match result {
-                        Ok(ref v) if v.is_true() => true,
-                        _ => false,
+                        Ok(ref v) if v.is_true() => false, // stop skipping
+                        _ => true,
                     }
                 }
             })

--- a/crates/nu-cli/tests/commands/skip_until.rs
+++ b/crates/nu-cli/tests/commands/skip_until.rs
@@ -12,20 +12,20 @@ fn condition_is_met() {
                 --------------------------------------------------------------------
                 Chicken Collection,29/04/2020,30/04/2020,31/04/2020,
                 Yellow Chickens,,,
-                Andrés,1,1,1
-                Jonathan,1,1,1
-                Jason,1,1,1
-                Yehuda,1,1,1
+                Andrés,0,0,1
+                Jonathan,0,0,1
+                Jason,0,0,1
+                Yehuda,0,0,1
                 Blue Chickens,,,
-                Andrés,1,1,2
-                Jonathan,1,1,2
-                Jason,1,1,2
-                Yehuda,1,1,2
+                Andrés,0,0,1
+                Jonathan,0,0,1
+                Jason,0,0,1
+                Yehuda,0,0,2
                 Red Chickens,,,
-                Andrés,1,1,3
-                Jonathan,1,1,3
-                Jason,1,1,3
-                Yehuda,1,1,3
+                Andrés,0,0,1
+                Jonathan,0,0,1
+                Jason,0,0,1
+                Yehuda,0,0,3
             "#,
         )]);
 
@@ -45,6 +45,6 @@ fn condition_is_met() {
                 "#
         ));
 
-        assert_eq!(actual.out, "12");
+        assert_eq!(actual.out, "6");
     })
 }


### PR DESCRIPTION
`skip-until` stopped working correctly. This fixes it. Test was changed to avoid the false positive.