### PR TITLE
Fix internal command (alias) parsing

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1381,10 +1381,11 @@ fn classify_pipeline(
                 if let Some(signature) =
                     registry.get(&format!("{} {}", lite_cmd.name.item, lite_cmd.args[0].item))
                 {
-                    let (internal_command, err) =
+                    let (mut internal_command, err) =
                         parse_internal_command(&lite_cmd, registry, &signature, 1);
 
                     error = error.or(err);
+                    internal_command.args.is_last = iter.peek().is_none();
                     commands.push(ClassifiedCommand::Internal(internal_command));
                     continue;
                 }
@@ -1392,10 +1393,11 @@ fn classify_pipeline(
 
             // Check if it's an internal command
             if let Some(signature) = registry.get(&lite_cmd.name.item) {
-                let (internal_command, err) =
+                let (mut internal_command, err) =
                     parse_internal_command(&lite_cmd, registry, &signature, 0);
 
                 error = error.or(err);
+                internal_command.args.is_last = iter.peek().is_none();
                 commands.push(ClassifiedCommand::Internal(internal_command));
                 continue;
             }


### PR DESCRIPTION
I believe this fixes #2133 and #2218 - during parsing, `args.is_last` was set for external but not internal commands. The `Call` for an `InternalCommand` created via `alias` would then have `is_last = false`, which is passed on to the alias' block when run. Now, aliased external commands (such as `alias  gl [] { git log --abbrev-commit }` and `alias v [] { vi }`) should know whether they're last and behave as if called directly.