### PR TITLE
updated dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,9 +243,9 @@ checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-trait"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -290,7 +290,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.1",
  "object",
  "rustc-demangle",
 ]
@@ -559,9 +559,12 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byte-unit"
-version = "3.1.4"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415301c9de11005d4b92193c0eb7ac7adc37e5a49e0ac9bed0a42343512744b8"
+checksum = "1c8758c32833faaae35b24a73d332e62d0528e89076ae841c63940e37008b153"
+dependencies = [
+ "utf8-width",
+]
 
 [[package]]
 name = "byteorder"
@@ -782,17 +785,17 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
 dependencies = [
  "lazy_static 1.4.0",
- "nom 4.2.3",
+ "nom 5.1.2",
  "rust-ini",
  "serde 1.0.115",
- "serde-hjson 0.8.2",
+ "serde-hjson",
  "serde_json",
- "toml 0.4.10",
+ "toml",
  "yaml-rust",
 ]
 
@@ -966,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4919d60f26ae233e14233cc39746c8c8bb8cd7b05840ace83604917b51b6c7"
+checksum = "858085e389f71d31a6909f2b55a56b87d1cb8b168c0f513dcbed5e66a3e1039c"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -1164,16 +1167,6 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d337a64190607d4fcca2cb78982c5dd57f4916e19696b48a575fa746b6cb0f"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "directories"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
@@ -1183,14 +1176,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "1.0.5"
+name = "directories"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
 dependencies = [
- "libc",
- "redox_users",
- "winapi 0.3.9",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1200,6 +1191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
  "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
  "dirs-sys",
 ]
 
@@ -1389,7 +1389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1465,20 +1465,20 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.17"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
+checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.3.7",
 ]
 
 [[package]]
@@ -1501,6 +1501,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
 
 [[package]]
 name = "fs_extra"
