### PR TITLE
Return error for unterminated string in bareword parser

### DIFF
--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -156,6 +156,43 @@ fn bare_simple_4() -> Result<(), ParseError> {
     Ok(())
 }
 
+#[test]
+fn bare_simple_5() -> Result<(), ParseError> {
+    let input = "'foo 'bar baz";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 6);
+
+    Ok(())
+}
+
+#[test]
+fn bare_invalid_1() -> Result<(), ParseError> {
+    let input = "'foo bar";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0);
+
+    assert_eq!(result.is_ok(), false);
+
+    Ok(())
+}
+
+#[test]
+fn bare_invalid_2() -> Result<(), ParseError> {
+    let input = "foo 'bar";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0);
+
+    assert_eq!(result.is_ok(), false);
+
+    Ok(())
+}
+
 fn command(src: &mut Input, span_offset: usize) -> Result<LiteCommand, ParseError> {
     let command = bare(src, span_offset)?;
     if command.item.is_empty() {

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -59,19 +59,20 @@ fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseErr
         0
     };
 
-    let mut delimiter = ' ';
+    let mut delimiter: Option<char> = None;
     let mut inside_quote = false;
     let mut block_level = vec![];
 
     while let Some((_, c)) = src.peek() {
         let c = *c;
         if inside_quote {
-            if c == delimiter {
+            if Some(c) == delimiter {
                 inside_quote = false;
+                delimiter = None;
             }
         } else if c == '\'' || c == '"' || c == '`' {
             inside_quote = true;
-            delimiter = c;
+            delimiter = Some(c);
         } else if c == '[' {
             block_level.push(c);
         } else if c == ']' {
@@ -164,7 +165,7 @@ fn bare_simple_5() -> Result<(), ParseError> {
     let result = bare(input, 0)?;
 
     assert_eq!(result.span.start(), 0);
-    assert_eq!(result.span.end(), 6);
+    assert_eq!(result.span.end(), 9);
 
     Ok(())
 }

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -104,6 +104,58 @@ fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseErr
     Ok(bare.spanned(span))
 }
 
+#[test]
+fn bare_simple_1() -> Result<(), ParseError> {
+    let input = "foo bar baz";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 3);
+
+    Ok(())
+}
+
+#[test]
+fn bare_simple_2() -> Result<(), ParseError> {
+    let input = "'foo bar' baz";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 9);
+
+    Ok(())
+}
+
+#[test]
+fn bare_simple_3() -> Result<(), ParseError> {
+    let input = "'foo\" bar' baz";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 10);
+
+    Ok(())
+}
+
+#[test]
+fn bare_simple_4() -> Result<(), ParseError> {
+    let input = "[foo bar] baz";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 9);
+
+    Ok(())
+}
+
 fn command(src: &mut Input, span_offset: usize) -> Result<LiteCommand, ParseError> {
     let command = bare(src, span_offset)?;
     if command.item.is_empty() {

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -52,7 +52,7 @@ fn skip_whitespace(src: &mut Input) {
 enum BlockKind {
     Paren,
     CurlyBracket,
-    SquareBracket
+    SquareBracket,
 }
 
 fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseError> {
@@ -107,15 +107,18 @@ fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseErr
     );
 
     if let Some(block) = block_level.last() {
-        return Err(ParseError::unexpected_eof(match block {
-            BlockKind::Paren => ")",
-            BlockKind::SquareBracket => "]",
-            BlockKind::CurlyBracket => "}",
-        }, span))
+        return Err(ParseError::unexpected_eof(
+            match block {
+                BlockKind::Paren => ")",
+                BlockKind::SquareBracket => "]",
+                BlockKind::CurlyBracket => "}",
+            },
+            span,
+        ));
     }
 
     if let Some(delimiter) = inside_quote {
-        return Err(ParseError::unexpected_eof(delimiter.to_string(), span))
+        return Err(ParseError::unexpected_eof(delimiter.to_string(), span));
     }
 
     Ok(bare.spanned(span))

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -49,6 +49,12 @@ fn skip_whitespace(src: &mut Input) {
     }
 }
 
+enum BlockKind {
+    Paren,
+    CurlyBracket,
+    SquareBracket
+}
+
 fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseError> {
     skip_whitespace(src);
 
@@ -59,36 +65,33 @@ fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseErr
         0
     };
 
-    let mut delimiter: Option<char> = None;
-    let mut inside_quote = false;
-    let mut block_level = vec![];
+    let mut inside_quote: Option<char> = None;
+    let mut block_level: Vec<BlockKind> = vec![];
 
     while let Some((_, c)) = src.peek() {
         let c = *c;
-        if inside_quote {
-            if Some(c) == delimiter {
-                inside_quote = false;
-                delimiter = None;
+        if inside_quote.is_some() {
+            if Some(c) == inside_quote {
+                inside_quote = None;
             }
         } else if c == '\'' || c == '"' || c == '`' {
-            inside_quote = true;
-            delimiter = Some(c);
+            inside_quote = Some(c);
         } else if c == '[' {
-            block_level.push(c);
+            block_level.push(BlockKind::SquareBracket);
         } else if c == ']' {
-            if let Some('[') = block_level.last() {
+            if let Some(BlockKind::SquareBracket) = block_level.last() {
                 let _ = block_level.pop();
             }
         } else if c == '{' {
-            block_level.push(c);
+            block_level.push(BlockKind::CurlyBracket);
         } else if c == '}' {
-            if let Some('{') = block_level.last() {
+            if let Some(BlockKind::CurlyBracket) = block_level.last() {
                 let _ = block_level.pop();
             }
         } else if c == '(' {
-            block_level.push(c);
+            block_level.push(BlockKind::Paren);
         } else if c == ')' {
-            if let Some('(') = block_level.last() {
+            if let Some(BlockKind::Paren) = block_level.last() {
                 let _ = block_level.pop();
             }
         } else if block_level.is_empty() && (c.is_whitespace() || c == '|' || c == ';') {
@@ -102,6 +105,19 @@ fn bare(src: &mut Input, span_offset: usize) -> Result<Spanned<String>, ParseErr
         start_offset + span_offset,
         start_offset + span_offset + bare.len(),
     );
+
+    if let Some(block) = block_level.last() {
+        return Err(ParseError::unexpected_eof(match block {
+            BlockKind::Paren => ")",
+            BlockKind::SquareBracket => "]",
+            BlockKind::CurlyBracket => "}",
+        }, span))
+    }
+
+    if let Some(delimiter) = inside_quote {
+        return Err(ParseError::unexpected_eof(delimiter.to_string(), span))
+    }
+
     Ok(bare.spanned(span))
 }
 
@@ -171,6 +187,71 @@ fn bare_simple_5() -> Result<(), ParseError> {
 }
 
 #[test]
+fn bare_simple_6() -> Result<(), ParseError> {
+    let input = "''foo baz";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 5);
+
+    Ok(())
+}
+
+#[test]
+fn bare_simple_7() -> Result<(), ParseError> {
+    let input = "'' foo";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 2);
+
+    Ok(())
+}
+
+#[test]
+fn bare_simple_8() -> Result<(), ParseError> {
+    let input = " '' foo";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 1);
+    assert_eq!(result.span.end(), 3);
+
+    Ok(())
+}
+
+#[test]
+fn bare_simple_9() -> Result<(), ParseError> {
+    let input = " 'foo' foo";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 1);
+    assert_eq!(result.span.end(), 6);
+
+    Ok(())
+}
+
+#[test]
+fn bare_ignore_future() -> Result<(), ParseError> {
+    let input = "foo 'bar";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0)?;
+
+    assert_eq!(result.span.start(), 0);
+    assert_eq!(result.span.end(), 3);
+
+    Ok(())
+}
+
+#[test]
 fn bare_invalid_1() -> Result<(), ParseError> {
     let input = "'foo bar";
 
@@ -184,7 +265,19 @@ fn bare_invalid_1() -> Result<(), ParseError> {
 
 #[test]
 fn bare_invalid_2() -> Result<(), ParseError> {
-    let input = "foo 'bar";
+    let input = "'bar";
+
+    let input = &mut input.char_indices().peekable();
+    let result = bare(input, 0);
+
+    assert_eq!(result.is_ok(), false);
+
+    Ok(())
+}
+
+#[test]
+fn bare_invalid_4() -> Result<(), ParseError> {
+    let input = " 'bar";
 
     let input = &mut input.char_indices().peekable();
     let result = bare(input, 0);


### PR DESCRIPTION
This PR adds some tests for the bareword parsing and also shores up some logic where an error would not be returned if there was an unterminated block or string literal.

Fixes #1968 

![echo](https://user-images.githubusercontent.com/1326208/86504822-2dc49200-bd72-11ea-8e0d-7c52fcccc28c.png)
