### PR TITLE
added a few more command chars

### DIFF
--- a/crates/nu-cli/src/commands/char_.rs
+++ b/crates/nu-cli/src/commands/char_.rs
@@ -64,19 +64,19 @@ fn str_to_character(s: &str) -> Option<String> {
     match s {
         "newline" | "enter" | "nl" => Some("\n".into()),
         "tab" => Some("\t".into()),
-        "branch" => Some('\u{e0a0}'.to_string().into()), // 
-        "branch_identical" => Some('\u{2263}'.to_string().into()), // ≣
-        "branch_untracked" => Some('\u{2262}'.to_string().into()), // ≢
-        "branch_ahead" => Some('\u{2191}'.to_string().into()), // ↑
-        "branch_behind" => Some('\u{2193}'.to_string().into()), // ↓
-        "branch_ahead_behind" => Some('\u{2195}'.to_string().into()), // ↕
-        "prompt" => Some('\u{25b6}'.to_string().into()), // ▶
-        "failed" => Some('\u{2a2f}'.to_string().into()), // ⨯
-        "elevated" => Some('\u{26a1}'.to_string().into()), // ⚡
-        "segment" => Some('\u{e0b0}'.to_string().into()), // 
-        "home" => Some("~".into()),                      // ~
-        "root" => Some("#".into()),                      // #
-        "hamburger" => Some('\u{2261}'.to_string().into()), // ≡
+        "branch" => Some('\u{e0a0}'.to_string()), // 
+        "branch_identical" => Some('\u{2263}'.to_string()), // ≣
+        "branch_untracked" => Some('\u{2262}'.to_string()), // ≢
+        "branch_ahead" => Some('\u{2191}'.to_string()), // ↑
+        "branch_behind" => Some('\u{2193}'.to_string()), // ↓
+        "branch_ahead_behind" => Some('\u{2195}'.to_string()), // ↕
+        "prompt" => Some('\u{25b6}'.to_string()), // ▶
+        "failed" => Some('\u{2a2f}'.to_string()), // ⨯
+        "elevated" => Some('\u{26a1}'.to_string()), // ⚡
+        "segment" => Some('\u{e0b0}'.to_string()), // 
+        "home" => Some("~".into()),               // ~
+        "root" => Some("#".into()),               // #
+        "hamburger" => Some('\u{2261}'.to_string()), // ≡
         _ => None,
     }
 }

--- a/crates/nu-cli/src/commands/char_.rs
+++ b/crates/nu-cli/src/commands/char_.rs
@@ -64,6 +64,19 @@ fn str_to_character(s: &str) -> Option<String> {
     match s {
         "newline" | "enter" | "nl" => Some("\n".into()),
         "tab" => Some("\t".into()),
+        "branch" => Some('\u{e0a0}'.to_string().into()), // 
+        "branch_identical" => Some('\u{2263}'.to_string().into()), // ≣
+        "branch_untracked" => Some('\u{2262}'.to_string().into()), // ≢
+        "branch_ahead" => Some('\u{2191}'.to_string().into()), // ↑
+        "branch_behind" => Some('\u{2193}'.to_string().into()), // ↓
+        "branch_ahead_behind" => Some('\u{2195}'.to_string().into()), // ↕
+        "prompt" => Some('\u{25b6}'.to_string().into()), // ▶
+        "failed" => Some('\u{2a2f}'.to_string().into()), // ⨯
+        "elevated" => Some('\u{26a1}'.to_string().into()), // ⚡
+        "segment" => Some('\u{e0b0}'.to_string().into()), // 
+        "home" => Some("~".into()),                      // ~
+        "root" => Some("#".into()),                      // #
+        "hamburger" => Some('\u{2261}'.to_string().into()), // ≡
         _ => None,
     }
 }

--- a/crates/nu-cli/src/commands/char_.rs
+++ b/crates/nu-cli/src/commands/char_.rs
@@ -64,19 +64,24 @@ fn str_to_character(s: &str) -> Option<String> {
     match s {
         "newline" | "enter" | "nl" => Some("\n".into()),
         "tab" => Some("\t".into()),
-        "branch" => Some('\u{e0a0}'.to_string()), // 
-        "branch_identical" => Some('\u{2263}'.to_string()), // ≣
-        "branch_untracked" => Some('\u{2262}'.to_string()), // ≢
-        "branch_ahead" => Some('\u{2191}'.to_string()), // ↑
-        "branch_behind" => Some('\u{2193}'.to_string()), // ↓
-        "branch_ahead_behind" => Some('\u{2195}'.to_string()), // ↕
-        "prompt" => Some('\u{25b6}'.to_string()), // ▶
-        "failed" => Some('\u{2a2f}'.to_string()), // ⨯
-        "elevated" => Some('\u{26a1}'.to_string()), // ⚡
+        // Unicode names came from https://www.compart.com/en/unicode
+        // Private Use Area (U+E000-U+F8FF)
+        "branch" => Some('\u{e0a0}'.to_string()),  // 
         "segment" => Some('\u{e0b0}'.to_string()), // 
-        "home" => Some("~".into()),               // ~
-        "root" => Some("#".into()),               // #
-        "hamburger" => Some('\u{2261}'.to_string()), // ≡
+
+        "identical_to" | "hamburger" => Some('\u{2261}'.to_string()), // ≡
+        "not_identical_to" | "branch_untracked" => Some('\u{2262}'.to_string()), // ≢
+        "strictly_equivalent_to" | "branch_identical" => Some('\u{2263}'.to_string()), // ≣
+
+        "upwards_arrow" | "branch_ahead" => Some('\u{2191}'.to_string()), // ↑
+        "downwards_arrow" | "branch_behind" => Some('\u{2193}'.to_string()), // ↓
+        "up_down_arrow" | "branch_ahead_behind" => Some('\u{2195}'.to_string()), // ↕
+
+        "black_right_pointing_triangle" | "prompt" => Some('\u{25b6}'.to_string()), // ▶
+        "vector_or_cross_product" | "failed" => Some('\u{2a2f}'.to_string()),       // ⨯
+        "high_voltage_sign" | "elevated" => Some('\u{26a1}'.to_string()),           // ⚡
+        "tilde" | "twiddle" | "squiggly" | "home" => Some("~".into()),              // ~
+        "hash" | "hashtag" | "pound_sign" | "sharp" | "root" => Some("#".into()),   // #
         _ => None,
     }
 }


### PR DESCRIPTION
Added these:
```
 0xe0a0 branch symbol
≣ 0x2263 branch identical
≢ 0x2262 branch untracked
↑ 0x2191 branch ahead
↓ 0x2193 branch behind
↕ 0x2195 branch ahead and behind
▶ 0x25b6 prompt indicator
⨯ 0x2a2f failed command
⚡ 0x26a1 elevated 
 0xe0b0 segment forward
~ home
# root
≡ 0x2261 hamburger
```
Works great with `Fira Code` font.
![image](https://user-images.githubusercontent.com/343840/86276582-be487a00-bb9a-11ea-95d8-99017bcd3a56.png)
