### PR TITLE
Move nu_errors::ParseError to nu_parser::errors::ParseError.

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -808,7 +808,7 @@ pub async fn cli(
 
                 match nu_parser::lite_parse(&prompt_line, 0).map_err(ShellError::from) {
                     Ok(result) => {
-                        let mut prompt_block =
+                        let (mut prompt_block, _err) =
                             nu_parser::classify_block(&result, context.registry());
 
                         let env = context.get_env();
@@ -973,7 +973,7 @@ pub async fn parse_and_eval(line: &str, ctx: &mut Context) -> Result<String, She
     let lite_result = nu_parser::lite_parse(&line, 0)?;
 
     // TODO ensure the command whose examples we're testing is actually in the pipeline
-    let mut classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
+    let (mut classified_block, _err) = nu_parser::classify_block(&lite_result, ctx.registry());
     classified_block.block.expand_it_usage();
 
     let input_stream = InputStream::empty();
@@ -1018,12 +1018,12 @@ pub async fn process_line(
             debug!("=== Parsed ===");
             debug!("{:#?}", result);
 
-            let mut classified_block = nu_parser::classify_block(&result, ctx.registry());
+            let (mut classified_block, err) = nu_parser::classify_block(&result, ctx.registry());
 
             debug!("{:#?}", classified_block);
             //println!("{:#?}", pipeline);
 
-            if let Some(failure) = classified_block.failed {
+            if let Some(failure) = err {
                 return LineResult::Error(line.to_string(), failure.into());
             }
 

--- a/crates/nu-cli/src/commands/classified/block.rs
+++ b/crates/nu-cli/src/commands/classified/block.rs
@@ -80,8 +80,6 @@ async fn run_pipeline(
                 run_expression_block(*expr, ctx, it, vars, env).await?
             }
 
-            ClassifiedCommand::Error(err) => return Err(err.into()),
-
             ClassifiedCommand::Internal(left) => {
                 run_internal_command(left, ctx, input, it, vars, env).await?
             }

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -63,7 +63,7 @@ impl WholeStreamCommand for Histogram {
             },
             Example {
                 description: "Get a histogram for a list of numbers",
-                example: "echo [1 2 3 1 1 1 2 2 1 1] | histogram",
+                example: "echo [1 2 3 1 1 1 2 2 1 1] | wrap number | histogram number",
                 result: None,
             },
         ]

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -67,7 +67,11 @@ fn parse_line(line: &'static str, ctx: &mut Context) -> Result<ClassifiedBlock, 
     let lite_result = nu_parser::lite_parse(&line, 0)?;
 
     // TODO ensure the command whose examples we're testing is actually in the pipeline
-    let mut classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
+    let (mut classified_block, err) = nu_parser::classify_block(&lite_result, ctx.registry());
+    if let Some(e) = err {
+        return Err(e.into());
+    }
+
     classified_block.block.expand_it_usage();
     Ok(classified_block)
 }

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -192,7 +192,7 @@ fn get_matching_arguments(
     let replace_string = (replace_pos..pos).map(|_| " ").collect::<String>();
     line_copy.replace_range(replace_pos..pos, &replace_string);
 
-    let result = nu_parser::classify_block(&lite_block, &context.registry);
+    let (result, _err) = nu_parser::classify_block(&lite_block, &context.registry);
 
     for pipeline in &result.block.block {
         for command in &pipeline.list {

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -127,7 +127,7 @@ impl Painter {
         match lite_block {
             Err(_) => Cow::Borrowed(line),
             Ok(lb) => {
-                let classified = nu_parser::classify_block(&lb, registry);
+                let (classified, _err) = nu_parser::classify_block(&lb, registry);
 
                 let shapes = nu_parser::shapes(&classified.block);
                 let mut painter = Painter::new(line);

--- a/crates/nu-errors/src/lib.rs
+++ b/crates/nu-errors/src/lib.rs
@@ -2,122 +2,12 @@ use ansi_term::Color;
 use bigdecimal::BigDecimal;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use derive_new::new;
-use getset::Getters;
 use nu_source::{b, DebugDocBuilder, HasFallibleSpan, PrettyDebug, Span, Spanned, SpannedItem};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Range;
-
-/// A structured reason for a ParseError. Note that parsing in nu is more like macro expansion in
-/// other languages, so the kinds of errors that can occur during parsing are more contextual than
-/// you might expect.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
-pub enum ParseErrorReason {
-    /// The parser encountered an EOF rather than what it was expecting
-    Eof { expected: String, span: Span },
-    /// The parser expected to see the end of a token stream (possibly the token
-    /// stream from inside a delimited token node), but found something else.
-    ExtraTokens { actual: Spanned<String> },
-    /// The parser encountered something other than what it was expecting
-    Mismatch {
-        expected: String,
-        actual: Spanned<String>,
-    },
-
-    /// An unexpected internal error has occurred
-    InternalError { message: Spanned<String> },
-
-    /// The parser tried to parse an argument for a command, but it failed for
-    /// some reason
-    ArgumentError {
-        command: Spanned<String>,
-        error: ArgumentError,
-    },
-}
-
-/// A newtype for `ParseErrorReason`
-#[derive(Debug, Clone, Getters, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
-pub struct ParseError {
-    #[get = "pub"]
-    reason: ParseErrorReason,
-}
-
-impl ParseError {
-    /// Construct a [ParseErrorReason::Eof](ParseErrorReason::Eof)
-    pub fn unexpected_eof(expected: impl Into<String>, span: Span) -> ParseError {
-        ParseError {
-            reason: ParseErrorReason::Eof {
-                expected: expected.into(),
-                span,
-            },
-        }
-    }
-
-    /// Construct a [ParseErrorReason::ExtraTokens](ParseErrorReason::ExtraTokens)
-    pub fn extra_tokens(actual: Spanned<impl Into<String>>) -> ParseError {
-        let Spanned { span, item } = actual;
-
-        ParseError {
-            reason: ParseErrorReason::ExtraTokens {
-                actual: item.into().spanned(span),
-            },
-        }
-    }
-
-    /// Construct a [ParseErrorReason::Mismatch](ParseErrorReason::Mismatch)
-    pub fn mismatch(expected: impl Into<String>, actual: Spanned<impl Into<String>>) -> ParseError {
-        let Spanned { span, item } = actual;
-
-        ParseError {
-            reason: ParseErrorReason::Mismatch {
-                expected: expected.into(),
-                actual: item.into().spanned(span),
-            },
-        }
-    }
-
-    /// Construct a [ParseErrorReason::InternalError](ParseErrorReason::InternalError)
-    pub fn internal_error(message: Spanned<impl Into<String>>) -> ParseError {
-        ParseError {
-            reason: ParseErrorReason::InternalError {
-                message: message.item.into().spanned(message.span),
-            },
-        }
-    }
-
-    /// Construct a [ParseErrorReason::ArgumentError](ParseErrorReason::ArgumentError)
-    pub fn argument_error(command: Spanned<impl Into<String>>, kind: ArgumentError) -> ParseError {
-        ParseError {
-            reason: ParseErrorReason::ArgumentError {
-                command: command.item.into().spanned(command.span),
-                error: kind,
-            },
-        }
-    }
-}
-
-/// Convert a [ParseError](ParseError) into a [ShellError](ShellError)
-impl From<ParseError> for ShellError {
-    fn from(error: ParseError) -> ShellError {
-        match error.reason {
-            ParseErrorReason::Eof { expected, span } => ShellError::unexpected_eof(expected, span),
-            ParseErrorReason::ExtraTokens { actual } => ShellError::type_error("nothing", actual),
-            ParseErrorReason::Mismatch { actual, expected } => {
-                ShellError::type_error(expected, actual)
-            }
-            ParseErrorReason::InternalError { message } => ShellError::labeled_error(
-                format!("Internal error: {}", message.item),
-                &message.item,
-                &message.span,
-            ),
-            ParseErrorReason::ArgumentError { command, error } => {
-                ShellError::argument_error(command, error)
-            }
-        }
-    }
-}
 
 /// ArgumentError describes various ways that the parser could fail because of unexpected arguments.
 /// Nu commands are like a combination of functions and macros, and these errors correspond to

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -1,0 +1,111 @@
+use nu_errors::{ArgumentError, ShellError};
+use nu_source::{Span, Spanned, SpannedItem};
+use serde::{Deserialize, Serialize};
+
+/// A structured reason for a ParseError. Note that parsing in nu is more like macro expansion in
+/// other languages, so the kinds of errors that can occur during parsing are more contextual than
+/// you might expect.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+pub enum ParseErrorReason {
+    /// The parser encountered an EOF rather than what it was expecting
+    Eof { expected: String, span: Span },
+    /// The parser expected to see the end of a token stream (possibly the token
+    /// stream from inside a delimited token node), but found something else.
+    ExtraTokens { actual: Spanned<String> },
+    /// The parser encountered something other than what it was expecting
+    Mismatch {
+        expected: String,
+        actual: Spanned<String>,
+    },
+
+    /// An unexpected internal error has occurred
+    InternalError { message: Spanned<String> },
+
+    /// The parser tried to parse an argument for a command, but it failed for
+    /// some reason
+    ArgumentError {
+        command: Spanned<String>,
+        error: ArgumentError,
+    },
+}
+
+/// A newtype for `ParseErrorReason`
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+pub struct ParseError {
+    reason: ParseErrorReason,
+}
+
+impl ParseError {
+    /// Construct a [ParseErrorReason::Eof](ParseErrorReason::Eof)
+    pub fn unexpected_eof(expected: impl Into<String>, span: Span) -> ParseError {
+        ParseError {
+            reason: ParseErrorReason::Eof {
+                expected: expected.into(),
+                span,
+            },
+        }
+    }
+
+    /// Construct a [ParseErrorReason::ExtraTokens](ParseErrorReason::ExtraTokens)
+    pub fn extra_tokens(actual: Spanned<impl Into<String>>) -> ParseError {
+        let Spanned { span, item } = actual;
+
+        ParseError {
+            reason: ParseErrorReason::ExtraTokens {
+                actual: item.into().spanned(span),
+            },
+        }
+    }
+
+    /// Construct a [ParseErrorReason::Mismatch](ParseErrorReason::Mismatch)
+    pub fn mismatch(expected: impl Into<String>, actual: Spanned<impl Into<String>>) -> ParseError {
+        let Spanned { span, item } = actual;
+
+        ParseError {
+            reason: ParseErrorReason::Mismatch {
+                expected: expected.into(),
+                actual: item.into().spanned(span),
+            },
+        }
+    }
+
+    /// Construct a [ParseErrorReason::InternalError](ParseErrorReason::InternalError)
+    pub fn internal_error(message: Spanned<impl Into<String>>) -> ParseError {
+        ParseError {
+            reason: ParseErrorReason::InternalError {
+                message: message.item.into().spanned(message.span),
+            },
+        }
+    }
+
+    /// Construct a [ParseErrorReason::ArgumentError](ParseErrorReason::ArgumentError)
+    pub fn argument_error(command: Spanned<impl Into<String>>, kind: ArgumentError) -> ParseError {
+        ParseError {
+            reason: ParseErrorReason::ArgumentError {
+                command: command.item.into().spanned(command.span),
+                error: kind,
+            },
+        }
+    }
+}
+
+/// Convert a [ParseError](ParseError) into a [ShellError](ShellError)
+impl From<ParseError> for ShellError {
+    fn from(error: ParseError) -> ShellError {
+        match error.reason {
+            ParseErrorReason::Eof { expected, span } => ShellError::unexpected_eof(expected, span),
+            ParseErrorReason::ExtraTokens { actual } => ShellError::type_error("nothing", actual),
+            ParseErrorReason::Mismatch { actual, expected } => {
+                ShellError::type_error(expected, actual)
+            }
+            ParseErrorReason::InternalError { message } => ShellError::labeled_error(
+                format!("Internal error: {}", message.item),
+                &message.item,
+                &message.span,
+            ),
+            ParseErrorReason::ArgumentError { command, error } => {
+                ShellError::argument_error(command, error)
+            }
+        }
+    }
+}

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -1,11 +1,13 @@
+mod errors;
 mod lite_parse;
 mod parse;
 mod path;
 mod shapes;
 mod signature;
 
-pub use crate::lite_parse::{lite_parse, LiteBlock};
-pub use crate::parse::{classify_block, garbage, parse_full_column_path};
-pub use crate::path::expand_ndots;
-pub use crate::shapes::shapes;
-pub use crate::signature::{Signature, SignatureRegistry};
+pub use errors::ParseError;
+pub use lite_parse::{lite_parse, LiteBlock};
+pub use parse::{classify_block, garbage, parse_full_column_path};
+pub use path::expand_ndots;
+pub use shapes::shapes;
+pub use signature::{Signature, SignatureRegistry};

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -1,8 +1,9 @@
 use std::iter::Peekable;
 use std::str::CharIndices;
 
-use nu_errors::ParseError;
 use nu_source::{Span, Spanned, SpannedItem};
+
+use crate::ParseError;
 
 type Input<'t> = Peekable<CharIndices<'t>>;
 
@@ -308,10 +309,7 @@ fn pipeline(src: &mut Input, span_offset: usize) -> Result<LiteBlock, ParseError
     while src.peek().is_some() {
         // If there is content there, let's parse it
 
-        let mut cmd = match command(src, span_offset) {
-            Ok(cmd) => cmd,
-            Err(e) => return Err(e),
-        };
+        let mut cmd = command(src, span_offset)?;
 
         loop {
             skip_whitespace(src);

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -9,7 +9,6 @@ use crate::{hir, Primitive, UntaggedValue};
 use crate::{PathMember, ShellTypeName};
 use derive_new::new;
 
-use nu_errors::ParseError;
 use nu_source::{
     b, DebugDocBuilder, HasSpan, PrettyDebug, PrettyDebugRefineKind, PrettyDebugWithSource,
 };
@@ -56,14 +55,11 @@ impl InternalCommand {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub struct ClassifiedBlock {
     pub block: Block,
-    // this is not a Result to make it crystal clear that these shapes
-    // aren't intended to be used directly with `?`
-    pub failed: Option<ParseError>,
 }
 
 impl ClassifiedBlock {
-    pub fn new(block: Block, failed: Option<ParseError>) -> ClassifiedBlock {
-        ClassifiedBlock { block, failed }
+    pub fn new(block: Block) -> ClassifiedBlock {
+        ClassifiedBlock { block }
     }
 }
 
@@ -84,7 +80,6 @@ pub enum ClassifiedCommand {
     #[allow(unused)]
     Dynamic(crate::hir::Call),
     Internal(InternalCommand),
-    Error(ParseError),
 }
 
 impl ClassifiedCommand {


### PR DESCRIPTION
This is a first step to provide more information in the parse error with regards to what successfully parsed, and the shape of what's incomplete. This will be necessary information for the completion engine. For example:

    > ls "testing

would parse with an EOF error that has a single pipeline, with a single command, which has the name "ls" and partial arg "testing". I'm not sure exactly how we'll convey this information, but it will require us to reference parser-specific types, which is the driving factor for this move.

This does mean that other crates can't work with a `ParseError` directly, unless they depend on nu-parser (which may be undesirable). With the changes in this PR, no crate needs to have such a dependency, so I'd rather cross that bridge when we get to it.