### PR TITLE
Improve the error message if alias type inference fails

### DIFF
--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -189,10 +189,12 @@ fn check_insert(
                 Some(shape) => match shape {
                     SyntaxShape::Any => Ok(()),
                     shape if shape == new => Ok(()),
-                    _ => Err(ShellError::labeled_error(
+                    _ => Err(ShellError::labeled_error_with_secondary(
                         "Type conflict in alias variable use",
-                        "creates type conflict",
+                        format!("{:?}", (to_add.1).1),
                         (to_add.1).0,
+                        format!("{:?}", shape),
+                        exist.0,
                     )),
                 },
             },

--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -191,7 +191,7 @@ fn check_insert(
                     shape if shape == new => Ok(()),
                     _ => Err(ShellError::labeled_error_with_secondary(
                         "Type conflict in alias variable use",
-                        format!("{:?}", (to_add.1).1),
+                        format!("{:?}", new),
                         (to_add.1).0,
                         format!("{:?}", shape),
                         exist.0,


### PR DESCRIPTION
Gives a better error if types mismatch during alias's type inference:

```
> alias s [a] {if $(= $a | empty?) == $true { cd ~ } { cd $a }}
error: Type conflict in alias variable use
  ┌─ shell:1:21
  │
1 │ alias s [a] {if $(= $a | empty?) == $true { cd ~ } { cd $a }}
  │                     --                                  ^^ Path
  │                     │                                    
  │                     Math
```