### PR TITLE
Solving the issue "`sort-by` should fail gracefully if mismatched types are compared"

### DIFF
--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -142,7 +142,7 @@ pub fn sort(
                 return Err(ShellError::labeled_error(
                     "Not all values can be compared",
                     "not all values compare",
-                    tag
+                    tag,
                 ));
             }
 

--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -139,9 +139,11 @@ pub fn sort(
                 .windows(2)
                 .all(|elem| coerce_compare(&elem[0], &elem[1]).is_ok())
             {
-                return Err(ShellError::labeled_error("Can't reduce all the values to all the values to the same type",
-                                                        "All these values should have some relation between then such that the shell knows how to compare them",
-                                                        tag));
+                return Err(ShellError::labeled_error(
+                    "Not all values can be compared",
+                    "not all values compare",
+                    tag
+                ));
             }
 
             vec.sort_by(|a, b| {

--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -135,6 +135,12 @@ pub fn sort(
         } => {
             let should_sort_case_insensitively = insensitive && vec.iter().all(|x| x.is_string());
 
+            if !vec.windows(2).all(|elem| match coerce_compare(&elem[0], &elem[1]) { Ok(_) => true, Err(_) => false } ) {
+                return Err(ShellError::labeled_error("Can't reduce all the values to all the values to the same type",
+                                                        "All these values should have some relation between then such that the shell knows how to compare them",
+                                                        tag))
+            }
+
             vec.sort_by(|a, b| {
                 if should_sort_case_insensitively {
                     let lowercase_a_string = a.expect_string().to_ascii_lowercase();

--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -135,10 +135,13 @@ pub fn sort(
         } => {
             let should_sort_case_insensitively = insensitive && vec.iter().all(|x| x.is_string());
 
-            if !vec.windows(2).all(|elem| match coerce_compare(&elem[0], &elem[1]) { Ok(_) => true, Err(_) => false } ) {
+            if !vec
+                .windows(2)
+                .all(|elem| coerce_compare(&elem[0], &elem[1]).is_ok())
+            {
                 return Err(ShellError::labeled_error("Can't reduce all the values to all the values to the same type",
                                                         "All these values should have some relation between then such that the shell knows how to compare them",
-                                                        tag))
+                                                        tag));
             }
 
             vec.sort_by(|a, b| {

--- a/crates/nu-cli/tests/commands/sort_by.rs
+++ b/crates/nu-cli/tests/commands/sort_by.rs
@@ -46,6 +46,21 @@ fn by_invalid_column() {
 }
 
 #[test]
+fn by_invalid_types() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open cargo_sample.toml --raw
+            | echo [1 "foo"]
+            | sort-by
+        "#
+    ));
+
+    assert!(actual.err.contains("Can't reduce all the values to all the values to the same type"));
+    assert!(actual.err.contains("All these values should have some relation between then such that the shell knows how to compare them"));
+}
+
+#[test]
 fn sort_primitive_values() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-cli/tests/commands/sort_by.rs
+++ b/crates/nu-cli/tests/commands/sort_by.rs
@@ -56,10 +56,8 @@ fn by_invalid_types() {
         "#
     ));
 
-    assert!(actual
-        .err
-        .contains("Can't reduce all the values to all the values to the same type"));
-    assert!(actual.err.contains("All these values should have some relation between then such that the shell knows how to compare them"));
+    assert!(actual.err.contains("Not all values can be compared"));
+    assert!(actual.err.contains("not all values compare"));
 }
 
 #[test]

--- a/crates/nu-cli/tests/commands/sort_by.rs
+++ b/crates/nu-cli/tests/commands/sort_by.rs
@@ -56,7 +56,9 @@ fn by_invalid_types() {
         "#
     ));
 
-    assert!(actual.err.contains("Can't reduce all the values to all the values to the same type"));
+    assert!(actual
+        .err
+        .contains("Can't reduce all the values to all the values to the same type"));
     assert!(actual.err.contains("All these values should have some relation between then such that the shell knows how to compare them"));
 }
 


### PR DESCRIPTION
This Pull Request intends to solve the issue https://github.com/nushell/nushell/issues/2357 This is my first pull request in a Open Source project controlled by someone else, so i would appreciate advice.
The issue talked about returning an error instead of using expect() the problem that i encountered was that the closure inside the sort_by has to return a enum:cmp i tried to somehow catch the panic but that didn't work also, so what i decided to do was make the coerce check before the sort, i could probably make this already change the values to be coerced, but i didn't want to mess up anything, so i made the new lines just check and return an error, which can probably be considered more convoluted.
I would like to know if anyone thought of a better solution, or if i should just tried to convert all the elems instead of just checking.
ps: sorry for my english