### PR TITLE
Indices are (now) green, bold, right-aligned

### DIFF
--- a/crates/nu-cli/src/commands/table.rs
+++ b/crates/nu-cli/src/commands/table.rs
@@ -187,7 +187,7 @@ fn values_to_entries(
                 StyledString::new(
                     (starting_idx + idx).to_string(),
                     TextStyle {
-                        alignment: Alignment::Center,
+                        alignment: Alignment::Right,
                         color: Some(ansi_term::Color::Green),
                         is_bold: true,
                     },


### PR DESCRIPTION
With https://github.com/nushell/nushell/pull/355 the (numeric) index column of tables was changed to be right-aligned. After the move to `nu-table` the index column is now centered instead of right-aligned. I think this is a copy-paste bug where [this line](https://github.com/nushell/nushell/blob/71e55541d7ede7cfc318bb5d15bd5c2e187db6a6/crates/nu-cli/src/commands/table.rs#L190) has been copied from [this line](https://github.com/nushell/nushell/blob/71e55541d7ede7cfc318bb5d15bd5c2e187db6a6/crates/nu-cli/src/commands/table.rs#L207), since the code is out-of-sync with [the comment](https://github.com/nushell/nushell/blob/71e55541d7ede7cfc318bb5d15bd5c2e187db6a6/crates/nu-cli/src/commands/table.rs#L183). This change restores harmony between the description and the function of the code.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/12575/87497814-74878580-c6aa-11ea-85ec-3d96f100ea7e.png)  | ![image](https://user-images.githubusercontent.com/12575/87497764-5457c680-c6aa-11ea-93fd-53f7d3bd507e.png) |

