### PR TITLE
Remove custom escaping for external args.

### DIFF
--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -118,29 +118,18 @@ async fn run_with_stdin(
         let value =
             evaluate_baseline_expr(arg, &context.registry, &scope.it, &scope.vars, &scope.env)
                 .await?;
+
         // Skip any arguments that don't really exist, treating them as optional
         // FIXME: we may want to preserve the gap in the future, though it's hard to say
         // what value we would put in its place.
         if value.value.is_none() {
             continue;
         }
+
         // Do the cleanup that we need to do on any argument going out:
         let trimmed_value_string = value.as_string()?.trim_end_matches('\n').to_string();
 
-        let value_string;
-        #[cfg(not(windows))]
-        {
-            value_string = trimmed_value_string
-                .replace('$', "\\$")
-                .replace('"', "\\\"")
-                .to_string()
-        }
-        #[cfg(windows)]
-        {
-            value_string = trimmed_value_string
-        }
-
-        command_args.push(value_string);
+        command_args.push(trimmed_value_string);
     }
 
     let process_args = command_args

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -192,6 +192,15 @@ mod external_words {
 
         assert_eq!(actual.out, "joturner@foo.bar.baz");
     }
+
+    #[test]
+    fn no_escaping_for_single_quoted_strings() {
+        let actual = nu!(cwd: ".", r#"
+        nu --testbin cococo 'test "things"'
+        "#);
+
+        assert_eq!(actual.out, "test \"things\"");
+    }
 }
 
 mod nu_commands {


### PR DESCRIPTION
Our own custom escaping unfortunately is far too simple to cover all cases. Instead, the parser will now do no transforms on the args passed to an external command, letting the process spawning library deal entirely with escaping.

Closes https://github.com/nushell/nushell/issues/1957

Still works for these two:
- https://github.com/nushell/nushell/issues/1439
- https://github.com/nushell/nushell/issues/1617

One case that doesn't work, but would likely require us to build custom parsing for external strings:

```
$ ^echo test' "ing"'
test' ing'
```

For that one I would have expected the output to be `test "ing"`

