### PR TITLE
add requoting for completions

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -798,7 +798,9 @@ fn is_hidden_dir(dir: impl AsRef<Path>) -> bool {
     }
 }
 
-fn requote(completions: Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError>) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError> {
+fn requote(
+    completions: Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError>,
+) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError> {
     match completions {
         Ok(items) => {
             let mut new_items = Vec::with_capacity(items.0);
@@ -818,7 +820,7 @@ fn requote(completions: Result<(usize, Vec<rustyline::completion::Pair>), rustyl
             }
 
             Ok((items.0, new_items))
-        },
+        }
         Err(err) => Err(err),
     }
 }


### PR DESCRIPTION
Fix for issue #2121 with a "requoter" to quote any `\` escaped completions (until a better way is found).