### PR TITLE
More bug fixes for completions

### DIFF
--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -232,10 +232,10 @@ pub fn completion_location(line: &str, block: &Block, pos: usize) -> Vec<Complet
             // is after some character that would imply we're in the command position.
             let start = prev.span.end();
             if line[start..pos].contains(BEFORE_COMMAND_CHARS) {
-                vec![LocationType::Command.spanned(Span::unknown())]
+                vec![LocationType::Command.spanned(Span::new(pos, pos))]
             } else {
                 // TODO this should be able to be mapped to a command
-                vec![LocationType::Argument(command, None).spanned(Span::unknown())]
+                vec![LocationType::Argument(command, None).spanned(Span::new(pos, pos))]
             }
         } else {
             // Cursor is before any possible completion location, so must be a command

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -54,7 +54,7 @@ impl rustyline::completion::Completer for Helper {
     }
 
     fn update(&self, line: &mut rustyline::line_buffer::LineBuffer, start: usize, elected: &str) {
-        let end = (start + elected.len()).min(line.len());
+        let end = line.pos();
         line.replace(start..end, elected)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/2475

Fixes two completion bugs.

The first bug is where one tries to complete

    ls <TAB>

but would have the entire line replaced. This was due to use of an unknown `Span`, when really we know the replacement should occur at the cursor, which is exactly the fix that we made.

The second occurs in circular completion mode, where one cycles through suggestions. When moving from a longer suggestion to a shorter one, we'd see some of the old suggestion lingering around. A previous change to the update behaviour was reverted, so this no longer is a problem, but reintroduces buggy behaviour when completion is requested in the middle of an argument.