### PR TITLE
Bump to 0.18.2. Move starship external.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,21 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
-name = "attohttpc"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93610ce1c035e8a273fe56a19852e42798f3c019ca2726e52d2971197f116525"
-dependencies = [
- "http 0.2.1",
- "log 0.4.11",
- "native-tls",
- "openssl",
- "serde 1.0.115",
- "serde_urlencoded 0.6.1",
- "url 2.1.1",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,16 +1714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,9 +1762,9 @@ dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
+ "log 0.4.11",
  "openssl-probe",
  "openssl-sys",
- "log 0.4.11",
  "url 2.1.1",
 ]
 
@@ -1822,7 +1797,7 @@ dependencies = [
  "bytes 0.4.12",
  "fnv",
  "futures 0.1.29",
- "http 0.1.21",
+ "http",
  "indexmap",
  "log 0.4.11",
  "slab 0.4.2",
@@ -2066,17 +2041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,7 +2048,7 @@ checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "http 0.1.21",
+ "http",
  "tokio-buf",
 ]
 
@@ -2140,7 +2104,7 @@ dependencies = [
  "futures 0.1.29",
  "futures-cpupool",
  "h2",
- "http 0.1.21",
+ "http",
  "http-body",
  "httparse",
  "iovec",
@@ -2300,7 +2264,7 @@ dependencies = [
  "curl-sys",
  "futures-io-preview",
  "futures-util-preview",
- "http 0.1.21",
+ "http",
  "lazy_static 1.4.0",
  "log 0.4.11",
  "slab 0.4.2",
@@ -2432,19 +2396,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
-dependencies = [
- "arrayvec 0.5.1",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -2952,17 +2903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check 0.9.2",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "clap",
  "crossterm",
@@ -3008,7 +2948,6 @@ dependencies = [
  "quick-xml 0.18.1",
  "semver 0.10.0",
  "serde 1.0.115",
- "starship",
  "syntect",
  "toml 0.5.6",
  "url 2.1.1",
@@ -3016,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs2",
@@ -3092,7 +3031,6 @@ dependencies = [
  "serde_yaml",
  "sha2 0.9.1",
  "shellexpand",
- "starship",
  "strip-ansi-escapes",
  "tempfile",
  "term",
@@ -3112,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "nu-errors"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ansi_term 0.12.1",
  "bigdecimal",
@@ -3131,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "bigdecimal",
  "codespan-reporting",
@@ -3150,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "bigdecimal",
  "indexmap",
@@ -3165,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ansi_term 0.12.1",
  "bigdecimal",
@@ -3194,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "nu-source"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "codespan-reporting",
  "derive-new",
@@ -3206,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ansi_term 0.12.1",
  "unicode-width",
@@ -3214,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "directories 2.0.2",
  "dunce",
@@ -3229,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "nu-value-ext"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "indexmap",
  "itertools",
@@ -3242,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_binaryview"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ansi_term 0.12.1",
  "crossterm",
@@ -3258,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_fetch"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "base64 0.12.3",
  "futures 0.3.5",
@@ -3272,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_from_bson"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "bigdecimal",
  "bson",
@@ -3286,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_from_sqlite"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "bigdecimal",
  "nu-errors",
@@ -3301,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "nu-errors",
  "nu-plugin",
@@ -3313,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_match"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "futures 0.3.5",
  "nu-errors",
@@ -3325,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_post"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "base64 0.12.3",
  "futures 0.3.5",
@@ -3341,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_ps"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "futures 0.3.5",
  "futures-timer",
@@ -3354,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_s3"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "futures 0.3.5",
  "nu-errors",
@@ -3366,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_start"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "glob",
  "nu-errors",
@@ -3379,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_sys"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "battery",
  "futures 0.3.5",
@@ -3394,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_textview"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ansi_term 0.12.1",
  "bat",
@@ -3411,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_to_bson"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "bson",
  "nu-errors",
@@ -3424,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_to_sqlite"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "hex 0.4.2",
  "nu-errors",
@@ -3439,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_tree"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "derive-new",
  "nu-errors",
@@ -3712,17 +3650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 
 [[package]]
-name = "os_info"
-version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc1b4330bb29087e791ae2a5cf56be64fb8946a4ff5aec2ba11c6ca51f5d60"
-dependencies = [
- "log 0.4.11",
- "serde 1.0.115",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "parking"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,12 +3739,6 @@ checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
  "regex 1.3.9",
 ]
-
-[[package]]
-name = "path-slash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff65715a17cba8979903db6294baef56c5d39e05c8b054cffa31e69e61f24c68"
 
 [[package]]
 name = "path_abs"
@@ -4513,7 +4434,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures 0.1.29",
- "http 0.1.21",
+ "http",
  "hyper 0.12.35",
  "hyper-tls",
  "log 0.4.11",
@@ -4709,7 +4630,7 @@ dependencies = [
  "failure_derive",
  "hmac",
  "hmac-sha1",
- "http 0.1.21",
+ "http",
  "hyper 0.11.27",
  "log 0.4.11",
  "md5 0.3.8",
@@ -5124,61 +5045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "starship"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae08e37c960a62130af61e37bf1f6c4703f277a42dcf0cdeea4955c8d049a6e"
-dependencies = [
- "ansi_term 0.12.1",
- "attohttpc",
- "battery",
- "byte-unit",
- "chrono",
- "clap",
- "dirs-next",
- "gethostname",
- "git2",
- "log 0.4.11",
- "nom 5.1.2",
- "once_cell",
- "open",
- "os_info",
- "path-slash",
- "pest",
- "pest_derive",
- "pretty_env_logger",
- "rayon",
- "regex 1.3.9",
- "serde_json",
- "starship_module_config_derive",
- "sysinfo",
- "term_size",
- "textwrap",
- "toml 0.5.6",
- "unicode-segmentation",
- "unicode-width",
- "urlencoding",
- "yaml-rust",
-]
-
-[[package]]
-name = "starship_module_config_derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ccdf8467ad115d088ab970010266b27deec41b9d940f154c785b3808bd04e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "std_prelude"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,7 +5081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741a8008f8a833ef16f47df94a30754478fb2c2bf822b9c2e6f7f09203b97ace"
 dependencies = [
  "futures-preview",
- "http 0.1.21",
+ "http",
  "isahc",
  "js-sys",
  "log 0.4.11",
@@ -5274,21 +5140,6 @@ dependencies = [
  "serde_json",
  "walkdir",
  "yaml-rust",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
-dependencies = [
- "cfg-if",
- "doc-comment",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5687,7 +5538,6 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "indexmap",
  "serde 1.0.115",
 ]
 
@@ -5871,12 +5721,6 @@ dependencies = [
  "matches",
  "percent-encoding 2.1.0",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
 
 [[package]]
 name = "user32-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nu"
 readme = "README.md"
 repository = "https://github.com/nushell/nushell"
-version = "0.18.1"
+version = "0.18.2"
 
 [workspace]
 members = ["crates/*/"]
@@ -18,29 +18,29 @@ members = ["crates/*/"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-cli = {version = "0.18.1", path = "./crates/nu-cli"}
-nu-errors = {version = "0.18.1", path = "./crates/nu-errors"}
-nu-parser = {version = "0.18.1", path = "./crates/nu-parser"}
-nu-plugin = {version = "0.18.1", path = "./crates/nu-plugin"}
-nu-protocol = {version = "0.18.1", path = "./crates/nu-protocol"}
-nu-source = {version = "0.18.1", path = "./crates/nu-source"}
-nu-value-ext = {version = "0.18.1", path = "./crates/nu-value-ext"}
+nu-cli = {version = "0.18.2", path = "./crates/nu-cli"}
+nu-errors = {version = "0.18.2", path = "./crates/nu-errors"}
+nu-parser = {version = "0.18.2", path = "./crates/nu-parser"}
+nu-plugin = {version = "0.18.2", path = "./crates/nu-plugin"}
+nu-protocol = {version = "0.18.2", path = "./crates/nu-protocol"}
+nu-source = {version = "0.18.2", path = "./crates/nu-source"}
+nu-value-ext = {version = "0.18.2", path = "./crates/nu-value-ext"}
 
-nu_plugin_binaryview = {version = "0.18.1", path = "./crates/nu_plugin_binaryview", optional = true}
-nu_plugin_fetch = {version = "0.18.1", path = "./crates/nu_plugin_fetch", optional = true}
-nu_plugin_from_bson = {version = "0.18.1", path = "./crates/nu_plugin_from_bson", optional = true}
-nu_plugin_from_sqlite = {version = "0.18.1", path = "./crates/nu_plugin_from_sqlite", optional = true}
-nu_plugin_inc = {version = "0.18.1", path = "./crates/nu_plugin_inc", optional = true}
-nu_plugin_match = {version = "0.18.1", path = "./crates/nu_plugin_match", optional = true}
-nu_plugin_post = {version = "0.18.1", path = "./crates/nu_plugin_post", optional = true}
-nu_plugin_ps = {version = "0.18.1", path = "./crates/nu_plugin_ps", optional = true}
-nu_plugin_start = {version = "0.18.1", path = "./crates/nu_plugin_start", optional = true}
-nu_plugin_sys = {version = "0.18.1", path = "./crates/nu_plugin_sys", optional = true}
-nu_plugin_textview = {version = "0.18.1", path = "./crates/nu_plugin_textview", optional = true}
-nu_plugin_to_bson = {version = "0.18.1", path = "./crates/nu_plugin_to_bson", optional = true}
-nu_plugin_to_sqlite = {version = "0.18.1", path = "./crates/nu_plugin_to_sqlite", optional = true}
-nu_plugin_tree = {version = "0.18.1", path = "./crates/nu_plugin_tree", optional = true}
-nu_plugin_s3 = { version = "0.18.1", path = "./crates/nu_plugin_s3", optional=true }
+nu_plugin_binaryview = {version = "0.18.2", path = "./crates/nu_plugin_binaryview", optional = true}
+nu_plugin_fetch = {version = "0.18.2", path = "./crates/nu_plugin_fetch", optional = true}
+nu_plugin_from_bson = {version = "0.18.2", path = "./crates/nu_plugin_from_bson", optional = true}
+nu_plugin_from_sqlite = {version = "0.18.2", path = "./crates/nu_plugin_from_sqlite", optional = true}
+nu_plugin_inc = {version = "0.18.2", path = "./crates/nu_plugin_inc", optional = true}
+nu_plugin_match = {version = "0.18.2", path = "./crates/nu_plugin_match", optional = true}
+nu_plugin_post = {version = "0.18.2", path = "./crates/nu_plugin_post", optional = true}
+nu_plugin_ps = {version = "0.18.2", path = "./crates/nu_plugin_ps", optional = true}
+nu_plugin_start = {version = "0.18.2", path = "./crates/nu_plugin_start", optional = true}
+nu_plugin_sys = {version = "0.18.2", path = "./crates/nu_plugin_sys", optional = true}
+nu_plugin_textview = {version = "0.18.2", path = "./crates/nu_plugin_textview", optional = true}
+nu_plugin_to_bson = {version = "0.18.2", path = "./crates/nu_plugin_to_bson", optional = true}
+nu_plugin_to_sqlite = {version = "0.18.2", path = "./crates/nu_plugin_to_sqlite", optional = true}
+nu_plugin_tree = {version = "0.18.2", path = "./crates/nu_plugin_tree", optional = true}
+nu_plugin_s3 = { version = "0.18.2", path = "./crates/nu_plugin_s3", optional=true }
 
 crossterm = {version = "0.17.5", optional = true}
 semver = {version = "0.10.0", optional = true}
@@ -54,10 +54,9 @@ futures = {version = "0.3", features = ["compat", "io-compat"]}
 log = "0.4.8"
 pretty_env_logger = "0.4.0"
 quick-xml = "0.18.1"
-starship = "0.43.0"
 
 [dev-dependencies]
-nu-test-support = {version = "0.18.1", path = "./crates/nu-test-support"}
+nu-test-support = {version = "0.18.2", path = "./crates/nu-test-support"}
 
 [build-dependencies]
 serde = {version = "1.0.110", features = ["derive"]}
@@ -77,7 +76,7 @@ default = [
   "term-support",
   "uuid-support",
 ]
-stable = ["default", "binaryview", "match", "tree", "post", "fetch", "clipboard-cli", "trash-support", "start", "starship-prompt", "bson", "sqlite", "s3"]
+stable = ["default", "binaryview", "match", "tree", "post", "fetch", "clipboard-cli", "trash-support", "start", "bson", "sqlite", "s3"]
 
 # Default
 inc = ["semver", "nu_plugin_inc"]
@@ -102,7 +101,6 @@ ctrlc-support = ["nu-cli/ctrlc"]
 directories-support = ["nu-cli/directories", "nu-cli/dirs"]
 git-support = ["nu-cli/git2"]
 ptree-support = ["nu-cli/ptree"]
-starship-prompt = ["nu-cli/starship-prompt"]
 term-support = ["nu-cli/term"]
 trash-support = ["nu-cli/trash-support"]
 uuid-support = ["nu-cli/uuid_crate"]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -4,20 +4,20 @@ description = "CLI for nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-cli"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = {version = "0.18.1", path = "../nu-errors"}
-nu-parser = {version = "0.18.1", path = "../nu-parser"}
-nu-plugin = {version = "0.18.1", path = "../nu-plugin"}
-nu-protocol = {version = "0.18.1", path = "../nu-protocol"}
-nu-source = {version = "0.18.1", path = "../nu-source"}
-nu-table = {version = "0.18.1", path = "../nu-table"}
-nu-test-support = {version = "0.18.1", path = "../nu-test-support"}
-nu-value-ext = {version = "0.18.1", path = "../nu-value-ext"}
+nu-errors = {version = "0.18.2", path = "../nu-errors"}
+nu-parser = {version = "0.18.2", path = "../nu-parser"}
+nu-plugin = {version = "0.18.2", path = "../nu-plugin"}
+nu-protocol = {version = "0.18.2", path = "../nu-protocol"}
+nu-source = {version = "0.18.2", path = "../nu-source"}
+nu-table = {version = "0.18.2", path = "../nu-table"}
+nu-test-support = {version = "0.18.2", path = "../nu-test-support"}
+nu-value-ext = {version = "0.18.2", path = "../nu-value-ext"}
 
 ansi_term = "0.12.1"
 app_dirs = {version = "2", package = "app_dirs2"}
@@ -95,7 +95,6 @@ clipboard = {version = "0.5", optional = true}
 encoding_rs = "0.8.23"
 quick-xml = "0.18.1"
 rayon = "1.3.1"
-starship = {version = "0.43.0", optional = true}
 trash = {version = "1.0.1", optional = true}
 url = {version = "2.1.1"}
 
@@ -124,5 +123,4 @@ quickcheck_macros = "0.9"
 [features]
 clipboard-cli = ["clipboard"]
 stable = []
-starship-prompt = ["starship"]
 trash-support = ["trash"]

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -228,22 +228,6 @@ impl History {
     }
 }
 
-#[allow(dead_code)]
-fn create_default_starship_config() -> Option<toml::Value> {
-    let mut map = toml::value::Table::new();
-    map.insert("add_newline".into(), toml::Value::Boolean(false));
-
-    let mut git_branch = toml::value::Table::new();
-    git_branch.insert("symbol".into(), toml::Value::String("📙 ".into()));
-    map.insert("git_branch".into(), toml::Value::Table(git_branch));
-
-    let mut git_status = toml::value::Table::new();
-    git_status.insert("disabled".into(), toml::Value::Boolean(true));
-    map.insert("git_status".into(), toml::Value::Table(git_status));
-
-    Some(toml::Value::Table(map))
-}
-
 pub fn create_default_context(
     syncer: &mut crate::EnvironmentSyncer,
     interactive: bool,
@@ -746,11 +730,6 @@ pub async fn cli(
         );
     }
 
-    let use_starship = config
-        .get("use_starship")
-        .map(|x| x.is_true())
-        .unwrap_or(false);
-
     #[cfg(windows)]
     {
         let _ = ansi_term::enable_ansi_support();
@@ -808,37 +787,7 @@ pub async fn cli(
         )));
 
         let colored_prompt = {
-            if use_starship {
-                #[cfg(feature = "starship")]
-                {
-                    std::env::set_var("STARSHIP_SHELL", "");
-                    std::env::set_var("PWD", &cwd);
-                    let mut starship_context =
-                        starship::context::Context::new_with_dir(clap::ArgMatches::default(), cwd);
-
-                    match starship_context.config.config {
-                        None => {
-                            starship_context.config.config = create_default_starship_config();
-                        }
-                        Some(toml::Value::Table(t)) if t.is_empty() => {
-                            starship_context.config.config = create_default_starship_config();
-                        }
-                        _ => {}
-                    };
-                    starship::print::get_prompt(starship_context)
-                }
-                #[cfg(not(feature = "starship"))]
-                {
-                    format!(
-                        "\x1b[32m{}{}\x1b[m> ",
-                        cwd,
-                        match current_branch() {
-                            Some(s) => format!("({})", s),
-                            None => "".to_string(),
-                        }
-                    )
-                }
-            } else if let Some(prompt) = config.get("prompt") {
+            if let Some(prompt) = config.get("prompt") {
                 let prompt_line = prompt.as_string()?;
 
                 match nu_parser::lite_parse(&prompt_line, 0).map_err(ShellError::from) {

--- a/crates/nu-cli/src/commands/version.rs
+++ b/crates/nu-cli/src/commands/version.rs
@@ -79,11 +79,6 @@ fn features_enabled(tag: impl Into<Tag>) -> TaggedListBuilder {
         names.push_untagged(UntaggedValue::string("trash"));
     }
 
-    #[cfg(feature = "starship-prompt")]
-    {
-        names.push_untagged(UntaggedValue::string("starship"));
-    }
-
     names
 }
 

--- a/crates/nu-cli/src/git.rs
+++ b/crates/nu-cli/src/git.rs
@@ -1,41 +1,26 @@
-use crate::prelude::*;
-
 pub fn current_branch() -> Option<String> {
-    if let Ok(config) = crate::data::config::config(Tag::unknown()) {
-        let use_starship = config
-            .get("use_starship")
-            .map(|x| x.is_true())
-            .unwrap_or(false);
+    #[cfg(feature = "git2")]
+    {
+        use git2::{Repository, RepositoryOpenFlags};
+        use std::ffi::OsString;
 
-        if !use_starship {
-            #[cfg(feature = "git2")]
-            {
-                use git2::{Repository, RepositoryOpenFlags};
-                use std::ffi::OsString;
-
-                let v: Vec<OsString> = vec![];
-                match Repository::open_ext(".", RepositoryOpenFlags::empty(), v) {
-                    Ok(repo) => {
-                        let r = repo.head();
-                        match r {
-                            Ok(r) => match r.shorthand() {
-                                Some(s) => Some(s.to_string()),
-                                None => None,
-                            },
-                            _ => None,
-                        }
-                    }
+        let v: Vec<OsString> = vec![];
+        match Repository::open_ext(".", RepositoryOpenFlags::empty(), v) {
+            Ok(repo) => {
+                let r = repo.head();
+                match r {
+                    Ok(r) => match r.shorthand() {
+                        Some(s) => Some(s.to_string()),
+                        None => None,
+                    },
                     _ => None,
                 }
             }
-            #[cfg(not(feature = "git2"))]
-            {
-                None
-            }
-        } else {
-            None
+            _ => None,
         }
-    } else {
+    }
+    #[cfg(not(feature = "git2"))]
+    {
         None
     }
 }

--- a/crates/nu-cli/tests/commands/save.rs
+++ b/crates/nu-cli/tests/commands/save.rs
@@ -32,16 +32,30 @@ fn figures_out_intelligently_where_to_write_out_with_metadata() {
 
 #[test]
 fn writes_out_csv() {
-    Playground::setup("save_test_2", |dirs, _| {
+    Playground::setup("save_test_2", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent(
+            "cargo_sample.json",
+            r#"
+            {
+                "package": {
+                        "name": "nu",
+                        "version": "0.14",
+                        "description": "A new type of shell",
+                        "license": "MIT",
+                        "edition": "2018"
+                }
+            }
+            "#,
+        )]);
+
         let expected_file = dirs.test().join("cargo_sample.csv");
 
         nu!(
             cwd: dirs.root(),
-            "open \"{}/cargo_sample.toml\" | get package | save save_test_2/cargo_sample.csv",
-            dirs.formats()
+            "open save_test_2/cargo_sample.json | get package | save save_test_2/cargo_sample.csv",
         );
 
         let actual = file_contents(expected_file);
-        assert!(actual.contains("nu,0.1.1,[Table],a new type of shell,ISC,2018"));
+        assert!(actual.contains("nu,0.14,A new type of shell,MIT,2018"));
     })
 }

--- a/crates/nu-errors/Cargo.toml
+++ b/crates/nu-errors/Cargo.toml
@@ -4,13 +4,13 @@ description = "Core error subsystem for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-errors"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 
 ansi_term = "0.12.1"
 bigdecimal = {version = "0.1.2", features = ["serde"]}

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -4,7 +4,7 @@ description = "Nushell parser"
 edition = "2018"
 license = "MIT"
 name = "nu-parser"
-version = "0.18.1"
+version = "0.18.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,9 +20,9 @@ parking_lot = "0.11.0"
 serde = "1.0.114"
 shellexpand = "2.0.0"
 
-nu-errors = {version = "0.18.1", path = "../nu-errors"}
-nu-protocol = {version = "0.18.1", path = "../nu-protocol"}
-nu-source = {version = "0.18.1", path = "../nu-source"}
+nu-errors = {version = "0.18.2", path = "../nu-errors"}
+nu-protocol = {version = "0.18.2", path = "../nu-protocol"}
+nu-source = {version = "0.18.2", path = "../nu-source"}
 
 [features]
 stable = []

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -4,16 +4,16 @@ description = "Nushell Plugin"
 edition = "2018"
 license = "MIT"
 name = "nu-plugin"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
-nu-value-ext = {path = "../nu-value-ext", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
+nu-value-ext = {path = "../nu-value-ext", version = "0.18.2"}
 
 bigdecimal = {version = "0.1.2", features = ["serde"]}
 indexmap = {version = "1.4.0", features = ["serde-1"]}

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -4,7 +4,7 @@ description = "Core values and protocols for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-protocol"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
@@ -21,8 +21,8 @@ indexmap = {version = "1.4.0", features = ["serde-1"]}
 itertools = "0.9.0"
 log = "0.4.8"
 natural = "0.5.0"
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 num-bigint = {version = "0.2.6", features = ["serde"]}
 num-integer = "0.1.42"
 num-traits = "0.2.12"

--- a/crates/nu-source/Cargo.toml
+++ b/crates/nu-source/Cargo.toml
@@ -4,7 +4,7 @@ description = "A source string characterizer for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-source"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -4,7 +4,7 @@ description = "Nushell table printing"
 edition = "2018"
 license = "MIT"
 name = "nu-table"
-version = "0.18.1"
+version = "0.18.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -4,15 +4,15 @@ description = "A source string characterizer for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-test-support"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-parser = {path = "../nu-parser", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-parser = {path = "../nu-parser", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 
 directories = "2.0.2"
 dunce = "1.0.1"

--- a/crates/nu-value-ext/Cargo.toml
+++ b/crates/nu-value-ext/Cargo.toml
@@ -4,16 +4,16 @@ description = "Extension traits for values in Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-value-ext"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-parser = {path = "../nu-parser", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-parser = {path = "../nu-parser", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 
 indexmap = {version = "1.4.0", features = ["serde-1"]}
 itertools = "0.9.0"

--- a/crates/nu_plugin_binaryview/Cargo.toml
+++ b/crates/nu_plugin_binaryview/Cargo.toml
@@ -4,7 +4,7 @@ description = "A binary viewer plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_binaryview"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
@@ -14,10 +14,10 @@ ansi_term = "0.12.1"
 crossterm = {version = "0.17.5"}
 image = {version = "0.22.4", default_features = false, features = ["png_codec", "jpeg"]}
 neso = "0.5.0"
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 pretty-hex = "0.1.1"
 rawkey = "0.1.2"
 

--- a/crates/nu_plugin_fetch/Cargo.toml
+++ b/crates/nu_plugin_fetch/Cargo.toml
@@ -4,7 +4,7 @@ description = "A URL fetch plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_fetch"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
@@ -12,10 +12,10 @@ doctest = false
 [dependencies]
 base64 = "0.12.3"
 futures = {version = "0.3", features = ["compat", "io-compat"]}
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 surf = "1.0.3"
 url = "2.1.1"
 

--- a/crates/nu_plugin_from_bson/Cargo.toml
+++ b/crates/nu_plugin_from_bson/Cargo.toml
@@ -4,7 +4,7 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_bson"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
@@ -12,11 +12,11 @@ doctest = false
 [dependencies]
 bigdecimal = "0.1.2"
 bson = {version = "0.14.1", features = ["decimal128"]}
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
-nu-value-ext = {path = "../nu-value-ext", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
+nu-value-ext = {path = "../nu-value-ext", version = "0.18.2"}
 num-traits = "0.2.12"
 
 [build-dependencies]

--- a/crates/nu_plugin_from_sqlite/Cargo.toml
+++ b/crates/nu_plugin_from_sqlite/Cargo.toml
@@ -4,18 +4,18 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_sqlite"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
 bigdecimal = "0.1.2"
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
-nu-value-ext = {path = "../nu-value-ext", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
+nu-value-ext = {path = "../nu-value-ext", version = "0.18.2"}
 num-traits = "0.2.12"
 tempfile = "3.1.0"
 

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -4,17 +4,17 @@ description = "A version incrementer plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
-nu-value-ext = {path = "../nu-value-ext", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
+nu-value-ext = {path = "../nu-value-ext", version = "0.18.2"}
 
 semver = "0.10.0"
 

--- a/crates/nu_plugin_match/Cargo.toml
+++ b/crates/nu_plugin_match/Cargo.toml
@@ -4,17 +4,17 @@ description = "A regex match plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_match"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
 futures = {version = "0.3", features = ["compat", "io-compat"]}
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 regex = "1"
 
 [build-dependencies]

--- a/crates/nu_plugin_post/Cargo.toml
+++ b/crates/nu_plugin_post/Cargo.toml
@@ -4,7 +4,7 @@ description = "An HTTP post plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_post"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
@@ -12,10 +12,10 @@ doctest = false
 [dependencies]
 base64 = "0.12.3"
 futures = {version = "0.3", features = ["compat", "io-compat"]}
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 num-traits = "0.2.12"
 serde_json = "1.0.55"
 surf = "1.0.3"

--- a/crates/nu_plugin_ps/Cargo.toml
+++ b/crates/nu_plugin_ps/Cargo.toml
@@ -4,16 +4,16 @@ description = "A process list plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_ps"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 
 futures = {version = "0.3", features = ["compat", "io-compat"]}
 futures-timer = "3.0.2"

--- a/crates/nu_plugin_s3/Cargo.toml
+++ b/crates/nu_plugin_s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu_plugin_s3"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["The Nu Project Contributors"]
 edition = "2018"
 description = "An S3 plugin for Nushell"
@@ -10,10 +10,10 @@ license = "MIT"
 doctest = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.18.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.18.1" }
-nu-source = { path = "../nu-source", version = "0.18.1" }
-nu-errors = { path = "../nu-errors", version = "0.18.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.18.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.18.2" }
+nu-source = { path = "../nu-source", version = "0.18.2" }
+nu-errors = { path = "../nu-errors", version = "0.18.2" }
 futures = { version = "0.3", features = ["compat", "io-compat"] }
 s3handler = "0.5.0"
 

--- a/crates/nu_plugin_start/Cargo.toml
+++ b/crates/nu_plugin_start/Cargo.toml
@@ -4,20 +4,20 @@ description = "A plugin to open files/URLs directly from Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_start"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
 glob = "0.3.0"
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 open = "1.4.0"
 url = "2.1.1"
 
 [build-dependencies]
-nu-errors = {version = "0.18.1", path = "../nu-errors"}
-nu-source = {version = "0.18.1", path = "../nu-source"}
+nu-errors = {version = "0.18.2", path = "../nu-errors"}
+nu-source = {version = "0.18.2", path = "../nu-source"}

--- a/crates/nu_plugin_sys/Cargo.toml
+++ b/crates/nu_plugin_sys/Cargo.toml
@@ -4,16 +4,16 @@ description = "A system info plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_sys"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 
 battery = "0.7.5"
 futures = {version = "0.3", features = ["compat", "io-compat"]}

--- a/crates/nu_plugin_textview/Cargo.toml
+++ b/crates/nu_plugin_textview/Cargo.toml
@@ -4,17 +4,17 @@ description = "Text viewer plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_textview"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-cli = {path = "../nu-cli", version = "0.18.1"}
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-cli = {path = "../nu-cli", version = "0.18.2"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 
 ansi_term = "0.12.1"
 bat = "0.15.4"

--- a/crates/nu_plugin_to_bson/Cargo.toml
+++ b/crates/nu_plugin_to_bson/Cargo.toml
@@ -4,18 +4,18 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_bson"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
 bson = "0.14.1"
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
-nu-value-ext = {path = "../nu-value-ext", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
+nu-value-ext = {path = "../nu-value-ext", version = "0.18.2"}
 num-traits = "0.2.12"
 
 [build-dependencies]

--- a/crates/nu_plugin_to_sqlite/Cargo.toml
+++ b/crates/nu_plugin_to_sqlite/Cargo.toml
@@ -4,18 +4,18 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_sqlite"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
 hex = "0.4.2"
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
-nu-value-ext = {path = "../nu-value-ext", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
+nu-value-ext = {path = "../nu-value-ext", version = "0.18.2"}
 num-traits = "0.2.12"
 tempfile = "3.1.0"
 

--- a/crates/nu_plugin_tree/Cargo.toml
+++ b/crates/nu_plugin_tree/Cargo.toml
@@ -4,17 +4,17 @@ description = "Tree viewer plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_tree"
-version = "0.18.1"
+version = "0.18.2"
 
 [lib]
 doctest = false
 
 [dependencies]
 derive-new = "0.5.8"
-nu-errors = {path = "../nu-errors", version = "0.18.1"}
-nu-plugin = {path = "../nu-plugin", version = "0.18.1"}
-nu-protocol = {path = "../nu-protocol", version = "0.18.1"}
-nu-source = {path = "../nu-source", version = "0.18.1"}
+nu-errors = {path = "../nu-errors", version = "0.18.2"}
+nu-plugin = {path = "../nu-plugin", version = "0.18.2"}
+nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
+nu-source = {path = "../nu-source", version = "0.18.2"}
 ptree = {version = "0.2"}
 
 [build-dependencies]

--- a/docs/commands/to-toml.md
+++ b/docs/commands/to-toml.md
@@ -88,7 +88,7 @@ version = "0.4.6"
 [dependencies.cursive]
 default-features = false
 features = ["pancurses-backend"]
-version = "0.18.1"
+version = "0.18.2"
 
 [dependencies.futures-preview]
 features = ["compat", "io-compat"]

--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -10,7 +10,6 @@ pivot_mode = "auto"
 ctrlc_exit = false
 complete_from_path = true
 rm_always_trash = true
-use_starship = false
 prompt = "echo [ $(ansi gb) $(pwd) $(ansi reset) \"(\" $(ansi cb) $(do -i { git rev-parse --abbrev-ref HEAD | trim }) $(ansi reset) \")\" $(char newline) $(ansi yb) $(date --format \"%m/%d/%Y %I:%M:%S%.3f %p\" --raw) $(ansi reset) \"> \" ] | str collect"
 
 [line_editor]


### PR DESCRIPTION
Based on recent feedback, it looks like it's now preferred to call starship from external rather than to use the internally-built starship. We're seeing that:

* External starship plays nicer if you switch between shells
* With configurable prompts, it's easier to call into external starship

```sh
> config get prompt
echo $(starship prompt)
```

* The same technique also lets users easily switch to other prompts, like powerline. Eg)

```sh
> config get prompt
echo $(powerline shell left)
```

With this, plus being able to remove an optional build dependency that causes longer build times, it looks like it's now the correct move to take our starship from an external source rather than the built-in dependency.

