### PR TITLE
Add missing math commands to docs

### DIFF
--- a/docs/commands/math.md
+++ b/docs/commands/math.md
@@ -5,11 +5,14 @@ Currently the following functions are implemented:
 
 * `math avg`: Finds the average of a list of numbers or tables
 * [`math eval`](math-eval.md): Evaluates a list of math expressions into numbers
-* `math min`: Finds the minimum within a list of numbers or tables
 * `math max`: Finds the maximum within a list of numbers or tables
 * `math median`: Finds the median of a list of numbers or tables
+* `math min`: Finds the minimum within a list of numbers or tables
+* `math mode`: Finds the most frequent element(s) within a list of numbers or tables
+* `math stddev`: Finds the standard deviation of a list of numbers or tables
 * `math sum`: Finds the sum of a list of numbers or tables
 * `math product`: Finds the product of a list of numbers or tables
+* `math variance`: Finds the variance of a list of numbers or tables
 
 However, the mathematical functions like `min` and `max` are more permissive and also work on `Dates`.
 
@@ -92,8 +95,26 @@ To get the average of the file sizes in a directory, simply pipe the size column
 ```
 
 ```shell
+> echo [3 3 9 12 12 15] | math mode
+───┬────
+ 0 │  3
+ 1 │ 12
+───┴────
+```
+
+```shell
 > echo [2 3 3 4] | math product
 72
+```
+
+```shell
+> echo [1 4 6 10 50] | math stddev
+18.1372
+```
+
+```shell
+> echo [1 4 6 10 50] | math variance
+328.96
 ```
 
 ### Dates


### PR DESCRIPTION
I noticed a few existing math commands aren't mentioned in the docs, so I added them.

One thing I noticed is that `stddev` doesn't truncate floating point, it ends up being huge, is this intended?

```
echo [1 4 6 10 50] | math stddev
18.1372544780074142289927665486772038998991290109304180183807006388780888095751453498123844567330072
```