### PR TITLE
Allow `math avg` to work on durations

### DIFF
--- a/crates/nu-cli/src/commands/math/avg.rs
+++ b/crates/nu-cli/src/commands/math/avg.rs
@@ -70,16 +70,6 @@ fn to_byte(value: &Value) -> Option<Value> {
     }
 }
 
-fn to_duration(value: &Value) -> Option<Value> {
-    match &value.value {
-        UntaggedValue::Primitive(Primitive::Int(duration)) => Some(
-            UntaggedValue::Primitive(Primitive::Duration((*duration).clone()))
-                .into_untagged_value(),
-        ),
-        _ => None,
-    }
-}
-
 pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
     let sum = reducer_for(Reduce::Summation);
 
@@ -96,13 +86,6 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
         })?
         .is_filesize();
 
-    let is_duration = values
-        .get(0)
-        .ok_or_else(|| {
-            ShellError::unexpected("Cannot perform aggregate math operation on empty data")
-        })?
-        .is_duration();
-
     let total = if are_bytes {
         to_byte(&sum(
             UntaggedValue::int(0).into_untagged_value(),
@@ -114,28 +97,6 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                         value: UntaggedValue::Primitive(Primitive::Filesize(num)),
                         ..
                     } => UntaggedValue::int(*num as usize).into_untagged_value(),
-                    other => other.clone(),
-                })
-                .collect::<Vec<_>>(),
-        )?)
-        .ok_or_else(|| {
-            ShellError::labeled_error(
-                "could not convert to big decimal",
-                "could not convert to big decimal",
-                &name.span,
-            )
-        })
-    } else if is_duration {
-        to_duration(&sum(
-            UntaggedValue::int(0).into_untagged_value(),
-            values
-                .to_vec()
-                .iter()
-                .map(|v| match v {
-                    Value {
-                        value: UntaggedValue::Primitive(Primitive::Duration(duration)),
-                        ..
-                    } => UntaggedValue::int((*duration).clone()).into_untagged_value(),
                     other => other.clone(),
                 })
                 .collect::<Vec<_>>(),

--- a/crates/nu-cli/src/commands/math/avg.rs
+++ b/crates/nu-cli/src/commands/math/avg.rs
@@ -73,10 +73,8 @@ fn to_byte(value: &Value) -> Option<Value> {
 fn to_duration(value: &Value) -> Option<Value> {
     match &value.value {
         UntaggedValue::Primitive(Primitive::Int(duration)) => Some(
-            UntaggedValue::Primitive(Primitive::Duration(
-                BigInt::from((*duration).clone())
-            ))
-            .into_untagged_value(),
+            UntaggedValue::Primitive(Primitive::Duration(BigInt::from((*duration).clone())))
+                .into_untagged_value(),
         ),
         _ => None,
     }

--- a/crates/nu-cli/src/commands/math/avg.rs
+++ b/crates/nu-cli/src/commands/math/avg.rs
@@ -73,7 +73,7 @@ fn to_byte(value: &Value) -> Option<Value> {
 fn to_duration(value: &Value) -> Option<Value> {
     match &value.value {
         UntaggedValue::Primitive(Primitive::Int(duration)) => Some(
-            UntaggedValue::Primitive(Primitive::Duration(BigInt::from((*duration).clone())))
+            UntaggedValue::Primitive(Primitive::Duration((*duration).clone()))
                 .into_untagged_value(),
         ),
         _ => None,
@@ -180,7 +180,7 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
             value: UntaggedValue::Primitive(Primitive::Duration(duration)),
             ..
         } => {
-            let left = UntaggedValue::from(Primitive::Duration(duration.into()));
+            let left = UntaggedValue::from(Primitive::Duration(duration));
             let result = nu_data::value::compute_values(Operator::Divide, &left, &total_rows);
 
             match result {

--- a/crates/nu-cli/src/commands/math/sum.rs
+++ b/crates/nu-cli/src/commands/math/sum.rs
@@ -103,10 +103,7 @@ pub fn summation(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                 &name.span,
             )
         }),
-        v if v.is_duration() => sum(
-            UntaggedValue::int(0).into_untagged_value(),
-            values.to_vec(),
-        ),
+        v if v.is_duration() => sum(UntaggedValue::int(0).into_untagged_value(), values.to_vec()),
         // v is nothing primitive
         v if v.is_none() => sum(
             UntaggedValue::int(0).into_untagged_value(),

--- a/crates/nu-cli/src/commands/math/sum.rs
+++ b/crates/nu-cli/src/commands/math/sum.rs
@@ -74,16 +74,6 @@ fn to_byte(value: &Value) -> Option<Value> {
     }
 }
 
-fn to_duration(value: &Value) -> Option<Value> {
-    match &value.value {
-        UntaggedValue::Primitive(Primitive::Int(duration)) => Some(
-            UntaggedValue::Primitive(Primitive::Duration((*duration).clone()))
-                .into_untagged_value(),
-        ),
-        _ => None,
-    }
-}
-
 pub fn summation(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
     let sum = reducer_for(Reduce::Summation);
 
@@ -113,27 +103,10 @@ pub fn summation(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                 &name.span,
             )
         }),
-        v if v.is_duration() => to_duration(&sum(
+        v if v.is_duration() => sum(
             UntaggedValue::int(0).into_untagged_value(),
-            values
-                .to_vec()
-                .iter()
-                .map(|v| match v {
-                    Value {
-                        value: UntaggedValue::Primitive(Primitive::Duration(duration)),
-                        ..
-                    } => UntaggedValue::int((*duration).clone()).into_untagged_value(),
-                    other => other.clone(),
-                })
-                .collect::<Vec<_>>(),
-        )?)
-        .ok_or_else(|| {
-            ShellError::labeled_error(
-                "could not convert to big decimal",
-                "could not convert to big decimal",
-                &name.span,
-            )
-        }),
+            values.to_vec(),
+        ),
         // v is nothing primitive
         v if v.is_none() => sum(
             UntaggedValue::int(0).into_untagged_value(),

--- a/crates/nu-cli/src/commands/math/sum.rs
+++ b/crates/nu-cli/src/commands/math/sum.rs
@@ -77,7 +77,7 @@ fn to_byte(value: &Value) -> Option<Value> {
 fn to_duration(value: &Value) -> Option<Value> {
     match &value.value {
         UntaggedValue::Primitive(Primitive::Int(duration)) => Some(
-            UntaggedValue::Primitive(Primitive::Duration(BigInt::from((*duration).clone())))
+            UntaggedValue::Primitive(Primitive::Duration((*duration).clone()))
                 .into_untagged_value(),
         ),
         _ => None,

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -212,6 +212,20 @@ pub fn compute_values(
 
                 Ok(UntaggedValue::Primitive(Primitive::Duration(result)))
             }
+            (Primitive::Duration(x), Primitive::Decimal(y)) => {
+                let result = match operator {
+                    Operator::Divide => {
+                        if y.is_zero() {
+                            return Ok(zero_division_error());
+                        }
+                        let y = y.as_bigint_and_exponent();
+                        Ok(x / y.0)
+                    },
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+
+                Ok(UntaggedValue::Primitive(Primitive::Duration(result)))
+            }
             _ => Err((left.type_name(), right.type_name())),
         },
         _ => Err((left.type_name(), right.type_name())),

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -212,6 +212,15 @@ pub fn compute_values(
 
                 Ok(UntaggedValue::Primitive(Primitive::Duration(result)))
             }
+            (Primitive::Int(x), Primitive::Duration(y)) => {
+                let result = match operator {
+                    Operator::Plus => Ok(x + y),
+                    Operator::Minus => Ok(x - y),
+                    _ => Err((left.type_name(), right.type_name())),
+                }?;
+
+                Ok(UntaggedValue::Primitive(Primitive::Duration(result)))
+            }
             (Primitive::Duration(x), Primitive::Decimal(y)) => {
                 let result = match operator {
                     Operator::Divide => {

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -220,7 +220,7 @@ pub fn compute_values(
                         }
                         let y = y.as_bigint_and_exponent();
                         Ok(x / y.0)
-                    },
+                    }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
 

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -83,6 +83,10 @@ impl UntaggedValue {
         matches!(self, UntaggedValue::Primitive(Primitive::Filesize(_)))
     }
 
+    pub fn is_duration(&self) -> bool {
+        matches!(self, UntaggedValue::Primitive(Primitive::Duration(_)))
+    }
+
     /// Returns true if this value represents a table
     pub fn is_table(&self) -> bool {
         matches!(self, UntaggedValue::Table(_))


### PR DESCRIPTION
issue #2511 

Extend `math avg` to be able to handle durations

Example:
`> echo 1sec 1ms | math avg`
`500ms 500us`