### PR TITLE
Numbered `each`

### DIFF
--- a/crates/nu-cli/src/commands/compact.rs
+++ b/crates/nu-cli/src/commands/compact.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for Compact {
         vec![
             Example {
                 description: "Filter out all null entries in a list",
-                example: "echo [1 2 $null 3 $null $null] | compact target",
+                example: "echo [1 2 $null 3 $null $null] | compact",
                 result: Some(vec![
                     UntaggedValue::int(1).into(),
                     UntaggedValue::int(2).into(),

--- a/crates/nu-cli/src/commands/each.rs
+++ b/crates/nu-cli/src/commands/each.rs
@@ -50,6 +50,11 @@ impl WholeStreamCommand for Each {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
+                description: "Echo the sum of each row",
+                example: "echo [[1 2] [3 4]] | each { echo $it | math sum }",
+                result: None,
+            },
+            Example {
                 description: "Echo the square of each integer",
                 example: "echo [1 2 3] | each { echo $(= $it * $it) }",
                 result: Some(vec![
@@ -59,21 +64,10 @@ impl WholeStreamCommand for Each {
                 ]),
             },
             Example {
-                description: "Echo the sum of each row",
-                example: "echo [[1 2] [3 4]] | each { echo $it | math sum }",
-                result: Some(vec![
-                    UntaggedValue::int(3).into(),
-                    UntaggedValue::int(7).into(),
-                ]),
-            },
-            Example {
                 description: "Number each item and echo a message",
                 example:
                     "echo ['bob' 'fred'] | each --numbered { echo `{{$it.index}} is {{$it.item}}` }",
-                result: Some(vec![
-                    UntaggedValue::string("0 is bob").into(),
-                    UntaggedValue::string("1 is box").into(),
-                ]),
+                result: Some(vec![Value::from("0 is bob"), Value::from("1 is fred")]),
             },
         ]
     }


### PR DESCRIPTION
With this, you can now pass `--numbered` to `each` to have it send you a structured `$it` with two fields:

* `index` - the number of the row
* `item` - the data of the row