### PR TITLE
Adds random command with uuid subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "umask",
  "unicode-xid",
  "users",
+ "uuid",
  "which",
 ]
 
@@ -4458,6 +4459,15 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "vcpkg"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -85,6 +85,7 @@ toml = "0.5.6"
 typetag = "0.1.4"
 umask = "1.0.0"
 unicode-xid = "0.2.0"
+uuid_crate = { package = "uuid", version = "0.8.1", features = ["v4"] }
 which = "4.0.1"
 
 trash = { version = "1.0.1", optional = true }

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -389,6 +389,9 @@ pub fn create_default_context(
             whole_stream_command(FromVcf),
             // "Private" commands (not intended to be accessed directly)
             whole_stream_command(RunExternalCommand { interactive }),
+            // Random value generation
+            whole_stream_command(Random),
+            whole_stream_command(RandomUUID),
         ]);
 
         cfg_if::cfg_if! {

--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -81,6 +81,7 @@ pub(crate) mod plugin;
 pub(crate) mod prepend;
 pub(crate) mod prev;
 pub(crate) mod pwd;
+pub(crate) mod random;
 pub(crate) mod range;
 #[allow(unused)]
 pub(crate) mod reduce_by;
@@ -212,6 +213,7 @@ pub(crate) use pivot::Pivot;
 pub(crate) use prepend::Prepend;
 pub(crate) use prev::Previous;
 pub(crate) use pwd::Pwd;
+pub(crate) use random::{Random, RandomUUID};
 pub(crate) use range::Range;
 #[allow(unused_imports)]
 pub(crate) use reduce_by::ReduceBy;

--- a/crates/nu-cli/src/commands/random/command.rs
+++ b/crates/nu-cli/src/commands/random/command.rs
@@ -1,0 +1,32 @@
+use crate::commands::WholeStreamCommand;
+use crate::prelude::*;
+use nu_errors::ShellError;
+use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
+
+pub struct Command;
+
+#[async_trait]
+impl WholeStreamCommand for Command {
+    fn name(&self) -> &str {
+        "random"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("random")
+    }
+
+    fn usage(&self) -> &str {
+        "Generate random values"
+    }
+
+    async fn run(
+        &self,
+        _args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+            UntaggedValue::string(crate::commands::help::get_help(&Command, &registry.clone()))
+                .into_value(Tag::unknown()),
+        ))))
+    }
+}

--- a/crates/nu-cli/src/commands/random/mod.rs
+++ b/crates/nu-cli/src/commands/random/mod.rs
@@ -1,0 +1,5 @@
+pub mod command;
+pub mod uuid;
+
+pub use command::Command as Random;
+pub use uuid::SubCommand as RandomUUID;

--- a/crates/nu-cli/src/commands/random/uuid.rs
+++ b/crates/nu-cli/src/commands/random/uuid.rs
@@ -1,0 +1,59 @@
+use crate::commands::WholeStreamCommand;
+use crate::prelude::*;
+use nu_errors::ShellError;
+use nu_protocol::{ReturnSuccess, Signature};
+use uuid_crate::Uuid;
+
+pub struct SubCommand;
+
+#[async_trait]
+impl WholeStreamCommand for SubCommand {
+    fn name(&self) -> &str {
+        "random uuid"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("random uuid")
+    }
+
+    fn usage(&self) -> &str {
+        "Generate a random uuid4 string"
+    }
+
+    async fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        uuid(args, registry).await
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Generate a random uuid4 string",
+            example: "random uuid",
+            result: None,
+        }]
+    }
+}
+
+pub async fn uuid(
+    _args: CommandArgs,
+    _registry: &CommandRegistry,
+) -> Result<OutputStream, ShellError> {
+    let uuid_4 = Uuid::new_v4().to_hyphenated().to_string();
+
+    Ok(OutputStream::one(ReturnSuccess::value(uuid_4)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubCommand;
+
+    #[test]
+    fn examples_work_as_expected() {
+        use crate::examples::test as test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -31,6 +31,7 @@ mod mv;
 mod open;
 mod parse;
 mod prepend;
+mod random;
 mod range;
 mod rename;
 mod reverse;

--- a/crates/nu-cli/tests/commands/random/mod.rs
+++ b/crates/nu-cli/tests/commands/random/mod.rs
@@ -1,0 +1,1 @@
+mod uuid;

--- a/crates/nu-cli/tests/commands/random/uuid.rs
+++ b/crates/nu-cli/tests/commands/random/uuid.rs
@@ -1,0 +1,16 @@
+use nu_test_support::{nu, pipeline};
+use uuid_crate::Uuid;
+
+#[test]
+fn makes_valid_uuid4() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        random uuid
+        "#
+    ));
+
+    let result = Uuid::parse_str(actual.out.as_str());
+
+    assert!(result.is_ok());
+}

--- a/docs/commands/random.md
+++ b/docs/commands/random.md
@@ -1,0 +1,12 @@
+# random
+
+Use `random` to generate random values
+
+* `random uuid`: Generate a random uuid4 string
+
+## Examples
+
+```shell
+> random uuid
+8af4de39-acbc-42f0-94d1-7cfad6c01f8b
+```


### PR DESCRIPTION
Here is the first bit of what I was suggesting.  

The `random` command here only has one subcommand, `uuid`, which generates a uuid4.  

Some issues / PRs can be made out of:

- Adding different UUID flags to the uuid subcommand to override which version of uuid to use (some of these uuid versions might require some sort of input from the user, so the flag might need to take in a string).  My opinion is that once flags for different uuid versions are added, it should still default to uuid4 when no flag is provided, unless someone else has a strong opinion on it.  I wouldn't mind trying to add these, if the maintainers agree with it.

- Adding something like a `number` subcommand that has some sort of default ranges (maybe 0 to max size), with flags to allow for negative numbers, floats, and to specify the min and max values.

Of course, these are just my suggestions and the maintainers have the ultimate say so.