### PR TITLE
Fix column count to not break on empty tables

### DIFF
--- a/crates/nu-cli/tests/commands/count.rs
+++ b/crates/nu-cli/tests/commands/count.rs
@@ -11,3 +11,15 @@ fn count_columns_in_cal_table() {
 
     assert_eq!(actual.out, "7");
 }
+
+#[test]
+fn count_columns_regular_values_empty() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo [] | count -c
+        "#
+    ));
+
+    assert_eq!(actual.out, "0");
+}

--- a/crates/nu-cli/tests/commands/count.rs
+++ b/crates/nu-cli/tests/commands/count.rs
@@ -13,7 +13,7 @@ fn count_columns_in_cal_table() {
 }
 
 #[test]
-fn count_columns_regular_values_empty() {
+fn count_columns_no_rows() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"


### PR DESCRIPTION
If you run `count -c` on a table that ends up having nothing in it, it will crash Nushell.  Here's a contrived example (but I could see a real situation occurring):

```shell
> echo [] | count -c
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', crates/nu-cli/src/commands/count.rs:43:48
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
josephlyons@Josephs-MacBook-Pro nushell % 
```

The error comes from trying to access an empty `rows` `vec` here: https://github.com/nushell/nushell/blob/43e061f8c621368eea3bb2872e359105eeccabe4/crates/nu-cli/src/commands/count.rs#L43

This PR simply returns 0 if the `rows` `vec` is empty.  I added a test as well and changed the `if let` to a `match` because it seemed cleaner.