### PR TITLE
Remove space from command name completion suggestion.

### DIFF
--- a/crates/nu-cli/src/completion/command.rs
+++ b/crates/nu-cli/src/completion/command.rs
@@ -27,7 +27,7 @@ impl Completer {
             .into_iter()
             .filter(|v| v.starts_with(partial))
             .map(|v| Suggestion {
-                replacement: format!("{} ", v),
+                replacement: v.clone(),
                 display: v,
             })
             .collect();


### PR DESCRIPTION
Although convenient, since the user doesn't have to type the space, it could be a little surprising to users since they may think that was the only completion in certain completions modes (for example, `circular`).