### PR TITLE
Add release automation with GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,209 @@
+name: Create Release Draft
+
+on:
+  push:
+    tags: ['[0-9]+.[0-9]+.[0-9]+*']
+
+jobs:
+  linux:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install libxcb
+        run: sudo apt-get install libxcb-composite0-dev
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all --features=stable
+      - name: Create output directory
+        run: mkdir output
+      - name: Copy files to output
+        run: |
+          cp target/release/nu target/release/nu_plugin_* output/
+          cp README.build.txt output/README.txt
+          rm output/*.d
+          rm output/nu_plugin_core_*
+          rm output/nu_plugin_stable_*
+      # Note: If OpenSSL changes, this path will need to be updated
+      - name: Copy OpenSSL to output
+        run: cp /usr/lib/x86_64-linux-gnu/libssl.so.1.1 output/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux
+          path: output/*
+
+  macos:
+    name: Build macOS
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all --features=stable
+      - name: Create output directory
+        run: mkdir output
+      - name: Copy files to output
+        run: |
+          cp target/release/nu target/release/nu_plugin_* output/
+          cp README.build.txt output/README.txt
+          rm output/*.d
+          rm output/nu_plugin_core_*
+          rm output/nu_plugin_stable_*
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: macos
+          path: output/*
+
+  windows:
+    name: Build Windows
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all --features=stable
+      - name: Create output directory
+        run: mkdir output
+      - name: Copy files to output
+        run: |
+          cp target\release\nu.exe output\
+          cp target\release\nu_plugin_*.exe output\
+          cp README.build.txt output\README.txt
+          rm output\nu_plugin_core_*.exe
+          rm output\nu_plugin_stable_*.exe
+      # Note: If the version of `less.exe` needs to be changed, update this URL
+      # Similarly, if `less.exe` is checked into the repo, copy from the local path here
+      - name: Download Less Binary
+        run: Invoke-WebRequest -Uri "https://github.com/jftuga/less-Windows/releases/download/less-v562.1/less.exe" -OutFile "output\less.exe"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows
+          path: output/*
+
+  release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs:
+      - linux
+      - macos
+      - windows
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Determine Release Info
+        id: info
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          VERSION=${GITHUB_REF##*/}
+          MAJOR=${VERSION%%.*}
+          MINOR=${VERSION%.*}
+          MINOR=${MINOR#*.}
+          PATCH=${VERSION##*.}
+          echo "::set-output name=version::${VERSION}"
+          echo "::set-output name=linuxdir::nu_${MAJOR}_${MINOR}_${PATCH}_linux"
+          echo "::set-output name=macosdir::nu_${MAJOR}_${MINOR}_${PATCH}_macOS"
+          echo "::set-output name=windowsdir::nu_${MAJOR}_${MINOR}_${PATCH}_windows"
+          echo "::set-output name=innerdir::nushell-${VERSION}"
+      - name: Create Release Draft
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ steps.info.outputs.version }} Release
+          draft: true
+      - name: Create Linux Directory
+        run: mkdir -p ${{ steps.info.outputs.linuxdir }}/${{ steps.info.outputs.innerdir }}
+      - name: Download Linux Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: linux
+          path: ${{ steps.info.outputs.linuxdir }}/${{ steps.info.outputs.innerdir }}
+      - name: Restore Linux File Modes
+        run: |
+          chmod 755 ${{ steps.info.outputs.linuxdir }}/${{ steps.info.outputs.innerdir }}/nu*
+          chmod 755 ${{ steps.info.outputs.linuxdir }}/${{ steps.info.outputs.innerdir }}/libssl*
+      - name: Create Linux tarball
+        run: tar -zcvf ${{ steps.info.outputs.linuxdir }}.tar.gz ${{ steps.info.outputs.linuxdir }}
+      - name: Upload Linux Artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ steps.info.outputs.linuxdir }}.tar.gz
+          asset_name: ${{ steps.info.outputs.linuxdir }}.tar.gz
+          asset_content_type: application/gzip
+      - name: Create macOS Directory
+        run: mkdir -p ${{ steps.info.outputs.macosdir }}/${{ steps.info.outputs.innerdir }}
+      - name: Download macOS Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: macos
+          path: ${{ steps.info.outputs.macosdir }}/${{ steps.info.outputs.innerdir }}
+      - name: Restore macOS File Modes
+        run: chmod 755 ${{ steps.info.outputs.macosdir }}/${{ steps.info.outputs.innerdir }}/nu*
+      - name: Create macOS Archive
+        run: zip -r ${{ steps.info.outputs.macosdir }}.zip ${{ steps.info.outputs.macosdir }}
+      - name: Upload macOS Artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ steps.info.outputs.macosdir }}.zip
+          asset_name: ${{ steps.info.outputs.macosdir }}.zip
+          asset_content_type: application/zip
+      - name: Create Windows Directory
+        run: mkdir -p ${{ steps.info.outputs.windowsdir }}/${{ steps.info.outputs.innerdir }}
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: windows
+          path: ${{ steps.info.outputs.windowsdir }}/${{ steps.info.outputs.innerdir }}
+      # TODO: Remove Show
+      - name: Show Windows Artifacts
+        run: ls -la ${{ steps.info.outputs.windowsdir }}/${{ steps.info.outputs.innerdir }}
+      - name: Create Windows Archive
+        run: zip -r ${{ steps.info.outputs.windowsdir }}.zip ${{ steps.info.outputs.windowsdir }}
+      - name: Upload Windows Artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ steps.info.outputs.windowsdir }}.zip
+          asset_name: ${{ steps.info.outputs.windowsdir }}.zip
+          asset_content_type: application/zip

--- a/README.build.txt
+++ b/README.build.txt
@@ -1,0 +1,1 @@
+Nu will look for the plugins in your PATH on startup. While nu will have some functionality without them, for full functionality you'll need to copy them into your path so they can be loaded.


### PR DESCRIPTION
Summary
-----
Use GitHub Actions to compile and create a release draft every time a tag of the form `<MAJOR>.<MINOR>.<PATCH>` is pushed into the repo. The steps for each build are taken from #2042 and then the builds are compiled together and added as artifacts to the release.

Workflow
-----
With this Action, the workflow for creating a new release should be roughly:

* Make the changes to the code base to prepare for the release (updating `Cargo.toml`, etc.)
* Create a new tag locally with `git tag <VERSION>`
* Push the tag to the GitHub repo with `git push upstream <VERSION>` (using whatever your remote is named for this repo in place of `upstream`)
* Wait for CI to finish
* Open the draft `Release <VERSION>`
* Add the description to the Release
* Hit "Publish"

Tested
-----
I tested this using my fork of the repo. You can see the Release that was created by this Workflow here: https://github.com/charlespierce/nushell/releases/tag/0.99.14

Notes
-----
* Fetching `less.exe` for the Windows build is currently hard-coded. I added a comment in the YAML file noting that if the version changes that URL will need to be updated. Also, a comment in #2042 indicated that file may at some point be checked in to the repo. In that case, the file will simply need to be copied to the `output/` directory, instead of fetched from the internet.
* Similarly, pulling in the OpenSSL version is hard-coded to `libssl.so.1.1`, so that may need to be updated to be more robust going forward.
* I didn't tackle the `cargo publish` step, as that requires using secrets and I don't have any experience working with those.