### PR TITLE
Remove `with-symlink-targets` flag from `ls`

### DIFF
--- a/crates/nu-cli/src/commands/ls.rs
+++ b/crates/nu-cli/src/commands/ls.rs
@@ -14,8 +14,6 @@ pub struct LsArgs {
     pub long: bool,
     #[serde(rename = "short-names")]
     pub short_names: bool,
-    #[serde(rename = "with-symlink-targets")]
-    pub with_symlink_targets: bool,
     #[serde(rename = "du")]
     pub du: bool,
 }
@@ -43,12 +41,6 @@ impl WholeStreamCommand for Ls {
                 "short-names",
                 "Only print the file names and not the path",
                 Some('s'),
-            )
-            .switch(
-                // Delete this
-                "with-symlink-targets",
-                "Display the paths to the target files that symlinks point to",
-                Some('w'),
             )
             .switch(
                 "du",

--- a/crates/nu-cli/src/data/files.rs
+++ b/crates/nu-cli/src/data/files.rs
@@ -39,7 +39,6 @@ pub(crate) fn dir_entry_dict(
     tag: impl Into<Tag>,
     long: bool,
     short_name: bool,
-    with_symlink_targets: bool,
     du: bool,
     ctrl_c: Arc<AtomicBool>,
 ) -> Result<Value, ShellError> {
@@ -71,7 +70,7 @@ pub(crate) fn dir_entry_dict(
         }
     } else {
         for column in ["name", "type", "target", "size", "modified"].iter() {
-            if *column == "target" && !with_symlink_targets {
+            if *column == "target" {
                 continue;
             }
             dict.insert_untagged(*column, UntaggedValue::nothing());
@@ -97,7 +96,7 @@ pub(crate) fn dir_entry_dict(
         dict.insert_untagged("type", get_file_type(md));
     }
 
-    if long || with_symlink_targets {
+    if long {
         if let Some(md) = metadata {
             if md.file_type().is_symlink() {
                 let symlink_target_untagged_value: UntaggedValue;

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -97,7 +97,6 @@ impl Shell for FilesystemShell {
             all,
             long,
             short_names,
-            with_symlink_targets,
             du,
         }: LsArgs,
         name_tag: Tag,
@@ -166,7 +165,6 @@ impl Shell for FilesystemShell {
                 name_tag.clone(),
                 long,
                 short_names,
-                with_symlink_targets,
                 du,
                 ctrl_c.clone(),
             )

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -184,7 +184,7 @@ fn list_all_columns() {
             ]
             .join("");
 
-            assert_eq!(actual.out, expected, "column names are incorrect for ls -w");
+            assert_eq!(actual.out, expected, "column names are incorrect for ls -l");
             // Long
             let actual = nu!(
                 cwd: dirs.test(),

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -173,18 +173,6 @@ fn list_all_columns() {
             );
             let expected = ["name", "type", "size", "modified"].join("");
             assert_eq!(actual.out, expected, "column names are incorrect for ls");
-            // Symbolic Links
-            let actual = nu!(
-                cwd: dirs.test(),
-                "ls -l | get | to md"
-            );
-            let expected = [
-                "name", "type", "target", "readonly", "mode", "uid", "group", "size", "created",
-                "accessed", "modified",
-            ]
-            .join("");
-
-            assert_eq!(actual.out, expected, "column names are incorrect for ls -l");
             // Long
             let actual = nu!(
                 cwd: dirs.test(),

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -176,9 +176,14 @@ fn list_all_columns() {
             // Symbolic Links
             let actual = nu!(
                 cwd: dirs.test(),
-                "ls -w | get | to md"
+                "ls -l | get | to md"
             );
-            let expected = ["name", "type", "target", "size", "modified"].join("");
+            let expected = [
+                "name", "type", "target", "readonly", "mode", "uid", "group", "size", "created",
+                "accessed", "modified",
+            ]
+            .join("");
+
             assert_eq!(actual.out, expected, "column names are incorrect for ls -w");
             // Long
             let actual = nu!(


### PR DESCRIPTION
[This PR](https://github.com/nushell/nushell/pull/1292) added the ability to show where symlinks pointed in the `ls` command.  Currently, you can see this is you use `ls -l` or `ls --with-symlink-targets`.  Some time has passed and the second option seems unnecessary and out of place now.  There are no other flags on `ls` that add in some hidden column that is only shown in `ls -l`, which makes this flag seem out of place.  I think we can get rid of it, and only rely on `ls -l`.