### PR TITLE
Show directories and executable for command completion.

### DIFF
--- a/crates/nu-cli/src/completion/command.rs
+++ b/crates/nu-cli/src/completion/command.rs
@@ -1,4 +1,4 @@
-use std::fs::{read_dir, DirEntry};
+use std::fs::Metadata;
 use std::iter::FromIterator;
 
 use indexmap::set::IndexSet;
@@ -13,19 +13,37 @@ impl Completer {
         let context: &context::Context = ctx.as_ref();
         let mut commands: IndexSet<String> = IndexSet::from_iter(context.registry.names());
 
+        // Command suggestions can come from three possible sets:
+        //   1. internal command names,
+        //   2. external command names relative to PATH env var, and
+        //   3. any other executable (that matches what's been typed so far).
+
         let path_executables = find_path_executables().unwrap_or_default();
 
         // TODO quote these, if necessary
         commands.extend(path_executables.into_iter());
 
-        commands
+        let mut suggestions: Vec<_> = commands
             .into_iter()
             .filter(|v| v.starts_with(partial))
             .map(|v| Suggestion {
                 replacement: format!("{} ", v),
                 display: v,
             })
-            .collect()
+            .collect();
+
+        if partial != "" {
+            let path_completer = crate::completion::path::Completer::new();
+            let path_results = path_completer.complete(ctx, partial);
+            suggestions.extend(path_results.into_iter().filter(|suggestion| {
+                std::fs::metadata(&suggestion.replacement)
+                    .ok()
+                    .map(|metadata| metadata.is_dir() || is_executable(metadata))
+                    .unwrap_or(false)
+            }));
+        }
+
+        suggestions
     }
 }
 
@@ -41,22 +59,18 @@ fn pathext() -> Option<Vec<String>> {
 }
 
 #[cfg(windows)]
-fn is_executable(file: &DirEntry) -> bool {
-    if let Ok(metadata) = file.metadata() {
-        let file_type = metadata.file_type();
+fn is_executable(metadata: Metadata) -> bool {
+    let file_type = metadata.file_type();
 
-        // If the entry isn't a file, it cannot be executable
-        if !(file_type.is_file() || file_type.is_symlink()) {
-            return false;
-        }
+    // If the entry isn't a file, it cannot be executable
+    if !(file_type.is_file() || file_type.is_symlink()) {
+        return false;
+    }
 
-        if let Some(extension) = file.path().extension() {
-            if let Some(exts) = pathext() {
-                exts.iter()
-                    .any(|ext| extension.to_string_lossy().eq_ignore_ascii_case(ext))
-            } else {
-                false
-            }
+    if let Some(extension) = file.path().extension() {
+        if let Some(exts) = pathext() {
+            exts.iter()
+                .any(|ext| extension.to_string_lossy().eq_ignore_ascii_case(ext))
         } else {
             false
         }
@@ -66,26 +80,20 @@ fn is_executable(file: &DirEntry) -> bool {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn is_executable(_file: &DirEntry) -> bool {
+fn is_executable(_metadata: Metadata) -> bool {
     false
 }
 
 #[cfg(unix)]
-fn is_executable(file: &DirEntry) -> bool {
+fn is_executable(metadata: Metadata) -> bool {
     use std::os::unix::fs::PermissionsExt;
 
-    let metadata = file.metadata();
+    let filetype = metadata.file_type();
+    let permissions = metadata.permissions();
 
-    if let Ok(metadata) = metadata {
-        let filetype = metadata.file_type();
-        let permissions = metadata.permissions();
-
-        // The file is executable if it is a directory or a symlink and the permissions are set for
-        // owner, group, or other
-        (filetype.is_file() || filetype.is_symlink()) && (permissions.mode() & 0o111 != 0)
-    } else {
-        false
-    }
+    // The file is executable if it is a directory or a symlink and the permissions are set for
+    // owner, group, or other
+    (filetype.is_file() || filetype.is_symlink()) && (permissions.mode() & 0o111 != 0)
 }
 
 // TODO cache these, but watch for changes to PATH
@@ -95,11 +103,13 @@ fn find_path_executables() -> Option<IndexSet<String>> {
 
     let mut executables: IndexSet<String> = IndexSet::new();
     for path in paths {
-        if let Ok(mut contents) = read_dir(path) {
+        if let Ok(mut contents) = std::fs::read_dir(path) {
             while let Some(Ok(item)) = contents.next() {
-                if is_executable(&item) {
-                    if let Ok(name) = item.file_name().into_string() {
-                        executables.insert(name);
+                if let Ok(metadata) = item.metadata() {
+                    if is_executable(metadata) {
+                        if let Ok(name) = item.file_name().into_string() {
+                            executables.insert(name);
+                        }
                     }
                 }
             }

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -36,7 +36,7 @@ impl NuCompleter {
                     let partial = location.span.slice(line);
                     match location.item {
                         LocationType::Command => {
-                            let command_completer = crate::completion::command::Completer {};
+                            let command_completer = crate::completion::command::Completer;
                             command_completer.complete(context, partial)
                         }
 


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/2393

Previously we chose from two sets for completing the command position:

1. internal commands, and
2. executables relative to the PATH environment variable.

We now also show directories/executables that match the relative/absolute path that has been partially typed.