### PR TITLE
Support ~ (home directory) in completions.

### DIFF
--- a/crates/nu-cli/src/completion/path.rs
+++ b/crates/nu-cli/src/completion/path.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::PathBuf;
 
 use crate::completion::{Context, Suggestion};
 
@@ -17,9 +17,18 @@ impl Completer {
         };
 
         let base_dir = if base_dir_name == "" {
-            Path::new(".")
+            PathBuf::from(".")
+        } else if base_dir_name == format!("~{}", SEP) {
+            #[cfg(feature = "directories")]
+            {
+                dirs::home_dir().unwrap_or_else(|| PathBuf::from("~"))
+            }
+            #[cfg(not(feature = "directories"))]
+            {
+                PathBuf::from("~")
+            }
         } else {
-            Path::new(base_dir_name)
+            PathBuf::from(base_dir_name)
         };
 
         if let Ok(result) = base_dir.read_dir() {


### PR DESCRIPTION
This requires a bit of a hack in command completions, since we don't expand `~` for the replacement, just long enough to get child entries.

I can't think of a great way to handle this right now, but likely we'll want the path completer to have a separate method that returns path objects. The command completer can then convert those into `Suggestion`s.