### PR TITLE
Sort primitives explictly.

### DIFF
--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -1,4 +1,5 @@
 use crate::commands::WholeStreamCommand;
+use crate::data::base::coerce_compare;
 use crate::prelude::*;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
@@ -112,7 +113,7 @@ pub fn sort(
             value: UntaggedValue::Primitive(_),
             ..
         } => {
-            vec.sort();
+            vec.sort_by(|a, b| coerce_compare(a, b).expect("Unimplemented BUG: What about primitives that don't have an order defined?").compare());
         }
         _ => {
             let calc_key = |item: &Value| {

--- a/crates/nu-cli/tests/commands/math/median.rs
+++ b/crates/nu-cli/tests/commands/math/median.rs
@@ -27,3 +27,17 @@ fn median_numbers_with_odd_rows() {
 
     assert_eq!(actual.out, "10.5")
 }
+
+#[test]
+fn median_mixed_numbers() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+             echo [-11.5 -13.5 10]
+             | math median
+             | echo $it
+         "#
+    ));
+
+    assert_eq!(actual.out, "-11.5")
+}


### PR DESCRIPTION
`math median` sorts the values before finding the answer. When sorting is attempted against a list of primitives of different types, an incorrect sorted list is the result. This fixes it and allows `median` to work correctly with list of different types of primitives and closing #2006