### PR TITLE
`ls .file` and `ls **/.*` show hidden files

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -124,6 +124,8 @@ impl Shell for FilesystemShell {
             }
         };
 
+        let hidden_dir_specified = is_hidden_dir(&path);
+
         let mut paths = glob::glob(&path.to_string_lossy())
             .map_err(|e| ShellError::labeled_error(e.to_string(), "invalid pattern", &p_tag))?
             .peekable();
@@ -144,7 +146,7 @@ impl Shell for FilesystemShell {
                 Err(err) => return Some(Err(err)),
             };
 
-            if !all && is_hidden_dir(&path) {
+            if !all && !hidden_dir_specified && is_hidden_dir(&path) {
                 return None;
             }
 

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -156,6 +156,65 @@ fn list_files_from_two_parents_up_using_multiple_dots() {
 }
 
 #[test]
+fn lists_hidden_file_when_explicitly_specified() {
+    Playground::setup("ls_test_7", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+            EmptyFile(".testdotfile"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls .testdotfile
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "1");
+    })
+}
+
+#[test]
+fn lists_all_hidden_files_when_glob_contains_dot() {
+    Playground::setup("ls_test_8", |dirs, sandbox| {
+        sandbox
+            .with_files(vec![
+                EmptyFile("root1.txt"),
+                EmptyFile("root2.txt"),
+                EmptyFile(".dotfile1"),
+            ])
+            .within("dir_a")
+            .with_files(vec![
+                EmptyFile("yehuda.10.txt"),
+                EmptyFile("jonathan.10.txt"),
+                EmptyFile(".dotfile2"),
+            ])
+            .within("dir_b")
+            .with_files(vec![
+                EmptyFile("andres.10.txt"),
+                EmptyFile("chicken_not_to_be_picked_up.100.txt"),
+                EmptyFile(".dotfile3"),
+            ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls **/.*
+                | count
+                | echo $it
+            "#
+        ));
+
+        assert_eq!(actual.out, "3");
+    })
+}
+
+#[test]
 fn list_all_columns() {
     Playground::setup(
         "ls_test_all_columns",
@@ -204,3 +263,4 @@ fn list_all_columns() {
         },
     );
 }
+


### PR DESCRIPTION
Relates to #2318 - not sure if it fully closes the ticket though.

`ls .file` and `ls **/.*` show the hidden file(s) without requiring `-a`.
Added some tests too.

One question regarding ./. and ./.., as far as I can tell they only show up for `ls .*` and `ls -a .*` but not for anything else. Is this what is expected?

In bash, they appear for `ls -a` (admittedly as `.` and `..`) as well.