### PR TITLE
Uniq: `--count` flag to count occurences

### DIFF
--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -1,9 +1,11 @@
 use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
-use indexmap::set::IndexSet;
+use indexmap::map::IndexMap;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature};
+use nu_protocol::Signature;
+
+use num_bigint::ToBigUint;
 
 pub struct Uniq;
 
@@ -32,15 +34,33 @@ impl WholeStreamCommand for Uniq {
 
 async fn uniq(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     let input = args.input;
-    let uniq_values: IndexSet<_> = input.collect().await;
+    let uniq_values = {
+        let mut counter = IndexMap::<nu_protocol::Value, usize>::new();
+        for line in input.into_vec().await {
+            // TODO: Is there a way to collect and await at the end of the loop? (input.map() failed)
+            *counter.entry(line).or_insert(0) += 1;
+        }
+        counter
+    };
 
-    let mut values_vec_deque = VecDeque::new();
+    let mut values_vec_deque = VecDeque::<nu_protocol::Value>::new();
 
-    for item in uniq_values
-        .iter()
-        .map(|row| ReturnSuccess::value(row.clone()))
-    {
-        values_vec_deque.push_back(item);
+    for item in uniq_values {
+        use nu_protocol::{UntaggedValue, Value};
+        let value = match item.0.value {
+            UntaggedValue::Row(mut row) => {
+                row.entries.insert(
+                    "count".to_string(),
+                    UntaggedValue::int(item.1.to_biguint().unwrap()).into_untagged_value(),
+                );
+                Value {
+                    value: UntaggedValue::Row(row),
+                    tag: item.0.tag,
+                }
+            }
+            _ => panic!("Could not match: {:#?}", item),
+        };
+        values_vec_deque.push_back(value);
     }
 
     Ok(futures::stream::iter(values_vec_deque).to_output_stream())

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -43,7 +43,7 @@ async fn uniq(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputSt
         counter
     };
 
-    let mut values_vec_deque = VecDeque::<nu_protocol::Value>::new();
+    let mut values_vec_deque = VecDeque::new();
 
     for item in uniq_values {
         use nu_protocol::{UntaggedValue, Value};

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -62,7 +62,23 @@ async fn uniq(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
                             tag: item.0.tag,
                         }
                     }
+                    UntaggedValue::Primitive(p) => {
+                        let mut map = IndexMap::<String, Value>::new();
+                        map.insert(
+                            "value".to_string(),
+                            UntaggedValue::Primitive(p).into_untagged_value(),
+                        );
+                        map.insert(
+                            "count".to_string(),
+                            UntaggedValue::int(item.1.to_biguint().unwrap()).into_untagged_value(),
+                        );
+                        Value {
+                            value: UntaggedValue::row(map),
+                            tag: item.0.tag,
+                        }
+                    }
                     _ => panic!("Could not match: {:#?}", item),
+                    // _ => item.0
                 }
             };
             values_vec_deque.push_back(value);

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -5,9 +5,6 @@ use indexmap::map::IndexMap;
 use nu_errors::ShellError;
 use nu_protocol::Signature;
 
-use num_bigint::ToBigUint;
-use num_traits::Zero;
-
 pub struct Uniq;
 
 #[async_trait]
@@ -40,7 +37,7 @@ async fn uniq(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     let uniq_values = {
         let mut counter = IndexMap::<nu_protocol::Value, usize>::new();
         for line in input.into_vec().await {
-            *counter.entry(line).or_insert(Zero::zero()) += 1;
+            *counter.entry(line).or_insert(0) += 1;
         }
         counter
     };
@@ -78,12 +75,10 @@ async fn uniq(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
                         }
                     }
                     UntaggedValue::Table(_) => Value {
-                        value: UntaggedValue::Error(ShellError::type_error(
-                             "a row or primitive type".to_string(),
-                             nu_source::Spanned{
-                                span: item.0.tag.span,
-                                item: "a table".to_string(),
-                             }
+                        value: UntaggedValue::Error(ShellError::labeled_error(
+                            "uniq -c cannot operate on tables.",
+                            "source",
+                            item.0.tag.span,
                         )),
                         tag: item.0.tag,
                     },

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -74,14 +74,13 @@ async fn uniq(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
                             tag: item.0.tag,
                         }
                     }
-                    UntaggedValue::Table(_) => Value {
-                        value: UntaggedValue::Error(ShellError::labeled_error(
+                    UntaggedValue::Table(_) => {
+                        return Err(ShellError::labeled_error(
                             "uniq -c cannot operate on tables.",
                             "source",
                             item.0.tag.span,
-                        )),
-                        tag: item.0.tag,
-                    },
+                        ))
+                    }
                     UntaggedValue::Error(_) | UntaggedValue::Block(_) => item.0,
                 }
             };

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -77,6 +77,9 @@ async fn uniq(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
                             tag: item.0.tag,
                         }
                     }
+                    // TODO(siedentop): Obviously, the panic should be removed (as well as the unwraps above). However,
+                    // is there a way to collect the failures in an outside chanel (stderr, logs, telemetry)? Just staying
+                    // silent on what is most likely programmer error, does not feel right.
                     _ => panic!("Could not match: {:#?}", item),
                     // _ => item.0
                 }

