### PR TITLE
Size: count unicode graphmemes as single char

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,6 +3093,7 @@ dependencies = [
  "trash",
  "typetag",
  "umask",
+ "unicode-segmentation",
  "unicode-xid",
  "url 2.1.1",
  "users",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -87,6 +87,7 @@ termcolor = "1.1.0"
 toml = "0.5.6"
 typetag = "0.1.5"
 umask = "1.0.0"
+unicode-segmentation = "1.6.0"
 unicode-xid = "0.2.1"
 uuid_crate = {package = "uuid", version = "0.8.1", features = ["v4"], optional = true}
 which = {version = "4.0.2", optional = true}


### PR DESCRIPTION
Closes #2465 

This change uses the [UnicodeSegmentation crate](https://crates.io/crates/unicode-segmentation) to iterate over the content as unicode graphmemes instead of a Rust char. This prevents a single visual Unicode graphmeme from getting split into several chars and affecting the counts.

I used TDD with a sample test case from the issue, which also helps clarify as an example. 