### PR TITLE
Num links added to ls -l output

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -865,8 +865,18 @@ pub(crate) fn dir_entry_dict(
         #[cfg(unix)]
         {
             for column in [
-                "name", "type", "target", "readonly", "mode", "uid", "group", "size", "created",
-                "accessed", "modified",
+                "name",
+                "type",
+                "target",
+                "num_links",
+                "readonly",
+                "mode",
+                "uid",
+                "group",
+                "size",
+                "created",
+                "accessed",
+                "modified",
             ]
             .iter()
             {
@@ -932,6 +942,9 @@ pub(crate) fn dir_entry_dict(
                     "mode",
                     UntaggedValue::string(umask::Mode::from(mode).to_string()),
                 );
+
+                let nlinks = md.nlink();
+                dict.insert_untagged("num_links", UntaggedValue::string(nlinks.to_string()));
 
                 if let Some(user) = users::get_user_by_uid(md.uid()) {
                     dict.insert_untagged(

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -241,8 +241,18 @@ fn list_all_columns() {
                 #[cfg(unix)]
                 {
                     [
-                        "name", "type", "target", "readonly", "mode", "uid", "group", "size",
-                        "created", "accessed", "modified",
+                        "name",
+                        "type",
+                        "target",
+                        "num_links",
+                        "readonly",
+                        "mode",
+                        "uid",
+                        "group",
+                        "size",
+                        "created",
+                        "accessed",
+                        "modified",
                     ]
                     .join("")
                 }


### PR DESCRIPTION
1. Num links added to `ls -l` output

This information is displayed in the Unix `ls -l` command, thought it would be useful to include in this table as well.

Screenshot from running `ls -l` in `nu`:

![image](https://user-images.githubusercontent.com/6572184/92314187-6eff3b00-ef89-11ea-8986-31f382da473f.png)
