### PR TITLE
fix the name of 'do'

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -41,10 +41,10 @@ steps:
         rustup component add clippy --toolchain stable-x86_64-apple-darwin
         export PATH=$HOME/.cargo/bin:$PATH
       fi
-      rustup update
-      rustc -Vv
-      echo "##vso[task.prependpath]$HOME/.cargo/bin"
-      rustup component add rustfmt
+  #     rustup update
+  #     rustc -Vv
+  #     echo "##vso[task.prependpath]$HOME/.cargo/bin"
+  #     rustup component add rustfmt
     displayName: Install Rust
   - bash: RUSTFLAGS="-D warnings" cargo test --all --features stable
     condition: eq(variables['style'], 'unflagged')

--- a/crates/nu-cli/src/commands/do_.rs
+++ b/crates/nu-cli/src/commands/do_.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for Do {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("with-env")
+        Signature::build("do")
             .required("block", SyntaxShape::Block, "the block to run ")
             .switch(
                 "ignore_errors",


### PR DESCRIPTION
Oops, a copy/paste issue with with_env and do. Should be better now