### PR TITLE
More informative error messages when "rm" fails

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -12,7 +12,6 @@ use crate::shell::completer::NuCompleter;
 use crate::shell::shell::Shell;
 use crate::utils::FileStructure;
 
-use log::debug;
 use rustyline::completion::FilenameCompleter;
 use rustyline::hint::{Hinter, HistoryHinter};
 use std::collections::HashMap;
@@ -608,8 +607,7 @@ impl Shell for FilesystemShell {
                         }
 
                         if let Err(e) = result {
-                            debug!("{:?}", e.kind());
-                            let msg = format!("Could not delete {:}", e);
+                            let msg = format!("Could not delete because: {:}", e);
                             Err(ShellError::labeled_error(msg, e.to_string(), tag))
                         } else {
                             let val = format!("deleted {:}", f.to_string_lossy()).into();


### PR DESCRIPTION
fixes #1862 

A nicer error message to describe why we can't delete "that" file. (e.g. insufficient permissions)

![rm-nicer-message](https://user-images.githubusercontent.com/10860860/86521614-015b5500-be08-11ea-8329-1fcc39160e2f.PNG)

Summary:
- Do not throw away error information in `map_err` for `rm`. 
Instead do a naive conversion of `trash::Error` into `std::io::Error`
