### PR TITLE
Provide path as part of the suggestion from the path completer.

### DIFF
--- a/crates/nu-cli/src/completion/path.rs
+++ b/crates/nu-cli/src/completion/path.rs
@@ -6,8 +6,13 @@ const SEP: char = std::path::MAIN_SEPARATOR;
 
 pub struct Completer;
 
+pub struct PathSuggestion {
+    pub(crate) path: PathBuf,
+    pub(crate) suggestion: Suggestion,
+}
+
 impl Completer {
-    pub fn complete(&self, _ctx: &Context<'_>, partial: &str) -> Vec<Suggestion> {
+    pub fn path_suggestions(&self, _ctx: &Context<'_>, partial: &str) -> Vec<PathSuggestion> {
         let expanded = nu_parser::expand_ndots(partial);
         let expanded = expanded.as_ref();
 
@@ -43,9 +48,12 @@ impl Completer {
                                 file_name.push(std::path::MAIN_SEPARATOR);
                             }
 
-                            Some(Suggestion {
-                                replacement: path,
-                                display: file_name,
+                            Some(PathSuggestion {
+                                path: entry.path(),
+                                suggestion: Suggestion {
+                                    replacement: path,
+                                    display: file_name,
+                                },
                             })
                         } else {
                             None
@@ -56,5 +64,12 @@ impl Completer {
         } else {
             Vec::new()
         }
+    }
+
+    pub fn complete(&self, ctx: &Context<'_>, partial: &str) -> Vec<Suggestion> {
+        self.path_suggestions(ctx, partial)
+            .into_iter()
+            .map(|v| v.suggestion)
+            .collect()
     }
 }


### PR DESCRIPTION
This greatly simplifies the consumption of path suggestions when the caller wants to filter those suggestions. Returning the underlying `Path` means the replacement can maintain path elements that nushell understands, but `std::path` and `std::fs` do not. For example, `~/` for the user's home directory, `...` for two directories above, and so on.

[EDIT]
This also appears to fix directory suggestions in the command position (for "auto cd")