### PR TITLE
update history max size with two different calls.

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -644,7 +644,9 @@ pub async fn cli(
             .map(|i| i.value.expect_int())
             .unwrap_or(100_000);
 
-        rl.set_max_history_size(max_history_size as usize);
+        // rl.set_max_history_size(max_history_size as usize);
+        rustyline::config::Configurer::set_max_history_size(&mut rl, max_history_size as usize);
+        rustyline::Editor::set_max_history_size(&mut rl, max_history_size as usize);
 
         let key_timeout = config
             .get("key_timeout")


### PR DESCRIPTION
Closes #2193
hopefully this works for all. previously my history never went over 101. Now it's in the 110's - wow! hehe.