### PR TITLE
Slim down configuration readings and nu_cli clean up.

### DIFF
--- a/crates/nu-cli/src/commands/autoview/options.rs
+++ b/crates/nu-cli/src/commands/autoview/options.rs
@@ -37,7 +37,7 @@ pub trait ConfigExtensions: Debug + Send {
 }
 
 pub fn pivot_mode(config: &NuConfig) -> AutoPivotMode {
-    let vars = config.vars.lock();
+    let vars = &config.vars;
 
     if let Some(mode) = vars.get("pivot_mode") {
         let mode = match mode.as_string() {

--- a/crates/nu-cli/src/commands/table/options.rs
+++ b/crates/nu-cli/src/commands/table/options.rs
@@ -27,7 +27,7 @@ pub fn header_alignment_from_value(align_value: Option<&Value>) -> nu_table::Ali
 }
 
 pub fn get_color_from_key_and_subkey(config: &NuConfig, key: &str, subkey: &str) -> Option<Value> {
-    let vars = config.vars.lock();
+    let vars = &config.vars;
 
     if let Some(config_vars) = vars.get(key) {
         for (kee, value) in config_vars.row_entries() {
@@ -47,7 +47,7 @@ pub fn header_bold_from_value(bold_value: Option<&Value>) -> bool {
 }
 
 pub fn table_mode(config: &NuConfig) -> nu_table::Theme {
-    let vars = config.vars.lock();
+    let vars = &config.vars;
 
     vars.get("table_mode")
         .map_or(nu_table::Theme::compact(), |mode| match mode.as_string() {
@@ -62,7 +62,7 @@ pub fn table_mode(config: &NuConfig) -> nu_table::Theme {
 }
 
 pub fn disabled_indexes(config: &NuConfig) -> bool {
-    let vars = config.vars.lock();
+    let vars = &config.vars;
 
     vars.get("disable_table_indexes")
         .map_or(false, |x| x.as_bool().unwrap_or(false))

--- a/crates/nu-cli/src/context.rs
+++ b/crates/nu-cli/src/context.rs
@@ -210,6 +210,14 @@ impl Context {
         }
     }
 
+    pub(crate) fn configure<T>(
+        &mut self,
+        config: &dyn nu_data::config::Conf,
+        block: impl FnOnce(&dyn nu_data::config::Conf, &mut Self) -> T,
+    ) {
+        block(config, &mut *self);
+    }
+
     pub(crate) fn with_host<T>(&mut self, block: impl FnOnce(&mut dyn Host) -> T) -> T {
         let mut host = self.host.lock();
 

--- a/crates/nu-cli/src/evaluate/variables.rs
+++ b/crates/nu-cli/src/evaluate/variables.rs
@@ -47,7 +47,8 @@ pub fn nu(env: &IndexMap<String, String>, tag: impl Into<Tag>) -> Result<Value, 
         UntaggedValue::path(keybinding_path).into_value(&tag),
     );
 
-    let history = crate::commands::history::history_path(&nu_data::config::NuConfig::new());
+    let config: Box<dyn nu_data::config::Conf> = Box::new(nu_data::config::NuConfig::new());
+    let history = crate::commands::history::history_path(&config);
     nu_dict.insert_value(
         "history-path",
         UntaggedValue::path(history).into_value(&tag),

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -204,6 +204,33 @@ pub fn user_data() -> Result<PathBuf, ShellError> {
     Ok(std::path::PathBuf::from("/"))
 }
 
+#[derive(Debug, Clone)]
+pub enum Status {
+    LastModified(std::time::SystemTime),
+    Unavailable,
+}
+
+impl Default for Status {
+    fn default() -> Self {
+        Status::Unavailable
+    }
+}
+
+pub fn last_modified(at: &Option<PathBuf>) -> Result<Status, Box<dyn std::error::Error>> {
+    let filename = default_path()?;
+
+    let filename = match at {
+        None => filename,
+        Some(ref file) => file.clone(),
+    };
+
+    if let Ok(time) = filename.metadata()?.modified() {
+        return Ok(Status::LastModified(time));
+    }
+
+    Ok(Status::Unavailable)
+}
+
 pub fn read(
     tag: impl Into<Tag>,
     at: &Option<PathBuf>,

--- a/crates/nu-data/src/config/conf.rs
+++ b/crates/nu-data/src/config/conf.rs
@@ -2,13 +2,23 @@ use nu_protocol::Value;
 use std::fmt::Debug;
 
 pub trait Conf: Debug + Send {
+    fn is_modified(&self) -> Result<bool, Box<dyn std::error::Error>>;
+    fn var(&self, key: &str) -> Option<Value>;
     fn env(&self) -> Option<Value>;
     fn path(&self) -> Option<Value>;
-    fn reload(&self);
+    fn reload(&mut self);
     fn clone_box(&self) -> Box<dyn Conf>;
 }
 
 impl Conf for Box<dyn Conf> {
+    fn is_modified(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        (**self).is_modified()
+    }
+
+    fn var(&self, key: &str) -> Option<Value> {
+        (**self).var(key)
+    }
+
     fn env(&self) -> Option<Value> {
         (**self).env()
     }
@@ -17,7 +27,7 @@ impl Conf for Box<dyn Conf> {
         (**self).path()
     }
 
-    fn reload(&self) {
+    fn reload(&mut self) {
         (**self).reload();
     }
 

--- a/crates/nu-data/src/config/nuconfig.rs
+++ b/crates/nu-data/src/config/nuconfig.rs
@@ -1,17 +1,24 @@
-use crate::config::{read, Conf};
+use crate::config::{last_modified, read, Conf, Status};
 use indexmap::IndexMap;
 use nu_protocol::Value;
 use nu_source::Tag;
-use parking_lot::Mutex;
 use std::fmt::Debug;
-use std::sync::Arc;
 
 #[derive(Debug, Clone, Default)]
 pub struct NuConfig {
-    pub vars: Arc<Mutex<IndexMap<String, Value>>>,
+    pub vars: IndexMap<String, Value>,
+    pub modified_at: Status,
 }
 
 impl Conf for NuConfig {
+    fn is_modified(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        self.is_modified()
+    }
+
+    fn var(&self, key: &str) -> Option<Value> {
+        self.var(key)
+    }
+
     fn env(&self) -> Option<Value> {
         self.env()
     }
@@ -20,11 +27,17 @@ impl Conf for NuConfig {
         self.path()
     }
 
-    fn reload(&self) {
-        let mut vars = self.vars.lock();
+    fn reload(&mut self) {
+        let vars = &mut self.vars;
 
         if let Ok(variables) = read(Tag::unknown(), &None) {
             vars.extend(variables);
+
+            self.modified_at = if let Ok(status) = last_modified(&None) {
+                status
+            } else {
+                Status::Unavailable
+            };
         }
     }
 
@@ -34,6 +47,24 @@ impl Conf for NuConfig {
 }
 
 impl NuConfig {
+    pub fn with(config_file: Option<std::path::PathBuf>) -> NuConfig {
+        match &config_file {
+            None => NuConfig::new(),
+            Some(_) => {
+                let vars = if let Ok(variables) = read(Tag::unknown(), &config_file) {
+                    variables
+                } else {
+                    IndexMap::default()
+                };
+
+                NuConfig {
+                    vars,
+                    modified_at: NuConfig::get_last_modified(&config_file),
+                }
+            }
+        }
+    }
+
     pub fn new() -> NuConfig {
         let vars = if let Ok(variables) = read(Tag::unknown(), &None) {
             variables
@@ -42,12 +73,45 @@ impl NuConfig {
         };
 
         NuConfig {
-            vars: Arc::new(Mutex::new(vars)),
+            vars,
+            modified_at: NuConfig::get_last_modified(&None),
         }
     }
 
+    pub fn get_last_modified(config_file: &Option<std::path::PathBuf>) -> Status {
+        if let Ok(status) = last_modified(config_file) {
+            status
+        } else {
+            Status::Unavailable
+        }
+    }
+
+    pub fn is_modified(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let modified_at = &self.modified_at;
+
+        Ok(match (NuConfig::get_last_modified(&None), modified_at) {
+            (Status::LastModified(left), Status::LastModified(right)) => {
+                let left = left.duration_since(std::time::UNIX_EPOCH)?;
+                let right = (*right).duration_since(std::time::UNIX_EPOCH)?;
+
+                left != right
+            }
+            (_, _) => false,
+        })
+    }
+
+    pub fn var(&self, key: &str) -> Option<Value> {
+        let vars = &self.vars;
+
+        if let Some(value) = vars.get(key) {
+            return Some(value.clone());
+        }
+
+        None
+    }
+
     pub fn env(&self) -> Option<Value> {
-        let vars = self.vars.lock();
+        let vars = &self.vars;
 
         if let Some(env_vars) = vars.get("env") {
             return Some(env_vars.clone());
@@ -57,7 +121,7 @@ impl NuConfig {
     }
 
     pub fn path(&self) -> Option<Value> {
-        let vars = self.vars.lock();
+        let vars = &self.vars;
 
         if let Some(env_vars) = vars.get("path") {
             return Some(env_vars.clone());

--- a/crates/nu-data/src/config/tests.rs
+++ b/crates/nu-data/src/config/tests.rs
@@ -1,17 +1,22 @@
-use crate::config::{read, Conf, NuConfig};
-use indexmap::IndexMap;
+use crate::config::{Conf, NuConfig, Status};
 use nu_protocol::Value;
-use nu_source::Tag;
-use parking_lot::Mutex;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FakeConfig {
     pub config: NuConfig,
+    source_file: Option<PathBuf>,
 }
 
 impl Conf for FakeConfig {
+    fn is_modified(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        self.is_modified()
+    }
+
+    fn var(&self, key: &str) -> Option<Value> {
+        self.config.var(key)
+    }
+
     fn env(&self) -> Option<Value> {
         self.config.env()
     }
@@ -20,8 +25,8 @@ impl Conf for FakeConfig {
         self.config.path()
     }
 
-    fn reload(&self) {
-        // no-op
+    fn reload(&mut self) {
+        self.reload()
     }
 
     fn clone_box(&self) -> Box<dyn Conf> {
@@ -31,18 +36,31 @@ impl Conf for FakeConfig {
 
 impl FakeConfig {
     pub fn new(config_file: &Path) -> FakeConfig {
-        let config_file = PathBuf::from(config_file);
-
-        let vars = if let Ok(variables) = read(Tag::unknown(), &Some(config_file)) {
-            variables
-        } else {
-            IndexMap::default()
-        };
+        let config_file = Some(PathBuf::from(config_file));
 
         FakeConfig {
-            config: NuConfig {
-                vars: Arc::new(Mutex::new(vars)),
-            },
+            config: NuConfig::with(config_file.clone()),
+            source_file: config_file,
         }
+    }
+
+    pub fn is_modified(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let modified_at = &self.config.modified_at;
+
+        Ok(
+            match (NuConfig::get_last_modified(&self.source_file), modified_at) {
+                (Status::LastModified(left), Status::LastModified(right)) => {
+                    let left = left.duration_since(std::time::UNIX_EPOCH)?;
+                    let right = (*right).duration_since(std::time::UNIX_EPOCH)?;
+
+                    left != right
+                }
+                (_, _) => false,
+            },
+        )
+    }
+
+    pub fn reload(&mut self) {
+        self.config = NuConfig::with(self.source_file.clone());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{App, Arg};
 use log::LevelFilter;
+use nu_cli::create_default_context;
 use nu_cli::utils::test_bins as binaries;
-use nu_cli::{create_default_context, EnvironmentSyncer};
 use std::error::Error;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
@@ -160,14 +160,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         None => {
-            let mut syncer = EnvironmentSyncer::new();
-            let mut context = create_default_context(&mut syncer, true)?;
+            let mut context = create_default_context(true)?;
 
             if !matches.is_present("skip-plugins") {
                 let _ = nu_cli::register_plugins(&mut context);
             }
 
-            futures::executor::block_on(nu_cli::cli(syncer, context))?;
+            futures::executor::block_on(nu_cli::cli(context))?;
         }
     }
 


### PR DESCRIPTION
We continue refactoring nu_cli and slim down a bit configuration
readings with a naive metadata `modified` field check.