### PR TITLE
Make config loading more resilient

### DIFF
--- a/crates/nu-cli/src/commands/do_.rs
+++ b/crates/nu-cli/src/commands/do_.rs
@@ -72,7 +72,7 @@ async fn do_(
         },
         input,
     ) = raw_args.process(&registry).await?;
-    block.set_is_last(!is_last);
+    block.set_is_last(is_last);
 
     let result = run_block(
         &block,

--- a/crates/nu-cli/src/commands/run_alias.rs
+++ b/crates/nu-cli/src/commands/run_alias.rs
@@ -41,7 +41,7 @@ impl WholeStreamCommand for AliasCommand {
         let call_info = args.call_info.clone();
         let registry = registry.clone();
         let mut block = self.block.clone();
-        block.set_is_last(!call_info.args.is_last);
+        block.set_is_last(call_info.args.is_last);
 
         let alias_command = self.clone();
         let mut context = Context::from_args(&args, &registry);

--- a/crates/nu-cli/src/stream/input.rs
+++ b/crates/nu-cli/src/stream/input.rs
@@ -75,6 +75,12 @@ impl InputStream {
                     bytes.extend_from_slice(&b);
                 }
                 Some(Value {
+                    value: UntaggedValue::Primitive(Primitive::Nothing),
+                    tag: value_t,
+                }) => {
+                    value_tag = value_t;
+                }
+                Some(Value {
                     tag: value_tag,
                     value,
                 }) => {

--- a/crates/nu-errors/src/lib.rs
+++ b/crates/nu-errors/src/lib.rs
@@ -177,8 +177,8 @@ impl PrettyDebug for ArgumentError {
 /// creating a cause chain.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Serialize, Deserialize, Hash)]
 pub struct ShellError {
-    error: ProximateShellError,
-    cause: Option<Box<ShellError>>,
+    pub error: ProximateShellError,
+    pub cause: Option<Box<ShellError>>,
 }
 
 /// `PrettyDebug` is for internal debugging. For user-facing debugging, [into_diagnostic](ShellError::into_diagnostic)
@@ -773,7 +773,7 @@ impl HasFallibleSpan for ProximateShellError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShellDiagnostic {
-    pub(crate) diagnostic: Diagnostic<usize>,
+    pub diagnostic: Diagnostic<usize>,
 }
 
 impl std::hash::Hash for ShellDiagnostic {


### PR DESCRIPTION
This improves our config and prompt loading to make them more resilient to failures to parse.

Now, if something fails, we'll try to detect it and print an error to the user, but still give them a usable prompt so they're no longer unceremoniously dropped out of Nu.