### PR TITLE
accept multiple variables in with-env(#2490)

### DIFF
--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -46,16 +46,18 @@ impl WholeStreamCommand for WithEnv {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Set the MYENV environment variable",
-            example: r#"with-env [MYENV "my env value"] { echo $nu.env.MYENV }"#,
-            result: Some(vec![Value::from("my env value")]),
-        },
-        Example {
-            description: "Set multiple environment variables",
-            example: r#"with-env [X Y W Z] { echo $nu.env.X $nu.env.W }"#,
-            result: Some(vec![Value::from("Y"), Value::from("Z")]),
-        }]
+        vec![
+            Example {
+                description: "Set the MYENV environment variable",
+                example: r#"with-env [MYENV "my env value"] { echo $nu.env.MYENV }"#,
+                result: Some(vec![Value::from("my env value")]),
+            },
+            Example {
+                description: "Set multiple environment variables",
+                example: r#"with-env [X Y W Z] { echo $nu.env.X $nu.env.W }"#,
+                result: Some(vec![Value::from("Y"), Value::from("Z")]),
+            },
+        ]
     }
 }
 

--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -9,7 +9,7 @@ pub struct WithEnv;
 
 #[derive(Deserialize, Debug)]
 struct WithEnvArgs {
-    variable: (Tagged<String>, Tagged<String>),
+    variable: Vec<Tagged<String>>,
     block: Block,
 }
 
@@ -64,7 +64,11 @@ async fn with_env(
     let mut scope = raw_args.call_info.scope.clone();
     let (WithEnvArgs { variable, block }, input) = raw_args.process(&registry).await?;
 
-    scope.env.insert(variable.0.item, variable.1.item);
+    for v in variable.chunks(2) {
+        if v.len() == 2 {
+            scope.env.insert(v[0].item.clone(), v[1].item.clone());
+        }
+    }
 
     let result = run_block(
         &block,

--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -50,6 +50,11 @@ impl WholeStreamCommand for WithEnv {
             description: "Set the MYENV environment variable",
             example: r#"with-env [MYENV "my env value"] { echo $nu.env.MYENV }"#,
             result: Some(vec![Value::from("my env value")]),
+        },
+        Example {
+            description: "Set multiple environment variables",
+            example: r#"with-env [X Y W Z] { echo $nu.env.X $nu.env.W }"#,
+            result: Some(vec![Value::from("Y"), Value::from("Z")]),
         }]
     }
 }


### PR DESCRIPTION
This PR accepts multiple environment variables in `with-env`.

If this PR will be merged, you can set temporary environment variables in one `with-env` command like following;
```
with-env [ X Y W Z ] { echo $nu.env.X $nu.env.W | to json}
// this will output ["Y", "Z"]
```