### PR TITLE
Add configuration option to disable hinter (#2403)

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -789,7 +789,18 @@ pub async fn cli(
 
         let cwd = context.shell_manager.path();
 
-        rl.set_helper(Some(crate::shell::Helper::new(context.clone())));
+        let disable_hinter = config::config(Tag::unknown())?
+            .get("disable_hinter")
+            .map(|s| s.value.expect_string() == "true")
+            .unwrap_or(false);
+
+        let hinter = if disable_hinter {
+            None
+        } else {
+            Some(rustyline::hint::HistoryHinter {})
+        };
+
+        rl.set_helper(Some(crate::shell::Helper::new(context.clone(), hinter)));
 
         let colored_prompt = {
             if let Some(prompt) = config.get("prompt") {

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -12,16 +12,16 @@ use crate::shell::palette::{DefaultPalette, Palette};
 
 pub struct Helper {
     completer: NuCompleter,
-    hinter: rustyline::hint::HistoryHinter,
+    hinter: Option<rustyline::hint::HistoryHinter>,
     context: Context,
     pub colored_prompt: String,
 }
 
 impl Helper {
-    pub(crate) fn new(context: Context) -> Helper {
+    pub(crate) fn new(context: Context, hinter: Option<rustyline::hint::HistoryHinter>) -> Helper {
         Helper {
             completer: NuCompleter {},
-            hinter: rustyline::hint::HistoryHinter {},
+            hinter,
             context,
             colored_prompt: String::new(),
         }
@@ -54,7 +54,7 @@ impl rustyline::completion::Completer for Helper {
 
 impl rustyline::hint::Hinter for Helper {
     fn hint(&self, line: &str, pos: usize, ctx: &rustyline::Context<'_>) -> Option<String> {
-        self.hinter.hint(line, pos, &ctx)
+        self.hinter.as_ref().and_then(|h| h.hint(line, pos, &ctx))
     }
 }
 


### PR DESCRIPTION
Add a configuration parameter `show_hinter` and if it is set to `false` disable hinting. By default it is assumed to be `true`.