### PR TITLE
Introduce completion abstractions to nushell.

### DIFF
--- a/crates/nu-cli/src/completion.rs
+++ b/crates/nu-cli/src/completion.rs
@@ -1,0 +1,26 @@
+use nu_errors::ShellError;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Suggestion {
+    pub display: String,
+    pub replacement: String,
+}
+
+pub struct Context<'a>(pub &'a rustyline::Context<'a>);
+
+impl<'a> AsRef<rustyline::Context<'a>> for Context<'a> {
+    fn as_ref(&self) -> &rustyline::Context<'a> {
+        self.0
+    }
+}
+
+pub trait Completer {
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &Context<'_>,
+    ) -> Result<(usize, Vec<Suggestion>), ShellError>;
+
+    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String>;
+}

--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -15,6 +15,7 @@ extern crate quickcheck_macros;
 
 mod cli;
 mod commands;
+mod completion;
 mod context;
 pub mod data;
 mod deserializer;

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -5,6 +5,7 @@ use crate::commands::ls::LsArgs;
 use crate::commands::mkdir::MkdirArgs;
 use crate::commands::move_::mv::Arguments as MvArgs;
 use crate::commands::rm::RemoveArgs;
+use crate::completion;
 use crate::data::dir_entry_dict;
 use crate::path::canonicalize;
 use crate::prelude::*;
@@ -722,13 +723,15 @@ impl Shell for FilesystemShell {
             )),
         }
     }
+}
 
+impl completion::Completer for FilesystemShell {
     fn complete(
         &self,
         line: &str,
         pos: usize,
-        ctx: &rustyline::Context<'_>,
-    ) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError> {
+        ctx: &completion::Context<'_>,
+    ) -> Result<(usize, Vec<completion::Suggestion>), ShellError> {
         let expanded = expand_ndots(&line);
 
         // Find the first not-matching char position, if there is one
@@ -749,11 +752,26 @@ impl Shell for FilesystemShell {
             pos
         };
 
-        requote(self.completer.complete(&expanded, pos, ctx))
+        self.completer
+            .complete(&expanded, pos, ctx.as_ref())
+            .map_err(|e| ShellError::untagged_runtime_error(format!("{}", e)))
+            .map(requote)
+            .map(|(pos, completions)| {
+                (
+                    pos,
+                    completions
+                        .into_iter()
+                        .map(|pair| completion::Suggestion {
+                            display: pair.display,
+                            replacement: pair.replacement,
+                        })
+                        .collect(),
+                )
+            })
     }
 
-    fn hint(&self, line: &str, pos: usize, ctx: &rustyline::Context<'_>) -> Option<String> {
-        self.hinter.hint(line, pos, ctx)
+    fn hint(&self, line: &str, pos: usize, ctx: &completion::Context<'_>) -> Option<String> {
+        self.hinter.hint(line, pos, ctx.as_ref())
     }
 }
 
@@ -845,28 +863,23 @@ fn is_hidden_dir(dir: impl AsRef<Path>) -> bool {
 }
 
 fn requote(
-    completions: Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError>,
-) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError> {
-    match completions {
-        Ok(items) => {
-            let mut new_items = Vec::with_capacity(items.0);
+    items: (usize, Vec<rustyline::completion::Pair>),
+) -> (usize, Vec<rustyline::completion::Pair>) {
+    let mut new_items = Vec::with_capacity(items.1.len());
 
-            for item in items.1 {
-                let unescaped = rustyline::completion::unescape(&item.replacement, Some('\\'));
-                let maybe_quote = if unescaped != item.replacement {
-                    "\""
-                } else {
-                    ""
-                };
+    for item in items.1 {
+        let unescaped = rustyline::completion::unescape(&item.replacement, Some('\\'));
+        let maybe_quote = if unescaped != item.replacement {
+            "\""
+        } else {
+            ""
+        };
 
-                new_items.push(rustyline::completion::Pair {
-                    display: item.display,
-                    replacement: format!("{}{}{}", maybe_quote, unescaped, maybe_quote),
-                });
-            }
-
-            Ok((items.0, new_items))
-        }
-        Err(err) => Err(err),
+        new_items.push(rustyline::completion::Pair {
+            display: item.display,
+            replacement: format!("{}{}{}", maybe_quote, unescaped, maybe_quote),
+        });
     }
+
+    (items.0, new_items)
 }

--- a/crates/nu-cli/src/shell/help_shell.rs
+++ b/crates/nu-cli/src/shell/help_shell.rs
@@ -5,6 +5,7 @@ use crate::commands::ls::LsArgs;
 use crate::commands::mkdir::MkdirArgs;
 use crate::commands::move_::mv::Arguments as MvArgs;
 use crate::commands::rm::RemoveArgs;
+use crate::completion;
 use crate::data::command_dict;
 use crate::prelude::*;
 use crate::shell::shell::Shell;
@@ -220,15 +221,15 @@ impl Shell for HelpShell {
             "save on help shell is not supported",
         ))
     }
