### PR TITLE
added compact_double table theme for funsies

### DIFF
--- a/crates/nu-cli/src/commands/table/options.rs
+++ b/crates/nu-cli/src/commands/table/options.rs
@@ -70,6 +70,7 @@ pub fn table_mode(config: &NuConfig) -> nu_table::Theme {
             Ok(m) if m == "compact" => nu_table::Theme::compact(),
             Ok(m) if m == "light" => nu_table::Theme::light(),
             Ok(m) if m == "thin" => nu_table::Theme::thin(),
+            Ok(m) if m == "compact_double" => nu_table::Theme::compact_double(),
             _ => nu_table::Theme::compact(),
         })
 }

--- a/crates/nu-data/src/config/table.rs
+++ b/crates/nu-data/src/config/table.rs
@@ -95,6 +95,7 @@ pub fn table_mode(config: &NuConfig) -> nu_table::Theme {
             Ok(m) if m == "compact" => nu_table::Theme::compact(),
             Ok(m) if m == "light" => nu_table::Theme::light(),
             Ok(m) if m == "thin" => nu_table::Theme::thin(),
+            Ok(m) if m == "compact_double" => nu_table::Theme::compact_double(),
             _ => nu_table::Theme::compact(),
         })
 }

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -203,6 +203,35 @@ impl Theme {
             print_bottom_border: true,
         }
     }
+    #[allow(unused)]
+    pub fn compact_double() -> Theme {
+        Theme {
+            top_left: '═',
+            middle_left: '═',
+            bottom_left: '═',
+            top_center: '╦',
+            center: '╬',
+            bottom_center: '╩',
+            top_right: '═',
+            middle_right: '═',
+            bottom_right: '═',
+            top_horizontal: '═',
+            middle_horizontal: '═',
+            bottom_horizontal: '═',
+
+            left_vertical: ' ',
+            center_vertical: '║',
+            right_vertical: ' ',
+
+            separate_header: true,
+            separate_rows: false,
+
+            print_left_border: false,
+            print_right_border: false,
+            print_top_border: true,
+            print_bottom_border: true,
+        }
+    }
 }
 
 impl Table {


### PR DESCRIPTION
Just for fun - change `table_mode = compact_double` and you'll get this.
```
═══╦════════════════════════╦══════╦══════════╦══════════════
 # ║          name          ║ type ║   size   ║   modified
═══╬════════════════════════╬══════╬══════════╬══════════════
 0 ║ ..\cargo-commands.txt  ║ File ║   2.8 KB ║ 2 months ago
 1 ║ ..\foo.csv             ║ File ║ 156.5 KB ║ 1 month ago
 2 ║ ..\ichwh-rs            ║ Dir  ║   4.1 KB ║ 1 month ago
 3 ║ ..\install_nushell.cmd ║ File ║   1.6 KB ║ 2 weeks ago
 4 ║ ..\nushell             ║ Dir  ║   8.2 KB ║ 20 hours ago
 5 ║ ..\rustyline           ║ Dir  ║   4.1 KB ║ 1 month ago
═══╩════════════════════════╩══════╩══════════╩══════════════
```