--- a/crates/nu-cli/tests/commands/uniq.rs
+++ b/crates/nu-cli/tests/commands/uniq.rs
@@ -140,3 +140,26 @@ fn uniq_when_keys_out_of_order() {
 
     assert_eq!(actual.out, "1");
 }
+
+#[test]
+fn uniq_counting() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            echo '["A", "B", "A"]'
+            | from json
+            | wrap item
+            | uniq -c
+        "#
+    ));
+    let expected = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        echo '[{"item": "A", "count": 2}, {"item": "B", "count": 1}]'
+        | from json
+        "#
+    ));
+    print!("{}", actual.out);
+    print!("{}", expected.out);
+    assert_eq!(actual.out, expected.out);
+}

--- a/crates/nu-cli/tests/commands/uniq.rs
+++ b/crates/nu-cli/tests/commands/uniq.rs
@@ -149,7 +149,7 @@ fn uniq_counting() {
             echo '["A", "B", "A"]'
             | from json
             | wrap item
-            | uniq -c
+            | uniq --count
         "#
     ));
     let expected = nu!(

--- a/docs/commands/uniq.md
+++ b/docs/commands/uniq.md
@@ -36,9 +36,14 @@ Yehuda,Katz,10/11/2013,A
 ```
 
 ### Counting
-`uniq -c` is the flag to output a `count` column.
+`--count` or `-c` is the flag to output a `count` column.
 
 ```
 > `open test.csv | get type | uniq -c`
-
+───┬───────┬───────
+ # │ value │ count 
+───┼───────┼───────
+ 0 │ A     │     3 
+ 1 │ B     │     2 
+───┴───────┴───────
 ```

--- a/docs/commands/uniq.md
+++ b/docs/commands/uniq.md
@@ -34,3 +34,11 @@ Yehuda,Katz,10/11/2013,A
  1 │ B
 ━━━┷━━━━━━━━━
 ```
+
+### Counting
+`uniq -c` is the flag to output a `count` column.
+
+```
+> `open test.csv | get type | uniq -c`
+
+```


### PR DESCRIPTION
As discussed in discord [1], I feel that `uniq -c` would be a great addition to *nushell*.

> @jonathandturner Yesterday at 1:00 AM
> Christoph I was wondering if uniq should take a flag to add a count column
> Oh you say that oops
> Yeah, that. I'd say feel free to clean it up and submit. I'm sure folks will like it

This was motivated by looking for Nushell equivalence to a common bash idiom [2]:

> Christoph 06/17/2020
> Hi again :slight_smile: , Anyone know how to count unique lines in a file?
> 
> In Bash it's this: `cat my_file | sort | uniq -c | sort -rn | head`
> 
> I figured that this would be an excellent use case for Nu.
> 
> BTW, this is from here: https://www.tbray.org/ongoing/When/202x/2020/05/18/TopFew
> [2]


## Example
This Bash-line find the most common lines and shows the top 10: 
```bash
cat my_file | sort | uniq -c | sort -rn | head
```

Here's the same in Nu!

```shell
fetch https://raw.githubusercontent.com/timbray/topfew/master/test/data/access-1k
  | lines | uniq -c | sort-by count | last 10
```

## Notes
0. **Not ready: I am looking for some early feedback, please!**
1. Please let me know any suggestions on how to improve the Rust code. I am still learning Rust and would welcome any feedback. (This can also be as a [DM on Twitter][3] or Discord: Christoph#2627).
2. There are two *TODOs* in the code. **I do not wish to merge** it before they are resolved.
3. There are still some unwraps. I'll remove those.

### Q1
This line: 
`    let uniq_values: IndexSet<_> = input.collect().await;`

became this: 

```rust
    let uniq_values = {
        let mut counter = IndexMap::<nu_protocol::Value, usize>::new();
        for line in input.into_vec().await {
            // TODO: Is there a way to collect and await at the end of the loop? (input.map() failed)
            *counter.entry(line).or_insert(0) += 1;
        }
        counter
    };
```

I don't think the early `await` is performance-wise a problem. The program has to block until all content is consumed. The new version blocks earlier, (I think?). So, my gut feeling is to remove the TODO and do nothing.

### Q2

I currently handle `Row` and `Primitive` inputs and panic on other inputs. The panic has to go. But is it okay, to just silently fail in those cases? Or should I implement all possible `UntaggedValue` enum values?

```rust
 // TODO(siedentop): Obviously, the panic should be removed (as well as the unwraps above). However,
 // is there a way to collect the failures in an outside chanel (stderr, logs, telemetry)? Just staying
 // silent on what is most likely programmer error, does not feel right.
_ => panic!("Could not match: {:#?}", item),
// _ => item.0
```


### Q3
On encountering a `Primitive` I transform this into a `Row`. Is this correct?




[1]: https://discord.com/channels/601130461678272522/615962413203718156/723084699060142170
[2]: https://discord.com/channels/601130461678272522/614593951969574961/722912736803160194
[3]: https://twitter.com/chsiedentop
