### PR TITLE
Make str more strict.

### DIFF
--- a/crates/nu-cli/src/commands/str_/to_integer.rs
+++ b/crates/nu-cli/src/commands/str_/to_integer.rs
@@ -101,7 +101,13 @@ fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
             let other = s.trim();
             let out = match BigInt::from_str(other) {
                 Ok(v) => UntaggedValue::int(v),
-                Err(_) => UntaggedValue::string(s),
+                Err(reason) => {
+                    return Err(ShellError::labeled_error(
+                        "could not parse as an integer",
+                        reason.to_string(),
+                        tag.into().span,
+                    ))
+                }
             };
             Ok(out.into_value(tag))
         }
@@ -136,5 +142,14 @@ mod tests {
 
         let actual = action(&word, Tag::unknown()).unwrap();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn communicates_parsing_error_given_an_invalid_integerlike_string() {
+        let integer_str = string("36anra");
+
+        let actual = action(&integer_str, Tag::unknown());
+
+        assert!(actual.is_err());
     }
 }

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -44,6 +44,7 @@ mod save;
 mod select;
 mod semicolon;
 mod skip_until;
+mod skip_while;
 mod sort_by;
 mod split_by;
 mod split_column;

--- a/crates/nu-cli/tests/commands/skip_until.rs
+++ b/crates/nu-cli/tests/commands/skip_until.rs
@@ -38,6 +38,7 @@ fn condition_is_met() {
                 | split column ','
                 | headers
                 | skip-until "Chicken Collection" == "Red Chickens"
+                | skip 1
                 | str to-int "31/04/2020"
                 | get "31/04/2020"
                 | math sum

--- a/crates/nu-cli/tests/commands/skip_while.rs
+++ b/crates/nu-cli/tests/commands/skip_while.rs
@@ -4,7 +4,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn condition_is_met() {
-    Playground::setup("keep-until_test_1", |dirs, sandbox| {
+    Playground::setup("skip-while_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "caballeros.txt",
             r#"
@@ -12,20 +12,20 @@ fn condition_is_met() {
                 --------------------------------------------------------------------
                 Chicken Collection,29/04/2020,30/04/2020,31/04/2020,
                 Yellow Chickens,,,
-                Andrés,1,1,1
-                Jonathan,1,1,1
-                Jason,1,1,1
-                Yehuda,1,1,1
+                Andrés,0,0,1
+                Jonathan,0,0,1
+                Jason,0,0,1
+                Yehuda,0,0,1
                 Blue Chickens,,,
-                Andrés,1,1,2
-                Jonathan,1,1,2
-                Jason,1,1,2
-                Yehuda,1,1,2
+                Andrés,0,0,1
+                Jonathan,0,0,1
+                Jason,0,0,1
+                Yehuda,0,0,2
                 Red Chickens,,,
-                Andrés,1,1,3
-                Jonathan,1,1,3
-                Jason,1,1,3
-                Yehuda,1,1,3
+                Andrés,0,0,1
+                Jonathan,0,0,1
+                Jason,0,0,1
+                Yehuda,0,0,3
             "#,
         )]);
 
@@ -37,8 +37,7 @@ fn condition_is_met() {
                 | skip 2
                 | split column ','
                 | headers
-                | skip-while "Chicken Collection" != "Blue Chickens"
-                | keep-until "Chicken Collection" == "Red Chickens"
+                | skip-while "Chicken Collection" != "Red Chickens"
                 | skip 1
                 | str to-int "31/04/2020"
                 | get "31/04/2020"
@@ -47,6 +46,6 @@ fn condition_is_met() {
                 "#
         ));
 
-        assert_eq!(actual.out, "8");
+        assert_eq!(actual.out, "6");
     })
 }


### PR DESCRIPTION
Many times we need  to try pipelines (and use extensively `debug --raw`) just to verify we are parsing, say, a `string` to a `datettime`. This PR (same for `str to-decimal` and `str to-int`) errors if parsing fails. Old behavior was to pass the input string back without failure.

Interestingly enough this change made a test or two that relied on `str` parsing to fail. We didn't see the false positives since (and we need to look more into) `math sum` doesn't fail in certain cases when adding mixed types (which is what in said tests was used after using `str`)