### PR TITLE
added more verbose message to assert

### DIFF
--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -274,7 +274,7 @@ impl Signature {
         short: Option<char>,
     ) -> Signature {
         let s = short.and_then(|c| {
-            debug_assert!(!self.get_shorts().contains(&c));
+            debug_assert!(!self.get_shorts().contains(&c), "There may be duplicate short flags, such as -h");
             Some(c)
         });
 

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -274,7 +274,10 @@ impl Signature {
         short: Option<char>,
     ) -> Signature {
         let s = short.and_then(|c| {
-            debug_assert!(!self.get_shorts().contains(&c), "There may be duplicate short flags, such as -h");
+            debug_assert!(
+                !self.get_shorts().contains(&c),
+                "There may be duplicate short flags, such as -h"
+            );
             Some(c)
         });
 


### PR DESCRIPTION
having a -h short is bad for any command since it's already used by --help.