+}
 
+impl completion::Completer for HelpShell {
     fn complete(
         &self,
         line: &str,
         pos: usize,
-        _ctx: &rustyline::Context<'_>,
-    ) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError> {
-        let mut completions = vec![];
-
+        _ctx: &completion::Context<'_>,
+    ) -> Result<(usize, Vec<completion::Suggestion>), ShellError> {
         let mut possible_completion = vec![];
         let commands = self.commands();
         for cmd in commands {
@@ -247,6 +248,7 @@ impl Shell for HelpShell {
             replace_pos -= 1;
         }
 
+        let mut completions = vec![];
         for command in possible_completion.iter() {
             let mut pos = replace_pos;
             let mut matched = true;
@@ -264,7 +266,7 @@ impl Shell for HelpShell {
             }
 
             if matched {
-                completions.push(rustyline::completion::Pair {
+                completions.push(completion::Suggestion {
                     display: command.to_string(),
                     replacement: command.to_string(),
                 });
@@ -273,7 +275,7 @@ impl Shell for HelpShell {
         Ok((replace_pos, completions))
     }
 
-    fn hint(&self, _line: &str, _pos: usize, _ctx: &rustyline::Context<'_>) -> Option<String> {
+    fn hint(&self, _line: &str, _pos: usize, _ctx: &completion::Context<'_>) -> Option<String> {
         None
     }
 }

--- a/crates/nu-cli/src/shell/shell.rs
+++ b/crates/nu-cli/src/shell/shell.rs
@@ -6,13 +6,15 @@ use crate::commands::ls::LsArgs;
 use crate::commands::mkdir::MkdirArgs;
 use crate::commands::move_::mv::Arguments as MvArgs;
 use crate::commands::rm::RemoveArgs;
+use crate::completion;
 use crate::prelude::*;
 use crate::stream::OutputStream;
+
 use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use std::path::PathBuf;
 
-pub trait Shell: std::fmt::Debug {
+pub trait Shell: completion::Completer + std::fmt::Debug {
     fn name(&self) -> String;
     fn homedir(&self) -> Option<PathBuf>;
 
@@ -42,13 +44,4 @@ pub trait Shell: std::fmt::Debug {
         contents: &[u8],
         name: Span,
     ) -> Result<OutputStream, ShellError>;
-
-    fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        ctx: &rustyline::Context<'_>,
-    ) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError>;
-
-    fn hint(&self, _line: &str, _pos: usize, _ctx: &rustyline::Context<'_>) -> Option<String>;
 }

--- a/crates/nu-cli/src/shell/shell_manager.rs
+++ b/crates/nu-cli/src/shell/shell_manager.rs
@@ -6,10 +6,12 @@ use crate::commands::ls::LsArgs;
 use crate::commands::mkdir::MkdirArgs;
 use crate::commands::move_::mv::Arguments as MvArgs;
 use crate::commands::rm::RemoveArgs;
+use crate::completion::{self, Completer};
 use crate::prelude::*;
 use crate::shell::filesystem_shell::FilesystemShell;
 use crate::shell::shell::Shell;
 use crate::stream::OutputStream;
+
 use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use parking_lot::Mutex;
@@ -102,25 +104,6 @@ impl ShellManager {
         self.shells.lock()[self.current_shell()].save(full_path, save_data, name)
     }
 
-    pub fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        ctx: &rustyline::Context<'_>,
-    ) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError> {
-        self.shells.lock()[self.current_shell()].complete(line, pos, ctx)
-    }
-
-    pub fn hint(
-        &self,
-        line: &str,
-        pos: usize,
-        ctx: &rustyline::Context<'_>,
-        //context: ExpandContext,
-    ) -> Option<String> {
-        self.shells.lock()[self.current_shell()].hint(line, pos, ctx)
-    }
-
     pub fn next(&mut self) {
         {
             let shell_len = self.shells.lock().len();
@@ -196,5 +179,26 @@ impl ShellManager {
 
         let path = shells[self.current_shell()].path();
         shells[self.current_shell()].mv(args, name, &path)
+    }
+}
+
+impl Completer for ShellManager {
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &completion::Context<'_>,
+    ) -> Result<(usize, Vec<completion::Suggestion>), ShellError> {
+        self.shells.lock()[self.current_shell()].complete(line, pos, ctx)
+    }
+
+    fn hint(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &completion::Context<'_>,
+        //context: ExpandContext,
+    ) -> Option<String> {
+        self.shells.lock()[self.current_shell()].hint(line, pos, ctx)
     }
 }

--- a/crates/nu-cli/src/shell/value_shell.rs
+++ b/crates/nu-cli/src/shell/value_shell.rs
@@ -5,6 +5,7 @@ use crate::commands::ls::LsArgs;
 use crate::commands::mkdir::MkdirArgs;
 use crate::commands::move_::mv::Arguments as MvArgs;
 use crate::commands::rm::RemoveArgs;
+use crate::completion;
 use crate::prelude::*;
 use crate::shell::shell::Shell;
 use crate::utils::ValueStructure;
@@ -253,15 +254,15 @@ impl Shell for ValueShell {
             "save on help shell is not supported",
         ))
     }
+}
 
+impl completion::Completer for ValueShell {
     fn complete(
         &self,
         line: &str,
         pos: usize,
-        _ctx: &rustyline::Context<'_>,
-    ) -> Result<(usize, Vec<rustyline::completion::Pair>), rustyline::error::ReadlineError> {
-        let mut completions = vec![];
-
+        _ctx: &completion::Context<'_>,
+    ) -> Result<(usize, Vec<completion::Suggestion>), ShellError> {
         let mut possible_completion = vec![];
         let members = self.members();
         for member in members {
@@ -280,6 +281,7 @@ impl Shell for ValueShell {
             replace_pos -= 1;
         }
 
+        let mut completions = vec![];
         for command in possible_completion.iter() {
             let mut pos = replace_pos;
             let mut matched = true;
@@ -297,7 +299,7 @@ impl Shell for ValueShell {
             }
 
             if matched {
-                completions.push(rustyline::completion::Pair {
+                completions.push(completion::Suggestion {
                     display: command.to_string(),
                     replacement: command.to_string(),
                 });
@@ -306,7 +308,7 @@ impl Shell for ValueShell {
         Ok((replace_pos, completions))
     }
 
-    fn hint(&self, _line: &str, _pos: usize, _ctx: &rustyline::Context<'_>) -> Option<String> {
+    fn hint(&self, _line: &str, _pos: usize, _ctx: &completion::Context<'_>) -> Option<String> {
         None
     }
 }

--- a/crates/nu-cli/src/shell/value_shell.rs
+++ b/crates/nu-cli/src/shell/value_shell.rs
@@ -308,7 +308,7 @@ impl completion::Completer for ValueShell {
         Ok((replace_pos, completions))
     }
 
-    fn hint(&self, _line: &str, _pos: usize, _ctx: &completion::Context<'_>) -> Option<String> {
+    fn hint(&self, _line: &str, _pos: usize, _context: &completion::Context<'_>) -> Option<String> {
         None
     }
 }


### PR DESCRIPTION
Currently, we rely on rustyline's completion structures for completion inside of nushell.

What I'd like to do is abstract this away, relying only on nushell structures (as much as possible). This makes it easy to swap a completion "engine" in and out, without impacting the rest of nushell. My plan is actually to introduce a custom nushell completer, so this is the first step in making it easy to do that.

For now, I've followed essentially the same interface as rustyline's `Completer`, but we may eventually want to change that.