### PR TITLE
Command expression need not carry span information.

### DIFF
--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -27,7 +27,7 @@ impl<'s> Flatten<'s> {
             Expression::Block(block) => self.completion_locations(block),
             Expression::Invocation(block) => self.completion_locations(block),
             Expression::List(exprs) => exprs.iter().flat_map(|v| self.expression(v)).collect(),
-            Expression::Command(span) => vec![LocationType::Command.spanned(*span)],
+            Expression::Command => vec![LocationType::Command.spanned(e.span)],
             Expression::Path(path) => self.expression(&path.head),
             Expression::Variable(_) => vec![LocationType::Variable.spanned(e.span)],
 
@@ -69,7 +69,7 @@ impl<'s> Flatten<'s> {
         let mut result = Vec::new();
 
         match internal.args.head.expr {
-            Expression::Command(_) => {
+            Expression::Command => {
                 result.push(LocationType::Command.spanned(internal.name_span));
             }
             Expression::Literal(Literal::String(_)) => {

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -34,7 +34,7 @@ pub(crate) async fn evaluate_baseline_expr(
             Ok(UntaggedValue::string(s).into_untagged_value())
         }
         Expression::Variable(var) => evaluate_reference(&var, it, vars, env, tag),
-        Expression::Command(_) => unimplemented!(),
+        Expression::Command => unimplemented!(),
         Expression::Invocation(block) => evaluate_invocation(block, registry, it, vars, env).await,
         Expression::ExternalCommand(_) => unimplemented!(),
         Expression::Binary(binary) => {

--- a/crates/nu-parser/src/shapes.rs
+++ b/crates/nu-parser/src/shapes.rs
@@ -26,7 +26,7 @@ pub fn expression_to_flat_shape(e: &SpannedExpression) -> Vec<Spanned<FlatShape>
             }
             output
         }
-        Expression::Command(command) => vec![FlatShape::InternalCommand.spanned(*command)],
+        Expression::Command => vec![FlatShape::InternalCommand.spanned(e.span)],
         Expression::Literal(Literal::Bare(_)) => vec![FlatShape::BareMember.spanned(e.span)],
         Expression::Literal(Literal::ColumnPath(_)) => vec![FlatShape::Path.spanned(e.span)],
         Expression::Literal(Literal::GlobPattern(_)) => {

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -35,10 +35,7 @@ impl InternalCommand {
             name,
             name_span,
             args: crate::hir::Call::new(
-                Box::new(SpannedExpression::new(
-                    Expression::Command(name_span),
-                    name_span,
-                )),
+                Box::new(SpannedExpression::new(Expression::Command, name_span)),
                 full_span,
             ),
         }
@@ -724,7 +721,7 @@ impl PrettyDebugWithSource for SpannedExpression {
                 Expression::ExternalCommand(external) => {
                     b::keyword("^") + b::keyword(external.name.span.slice(source))
                 }
-                Expression::Command(command) => b::keyword(command.slice(source)),
+                Expression::Command => b::keyword(self.span.slice(source)),
                 Expression::Boolean(boolean) => match boolean {
                     true => b::primitive("$yes"),
                     false => b::primitive("$no"),
@@ -765,9 +762,7 @@ impl PrettyDebugWithSource for SpannedExpression {
                 "command",
                 b::keyword("^") + b::primitive(external.name.span.slice(source)),
             ),
-            Expression::Command(command) => {
-                b::typed("command", b::primitive(command.slice(source)))
-            }
+            Expression::Command => b::typed("command", b::primitive(self.span.slice(source))),
             Expression::Boolean(boolean) => match boolean {
                 true => b::primitive("$yes"),
                 false => b::primitive("$no"),
@@ -969,7 +964,7 @@ pub enum Expression {
 
     FilePath(PathBuf),
     ExternalCommand(ExternalStringCommand),
-    Command(Span),
+    Command,
     Invocation(hir::Block),
 
     Boolean(bool),
@@ -985,7 +980,7 @@ impl ShellTypeName for Expression {
         match self {
             Expression::Literal(literal) => literal.type_name(),
             Expression::Synthetic(synthetic) => synthetic.type_name(),
-            Expression::Command(..) => "command",
+            Expression::Command => "command",
             Expression::ExternalWord => "external word",
             Expression::FilePath(..) => "file path",
             Expression::Variable(..) => "variable",


### PR DESCRIPTION
Commands being `SpannedExpression`s already contain the span needed.

Partial example:
```
Internal(
                        InternalCommand {
                            name: "get",
                            name_span: Span {
                                start: 15,
                                end: 18,
                            },
                            args: Call {
                                head: SpannedExpression {
                                    expr: Command(
                                        Span {
                                            start: 15,
                                            end: 18,
                                        },
                                    ),
                                    span: Span {
                                        start: 15,
                                        end: 18,
                                    },
                                },
```