### PR TITLE
added pkg_mgrs/winget + yaml

### DIFF
--- a/pkg_mgrs/winget/0.17.yml
+++ b/pkg_mgrs/winget/0.17.yml
@@ -1,0 +1,16 @@
+Id: Nushell.Nushell
+Publisher: Nushell
+Name: Nushell
+Version: 0.17.0
+License: MIT
+LicenseUrl: https://github.com/nushell/nushell/blob/main/LICENSE
+AppMoniker: nushell
+Tags: shell, nu, nushell, functional, data, analysis
+Description: Nushell. A new type of shell.
+Homepage: https://www.nushell.sh/
+InstallerType: msi
+Installers:
+  - Arch: x64
+    Url: https://github.com/nushell/nushell/releases/download/0.17.0/nu_0_17_0_windows.msi
+    Sha256: 3EF3FCE4069510AD78577DC61E29F3DC02F4A384DE5E2CCD9D9862FC7E4D849E
+ManifestVersion: 0.1.0


### PR DESCRIPTION
started a root branch for package managers named `pkg_mgrs` assuming there may be other pkg_mgrs we want to add for new. added `winget/0.17.yml`. I tested the winget release using `winget validate 0.17.yml` as well was `winget install -m 0.17.yml`. The install revealed that:
* we have no icon for the installer
* we do not put `nu` in the start menu
* we have no signed our msi, so it will prompt users to make sure they want to install it
* we're not using silent installer for msi (not sure if we can with a `blocked` msi)

moving forward anyway