### PR TITLE
Extend 'Shell' with open and save capabilities

### DIFF
--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -155,7 +155,7 @@ async fn open(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     let with_encoding = if encoding.is_none() {
         None
     } else {
-        Some(get_encoding(encoding)?.clone())
+        Some(get_encoding(encoding)?)
     };
 
     let sob_stream = shell_manager.open(&path.item, path.tag.span, with_encoding)?;

--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -1,17 +1,14 @@
-use crate::commands::classified::maybe_text_codec::{MaybeTextCodec, StringOrBinary};
+use crate::commands::classified::maybe_text_codec::StringOrBinary;
+use crate::commands::constants::BAT_LANGUAGES;
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
-use futures_codec::FramedRead;
+use encoding_rs::{Encoding, UTF_8};
+use futures_util::StreamExt;
+use log::debug;
 use nu_errors::ShellError;
 use nu_protocol::{CommandAction, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::{AnchorLocation, Span, Tagged};
 use std::path::PathBuf;
-extern crate encoding_rs;
-use crate::commands::constants::BAT_LANGUAGES;
-use encoding_rs::*;
-use futures::prelude::*;
-use log::debug;
-use std::fs::File;
 
 pub struct Open;
 
@@ -103,6 +100,7 @@ pub fn get_encoding(opt: Option<Tagged<String>>) -> Result<&'static Encoding, Sh
 async fn open(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStream, ShellError> {
     let cwd = PathBuf::from(args.shell_manager.path());
     let registry = registry.clone();
+    let shell_manager = args.shell_manager.clone();
 
     let (
         OpenArgs {
@@ -157,19 +155,10 @@ async fn open(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
     let with_encoding = if encoding.is_none() {
         None
     } else {
-        Some(get_encoding(encoding)?)
+        Some(get_encoding(encoding)?.clone())
     };
-    let f = File::open(&path).map_err(|e| {
-        ShellError::labeled_error(
-            format!("Error opening file: {:?}", e),
-            "Error opening file",
-            path.span(),
-        )
-    })?;
-    let async_reader = futures::io::AllowStdIo::new(f);
-    let sob_stream = FramedRead::new(async_reader, MaybeTextCodec::new(with_encoding))
-        .map_err(|e| ShellError::unexpected(format!("AsyncRead failed in open function: {:?}", e)))
-        .into_stream();
+
+    let sob_stream = shell_manager.open(&path.item, path.tag.span, with_encoding)?;
 
     let final_stream = sob_stream.map(move |x| {
         // The tag that will used when returning a Value

--- a/crates/nu-cli/src/commands/save.rs
+++ b/crates/nu-cli/src/commands/save.rs
@@ -170,7 +170,7 @@ async fn save(
     let host = raw_args.host.clone();
     let ctrl_c = raw_args.ctrl_c.clone();
     let current_errors = raw_args.current_errors.clone();
-    let shell_manager = raw_args.shell_manager.clone();
+    let mut shell_manager = raw_args.shell_manager.clone();
 
     let head = raw_args.call_info.args.head.clone();
     let (
@@ -219,7 +219,7 @@ async fn save(
                         host,
                         ctrl_c,
                         current_errors,
-                        shell_manager,
+                        shell_manager: shell_manager.clone(),
                         call_info: UnevaluatedCallInfo {
                             args: nu_protocol::hir::Call {
                                 head,
@@ -252,14 +252,7 @@ async fn save(
     };
 
     match content {
-        Ok(save_data) => match std::fs::write(full_path, save_data) {
-            Ok(_) => Ok(OutputStream::empty()),
-            Err(e) => Err(ShellError::labeled_error(
-                e.to_string(),
-                "IO error while saving",
-                name,
-            )),
-        },
+        Ok(save_data) => shell_manager.save(&full_path, &save_data, name.span),
         Err(e) => Err(e),
     }
 }

--- a/crates/nu-cli/src/shell/help_shell.rs
+++ b/crates/nu-cli/src/shell/help_shell.rs
@@ -12,6 +12,8 @@ use crate::shell::shell::Shell;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
+use crate::commands::classified::maybe_text_codec::StringOrBinary;
+use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use nu_protocol::{
     Primitive, ReturnSuccess, ShellTypeName, TaggedDictBuilder, UntaggedValue, Value,
@@ -195,6 +197,28 @@ impl Shell for HelpShell {
 
     fn rm(&self, _args: RemoveArgs, _name: Tag, _path: &str) -> Result<OutputStream, ShellError> {
         Ok(OutputStream::empty())
+    }
+
+    fn open(
+        &self,
+        _path: &PathBuf,
+        _name: Span,
+        _with_encoding: Option<&'static Encoding>,
+    ) -> Result<BoxStream<'static, Result<StringOrBinary, ShellError>>, ShellError> {
+        Err(ShellError::unimplemented(
+            "open on help shell is not supported",
+        ))
+    }
+
+    fn save(
+        &mut self,
+        _path: &PathBuf,
+        _contents: &[u8],
+        _name: Span,
+    ) -> Result<OutputStream, ShellError> {
+        Err(ShellError::unimplemented(
+            "save on help shell is not supported",
+        ))
     }
 
     fn complete(

--- a/crates/nu-cli/src/shell/shell.rs
+++ b/crates/nu-cli/src/shell/shell.rs
@@ -1,4 +1,5 @@
 use crate::commands::cd::CdArgs;
+use crate::commands::classified::maybe_text_codec::StringOrBinary;
 use crate::commands::command::EvaluatedWholeStreamCommandArgs;
 use crate::commands::cp::CopyArgs;
 use crate::commands::ls::LsArgs;
@@ -7,6 +8,7 @@ use crate::commands::move_::mv::Arguments as MvArgs;
 use crate::commands::rm::RemoveArgs;
 use crate::prelude::*;
 use crate::stream::OutputStream;
+use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use std::path::PathBuf;
 
@@ -28,6 +30,18 @@ pub trait Shell: std::fmt::Debug {
     fn path(&self) -> String;
     fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError>;
     fn set_path(&mut self, path: String);
+    fn open(
+        &self,
+        path: &PathBuf,
+        name: Span,
+        with_encoding: Option<&'static Encoding>,
+    ) -> Result<BoxStream<'static, Result<StringOrBinary, ShellError>>, ShellError>;
+    fn save(
+        &mut self,
+        path: &PathBuf,
+        contents: &[u8],
+        name: Span,
+    ) -> Result<OutputStream, ShellError>;
 
     fn complete(
         &self,

--- a/crates/nu-cli/src/shell/shell_manager.rs
+++ b/crates/nu-cli/src/shell/shell_manager.rs
@@ -1,4 +1,5 @@
 use crate::commands::cd::CdArgs;
+use crate::commands::classified::maybe_text_codec::StringOrBinary;
 use crate::commands::command::EvaluatedWholeStreamCommandArgs;
 use crate::commands::cp::CopyArgs;
 use crate::commands::ls::LsArgs;
@@ -9,6 +10,7 @@ use crate::prelude::*;
 use crate::shell::filesystem_shell::FilesystemShell;
 use crate::shell::shell::Shell;
 use crate::stream::OutputStream;
+use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use parking_lot::Mutex;
 use std::error::Error;
@@ -79,6 +81,25 @@ impl ShellManager {
 
     pub fn set_path(&mut self, path: String) {
         self.shells.lock()[self.current_shell()].set_path(path)
+    }
+
+    pub fn open(
+        &self,
+        full_path: &PathBuf,
+        name: Span,
+        with_encoding: Option<&'static Encoding>,
+    ) -> Result<impl Stream<Item = Result<StringOrBinary, ShellError>> + Send + 'static, ShellError>
+    {
+        self.shells.lock()[self.current_shell()].open(full_path, name, with_encoding)
+    }
+
+    pub fn save(
+        &mut self,
+        full_path: &PathBuf,
+        save_data: &[u8],
+        name: Span,
+    ) -> Result<OutputStream, ShellError> {
+        self.shells.lock()[self.current_shell()].save(full_path, save_data, name)
     }
 
     pub fn complete(

--- a/crates/nu-cli/src/shell/value_shell.rs
+++ b/crates/nu-cli/src/shell/value_shell.rs
@@ -9,6 +9,8 @@ use crate::prelude::*;
 use crate::shell::shell::Shell;
 use crate::utils::ValueStructure;
 
+use crate::commands::classified::maybe_text_codec::StringOrBinary;
+use encoding_rs::Encoding;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
@@ -228,6 +230,28 @@ impl Shell for ValueShell {
     fn set_path(&mut self, path: String) {
         self.last_path = self.path.clone();
         self.path = path;
+    }
+
+    fn open(
+        &self,
+        _path: &PathBuf,
+        _name: Span,
+        _with_encoding: Option<&'static Encoding>,
+    ) -> Result<BoxStream<'static, Result<StringOrBinary, ShellError>>, ShellError> {
+        Err(ShellError::unimplemented(
+            "open on help shell is not supported",
+        ))
+    }
+
+    fn save(
+        &mut self,
+        _path: &PathBuf,
+        _contents: &[u8],
+        _name: Span,
+    ) -> Result<OutputStream, ShellError> {
+        Err(ShellError::unimplemented(
+            "save on help shell is not supported",
+        ))
     }
 
     fn complete(


### PR DESCRIPTION
In preparation for using Nu in more places, including wasm, I've extended Shell (our system abstraction layer) to also handle `open` and `save`. The idea here is that on the wasm/JS side, we can implement these in terms of a virtual FS that's available on the website. These could also be used for sandboxed functionality in the future.