### PR TITLE
Fix cal command week-start example

### DIFF
--- a/docs/commands/cal.md
+++ b/docs/commands/cal.md
@@ -191,7 +191,7 @@ Use `cal` to display a calendar.
 ```
 
 ```shell
-> cal -ymq --month-names --week-start-day monday
+> cal -ymq --month-names --week-start monday
 ───┬──────┬─────────┬───────┬────────┬─────────┬───────────┬──────────┬────────┬──────────┬────────
  # │ year │ quarter │ month │ monday │ tuesday │ wednesday │ thursday │ friday │ saturday │ sunday
 ───┼──────┼─────────┼───────┼────────┼─────────┼───────────┼──────────┼────────┼──────────┼────────


### PR DESCRIPTION
Must've pushed the wrong version of the flag up last time, sorry.