### PR TITLE
Bubble errors even if pipeline isn't used

### DIFF
--- a/crates/nu-cli/src/commands/autoview.rs
+++ b/crates/nu-cli/src/commands/autoview.rs
@@ -121,7 +121,7 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
 
                 if let Some(table) = table {
                     let command_args = create_default_command_args(&context).with_input(stream);
-                    let result = table.run(command_args, &context.registry).await;
+                    let result = table.run(command_args, &context.registry).await?;
                     result.collect::<Vec<_>>().await;
                 }
             }
@@ -138,7 +138,7 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
                             );
                             let command_args =
                                 create_default_command_args(&context).with_input(stream);
-                            let result = text.run(command_args, &context.registry).await;
+                            let result = text.run(command_args, &context.registry).await?;
                             result.collect::<Vec<_>>().await;
                         } else {
                             out!("{}", s);
@@ -161,7 +161,7 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
                             );
                             let command_args =
                                 create_default_command_args(&context).with_input(stream);
-                            let result = text.run(command_args, &context.registry).await;
+                            let result = text.run(command_args, &context.registry).await?;
                             result.collect::<Vec<_>>().await;
                         } else {
                             out!("{}\n", s);
@@ -236,7 +236,7 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
                             stream.push_back(x);
                             let command_args =
                                 create_default_command_args(&context).with_input(stream);
-                            let result = binary.run(command_args, &context.registry).await;
+                            let result = binary.run(command_args, &context.registry).await?;
                             result.collect::<Vec<_>>().await;
                         } else {
                             use pretty_hex::*;
@@ -298,7 +298,7 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
                             stream.push_back(x);
                             let command_args =
                                 create_default_command_args(&context).with_input(stream);
-                            let result = table.run(command_args, &context.registry).await;
+                            let result = table.run(command_args, &context.registry).await?;
                             result.collect::<Vec<_>>().await;
                         } else {
                             out!("{:?}", item);

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -343,18 +343,19 @@ impl Command {
         self.0.usage()
     }
 
-    pub async fn run(&self, args: CommandArgs, registry: &CommandRegistry) -> OutputStream {
+    pub async fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
         if args.call_info.switch_present("help") {
             let cl = self.0.clone();
             let registry = registry.clone();
-            OutputStream::one(Ok(ReturnSuccess::Value(
+            Ok(OutputStream::one(Ok(ReturnSuccess::Value(
                 UntaggedValue::string(get_help(&*cl, &registry)).into_value(Tag::unknown()),
-            )))
+            ))))
         } else {
-            match self.0.run(args, registry).await {
-                Ok(stream) => stream,
-                Err(err) => OutputStream::one(Err(err)),
-            }
+            self.0.run(args, registry).await
         }
     }
 

--- a/crates/nu-cli/src/commands/enter.rs
+++ b/crates/nu-cli/src/commands/enter.rs
@@ -158,7 +158,7 @@ async fn enter(
                         };
                         let mut result = converter
                             .run(new_args.with_input(vec![tagged_contents]), &registry)
-                            .await;
+                            .await?;
                         let result_vec: Vec<Result<ReturnSuccess, ShellError>> =
                             result.drain_vec().await;
 

--- a/crates/nu-cli/src/commands/save.rs
+++ b/crates/nu-cli/src/commands/save.rs
@@ -232,7 +232,7 @@ async fn save(
                             scope,
                         },
                     };
-                    let mut result = converter.run(new_args.with_input(input), &registry).await;
+                    let mut result = converter.run(new_args.with_input(input), &registry).await?;
                     let result_vec: Vec<Result<ReturnSuccess, ShellError>> =
                         result.drain_vec().await;
                     if converter.is_binary() {

--- a/crates/nu-cli/src/context.rs
+++ b/crates/nu-cli/src/context.rs
@@ -184,6 +184,10 @@ impl Context {
         self.current_errors.lock().clone()
     }
 
+    pub(crate) fn add_error(&self, err: ShellError) {
+        self.current_errors.lock().push(err);
+    }
+
     pub(crate) fn maybe_print_errors(&mut self, source: Text) -> bool {
         let errors = self.current_errors.clone();
         let mut errors = errors.lock();
@@ -232,7 +236,7 @@ impl Context {
         args: hir::Call,
         scope: &Scope,
         input: InputStream,
-    ) -> OutputStream {
+    ) -> Result<OutputStream, ShellError> {
         let command_args = self.command_args(args, input, name_tag, scope);
         command.run(command_args, self.registry()).await
     }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -11,6 +11,16 @@ fn shows_error_for_command_not_found() {
 }
 
 #[test]
+fn shows_error_for_command_not_found_in_pipeline() {
+    let actual = nu!(
+        cwd: ".",
+        "ferris_is_not_here.exe | echo done"
+    );
+
+    assert!(actual.err.contains("Command not found"));
+}
+
+#[test]
 fn automatically_change_directory() {
     use nu_test_support::playground::Playground;
 


### PR DESCRIPTION
fixes https://github.com/nushell/nushell/issues/2076

With this PR, we'll bubble up that an error occurred to the function that's responsible for processing the data between pipeline elements.This should allow us to detect if an error happened in a function before any data could be produced.