### PR TITLE
Size command: rename max length to bytes

### DIFF
--- a/crates/nu-cli/src/commands/size.rs
+++ b/crates/nu-cli/src/commands/size.rs
@@ -36,7 +36,7 @@ impl WholeStreamCommand for Size {
                 "lines".to_string() => UntaggedValue::int(0).into(),
                 "words".to_string() => UntaggedValue::int(7).into(),
                 "chars".to_string() => UntaggedValue::int(38).into(),
-                "max length".to_string() => UntaggedValue::int(38).into(),
+                "bytes".to_string() => UntaggedValue::int(38).into(),
             })
             .into()]),
         }]
@@ -96,7 +96,7 @@ fn count(contents: &str, tag: impl Into<Tag>) -> Value {
     dict.insert_untagged("lines", UntaggedValue::int(lines));
     dict.insert_untagged("words", UntaggedValue::int(words));
     dict.insert_untagged("chars", UntaggedValue::int(chars));
-    dict.insert_untagged("max length", UntaggedValue::int(bytes));
+    dict.insert_untagged("bytes", UntaggedValue::int(bytes));
 
     dict.into_value()
 }

--- a/docs/commands/debug.md
+++ b/docs/commands/debug.md
@@ -40,7 +40,7 @@
 
 ```shell
 > open --raw Cargo.toml | size | debug
-(lines=139 words=560 chars=4607 max length=4607)
+(lines=139 words=560 chars=4607 bytes=4607)
 ```
 
 ```shell

--- a/docs/commands/math.md
+++ b/docs/commands/math.md
@@ -134,7 +134,7 @@ To get the average of the file sizes in a directory, simply pipe the size column
 ```shell
 >  pwd | split row / | size
 ───┬───────┬───────┬───────┬────────────
- # │ lines │ words │ chars │ max length
+ # │ lines │ words │ chars │ bytes
 ───┼───────┼───────┼───────┼────────────
  0 │     0 │     1 │     5 │          5
  1 │     0 │     1 │    11 │         11
@@ -151,7 +151,7 @@ To get the average of the file sizes in a directory, simply pipe the size column
  lines      │ 0
  words      │ 2
  chars      │ 12
- max length │ 12
+ bytes │ 12
 ────────────┴────
 ```
 
@@ -161,7 +161,7 @@ To get the average of the file sizes in a directory, simply pipe the size column
  lines      │ 0.0000
  words      │ 1.1666
  chars      │ 8.3333
- max length │ 8.3333
+ bytes │ 8.3333
 ────────────┴────────
 ```
 

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -7,7 +7,7 @@ This commands gives word count statistics on any text.
 ```shell
 > open lalala.txt | size
 ━━━━━━━┯━━━━━━━┯━━━━━━━┯━━━━━━━━━━━━
- lines │ words │ chars │ max length
+ lines │ words │ chars │ bytes
 ───────┼───────┼───────┼────────────
      4 │    10 │    72 │         72
 ━━━━━━━┷━━━━━━━┷━━━━━━━┷━━━━━━━━━━━━
@@ -16,7 +16,7 @@ This commands gives word count statistics on any text.
 ```shell
 > open the_mysterious_affair_at_styles.txt | size
 ━━━━━━━┯━━━━━━━┯━━━━━━━━┯━━━━━━━━━━━━
- lines │ words │ chars  │ max length
+ lines │ words │ chars  │ bytes
 ───────┼───────┼────────┼────────────
   8935 │ 62352 │ 349459 │     361771
 ━━━━━━━┷━━━━━━━┷━━━━━━━━┷━━━━━━━━━━━━


### PR DESCRIPTION
Since "max length" is just getting the byte length, rename it to `bytes`
in order to be more clear. 

This was discussed in https://github.com/nushell/nushell/issues/2465.