### PR TITLE
Split (evaluated) external positionals on whitespace

### DIFF
--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -81,8 +81,13 @@ async fn run_with_stdin(
                 }
             }
             _ => {
-                let trimmed_value_string = value.as_string()?.trim_end_matches('\n').to_string();
-                command_args.push(trimmed_value_string);
+                let trimmed_value_string: Vec<String> = value
+                    .as_string()?
+                    .trim_end_matches('\n')
+                    .split_whitespace()
+                    .map(String::from)
+                    .collect();
+                command_args.extend(trimmed_value_string);
             }
         }
     }


### PR DESCRIPTION
I was trying to do `sudo $(history | last 1)` in lieu of `sudo !!`, but `$(history | last 1)` evaluates to a string (say `bash test.sh`), which is passed whole to `sudo` as a single positional. This tweak splits positionals on whitespace before passing off the command. I can see a potential issue where quotes are used to designate a single positional and we shouldn't split, but I wanted to get feedback on other unforseen issues (or reasons why this is a bad idea entirely).