### PR TITLE
Fix Dockerfile (cache clear of apt)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,9 @@ FROM quay.io/nushell/nu-base:${FROMTAG} as base
 FROM ubuntu:18.04
 COPY --from=base /usr/local/bin/nu /usr/local/bin/nu
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y libssl-dev \
-    pkg-config
+RUN apt-get update \
+    && apt-get install -y libssl-dev pkg-config \
+    && apt-get clean \
+    && rm -fr /var/lib/apt/lists/*
 ENTRYPOINT ["nu"]
 CMD ["-l", "info"]


### PR DESCRIPTION
Add processing to clear apt cache to Dockerfile.

This will reduce the size of the image by about 30MB.

```
REPOSITORY           TAG                 IMAGE ID            CREATED             SIZE
quay.io/nushell/nu   before             2a7d2ed79cfa        14 minutes ago      365MB
quay.io/nushell/nu   after                35998b658505        7 minutes ago       336MB
```