### PR TITLE
Add modulo operator and simplify in/not-in

### DIFF
--- a/crates/nu-cli/src/evaluate/operator.rs
+++ b/crates/nu-cli/src/evaluate/operator.rs
@@ -33,6 +33,14 @@ pub fn apply_operator(
             )),
             _ => res,
         }),
+        Operator::Modulo => value::compute_values(op, left, right).map(|res| match res {
+            UntaggedValue::Error(_) => UntaggedValue::Error(ShellError::labeled_error(
+                "Evaluation error",
+                "division by zero",
+                &right.tag.span,
+            )),
+            _ => res,
+        }),
         Operator::In => table_contains(left, right).map(UntaggedValue::boolean),
         Operator::NotIn => table_contains(left, right).map(|x| UntaggedValue::boolean(!x)),
         Operator::And => match (left.as_bool(), right.as_bool()) {

--- a/crates/nu-cli/tests/commands/math/mod.rs
+++ b/crates/nu-cli/tests/commands/math/mod.rs
@@ -162,6 +162,18 @@ fn parens_precedence() {
 }
 
 #[test]
+fn modulo() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            = 9 mod 2
+        "#
+    ));
+
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
 fn duration_math() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-cli/tests/commands/merge.rs
+++ b/crates/nu-cli/tests/commands/merge.rs
@@ -31,7 +31,7 @@ fn row() {
             r#"
                 open caballeros.csv
                 | merge { open new_caballeros.csv }
-                | where country in: ["Guayaquil Ecuador" "New Zealand"]
+                | where country in ["Guayaquil Ecuador" "New Zealand"]
                 | get luck
                 | math sum
                 | echo $it

--- a/crates/nu-cli/tests/commands/where_.rs
+++ b/crates/nu-cli/tests/commands/where_.rs
@@ -27,7 +27,7 @@ fn filters_with_nothing_comparison() {
 fn where_in_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name in: ["foo"] | get size | math sum | echo $it"#
+        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name in ["foo"] | get size | math sum | echo $it"#
     );
 
     assert_eq!(actual.out, "5");
@@ -37,7 +37,7 @@ fn where_in_table() {
 fn where_not_in_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name not-in: ["foo"] | get size | math sum | echo $it"#
+        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name not-in ["foo"] | get size | math sum | echo $it"#
     );
 
     assert_eq!(actual.out, "4");

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -131,6 +131,13 @@ pub fn compute_values(
                         )))
                     }
                 }
+                Operator::Modulo => {
+                    if y.is_zero() {
+                        Ok(zero_division_error())
+                    } else {
+                        Ok(UntaggedValue::Primitive(Primitive::Int(x % y)))
+                    }
+                }
                 _ => Err((left.type_name(), right.type_name())),
             },
             (Primitive::Decimal(x), Primitive::Int(y)) => {

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -286,8 +286,9 @@ fn parse_operator(lite_arg: &Spanned<String>) -> (SpannedExpression, Option<Pars
         "-" => Operator::Minus,
         "*" => Operator::Multiply,
         "/" => Operator::Divide,
-        "in:" => Operator::In,
-        "not-in:" => Operator::NotIn,
+        "in" => Operator::In,
+        "not-in" => Operator::NotIn,
+        "mod" => Operator::Modulo,
         "&&" => Operator::And,
         "||" => Operator::Or,
         _ => {

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -575,7 +575,7 @@ impl SpannedExpression {
                 // Higher precedence binds tighter
 
                 match operator {
-                    Operator::Multiply | Operator::Divide => 100,
+                    Operator::Multiply | Operator::Divide | Operator::Modulo => 100,
                     Operator::Plus | Operator::Minus => 90,
                     Operator::NotContains
                     | Operator::Contains
@@ -848,6 +848,7 @@ pub enum Operator {
     Divide,
     In,
     NotIn,
+    Modulo,
     And,
     Or,
 }


### PR DESCRIPTION
This does two things:

* introduces a new `mod` operator to do modulo operations. eg) `= 9 mod 2`

* renames `in:` and `not-in:` to `in` and `not-in`. The colon was there originally to help disambiguate, but in math mode it's not ambiguous. There may be cases of it being visually ambiguous, which we'll need watch for, but should generally be easier to use and read (with any luck)
