### PR TITLE
Add support for multiline rustyline edits

### DIFF
--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -15,6 +15,7 @@ pub struct Helper {
     hinter: Option<rustyline::hint::HistoryHinter>,
     context: Context,
     pub colored_prompt: String,
+    validator: NuValidator,
 }
 
 impl Helper {
@@ -24,6 +25,7 @@ impl Helper {
             hinter,
             context,
             colored_prompt: String::new(),
+            validator: NuValidator {},
         }
     }
 }
@@ -87,6 +89,44 @@ impl rustyline::highlight::Highlighter for Helper {
 
     fn highlight_char(&self, _line: &str, _pos: usize) -> bool {
         true
+    }
+}
+
+impl rustyline::validate::Validator for Helper {
+    fn validate(
+        &self,
+        ctx: &mut rustyline::validate::ValidationContext,
+    ) -> rustyline::Result<rustyline::validate::ValidationResult> {
+        self.validator.validate(ctx)
+    }
+
+    fn validate_while_typing(&self) -> bool {
+        self.validator.validate_while_typing()
+    }
+}
+
+struct NuValidator {}
+
+impl rustyline::validate::Validator for NuValidator {
+    fn validate(
+        &self,
+        ctx: &mut rustyline::validate::ValidationContext,
+    ) -> rustyline::Result<rustyline::validate::ValidationResult> {
+        let src = ctx.input();
+
+        let lite_result = nu_parser::lite_parse(src, 0);
+
+        match lite_result {
+            Err(err) => match err.cause.reason() {
+                nu_errors::ParseErrorReason::Eof { .. } => {
+                    return Ok(rustyline::validate::ValidationResult::Incomplete)
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+
+        Ok(rustyline::validate::ValidationResult::Valid(None))
     }
 }
 
@@ -189,7 +229,3 @@ impl Painter {
 }
 
 impl rustyline::Helper for Helper {}
-
-// Use default validator for normal single line behaviour
-// In the future we can implement this for custom multi-line support
-impl rustyline::validate::Validator for Helper {}

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -116,14 +116,10 @@ impl rustyline::validate::Validator for NuValidator {
 
         let lite_result = nu_parser::lite_parse(src, 0);
 
-        match lite_result {
-            Err(err) => match err.cause.reason() {
-                nu_errors::ParseErrorReason::Eof { .. } => {
-                    return Ok(rustyline::validate::ValidationResult::Incomplete)
-                }
-                _ => {}
-            },
-            _ => {}
+        if let Err(err) = lite_result {
+            if let nu_errors::ParseErrorReason::Eof { .. } = err.cause.reason() {
+                return Ok(rustyline::validate::ValidationResult::Incomplete);
+            }
         }
 
         Ok(rustyline::validate::ValidationResult::Valid(None))


### PR DESCRIPTION
Adds support for multiline edits. We key whether we should continue to multiple lines if we get the parse error "unexpected EOF", meaning that there is an unclosed paren/curly/quote/etc.

This allows us to span tables, blocks, and more across multiple rustyline lines. For example:

```
> echo [
[Name, Age];
[JT, 42]
]
───┬──────┬─────
 # │ Name │ Age 
───┼──────┼─────
 0 │ JT   │  42 
───┴──────┴─────
```

You can use `do` as well to span a pipeline across lines:

```
> do {
ls |
get name
}
────┬────────────────────
  0 │ CODE_OF_CONDUCT.md 
  1 │ CONTRIBUTING.md    
  2 │ Cargo.lock         
...
```