### PR TITLE
Implement exclusive and inclusive ranges with ..< and ..

### DIFF
--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -83,8 +83,8 @@ pub(crate) async fn evaluate_baseline_expr(
             let right = (
                 right.as_primitive()?.spanned(right_span),
                 match &range.operator.item {
-                    RangeOperator::DotDot => RangeInclusion::Exclusive,
-                    RangeOperator::DotDotEquals => RangeInclusion::Inclusive,
+                    RangeOperator::Inclusive => RangeInclusion::Inclusive,
+                    RangeOperator::RightExclusive => RangeInclusion::Exclusive,
                 },
             );
 

--- a/crates/nu-cli/src/evaluate/evaluator.rs
+++ b/crates/nu-cli/src/evaluate/evaluator.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use async_recursion::async_recursion;
 use log::trace;
 use nu_errors::{ArgumentError, ShellError};
-use nu_protocol::hir::{self, Expression, ExternalRedirection, SpannedExpression};
+use nu_protocol::hir::{self, Expression, ExternalRedirection, RangeOperator, SpannedExpression};
 use nu_protocol::{
     ColumnPath, Primitive, RangeInclusion, UnspannedPathMember, UntaggedValue, Value,
 };
@@ -82,7 +82,10 @@ pub(crate) async fn evaluate_baseline_expr(
             );
             let right = (
                 right.as_primitive()?.spanned(right_span),
-                RangeInclusion::Inclusive,
+                match &range.operator.item {
+                    RangeOperator::DotDot => RangeInclusion::Exclusive,
+                    RangeOperator::DotDotEquals => RangeInclusion::Inclusive,
+                },
             );
 
             Ok(UntaggedValue::range(left, right).into_value(tag))

--- a/crates/nu-cli/src/shell/palette.rs
+++ b/crates/nu-cli/src/shell/palette.rs
@@ -26,6 +26,7 @@ impl Palette for DefaultPalette {
             }
             FlatShape::Type => single_style_span(Color::Blue.bold(), shape.span),
             FlatShape::Operator => single_style_span(Color::Yellow.normal(), shape.span),
+            FlatShape::DotDotEquals => single_style_span(Color::Yellow.bold(), shape.span),
             FlatShape::DotDot => single_style_span(Color::Yellow.bold(), shape.span),
             FlatShape::Dot => single_style_span(Style::new().fg(Color::White), shape.span),
             FlatShape::InternalCommand => single_style_span(Color::Cyan.bold(), shape.span),
@@ -91,6 +92,7 @@ impl Palette for ThemedPalette {
             FlatShape::Identifier => single_style_span(self.theme.identifier.normal(), shape.span),
             FlatShape::Type => single_style_span(self.theme.r#type.bold(), shape.span),
             FlatShape::Operator => single_style_span(self.theme.operator.normal(), shape.span),
+            FlatShape::DotDotEquals => single_style_span(self.theme.dot_dot.bold(), shape.span),
             FlatShape::DotDot => single_style_span(self.theme.dot_dot.bold(), shape.span),
             FlatShape::Dot => single_style_span(Style::new().fg(*self.theme.dot), shape.span),
             FlatShape::InternalCommand => {

--- a/crates/nu-cli/src/shell/palette.rs
+++ b/crates/nu-cli/src/shell/palette.rs
@@ -26,7 +26,9 @@ impl Palette for DefaultPalette {
             }
             FlatShape::Type => single_style_span(Color::Blue.bold(), shape.span),
             FlatShape::Operator => single_style_span(Color::Yellow.normal(), shape.span),
-            FlatShape::DotDotEquals => single_style_span(Color::Yellow.bold(), shape.span),
+            FlatShape::DotDotLeftAngleBracket => {
+                single_style_span(Color::Yellow.bold(), shape.span)
+            }
             FlatShape::DotDot => single_style_span(Color::Yellow.bold(), shape.span),
             FlatShape::Dot => single_style_span(Style::new().fg(Color::White), shape.span),
             FlatShape::InternalCommand => single_style_span(Color::Cyan.bold(), shape.span),
@@ -92,7 +94,9 @@ impl Palette for ThemedPalette {
             FlatShape::Identifier => single_style_span(self.theme.identifier.normal(), shape.span),
             FlatShape::Type => single_style_span(self.theme.r#type.bold(), shape.span),
             FlatShape::Operator => single_style_span(self.theme.operator.normal(), shape.span),
-            FlatShape::DotDotEquals => single_style_span(self.theme.dot_dot.bold(), shape.span),
+            FlatShape::DotDotLeftAngleBracket => {
+                single_style_span(self.theme.dot_dot.bold(), shape.span)
+            }
             FlatShape::DotDot => single_style_span(self.theme.dot_dot.bold(), shape.span),
             FlatShape::Dot => single_style_span(Style::new().fg(*self.theme.dot), shape.span),
             FlatShape::InternalCommand => {

--- a/crates/nu-cli/tests/commands/str_/collect.rs
+++ b/crates/nu-cli/tests/commands/str_/collect.rs
@@ -5,7 +5,7 @@ fn test_1() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1..=5 | str from | str collect 
+        echo 1..5 | str from | str collect 
         "#
         )
     );
@@ -44,7 +44,7 @@ fn sum_one_to_four() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1..=4 | str from | str collect "+" | math eval
+        echo 1..4 | str from | str collect "+" | math eval
         "#
         )
     );

--- a/crates/nu-cli/tests/commands/str_/collect.rs
+++ b/crates/nu-cli/tests/commands/str_/collect.rs
@@ -5,7 +5,7 @@ fn test_1() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1..5 | str from | str collect 
+        echo 1..=5 | str from | str collect 
         "#
         )
     );
@@ -44,7 +44,7 @@ fn sum_one_to_four() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1..4 | str from | str collect "+" | math eval
+        echo 1..=4 | str from | str collect "+" | math eval
         "#
         )
     );

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -142,8 +142,8 @@ impl PrettyDebug for FormatInlineShape {
                 let (right, right_inclusion) = &range.to;
 
                 let op = match (left_inclusion, right_inclusion) {
-                    (RangeInclusion::Inclusive, RangeInclusion::Exclusive) => "..",
-                    (RangeInclusion::Inclusive, RangeInclusion::Inclusive) => "..=",
+                    (RangeInclusion::Inclusive, RangeInclusion::Inclusive) => "..",
+                    (RangeInclusion::Inclusive, RangeInclusion::Exclusive) => "..<",
                     _ => unimplemented!(
                         "No syntax for ranges that aren't inclusive on the left and exclusive \
                          or inclusive on the right"

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -142,8 +142,12 @@ impl PrettyDebug for FormatInlineShape {
                 let (right, right_inclusion) = &range.to;
 
                 let op = match (left_inclusion, right_inclusion) {
-                    (RangeInclusion::Inclusive, RangeInclusion::Inclusive) => "..",
-                    _ => unimplemented!("No syntax for ranges that aren't inclusive on the left and inclusive on the right")
+                    (RangeInclusion::Inclusive, RangeInclusion::Exclusive) => "..",
+                    (RangeInclusion::Inclusive, RangeInclusion::Inclusive) => "..=",
+                    _ => unimplemented!(
+                        "No syntax for ranges that aren't inclusive on the left and exclusive \
+                         or inclusive on the right"
+                    ),
                 };
 
                 left.clone().format().pretty() + b::operator(op) + right.clone().format().pretty()

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -242,10 +242,10 @@ fn parse_range(
 ) -> (SpannedExpression, Option<ParseError>) {
     let lite_arg_span_start = lite_arg.span.start();
     let lite_arg_len = lite_arg.item.len();
-    let (dotdot_pos, operator_str, operator) = if let Some(pos) = lite_arg.item.find("..=") {
-        (pos, "..=", RangeOperator::DotDotEquals)
+    let (dotdot_pos, operator_str, operator) = if let Some(pos) = lite_arg.item.find("..<") {
+        (pos, "..<", RangeOperator::RightExclusive)
     } else if let Some(pos) = lite_arg.item.find("..") {
-        (pos, "..", RangeOperator::DotDot)
+        (pos, "..", RangeOperator::Inclusive)
     } else {
         return (
             garbage(lite_arg.span),

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -5,7 +5,7 @@ use nu_errors::{ArgumentError, ParseError};
 use nu_protocol::hir::{
     self, Binary, Block, ClassifiedBlock, ClassifiedCommand, ClassifiedPipeline, Commands,
     Expression, ExternalRedirection, Flag, FlagKind, InternalCommand, Member, NamedArguments,
-    Operator, SpannedExpression, Unit,
+    Operator, RangeOperator, SpannedExpression, Unit,
 };
 use nu_protocol::{NamedType, PositionalType, Signature, SyntaxShape, UnspannedPathMember};
 use nu_source::{Span, Spanned, SpannedItem};
@@ -242,8 +242,18 @@ fn parse_range(
 ) -> (SpannedExpression, Option<ParseError>) {
     let lite_arg_span_start = lite_arg.span.start();
     let lite_arg_len = lite_arg.item.len();
-    let dotdot_pos = lite_arg.item.find("..");
-    let numbers: Vec<_> = lite_arg.item.split("..").collect();
+    let (dotdot_pos, operator_str, operator) = if let Some(pos) = lite_arg.item.find("..=") {
+        (pos, "..=", RangeOperator::DotDotEquals)
+    } else if let Some(pos) = lite_arg.item.find("..") {
+        (pos, "..", RangeOperator::DotDot)
+    } else {
+        return (
+            garbage(lite_arg.span),
+            Some(ParseError::mismatch("range", lite_arg.clone())),
+        );
+    };
+
+    let numbers: Vec<_> = lite_arg.item.split(operator_str).collect();
 
     if numbers.len() != 2 {
         return (
@@ -252,19 +262,19 @@ fn parse_range(
         );
     }
 
-    let dotdot_pos = dotdot_pos.expect("Internal error: range .. can't be found but should be");
+    let right_number_offset = operator_str.len();
 
     let lhs = numbers[0].to_string().spanned(Span::new(
         lite_arg_span_start,
         lite_arg_span_start + dotdot_pos,
     ));
     let rhs = numbers[1].to_string().spanned(Span::new(
-        lite_arg_span_start + dotdot_pos + 2,
+        lite_arg_span_start + dotdot_pos + right_number_offset,
         lite_arg_span_start + lite_arg_len,
     ));
 
     let left_hand_open = dotdot_pos == 0;
-    let right_hand_open = dotdot_pos == lite_arg_len - 2;
+    let right_hand_open = dotdot_pos == lite_arg_len - right_number_offset;
 
     let left = if left_hand_open {
         None
@@ -292,10 +302,10 @@ fn parse_range(
         SpannedExpression::new(
             Expression::range(
                 left,
-                Span::new(
+                operator.spanned(Span::new(
                     lite_arg_span_start + dotdot_pos,
-                    lite_arg_span_start + dotdot_pos + 2,
-                ),
+                    lite_arg_span_start + dotdot_pos + right_number_offset,
+                )),
                 right,
             ),
             lite_arg.span,

--- a/crates/nu-parser/src/shapes.rs
+++ b/crates/nu-parser/src/shapes.rs
@@ -68,7 +68,13 @@ pub fn expression_to_flat_shape(e: &SpannedExpression) -> Vec<Spanned<FlatShape>
             if let Some(left) = &range.left {
                 output.append(&mut expression_to_flat_shape(left));
             }
-            output.push(FlatShape::DotDot.spanned(range.dotdot));
+            output.push(
+                match &range.operator.item {
+                    RangeOperator::DotDot => FlatShape::DotDot,
+                    RangeOperator::DotDotEquals => FlatShape::DotDotEquals,
+                }
+                .spanned(&range.operator.span),
+            );
             if let Some(right) = &range.right {
                 output.append(&mut expression_to_flat_shape(right));
             }

--- a/crates/nu-parser/src/shapes.rs
+++ b/crates/nu-parser/src/shapes.rs
@@ -70,8 +70,8 @@ pub fn expression_to_flat_shape(e: &SpannedExpression) -> Vec<Spanned<FlatShape>
             }
             output.push(
                 match &range.operator.item {
-                    RangeOperator::DotDot => FlatShape::DotDot,
-                    RangeOperator::DotDotEquals => FlatShape::DotDotEquals,
+                    RangeOperator::Inclusive => FlatShape::DotDot,
+                    RangeOperator::RightExclusive => FlatShape::DotDotLeftAngleBracket,
                 }
                 .spanned(&range.operator.span),
             );

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -906,7 +906,7 @@ impl ShellTypeName for Synthetic {
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize)]
 pub struct Range {
     pub left: Option<SpannedExpression>,
-    pub dotdot: Span,
+    pub operator: Spanned<RangeOperator>,
     pub right: Option<SpannedExpression>,
 }
 
@@ -919,7 +919,7 @@ impl PrettyDebugWithSource for Range {
             } else {
                 DebugDocBuilder::blank()
             }) + b::space()
-                + b::keyword(self.dotdot.slice(source))
+                + b::keyword(self.operator.span().slice(source))
                 + b::space()
                 + (if let Some(right) = &self.right {
                     right.pretty_debug(source)
@@ -930,6 +930,12 @@ impl PrettyDebugWithSource for Range {
         )
         .group()
     }
+}
+
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize)]
+pub enum RangeOperator {
+    DotDot,
+    DotDotEquals,
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize)]
@@ -1107,12 +1113,12 @@ impl Expression {
 
     pub fn range(
         left: Option<SpannedExpression>,
-        dotdot: Span,
+        operator: Spanned<RangeOperator>,
         right: Option<SpannedExpression>,
     ) -> Expression {
         Expression::Range(Box::new(Range {
             left,
-            dotdot,
+            operator,
             right,
         }))
     }
@@ -1291,6 +1297,7 @@ pub enum FlatShape {
     Operator,
     Dot,
     DotDot,
+    DotDotEquals,
     InternalCommand,
     ExternalCommand,
     ExternalWord,

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -934,8 +934,8 @@ impl PrettyDebugWithSource for Range {
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize)]
 pub enum RangeOperator {
-    DotDot,
-    DotDotEquals,
+    Inclusive,
+    RightExclusive,
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize)]
@@ -1297,7 +1297,7 @@ pub enum FlatShape {
     Operator,
     Dot,
     DotDot,
-    DotDotEquals,
+    DotDotLeftAngleBracket,
     InternalCommand,
     ExternalCommand,
     ExternalWord,

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -254,9 +254,9 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
             "{}..{}{}",
             format_primitive(&range.from.0.item, None),
             if range.to.1 == RangeInclusion::Exclusive {
-                ""
+                "<"
             } else {
-                "="
+                ""
             },
             format_primitive(&range.to.0.item, None)
         ),

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -1,6 +1,6 @@
 use crate::type_name::ShellTypeName;
 use crate::value::column_path::ColumnPath;
-use crate::value::range::Range;
+use crate::value::range::{Range, RangeInclusion};
 use crate::value::{serde_bigdecimal, serde_bigint};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
@@ -251,8 +251,13 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
         Primitive::Int(i) => i.to_string(),
         Primitive::Decimal(decimal) => format!("{:.4}", decimal),
         Primitive::Range(range) => format!(
-            "{}..{}",
+            "{}..{}{}",
             format_primitive(&range.from.0.item, None),
+            if &range.to.1 == &RangeInclusion::Exclusive {
+                ""
+            } else {
+                "="
+            },
             format_primitive(&range.to.0.item, None)
         ),
         Primitive::Pattern(s) => s.to_string(),

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -253,7 +253,7 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
         Primitive::Range(range) => format!(
             "{}..{}{}",
             format_primitive(&range.from.0.item, None),
-            if &range.to.1 == &RangeInclusion::Exclusive {
+            if range.to.1 == RangeInclusion::Exclusive {
                 ""
             } else {
                 "="

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -411,7 +411,7 @@ fn echoing_ranges() {
     let actual = nu!(
         cwd: ".",
         r#"
-            echo 1..=3 | math sum
+            echo 1..3 | math sum
         "#
     );
 
@@ -423,7 +423,7 @@ fn echoing_exclusive_ranges() {
     let actual = nu!(
         cwd: ".",
         r#"
-            echo 1..4 | math sum
+            echo 1..<4 | math sum
         "#
     );
 
@@ -471,7 +471,7 @@ fn range_with_left_var() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo [[size]; [3]] | echo $it.size..=10 | math sum
+        echo [[size]; [3]] | echo $it.size..10 | math sum
         "#
     );
 
@@ -483,7 +483,7 @@ fn range_with_right_var() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo [[size]; [30]] | echo 4..=$it.size | math sum
+        echo [[size]; [30]] | echo 4..$it.size | math sum
         "#
     );
 
@@ -495,7 +495,7 @@ fn range_with_open_left() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo ..=30 | math sum
+        echo ..30 | math sum
         "#
     );
 
@@ -507,7 +507,7 @@ fn exclusive_range_with_open_left() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo ..31 | math sum
+        echo ..<31 | math sum
         "#
     );
 
@@ -519,7 +519,7 @@ fn range_with_open_right() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo 5..= | first 10 | math sum
+        echo 5.. | first 10 | math sum
         "#
     );
 
@@ -531,7 +531,7 @@ fn exclusive_range_with_open_right() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo 5.. | first 10 | math sum
+        echo 5..< | first 10 | math sum
         "#
     );
 
@@ -543,7 +543,7 @@ fn range_with_mixed_types() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo 1..=10.5 | math sum
+        echo 1..10.5 | math sum
         "#
     );
 
@@ -555,7 +555,7 @@ fn exclusive_range_with_mixed_types() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo 1..10.5 | math sum
+        echo 1..<10.5 | math sum
         "#
     );
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -411,7 +411,19 @@ fn echoing_ranges() {
     let actual = nu!(
         cwd: ".",
         r#"
-            echo 1..3 | math sum
+            echo 1..=3 | math sum
+        "#
+    );
+
+    assert_eq!(actual.out, "6");
+}
+
+#[test]
+fn echoing_exclusive_ranges() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo 1..4 | math sum
         "#
     );
 
@@ -459,7 +471,7 @@ fn range_with_left_var() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo [[size]; [3]] | echo $it.size..10 | math sum
+        echo [[size]; [3]] | echo $it.size..=10 | math sum
         "#
     );
 
@@ -471,7 +483,7 @@ fn range_with_right_var() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo [[size]; [30]] | echo 4..$it.size | math sum
+        echo [[size]; [30]] | echo 4..=$it.size | math sum
         "#
     );
 
@@ -483,7 +495,19 @@ fn range_with_open_left() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo ..30 | math sum
+        echo ..=30 | math sum
+        "#
+    );
+
+    assert_eq!(actual.out, "465");
+}
+
+#[test]
+fn exclusive_range_with_open_left() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        echo ..31 | math sum
         "#
     );
 
@@ -492,6 +516,18 @@ fn range_with_open_left() {
 
 #[test]
 fn range_with_open_right() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        echo 5..= | first 10 | math sum
+        "#
+    );
+
+    assert_eq!(actual.out, "95");
+}
+
+#[test]
+fn exclusive_range_with_open_right() {
     let actual = nu!(
         cwd: ".",
         r#"
@@ -504,6 +540,18 @@ fn range_with_open_right() {
 
 #[test]
 fn range_with_mixed_types() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        echo 1..=10.5 | math sum
+        "#
+    );
+
+    assert_eq!(actual.out, "55");
+}
+
+#[test]
+fn exclusive_range_with_mixed_types() {
     let actual = nu!(
         cwd: ".",
         r#"


### PR DESCRIPTION
This commit adds right-exclusive ranges. #2459

The original a..b inclusive syntax was changed to exclusive to reflect the Rust notation.
New a..=b syntax was introduced to have the old behavior.

Currently, both `a..` and `a..=` is valid, and it is unclear to me whether it's valid
to impose restrictions here.

The original issue suggests .. for inclusive and ..< for exclusive ranges,
this can be implemented by making simple changes to this PR.