### PR TITLE
Only requote path arguments.

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -76,15 +76,16 @@ impl NuCompleter {
                                 "cd" => select_directory_suggestions(completed_paths),
                                 _ => completed_paths,
                             }
+                            .into_iter()
+                            .map(|suggestion| Suggestion {
+                                replacement: requote(suggestion.replacement),
+                                display: suggestion.display,
+                            })
+                            .collect()
                         }
 
                         LocationType::Variable => Vec::new(),
                     }
-                    .into_iter()
-                })
-                .map(|suggestion| Suggestion {
-                    replacement: requote(suggestion.replacement),
-                    display: suggestion.display,
                 })
                 .collect();
 


### PR DESCRIPTION
Requoting negatively impacted command completions, which end in a space. This resulted in quotes getting added unnecessarily to command completions that did not need them.

Two important things to note here:

1. This isn't an ideal solution. The command completer adding a space at the end is a convenience, but it would make more sense for `NuCompleter` to do this, not the individual completers. It has more context to make such a decision.
2. We need tests 😬 