### PR TITLE
Make history location configurable

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -202,12 +202,25 @@ pub struct History;
 impl History {
     pub fn path() -> PathBuf {
         const FNAME: &str = "history.txt";
-        config::user_data()
+        let default = config::user_data()
             .map(|mut p| {
                 p.push(FNAME);
                 p
             })
-            .unwrap_or_else(|_| PathBuf::from(FNAME))
+            .unwrap_or_else(|_| PathBuf::from(FNAME));
+
+        let cfg = crate::data::config::config(Tag::unknown());
+        if let Ok(c) = cfg {
+            match &c["history-path"].value {
+                UntaggedValue::Primitive(p) => match p {
+                    Primitive::String(path) => PathBuf::from(path),
+                    _ => default,
+                },
+                _ => default,
+            }
+        } else {
+            default
+        }
     }
 }
 


### PR DESCRIPTION
Add history-path to your config.toml if you want an alternate history file location