### PR TITLE
Improve support for completing within quotes.

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -63,7 +63,7 @@ impl NuCompleter {
 
                             let partial = if let Some(quote_char) = quote_char {
                                 if partial.ends_with(quote_char) {
-                                    &partial[..partial.len()]
+                                    &partial[..partial.len() - 1]
                                 } else {
                                     partial
                                 }

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -52,6 +52,11 @@ impl rustyline::completion::Completer for Helper {
         let ctx = completion::Context::new(&self.context);
         Ok(self.completer.complete(line, pos, &ctx))
     }
+
+    fn update(&self, line: &mut rustyline::line_buffer::LineBuffer, start: usize, elected: &str) {
+        let end = (start + elected.len()).min(line.len());
+        line.replace(start..end, elected)
+    }
 }
 
 impl rustyline::hint::Hinter for Helper {


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/2136

We ensure the partially cimpleted item doesn't include the end quote. We also ensure that the appropriate span is replaced, not just the suggested position up to the cursor position.