### PR TITLE
Basic features nu-cli especific reporting.

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -52,7 +52,6 @@ ical = "0.6.*"
 ichwh = {version = "0.3.4", optional = true}
 indexmap = {version = "1.4.0", features = ["serde-1"]}
 itertools = "0.9.0"
-last-git-commit = "0.2.0"
 log = "0.4.8"
 meval = "0.2"
 natural = "0.5.0"
@@ -115,7 +114,6 @@ optional = true
 version = "0.23.1"
 
 [build-dependencies]
-git2 = "0.13"
 
 [dev-dependencies]
 quickcheck = "0.9"


### PR DESCRIPTION
Often when someone asks if something is not working (that requires a feature at build time) we need to ask folks to rebuild to double confirm. With this commit we can ask what `version` says to know if the binary was built with the required feature or not.

Also, removing Nu commit hashes since more investigation is needed when publishing  crate and avoiding build fealures.