### PR TITLE
Set auto-pivot to never by default

### DIFF
--- a/crates/nu-cli/src/commands/autoview/options.rs
+++ b/crates/nu-cli/src/commands/autoview/options.rs
@@ -44,13 +44,13 @@ pub fn pivot_mode(config: &NuConfig) -> AutoPivotMode {
             Ok(m) if m.to_lowercase() == "auto" => AutoPivotMode::Auto,
             Ok(m) if m.to_lowercase() == "always" => AutoPivotMode::Always,
             Ok(m) if m.to_lowercase() == "never" => AutoPivotMode::Never,
-            _ => AutoPivotMode::Always,
+            _ => AutoPivotMode::Never,
         };
 
         return mode;
     }
 
-    AutoPivotMode::Always
+    AutoPivotMode::Never
 }
 
 impl ConfigExtensions for NuConfig {


### PR DESCRIPTION
We've had feedback from a few folks that pivoting a table when it's not expected can be very disorienting. It's better to less attractive but also less confusing as the default. Once people understand Nu better, they can explore turning on auto pivot.