### PR TITLE
Clarification needed: Parse lite_args starting with $ and without "." as Variable?

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -517,13 +517,18 @@ fn parse_interpolated_string(
     (call, error)
 }
 
+// TODO this comment is copied from parse_arg and wrong here
 /// Parses the given argument using the shape as a guide for how to correctly parse the argument
 fn parse_external_arg(
     registry: &dyn SignatureRegistry,
     lite_arg: &Spanned<String>,
 ) -> (SpannedExpression, Option<ParseError>) {
     if lite_arg.item.starts_with('$') {
-        return parse_full_column_path(&lite_arg, registry);
+        if !lite_arg.item.contains('.'){
+            return (SpannedExpression::new(Expression::variable(lite_arg.item.clone(), lite_arg.span.clone()), lite_arg.span), None);
+        }else{
+            return parse_full_column_path(&lite_arg, registry);
+        }
     }
 
     if lite_arg.item.starts_with('`') && lite_arg.item.len() > 1 && lite_arg.item.ends_with('`') {
@@ -544,7 +549,11 @@ fn parse_arg(
     lite_arg: &Spanned<String>,
 ) -> (SpannedExpression, Option<ParseError>) {
     if lite_arg.item.starts_with('$') {
-        return parse_full_column_path(&lite_arg, registry);
+        if !lite_arg.item.contains('.'){
+            return (SpannedExpression::new(Expression::variable(lite_arg.item.clone(), lite_arg.span.clone()), lite_arg.span), None);
+        }else{
+            return parse_full_column_path(&lite_arg, registry);
+        }
     }
 
     match expected_type {


### PR DESCRIPTION
The parser always creates an Expression of type: Path where a simple Variable is fitting better.
I am not even sure the parser is creating Expressions of type Variable anywhere. By quickly scanning over the code I would say no.

Can you verify that this is correct behavior. It seems strange to me.

---
I found this behavior testing some type deduction code: Relevant code can be found at: https://github.com/LhKipp/nushell/tree/VarArgs
Here is the test: 
```rust
    #[test]
    fn alias_args_work() {
        Playground::setup("append_test_1", |dirs, _| {
            let actual = nu!(
                cwd: dirs.root(),
                r#"
                alias double_echo [b] {echo $b}
                double_echo 1 | to json
            "#
            );

            assert_eq!(actual.out, "1");
        })
    }
```
And here is the trace output:

```shell
 TRACE nu_cli::commands::deduction > Deducing shapes for vars: [VarDeclaration { name: "$b", is_var_arg: false, span: Span { start: 35, end: 36 } }]
 TRACE nu_cli::commands::deduction > Infering vars in shape
 TRACE nu_cli::commands::deduction > Infering vars in pipeline
 TRACE nu_cli::commands::deduction > Infering vars in positionals
 TRACE nu_cli::commands::deduction > Positionals len: 1
 TRACE nu_cli::commands::deduction > Handling pos_idx: 0 of type: SpannedExpression { expr: Path(Path { head: SpannedExpression { expr: Variable(Other("$b", Span { start: 44, end: 46 })), span: Span { start: 44, end: 46 } }, tail: [] }), span: Span { start: 44, end: 46 } }
 TRACE nu_cli::commands::deduction > Infering vars in named
 TRACE nu_cli::commands::deduction > Infering vars in positional exprs
 TRACE nu_cli::commands::deduction > Trying to insert for: "$b" possible shapes:[Int, String]
 TRACE nu_cli::commands::deduction > Infering vars in named exprs
 TRACE nu_cli::commands::deduction > Found shapes for vars: {VarUsage { name: "$b", span: Span { start: 44, end: 46 } }: [VarShapeDeduction { deduction: String, deducted_from: [Span { start: 44, end: 46 }], many_of_shapes: false }, VarShapeDeduction { deduction: Int, deducted_from: [Span { start: 44, end: 46 }], many_of_shapes: false }]}

thread 'commands::alias::tests::alias_args_work' panicked at 'assertion failed: `(left == right)`
  left: `"\"1\""`,
 right: `"1"`', crates/nu-cli/tests/commands/alias.rs:33:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    commands::alias::tests::alias_args_work

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 336 filtered out

error: test failed, to rerun pass '-p nu-cli --test main'
[I] leonhard@leonhard ~/p/nushell (VarArgs) [101]> 
```
