### PR TITLE
Make all bullet point items uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To build Nu, you will need to use the **latest stable (1.41 or later)** version 
 Required dependencies:
 
 * pkg-config and libssl (only needed on Linux)
-  * on Debian/Ubuntu: `apt install pkg-config libssl-dev`
+  * On Debian/Ubuntu: `apt install pkg-config libssl-dev`
 
 Optional dependencies:
 
 * To use Nu with all possible optional features enabled, you'll also need the following:
-  * on Linux (on Debian/Ubuntu): `apt install libxcb-composite0-dev libx11-dev`
+  * On Linux (on Debian/Ubuntu): `apt install libxcb-composite0-dev libx11-dev`
 
 To install Nu via cargo (make sure you have installed [rustup](https://rustup.rs/) and the latest stable compiler via `rustup install stable`):
 

--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -6,9 +6,9 @@ Syntax: `alias {flags} <name> [<parameters>] {<body>}`
 
 The command expects three parameters:
 
-* the name of alias
-* the parameters as a space-separated list (`[a b ...]`), can be empty (`[]`)
-* the body of the alias as a `{...}` block
+* The name of alias
+* The parameters as a space-separated list (`[a b ...]`), can be empty (`[]`)
+* The body of the alias as a `{...}` block
 
 ## Flags
 

--- a/docs/commands/math-eval.md
+++ b/docs/commands/math-eval.md
@@ -6,8 +6,8 @@ This command supports the following operations -
 
 operations:
 
-* binary operators: +, -, *, /, % (remainder), ^ (power)
-* unary operators: +, -, ! (factorial)
+* Binary operators: +, -, *, /, % (remainder), ^ (power)
+* Unary operators: +, -, ! (factorial)
 
 functions:
 


### PR DESCRIPTION
Unless the bullet point starts off with a command (or any item that should be lowercase), I capitalized them, to keep it consistent across the board.