### PR TITLE
Add --char flag to 'str trim'

### DIFF
--- a/crates/nu-cli/src/commands/str_/from.rs
+++ b/crates/nu-cli/src/commands/str_/from.rs
@@ -207,7 +207,7 @@ fn format_decimal(mut decimal: BigDecimal, digits: Option<u64>, group_digits: bo
             .take(n as usize)
             .collect()
     } else {
-        trim_char(dec_part, '0', false, true)
+        trim_char(&dec_part, '0', false, true)
     };
 
     let format_default_loc = |int_part: BigInt| {

--- a/crates/nu-cli/tests/commands/str_.rs
+++ b/crates/nu-cli/tests/commands/str_.rs
@@ -23,6 +23,19 @@ fn trims() {
 }
 
 #[test]
+fn error_trim_multiple_chars() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo 'does it work now?!' | str trim -c '?!'
+        "#
+        )
+    );
+
+    assert!(actual.err.contains("char"));
+}
+
+#[test]
 fn capitalizes() {
     Playground::setup("str_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContent(


### PR DESCRIPTION
Re: #2092 - I needed this for my previous PR, so I added it to the command.

One issue: in the command signature, SyntaxShape::String is not a perfect match. This leads to an unlabeled `error: Error: Error("invalid value: string \"?!\", expected a character", line: 1, column: 63)` sort of error (bubbled up during deserialization), rather than a pretty labeled error from parsing. Options I've thought of:
 - Leave it as is (the current error is perfectly descriptive).
 - Create SyntaxShape::Char (if that makes sense and would be relevant elsewhere).
 - Treat the flag argument as a set of chars, all of which are trimmed (disregarding order, so you could throw in a bunch of punctuation, for example).