### PR TITLE
Properly redirect invocations

### DIFF
--- a/crates/nu-cli/src/commands/do_.rs
+++ b/crates/nu-cli/src/commands/do_.rs
@@ -72,7 +72,7 @@ async fn do_(
         },
         input,
     ) = raw_args.process(&registry).await?;
-    block.redirect_output(!is_last);
+    block.set_is_last(!is_last);
 
     let result = run_block(
         &block,

--- a/crates/nu-cli/src/commands/do_.rs
+++ b/crates/nu-cli/src/commands/do_.rs
@@ -61,16 +61,18 @@ async fn do_(
     registry: &CommandRegistry,
 ) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
+    let is_last = raw_args.call_info.args.is_last;
 
     let mut context = Context::from_raw(&raw_args, &registry);
     let scope = raw_args.call_info.scope.clone();
     let (
         DoArgs {
             ignore_errors,
-            block,
+            mut block,
         },
         input,
     ) = raw_args.process(&registry).await?;
+    block.redirect_output(!is_last);
 
     let result = run_block(
         &block,

--- a/crates/nu-cli/src/commands/run_alias.rs
+++ b/crates/nu-cli/src/commands/run_alias.rs
@@ -40,7 +40,9 @@ impl WholeStreamCommand for AliasCommand {
     ) -> Result<OutputStream, ShellError> {
         let call_info = args.call_info.clone();
         let registry = registry.clone();
-        let block = self.block.clone();
+        let mut block = self.block.clone();
+        block.redirect_output(!call_info.args.is_last);
+
         let alias_command = self.clone();
         let mut context = Context::from_args(&args, &registry);
         let input = args.input;

--- a/crates/nu-cli/src/commands/run_alias.rs
+++ b/crates/nu-cli/src/commands/run_alias.rs
@@ -41,7 +41,7 @@ impl WholeStreamCommand for AliasCommand {
         let call_info = args.call_info.clone();
         let registry = registry.clone();
         let mut block = self.block.clone();
-        block.redirect_output(!call_info.args.is_last);
+        block.set_is_last(!call_info.args.is_last);
 
         let alias_command = self.clone();
         let mut context = Context::from_args(&args, &registry);

--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -60,18 +60,9 @@ async fn with_env(
 ) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
 
-    let is_last = raw_args.call_info.args.is_last;
     let mut context = Context::from_raw(&raw_args, &registry);
     let mut scope = raw_args.call_info.scope.clone();
-    let (
-        WithEnvArgs {
-            variable,
-            mut block,
-        },
-        input,
-    ) = raw_args.process(&registry).await?;
-
-    block.redirect_output(!is_last);
+    let (WithEnvArgs { variable, block }, input) = raw_args.process(&registry).await?;
 
     scope.env.insert(variable.0.item, variable.1.item);
 

--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -60,9 +60,18 @@ async fn with_env(
 ) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
 
+    let is_last = raw_args.call_info.args.is_last;
     let mut context = Context::from_raw(&raw_args, &registry);
     let mut scope = raw_args.call_info.scope.clone();
-    let (WithEnvArgs { variable, block }, input) = raw_args.process(&registry).await?;
+    let (
+        WithEnvArgs {
+            variable,
+            mut block,
+        },
+        input,
+    ) = raw_args.process(&registry).await?;
+
+    block.redirect_output(!is_last);
 
     scope.env.insert(variable.0.item, variable.1.item);
 

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -197,7 +197,7 @@ async fn evaluate_invocation(
     let input = InputStream::empty();
 
     let mut block = block.clone();
-    block.redirect_output(true);
+    block.set_is_last(true);
 
     let result = run_block(&block, &mut context, input, it, vars, env).await?;
 

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -196,6 +196,9 @@ async fn evaluate_invocation(
 
     let input = InputStream::empty();
 
+    let mut block = block.clone();
+    block.redirect_output(true);
+
     let result = run_block(&block, &mut context, input, it, vars, env).await?;
 
     let output = result.into_vec().await;

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -201,14 +201,26 @@ impl Block {
         }
     }
 
-    pub fn redirect_output(&mut self, redirect: bool) {
+    pub fn set_is_last(&mut self, is_last: bool) {
         if let Some(pipeline) = self.block.last_mut() {
             if let Some(command) = pipeline.list.last_mut() {
                 if let ClassifiedCommand::Internal(internal) = command {
-                    internal.args.is_last = !redirect;
+                    internal.args.is_last = is_last;
                 }
             }
         }
+    }
+
+    pub fn get_is_last(&mut self) -> Option<bool> {
+        if let Some(pipeline) = self.block.last_mut() {
+            if let Some(command) = pipeline.list.last_mut() {
+                if let ClassifiedCommand::Internal(internal) = command {
+                    return Some(internal.args.is_last);
+                }
+            }
+        }
+
+        None
     }
 }
 

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -200,6 +200,16 @@ impl Block {
             commands.expand_it_usage();
         }
     }
+
+    pub fn redirect_output(&mut self, redirect: bool) {
+        if let Some(pipeline) = self.block.last_mut() {
+            if let Some(command) = pipeline.list.last_mut() {
+                if let ClassifiedCommand::Internal(internal) = command {
+                    internal.args.is_last = !redirect;
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize)]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -85,12 +85,24 @@ fn it_expansion_of_invocation() {
 }
 
 #[test]
+fn invocation_properly_redirects() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo $(nu --testbin cococo "hello") | str collect
+        "#
+    );
+
+    assert_eq!(actual.out, "hello");
+}
+
+#[test]
 fn argument_invocation() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo "foo" | echo $(echo $it)
-            "#
+            echo "foo" | echo $(echo $it)
+        "#
     );
 
     assert_eq!(actual.out, "foo");


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/2069

Previously, when we used an invocation, we were not properly redirect the output to ensure that we would capture any external commands output. The result is that `echo $(tty)` would be treated as a non-redirected `tty` call, so it would just output to the screen, and we would instead return `nothing`.

With this PR, we now will always redirect invocations so that the contents of a possible external in the last position is not lost.