### PR TITLE
Show entire table if number of rows requested for `last` is greater than table size

### DIFF
--- a/crates/nu-cli/src/commands/last.rs
+++ b/crates/nu-cli/src/commands/last.rs
@@ -69,16 +69,18 @@ async fn last(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
         1
     };
 
-    let mut values_vec_deque = VecDeque::new();
-
     let count = rows_desired as usize;
 
-    if count < v.len() {
-        let k = v.len() - count;
+    let k = if count < v.len() {
+        v.len() - count
+    } else {
+        return Ok(futures::stream::iter(v).to_output_stream())
+    };
 
-        for x in v[k..].iter() {
-            values_vec_deque.push_back(ReturnSuccess::value(x.clone()));
-        }
+    let mut values_vec_deque = VecDeque::new();
+
+    for x in v[k..].iter() {
+        values_vec_deque.push_back(ReturnSuccess::value(x.clone()));
     }
 
     Ok(futures::stream::iter(values_vec_deque).to_output_stream())

--- a/crates/nu-cli/src/commands/last.rs
+++ b/crates/nu-cli/src/commands/last.rs
@@ -74,7 +74,7 @@ async fn last(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     let k = if count < v.len() {
         v.len() - count
     } else {
-        return Ok(futures::stream::iter(v).to_output_stream())
+        return Ok(futures::stream::iter(v).to_output_stream());
     };
 
     let mut values_vec_deque = VecDeque::new();

--- a/crates/nu-cli/tests/commands/last.rs
+++ b/crates/nu-cli/tests/commands/last.rs
@@ -54,3 +54,15 @@ fn gets_last_row_when_no_amount_given() {
         assert_eq!(actual.out, "1");
     })
 }
+
+#[test]
+fn requests_more_rows_than_table_has() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        date | last 50 | count
+        "#
+    ));
+
+    assert_eq!(actual.out, "1");
+}


### PR DESCRIPTION
Previously, nushell would return nothing if you supplied a value to `last` that was greater than, or equal to, the size of the table.  This PR changes that to just return the full table in this scenario.