### PR TITLE
Update documentation to properly refer to subcommands with spaces

### DIFF
--- a/docs/commands/from-csv.md
+++ b/docs/commands/from-csv.md
@@ -92,7 +92,7 @@ error: Expected a string from pipeline
 ━━━┷━━━━━━━━━━━┷━━━━━━━━━┷━━━━━━
 ```
 
-The string '\t' can be used to separate on tabs. Note that this is the same as using the from-tsv command.
+The string '\t' can be used to separate on tabs. Note that this is the same as using the from tsv command.
 
 Newlines '\n' are not acceptable separators.
 

--- a/docs/commands/from.md
+++ b/docs/commands/from.md
@@ -1,4 +1,4 @@
-# from-csv
+# from csv
 
 Converts content (string or binary) into a table. The source format is specified as a subcommand, like `from csv` or `from json`.
 

--- a/docs/commands/group-by.md
+++ b/docs/commands/group-by.md
@@ -7,7 +7,7 @@ This command creates a new table with the data from the table rows grouped by th
 Let's say we have this table of all countries in the world sorted by their population:
 
 ```shell
-> open countries_by_population.json | from-json | first 10
+> open countries_by_population.json | from json | first 10
 ━━━┯━━━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━━
  # │ rank │ country or area │ UN continental region │ UN statistical region │ population 2018 │ population 2019 │ change
 ───┼──────┼─────────────────┼───────────────────────┼───────────────────────┼─────────────────┼─────────────────┼────────
@@ -29,7 +29,7 @@ Here we have listed only the first 10 lines. In total this table has got 233 row
 We can use the `group-by` command on 'UN statistical region' to create a table per continental region.
 
 ```shell
-> open countries_by_population.json | from-json | group-by "UN continental region"
+> open countries_by_population.json | from json | group-by "UN continental region"
 ━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━
  Asia             │ Americas         │ Africa           │ Europe           │ Oceania
 ──────────────────┼──────────────────┼──────────────────┼──────────────────┼──────────────────
@@ -41,7 +41,7 @@ Now we can already get some information like "which continental regions are ther
 If we want to see only the countries in the continental region of Oceania we can type:
 
 ```shell
-> open countries_by_population.json | from-json | group-by "UN continental region" | get Oceania
+> open countries_by_population.json | from json | group-by "UN continental region" | get Oceania
 ━━━━┯━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━┯━━━━━━━━
  #  │ rank │ country or area                │ UN continental region │ UN statistical region     │ population 2018 │ population 2019 │ change
 ────┼──────┼────────────────────────────────┼───────────────────────┼───────────────────────────┼─────────────────┼─────────────────┼────────

--- a/docs/commands/save.md
+++ b/docs/commands/save.md
@@ -1,6 +1,6 @@
 # save
 
-This command saves the contents of the pipeline to a file. Use this in combination with the `to-json`, `to-csv`, ... commands to save the contents in the specified format.
+This command saves the contents of the pipeline to a file. Use this in combination with the `to json`, `to csv`, ... commands to save the contents in the specified format.
 
 Syntax: `save (path) {flags}`
 

--- a/docs/commands/str.md
+++ b/docs/commands/str.md
@@ -55,7 +55,7 @@ Applies the subcommand to a value or a table.
 ```
 
 ```shell
-> echo "1, 2, 3" | split row "," | str to-int | math sum
+> echo "1, 2, 3" | split row "," | str to int | math sum
 6
 ```
 

--- a/docs/commands/to-csv.md
+++ b/docs/commands/to-csv.md
@@ -106,7 +106,7 @@ X;filesystem;/home/shaurya
  ;filesystem;/home/shaurya/Desktop
 ```
 
-The string '\t' can be used to separate on tabs. Note that this is the same as using the to-tsv command.
+The string '\t' can be used to separate on tabs. Note that this is the same as using the to tsv command.
 
 Newlines '\n' are not acceptable separators.
 
@@ -115,9 +115,9 @@ Note that separators are currently provided as strings and need to be wrapped in
 It is also considered an error to use a separator greater than one char:
 
 ```shell
-> open pets.txt | from-csv --separator '123'
+> open pets.txt | from csv --separator '123'
 error: Expected a single separator char from --separator
 - shell:1:37
-1 | open pets.txt | from-csv --separator '123'
+1 | open pets.txt | from csv --separator '123'
   |                                      ^^^^^ requires a single character string input
 ```


### PR DESCRIPTION
Begins to address https://github.com/nushell/nushell/issues/2124
After this merge need to update the website

Searched for:
to, from, str, split

`to-csv` -> `to csv`