### PR TITLE
Implemented safe date formatting

### DIFF
--- a/crates/nu-cli/src/commands/date/format.rs
+++ b/crates/nu-cli/src/commands/date/format.rs
@@ -55,7 +55,7 @@ pub async fn format(
         if let Some(true) = raw {
             UntaggedValue::string(date_to_value_raw(local, dt_fmt)).into_untagged_value()
         } else {
-            date_to_value(local, tag, dt_fmt)
+            date_to_value(local, tag, dt_fmt)?
         }
     };
 

--- a/crates/nu-cli/src/commands/date/now.rs
+++ b/crates/nu-cli/src/commands/date/now.rs
@@ -43,7 +43,7 @@ pub async fn now(
 
     let value = {
         let local: DateTime<Local> = Local::now();
-        date_to_value(local, tag, no_fmt)
+        date_to_value(local, tag, no_fmt)?
     };
 
     Ok(OutputStream::one(value))

--- a/crates/nu-cli/src/commands/date/utc.rs
+++ b/crates/nu-cli/src/commands/date/utc.rs
@@ -43,7 +43,7 @@ pub async fn utc(
 
     let value = {
         let local: DateTime<Utc> = Utc::now();
-        date_to_value(local, tag, no_fmt)
+        date_to_value(local, tag, no_fmt)?
     };
 
     Ok(OutputStream::one(value))

--- a/crates/nu-cli/src/commands/date/utils.rs
+++ b/crates/nu-cli/src/commands/date/utils.rs
@@ -80,3 +80,28 @@ where
 
     Ok(UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Local;
+
+    #[test]
+    fn invalid_format_returns_err() {
+        let result = date_to_value(Local::now(), Tag::default(), "%q".to_string());
+
+        assert_eq!(
+            result,
+            Err(ShellError::untagged_runtime_error(
+                "an error occurred when formatting an argument"
+            ),)
+        );
+    }
+
+    #[test]
+    fn correct_format_returns_formatted_date() {
+        let result = date_to_value(Local::now(), Tag::default(), "%y".to_string());
+
+        assert_eq!(true, result.is_ok());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/2398

- Shows `error: Error: an error occurred when formatting an argument` when `format!()` fails while formatting a date
- commands::date::utils::date_to_value now returns a `Result<Value, ShellError>` instead

The error could definitely be improved so I'm open for any suggestions