### PR TITLE
use fs_extra to recursively move folders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3038,7 @@ dependencies = [
  "eml-parser",
  "encoding_rs",
  "filesize",
+ "fs_extra",
  "futures 0.3.5",
  "futures-util",
  "futures_codec",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -41,6 +41,7 @@ dtparse = "1.1.0"
 dunce = "1.0.1"
 eml-parser = "0.1.0"
 filesize = "0.2.0"
+fs_extra = "1.2.0"
 futures = {version = "0.3", features = ["compat", "io-compat"]}
 futures-util = "0.3.5"
 futures_codec = "0.4"

--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -751,17 +751,31 @@ fn move_file(from: TaggedPathBuf, to: TaggedPathBuf) -> Result<(), ShellError> {
         to.push(from_file_name);
     }
 
+    move_item(&from, from_tag, &to)
+}
+
+fn move_item(from: &Path, from_tag: &Tag, to: &Path) -> Result<(), ShellError> {
     // We first try a rename, which is a quick operation. If that doesn't work, we'll try a copy
-    // and remove the old file. This is necessary if we're moving across filesystems.
-    std::fs::rename(&from, &to)
-        .or_else(|_| std::fs::copy(&from, &to).and_then(|_| std::fs::remove_file(&from)))
-        .map_err(|e| {
-            ShellError::labeled_error(
+    // and remove the old file/folder. This is necessary if we're moving across filesystems or devices.
+    std::fs::rename(&from, &to).or_else(|_| {
+        match if from.is_file() {
+            let mut options = fs_extra::file::CopyOptions::new();
+            options.overwrite = true;
+            fs_extra::file::move_file(from, to, &options)
+        } else {
+            let mut options = fs_extra::dir::CopyOptions::new();
+            options.overwrite = true;
+            options.copy_inside = true;
+            fs_extra::dir::move_dir(from, to, &options)
+        } {
+            Ok(_) => Ok(()),
+            Err(e) => Err(ShellError::labeled_error(
                 format!("Could not move {:?} to {:?}. {:}", from, to, e.to_string()),
                 "could not move",
                 from_tag,
-            )
-        })
+            )),
+        }
+    })
 }
 
 fn is_empty_dir(dir: impl AsRef<Path>) -> bool {


### PR DESCRIPTION
Fixes #2470 by using `fs_extra` to do the recursive copy/remove in case `std::fs::rename` could not be used.
