### PR TITLE
Stream results of drop command

### DIFF
--- a/crates/nu-cli/src/commands/drop.rs
+++ b/crates/nu-cli/src/commands/drop.rs
@@ -71,7 +71,7 @@ async fn drop(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
         futures::stream::iter(v).to_output_stream()
     } else {
         let k = if v.len() < rows_to_drop {
-            v.len()
+            0
         } else {
             v.len() - rows_to_drop
         };

--- a/crates/nu-cli/tests/commands/drop.rs
+++ b/crates/nu-cli/tests/commands/drop.rs
@@ -1,4 +1,4 @@
-use nu_test_support::nu;
+use nu_test_support::{nu, pipeline};
 
 #[test]
 fn drop_rows() {
@@ -8,4 +8,16 @@ fn drop_rows() {
     );
 
     assert_eq!(actual.out, "3");
+}
+
+#[test]
+fn drop_more_rows_than_table_has() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        date | drop 50 | count
+        "#
+    ));
+
+    assert_eq!(actual.out, "0");
 }


### PR DESCRIPTION
This is a little weird because the command initially creates a vec so that it can use the vec `len()` function in various parts, so this may not really be streaming entirely.  It would be nice if there was a way to get a size from an iterator without creating a vec.  Then, in the case that we are dropping 0 rows, we would just directly return the InputStream as OutputStream, otherwise, we would use the InputStream to generate the new iterator that we run `take()`.  I'm not sure how that can be done currently.  At least the function is returning an iterator now.

https://github.com/nushell/nushell/issues/2110