### PR TITLE
histogram: optionally use a column as valuator.

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -52,13 +52,13 @@ steps:
   - bash: RUSTFLAGS="-D warnings" cargo test --all --features stable
     condition: eq(variables['style'], 'unflagged')
     displayName: Run tests
-  - bash: RUSTFLAGS="-D warnings" cargo clippy --all --features=stable -- -D clippy::result_unwrap_used -D clippy::option_unwrap_used
+  - bash: RUSTFLAGS="-D warnings" cargo clippy --all --features=stable -- -D clippy::unwrap_used
     condition: eq(variables['style'], 'unflagged')
     displayName: Check clippy lints
   - bash: RUSTFLAGS="-D warnings" cargo test --all --features stable
     condition: eq(variables['style'], 'canary')
     displayName: Run tests
-  - bash: RUSTFLAGS="-D warnings" cargo clippy --all --features=stable -- -D clippy::result_unwrap_used -D clippy::option_unwrap_used
+  - bash: RUSTFLAGS="-D warnings" cargo clippy --all --features=stable -- -D clippy::unwrap_used
     condition: eq(variables['style'], 'canary')
     displayName: Check clippy lints
   - bash: RUSTFLAGS="-D warnings" cargo test --all --no-default-features

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -96,9 +96,9 @@ pub async fn histogram(
     let frequency_column_name = if columns.is_empty() {
         "frequency".to_string()
     } else if let Some((key, _)) = columns[0].split_last() {
-            key.as_string()
+        key.as_string()
     } else {
-            "frecuency".to_string()
+        "frecuency".to_string()
     };
 
     let column = if let Some(ref column) = column_grouper {

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -127,13 +127,13 @@ pub async fn histogram(
             .table_entries()
             .map(move |value| {
                 let values = value.table_entries().cloned().collect::<Vec<_>>();
-                let count = values.len();
+                let ocurrences = values.len();
 
-                (count, values[count - 1].clone())
+                (ocurrences, values[ocurrences - 1].clone())
             })
             .collect::<Vec<_>>()
             .into_iter()
-            .map(move |(count, value)| {
+            .map(move |(ocurrences, value)| {
                 let mut fact = TaggedDictBuilder::new(&name);
                 let column_value = labels
                     .get(idx)
@@ -147,7 +147,7 @@ pub async fn histogram(
                     .clone();
 
                 fact.insert_value(&column.item, column_value);
-                fact.insert_untagged("count", UntaggedValue::int(count));
+                fact.insert_untagged("ocurrences", UntaggedValue::int(ocurrences));
 
                 let percentage = format!(
                     "{}%",

--- a/crates/nu-cli/tests/commands/histogram.rs
+++ b/crates/nu-cli/tests/commands/histogram.rs
@@ -54,7 +54,7 @@ fn summarizes_by_values() {
                 | get rusty_at
                 | histogram
                 | where value == "Estados Unidos"
-                | get count
+                | get ocurrences
                 | echo $it
             "#
         ));
@@ -93,20 +93,20 @@ fn help() {
 }
 
 #[test]
-fn count() {
+fn ocurrences() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
             echo "[{"bit":1},{"bit":0},{"bit":0},{"bit":0},{"bit":0},{"bit":0},{"bit":0},{"bit":1}]"
             | from json
             | histogram bit
-            | sort-by count
+            | sort-by ocurrences
             | reject frequency
             | to json
         "#
     ));
 
-    let bit_json = r#"[{"bit":"1","count":2,"percentage":"33.33%"},{"bit":"0","count":6,"percentage":"100.00%"}]"#;
+    let bit_json = r#"[{"bit":"1","ocurrences":2,"percentage":"33.33%"},{"bit":"0","ocurrences":6,"percentage":"100.00%"}]"#;
 
     assert_eq!(actual.out, bit_json);
 }


### PR DESCRIPTION
* clippy lint result/unwrap renaming.
* Column 'count' renamed to `ocurrences'.
* `use` named flag was introduced. Sometimes we want to use another value to valuate when accumulating results. For instance, we have the following (for illustration purposes):

```
> open tests/fixtures/formats/caco3_plastics.csv | reject name tariff_item shipped_at arrived_at cif_price | update net_weight { get net_weight | str find-replace , '' | str to-decimal } | insert cost { = (100 * $it.cif_per_net_weight) * $it.net_weight }

───┬────────────────────────────────────────┬─────────────────────────────────────────────────┬──────────┬─────────────┬───────────┬────────────────────┬──────────────
 # │ importer                               │ shipper                                         │ origin   │ net_weight  │ fob_price │ cif_per_net_weight │ cost
───┼────────────────────────────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼───────────┼────────────────────┼──────────────
 0 │ PLASTICOS RIVAL CIA LTDA               │ S A REVERTE                                     │ SPAIN    │  81000.0000 │ 14,417.58 │             0.2300 │ 1863000.0000
 1 │ MEXICHEM ECUADOR S.A.                  │ OMYA ANDINA S A                                 │ COLOMBIA │  26000.0000 │ 7,072.00  │             0.3100 │  806000.0000
 2 │ PLASTIAZUAY SA                         │ SA REVERTE                                      │ SPAIN    │  81000.0000 │ 8,100.00  │             0.1400 │ 1134000.0000
 3 │ PLASTICOS RIVAL CIA LTDA               │ AND ENDUSTRIYEL HAMMADDELER DIS TCARET LTD.STI. │ TURKEY   │ 100000.0000 │ 17,500.00 │             0.2300 │ 2300000.0000
 4 │ QUIMICA COMERCIAL QUIMICIAL CIA. LTDA. │ SA REVERTE                                      │ SPAIN    │  27000.0000 │ 3,258.90  │             0.2100 │  567000.0000
 5 │ PICA PLASTICOS INDUSTRIALES C.A.       │ OMYA ANDINA S.A                                 │ COLOMBIA │  66500.0000 │ 12,635.00 │             0.2800 │ 1862000.0000
 6 │ PLASTIQUIM S.A.                        │ OMYA ANDINA S.A NIT 830.027.386-6               │ COLOMBIA │  33000.0000 │ 6,270.00  │             0.3000 │  990000.0000
 7 │ QUIMICOS ANDINOS QUIMANDI S.A.         │ SIBELCO COLOMBIA SAS                            │ COLOMBIA │  52000.0000 │ 8,944.00  │             0.2500 │ 1300000.0000
 8 │ TIGRE ECUADOR S.A. ECUATIGRE           │ OMYA ANDINA S.A NIT 830.027.386-6               │ COLOMBIA │  66000.0000 │ 11,748.00 │             0.2800 │ 1848000.0000
───┴────────────────────────────────────────┴─────────────────────────────────────────────────┴──────────┴─────────────┴───────────┴────────────────────┴──────────────
```

We updated the `net_weight` field from a string type to a decimal. We also added `cost` that multiplies the cif per net weight price to the net weight. This is a small sample dataset that lists imports made in Ecuador of Calcium Carbonate raw material where the field `net_weight` means total metric tons of a shipment and `cif_per_net_weight` the Incoterms CFI (denoting Cost, Insurance, and Freight)

We can `histogram` using the `importer` column, like so:

```
...above's pipeline | histogram importer
───┬────────────────────────────────────────┬────────────┬────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────
 # │ importer                               │ ocurrences │ percentage │ frequency
───┼────────────────────────────────────────┼────────────┼────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────
 0 │ MEXICHEM ECUADOR S.A.                  │          1 │ 50.00%     │ **************************************************
 1 │ PICA PLASTICOS INDUSTRIALES C.A.       │          1 │ 50.00%     │ **************************************************
 2 │ PLASTIAZUAY SA                         │          1 │ 50.00%     │ **************************************************
 3 │ PLASTICOS RIVAL CIA LTDA               │          2 │ 100.00%    │ ****************************************************************************************************
 4 │ PLASTIQUIM S.A.                        │          1 │ 50.00%     │ **************************************************
 5 │ QUIMICA COMERCIAL QUIMICIAL CIA. LTDA. │          1 │ 50.00%     │ **************************************************
 6 │ QUIMICOS ANDINOS QUIMANDI S.A.         │          1 │ 50.00%     │ **************************************************
 7 │ TIGRE ECUADOR S.A. ECUATIGRE           │          1 │ 50.00%     │ **************************************************
───┴────────────────────────────────────────┴────────────┴────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────
```

...And now we can also do the same but *use* the column `cost` for valuation, like so:

```
open tests/fixtures/formats/caco3_plastics.csv | reject name tariff_item shipped_at arrived_at cif_price | update net_weight { get net_weight | str find-replace , '' | str to-decimal } | insert cost { = (100 * $it.cif_per_net_weight) * $it.net_weight } | histogram importer --use cost
───┬────────────────────────────────────────┬────────────┬────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────
 # │ importer                               │ ocurrences │ percentage │ frequency
───┼────────────────────────────────────────┼────────────┼────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────
 0 │ MEXICHEM ECUADOR S.A.                  │          1 │ 19.36%     │ *******************
 1 │ PICA PLASTICOS INDUSTRIALES C.A.       │          1 │ 44.73%     │ ********************************************
 2 │ PLASTIAZUAY SA                         │          1 │ 27.24%     │ ***************************
 3 │ PLASTICOS RIVAL CIA LTDA               │          2 │ 100.00%    │ ****************************************************************************************************
 4 │ PLASTIQUIM S.A.                        │          1 │ 23.78%     │ ***********************
 5 │ QUIMICA COMERCIAL QUIMICIAL CIA. LTDA. │          1 │ 13.62%     │ *************
 6 │ QUIMICOS ANDINOS QUIMANDI S.A.         │          1 │ 31.23%     │ *******************************
 7 │ TIGRE ECUADOR S.A. ECUATIGRE           │          1 │ 44.39%     │ ********************************************
───┴────────────────────────────────────────┴────────────┴────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────
```

Another example: We can histogram Ecuador's 24 provinces (States) all cause mortality for the year by fetching a file that has recorded daily deaths per province, however, it won't be helpful unless we `use` the `total` column that each province has recorded the mortalities for a particular day, like so:

```
fetch "https://raw.githubusercontent.com/andrab/ecuacovid/master/datos_crudos/defunciones/provincias.csv" | histogram provincia  --use total
────┬────────────────────────┬────────────┬────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────
 #  │ provincia              │ ocurrences │ percentage │ frequency
────┼────────────────────────┼────────────┼────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────
  0 │ Azuay                  │        223 │ 9.47%      │ *********
  1 │ Bolívar                │        223 │ 2.35%      │ **
  2 │ Carchi                 │        223 │ 1.75%      │ *
  3 │ Cañar                  │        223 │ 2.83%      │ **
  4 │ Chimborazo             │        223 │ 7.15%      │ *******
  5 │ Cotopaxi               │        223 │ 5.14%      │ *****
  6 │ El Oro                 │        223 │ 11.13%     │ ***********
  7 │ Esmeraldas             │        223 │ 4.80%      │ ****
  8 │ Galápagos              │        223 │ 0.96%      │
  9 │ Guayas                 │        223 │ 100.00%    │ ***************************************************************************************************
 10 │ Imbabura               │        223 │ 5.10%      │ *****
 11 │ Loja                   │        223 │ 5.47%      │ *****
 12 │ Los Ríos               │        223 │ 11.34%     │ ***********
 13 │ Manabí                 │        223 │ 22.33%     │ **********************
 14 │ Morona Santiago        │        223 │ 1.25%      │ *
 15 │ Napo                   │        223 │ 1.11%      │ *
 16 │ Orellana               │        223 │ 1.13%      │ *
 17 │ Pastaza                │        223 │ 0.88%      │
 18 │ Pichincha              │        223 │ 42.10%     │ ******************************************
 19 │ Santa Elena            │        223 │ 7.59%      │ *******
 20 │ Sto. Domingo Tsáchilas │        223 │ 7.14%      │ *******
 21 │ Sucumbíos              │        223 │ 2.50%      │ **
 22 │ Tungurahua             │        223 │ 9.40%      │ *********
 23 │ Zamora Chinchipe       │        223 │ 0.70%      │
────┴────────────────────────┴────────────┴────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────
```

if we don't `use` the `total` column we get information not that useful, but correct. Since for each province, there is a single record per day for the past (time of this fetch call) 223 days since January 01, 2020.

```
fetch "https://raw.githubusercontent.com/andrab/ecuacovid/master/datos_crudos/defunciones/provincias.csv" | histogram provincia
────┬────────────────────────┬────────────┬────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────
 #  │ provincia              │ ocurrences │ percentage │ frequency
────┼────────────────────────┼────────────┼────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────
  0 │ Azuay                  │        223 │ 100.00%    │ ****************************************************************************************************
  1 │ Bolívar                │        223 │ 100.00%    │ ****************************************************************************************************
  2 │ Carchi                 │        223 │ 100.00%    │ ****************************************************************************************************
  3 │ Cañar                  │        223 │ 100.00%    │ ****************************************************************************************************
  4 │ Chimborazo             │        223 │ 100.00%    │ ****************************************************************************************************
  5 │ Cotopaxi               │        223 │ 100.00%    │ ****************************************************************************************************
  6 │ El Oro                 │        223 │ 100.00%    │ ****************************************************************************************************
  7 │ Esmeraldas             │        223 │ 100.00%    │ ****************************************************************************************************
  8 │ Galápagos              │        223 │ 100.00%    │ ****************************************************************************************************
  9 │ Guayas                 │        223 │ 100.00%    │ ****************************************************************************************************
 10 │ Imbabura               │        223 │ 100.00%    │ ****************************************************************************************************
 11 │ Loja                   │        223 │ 100.00%    │ ****************************************************************************************************
 12 │ Los Ríos               │        223 │ 100.00%    │ ****************************************************************************************************
 13 │ Manabí                 │        223 │ 100.00%    │ ****************************************************************************************************
 14 │ Morona Santiago        │        223 │ 100.00%    │ ****************************************************************************************************
 15 │ Napo                   │        223 │ 100.00%    │ ****************************************************************************************************
 16 │ Orellana               │        223 │ 100.00%    │ ****************************************************************************************************
 17 │ Pastaza                │        223 │ 100.00%    │ ****************************************************************************************************
 18 │ Pichincha              │        223 │ 100.00%    │ ****************************************************************************************************
 19 │ Santa Elena            │        223 │ 100.00%    │ ****************************************************************************************************
 20 │ Sto. Domingo Tsáchilas │        223 │ 100.00%    │ ****************************************************************************************************
 21 │ Sucumbíos              │        223 │ 100.00%    │ ****************************************************************************************************
 22 │ Tungurahua             │        223 │ 100.00%    │ ****************************************************************************************************
 23 │ Zamora Chinchipe       │        223 │ 100.00%    │ ****************************************************************************************************
────┴────────────────────────┴────────────┴────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────
```