### PR TITLE
Fix path completions for `cd` command.

### DIFF
--- a/crates/nu-cli/src/completion/path.rs
+++ b/crates/nu-cli/src/completion/path.rs
@@ -70,11 +70,4 @@ impl Completer {
             Vec::new()
         }
     }
-
-    pub fn complete(&self, ctx: &Context<'_>, partial: &str) -> Vec<Suggestion> {
-        self.path_suggestions(ctx, partial)
-            .into_iter()
-            .map(|v| v.suggestion)
-            .collect()
-    }
 }


### PR DESCRIPTION
Previously, we weren't expanding `~`, so `std::fs::metadata` was failing. We now make use of `PathSuggestion` to get the actual path, as represented by a `PathBuf`. This allows us to fetch the metadata and properly filter out anything that isn't a directory.