### PR TITLE
Add some tests for `parse_arg`

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -734,6 +734,7 @@ fn parse_arg(
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
 
@@ -747,11 +748,11 @@ mod test {
     }
 
     impl SignatureRegistry for MockRegistry {
-        fn has(&self, name: &str) -> bool {
+        fn has(&self, _name: &str) -> bool {
             false
         }
 
-        fn get(&self, name: &str) -> Option<nu_protocol::Signature> {
+        fn get(&self, _name: &str) -> Option<nu_protocol::Signature> {
             None
         }
 

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -734,6 +734,92 @@ fn parse_arg(
     }
 }
 
+mod test {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct MockRegistry {
+    }
+
+    impl MockRegistry {
+        fn new() -> Self {
+            MockRegistry {}
+        }
+    }
+
+    impl SignatureRegistry for MockRegistry {
+        fn has(&self, name: &str) -> bool {
+            false
+        }
+
+        fn get(&self, name: &str) -> Option<nu_protocol::Signature> {
+            None
+        }
+
+        fn clone_box(&self) -> Box<dyn SignatureRegistry> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[test]
+    fn parse_integer() -> Result<(), ParseError> {
+        let raw = "32".to_string();
+        let input = raw.clone().spanned(Span::new(0, raw.len()));
+        let registry = MockRegistry::new();
+        let result = parse_arg(SyntaxShape::Int, &registry, &input);
+        assert_eq!(result.1, None);
+        assert_eq!(
+            result.0.expr,
+            Expression::integer(32)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_number() -> Result<(), ParseError> {
+        let raw = "-32.2".to_string();
+        let input = raw.clone().spanned(Span::new(0, raw.len()));
+        let registry = MockRegistry::new();
+        let result = parse_arg(SyntaxShape::Number, &registry, &input);
+        assert_eq!(result.1, None);
+        assert_eq!(
+            result.0.expr,
+            Expression::decimal(-32.2)
+        );
+
+        let raw = "32.2".to_string();
+        let input = raw.clone().spanned(Span::new(0, raw.len()));
+        let registry = MockRegistry::new();
+        let result = parse_arg(SyntaxShape::Number, &registry, &input);
+        assert_eq!(result.1, None);
+        assert_eq!(
+            result.0.expr,
+            Expression::decimal(32.2)
+        );
+
+        let raw = "-34".to_string();
+        let input = raw.clone().spanned(Span::new(0, raw.len()));
+        let registry = MockRegistry::new();
+        let result = parse_arg(SyntaxShape::Number, &registry, &input);
+        assert_eq!(result.1, None);
+        assert_eq!(
+            result.0.expr,
+            Expression::integer(-34)
+        );
+
+        let raw = "34".to_string();
+        let input = raw.clone().spanned(Span::new(0, raw.len()));
+        let registry = MockRegistry::new();
+        let result = parse_arg(SyntaxShape::Number, &registry, &input);
+        assert_eq!(result.1, None);
+        assert_eq!(
+            result.0.expr,
+            Expression::integer(34)
+        );
+        Ok(())
+    }
+}
+
 /// Match the available flags in a signature with what the user provided. This will check both long-form flags (--full) and shorthand flags (-f)
 /// This also allows users to provide a group of shorthand flags (-af) that correspond to multiple shorthand flags at once.
 fn get_flags_from_flag(

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -738,8 +738,7 @@ mod test {
     use super::*;
 
     #[derive(Clone, Debug)]
-    struct MockRegistry {
-    }
+    struct MockRegistry {}
 
     impl MockRegistry {
         fn new() -> Self {
@@ -768,10 +767,7 @@ mod test {
         let registry = MockRegistry::new();
         let result = parse_arg(SyntaxShape::Int, &registry, &input);
         assert_eq!(result.1, None);
-        assert_eq!(
-            result.0.expr,
-            Expression::integer(32)
-        );
+        assert_eq!(result.0.expr, Expression::integer(32));
         Ok(())
     }
 
@@ -782,40 +778,28 @@ mod test {
         let registry = MockRegistry::new();
         let result = parse_arg(SyntaxShape::Number, &registry, &input);
         assert_eq!(result.1, None);
-        assert_eq!(
-            result.0.expr,
-            Expression::decimal(-32.2)
-        );
+        assert_eq!(result.0.expr, Expression::decimal(-32.2));
 
         let raw = "32.2".to_string();
         let input = raw.clone().spanned(Span::new(0, raw.len()));
         let registry = MockRegistry::new();
         let result = parse_arg(SyntaxShape::Number, &registry, &input);
         assert_eq!(result.1, None);
-        assert_eq!(
-            result.0.expr,
-            Expression::decimal(32.2)
-        );
+        assert_eq!(result.0.expr, Expression::decimal(32.2));
 
         let raw = "-34".to_string();
         let input = raw.clone().spanned(Span::new(0, raw.len()));
         let registry = MockRegistry::new();
         let result = parse_arg(SyntaxShape::Number, &registry, &input);
         assert_eq!(result.1, None);
-        assert_eq!(
-            result.0.expr,
-            Expression::integer(-34)
-        );
+        assert_eq!(result.0.expr, Expression::integer(-34));
 
         let raw = "34".to_string();
         let input = raw.clone().spanned(Span::new(0, raw.len()));
         let registry = MockRegistry::new();
         let result = parse_arg(SyntaxShape::Number, &registry, &input);
         assert_eq!(result.1, None);
-        assert_eq!(
-            result.0.expr,
-            Expression::integer(34)
-        );
+        assert_eq!(result.0.expr, Expression::integer(34));
         Ok(())
     }
 }


### PR DESCRIPTION
This adds some unit tests for the `parse_arg` function. Would be interested to hear if there are any parts of parse_arg's functionality that are particularly buggy that the project would like to have more coverage on. I would just build out tests for everything, but I suspect a lot of it would be duplicative and also it'd be a lot of work, so there is a question of what'd be highest leverage.