### PR TITLE
Add some cross-references to usage texts

### DIFF
--- a/crates/nu-cli/src/commands/drop.rs
+++ b/crates/nu-cli/src/commands/drop.rs
@@ -22,12 +22,12 @@ impl WholeStreamCommand for Drop {
         Signature::build("drop").optional(
             "rows",
             SyntaxShape::Number,
-            "starting from the back, the number of rows to drop",
+            "starting from the back, the number of rows to remove",
         )
     }
 
     fn usage(&self) -> &str {
-        "Drop the last number of rows."
+        "Remove the last number of rows. If you want to remove columns, try 'reject'."
     }
 
     async fn run(

--- a/crates/nu-cli/src/commands/reject.rs
+++ b/crates/nu-cli/src/commands/reject.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for Reject {
     }
 
     fn usage(&self) -> &str {
-        "Remove the given columns from the table."
+        "Remove the given columns from the table. If you want to remove rows, try 'drop'."
     }
 
     async fn run(


### PR DESCRIPTION
This is an idea I mentioned on Discord earlier and wanted to try out.

For a start, here the drop command mentions the reject command, and vice-versa.

If this or a similar implementation makes sense, we could apply that to other pairs or groups of commands, too. Like sort-by (rows) and ??? (columns, if there is one). `get` for columns, `where` for rows?

Maybe this approach is bad, but I think improving discovery by hinting at related commands has some merit.