### PR TITLE
Cleanup header to work like before

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4617,12 +4617,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "b5fe1a9cb33fe7cf77d431070d0223e544b1e4e7f7764bad0a3e691a6678a131"
 dependencies = [
- "failure",
  "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -406,7 +406,10 @@ impl WrappedTable {
             self.print_separator(SeparatorPosition::Top);
         }
 
-        if !self.headers.is_empty() {
+        let skip_headers = (self.headers.len() == 2 && self.headers[1].max_width == 0)
+            || (self.headers.len() == 1 && self.headers[0].max_width == 0);
+
+        if !self.headers.is_empty() && !skip_headers {
             self.print_cell_contents(&self.headers);
         }
 
@@ -420,7 +423,7 @@ impl WrappedTable {
             } else {
                 first_row = false;
 
-                if self.theme.separate_header && !self.headers.is_empty() {
+                if self.theme.separate_header && !self.headers.is_empty() && !skip_headers {
                     self.print_separator(SeparatorPosition::Middle);
                 }
             }


### PR DESCRIPTION
This makes the table header work as it did pre-`nu-table`. Now, if you grab out a column of values, we make it a list without a header (matching the previous behavior)