### PR TITLE
Match cleanup

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -149,10 +149,7 @@ pub fn load_plugins(context: &mut Context) -> Result<(), ShellError> {
             .map(|path| {
                 let bin_name = {
                     if let Some(name) = path.file_name() {
-                        match name.to_str() {
-                            Some(raw) => raw,
-                            None => "",
-                        }
+                        name.to_str().unwrap_or("")
                     } else {
                         ""
                     }

--- a/crates/nu-cli/src/commands/str_/capitalize.rs
+++ b/crates/nu-cli/src/commands/str_/capitalize.rs
@@ -62,10 +62,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/downcase.rs
+++ b/crates/nu-cli/src/commands/str_/downcase.rs
@@ -62,10 +62,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/find_replace.rs
+++ b/crates/nu-cli/src/commands/str_/find_replace.rs
@@ -80,10 +80,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, &options, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, &options, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/from.rs
+++ b/crates/nu-cli/src/commands/str_/from.rs
@@ -96,10 +96,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, v.tag(), digits, group_digits) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, v.tag(), digits, group_digits)?)
             } else {
                 let mut ret = v;
                 for path in &column_paths {

--- a/crates/nu-cli/src/commands/str_/set.rs
+++ b/crates/nu-cli/src/commands/str_/set.rs
@@ -73,10 +73,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, &options, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, &options, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -108,10 +108,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, &options, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, &options, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/to_datetime.rs
+++ b/crates/nu-cli/src/commands/str_/to_datetime.rs
@@ -81,10 +81,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, &options, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, &options, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/to_decimal.rs
+++ b/crates/nu-cli/src/commands/str_/to_decimal.rs
@@ -65,10 +65,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/to_integer.rs
+++ b/crates/nu-cli/src/commands/str_/to_integer.rs
@@ -65,10 +65,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/trim.rs
+++ b/crates/nu-cli/src/commands/str_/trim.rs
@@ -79,10 +79,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, v.tag(), to_trim) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, v.tag(), to_trim)?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/commands/str_/upcase.rs
+++ b/crates/nu-cli/src/commands/str_/upcase.rs
@@ -62,10 +62,7 @@ async fn operate(
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                match action(&v, v.tag()) {
-                    Ok(out) => ReturnSuccess::value(out),
-                    Err(err) => Err(err),
-                }
+                ReturnSuccess::value(action(&v, v.tag())?)
             } else {
                 let mut ret = v;
 

--- a/crates/nu-cli/src/utils.rs
+++ b/crates/nu-cli/src/utils.rs
@@ -37,10 +37,7 @@ impl ValueStructure {
         }
 
         let path = if path.starts_with("/") {
-            match path.strip_prefix("/") {
-                Ok(p) => p,
-                Err(_) => path,
-            }
+            path.strip_prefix("/").unwrap_or(path)
         } else {
             path
         };


### PR DESCRIPTION
I've been looking over all the `match` statements in nushell and specifically watching out for cases where `match` is doing something that another operator or function is designed specifically to handle (resulting is a reduction of lines of code).