### PR TITLE
Align tables in "ls -f"

### DIFF
--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -45,24 +45,28 @@ pub(crate) fn dir_entry_dict(
 ) -> Result<Value, ShellError> {
     let tag = tag.into();
     let mut dict = TaggedDictBuilder::new(&tag);
-    // Insert all columns first to maintain proper table alignment if we can't find (are not allowed to view) any information
+    // Insert all columns first to maintain proper table alignment if we can't find (or are not allowed to view) any information
     if full {
-        for column in [
-            "name", "type", "target", "readonly", "size", "created", "accessed", "modified",
-        ]
-        .iter()
-        {
-            dict.insert_untagged(*column, UntaggedValue::nothing());
-        }
-        #[cfg(unix)]
+        #[cfg(windows)]
         {
             for column in [
-                "name", "type", "target", "readonly", "mode", "uid", "group", "created", "size",
-                "accessed", "modified",
+                "name", "type", "target", "readonly", "size", "created", "accessed", "modified",
             ]
             .iter()
             {
                 dict.insert_untagged(*column, UntaggedValue::nothing());
+            }
+        }
+
+        #[cfg(unix)]
+        {
+            for column in [
+                "name", "type", "target", "readonly", "mode", "uid", "group", "size", "created",
+                "accessed", "modified",
+            ]
+            .iter()
+            {
+                dict.insert_untagged(&(*column.to_owned()), UntaggedValue::nothing());
             }
         }
     } else {
@@ -140,7 +144,7 @@ pub(crate) fn dir_entry_dict(
                     );
                 }
             }
-        } 
+        }
     }
 
     if let Some(md) = metadata {
@@ -190,7 +194,7 @@ pub(crate) fn dir_entry_dict(
         if let Ok(m) = md.modified() {
             dict.insert_untagged("modified", UntaggedValue::system_date(m));
         }
-    } 
+    }
 
     Ok(dict.into_value())
 }

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -68,9 +68,10 @@ pub(crate) fn dir_entry_dict(
     }
 
     if full || with_symlink_targets {
+        // Even if we can't find (or aren't allowed to view) the metadata
+        // We still want to insert a "Nothing" to keep tables aligned
+        let mut symlink_target_untagged_value: UntaggedValue = UntaggedValue::nothing();
         if let Some(md) = metadata {
-            let mut symlink_target_untagged_value: UntaggedValue = UntaggedValue::nothing();
-
             if md.file_type().is_symlink() {
                 if let Ok(path_to_link) = filename.read_link() {
                     symlink_target_untagged_value =
@@ -80,9 +81,8 @@ pub(crate) fn dir_entry_dict(
                         UntaggedValue::string("Could not obtain target file's path");
                 }
             }
-
-            dict.insert_untagged("target", symlink_target_untagged_value);
         }
+        dict.insert_untagged("target", symlink_target_untagged_value);
     }
 
     if full {

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -1,5 +1,5 @@
 use nu_test_support::fs::Stub::EmptyFile;
-use nu_test_support::playground::Playground;
+use nu_test_support::playground::{Dirs, Playground};
 use nu_test_support::{nu, pipeline};
 
 #[test]
@@ -153,4 +153,61 @@ fn list_files_from_two_parents_up_using_multiple_dots() {
 
         assert_eq!(actual.out, "5");
     })
+}
+
+#[test]
+fn list_all_columns() {
+    Playground::setup(
+        "ls_test_all_columns",
+        |dirs: Dirs, sandbox: &mut Playground| {
+            sandbox.with_files(vec![
+                EmptyFile("Leonardo.yaml"),
+                EmptyFile("Raphael.json"),
+                EmptyFile("Donatello.xml"),
+                EmptyFile("Michelangelo.txt"),
+            ]);
+            // Normal Operation
+            let actual = nu!(
+                cwd: dirs.test(),
+                "ls | get | to md"
+            );
+            let expected = ["name", "type", "size", "modified"].join("");
+            assert_eq!(actual.out, expected, "column names are incorrect for ls");
+            // Symbolic Links
+            let actual = nu!(
+                cwd: dirs.test(),
+                "ls -w | get | to md"
+            );
+            let expected = ["name", "type", "target", "size", "modified"].join("");
+            assert_eq!(actual.out, expected, "column names are incorrect for ls -w");
+            // Full
+            let actual = nu!(
+                cwd: dirs.test(),
+                "ls -f | get | to md"
+            );
+            let expected = {
+                #[cfg(unix)]
+                {
+                    [
+                        "name", "type", "target", "readonly", "mode", "uid", "group", "size",
+                        "created", "accessed", "modified",
+                    ]
+                    .join("")
+                }
+
+                #[cfg(windows)]
+                {
+                    [
+                        "name", "type", "target", "readonly", "size", "created", "accessed",
+                        "modified",
+                    ]
+                    .join("")
+                }
+            };
+            assert_eq!(
+                actual.out, expected,
+                "column names are incorrect for ls full"
+            );
+        },
+    );
 }


### PR DESCRIPTION
Addresses:
https://github.com/nushell/nushell/issues/1929
https://github.com/nushell/nushell/issues/1985

Summary:
- Add all necessary columns for `ls` at the very start to avoid table alignment going out of wack.
- Remove now superfluous else clauses 
