### PR TITLE
Update rawkey for ARM support

### DIFF
--- a/crates/nu_plugin_binaryview/Cargo.toml
+++ b/crates/nu_plugin_binaryview/Cargo.toml
@@ -19,6 +19,6 @@ nu-plugin = {path = "../nu-plugin", version = "0.19.0"}
 nu-protocol = {path = "../nu-protocol", version = "0.19.0"}
 nu-source = {path = "../nu-source", version = "0.19.0"}
 pretty-hex = "0.2.0"
-rawkey = "0.1.2"
+rawkey = "0.1.3"
 
 [build-dependencies]


### PR DESCRIPTION
v0.1.2 of rawkey currently doesn't compile on ARM; v0.1.3 remedies this.