### PR TITLE
Convert table of primitives to positional arguments for external cmd

### DIFF
--- a/crates/nu-cli/src/utils/test_bins.rs
+++ b/crates/nu-cli/src/utils/test_bins.rs
@@ -7,12 +7,7 @@ pub fn cococo() {
         // Write back out all the arguments passed
         // if given at least 1 instead of chickens
         // speaking co co co.
-        let mut arguments = args.iter();
-        arguments.next();
-
-        for arg in arguments {
-            println!("{}", &arg);
-        }
+        println!("{}", &args[1..].join(" "));
     } else {
         println!("cococo");
     }

--- a/crates/nu-cli/tests/commands/with_env.rs
+++ b/crates/nu-cli/tests/commands/with_env.rs
@@ -27,7 +27,7 @@ fn shorthand_doesnt_reorder_arguments() {
         "FOO=BARRRR nu --testbin cococo first second"
     );
 
-    assert_eq!(actual.out, "firstsecond");
+    assert_eq!(actual.out, "first second");
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -281,16 +281,23 @@ mod external_command_arguments {
         Playground::setup(
             "expands_table_of_primitives_to_positional_arguments",
             |dirs, sandbox| {
-                sandbox.with_files(vec![EmptyFile("jonathan_likes_cake.txt")]);
+                sandbox.with_files(vec![
+                    EmptyFile("jonathan_likes_cake.txt"),
+                    EmptyFile("andres_likes_arepas.txt"),
+                    EmptyFile("ferris_not_here.txt"),
+                ]);
 
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(
                 r#"
-                nu --testbin cococo $(ls | get name)
+                    nu --testbin cococo $(ls | get name)
                 "#
                 ));
 
-                assert_eq!(actual.out, "jonathan_likes_cake.txt");
+                assert_eq!(
+                    actual.out,
+                    "andres_likes_arepas.txt ferris_not_here.txt jonathan_likes_cake.txt"
+                );
             },
         )
     }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -271,3 +271,27 @@ mod tilde_expansion {
         assert_eq!(actual.out, "1~1");
     }
 }
+
+mod external_command_arguments {
+    use super::nu;
+    use nu_test_support::fs::Stub::EmptyFile;
+    use nu_test_support::{pipeline, playground::Playground};
+    #[test]
+    fn expands_table_of_primitives_to_positional_arguments() {
+        Playground::setup(
+            "expands_table_of_primitives_to_positional_arguments",
+            |dirs, sandbox| {
+                sandbox.with_files(vec![EmptyFile("jonathan_likes_cake.txt")]);
+
+                let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                nu --testbin cococo $(ls | get name)
+                "#
+                ));
+
+                assert_eq!(actual.out, "jonathan_likes_cake.txt");
+            },
+        )
+    }
+}


### PR DESCRIPTION
Resolves #2169. Now external command such as `nvim $(ls | where type == File | get name)` will open all files given by `$(ls | where type == File | get name)`. Are there any other cases except table that should be covered?