### PR TITLE
Cal improvements

### DIFF
--- a/crates/nu-cli/src/commands/cal.rs
+++ b/crates/nu-cli/src/commands/cal.rs
@@ -84,17 +84,15 @@ pub async fn cal(
     let mut selected_year: i32 = current_year;
     let mut current_day_option: Option<u32> = Some(current_day);
 
-    let month_range = if args.has("full-year") {
-        if let Some(full_year_value) = args.get("full-year") {
-            if let Ok(year_u64) = full_year_value.as_u64() {
-                selected_year = year_u64 as i32;
+    let month_range = if let Some(full_year_value) = args.get("full-year") {
+        if let Ok(year_u64) = full_year_value.as_u64() {
+            selected_year = year_u64 as i32;
 
-                if selected_year != current_year {
-                    current_day_option = None
-                }
-            } else {
-                return Err(get_invalid_year_shell_error(&full_year_value.tag()));
+            if selected_year != current_year {
+                current_day_option = None
             }
+        } else {
+            return Err(get_invalid_year_shell_error(&full_year_value.tag()));
         }
 
         (1, 12)

--- a/crates/nu-cli/src/commands/cal.rs
+++ b/crates/nu-cli/src/commands/cal.rs
@@ -298,7 +298,7 @@ fn add_month_to_table(
             );
         }
 
-        if should_show_month_column {
+        if should_show_month_column || should_show_month_names {
             let month_value = if should_show_month_names {
                 UntaggedValue::string(month_helper.month_name.clone()).into_value(tag)
             } else {


### PR DESCRIPTION
The main reason for opening this PR is because I always use the `--month-names` flag on the cal command to show the actual month name over the month integer.  However, if you just call it on its own, nothing happens:

<img width="866" alt="Screen Shot 2020-06-28 at 1 51 50 AM" src="https://user-images.githubusercontent.com/19867440/85939275-04bf7f80-b8e2-11ea-868b-a36b4936c3fe.png">

This can be misleading; you must call the `-m` flag first to insert the month column, and then the `--month-names` to get the non-integer form:

<img width="890" alt="Screen Shot 2020-06-28 at 1 52 15 AM" src="https://user-images.githubusercontent.com/19867440/85939287-16a12280-b8e2-11ea-8243-90453601de5d.png">

I sometimes forget this, despite being the one who wrote it.  I think it makes sense that if the user supplies `--month-names`, that it is implied they want to see the month column and they shouldn't need to supply `-m`

<img width="866" alt="Screen Shot 2020-06-28 at 1 49 40 AM" src="https://user-images.githubusercontent.com/19867440/85939303-2a4c8900-b8e2-11ea-8f3c-7950041ab767.png">

There was also an unnecessary check I removed as well and tossed it into this PR.