### PR TITLE
Set active shell column to boolean

### DIFF
--- a/crates/nu-cli/src/commands/shells.rs
+++ b/crates/nu-cli/src/commands/shells.rs
@@ -37,9 +37,9 @@ fn shells(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream
         let mut dict = TaggedDictBuilder::new(&tag);
 
         if index == (*args.shell_manager.current_shell).load(Ordering::SeqCst) {
-            dict.insert_untagged("active", "X".to_string());
+            dict.insert_untagged("active", true);
         } else {
-            dict.insert_untagged("active", " ".to_string());
+            dict.insert_untagged("active", false);
         }
         dict.insert_untagged("name", shell.name());
         dict.insert_untagged("path", shell.path());

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -136,6 +136,13 @@ impl Primitive {
     }
 }
 
+impl From<bool> for Primitive {
+    /// Helper to convert from boolean to a primitive
+    fn from(b: bool) -> Primitive {
+        Primitive::Boolean(b)
+    }
+}
+
 impl From<&str> for Primitive {
     /// Helper to convert from string slices to a primitive
     fn from(s: &str) -> Primitive {


### PR DESCRIPTION
Closes #2539 

1.  Set active shell column to boolean
2. Helper to convert bool to primitive

`> shells | where active == $true`

![image](https://user-images.githubusercontent.com/6572184/93007192-c87fe080-f51a-11ea-9df3-ec3921283b3d.png)
