### PR TITLE
Fix autoenv executing scripts multiple times

### DIFF
--- a/crates/nu-cli/src/env/directory_specific_environment.rs
+++ b/crates/nu-cli/src/env/directory_specific_environment.rs
@@ -20,7 +20,6 @@ pub struct DirectorySpecificEnvironment {
     //If an environment var has been added from a .nu in a directory, we track it here so we can remove it when the user leaves the directory.
     //If setting the var overwrote some value, we save the old value in an option so we can restore it later.
     added_vars: IndexMap<PathBuf, IndexMap<EnvKey, Option<EnvVal>>>,
-    visited_dirs: IndexSet<PathBuf>,
     exitscripts: IndexMap<PathBuf, Vec<String>>,
 }
 
@@ -43,7 +42,6 @@ impl DirectorySpecificEnvironment {
         DirectorySpecificEnvironment {
             last_seen_directory: root_dir,
             added_vars: IndexMap::new(),
-            visited_dirs: IndexSet::new(),
             exitscripts: IndexMap::new(),
         }
     }
@@ -79,11 +77,11 @@ impl DirectorySpecificEnvironment {
 
         let mut added_keys = IndexSet::new();
         //We note which directories we pass so we can clear unvisited dirs later.
-        let mut seen_directories_this_run = IndexSet::new();
+        let mut seen_directories = IndexSet::new();
 
         //Add all .nu-envs until we reach a dir which we have already added, or we reached the root.
         let mut popped = true;
-        while !self.visited_dirs.contains(&dir) && popped {
+        while !self.added_vars.contains_key(&dir) && popped {
             let nu_env_file = dir.join(".nu-env");
             if nu_env_file.exists() {
                 let nu_env_doc = self.toml_if_trusted(&nu_env_file)?;
@@ -116,20 +114,17 @@ impl DirectorySpecificEnvironment {
                 if let Some(es) = nu_env_doc.exitscripts {
                     self.exitscripts.insert(dir.clone(), es);
                 }
-                self.visited_dirs.insert(dir.clone());
             }
-
-            seen_directories_this_run.insert(dir.clone());
+            seen_directories.insert(dir.clone());
             popped = dir.pop();
         }
 
         //Time to clear out vars set by directories that we have left.
         let mut new_vars = IndexMap::new();
         for (dir, dirmap) in self.added_vars.drain(..) {
-            if seen_directories_this_run.contains(&dir) {
+            if seen_directories.contains(&dir) {
                 new_vars.insert(dir, dirmap);
             } else {
-                self.visited_dirs.remove(&dir);
                 for (k, v) in dirmap {
                     if let Some(v) = v {
                         std::env::set_var(k, v);
@@ -137,13 +132,22 @@ impl DirectorySpecificEnvironment {
                         std::env::remove_var(k);
                     }
                 }
-                if let Some(es) = self.exitscripts.get(&dir) {
-                    for s in es {
-                        run(s.as_str())?;
-                    }
+            }
+        }
+
+        //Run exitscripts, can not be done in same loop as new vars as some files can contain only exitscripts
+        let mut new_exitscripts = IndexMap::new();
+        for (dir, scripts) in self.exitscripts.drain(..) {
+            if seen_directories.contains(&dir) {
+                new_exitscripts.insert(dir, scripts);
+            } else {
+                for s in scripts {
+                    run(s.as_str())?;
                 }
             }
         }
+
+        self.exitscripts = new_exitscripts;
         self.added_vars = new_vars;
         self.last_seen_directory = current_dir()?;
         Ok(())

--- a/crates/nu-cli/src/env/directory_specific_environment.rs
+++ b/crates/nu-cli/src/env/directory_specific_environment.rs
@@ -79,9 +79,20 @@ impl DirectorySpecificEnvironment {
         //We note which directories we pass so we can clear unvisited dirs later.
         let mut seen_directories = IndexSet::new();
 
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .create(true)
+            .append(true)
+            .write(true)
+            .open("/home/sam/output")
+            .unwrap();
+        use std::io::Write;
+
         //Add all .nu-envs until we reach a dir which we have already added, or we reached the root.
         let mut popped = true;
         while !self.added_vars.contains_key(&dir) && popped {
+
+            write!(&mut file, "inside {:?}\n", dir).unwrap();
             let nu_env_file = dir.join(".nu-env");
             if nu_env_file.exists() {
                 let nu_env_doc = self.toml_if_trusted(&nu_env_file)?;

--- a/crates/nu-cli/src/env/directory_specific_environment.rs
+++ b/crates/nu-cli/src/env/directory_specific_environment.rs
@@ -93,7 +93,6 @@ impl DirectorySpecificEnvironment {
         //Add all .nu-envs until we reach a dir which we have already added, or we reached the root.
         let mut popped = true;
         while !self.added_vars.contains_key(&dir) && popped && !self.visited_dirs.contains(&dir) {
-            self.visited_dirs.insert(dir.clone());
             write!(&mut file, "inside {:?}\n", dir).unwrap();
             let nu_env_file = dir.join(".nu-env");
             if nu_env_file.exists() {
@@ -105,6 +104,7 @@ impl DirectorySpecificEnvironment {
                         self.maybe_add_key(&mut added_keys, &dir, &env_key, &env_val);
                     }
                 }
+                self.visited_dirs.insert(dir.clone());
 
                 //Add variables that need to evaluate scripts to run, from [scriptvars] section
                 if let Some(sv) = nu_env_doc.scriptvars {

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -93,10 +93,21 @@ fn autoenv() {
             )
         ]);
 
+        // Make sure entry scripts are run
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"cd ..
+               autoenv trust autoenv_test
+               cd autoenv_test
+               ls | where name == "hello.txt" | get name"#
+        );
+        assert!(actual.out.contains("hello.txt"));
+
         // Make sure entry scripts are run when re-visiting a directory
         let actual = nu!(
             cwd: dirs.test(),
-            r#"cd bizz
+            r#"autoenv trust bizz
+               cd bizz
                rm hello.txt
                cd ..
                cd bizz
@@ -104,7 +115,7 @@ fn autoenv() {
         );
         assert!(actual.out.contains("hello.txt"));
 
-        // // Entryscripts should not run after changing to a subdirectory.
+        // Entryscripts should not run after changing to a subdirectory.
         let actual = nu!(
             cwd: dirs.test(),
             r#"autoenv trust bizz

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -186,6 +186,16 @@ fn autoenv() {
         );
         assert!(actual.out.contains("bye.txt"));
 
+        //Variables set in parent directories should be set even if you directly cd to a subdir
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"autoenv trust foo
+                   cd foo/bar
+                   autoenv trust
+                   echo $nu.env.fookey"#
+        );
+        assert!(actual.out.ends_with("fooval"));
+
         //Subdirectories should overwrite the values of parent directories.
         let actual = nu!(
             cwd: dirs.test(),
@@ -196,15 +206,6 @@ fn autoenv() {
         );
         assert!(actual.out.ends_with("set_in_bar"));
 
-        //Variables set in parent directories should be set even if you directly cd to a subdir
-        let actual = nu!(
-            cwd: dirs.test(),
-            r#"autoenv trust foo
-                   cd foo/bar
-                   autoenv trust
-                   echo $nu.env.fookey"#
-        );
-        assert!(actual.out.ends_with("fooval"));
 
         //Make sure that overwritten values are restored.
         //By deleting foo/.nu-env, we make sure that the value is actually restored and not just set again by autoenv when we re-visit foo.

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -93,15 +93,26 @@ fn autoenv() {
             )
         ]);
 
+        // Make sure entry scripts are run when re-visiting a directory
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"cd bizz
+               rm hello.txt
+               cd ..
+               cd bizz
+               ls | where name == "hello.txt" | get name"#
+        );
+        assert!(actual.out.contains("hello.txt"));
+
         // // Entryscripts should not run after changing to a subdirectory.
-        // let actual = nu!(
-        //     cwd: dirs.test(),
-        //     r#"autoenv trust bizz
-        //        cd bizz
-        //        cd buzz
-        //        ls | where name == hello.txt | get name"#
-        // );
-        // assert!(!actual.out.ends_with("hello.txt"));
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"autoenv trust bizz
+               cd bizz
+               cd buzz
+               ls | where name == hello.txt | get name"#
+        );
+        assert!(!actual.out.ends_with("hello.txt"));
 
         //Make sure basic keys are set
         let actual = nu!(
@@ -155,17 +166,6 @@ fn autoenv() {
         );
         assert!(actual.out.contains("hello.txt"));
 
-
-        // Make sure entry scripts are run when re-visiting a directory
-        let actual = nu!(
-            cwd: dirs.test(),
-            r#"cd bizz
-               rm hello.txt
-               cd ..
-               cd bizz
-               ls | where name == "hello.txt" | get name"#
-        );
-        assert!(actual.out.contains("hello.txt"));
 
         // Make sure exit scripts are run
         let actual = nu!(

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -89,8 +89,8 @@ fn autoenv() {
                 "bizz/.nu-env",
                 r#"[scripts]
                     entryscripts = ["touch hello.txt"]
-                    exitscripts = ["touch bye.txt"]"#
-            )
+                    exitscripts = ["touch bye.txt"]"#,
+            ),
         ]);
 
         // Make sure entry scripts are run
@@ -141,7 +141,6 @@ fn autoenv() {
         );
         assert!(!actual.out.ends_with("testvalue"));
 
-
         // Make sure script keys are set
         let actual = nu!(
             cwd: dirs.test(),
@@ -177,7 +176,6 @@ fn autoenv() {
         );
         assert!(actual.out.contains("hello.txt"));
 
-
         // Make sure exit scripts are run
         let actual = nu!(
             cwd: dirs.test(),
@@ -205,7 +203,6 @@ fn autoenv() {
                    echo $nu.env.overwrite_me"#
         );
         assert!(actual.out.ends_with("set_in_bar"));
-
 
         //Make sure that overwritten values are restored.
         //By deleting foo/.nu-env, we make sure that the value is actually restored and not just set again by autoenv when we re-visit foo.


### PR DESCRIPTION
This issue was introduced in the tests & bugfix PR https://github.com/nushell/nushell/pull/2148 . If the user only specified entry or exitscripts in a .nu-env the scripts
would execute each time the user changed directory. This should be fixed now.

I have never had so little code give me so much trouble, but I guess that's what happens when your code is interacting with unpredictable humans. Presumably, this won't be the last bugfix PR I make, but now that there are tests (and more and more are being added), the speed of development is increased. I hope that I don't blow up any computers in the process of getting things right.