### PR TITLE
make duration pretty print clearer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "nu-errors",
  "nu-source",
  "num-bigint",
+ "num-integer",
  "num-traits 0.2.12",
  "query_interface",
  "serde 1.0.114",
@@ -2820,6 +2821,7 @@ dependencies = [
  "nu-plugin",
  "nu-protocol",
  "nu-source",
+ "num-bigint",
 ]
 
 [[package]]

--- a/crates/nu-cli/tests/commands/math/mod.rs
+++ b/crates/nu-cli/tests/commands/math/mod.rs
@@ -168,7 +168,7 @@ fn duration_math() {
         "#
     ));
 
-    assert_eq!(actual.out, "8:00:00:00.0");
+    assert_eq!(actual.out, "8d");
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn duration_math_with_nanoseconds() {
         "#
     ));
 
-    assert_eq!(actual.out, "7:00:00:00.00000001");
+    assert_eq!(actual.out, "7d 10ns");
 }
 
 #[test]
@@ -192,7 +192,7 @@ fn duration_math_with_negative() {
         "#
     ));
 
-    assert_eq!(actual.out, "-6:00:00:00.0");
+    assert_eq!(actual.out, "-6d");
 }
 
 #[test]

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -368,32 +368,42 @@ pub fn format_duration(duration: &BigInt) -> String {
     let (mins, secs): (BigInt, BigInt) = secs.div_rem(&big_int_60);
     let (hours, mins): (BigInt, BigInt) = mins.div_rem(&big_int_60);
     let (days, hours): (BigInt, BigInt) = hours.div_rem(&big_int_24);
-    let decimals = if millis.is_zero() && micros.is_zero() && nanos.is_zero() {
-        String::from("0")
-    } else {
-        format!("{:03}{:03}{:03}", millis, micros, nanos)
-            .trim_end_matches('0')
-            .to_string()
-    };
-    match (
-        days.is_zero(),
-        hours.is_zero(),
-        mins.is_zero(),
-        secs.is_zero(),
-    ) {
-        (true, true, true, true) => format!("{}.{}", if sign == 1 { "0" } else { "-0" }, decimals),
-        (true, true, true, _) => format!("{}.{}", sign * secs, decimals),
-        (true, true, _, _) => format!("{}:{:02}.{}", sign * mins, secs, decimals),
-        (true, _, _, _) => format!("{}:{:02}:{:02}.{}", sign * hours, mins, secs, decimals),
-        _ => format!(
-            "{}:{:02}:{:02}:{:02}.{}",
-            sign * days,
-            hours,
-            mins,
-            secs,
-            decimals
-        ),
+
+    let mut output_prep = vec![];
+
+    if !days.is_zero() {
+        output_prep.push(format!("{}d", days));
     }
+
+    if !hours.is_zero() {
+        output_prep.push(format!("{}h", hours));
+    }
+
+    if !mins.is_zero() {
+        output_prep.push(format!("{}m", mins));
+    }
+
+    if !secs.is_zero() {
+        output_prep.push(format!("{}s", secs));
+    }
+
+    if !millis.is_zero() {
+        output_prep.push(format!("{}ms", millis));
+    }
+
+    if !micros.is_zero() {
+        output_prep.push(format!("{}us", micros));
+    }
+
+    if !nanos.is_zero() {
+        output_prep.push(format!("{}ns", days));
+    }
+
+    format!(
+        "{}{}",
+        if sign == -1 { "-" } else { "" },
+        output_prep.join(" ")
+    )
 }
 
 #[allow(clippy::cognitive_complexity)]

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -396,7 +396,7 @@ pub fn format_duration(duration: &BigInt) -> String {
     }
 
     if !nanos.is_zero() {
-        output_prep.push(format!("{}ns", days));
+        output_prep.push(format!("{}ns", nanos));
     }
 
     format!(


### PR DESCRIPTION
# Example 1

## Before

08:00:00:01.004

## Now

8d 1s 4ms

# Example 2

## Before
7:00:00:00.00000001

## After
7d 10ns
