### PR TITLE
Expose all rustyline configuration points

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -7,8 +7,8 @@ use crate::context::Context;
 use crate::git::current_branch;
 use crate::path::canonicalize;
 use crate::prelude::*;
-use crate::EnvironmentSyncer;
 use crate::shell::Helper;
+use crate::EnvironmentSyncer;
 use futures_codec::FramedRead;
 use nu_errors::{ProximateShellError, ShellDiagnostic, ShellError};
 use nu_protocol::hir::{ClassifiedCommand, Expression, InternalCommand, Literal, NamedArguments};
@@ -17,11 +17,9 @@ use nu_protocol::{Primitive, ReturnSuccess, Signature, UntaggedValue, Value};
 use nu_source::Tagged;
 
 use log::{debug, trace};
+use rustyline::config::{ColorMode, CompletionType, Config};
 use rustyline::error::ReadlineError;
-use rustyline::{
-    self, config::Configurer, At, Cmd, Editor, KeyPress, Movement, Word
-};
-use rustyline::config::{ColorMode, Config, CompletionType};
+use rustyline::{self, config::Configurer, At, Cmd, Editor, KeyPress, Movement, Word};
 use std::error::Error;
 use std::io::{BufRead, BufReader, Write};
 use std::iter::Iterator;
@@ -626,9 +624,7 @@ pub fn set_rustyline_configuration() -> (Editor<Helper>, IndexMap<String, Value>
                     }
                     "edit_mode" => {
                         let edit_mode = match value.as_string() {
-                            Ok(s) if s.to_lowercase() == "vi" => {
-                                rustyline::config::EditMode::Vi
-                            }
+                            Ok(s) if s.to_lowercase() == "vi" => rustyline::config::EditMode::Vi,
                             Ok(s) if s.to_lowercase() == "emacs" => {
                                 rustyline::config::EditMode::Emacs
                             }
@@ -660,12 +656,8 @@ pub fn set_rustyline_configuration() -> (Editor<Helper>, IndexMap<String, Value>
                     }
                     "color_mode" => {
                         let color_mode = match value.as_string() {
-                            Ok(s) if s.to_lowercase() == "enabled" => {
-                                rustyline::ColorMode::Enabled
-                            }
-                            Ok(s) if s.to_lowercase() == "forced" => {
-                                rustyline::ColorMode::Forced
-                            }
+                            Ok(s) if s.to_lowercase() == "enabled" => rustyline::ColorMode::Enabled,
+                            Ok(s) if s.to_lowercase() == "forced" => rustyline::ColorMode::Forced,
                             Ok(s) if s.to_lowercase() == "disabled" => {
                                 rustyline::ColorMode::Disabled
                             }
@@ -694,7 +686,6 @@ pub async fn cli(
     mut syncer: EnvironmentSyncer,
     mut context: Context,
 ) -> Result<(), Box<dyn Error>> {
-
     let _ = load_plugins(&mut context);
 
     let (mut rl, config) = set_rustyline_configuration();

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -523,19 +523,6 @@ pub async fn run_pipeline_standalone(
 }
 
 pub fn set_rustyline_configuration() -> (Editor<Helper>, IndexMap<String, Value>) {
-    // let mut max_history_size = 100_000;
-    // // let mut history_duplicates = rustyline::config::HistoryDuplicates::AlwaysAdd; //alwaysadd, ignoreconsecutive
-    // let mut history_duplicates = true; //false = alwaysadd, true = ignoreconsecutive
-    // let mut history_ignore_space = true;
-    // let mut completion_type = rustyline::config::CompletionType::Circular; // cirular, list, fuzzy
-    // let mut completion_prompt_limit = 1;
-    // let mut keyseq_timeout_ms = 500; //milliseconds
-    // let mut edit_mode = rustyline::config::EditMode::Vi; // vi, emacs
-    // let mut auto_add_history = true;
-    // let mut bell_style = rustyline::config::BellStyle::Audible; // audible, none, visible
-    // let mut color_mode = rustyline::config::ColorMode::Enabled; // enable, forced, disabled
-    // let mut tab_stop = 4;
-
     #[cfg(windows)]
     const DEFAULT_COMPLETION_MODE: CompletionType = CompletionType::Circular;
     #[cfg(not(windows))]
@@ -698,49 +685,6 @@ pub fn set_rustyline_configuration() -> (Editor<Helper>, IndexMap<String, Value>
             }
         }
     }
-
-
-    // // Set the max size of history before loading the history
-    // let max_history_size = config
-    //     .get("history_size")
-    //     .map(|i| i.value.expect_int())
-    //     .unwrap_or(100_000);
-
-    // rl.set_max_history_size(max_history_size as usize);
-    // // rustyline::config::Configurer::set_max_history_size(&mut rl, max_history_size as usize);
-    // // rustyline::Editor::set_max_history_size(&mut rl, max_history_size as usize);
-
-    // let _ = rl.load_history(&History::path());
-
-    // let edit_mode = config
-    //     .get("edit_mode")
-    //     .map(|s| match s.value.expect_string() {
-    //         "vi" => EditMode::Vi,
-    //         "emacs" => EditMode::Emacs,
-    //         _ => EditMode::Emacs,
-    //     })
-    //     .unwrap_or(EditMode::Emacs);
-
-    // rl.set_edit_mode(edit_mode);
-
-
-    // let key_timeout = config
-    //     .get("key_timeout")
-    //     .map(|s| s.value.expect_int())
-    //     .unwrap_or(1);
-
-    // rl.set_keyseq_timeout(key_timeout as i32);
-
-    // let completion_mode = config
-    //     .get("completion_mode")
-    //     .map(|s| match s.value.expect_string() {
-    //         "list" => CompletionType::List,
-    //         "circular" => CompletionType::Circular,
-    //         _ => DEFAULT_COMPLETION_MODE,
-    //     })
-    //     .unwrap_or(DEFAULT_COMPLETION_MODE);
-
-    // rl.set_completion_type(completion_mode);
 
     (rl, config)
 }

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -11,7 +11,7 @@ use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use std::borrow::Cow::{self, Owned};
 
-pub(crate) struct Helper {
+pub struct Helper {
     context: Context,
     pub colored_prompt: String,
 }


### PR DESCRIPTION
This change exposes all configuration points from rustyline. I added these so we can test with some of the configuration points that seem to allow items to bypass being added to the history file. There are some breaking changes as I moved all the configuration points into a toml section all to it's own and renamed some to better match rustyline.

### Here is an example toml section to go in your config.toml
```toml
[line_editor]
max_history_size = 1000
history_duplicates = "alwaysadd" #,ignoreconsecutive
history_ignore_space = true
completion_type = "circular" #, list, fuzzy
completion_prompt_limit = 1
keyseq_timeout_ms = 500 #ms
edit_mode = "vi" #, emacs
auto_add_history = true
bell_style = "audible" #, none, visible
color_mode = "enabled" #, forced, disabled
tab_stop = 4
```
Also, I haven't tested yet but fuzzy completion should be available on `(all(unix, feature = 'with-fuzzy'))` platforms.

### History Slowdown
This change also re-re-reverts the change that slowed down testing that @JosephTLyons, @jonathandturner and @andrasio  identified. However, I set the default max_history_size to 1000 and I also moved this load/reload of the history out of the loop section. So, hopefully there will be little to no impact even with larger max_history_sizes.

### Breaking changes 
rustyline configuration is in it's own section names [line_editor]
completion_mode is now completion_type 
keyseq_timeout is now keyseq_timeout_ms

Please test and let me know if you find any issues.


