### PR TITLE
Silence Rust 1.45 Clippy warnings

### DIFF
--- a/crates/nu-cli/src/commands/autoenv.rs
+++ b/crates/nu-cli/src/commands/autoenv.rs
@@ -36,11 +36,7 @@ pub fn read_trusted() -> Result<Trusted, ShellError> {
         .create(true)
         .write(true)
         .open(config_path)
-        .or_else(|_| {
-            Err(ShellError::untagged_runtime_error(
-                "Couldn't open nu-env.toml",
-            ))
-        })?;
+        .map_err(|_| ShellError::untagged_runtime_error("Couldn't open nu-env.toml"))?;
     let mut doc = String::new();
     file.read_to_string(&mut doc)?;
 

--- a/crates/nu-cli/src/commands/autoenv_trust.rs
+++ b/crates/nu-cli/src/commands/autoenv_trust.rs
@@ -54,10 +54,8 @@ impl WholeStreamCommand for AutoenvTrust {
             .insert(filename, Sha256::digest(&content).as_slice().to_vec());
 
         let config_path = config::default_path_for(&Some(PathBuf::from("nu-env.toml")))?;
-        let tomlstr = toml::to_string(&allowed).or_else(|_| {
-            Err(ShellError::untagged_runtime_error(
-                "Couldn't serialize allowed dirs to nu-env.toml",
-            ))
+        let tomlstr = toml::to_string(&allowed).map_err(|_| {
+            ShellError::untagged_runtime_error("Couldn't serialize allowed dirs to nu-env.toml")
         })?;
         fs::write(config_path, tomlstr).expect("Couldn't write to toml file");
 

--- a/crates/nu-cli/src/commands/autoenv_untrust.rs
+++ b/crates/nu-cli/src/commands/autoenv_untrust.rs
@@ -78,10 +78,8 @@ impl WholeStreamCommand for AutoenvUnTrust {
                 ));
         }
 
-        let tomlstr = toml::to_string(&allowed).or_else(|_| {
-            Err(ShellError::untagged_runtime_error(
-                "Couldn't serialize allowed dirs to nu-env.toml",
-            ))
+        let tomlstr = toml::to_string(&allowed).map_err(|_| {
+            ShellError::untagged_runtime_error("Couldn't serialize allowed dirs to nu-env.toml")
         })?;
         fs::write(config_path, tomlstr).expect("Couldn't write to toml file");
 

--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -141,6 +141,7 @@ fn action(input: &Value, options: &Substring, tag: impl Into<Tag>) -> Result<Val
                 )
             })?;
 
+            #[allow(clippy::useless_conversion)]
             let start: isize = options.0.try_into().map_err(|_| {
                 ShellError::labeled_error(
                     "could not perform substring",

--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -141,16 +141,8 @@ fn action(input: &Value, options: &Substring, tag: impl Into<Tag>) -> Result<Val
                 )
             })?;
 
-            #[allow(clippy::useless_conversion)]
-            let start: isize = options.0.try_into().map_err(|_| {
-                ShellError::labeled_error(
-                    "could not perform substring",
-                    "could not perform substring",
-                    tag.span,
-                )
-            })?;
-
-            let end = options.1;
+            let start: isize = options.0;
+            let end: isize = options.1;
 
             if start < len && end >= 0 {
                 match start.cmp(&end) {

--- a/crates/nu-cli/src/env/directory_specific_environment.rs
+++ b/crates/nu-cli/src/env/directory_specific_environment.rs
@@ -55,7 +55,7 @@ impl DirectorySpecificEnvironment {
 
         if autoenv::file_is_trusted(&nu_env_file, &content)? {
             let mut doc: NuEnvDoc = toml::de::from_slice(&content)
-                .or_else(|e| Err(ShellError::untagged_runtime_error(format!("{:?}", e))))?;
+                .map_err(|e| ShellError::untagged_runtime_error(format!("{:?}", e)))?;
 
             if let Some(scripts) = doc.scripts.as_ref() {
                 for (k, v) in scripts {
@@ -244,11 +244,11 @@ fn value_from_script(cmd: &str) -> Result<String, ShellError> {
             cmd
         )));
     }
-    let response = std::str::from_utf8(&command.stdout[..command.stdout.len()]).or_else(|e| {
-        Err(ShellError::untagged_runtime_error(format!(
+    let response = std::str::from_utf8(&command.stdout[..command.stdout.len()]).map_err(|e| {
+        ShellError::untagged_runtime_error(format!(
             "Couldn't parse stdout from command {:?}: {:?}",
             command, e
-        )))
+        ))
     })?;
 
     Ok(response.trim().to_string())

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -233,9 +233,9 @@ impl Signature {
         desc: impl Into<String>,
         short: Option<char>,
     ) -> Signature {
-        let s = short.and_then(|c| {
+        let s = short.map(|c| {
             debug_assert!(!self.get_shorts().contains(&c));
-            Some(c)
+            c
         });
         self.named.insert(
             name.into(),
@@ -253,9 +253,9 @@ impl Signature {
         desc: impl Into<String>,
         short: Option<char>,
     ) -> Signature {
-        let s = short.and_then(|c| {
+        let s = short.map(|c| {
             debug_assert!(!self.get_shorts().contains(&c));
-            Some(c)
+            c
         });
 
         self.named.insert(
@@ -273,12 +273,12 @@ impl Signature {
         desc: impl Into<String>,
         short: Option<char>,
     ) -> Signature {
-        let s = short.and_then(|c| {
+        let s = short.map(|c| {
             debug_assert!(
                 !self.get_shorts().contains(&c),
                 "There may be duplicate short flags, such as -h"
             );
-            Some(c)
+            c
         });
 
         self.named


### PR DESCRIPTION
This PR fixes some things that Clippy suggests in Rust 1.45.

I fixed 4 errors similar to this:

```shell
warning: using `Result.or_else(|x| Err(y))`, which is more succinctly expressed as `map_err(|x| y)`
  --> crates/nu-cli/src/commands/autoenv_trust.rs:57:23
   |
57 |           let tomlstr = toml::to_string(&allowed).or_else(|_| {
   |  _______________________^
58 | |             Err(ShellError::untagged_runtime_error(
59 | |                 "Couldn't serialize allowed dirs to nu-env.toml",
60 | |             ))
61 | |         })?;
   | |__________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bind_instead_of_map
```

However, for this Rust 1.45 Clipp Warning:

```shell
warning: useless conversion to the same type
   --> crates/nu-cli/src/commands/str_/substring.rs:144:32
    |
144 |             let start: isize = options.0.try_into().map_err(|_| {
    |                                ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::useless_conversion)]` on by default
    = help: consider removing `.try_into()`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: 1 warning emitted
```

Using the suggested fix breaks Nushell, so I've just supplied a `[allow(clippy::useless_conversion)]`.