### PR TITLE
Have lite-parse complete return a complete bare form.

### DIFF
--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -270,8 +270,13 @@ mod tests {
             registry: &dyn SignatureRegistry,
             pos: usize,
         ) -> Vec<LocationType> {
-            let lite_block = lite_parse(line, 0).expect("lite_parse");
+            let lite_block = match lite_parse(line, 0) {
+                Ok(v) => v,
+                Err(e) => e.partial.expect("lite_parse result"),
+            };
+
             let block = classify_block(&lite_block, registry);
+
             super::completion_location(line, &block.block, pos)
                 .into_iter()
                 .map(|v| v.item)
@@ -335,6 +340,17 @@ mod tests {
             assert_eq!(
                 completion_location(line, &registry, 7),
                 vec![LocationType::Flag("du".to_string())],
+            );
+        }
+
+        #[test]
+        fn completes_incomplete_nested_structure() {
+            let registry: VecRegistry = vec![Signature::build("sys")].into();
+            let line = "echo $(sy";
+
+            assert_eq!(
+                completion_location(line, &registry, 8),
+                vec![LocationType::Command],
             );
         }
 


### PR DESCRIPTION
Previously, lite parse would stack up opening delimiters in vec, and if we didn't close everything off, it would simply return an error with a partial form that didn't include the missing closing delimiters. This commits adds those delimiters so that `classify_block` can parse correctly.

## Notes

This handles completions for this case:

```
> echo $(<TAB>
```

But still doesn't handle:

```
> echo `{{$(<TAB>
```

That's because the latter form is essentially ignored by `lite_parse`. Once we "open" a string, we continue until it's closed. This could be problematic, since we can't do something like this this:

```
> echo `Host system name: {{$(sys | `{{host.name}}`)}}`
```