### PR TITLE
make cd command complete only folders

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -1,5 +1,6 @@
 use crate::completion::{self, Suggestion};
 use crate::context;
+use std::fs::metadata;
 
 pub(crate) struct NuCompleter {}
 
@@ -47,7 +48,12 @@ impl NuCompleter {
                         LocationType::Argument(_cmd, _arg_name) => {
                             // TODO use cmd and arg_name to narrow things down further
                             let path_completer = crate::completion::path::Completer::new();
-                            path_completer.complete(context, partial)
+                            let completed_paths = path_completer.complete(context, partial);
+                            if line[..2] == "cd".to_string() {
+                                autocomplete_only_folders(completed_paths)
+                            } else {
+                                completed_paths
+                            }
                         }
 
                         LocationType::Variable => Vec::new(),
@@ -60,6 +66,20 @@ impl NuCompleter {
             (pos, suggestions)
         }
     }
+}
+
+fn autocomplete_only_folders(
+    completed_paths: Vec<Suggestion>,
+) -> Vec<Suggestion> {
+    let mut result = Vec::new();
+    for path in completed_paths {
+        let filepath = path.replacement.clone();
+        let md = metadata(filepath).unwrap();
+        if md.is_dir() {
+            result.push(path);
+        }
+    } 
+    return result;
 }
 
 fn requote(item: Suggestion) -> Suggestion {

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -49,7 +49,7 @@ impl NuCompleter {
                             // TODO use cmd and arg_name to narrow things down further
                             let path_completer = crate::completion::path::Completer::new();
                             let completed_paths = path_completer.complete(context, partial);
-                            if line[..2] == "cd".to_string() {
+                            if &line[..2] == "cd" {
                                 autocomplete_only_folders(completed_paths)
                             } else {
                                 completed_paths

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -68,9 +68,7 @@ impl NuCompleter {
     }
 }
 
-fn autocomplete_only_folders(
-    completed_paths: Vec<Suggestion>,
-) -> Vec<Suggestion> {
+fn autocomplete_only_folders(completed_paths: Vec<Suggestion>) -> Vec<Suggestion> {
     let mut result = Vec::new();
     for path in completed_paths {
         let filepath = path.replacement.clone();
@@ -78,7 +76,7 @@ fn autocomplete_only_folders(
         if md.is_dir() {
             result.push(path);
         }
-    } 
+    }
     return result;
 }
 

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -49,7 +49,7 @@ impl NuCompleter {
                             // TODO use cmd and arg_name to narrow things down further
                             let path_completer = crate::completion::path::Completer::new();
                             let completed_paths = path_completer.complete(context, partial);
-                            if line[..2] == "cd".to_string() {
+                            if line[..2] == "cd" {
                                 autocomplete_only_folders(completed_paths)
                             } else {
                                 completed_paths
@@ -72,7 +72,7 @@ fn autocomplete_only_folders(completed_paths: Vec<Suggestion>) -> Vec<Suggestion
     let mut result = Vec::new();
     for path in completed_paths {
         let filepath = path.replacement.clone();
-        let md = metadata(filepath).unwrap();
+        let md = metadata(filepath).expect();
         if md.is_dir() {
             result.push(path);
         }

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -77,7 +77,7 @@ fn autocomplete_only_folders(completed_paths: Vec<Suggestion>) -> Vec<Suggestion
             result.push(path);
         }
     }
-    return result;
+    result
 }
 
 fn requote(item: Suggestion) -> Suggestion {

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -49,7 +49,7 @@ impl NuCompleter {
                             // TODO use cmd and arg_name to narrow things down further
                             let path_completer = crate::completion::path::Completer::new();
                             let completed_paths = path_completer.complete(context, partial);
-                            if line[..2] == "cd" {
+                            if line[..2] == "cd".to_string() {
                                 autocomplete_only_folders(completed_paths)
                             } else {
                                 completed_paths
@@ -72,7 +72,7 @@ fn autocomplete_only_folders(completed_paths: Vec<Suggestion>) -> Vec<Suggestion
     let mut result = Vec::new();
     for path in completed_paths {
         let filepath = path.replacement.clone();
-        let md = metadata(filepath).expect();
+        let md = metadata(filepath).expect("Expect filepath");
         if md.is_dir() {
             result.push(path);
         }


### PR DESCRIPTION
fix #2370 

Currently the cd command autocompletes all files and directories in the working directory.
However, it should only autocomplete folders.
I removed filenames from completion results when we use cd command.