### PR TITLE
Use '?' for error propagation, remove `match`

### DIFF
--- a/crates/nu-cli/src/commands/str_/capitalize.rs
+++ b/crates/nu-cli/src/commands/str_/capitalize.rs
@@ -67,17 +67,10 @@ async fn operate(
                 let mut ret = v;
 
                 for path in &column_paths {
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => return Err(err),
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/downcase.rs
+++ b/crates/nu-cli/src/commands/str_/downcase.rs
@@ -67,19 +67,10 @@ async fn operate(
                 let mut ret = v;
 
                 for path in &column_paths {
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/find_replace.rs
+++ b/crates/nu-cli/src/commands/str_/find_replace.rs
@@ -87,19 +87,10 @@ async fn operate(
                 for path in &column_paths {
                     let options = options.clone();
 
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, &options, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/from.rs
+++ b/crates/nu-cli/src/commands/str_/from.rs
@@ -100,18 +100,10 @@ async fn operate(
             } else {
                 let mut ret = v;
                 for path in &column_paths {
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, old.tag(), digits, group_digits)),
-                    );
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/set.rs
+++ b/crates/nu-cli/src/commands/str_/set.rs
@@ -80,19 +80,10 @@ async fn operate(
                 for path in &column_paths {
                     let options = options.clone();
 
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, &options, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -115,19 +115,10 @@ async fn operate(
                 for path in &column_paths {
                     let options = options.clone();
 
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, &options, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/to_datetime.rs
+++ b/crates/nu-cli/src/commands/str_/to_datetime.rs
@@ -87,19 +87,11 @@ async fn operate(
 
                 for path in &column_paths {
                     let options = options.clone();
-                    let swapping = ret.swap_data_by_column_path(
+
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, &options, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/to_decimal.rs
+++ b/crates/nu-cli/src/commands/str_/to_decimal.rs
@@ -70,19 +70,10 @@ async fn operate(
                 let mut ret = v;
 
                 for path in &column_paths {
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/to_integer.rs
+++ b/crates/nu-cli/src/commands/str_/to_integer.rs
@@ -70,19 +70,10 @@ async fn operate(
                 let mut ret = v;
 
                 for path in &column_paths {
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/trim.rs
+++ b/crates/nu-cli/src/commands/str_/trim.rs
@@ -84,19 +84,10 @@ async fn operate(
                 let mut ret = v;
 
                 for path in &column_paths {
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, old.tag(), to_trim)),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)

--- a/crates/nu-cli/src/commands/str_/upcase.rs
+++ b/crates/nu-cli/src/commands/str_/upcase.rs
@@ -67,19 +67,10 @@ async fn operate(
                 let mut ret = v;
 
                 for path in &column_paths {
-                    let swapping = ret.swap_data_by_column_path(
+                    ret = ret.swap_data_by_column_path(
                         path,
                         Box::new(move |old| action(old, old.tag())),
-                    );
-
-                    match swapping {
-                        Ok(new_value) => {
-                            ret = new_value;
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
+                    )?;
                 }
 
                 ReturnSuccess::value(ret)


### PR DESCRIPTION
Another one