### PR TITLE
Add cpu time to ps -l

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3379,6 +3379,7 @@ dependencies = [
  "nu-plugin",
  "nu-protocol",
  "nu-source",
+ "num-bigint",
 ]
 
 [[package]]

--- a/crates/nu_plugin_ps/Cargo.toml
+++ b/crates/nu_plugin_ps/Cargo.toml
@@ -15,6 +15,8 @@ nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 
+num-bigint = "0.2.6"
+
 futures = {version = "0.3", features = ["compat", "io-compat"]}
 futures-timer = "3.0.2"
 

--- a/crates/nu_plugin_ps/src/ps.rs
+++ b/crates/nu_plugin_ps/src/ps.rs
@@ -1,11 +1,13 @@
 use futures::{StreamExt, TryStreamExt};
 use heim::process::{self as process, Process, ProcessResult};
-use heim::units::{information, ratio, Ratio};
+use heim::units::{information, ratio, time, Ratio};
 use std::usize;
 
 use nu_errors::ShellError;
 use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
 use nu_source::Tag;
+
+use num_bigint::BigInt;
 
 use std::time::Duration;
 
@@ -68,6 +70,15 @@ pub async fn ps(tag: Tag, long: bool) -> Result<Vec<Value>, ShellError> {
                 UntaggedValue::filesize(memory.vms().get::<information::byte>()),
             );
             if long {
+                if let Ok(cpu_time) = process.cpu_time().await {
+                    let user_time = cpu_time.user().get::<time::nanosecond>().round() as i64;
+                    let system_time = cpu_time.system().get::<time::nanosecond>().round() as i64;
+
+                    dict.insert_untagged(
+                        "cpu_time",
+                        UntaggedValue::duration(BigInt::from(user_time + system_time)),
+                    )
+                }
                 if let Ok(parent_pid) = process.parent_pid().await {
                     dict.insert_untagged("parent", UntaggedValue::int(parent_pid))
                 }

--- a/docs/commands/ps.md
+++ b/docs/commands/ps.md
@@ -22,3 +22,26 @@ Syntax: `ps`
  69 │  8972 │ nu_plugin_ps.exe                                                   │ Running │ 58.00986000000000
 ━━━━┷━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━
 ```
+
+Find processes with the highest cpu time
+```shell
+> ps -l | sort-by cpu_time | last 2
+ # │ pid │       name       │ status  │  cpu   │   mem    │ virtual │     cpu_time      │ parent │         exe          │       command
+───┼─────┼──────────────────┼─────────┼────────┼──────────┼─────────┼───────────────────┼────────┼──────────────────────┼──────────────────────
+ 0 │ 396 │ Google Chrome    │ Running │ 0.0000 │ 271.6 MB │  5.8 GB │ 6hr 20min 28sec   │      1 │ /Applications/Google │ /Applications/Google
+   │     │                  │         │        │          │         │ 173ms 641us 315ns │        │ Chrome.app/Contents/ │ Chrome.app/Contents/
+   │     │                  │         │        │          │         │                   │        │ MacOS/Google         │ MacOS/Google
+   │     │                  │         │        │          │         │                   │        │ Chrome               │ Chrome
+ 1 │ 444 │ Google Chrome He │ Running │ 0.0000 │ 398.9 MB │  5.3 GB │ 10hr 36min 17sec  │    396 │ /Applications/Google │ /Applications/Google
+   │     │                  │         │        │          │         │ 304ms 66us 889ns  │        │ Chrome.app/Contents/ │ Chrome.app/Contents/
+   │     │                  │         │        │          │         │                   │        │ Frameworks/Google    │ Frameworks/Google
+   │     │                  │         │        │          │         │                   │        │ Chrome               │ Chrome
+   │     │                  │         │        │          │         │                   │        │ Framework.framework/ │ Framework.framework/
+   │     │                  │         │        │          │         │                   │        │ Versions/84.0.4147.1 │ Versions/84.0.4147.1
+   │     │                  │         │        │          │         │                   │        │ 25/Helpers/Google    │ 25/Helpers/Google
+   │     │                  │         │        │          │         │                   │        │ Chrome Helper        │ Chrome Helper
+   │     │                  │         │        │          │         │                   │        │ (GPU).app/Contents/M │ (GPU).app/Contents/M
+   │     │                  │         │        │          │         │                   │        │ acOS/Google          │ acOS/Google
+   │     │                  │         │        │          │         │                   │        │ Chrome Helper (GPU)  │ Chrome Helper (GPU)
+───┴─────┴──────────────────┴─────────┴────────┴──────────┴─────────┴───────────────────┴────────┴──────────────────────┴──────────────────────
+```


### PR DESCRIPTION
1. Add `cpu_time` to `ps -l` output

The cpu time includes both user + system time. I believe this matches the Unix `ps` `time` column.

![image](https://user-images.githubusercontent.com/6572184/92345748-7a349280-f07f-11ea-9e3a-d592875c1b2c.png)


Example command to find processes with the highest cpu time:

`ps -l | sort-by cpu_time | last 10`

![image](https://user-images.githubusercontent.com/6572184/92345552-a7347580-f07e-11ea-983b-1b37551075b6.png)