@@ -1778,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1823,9 +1833,9 @@ checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "git2"
-version = "0.13.10"
+version = "0.13.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d97249f21e9542caeee9f8e1d150905cd875bf723f5ff771bdb4852eb83a24"
+checksum = "1e094214efbc7fdbbdee952147e493b00e99a4e52817492277e98967ae918165"
 dependencies = [
  "bitflags",
  "libc",
@@ -1875,12 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
-dependencies = [
- "autocfg 1.0.1",
-]
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "heim"
@@ -2264,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
@@ -2337,18 +2344,6 @@ dependencies = [
  "log 0.4.11",
  "slab 0.4.2",
  "sluice",
-]
-
-[[package]]
-name = "isatty"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2466,6 +2461,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec 0.5.1",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,9 +2481,9 @@ checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.12+1.0.1"
+version = "0.12.13+1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0100ae90655025134424939f1f60e27e879460d451dff6afedde4f8226cbebfc"
+checksum = "069eea34f76ec15f2822ccf78fe0cdb8c9016764d0a12865278585a74dbdeae5"
 dependencies = [
  "cc",
  "libc",
@@ -2757,6 +2765,15 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
@@ -2951,12 +2968,13 @@ checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
  "memchr",
- "version_check 0.1.5",
+ "version_check",
 ]
 
 [[package]]
@@ -3006,7 +3024,7 @@ dependencies = [
  "quick-xml 0.18.1",
  "semver 0.10.0",
  "serde 1.0.115",
- "toml 0.5.6",
+ "toml",
  "url 2.1.1",
 ]
 
@@ -3031,8 +3049,8 @@ dependencies = [
  "csv",
  "ctrlc",
  "derive-new",
- "directories 2.0.2",
- "dirs 2.0.2",
+ "directories 3.0.1",
+ "dirs 3.0.1",
  "dtparse",
  "dunce",
  "eml-parser",
@@ -3083,11 +3101,11 @@ dependencies = [
  "rust-embed",
  "rustyline",
  "serde 1.0.115",
- "serde-hjson 0.9.1",
+ "serde-hjson",
  "serde_bytes",
  "serde_ini",
  "serde_json",
- "serde_urlencoded 0.6.1",
+ "serde_urlencoded 0.7.0",
  "serde_yaml",
  "sha2 0.9.1",
  "shellexpand",
@@ -3096,7 +3114,7 @@ dependencies = [
  "term",
  "term_size",
  "termcolor",
- "toml 0.5.6",
+ "toml",
  "trash",
  "typetag",
  "umask",
@@ -3118,8 +3136,8 @@ dependencies = [
  "byte-unit",
  "chrono",
  "derive-new",
- "directories 2.0.2",
- "dirs 2.0.2",
+ "directories 3.0.1",
+ "dirs 3.0.1",
  "getset",
  "indexmap",
  "log 0.4.11",
@@ -3134,7 +3152,7 @@ dependencies = [
  "parking_lot 0.11.0",
  "query_interface",
  "serde 1.0.115",
- "toml 0.5.6",
+ "toml",
  "umask",
  "users",
 ]
@@ -3155,7 +3173,7 @@ dependencies = [
  "serde 1.0.115",
  "serde_json",
  "serde_yaml",
- "toml 0.5.6",
+ "toml",
 ]
 
 [[package]]
@@ -3217,7 +3235,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_yaml",
- "toml 0.5.6",
+ "toml",
  "typetag",
 ]
 
@@ -3245,7 +3263,7 @@ dependencies = [
 name = "nu-test-support"
 version = "0.19.0"
 dependencies = [
- "directories 2.0.2",
+ "directories 3.0.1",
  "dunce",
  "getset",
  "glob",
@@ -3734,12 +3752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordermap"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-
-[[package]]
 name = "parking"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3902,12 +3914,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.4.13"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset",
- "ordermap",
+ "indexmap",
 ]
 
 [[package]]
@@ -3981,12 +3993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "podio"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
-
-[[package]]
 name = "polling"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "pretty-hex"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be91bcc43e73799dc46a6c194a55e7aae1d86cc867c860fd4a436019af21bd8c"
+checksum = "c8a6a27f79f3ec19193cd2ecfe9b73276b79026529466aef45d70d0f9eca651b"
 
 [[package]]
 name = "pretty_env_logger"
@@ -4035,7 +4041,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml 0.5.6",
+ "toml",
 ]
 
 [[package]]
@@ -4048,7 +4054,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -4059,7 +4065,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -4109,18 +4115,17 @@ dependencies = [
 
 [[package]]
 name = "ptree"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0a3be00b19ee7bd33238c1c523a7ab4df697345f6b36f90827a7860ea938d4"
+checksum = "828735579562f9be5e3a605016076cc47d7da3c29bf40aa44da28f161cb7f3c0"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term 0.12.1",
+ "atty",
  "config",
- "directories 1.0.2",
- "isatty",
+ "directories 2.0.2",
  "petgraph",
  "serde 1.0.115",
  "serde-value",
- "serde_derive",
  "tint",
 ]
 
@@ -4873,19 +4878,6 @@ dependencies = [
 
 [[package]]
 name = "serde-hjson"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b833c5ad67d52ced5f5938b2980f32a9c1c5ef047f0b4fb3127e7a423c76153"
-dependencies = [
- "lazy_static 0.2.11",
- "linked-hash-map 0.3.0",
- "num-traits 0.1.43",
- "regex 1.3.9",
- "serde 0.8.23",
-]
-
-[[package]]
-name = "serde-hjson"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
@@ -4899,9 +4891,9 @@ dependencies = [
 
 [[package]]
 name = "serde-value"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
+checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 dependencies = [
  "ordered-float",
  "serde 1.0.115",
@@ -4981,6 +4973,18 @@ dependencies = [
  "itoa",
  "serde 1.0.115",
  "url 2.1.1",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde 1.0.115",
 ]
 
 [[package]]
@@ -5153,6 +5157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "std_prelude"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5272,12 +5282,11 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
- "byteorder",
- "dirs 1.0.5",
+ "dirs 2.0.2",
  "winapi 0.3.9",
 ]
 
@@ -5633,15 +5642,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-dependencies = [
- "serde 1.0.115",
-]
-
-[[package]]
-name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
@@ -5739,7 +5739,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -5857,6 +5857,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
+
+[[package]]
 name = "utf8parse"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5915,15 +5921,9 @@ dependencies = [
  "regex 1.3.9",
  "semver-parser 0.9.0",
  "syn",
- "toml 0.5.6",
+ "toml",
  "url 2.1.1",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -6237,13 +6237,14 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58287c28d78507f5f91f2a4cf1e8310e2c76fd4c6932f93ac60fd1ceb402db7d"
+checksum = "d30de6e58104bb7b9a94f34b52a2bdabb8a40b678a64201cd0069e3d7119b5ff"
 dependencies = [
+ "byteorder",
  "bzip2",
  "crc32fast",
  "flate2",
- "podio",
+ "thiserror",
  "time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,15 @@ nu_plugin_to_bson = {version = "0.19.0", path = "./crates/nu_plugin_to_bson", op
 nu_plugin_to_sqlite = {version = "0.19.0", path = "./crates/nu_plugin_to_sqlite", optional = true}
 nu_plugin_tree = {version = "0.19.0", path = "./crates/nu_plugin_tree", optional = true}
 
-crossterm = {version = "0.17.5", optional = true}
-semver = {version = "0.10.0", optional = true}
-url = {version = "2.1.1", optional = true}
+crossterm = { version = "0.17.8", optional = true }
+semver = { version = "0.10.0", optional = true }
+url = { version = "2.1.1", optional = true }
 
-clap = "2.33.1"
-ctrlc = "3.1.4"
+clap = "2.33.3"
+ctrlc = "3.1.6"
 dunce = "1.0.1"
-futures = {version = "0.3", features = ["compat", "io-compat"]}
-log = "0.4.8"
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
+log = "0.4.11"
 pretty_env_logger = "0.4.0"
 quick-xml = "0.18.1"
 
@@ -59,7 +59,7 @@ quick-xml = "0.18.1"
 nu-test-support = {version = "0.19.0", path = "./crates/nu-test-support"}
 
 [build-dependencies]
-serde = {version = "1.0.110", features = ["derive"]}
+serde = { version = "1.0.115", features = ["derive"] }
 toml = "0.5.6"
 
 [features]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -21,68 +21,68 @@ nu-test-support = {version = "0.19.0", path = "../nu-test-support"}
 nu-value-ext = {version = "0.19.0", path = "../nu-value-ext"}
 
 ansi_term = "0.12.1"
-app_dirs = {version = "2", package = "app_dirs2"}
+app_dirs = { version = "2.3.0", package = "app_dirs2" }
 async-recursion = "0.3.1"
-async-trait = "0.1.36"
+async-trait = "0.1.40"
 base64 = "0.12.3"
-bigdecimal = {version = "0.1.2", features = ["serde"]}
-byte-unit = "3.1.3"
-bytes = "0.5.5"
-calamine = "0.16"
-chrono = {version = "0.4.11", features = ["serde"]}
-clap = "2.33.1"
+bigdecimal = { version = "0.1.2", features = ["serde"] }
+byte-unit = "4.0.9"
+bytes = "0.5.6"
+calamine = "0.16.1"
+chrono = { version = "0.4.15", features = ["serde"] }
+clap = "2.33.3"
 codespan-reporting = "0.9.5"
-csv = "1.1"
-ctrlc = {version = "3.1.4", optional = true}
+csv = "1.1.3"
+ctrlc = { version = "3.1.6", optional = true }
 derive-new = "0.5.8"
-directories = {version = "2.0.2", optional = true}
-dirs = {version = "2.0.2", optional = true}
+directories = { version = "3.0.1", optional = true }
+dirs = { version = "3.0.1", optional = true }
 dtparse = "1.1.0"
 dunce = "1.0.1"
 eml-parser = "0.1.0"
 filesize = "0.2.0"
 fs_extra = "1.2.0"
-futures = {version = "0.3", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 futures-util = "0.3.5"
-futures_codec = "0.4"
+futures_codec = "0.4.1"
 getset = "0.1.1"
-git2 = {version = "0.13.6", default_features = false, optional = true}
+git2 = { version = "0.13.11", default_features = false, optional = true }
 glob = "0.3.0"
-hex = "0.4"
+hex = "0.4.2"
 htmlescape = "0.3.1"
-ical = "0.6.*"
-ichwh = {version = "0.3.4", optional = true}
-indexmap = {version = "1.4.0", features = ["serde-1"]}
+ical = "0.6.0"
+ichwh = { version = "0.3.4", optional = true }
+indexmap = { version = "1.6.0", features = ["serde-1"] }
 itertools = "0.9.0"
-log = "0.4.8"
-meval = "0.2"
+log = "0.4.11"
+meval = "0.2.0"
 natural = "0.5.0"
-num-bigint = {version = "0.2.6", features = ["serde"]}
-num-format = {version = "0.4", features = ["with-num-bigint"]}
-num-traits = "0.2.11"
+num-bigint = { version = "0.2.6", features = ["serde"] }
+num-format = { version = "0.4.0", features = ["with-num-bigint"] }
+num-traits = "0.2.12"
 parking_lot = "0.11.0"
 pin-utils = "0.1.0"
-pretty-hex = "0.1.1"
+pretty-hex = "0.2.0"
 pretty_env_logger = "0.4.0"
-ptree = {version = "0.2", optional = true}
+ptree = { version = "0.3.0", optional = true }
 query_interface = "0.3.5"
-rand = "0.7"
-regex = "1"
+rand = "0.7.3"
+regex = "1.3.9"
 roxmltree = "0.13.0"
 rust-embed = "5.6.0"
 rustyline = "6.2.0"
-serde = {version = "1.0.114", features = ["derive"]}
+serde = { version = "1.0.115", features = ["derive"] }
 serde-hjson = "0.9.1"
 serde_bytes = "0.11.5"
 serde_ini = "0.2.0"
-serde_json = "1.0.55"
-serde_urlencoded = "0.6.1"
-serde_yaml = "0.8"
+serde_json = "1.0.57"
+serde_urlencoded = "0.7.0"
+serde_yaml = "0.8.13"
 sha2 = "0.9.1"
 shellexpand = "2.0.0"
 strip-ansi-escapes = "0.1.0"
 tempfile = "3.1.0"
-term = {version = "0.5.2", optional = true}
+term = { version = "0.6.1", optional = true }
 term_size = "0.3.2"
 termcolor = "1.1.0"
 toml = "0.5.6"
@@ -90,16 +90,16 @@ typetag = "0.1.5"
 umask = "1.0.0"
 unicode-segmentation = "1.6.0"
 unicode-xid = "0.2.1"
-uuid_crate = {package = "uuid", version = "0.8.1", features = ["v4"], optional = true}
-which = {version = "4.0.2", optional = true}
-zip = {version = "0.5.6", optional = true}
+uuid_crate = { package = "uuid", version = "0.8.1", features = ["v4"], optional = true }
+which = { version = "4.0.2", optional = true }
+zip = { version = "0.5.7", optional = true }
 
-clipboard = {version = "0.5", optional = true}
-encoding_rs = "0.8.23"
+clipboard = { version = "0.5.0", optional = true }
+encoding_rs = "0.8.24"
 quick-xml = "0.18.1"
-rayon = "1.3.1"
-trash = {version = "1.0.1", optional = true}
-url = {version = "2.1.1"}
+rayon = "1.4.0"
+trash = { version = "1.1.1", optional = true }
+url = "2.1.1"
 Inflector = "0.11"
 
 [target.'cfg(unix)'.dependencies]
@@ -117,12 +117,12 @@ optional = true
 version = "0.23.1"
 
 [build-dependencies]
-git2 = {version = "0.13", optional = true}
+git2 = { version = "0.13.11", optional = true }
 
 
 [dev-dependencies]
-quickcheck = "0.9"
-quickcheck_macros = "0.9"
+quickcheck = "0.9.2"
+quickcheck_macros = "0.9.1"
 
 [features]
 clipboard-cli = ["clipboard"]

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -12,21 +12,21 @@ doctest = false
 [dependencies]
 ansi_term = "0.12.1"
 bigdecimal = "0.1.2"
-byte-unit = "3.1.3"
+byte-unit = "4.0.9"
 
 chrono = "0.4.15"
 derive-new = "0.5.8"
-directories = {version = "2.0.2", optional = true}
-dirs = {version = "2.0.2", optional = true}
+directories = { version = "3.0.1", optional = true }
+dirs = { version = "3.0.1", optional = true }
 getset = "0.1.1"
-indexmap = {version = "1.4.0", features = ["serde-1"]}
-log = "0.4.8"
-num-bigint = {version = "0.2.6", features = ["serde"]}
-num-format = {version = "0.4", features = ["with-num-bigint"]}
-num-traits = "0.2.11"
+indexmap = { version = "1.6.0", features = ["serde-1"] }
+log = "0.4.11"
+num-bigint = { version = "0.2.6", features = ["serde"] }
+num-format = { version = "0.4.0", features = ["with-num-bigint"] }
+num-traits = "0.2.12"
 parking_lot = "0.11.0"
 query_interface = "0.3.5"
-serde = {version = "1.0.114", features = ["derive"]}
+serde = { version = "1.0.115", features = ["derive"] }
 toml = "0.5.6"
 umask = "1.0.0"
 

--- a/crates/nu-errors/Cargo.toml
+++ b/crates/nu-errors/Cargo.toml
@@ -13,18 +13,18 @@ doctest = false
 nu-source = {path = "../nu-source", version = "0.19.0"}
 
 ansi_term = "0.12.1"
-bigdecimal = {version = "0.1.2", features = ["serde"]}
-codespan-reporting = {version = "0.9.5", features = ["serialization"]}
+bigdecimal = { version = "0.1.2", features = ["serde"] }
+codespan-reporting = { version = "0.9.5", features = ["serialization"] }
 derive-new = "0.5.8"
 getset = "0.1.1"
-num-bigint = {version = "0.2.6", features = ["serde"]}
+num-bigint = { version = "0.2.6", features = ["serde"] }
 num-traits = "0.2.12"
-serde = {version = "1.0.114", features = ["derive"]}
+serde = { version = "1.0.115", features = ["derive"] }
 
 # implement conversions
 glob = "0.3.0"
-serde_json = "1.0.55"
-serde_yaml = "0.8"
+serde_json = "1.0.57"
+serde_yaml = "0.8.13"
 toml = "0.5.6"
 
 [build-dependencies]

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -9,15 +9,15 @@ version = "0.19.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bigdecimal = {version = "0.1.2", features = ["serde"]}
+bigdecimal = { version = "0.1.2", features = ["serde"] }
 codespan-reporting = "0.9.5"
 derive-new = "0.5.8"
-indexmap = {version = "1.4.0", features = ["serde-1"]}
-log = "0.4.8"
-num-bigint = {version = "0.2.6", features = ["serde"]}
+indexmap = { version = "1.6.0", features = ["serde-1"] }
+log = "0.4.11"
+num-bigint = { version = "0.2.6", features = ["serde"] }
 num-traits = "0.2.12"
 parking_lot = "0.11.0"
-serde = "1.0.114"
+serde = "1.0.115"
 shellexpand = "2.0.0"
 
 nu-errors = {version = "0.19.0", path = "../nu-errors"}

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -15,10 +15,10 @@ nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 nu-value-ext = {path = "../nu-value-ext", version = "0.19.0"}
 
-bigdecimal = {version = "0.1.2", features = ["serde"]}
-indexmap = {version = "1.4.0", features = ["serde-1"]}
-num-bigint = {version = "0.2.6", features = ["serde"]}
-serde = {version = "1.0.114", features = ["derive"]}
-serde_json = "1.0.55"
+bigdecimal = { version = "0.1.2", features = ["serde"] }
+indexmap = { version = "1.6.0", features = ["serde-1"] }
+num-bigint = { version = "0.2.6", features = ["serde"] }
+serde = { version = "1.0.115", features = ["derive"] }
+serde_json = "1.0.57"
 
 [build-dependencies]

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -11,29 +11,29 @@ doctest = false
 
 [dependencies]
 ansi_term = "0.12.1"
-bigdecimal = {version = "0.1.2", features = ["serde"]}
-byte-unit = "3.1.3"
-chrono = {version = "0.4.11", features = ["serde"]}
+bigdecimal = { version = "0.1.2", features = ["serde"] }
+byte-unit = "4.0.9"
+chrono = { version = "0.4.15", features = ["serde"] }
 codespan-reporting = "0.9.5"
 derive-new = "0.5.8"
 getset = "0.1.1"
-indexmap = {version = "1.4.0", features = ["serde-1"]}
+indexmap = { version = "1.6.0", features = ["serde-1"] }
 itertools = "0.9.0"
-log = "0.4.8"
+log = "0.4.11"
 natural = "0.5.0"
 nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
-num-bigint = {version = "0.2.6", features = ["serde"]}
-num-integer = "0.1.42"
+num-bigint = { version = "0.2.6", features = ["serde"] }
+num-integer = "0.1.43"
 num-traits = "0.2.12"
 query_interface = "0.3.5"
-serde = {version = "1.0.114", features = ["derive"]}
+serde = { version = "1.0.115", features = ["derive"] }
 serde_bytes = "0.11.5"
 typetag = "0.1.5"
 
 # implement conversions
-serde_json = "1.0.55"
-serde_yaml = "0.8"
+serde_json = "1.0.57"
+serde_yaml = "0.8.13"
 toml = "0.5.6"
 
 [build-dependencies]

--- a/crates/nu-source/Cargo.toml
+++ b/crates/nu-source/Cargo.toml
@@ -14,7 +14,7 @@ codespan-reporting = "0.9.5"
 derive-new = "0.5.8"
 getset = "0.1.1"
 pretty = "0.5.2"
-serde = {version = "1.0.114", features = ["derive"]}
+serde = { version = "1.0.115", features = ["derive"] }
 termcolor = "1.1.0"
 
 [build-dependencies]

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/main.rs"
 
 [dependencies]
 ansi_term = "0.12.1"
-unicode-width = "0.1.7"
+unicode-width = "0.1.8"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -14,11 +14,11 @@ nu-parser = {path = "../nu-parser", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 
-directories = "2.0.2"
+directories = "3.0.1"
 dunce = "1.0.1"
 getset = "0.1.1"
 glob = "0.3.0"
-indexmap = {version = "1.4.0", features = ["serde-1"]}
+indexmap = { version = "1.6.0", features = ["serde-1"] }
 tempfile = "3.1.0"
 
 [build-dependencies]

--- a/crates/nu-value-ext/Cargo.toml
+++ b/crates/nu-value-ext/Cargo.toml
@@ -15,7 +15,7 @@ nu-parser = {path = "../nu-parser", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 
-indexmap = {version = "1.4.0", features = ["serde-1"]}
+indexmap = { version = "1.6.0", features = ["serde-1"] }
 itertools = "0.9.0"
 num-traits = "0.2.12"
 

--- a/crates/nu_plugin_binaryview/Cargo.toml
+++ b/crates/nu_plugin_binaryview/Cargo.toml
@@ -11,14 +11,14 @@ doctest = false
 
 [dependencies]
 ansi_term = "0.12.1"
-crossterm = {version = "0.17.5"}
-image = {version = "0.22.4", default_features = false, features = ["png_codec", "jpeg"]}
+crossterm = "0.17.8"
+image = { version = "0.22.4", default_features = false, features = ["png_codec", "jpeg"] }
 neso = "0.5.0"
 nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
-pretty-hex = "0.1.1"
+pretty-hex = "0.2.0"
 rawkey = "0.1.2"
 
 [build-dependencies]

--- a/crates/nu_plugin_fetch/Cargo.toml
+++ b/crates/nu_plugin_fetch/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 base64 = "0.12.3"
-futures = {version = "0.3", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}

--- a/crates/nu_plugin_from_bson/Cargo.toml
+++ b/crates/nu_plugin_from_bson/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 bigdecimal = "0.1.2"
-bson = {version = "0.14.1", features = ["decimal128"]}
+bson = { version = "0.14.1", features = ["decimal128"] }
 nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}

--- a/crates/nu_plugin_match/Cargo.toml
+++ b/crates/nu_plugin_match/Cargo.toml
@@ -10,11 +10,11 @@ version = "0.19.0"
 doctest = false
 
 [dependencies]
-futures = {version = "0.3", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
-regex = "1"
+regex = "1.3.9"
 
 [build-dependencies]

--- a/crates/nu_plugin_post/Cargo.toml
+++ b/crates/nu_plugin_post/Cargo.toml
@@ -11,13 +11,13 @@ doctest = false
 
 [dependencies]
 base64 = "0.12.3"
-futures = {version = "0.3", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 num-traits = "0.2.12"
-serde_json = "1.0.55"
+serde_json = "1.0.57"
 surf = "1.0.3"
 url = "2.1.1"
 

--- a/crates/nu_plugin_ps/Cargo.toml
+++ b/crates/nu_plugin_ps/Cargo.toml
@@ -17,7 +17,7 @@ nu-source = {path = "../nu-source", version = "0.19.0"}
 
 num-bigint = "0.2.6"
 
-futures = {version = "0.3", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 futures-timer = "3.0.2"
 
 [dependencies.heim]

--- a/crates/nu_plugin_s3/Cargo.toml
+++ b/crates/nu_plugin_s3/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.19.0"
 doctest = false
 
 [dependencies]
-futures = {version = "0.3", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}

--- a/crates/nu_plugin_sys/Cargo.toml
+++ b/crates/nu_plugin_sys/Cargo.toml
@@ -16,7 +16,7 @@ nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 
 battery = "0.7.6"
-futures = {version = "0.3", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 futures-util = "0.3.5"
 num-bigint = "0.2.6"
 

--- a/crates/nu_plugin_textview/Cargo.toml
+++ b/crates/nu_plugin_textview/Cargo.toml
@@ -17,7 +17,7 @@ nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 
 ansi_term = "0.12.1"
-bat = {version = "0.15.4", features = ["regex-fancy", "paging"]}
+bat = { version = "0.15.4", features = ["regex-fancy", "paging"] }
 term_size = "0.3.2"
 url = "2.1.1"
 

--- a/crates/nu_plugin_tree/Cargo.toml
+++ b/crates/nu_plugin_tree/Cargo.toml
@@ -15,6 +15,6 @@ nu-errors = {path = "../nu-errors", version = "0.19.0"}
 nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
-ptree = {version = "0.2"}
+ptree = "0.3.0"
 
 [build-dependencies]


### PR DESCRIPTION
Using `cargo upgrade --workspace` I updated all the dependencies at once. There were lots of problems compiling afterward but I reversed the problem children and left those "hard ones" for @jonathandturner :) But a lot got upgraded.

The "hard ones" are [listed here](https://gist.githubusercontent.com/fdncred/a7aecb56193285968bc8a412082ab35b/raw/bb899c65802ad32d335cc81c0642861f83f65001/depends_to_fix.txt).
