### PR TITLE
Allow invocations and fix span error reporting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,18 +367,17 @@ dependencies = [
 
 [[package]]
 name = "battery"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a698e449024a5d18994a815998bf5e2e4bc1883e35a7d7ba95b6b69ee45907"
+checksum = "8775be4956c98c9ac7c11cc383d632636935d3a688dabddb71ac83ba00a3a72f"
 dependencies = [
  "cfg-if",
- "core-foundation 0.6.4",
+ "core-foundation",
  "lazycell",
  "libc",
- "mach 0.2.3",
- "nix 0.15.0",
+ "mach",
  "num-traits 0.2.12",
- "uom 0.26.0",
+ "uom 0.29.0",
  "winapi 0.3.9",
 ]
 
@@ -859,29 +858,13 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
-dependencies = [
- "core-foundation-sys 0.6.2",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1044,7 +1027,7 @@ version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
 dependencies = [
- "nix 0.17.0",
+ "nix",
  "winapi 0.3.9",
 ]
 
@@ -1907,13 +1890,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58d46c2c79530368c7a76e4808ff7263970029f38bcd544a9d43722ed0828527"
 dependencies = [
  "cfg-if",
- "core-foundation 0.7.0",
+ "core-foundation",
  "futures-core",
  "futures-util",
  "lazy_static 1.4.0",
  "libc",
- "mach 0.3.2",
- "nix 0.17.0",
+ "mach",
+ "nix",
  "pin-utils",
  "uom 0.28.0",
  "winapi 0.3.9",
@@ -1932,7 +1915,7 @@ dependencies = [
  "heim-runtime",
  "lazy_static 1.4.0",
  "libc",
- "mach 0.3.2",
+ "mach",
  "ntapi",
  "smol",
  "winapi 0.3.9",
@@ -1946,11 +1929,11 @@ checksum = "8c650cc53da13cb4027eba907bfeff7c764d801e83fd833e48b513c38ed78368"
 dependencies = [
  "bitflags",
  "cfg-if",
- "core-foundation 0.7.0",
+ "core-foundation",
  "heim-common",
  "heim-runtime",
  "libc",
- "mach 0.3.2",
+ "mach",
  "widestring",
  "winapi 0.3.9",
 ]
@@ -1967,7 +1950,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "libc",
  "log 0.4.11",
- "mach 0.3.2",
+ "mach",
  "ntapi",
  "platforms",
  "winapi 0.3.9",
@@ -1984,7 +1967,7 @@ dependencies = [
  "heim-runtime",
  "lazy_static 1.4.0",
  "libc",
- "mach 0.3.2",
+ "mach",
  "winapi 0.3.9",
 ]
 
@@ -2000,7 +1983,7 @@ dependencies = [
  "heim-runtime",
  "libc",
  "macaddr",
- "nix 0.17.0",
+ "nix",
 ]
 
 [[package]]
@@ -2020,7 +2003,7 @@ dependencies = [
  "heim-runtime",
  "lazy_static 1.4.0",
  "libc",
- "mach 0.3.2",
+ "mach",
  "memchr",
  "ntapi",
  "ordered-float",
@@ -2669,15 +2652,6 @@ checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "mach"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
@@ -2932,19 +2906,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "nix"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "void",
 ]
 
 [[package]]
@@ -4731,7 +4692,7 @@ dependencies = [
  "libc",
  "log 0.4.11",
  "memchr",
- "nix 0.17.0",
+ "nix",
  "scopeguard",
  "unicode-segmentation",
  "unicode-width",
@@ -4830,8 +4791,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
+ "core-foundation",
+ "core-foundation-sys",
  "libc",
  "security-framework-sys",
 ]
@@ -4842,7 +4803,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -5809,21 +5770,21 @@ dependencies = [
 
 [[package]]
 name = "uom"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec796ec5f7ac557631709079168286056205c51c60aac33f51764bdc7b8dc4"
+checksum = "627142a1043c2d460613232ce4f7e322e756636e000c0f1d1f2e779cb431358a"
 dependencies = [
+ "num-rational",
  "num-traits 0.2.12",
  "typenum",
 ]
 
 [[package]]
 name = "uom"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627142a1043c2d460613232ce4f7e322e756636e000c0f1d1f2e779cb431358a"
+checksum = "8bb593f5252356bfb829112f8fca2d0982d48588d2d6bb5a92553b0dfc4c9aba"
 dependencies = [
- "num-rational",
  "num-traits 0.2.12",
  "typenum",
 ]

--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
     did_you_mean, ColumnPath, PathMember, Primitive, ReturnSuccess, Signature, SyntaxShape,
     UnspannedPathMember, UntaggedValue, Value,
 };
-use nu_source::span_for_spanned_list;
+use nu_source::HasFallibleSpan;
 use nu_value_ext::get_data_by_column_path;
 
 pub struct Get;
@@ -65,7 +65,7 @@ pub fn get_column_path(path: &ColumnPath, obj: &Value) -> Result<Value, ShellErr
         obj,
         path,
         Box::new(move |(obj_source, column_path_tried, error)| {
-            let path_members_span = span_for_spanned_list(fields.members().iter().map(|p| p.span));
+            let path_members_span = fields.maybe_span().unwrap_or_else(Span::unknown);
 
             match &obj_source.value {
                 UntaggedValue::Table(rows) => match column_path_tried {

--- a/crates/nu-cli/src/commands/move_/column.rs
+++ b/crates/nu-cli/src/commands/move_/column.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 use nu_data::base::select_fields;
 use nu_errors::ShellError;
 use nu_protocol::{ColumnPath, ReturnSuccess, Signature, SyntaxShape, Value};
-use nu_source::span_for_spanned_list;
+use nu_source::HasFallibleSpan;
 
 pub struct SubCommand;
 
@@ -106,7 +106,7 @@ async fn operate(
                     .flatten()
                     .collect::<Vec<&ColumnPath>>();
 
-                let after_span = span_for_spanned_list(after.members().iter().map(|p| p.span));
+                let after_span = after.maybe_span().unwrap_or_else(Span::unknown);
 
                 if after.members().len() == 1 {
                     let keys = column_paths
@@ -154,7 +154,7 @@ async fn operate(
                     .flatten()
                     .collect::<Vec<&ColumnPath>>();
 
-                let before_span = span_for_spanned_list(before.members().iter().map(|p| p.span));
+                let before_span = before.maybe_span().unwrap_or_else(Span::unknown);
 
                 if before.members().len() == 1 {
                     let keys = column_paths
@@ -207,7 +207,7 @@ fn move_after(
     tag: impl Into<Tag>,
 ) -> Result<Value, ShellError> {
     let tag = tag.into();
-    let from_fields = span_for_spanned_list(from.members().iter().map(|p| p.span));
+    let from_fields = from.maybe_span().unwrap_or_else(Span::unknown);
     let from = if let Some((last, _)) = from.split_last() {
         last.as_string()
     } else {
@@ -270,7 +270,7 @@ fn move_before(
     tag: impl Into<Tag>,
 ) -> Result<Value, ShellError> {
     let tag = tag.into();
-    let from_fields = span_for_spanned_list(from.members().iter().map(|p| p.span));
+    let from_fields = from.maybe_span().unwrap_or_else(Span::unknown);
     let from = if let Some((last, _)) = from.split_last() {
         last.as_string()
     } else {

--- a/crates/nu-cli/src/commands/update.rs
+++ b/crates/nu-cli/src/commands/update.rs
@@ -3,7 +3,10 @@ use crate::commands::WholeStreamCommand;
 use crate::context::CommandRegistry;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ColumnPath, ReturnSuccess, Scope, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{
+    ColumnPath, Primitive, ReturnSuccess, Scope, Signature, SyntaxShape, UntaggedValue, Value,
+};
+use nu_source::HasFallibleSpan;
 use nu_value_ext::ValueExt;
 
 use futures::stream::once;
@@ -54,13 +57,15 @@ async fn process_row(
     input: Value,
     mut replacement: Arc<Value>,
     field: Arc<ColumnPath>,
+    tag: Arc<Tag>,
 ) -> Result<OutputStream, ShellError> {
+    let tag = &*tag;
     let replacement = Arc::make_mut(&mut replacement);
 
     Ok(match replacement {
         Value {
             value: UntaggedValue::Block(block),
-            ..
+            tag: block_tag,
         } => {
             let for_block = input.clone();
             let input_stream = once(async { Ok(for_block) }).to_input_stream();
@@ -110,35 +115,41 @@ async fn process_row(
                                 obj.tag,
                             ))),
                         },
-                        Value { tag, .. } => OutputStream::one(Err(ShellError::labeled_error(
+                        _ => OutputStream::one(Err(ShellError::labeled_error(
                             "Unrecognized type in stream",
                             "original value",
-                            tag,
+                            block_tag.clone(),
                         ))),
                     }
                 }
                 Err(e) => OutputStream::one(Err(e)),
             }
         }
-        _ => match input {
-            obj
-            @
+        replacement => match input {
             Value {
-                value: UntaggedValue::Row(_),
+                value: UntaggedValue::Primitive(Primitive::Nothing),
                 ..
-            } => match obj.replace_data_at_column_path(&field, replacement.clone()) {
+            } => match scope
+                .it
+                .replace_data_at_column_path(&field, replacement.clone())
+            {
                 Some(v) => OutputStream::one(ReturnSuccess::value(v)),
                 None => OutputStream::one(Err(ShellError::labeled_error(
                     "update could not find place to insert column",
                     "column name",
-                    obj.tag,
+                    field.maybe_span().unwrap_or_else(|| tag.span),
                 ))),
             },
-            Value { tag, .. } => OutputStream::one(Err(ShellError::labeled_error(
-                "Unrecognized type in stream",
-                "original value",
-                tag,
-            ))),
+            Value { value: _, ref tag } => {
+                match input.replace_data_at_column_path(&field, replacement.clone()) {
+                    Some(v) => OutputStream::one(ReturnSuccess::value(v)),
+                    None => OutputStream::one(Err(ShellError::labeled_error(
+                        "update could not find place to insert column",
+                        "column name",
+                        field.maybe_span().unwrap_or_else(|| tag.span),
+                    ))),
+                }
+            }
         },
     })
 }
@@ -148,6 +159,7 @@ async fn update(
     registry: &CommandRegistry,
 ) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
+    let name_tag = Arc::new(raw_args.call_info.name_tag.clone());
     let scope = Arc::new(raw_args.call_info.scope.clone());
     let context = Arc::new(Context::from_raw(&raw_args, &registry));
     let (UpdateArgs { field, replacement }, input) = raw_args.process(&registry).await?;
@@ -156,13 +168,14 @@ async fn update(
 
     Ok(input
         .then(move |input| {
+            let tag = name_tag.clone();
             let scope = scope.clone();
             let context = context.clone();
             let replacement = replacement.clone();
             let field = field.clone();
 
             async {
-                match process_row(scope, context, input, replacement, field).await {
+                match process_row(scope, context, input, replacement, field, tag).await {
                     Ok(s) => s,
                     Err(e) => OutputStream::one(Err(e)),
                 }

--- a/crates/nu-cli/tests/commands/insert.rs
+++ b/crates/nu-cli/tests/commands/insert.rs
@@ -30,3 +30,19 @@ fn sets_the_column_from_a_block_full_stream_output() {
 
     assert_eq!(actual.out, "true");
 }
+
+#[test]
+fn sets_the_column_from_an_invocation() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            wrap content
+            | insert content $(open --raw cargo_sample.toml | lines | first 5)
+            | get content.1
+            | str contains "nu"
+            | echo $it
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}

--- a/crates/nu-cli/tests/commands/update.rs
+++ b/crates/nu-cli/tests/commands/update.rs
@@ -46,3 +46,19 @@ fn sets_the_column_from_a_block_full_stream_output() {
 
     assert_eq!(actual.out, "true");
 }
+
+#[test]
+fn sets_the_column_from_an_invocation() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            wrap content
+            | update content $(open --raw cargo_sample.toml | lines | first 5)
+            | get content.1
+            | str contains "nu"
+            | echo $it
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -5,7 +5,9 @@ use nu_protocol::{
     ColumnPath, MaybeOwned, PathMember, Primitive, ShellTypeName, SpannedTypeName,
     UnspannedPathMember, UntaggedValue, Value,
 };
-use nu_source::{HasSpan, PrettyDebug, Spanned, SpannedItem, Tag, Tagged, TaggedItem};
+use nu_source::{
+    HasFallibleSpan, HasSpan, PrettyDebug, Span, Spanned, SpannedItem, Tag, Tagged, TaggedItem,
+};
 use num_traits::cast::ToPrimitive;
 
 pub trait ValueExt {
@@ -220,8 +222,7 @@ pub fn swap_data_by_column_path(
         &value,
         path,
         Box::new(move |(obj_source, column_path_tried, error)| {
-            let path_members_span =
-                nu_source::span_for_spanned_list(fields.members().iter().map(|p| p.span));
+            let path_members_span = fields.maybe_span().unwrap_or_else(Span::unknown);
 
             match &obj_source.value {
                 UntaggedValue::Table(rows) => match column_path_tried {


### PR DESCRIPTION
The same applies to `insert` command. Error reporting (correct spans) improved. Second example was not possible before. Need to investigate more regarding the difference when using invocation vs block. It seems that when using an invocation in a named param, implementation wise the `input` is nothing. To solve it, the input value is taken from the scope's `it` value.

```
Ⲗ > echo '{age: 20}' | from json | update age 10
─────┬────
 age │ 10
─────┴────

 Ⲗ > echo '{age: 20}' | from json | update age $(= $it.age + 10)
─────┬────
 age │ 30
─────┴────

 Ⲗ > echo '{age: 20}' | from json | update age { = $it.age + 10 }
─────┬────
 age │ 30
─────┴────
```