### PR TITLE
Initial version of prefix-based reverse search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,7 +3357,7 @@ dependencies = [
  "roxmltree",
  "rusqlite",
  "rust-embed",
- "rustyline",
+ "rustyline 8.2.0 (git+https://github.com/oberien/rustyline?rev=64f21b4c61e9cc29c5edcfd8cfb4b018584225ea)",
  "serde 1.0.126",
  "serde_bytes",
  "serde_ini",
@@ -3457,7 +3457,7 @@ dependencies = [
  "roxmltree",
  "rusqlite",
  "rust-embed",
- "rustyline",
+ "rustyline 8.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.126",
  "serde_bytes",
  "serde_ini",
@@ -5365,6 +5365,29 @@ name = "rustyline"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd4eaf7a7738f76c98e4f0395253ae853be3eb018f7b0bb57fe1b6c17e31874"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log 0.4.14",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "smallvec 1.6.1",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse 0.2.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rustyline"
+version = "8.2.0"
+source = "git+https://github.com/oberien/rustyline?rev=64f21b4c61e9cc29c5edcfd8cfb4b018584225ea#64f21b4c61e9cc29c5edcfd8cfb4b018584225ea"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -76,7 +76,8 @@ rayon = "1.5.0"
 regex = "1.4.3"
 roxmltree = "0.14.0"
 rust-embed = "5.9.0"
-rustyline = { version = "8.1.0", optional = true }
+#rustyline = { version = "8.1.0", optional = true }
+rustyline = { git = "https://github.com/oberien/rustyline", rev = "64f21b4c61e9cc29c5edcfd8cfb4b018584225ea", optional = true }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde_ini = "0.2.0"

--- a/crates/nu-cli/src/line_editor.rs
+++ b/crates/nu-cli/src/line_editor.rs
@@ -108,6 +108,7 @@ pub fn default_rustyline_editor_configuration() -> Editor<Helper> {
     rl.set_bell_style(rustyline::config::BellStyle::default());
     rl.set_color_mode(rustyline::ColorMode::Enabled);
     rl.set_tab_stop(8);
+    rl.set_history_search_behaviour(rustyline::config::HistorySearchBehaviour::LineByLine);
 
     if let Err(e) = crate::keybinding::load_keybindings(&mut rl) {
         println!("Error loading keybindings: {:?}", e);
@@ -222,6 +223,18 @@ pub fn configure_rustyline_editor(
                     if let Ok(tab_stop) = value.as_u64() {
                         rl.set_tab_stop(tab_stop as usize);
                     }
+                }
+                "history_search_behaviour" => {
+                    let history_search_behaviour = match value.as_string() {
+                        Ok(s) if s.to_lowercase() == "line_by_line" => {
+                            rustyline::config::HistorySearchBehaviour::LineByLine
+                        }
+                        Ok(s) if s.to_lowercase() == "prefix_reverse_search" => {
+                            rustyline::config::HistorySearchBehaviour::PrefixReverseSearch
+                        }
+                        _ => rustyline::config::HistorySearchBehaviour::LineByLine,
+                    };
+                    rl.set_history_search_behaviour(history_search_behaviour);
                 }
                 _ => (),
             }

--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -69,6 +69,7 @@ auto_add_history = true
 bell_style = "audible" # audible, none, visible
 color_mode = "enabled" # enabled, forced, disabled
 tab_stop = 4
+history_search_behaviour = "line_by_line" # line_by_line, prefix_reverse_search
 
 [textview]
 term_width = "default" # "default" or a number


### PR DESCRIPTION
Fix #465 

In kkawakam/rustyline#424 I'm implementing an option for prefix-based reverse search. With this PR, I'm adding a config option to nushell to allow using that reverse-search mode. I pointed the rustyline dependency directly to my commit. We'll need to wait until the PR is merged in rustyline and they released a new version of the crate. However, the functionality and changes of this PR should already be testable and reviewable.

Side-question: How can I set a sub-config-option in nushell with `config set`? I tried `config set line_editor.history_search_behaviour prefix_reverse_search`, but that added that literal string as top-level config option.