### PR TITLE
`to-xml.md` documentation update

### DIFF
--- a/docs/commands/to-xml.md
+++ b/docs/commands/to-xml.md
@@ -70,7 +70,7 @@ Converts table data into XML text.
 
 Due to XML and internal representation, `to xml` is currently limited, it will:
 
-* only process table data loaded from XML files (e.g. `open file.json | to xml` will fail)
-* drop XML prolog declarations
-* drop namespaces
-* drop comments
+* Only process table data loaded from XML files (e.g. `open file.json | to xml` will fail)
+* Drop XML prolog declarations
+* Drop namespaces
+* Drop comments

--- a/docs/commands/to-xml.md
+++ b/docs/commands/to-xml.md
@@ -4,7 +4,7 @@ Converts table data into XML text.
 
 ## Flags
 
--   `-p`, `--pretty` \<integer>: Formats the XML text with the provided indentation setting
+* `-p`, `--pretty` \<integer>: Formats the XML text with the provided indentation setting
 
 ## Example
 
@@ -70,7 +70,7 @@ Converts table data into XML text.
 
 Due to XML and internal representation, `to xml` is currently limited, it will:
 
--   only process table data loaded from XML files (e.g. `open file.json | to xml` will fail)
--   drop XML prolog declarations
--   drop namespaces
--   drop comments
+* only process table data loaded from XML files (e.g. `open file.json | to xml` will fail)
+* drop XML prolog declarations
+* drop namespaces
+* drop comments

--- a/docs/commands/to.md
+++ b/docs/commands/to.md
@@ -13,6 +13,7 @@ Converts table data into a string or binary. The target format is specified as a
 * [to toml](to-toml.md)
 * [to tsv](to-tsv.md)
 * [to url](to-url.md)
+* [to xml](to-xml.md)
 * [to yaml](to-yaml.md)
 
 *Subcommands without links are currently missing their documentation.*


### PR DESCRIPTION
Updates documentation to be consistent with the work done here:

https://github.com/JosephTLyons/nushell/commit/053bd926ecdd20d028b27092c4ae63ab66040c74

Also adds a link from `to.md` to `to-xml.md`