### PR TITLE
Tolerate os error while executing ls command

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -154,7 +154,7 @@ impl Shell for FilesystemShell {
             let metadata = match std::fs::symlink_metadata(&path) {
                 Ok(metadata) => Some(metadata),
                 Err(e) => {
-                    if e.kind() == ErrorKind::PermissionDenied {
+                    if e.kind() == ErrorKind::PermissionDenied || e.kind() == ErrorKind::Other {
                         None
                     } else {
                         return Some(Err(e.into()));


### PR DESCRIPTION
issue #2460 

Nushell doesn't forgive OS error while executing ls command and will error out.
I fixed this behavior and ls command shows all available files now.

