### PR TITLE
Use `matches!()` for true/false returning match statements

### DIFF
--- a/crates/nu-cli/src/commands/each.rs
+++ b/crates/nu-cli/src/commands/each.rs
@@ -74,13 +74,10 @@ impl WholeStreamCommand for Each {
 }
 
 fn is_expanded_it_usage(head: &SpannedExpression) -> bool {
-    match &*head {
-        SpannedExpression {
-            expr: Expression::Synthetic(Synthetic::String(s)),
-            ..
-        } if s == "expanded-each" => true,
-        _ => false,
-    }
+    matches!(&*head, SpannedExpression {
+        expr: Expression::Synthetic(Synthetic::String(s)),
+        ..
+    } if s == "expanded-each")
 }
 
 pub async fn process_row(

--- a/crates/nu-cli/src/commands/echo.rs
+++ b/crates/nu-cli/src/commands/echo.rs
@@ -90,10 +90,7 @@ impl RangeIterator {
             curr: range.from.0.item,
             end: range.to.0.item,
             tag,
-            is_end_inclusive: match range.to.1 {
-                RangeInclusion::Inclusive => true,
-                RangeInclusion::Exclusive => false,
-            },
+            is_end_inclusive: matches!(range.to.1, RangeInclusion::Inclusive),
             is_done: false,
         }
     }

--- a/crates/nu-cli/src/commands/keep_until.rs
+++ b/crates/nu-cli/src/commands/keep_until.rs
@@ -100,10 +100,7 @@ impl WholeStreamCommand for KeepUntil {
                     .await;
                     trace!("RESULT = {:?}", result);
 
-                    match result {
-                        Ok(ref v) if v.is_true() => false,
-                        _ => true,
-                    }
+                    !matches!(result, Ok(ref v) if v.is_true())
                 }
             })
             .to_output_stream())

--- a/crates/nu-cli/src/commands/keep_while.rs
+++ b/crates/nu-cli/src/commands/keep_while.rs
@@ -100,10 +100,7 @@ impl WholeStreamCommand for KeepWhile {
                     .await;
                     trace!("RESULT = {:?}", result);
 
-                    match result {
-                        Ok(ref v) if v.is_true() => true,
-                        _ => false,
-                    }
+                    matches!(result, Ok(ref v) if v.is_true())
                 }
             })
             .to_output_stream())

--- a/crates/nu-cli/src/commands/skip_until.rs
+++ b/crates/nu-cli/src/commands/skip_until.rs
@@ -99,10 +99,7 @@ impl WholeStreamCommand for SkipUntil {
                     .await;
                     trace!("RESULT = {:?}", result);
 
-                    match result {
-                        Ok(ref v) if v.is_true() => false, // stop skipping
-                        _ => true,
-                    }
+                    !matches!(result, Ok(ref v) if v.is_true())
                 }
             })
             .to_output_stream())

--- a/crates/nu-cli/src/commands/skip_while.rs
+++ b/crates/nu-cli/src/commands/skip_while.rs
@@ -99,10 +99,7 @@ impl WholeStreamCommand for SkipWhile {
                     .await;
                     trace!("RESULT = {:?}", result);
 
-                    match result {
-                        Ok(ref v) if v.is_true() => true,
-                        _ => false,
-                    }
+                    matches!(result, Ok(ref v) if v.is_true())
                 }
             })
             .to_output_stream())

