### PR TITLE
removed syntect dependency, limited bat to regex-fancy and paging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,7 +2948,6 @@ dependencies = [
  "quick-xml 0.18.1",
  "semver 0.10.0",
  "serde 1.0.115",
- "syntect",
  "toml 0.5.6",
  "url 2.1.1",
 ]
@@ -3342,7 +3341,6 @@ dependencies = [
  "nu-plugin",
  "nu-protocol",
  "nu-source",
- "syntect",
  "term_size",
  "url 2.1.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ nu_plugin_s3 = { version = "0.18.2", path = "./crates/nu_plugin_s3", optional=tr
 
 crossterm = {version = "0.17.5", optional = true}
 semver = {version = "0.10.0", optional = true}
-syntect = {version = "4.2", default-features = false, features = ["default-fancy"], optional = true}
 url = {version = "2.1.1", optional = true}
 
 clap = "2.33.1"
@@ -82,7 +81,7 @@ stable = ["default", "binaryview", "match", "tree", "post", "fetch", "clipboard-
 inc = ["semver", "nu_plugin_inc"]
 ps = ["nu_plugin_ps"]
 sys = ["nu_plugin_sys"]
-textview = ["crossterm", "syntect", "url", "nu_plugin_textview"]
+textview = ["crossterm", "url", "nu_plugin_textview"]
 
 # Stable
 binaryview = ["nu_plugin_binaryview"]

--- a/crates/nu_plugin_textview/Cargo.toml
+++ b/crates/nu_plugin_textview/Cargo.toml
@@ -17,9 +17,9 @@ nu-protocol = {path = "../nu-protocol", version = "0.18.2"}
 nu-source = {path = "../nu-source", version = "0.18.2"}
 
 ansi_term = "0.12.1"
-bat = "0.15.4"
+bat = {version = "0.15.4", features = ["regex-fancy", "paging"]}
+
 crossterm = "0.17.5"
-syntect = {version = "4.2", default-features = false, features = ["default-fancy"]}
 term_size = "0.3.2"
 url = "2.1.1"
 


### PR DESCRIPTION
remove syntect since it was used for syntaxes.bin and themes.bin in old versions
also changed bat aka textview to only contain a few dependencies