### PR TITLE
Math median tests and documentation additions

### DIFF
--- a/crates/nu-cli/src/commands/math/command.rs
+++ b/crates/nu-cli/src/commands/math/command.rs
@@ -35,7 +35,8 @@ impl WholeStreamCommand for Command {
 mod tests {
     use super::*;
     use crate::commands::math::{
-        avg::average, max::maximum, min::minimum, sum::summation, utils::MathFunction,
+        avg::average, max::maximum, median::median, min::minimum, sum::summation,
+        utils::MathFunction,
     };
     use nu_plugin::test_helpers::value::{decimal, int};
     use nu_protocol::Value;
@@ -67,13 +68,25 @@ mod tests {
                 description: "Single value",
                 values: vec![int(10)],
                 expected_err: None,
-                expected_res: vec![Ok(decimal(10)), Ok(int(10)), Ok(int(10)), Ok(int(10))],
+                expected_res: vec![
+                    Ok(decimal(10)),
+                    Ok(int(10)),
+                    Ok(int(10)),
+                    Ok(int(10)),
+                    Ok(int(10)),
+                ],
             },
             TestCase {
                 description: "Multiple Values",
-                values: vec![int(10), int(30), int(20)],
+                values: vec![int(10), int(20), int(30)],
                 expected_err: None,
-                expected_res: vec![Ok(decimal(20)), Ok(int(10)), Ok(int(30)), Ok(int(60))],
+                expected_res: vec![
+                    Ok(decimal(20)),
+                    Ok(int(10)),
+                    Ok(int(30)),
+                    Ok(int(20)),
+                    Ok(int(60)),
+                ],
             },
             TestCase {
                 description: "Mixed Values",
@@ -83,23 +96,31 @@ mod tests {
                     Ok(decimal(21)),
                     Ok(int(10)),
                     Ok(decimal(26.5)),
+                    Ok(decimal(26.5)),
                     Ok(decimal(63)),
                 ],
             },
             TestCase {
                 description: "Negative Values",
-                values: vec![int(10), int(-11), int(-14)],
+                values: vec![int(-14), int(-11), int(10)],
                 expected_err: None,
-                expected_res: vec![Ok(decimal(-5)), Ok(int(-14)), Ok(int(10)), Ok(int(-15))],
+                expected_res: vec![
+                    Ok(decimal(-5)),
+                    Ok(int(-14)),
+                    Ok(int(10)),
+                    Ok(int(-11)),
+                    Ok(int(-15)),
+                ],
             },
             TestCase {
                 description: "Mixed Negative Values",
-                values: vec![int(10), decimal(-11.5), decimal(-13.5)],
+                values: vec![decimal(-13.5), decimal(-11.5), int(10)],
                 expected_err: None,
                 expected_res: vec![
                     Ok(decimal(-5)),
                     Ok(decimal(-13.5)),
                     Ok(int(10)),
+                    Ok(decimal(-11.5)),
                     Ok(decimal(-15)),
                 ],
             },
@@ -126,7 +147,8 @@ mod tests {
 
         for tc in tt.iter() {
             let tc: &TestCase = tc; // Just for type annotations
-            let math_functions: Vec<MathFunction> = vec![average, minimum, maximum, summation];
+            let math_functions: Vec<MathFunction> =
+                vec![average, minimum, maximum, median, summation];
             let results = math_functions
                 .iter()
                 .map(|mf| mf(&tc.values, &test_tag))

--- a/docs/commands/math.md
+++ b/docs/commands/math.md
@@ -6,6 +6,7 @@ Currently the following functions are implemented:
 * `math avg`: Finds the average of a list of numbers or tables
 * `math min`: Finds the minimum within a list of numbers or tables
 * `math max`: Finds the maximum within a list of numbers or tables
+* `math median`: Finds the median of a list of numbers or tables
 * `math sum`: Finds the sum of a list of numbers or tables
 
 However, the mathematical functions like `min` and `max` are more permissive and also work on `Dates`.
@@ -46,6 +47,8 @@ To get the average of the file sizes in a directory, simply pipe the size column
 ```shell
 > ls | get size | math avg
 ───┬────────
+ # │
+───┼────────
  0 │ 7.2 KB
 ───┴────────
 ```
@@ -53,14 +56,17 @@ To get the average of the file sizes in a directory, simply pipe the size column
 ```shell
 > ls | get size | math min
 ───┬─────
+ # │
+───┼─────
  0 │ 0 B
 ───┴─────
 ```
 
 ```shell
-> ls | get size | math max
 ───┬──────────
- 0 │ 113.5 KB
+ # │
+───┼──────────
+ 0 │ 113.6 KB
 ───┴──────────
 ```
 
@@ -76,7 +82,9 @@ To get the average of the file sizes in a directory, simply pipe the size column
 ```shell
 > ls | get size | math sum
 ───┬──────────
- 0 │ 143.4 KB
+ # │
+───┼──────────
+ 0 │ 143.6 KB
 ───┴──────────
 ```
 

--- a/docs/commands/math.md
+++ b/docs/commands/math.md
@@ -65,6 +65,15 @@ To get the average of the file sizes in a directory, simply pipe the size column
 ```
 
 ```shell
+> ls | get size | math median
+───┬───────
+ # │
+───┼───────
+ 0 │ 320 B
+───┴───────
+```
+
+```shell
 > ls | get size | math sum
 ───┬──────────
  0 │ 143.4 KB

--- a/docs/commands/math.md
+++ b/docs/commands/math.md
@@ -116,12 +116,12 @@ To get the average of the file sizes in a directory, simply pipe the size column
 
 ```shell
 > pwd | split row / | size | math max
-───────────┬───
+────────────┬────
  lines      │ 0
- words      │ 1
- chars      │ 9
- max length │ 9
-────────────┴───
+ words      │ 2
+ chars      │ 12
+ max length │ 12
+────────────┴────
 ```
 
 ```shell

--- a/docs/commands/math.md
+++ b/docs/commands/math.md
@@ -108,9 +108,11 @@ To get the average of the file sizes in a directory, simply pipe the size column
  # │ lines │ words │ chars │ max length
 ───┼───────┼───────┼───────┼────────────
  0 │     0 │     1 │     5 │          5
- 1 │     0 │     1 │     7 │          7
- 2 │     0 │     1 │     9 │          9
- 3 │     0 │     1 │     7 │          7
+ 1 │     0 │     1 │    11 │         11
+ 2 │     0 │     1 │    11 │         11
+ 3 │     0 │     1 │     4 │          4
+ 4 │     0 │     2 │    12 │         12
+ 5 │     0 │     1 │     7 │          7
 ───┴───────┴───────┴───────┴────────────
 ```
 
@@ -128,9 +130,9 @@ To get the average of the file sizes in a directory, simply pipe the size column
 > pwd | split row / | size | math avg
 ────────────┬────────
  lines      │ 0.0000
- words      │ 1.0000
- chars      │ 7.0000
- max length │ 7.0000
+ words      │ 1.1666
+ chars      │ 8.3333
+ max length │ 8.3333
 ────────────┴────────
 ```
 


### PR DESCRIPTION
Closes https://github.com/nushell/nushell/issues/2005

I added the unit tests for `math median` and added an `math median` example to the math.md file, but its output was a bit different from the other examples, so I just updated all the examples there to keep them all consistent looking.