### PR TITLE
Add optional commas for items in lists and tables

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -549,7 +549,18 @@ fn parse_list(
     let lite_pipeline = &lite_block.block[0];
     let mut output = vec![];
     for lite_inner in &lite_pipeline.commands {
-        let (arg, err) = parse_arg(SyntaxShape::Any, registry, &lite_inner.name);
+        let item = if lite_inner.name.ends_with(',') {
+            let mut str: String = lite_inner.name.item.clone();
+            str.pop();
+            str.spanned(Span::new(
+                lite_inner.name.span.start(),
+                lite_inner.name.span.end() - 1,
+            ))
+        } else {
+            lite_inner.name.clone()
+        };
+
+        let (arg, err) = parse_arg(SyntaxShape::Any, registry, &item);
 
         output.push(arg);
         if error.is_none() {
@@ -557,7 +568,14 @@ fn parse_list(
         }
 
         for arg in &lite_inner.args {
-            let (arg, err) = parse_arg(SyntaxShape::Any, registry, &arg);
+            let item = if arg.ends_with(',') {
+                let mut str: String = arg.item.clone();
+                str.pop();
+                str.spanned(Span::new(arg.span.start(), arg.span.end() - 1))
+            } else {
+                arg.clone()
+            };
+            let (arg, err) = parse_arg(SyntaxShape::Any, registry, &item);
             output.push(arg);
 
             if error.is_none() {

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -442,6 +442,30 @@ fn table_literals2() {
     assert_eq!(actual.out, "33");
 }
 
+#[test]
+fn list_with_commas() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        echo [1, 2, 3] | math sum
+        "#
+    );
+
+    assert_eq!(actual.out, "6");
+}
+
+#[test]
+fn table_with_commas() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        echo [[name, age, height]; [JT, 42, 185] [Unknown, 99, 99]] | get age | math sum
+        "#
+    );
+
+    assert_eq!(actual.out, "141");
+}
+
 mod parse {
     use nu_test_support::nu;
 


### PR DESCRIPTION
Adds the ability to put a comma after items in a table or list:

```
> echo [[name, height]; [Jonathan, 185]]
───┬──────────┬────────
 # │   name   │ height 
───┼──────────┼────────
 0 │ Jonathan │    185 
───┴──────────┴────────
```

and

```
> echo [1, 2, 3]
───┬───
 0 │ 1 
 1 │ 2 
 2 │ 3 
───┴───
```