### PR TITLE
Sort subcommands in the help text

### DIFF
--- a/crates/nu-cli/src/documentation.rs
+++ b/crates/nu-cli/src/documentation.rs
@@ -131,13 +131,13 @@ pub fn get_documentation(
     long_desc.push_str(&cmd.usage());
     long_desc.push_str("\n");
 
-    let mut subcommands = String::new();
+    let mut subcommands = vec![];
     if !config.no_subcommands {
         for name in registry.names() {
             if name.starts_with(&format!("{} ", cmd_name)) {
                 let subcommand = registry.get_command(&name).expect("This shouldn't happen");
 
-                subcommands.push_str(&format!("  {} - {}\n", name, subcommand.usage()));
+                subcommands.push(format!("  {} - {}", name, subcommand.usage()));
             }
         }
     }
@@ -173,7 +173,9 @@ pub fn get_documentation(
 
     if !subcommands.is_empty() {
         long_desc.push_str("\nSubcommands:\n");
-        long_desc.push_str(&subcommands);
+        subcommands.sort();
+        long_desc.push_str(&subcommands.join("\n"));
+        long_desc.push_str("\n");
     }
 
     if !signature.positional.is_empty() || signature.rest_positional.is_some() {


### PR DESCRIPTION
Before:
```
Subcommands:
  str to-decimal - converts text into decimal
  str to-int - converts text into integer
  str downcase - downcases text
  str upcase - upcases text
  str capitalize - capitalizes text
  str find-replace - finds and replaces text
  str from - Converts numeric types to strings. Trims trailing zeros unless decimals parameter is specified.
  str substring - substrings text
  str set - sets text
  str to-datetime - converts text into datetime
  str contains - Checks if string contains pattern
  str index-of - Returns starting index of given pattern in string counting from 0. Returns -1 when there are no results.
  str trim - trims text
  str ltrim - trims whitespace or character from the beginning of text
  str rtrim - trims whitespace or character from the end of text
  str starts-with - checks if string starts with pattern
  str ends-with - checks if string ends with pattern
  str collect - collects a list of strings into a string
  str length - outputs the lengths of the strings in the pipeline
  str reverse - outputs the reversals of the strings in the pipeline
  str camel-case - converts a string to camelCase
  str pascal-case - converts a string to PascalCase
  str kebab-case - converts a string to kebab-case
  str snake-case - converts a string to snake_case
  str screaming-snake-case - converts a string to SCREAMING_SNAKE_CASE
```


After:
```
Subcommands:
  str camel-case - converts a string to camelCase
  str capitalize - capitalizes text
  str collect - collects a list of strings into a string
  str contains - Checks if string contains pattern
  str downcase - downcases text
  str ends-with - checks if string ends with pattern
  str find-replace - finds and replaces text
  str from - Converts numeric types to strings. Trims trailing zeros unless decimals parameter is specified.
  str index-of - Returns starting index of given pattern in string counting from 0. Returns -1 when there are no results.
  str kebab-case - converts a string to kebab-case
  str length - outputs the lengths of the strings in the pipeline
  str ltrim - trims whitespace or character from the beginning of text
  str pascal-case - converts a string to PascalCase
  str reverse - outputs the reversals of the strings in the pipeline
  str rtrim - trims whitespace or character from the end of text
  str screaming-snake-case - converts a string to SCREAMING_SNAKE_CASE
  str set - sets text
  str snake-case - converts a string to snake_case
  str starts-with - checks if string starts with pattern
  str substring - substrings text
  str to-datetime - converts text into datetime
  str to-decimal - converts text into decimal
  str to-int - converts text into integer
  str trim - trims text
  str upcase - upcases text
```