### PR TITLE
Prevent nushell from printing a default empty-state table

### DIFF
--- a/crates/nu-cli/src/commands/table.rs
+++ b/crates/nu-cli/src/commands/table.rs
@@ -291,7 +291,10 @@ async fn table(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 
         let input: Vec<Value> = new_input.into();
 
-        if !input.is_empty() {
+        let table_is_in_default_empty_state = input.len() == 1 && input[0].is_none();
+        let should_draw_table = !input.is_empty() && !table_is_in_default_empty_state;
+
+        if should_draw_table {
             let t = from_list(&input, start_number);
 
             draw_table(&t, term_width);


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/2138

More details:

It seems that when the input stream is emptied, it will automatically create an empty row with nothing in it for its default state:

https://github.com/nushell/nushell/blob/f3f40df4dd6d699f1902eceb993382d7ca070c7a/crates/nu-cli/src/stream/input.rs#L17

For certain commands that simply filter rows out of the table (`drop`, `first`, etc.), this blank table can print out if the command is used alone:

<img width="338" alt="Screen Shot 2020-07-12 at 1 43 22 AM" src="https://user-images.githubusercontent.com/19867440/87239795-16744d00-c3e1-11ea-820c-fbb8e2a7044b.png">

The code change here simply looks at the end of the pipeline and tells nushell not to draw the table under this condition:

<img width="1050" alt="Screen Shot 2020-07-12 at 1 44 14 AM" src="https://user-images.githubusercontent.com/19867440/87239801-3441b200-c3e1-11ea-9fec-6e57b3ba4e54.png">
