### PR TITLE
Expose more registry APIs

### DIFF
--- a/crates/nu-cli/src/context.rs
+++ b/crates/nu-cli/src/context.rs
@@ -40,30 +40,30 @@ impl CommandRegistry {
 }
 
 impl CommandRegistry {
-    pub(crate) fn get_command(&self, name: &str) -> Option<Command> {
+    pub fn get_command(&self, name: &str) -> Option<Command> {
         let registry = self.registry.lock();
 
         registry.get(name).cloned()
     }
 
-    pub(crate) fn expect_command(&self, name: &str) -> Result<Command, ShellError> {
+    pub fn expect_command(&self, name: &str) -> Result<Command, ShellError> {
         self.get_command(name).ok_or_else(|| {
             ShellError::untagged_runtime_error(format!("Could not load command: {}", name))
         })
     }
 
-    pub(crate) fn has(&self, name: &str) -> bool {
+    pub fn has(&self, name: &str) -> bool {
         let registry = self.registry.lock();
 
         registry.contains_key(name)
     }
 
-    pub(crate) fn insert(&mut self, name: impl Into<String>, command: Command) {
+    pub fn insert(&mut self, name: impl Into<String>, command: Command) {
         let mut registry = self.registry.lock();
         registry.insert(name.into(), command);
     }
 
-    pub(crate) fn names(&self) -> Vec<String> {
+    pub fn names(&self) -> Vec<String> {
         let registry = self.registry.lock();
         registry.keys().cloned().collect()
     }


### PR DESCRIPTION
Expose more registry APIs so it's easier to create commands from outside of the standard CLI host.