### PR TITLE
update line_editor defaults

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -675,9 +675,22 @@ pub fn set_rustyline_configuration() -> (Editor<Helper>, IndexMap<String, Value>
                     _ => (),
                 }
             }
+        } else {
+            // if the line_editor config section doesn't exist, let's set some defaults
+            rl.set_max_history_size(1000);
+            rl.set_history_ignore_dups(true);
+            rl.set_history_ignore_space(true);
+            rl.set_completion_type(DEFAULT_COMPLETION_MODE);
+            rl.set_completion_prompt_limit(1);
+            rl.set_keyseq_timeout(500);
+            rl.set_edit_mode(rustyline::config::EditMode::Vi);
+            rl.set_auto_add_history(true);
+            rl.set_bell_style(rustyline::config::BellStyle::None);
+            rl.set_color_mode(rustyline::ColorMode::Enabled);
+            rl.set_tab_stop(4);
         }
     } else {
-        // if the config section doesn't exist, let's set some defaults
+        // if the config file itself doesn't exist, let's set some defaults
         rl.set_max_history_size(1000);
         rl.set_history_ignore_dups(true);
         rl.set_history_ignore_space(true);


### PR DESCRIPTION
if config file doesn't exist, set defaults.
if line_editor in config doesn't exist, set defaults.