### PR TITLE
Rename 'bytes' to 'filesize'

### DIFF
--- a/crates/nu-cli/src/commands/du.rs
+++ b/crates/nu-cli/src/commands/du.rs
@@ -357,12 +357,12 @@ impl From<DirInfo> for Value {
 
         r.insert(
             "apparent".to_string(),
-            UntaggedValue::bytes(d.size).into_value(&d.tag),
+            UntaggedValue::filesize(d.size).into_value(&d.tag),
         );
 
         r.insert(
             "physical".to_string(),
-            UntaggedValue::bytes(d.blocks).into_value(&d.tag),
+            UntaggedValue::filesize(d.blocks).into_value(&d.tag),
         );
 
         r.insert("directories".to_string(), value_from_vec(d.dirs, &d.tag));
@@ -399,12 +399,12 @@ impl From<FileInfo> for Value {
 
         r.insert(
             "apparent".to_string(),
-            UntaggedValue::bytes(f.size).into_value(&f.tag),
+            UntaggedValue::filesize(f.size).into_value(&f.tag),
         );
 
         let b = f
             .blocks
-            .map(UntaggedValue::bytes)
+            .map(UntaggedValue::filesize)
             .unwrap_or_else(UntaggedValue::nothing)
             .into_value(&f.tag);
 

--- a/crates/nu-cli/src/commands/math/avg.rs
+++ b/crates/nu-cli/src/commands/math/avg.rs
@@ -71,7 +71,7 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
 
     match total {
         Value {
-            value: UntaggedValue::Primitive(Primitive::Bytes(num)),
+            value: UntaggedValue::Primitive(Primitive::Filesize(num)),
             ..
         } => {
             let left = UntaggedValue::from(Primitive::Int(num.into()));
@@ -81,7 +81,7 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                 Ok(UntaggedValue::Primitive(Primitive::Decimal(result))) => {
                     let number = Number::Decimal(result);
                     let number = convert_number_to_u64(&number);
-                    Ok(UntaggedValue::bytes(number).into_value(name))
+                    Ok(UntaggedValue::filesize(number).into_value(name))
                 }
                 Ok(_) => Err(ShellError::labeled_error(
                     "could not calculate average of non-integer or unrelated types",

--- a/crates/nu-cli/src/commands/math/median.rs
+++ b/crates/nu-cli/src/commands/math/median.rs
@@ -134,7 +134,7 @@ fn compute_average(values: &[Value], name: impl Into<Tag>) -> Result<Value, Shel
 
     match total {
         Value {
-            value: UntaggedValue::Primitive(Primitive::Bytes(num)),
+            value: UntaggedValue::Primitive(Primitive::Filesize(num)),
             ..
         } => {
             let left = UntaggedValue::from(Primitive::Int(num.into()));
@@ -144,7 +144,7 @@ fn compute_average(values: &[Value], name: impl Into<Tag>) -> Result<Value, Shel
                 Ok(UntaggedValue::Primitive(Primitive::Decimal(result))) => {
                     let number = Number::Decimal(result);
                     let number = convert_number_to_u64(&number);
-                    Ok(UntaggedValue::bytes(number).into_value(name))
+                    Ok(UntaggedValue::filesize(number).into_value(name))
                 }
                 Ok(_) => Err(ShellError::labeled_error(
                     "could not calculate median of non-numeric or unrelated types",

--- a/crates/nu-cli/src/commands/to_bson.rs
+++ b/crates/nu-cli/src/commands/to_bson.rs
@@ -41,7 +41,7 @@ pub fn value_to_bson_value(v: &Value) -> Result<Bson, ShellError> {
     Ok(match &v.value {
         UntaggedValue::Primitive(Primitive::Boolean(b)) => Bson::Boolean(*b),
         // FIXME: What about really big decimals?
-        UntaggedValue::Primitive(Primitive::Bytes(decimal)) => Bson::FloatingPoint(
+        UntaggedValue::Primitive(Primitive::Filesize(decimal)) => Bson::FloatingPoint(
             (decimal)
                 .to_f64()
                 .expect("Unimplemented BUG: What about big decimals?"),

--- a/crates/nu-cli/src/commands/to_delimited_data.rs
+++ b/crates/nu-cli/src/commands/to_delimited_data.rs
@@ -115,8 +115,8 @@ pub fn clone_tagged_value(v: &Value) -> Value {
         UntaggedValue::Primitive(Primitive::Path(x)) => {
             UntaggedValue::Primitive(Primitive::Path(x.clone()))
         }
-        UntaggedValue::Primitive(Primitive::Bytes(b)) => {
-            UntaggedValue::Primitive(Primitive::Bytes(*b))
+        UntaggedValue::Primitive(Primitive::Filesize(b)) => {
+            UntaggedValue::Primitive(Primitive::Filesize(*b))
         }
         UntaggedValue::Primitive(Primitive::Date(d)) => {
             UntaggedValue::Primitive(Primitive::Date(*d))
@@ -134,7 +134,7 @@ fn to_string_tagged_value(v: &Value) -> Result<String, ShellError> {
     match &v.value {
         UntaggedValue::Primitive(Primitive::String(_))
         | UntaggedValue::Primitive(Primitive::Line(_))
-        | UntaggedValue::Primitive(Primitive::Bytes(_))
+        | UntaggedValue::Primitive(Primitive::Filesize(_))
         | UntaggedValue::Primitive(Primitive::Boolean(_))
         | UntaggedValue::Primitive(Primitive::Decimal(_))
         | UntaggedValue::Primitive(Primitive::Path(_))

--- a/crates/nu-cli/src/commands/to_json.rs
+++ b/crates/nu-cli/src/commands/to_json.rs
@@ -62,7 +62,7 @@ impl WholeStreamCommand for ToJSON {
 pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
     Ok(match &v.value {
         UntaggedValue::Primitive(Primitive::Boolean(b)) => serde_json::Value::Bool(*b),
-        UntaggedValue::Primitive(Primitive::Bytes(b)) => serde_json::Value::Number(
+        UntaggedValue::Primitive(Primitive::Filesize(b)) => serde_json::Value::Number(
             serde_json::Number::from(b.to_u64().expect("What about really big numbers")),
         ),
         UntaggedValue::Primitive(Primitive::Duration(i)) => {

--- a/crates/nu-cli/src/commands/to_sqlite.rs
+++ b/crates/nu-cli/src/commands/to_sqlite.rs
@@ -93,7 +93,7 @@ fn nu_value_to_sqlite_string(v: Value) -> String {
             Primitive::Int(i) => format!("{}", i),
             Primitive::Duration(i) => format!("{}", i),
             Primitive::Decimal(f) => format!("{}", f),
-            Primitive::Bytes(u) => format!("{}", u),
+            Primitive::Filesize(u) => format!("{}", u),
             Primitive::Pattern(s) => format!("'{}'", s.replace("'", "''")),
             Primitive::String(s) => format!("'{}'", s.replace("'", "''")),
             Primitive::Line(s) => format!("'{}'", s.replace("'", "''")),

--- a/crates/nu-cli/src/commands/to_toml.rs
+++ b/crates/nu-cli/src/commands/to_toml.rs
@@ -44,7 +44,7 @@ impl WholeStreamCommand for ToTOML {
 fn helper(v: &Value) -> Result<toml::Value, ShellError> {
     Ok(match &v.value {
         UntaggedValue::Primitive(Primitive::Boolean(b)) => toml::Value::Boolean(*b),
-        UntaggedValue::Primitive(Primitive::Bytes(b)) => toml::Value::Integer(*b as i64),
+        UntaggedValue::Primitive(Primitive::Filesize(b)) => toml::Value::Integer(*b as i64),
         UntaggedValue::Primitive(Primitive::Duration(i)) => toml::Value::String(i.to_string()),
         UntaggedValue::Primitive(Primitive::Date(d)) => toml::Value::String(d.to_string()),
         UntaggedValue::Primitive(Primitive::EndOfStream) => {

--- a/crates/nu-cli/src/commands/to_yaml.rs
+++ b/crates/nu-cli/src/commands/to_yaml.rs
@@ -31,7 +31,7 @@ impl WholeStreamCommand for ToYAML {
 pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
     Ok(match &v.value {
         UntaggedValue::Primitive(Primitive::Boolean(b)) => serde_yaml::Value::Bool(*b),
-        UntaggedValue::Primitive(Primitive::Bytes(b)) => {
+        UntaggedValue::Primitive(Primitive::Filesize(b)) => {
             serde_yaml::Value::Number(serde_yaml::Number::from(b.to_f64().ok_or_else(|| {
                 ShellError::labeled_error(
                     "Could not convert to bytes",

--- a/crates/nu-cli/src/commands/trim.rs
+++ b/crates/nu-cli/src/commands/trim.rs
@@ -43,7 +43,7 @@ fn trim_primitive(p: &mut Primitive) {
         Primitive::Nothing
         | Primitive::Int(_)
         | Primitive::Decimal(_)
-        | Primitive::Bytes(_)
+        | Primitive::Filesize(_)
         | Primitive::ColumnPath(_)
         | Primitive::Pattern(_)
         | Primitive::Boolean(_)

--- a/crates/nu-cli/src/data/base.rs
+++ b/crates/nu-cli/src/data/base.rs
@@ -138,19 +138,19 @@ fn coerce_compare_primitive(
         (Int(left), Decimal(right)) => {
             CompareValues::Decimals(BigDecimal::zero() + left, right.clone())
         }
-        (Int(left), Bytes(right)) => CompareValues::Ints(left.clone(), BigInt::from(*right)),
+        (Int(left), Filesize(right)) => CompareValues::Ints(left.clone(), BigInt::from(*right)),
         (Decimal(left), Decimal(right)) => CompareValues::Decimals(left.clone(), right.clone()),
         (Decimal(left), Int(right)) => {
             CompareValues::Decimals(left.clone(), BigDecimal::zero() + right)
         }
-        (Decimal(left), Bytes(right)) => {
+        (Decimal(left), Filesize(right)) => {
             CompareValues::Decimals(left.clone(), BigDecimal::from(*right))
         }
-        (Bytes(left), Bytes(right)) => {
+        (Filesize(left), Filesize(right)) => {
             CompareValues::Ints(BigInt::from(*left), BigInt::from(*right))
         }
-        (Bytes(left), Int(right)) => CompareValues::Ints(BigInt::from(*left), right.clone()),
-        (Bytes(left), Decimal(right)) => {
+        (Filesize(left), Int(right)) => CompareValues::Ints(BigInt::from(*left), right.clone()),
+        (Filesize(left), Decimal(right)) => {
             CompareValues::Decimals(BigDecimal::from(*left), right.clone())
         }
         (Nothing, Nothing) => CompareValues::Booleans(true, true),

--- a/crates/nu-cli/src/data/base/shape.rs
+++ b/crates/nu-cli/src/data/base/shape.rs
@@ -64,7 +64,7 @@ impl InlineShape {
                 }))
             }
             Primitive::Decimal(decimal) => InlineShape::Decimal(decimal.clone()),
-            Primitive::Bytes(bytesize) => InlineShape::Bytesize(*bytesize),
+            Primitive::Filesize(bytesize) => InlineShape::Bytesize(*bytesize),
             Primitive::String(string) => InlineShape::String(string.clone()),
             Primitive::Line(string) => InlineShape::Line(string.clone()),
             Primitive::ColumnPath(path) => InlineShape::ColumnPath(path.clone()),

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -168,12 +168,12 @@ pub(crate) fn dir_entry_dict(
                 md.len()
             };
 
-            size_untagged_value = UntaggedValue::bytes(dir_size);
+            size_untagged_value = UntaggedValue::filesize(dir_size);
         } else if md.is_file() {
-            size_untagged_value = UntaggedValue::bytes(md.len());
+            size_untagged_value = UntaggedValue::filesize(md.len());
         } else if md.file_type().is_symlink() {
             if let Ok(symlink_md) = filename.symlink_metadata() {
-                size_untagged_value = UntaggedValue::bytes(symlink_md.len() as u64);
+                size_untagged_value = UntaggedValue::filesize(symlink_md.len() as u64);
             }
         }
 

--- a/crates/nu-cli/src/data/primitive.rs
+++ b/crates/nu-cli/src/data/primitive.rs
@@ -12,7 +12,9 @@ pub fn number(number: impl Into<Number>) -> Primitive {
 
 pub fn style_primitive(primitive: &Primitive) -> TextStyle {
     match primitive {
-        Primitive::Int(_) | Primitive::Bytes(_) | Primitive::Decimal(_) => TextStyle::basic_right(),
+        Primitive::Int(_) | Primitive::Filesize(_) | Primitive::Decimal(_) => {
+            TextStyle::basic_right()
+        }
         _ => TextStyle::basic(),
     }
 }

--- a/crates/nu-cli/src/data/value.rs
+++ b/crates/nu-cli/src/data/value.rs
@@ -47,13 +47,13 @@ pub fn compute_values(
 ) -> Result<UntaggedValue, (&'static str, &'static str)> {
     match (left, right) {
         (UntaggedValue::Primitive(lhs), UntaggedValue::Primitive(rhs)) => match (lhs, rhs) {
-            (Primitive::Bytes(x), Primitive::Bytes(y)) => {
+            (Primitive::Filesize(x), Primitive::Filesize(y)) => {
                 let result = match operator {
                     Operator::Plus => Ok(x + y),
                     Operator::Minus => Ok(x - y),
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
-                Ok(UntaggedValue::Primitive(Primitive::Bytes(result)))
+                Ok(UntaggedValue::Primitive(Primitive::Filesize(result)))
             }
             (Primitive::Int(x), Primitive::Int(y)) => match operator {
                 Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -497,13 +497,13 @@ impl Unit {
         let size = size.clone();
 
         match self {
-            Unit::Byte => bytes(convert_number_to_u64(&size)),
-            Unit::Kilobyte => bytes(convert_number_to_u64(&size) * 1024),
-            Unit::Megabyte => bytes(convert_number_to_u64(&size) * 1024 * 1024),
-            Unit::Gigabyte => bytes(convert_number_to_u64(&size) * 1024 * 1024 * 1024),
-            Unit::Terabyte => bytes(convert_number_to_u64(&size) * 1024 * 1024 * 1024 * 1024),
+            Unit::Byte => filesize(convert_number_to_u64(&size)),
+            Unit::Kilobyte => filesize(convert_number_to_u64(&size) * 1024),
+            Unit::Megabyte => filesize(convert_number_to_u64(&size) * 1024 * 1024),
+            Unit::Gigabyte => filesize(convert_number_to_u64(&size) * 1024 * 1024 * 1024),
+            Unit::Terabyte => filesize(convert_number_to_u64(&size) * 1024 * 1024 * 1024 * 1024),
             Unit::Petabyte => {
-                bytes(convert_number_to_u64(&size) * 1024 * 1024 * 1024 * 1024 * 1024)
+                filesize(convert_number_to_u64(&size) * 1024 * 1024 * 1024 * 1024 * 1024)
             }
             Unit::Nanosecond => duration(size.to_bigint().expect("Conversion should never fail.")),
             Unit::Microsecond => {
@@ -571,8 +571,8 @@ impl Unit {
     }
 }
 
-pub fn bytes(size: u64) -> UntaggedValue {
-    UntaggedValue::Primitive(Primitive::Bytes(size))
+pub fn filesize(size_in_bytes: u64) -> UntaggedValue {
+    UntaggedValue::Primitive(Primitive::Filesize(size_in_bytes))
 }
 
 pub fn duration(nanos: BigInt) -> UntaggedValue {

--- a/crates/nu-protocol/src/type_shape.rs
+++ b/crates/nu-protocol/src/type_shape.rs
@@ -34,7 +34,7 @@ pub enum Type {
     /// A decimal (floating point) value
     Decimal,
     /// A filesize in bytes
-    Bytesize,
+    Filesize,
     /// A string of text
     String,
     /// A line of text (a string with trailing line ending)
@@ -138,7 +138,7 @@ impl Type {
                 Type::Range(Box::new(range))
             }
             Primitive::Decimal(_) => Type::Decimal,
-            Primitive::Bytes(_) => Type::Bytesize,
+            Primitive::Filesize(_) => Type::Filesize,
             Primitive::String(_) => Type::String,
             Primitive::Line(_) => Type::Line,
             Primitive::ColumnPath(_) => Type::ColumnPath,
@@ -220,7 +220,7 @@ impl PrettyDebug for Type {
                 )
             }
             Type::Decimal => ty("decimal"),
-            Type::Bytesize => ty("bytesize"),
+            Type::Filesize => ty("filesize"),
             Type::String => ty("string"),
             Type::Line => ty("line"),
             Type::ColumnPath => ty("column-path"),

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -183,9 +183,9 @@ impl UntaggedValue {
         UntaggedValue::Primitive(Primitive::Path(s.into()))
     }
 
-    /// Helper for creating bytesize values
-    pub fn bytes(s: impl Into<u64>) -> UntaggedValue {
-        UntaggedValue::Primitive(Primitive::Bytes(s.into()))
+    /// Helper for creating filesize values
+    pub fn filesize(s: impl Into<u64>) -> UntaggedValue {
+        UntaggedValue::Primitive(Primitive::Filesize(s.into()))
     }
 
     /// Helper for creating decimal values
@@ -282,7 +282,7 @@ impl Value {
             UntaggedValue::Primitive(Primitive::Boolean(x)) => format!("{}", x),
             UntaggedValue::Primitive(Primitive::Decimal(x)) => format!("{}", x),
             UntaggedValue::Primitive(Primitive::Int(x)) => format!("{}", x),
-            UntaggedValue::Primitive(Primitive::Bytes(x)) => format!("{}", x),
+            UntaggedValue::Primitive(Primitive::Filesize(x)) => format!("{}", x),
             UntaggedValue::Primitive(Primitive::Path(x)) => format!("{}", x.display()),
             UntaggedValue::Primitive(Primitive::ColumnPath(path)) => {
                 let joined = path

--- a/crates/nu-protocol/src/value/debug.rs
+++ b/crates/nu-protocol/src/value/debug.rs
@@ -33,7 +33,7 @@ impl PrettyType for Primitive {
             Primitive::Int(_) => ty("integer"),
             Primitive::Range(_) => ty("range"),
             Primitive::Decimal(_) => ty("decimal"),
-            Primitive::Bytes(_) => ty("bytesize"),
+            Primitive::Filesize(_) => ty("filesize"),
             Primitive::String(_) => ty("string"),
             Primitive::Line(_) => ty("line"),
             Primitive::ColumnPath(_) => ty("column-path"),
@@ -71,7 +71,7 @@ impl PrettyDebug for Primitive {
                     .group(),
                 )
             }
-            Primitive::Bytes(bytes) => primitive_doc(bytes, "bytesize"),
+            Primitive::Filesize(bytes) => primitive_doc(bytes, "filesize"),
             Primitive::String(string) => prim(string),
             Primitive::Line(string) => prim(string),
             Primitive::ColumnPath(path) => path.pretty(),

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -563,7 +563,7 @@ pub fn as_string(value: &Value) -> Result<String, ShellError> {
         UntaggedValue::Primitive(Primitive::Boolean(x)) => Ok(format!("{}", x)),
         UntaggedValue::Primitive(Primitive::Decimal(x)) => Ok(format!("{}", x)),
         UntaggedValue::Primitive(Primitive::Int(x)) => Ok(format!("{}", x)),
-        UntaggedValue::Primitive(Primitive::Bytes(x)) => Ok(format!("{}", x)),
+        UntaggedValue::Primitive(Primitive::Filesize(x)) => Ok(format!("{}", x)),
         UntaggedValue::Primitive(Primitive::Path(x)) => Ok(format!("{}", x.display())),
         UntaggedValue::Primitive(Primitive::ColumnPath(path)) => {
             let joined = path

--- a/crates/nu_plugin_inc/src/inc.rs
+++ b/crates/nu_plugin_inc/src/inc.rs
@@ -78,8 +78,8 @@ impl Inc {
             UntaggedValue::Primitive(Primitive::Int(i)) => {
                 Ok(UntaggedValue::int(i + 1).into_value(value.tag()))
             }
-            UntaggedValue::Primitive(Primitive::Bytes(b)) => {
-                Ok(UntaggedValue::bytes(b + 1 as u64).into_value(value.tag()))
+            UntaggedValue::Primitive(Primitive::Filesize(b)) => {
+                Ok(UntaggedValue::filesize(b + 1 as u64).into_value(value.tag()))
             }
             UntaggedValue::Primitive(Primitive::String(ref s)) => {
                 Ok(self.apply(&s)?.into_value(value.tag()))

--- a/crates/nu_plugin_post/src/post.rs
+++ b/crates/nu_plugin_post/src/post.rs
@@ -347,7 +347,7 @@ pub async fn post(
 pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
     Ok(match &v.value {
         UntaggedValue::Primitive(Primitive::Boolean(b)) => serde_json::Value::Bool(*b),
-        UntaggedValue::Primitive(Primitive::Bytes(b)) => serde_json::Value::Number(
+        UntaggedValue::Primitive(Primitive::Filesize(b)) => serde_json::Value::Number(
             serde_json::Number::from(b.to_u64().expect("What about really big numbers")),
         ),
         UntaggedValue::Primitive(Primitive::Duration(i)) => {

--- a/crates/nu_plugin_ps/src/ps.rs
+++ b/crates/nu_plugin_ps/src/ps.rs
@@ -61,11 +61,11 @@ pub async fn ps(tag: Tag, full: bool) -> Result<Vec<Value>, ShellError> {
             dict.insert_untagged("cpu", UntaggedValue::decimal(usage.get::<ratio::percent>()));
             dict.insert_untagged(
                 "mem",
-                UntaggedValue::bytes(memory.rss().get::<information::byte>()),
+                UntaggedValue::filesize(memory.rss().get::<information::byte>()),
             );
             dict.insert_untagged(
                 "virtual",
-                UntaggedValue::bytes(memory.vms().get::<information::byte>()),
+                UntaggedValue::filesize(memory.vms().get::<information::byte>()),
             );
             if full {
                 if let Ok(parent_pid) = process.parent_pid().await {

--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -57,22 +57,22 @@ async fn mem(tag: Tag) -> Value {
     if let Ok(memory) = memory_result {
         dict.insert_untagged(
             "total",
-            UntaggedValue::bytes(memory.total().get::<information::byte>()),
+            UntaggedValue::filesize(memory.total().get::<information::byte>()),
         );
         dict.insert_untagged(
             "free",
-            UntaggedValue::bytes(memory.free().get::<information::byte>()),
+            UntaggedValue::filesize(memory.free().get::<information::byte>()),
         );
     }
 
     if let Ok(swap) = swap_result {
         dict.insert_untagged(
             "swap total",
-            UntaggedValue::bytes(swap.total().get::<information::byte>()),
+            UntaggedValue::filesize(swap.total().get::<information::byte>()),
         );
         dict.insert_untagged(
             "swap free",
-            UntaggedValue::bytes(swap.free().get::<information::byte>()),
+            UntaggedValue::filesize(swap.free().get::<information::byte>()),
         );
     }
 
@@ -160,15 +160,15 @@ async fn disks(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
             if let Ok(usage) = disk::usage(part.mount_point().to_path_buf()).await {
                 dict.insert_untagged(
                     "total",
-                    UntaggedValue::bytes(usage.total().get::<information::byte>()),
+                    UntaggedValue::filesize(usage.total().get::<information::byte>()),
                 );
                 dict.insert_untagged(
                     "used",
-                    UntaggedValue::bytes(usage.used().get::<information::byte>()),
+                    UntaggedValue::filesize(usage.used().get::<information::byte>()),
                 );
                 dict.insert_untagged(
                     "free",
-                    UntaggedValue::bytes(usage.free().get::<information::byte>()),
+                    UntaggedValue::filesize(usage.free().get::<information::byte>()),
                 );
             }
 
@@ -295,11 +295,11 @@ async fn net(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
             network_idx.insert_untagged("name", UntaggedValue::string(nic.interface()));
             network_idx.insert_untagged(
                 "sent",
-                UntaggedValue::bytes(nic.bytes_sent().get::<information::byte>()),
+                UntaggedValue::filesize(nic.bytes_sent().get::<information::byte>()),
             );
             network_idx.insert_untagged(
                 "recv",
-                UntaggedValue::bytes(nic.bytes_recv().get::<information::byte>()),
+                UntaggedValue::filesize(nic.bytes_recv().get::<information::byte>()),
             );
             output.push(network_idx.into_value());
         }


### PR DESCRIPTION
Renames the Primitive type 'bytes' to be 'filesize' to make it clearer what it's used for.