--- a/crates/nu-cli/src/data/command.rs
+++ b/crates/nu-cli/src/data/command.rs
@@ -38,10 +38,7 @@ fn signature_dict(signature: Signature, tag: impl Into<Tag>) -> Value {
     let mut sig = TaggedListBuilder::new(&tag);
 
     for arg in signature.positional.iter() {
-        let is_required = match arg.0 {
-            PositionalType::Mandatory(_, _) => true,
-            PositionalType::Optional(_, _) => false,
-        };
+        let is_required = matches!(arg.0, PositionalType::Mandatory(_, _));
 
         sig.push_value(for_spec(arg.0.name(), "argument", is_required, &tag));
     }

--- a/crates/nu-cli/src/utils.rs
+++ b/crates/nu-cli/src/utils.rs
@@ -8,10 +8,7 @@ use nu_protocol::{UntaggedValue, Value};
 use std::path::{Component, Path, PathBuf};
 
 fn is_value_tagged_dir(value: &Value) -> bool {
-    match &value.value {
-        UntaggedValue::Row(_) | UntaggedValue::Table(_) => true,
-        _ => false,
-    }
+    matches!(&value.value, UntaggedValue::Row(_) | UntaggedValue::Table(_))
 }
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -265,13 +265,7 @@ impl ExternalCommand {
                 ..
             } => {
                 let Path { head, .. } = &**path;
-                match head {
-                    SpannedExpression {
-                        expr: Expression::Variable(Variable::It(_)),
-                        ..
-                    } => true,
-                    _ => false,
-                }
+                matches!(head, SpannedExpression{expr: Expression::Variable(Variable::It(_)), ..})
             }
             _ => false,
         })
@@ -1352,10 +1346,7 @@ impl NamedArguments {
     pub fn switch_present(&self, switch: &str) -> bool {
         self.named
             .get(switch)
-            .map(|t| match t {
-                NamedValue::PresentSwitch(_) => true,
-                _ => false,
-            })
+            .map(|t| matches!(t, NamedValue::PresentSwitch(_)))
             .unwrap_or(false)
     }
 }

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -77,18 +77,12 @@ impl UntaggedValue {
 
     /// Returns true if this value represents boolean true
     pub fn is_true(&self) -> bool {
-        match self {
-            UntaggedValue::Primitive(Primitive::Boolean(true)) => true,
-            _ => false,
-        }
+        matches!(self, UntaggedValue::Primitive(Primitive::Boolean(true)))
     }
 
     /// Returns true if this value represents a table
     pub fn is_table(&self) -> bool {
-        match self {
-            UntaggedValue::Table(_) => true,
-            _ => false,
-        }
+        matches!(self, UntaggedValue::Table(_))
     }
 
     /// Returns true if the value represents something other than Nothing
@@ -98,18 +92,12 @@ impl UntaggedValue {
 
     /// Returns true if the value represents Nothing
     pub fn is_none(&self) -> bool {
-        match self {
-            UntaggedValue::Primitive(Primitive::Nothing) => true,
-            _ => false,
-        }
+        matches!(self, UntaggedValue::Primitive(Primitive::Nothing))
     }
 
     /// Returns true if the value represents an error
     pub fn is_error(&self) -> bool {
-        match self {
-            UntaggedValue::Error(_err) => true,
-            _ => false,
-        }
+        matches!(self, UntaggedValue::Error(_err))
     }
 
     /// Expect this value to be an error and return it
@@ -341,10 +329,7 @@ impl Value {
 
     /// View the Value as a Primitive value, if possible
     pub fn is_primitive(&self) -> bool {
-        match &self.value {
-            UntaggedValue::Primitive(_) => true,
-            _ => false,
-        }
+        matches!(&self.value, UntaggedValue::Primitive(_))
     }
 
     /// View the Value as unsigned 64-bit, if possible

--- a/crates/nu-source/src/pretty.rs
+++ b/crates/nu-source/src/pretty.rs
@@ -264,10 +264,7 @@ impl DebugDocBuilder {
     }
 
     pub fn is_empty(&self) -> bool {
-        match &self.inner.1 {
-            pretty::Doc::Nil => true,
-            _ => false,
-        }
+        matches!(&self.inner.1, pretty::Doc::Nil)
     }
 
     pub fn or(self, doc: DebugDocBuilder) -> DebugDocBuilder {


### PR DESCRIPTION
There are quite a few places in Nushell that use a match statement to return a true or false.  With the new `matches!()` macro, some of these can be cleaned up quite a bit.