### PR TITLE
Remove rustyline context from nu's completion context

### DIFF
--- a/crates/nu-cli/src/completion/mod.rs
+++ b/crates/nu-cli/src/completion/mod.rs
@@ -13,23 +13,17 @@ pub struct Suggestion {
     pub replacement: String,
 }
 
-pub struct Context<'a>(&'a context::Context, &'a rustyline::Context<'a>);
+pub struct Context<'a>(&'a context::Context);
 
 impl<'a> Context<'a> {
-    pub fn new(a: &'a context::Context, b: &'a rustyline::Context<'a>) -> Context<'a> {
-        Context(a, b)
+    pub fn new(a: &'a context::Context) -> Context<'a> {
+        Context(a)
     }
 }
 
 impl<'a> AsRef<context::Context> for Context<'a> {
     fn as_ref(&self) -> &context::Context {
         self.0
-    }
-}
-
-impl<'a> AsRef<rustyline::Context<'a>> for Context<'a> {
-    fn as_ref(&self) -> &rustyline::Context<'a> {
-        self.1
     }
 }
 

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -45,9 +45,9 @@ impl rustyline::completion::Completer for Helper {
         &self,
         line: &str,
         pos: usize,
-        ctx: &rustyline::Context<'_>,
+        _ctx: &rustyline::Context<'_>,
     ) -> Result<(usize, Vec<Self::Candidate>), rustyline::error::ReadlineError> {
-        let ctx = completion::Context::new(&self.context, ctx);
+        let ctx = completion::Context::new(&self.context);
         Ok(self.completer.complete(line, pos, &ctx))
     }
 }


### PR DESCRIPTION
Title says it all.

With the introduction of our own completion engine in https://github.com/nushell/nushell/pull/2316, we no longer need rustyline for completions.