### PR TITLE
Cleanup code in get and nu-value-ext

### DIFF
--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -4,8 +4,8 @@ use indexmap::set::IndexSet;
 use log::trace;
 use nu_errors::ShellError;
 use nu_protocol::{
-    did_you_mean, ColumnPath, PathMember, Primitive, ReturnSuccess, Signature, SyntaxShape,
-    UnspannedPathMember, UntaggedValue, Value,
+    did_you_mean, ColumnPath, Dictionary, PathMember, Primitive, ReturnSuccess, Signature,
+    SyntaxShape, UnspannedPathMember, UntaggedValue, Value,
 };
 use nu_source::HasFallibleSpan;
 use nu_value_ext::get_data_by_column_path;
@@ -58,195 +58,212 @@ impl WholeStreamCommand for Get {
     }
 }
 
-pub fn get_column_path(path: &ColumnPath, obj: &Value) -> Result<Value, ShellError> {
-    let fields = path.clone();
-
-    get_data_by_column_path(
-        obj,
-        path,
-        Box::new(move |(obj_source, column_path_tried, error)| {
-            let path_members_span = fields.maybe_span().unwrap_or_else(Span::unknown);
-
-            match &obj_source.value {
-                UntaggedValue::Table(rows) => match column_path_tried {
-                    PathMember {
-                        unspanned: UnspannedPathMember::String(column),
-                        ..
-                    } => {
-                        let primary_label = format!("There isn't a column named '{}'", &column);
-
-                        let suggestions: IndexSet<_> = rows
-                            .iter()
-                            .filter_map(|r| did_you_mean(&r, &column_path_tried))
-                            .map(|s| s[0].1.to_owned())
-                            .collect();
-                        let mut existing_columns: IndexSet<_> = IndexSet::default();
-                        let mut names: Vec<String> = vec![];
-
-                        for row in rows {
-                            for field in row.data_descriptors() {
-                                if !existing_columns.contains(&field[..]) {
-                                    existing_columns.insert(field.clone());
-                                    names.push(field);
-                                }
-                            }
-                        }
-
-                        if names.is_empty() {
-                            return ShellError::labeled_error_with_secondary(
-                                "Unknown column",
-                                primary_label,
-                                column_path_tried.span,
-                                "Appears to contain rows. Try indexing instead.",
-                                column_path_tried.span.since(path_members_span),
-                            );
-                        } else {
-                            return ShellError::labeled_error_with_secondary(
-                                "Unknown column",
-                                primary_label,
-                                column_path_tried.span,
-                                format!(
-                                    "Perhaps you meant '{}'? Columns available: {}",
-                                    suggestions
-                                        .iter()
-                                        .map(|x| x.to_owned())
-                                        .collect::<Vec<String>>()
-                                        .join(","),
-                                    names.join(",")
-                                ),
-                                column_path_tried.span.since(path_members_span),
-                            );
-                        };
-                    }
-                    PathMember {
-                        unspanned: UnspannedPathMember::Int(idx),
-                        ..
-                    } => {
-                        let total = rows.len();
-
-                        let secondary_label = if total == 1 {
-                            "The table only has 1 row".to_owned()
-                        } else {
-                            format!("The table only has {} rows (0 to {})", total, total - 1)
-                        };
-
-                        return ShellError::labeled_error_with_secondary(
-                            "Row not found",
-                            format!("There isn't a row indexed at {}", idx),
-                            column_path_tried.span,
-                            secondary_label,
-                            column_path_tried.span.since(path_members_span),
-                        );
-                    }
-                },
-                UntaggedValue::Row(columns) => match column_path_tried {
-                    PathMember {
-                        unspanned: UnspannedPathMember::String(column),
-                        ..
-                    } => {
-                        let primary_label = format!("There isn't a column named '{}'", &column);
-
-                        if let Some(suggestions) = did_you_mean(&obj_source, column_path_tried) {
-                            return ShellError::labeled_error_with_secondary(
-                                "Unknown column",
-                                primary_label,
-                                column_path_tried.span,
-                                format!(
-                                    "Perhaps you meant '{}'? Columns available: {}",
-                                    suggestions[0].1,
-                                    &obj_source.data_descriptors().join(",")
-                                ),
-                                column_path_tried.span.since(path_members_span),
-                            );
-                        }
-                    }
-                    PathMember {
-                        unspanned: UnspannedPathMember::Int(idx),
-                        ..
-                    } => {
-                        return ShellError::labeled_error_with_secondary(
-                            "No rows available",
-                            format!("A row at '{}' can't be indexed.", &idx),
-                            column_path_tried.span,
-                            format!(
-                                "Appears to contain columns. Columns available: {}",
-                                columns.keys().join(",")
-                            ),
-                            column_path_tried.span.since(path_members_span),
-                        )
-                    }
-                },
-                _ => {}
-            }
-
-            if let Some(suggestions) = did_you_mean(&obj_source, column_path_tried) {
-                return ShellError::labeled_error(
-                    "Unknown column",
-                    format!("did you mean '{}'?", suggestions[0].1),
-                    column_path_tried.span.since(path_members_span),
-                );
-            }
-
-            error
-        }),
-    )
-}
-
 pub async fn get(
     args: CommandArgs,
     registry: &CommandRegistry,
 ) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
-    let (GetArgs { rest: mut fields }, mut input) = args.process(&registry).await?;
-    if fields.is_empty() {
+    let (GetArgs { rest: column_paths }, mut input) = args.process(&registry).await?;
+    if column_paths.is_empty() {
         let vec = input.drain_vec().await;
 
         let descs = nu_protocol::merge_descriptors(&vec);
 
         Ok(futures::stream::iter(descs.into_iter().map(ReturnSuccess::value)).to_output_stream())
     } else {
-        let member = fields.remove(0);
-        trace!("get {:?} {:?}", member, fields);
-
-        Ok(input
+        trace!("get {:?}", column_paths);
+        let output_stream = input
             .map(move |item| {
-                let member = vec![member.clone()];
-
-                let column_paths = vec![&member, &fields]
-                    .into_iter()
+                let output = column_paths
+                    .iter()
+                    .map(move |path| get_output(&item, path))
                     .flatten()
-                    .collect::<Vec<&ColumnPath>>();
-
-                let mut output = vec![];
-                for path in column_paths {
-                    let res = get_column_path(&path, &item);
-
-                    match res {
-                        Ok(got) => match got {
-                            Value {
-                                value: UntaggedValue::Table(rows),
-                                ..
-                            } => {
-                                for item in rows {
-                                    output.push(ReturnSuccess::value(item.clone()));
-                                }
-                            }
-                            Value {
-                                value: UntaggedValue::Primitive(Primitive::Nothing),
-                                ..
-                            } => {}
-                            other => output.push(ReturnSuccess::value(other.clone())),
-                        },
-                        Err(reason) => output.push(ReturnSuccess::value(
-                            UntaggedValue::Error(reason).into_untagged_value(),
-                        )),
-                    }
-                }
-
+                    .collect::<Vec<_>>();
                 futures::stream::iter(output)
             })
             .flatten()
-            .to_output_stream())
+            .to_output_stream();
+        Ok(output_stream)
+    }
+}
+
+fn get_output(item: &Value, path: &ColumnPath) -> Vec<Result<ReturnSuccess, ShellError>> {
+    match get_column_path(path, item) {
+        Ok(Value {
+            value: UntaggedValue::Primitive(Primitive::Nothing),
+            ..
+        }) => vec![],
+        Ok(Value {
+            value: UntaggedValue::Table(rows),
+            ..
+        }) => rows
+            .iter()
+            .map(|item| ReturnSuccess::value(item.clone()))
+            .collect(),
+        Ok(other) => vec![ReturnSuccess::value(other.clone())],
+        Err(reason) => vec![ReturnSuccess::value(
+            UntaggedValue::Error(reason).into_untagged_value(),
+        )],
+    }
+}
+
+pub fn get_column_path(path: &ColumnPath, obj: &Value) -> Result<Value, ShellError> {
+    get_data_by_column_path(obj, path, move |obj_source, column_path_tried, error| {
+        let path_members_span = path.maybe_span().unwrap_or_else(Span::unknown);
+
+        match &obj_source.value {
+            UntaggedValue::Table(rows) => {
+                return get_column_path_from_table_error(
+                    rows,
+                    column_path_tried,
+                    &path_members_span,
+                );
+            }
+            UntaggedValue::Row(columns) => {
+                if let Some(error) = get_column_from_row_error(
+                    columns,
+                    column_path_tried,
+                    &path_members_span,
+                    obj_source,
+                ) {
+                    return error;
+                }
+            }
+            _ => {}
+        }
+
+        if let Some(suggestions) = did_you_mean(&obj_source, column_path_tried) {
+            ShellError::labeled_error(
+                "Unknown column",
+                format!("did you mean '{}'?", suggestions[0].1),
+                column_path_tried.span.since(path_members_span),
+            )
+        } else {
+            error
+        }
+    })
+}
+
+pub fn get_column_path_from_table_error(
+    rows: &Vec<Value>,
+    column_path_tried: &PathMember,
+    path_members_span: &Span,
+) -> ShellError {
+    match column_path_tried {
+        PathMember {
+            unspanned: UnspannedPathMember::String(column),
+            ..
+        } => {
+            let primary_label = format!("There isn't a column named '{}'", &column);
+
+            let suggestions: IndexSet<_> = rows
+                .iter()
+                .filter_map(|r| did_you_mean(&r, &column_path_tried))
+                .map(|s| s[0].1.to_owned())
+                .collect();
+            let mut existing_columns: IndexSet<_> = IndexSet::default();
+            let mut names: Vec<String> = vec![];
+
+            for row in rows {
+                for field in row.data_descriptors() {
+                    if !existing_columns.contains(&field[..]) {
+                        existing_columns.insert(field.clone());
+                        names.push(field);
+                    }
+                }
+            }
+
+            if names.is_empty() {
+                return ShellError::labeled_error_with_secondary(
+                    "Unknown column",
+                    primary_label,
+                    column_path_tried.span,
+                    "Appears to contain rows. Try indexing instead.",
+                    column_path_tried.span.since(path_members_span),
+                );
+            } else {
+                return ShellError::labeled_error_with_secondary(
+                    "Unknown column",
+                    primary_label,
+                    column_path_tried.span,
+                    format!(
+                        "Perhaps you meant '{}'? Columns available: {}",
+                        suggestions
+                            .iter()
+                            .map(|x| x.to_owned())
+                            .collect::<Vec<String>>()
+                            .join(","),
+                        names.join(",")
+                    ),
+                    column_path_tried.span.since(path_members_span),
+                );
+            };
+        }
+        PathMember {
+            unspanned: UnspannedPathMember::Int(idx),
+            ..
+        } => {
+            let total = rows.len();
+
+            let secondary_label = if total == 1 {
+                "The table only has 1 row".to_owned()
+            } else {
+                format!("The table only has {} rows (0 to {})", total, total - 1)
+            };
+
+            return ShellError::labeled_error_with_secondary(
+                "Row not found",
+                format!("There isn't a row indexed at {}", idx),
+                column_path_tried.span,
+                secondary_label,
+                column_path_tried.span.since(path_members_span),
+            );
+        }
+    }
+}
+
+pub fn get_column_from_row_error(
+    columns: &Dictionary,
+    column_path_tried: &PathMember,
+    path_members_span: &Span,
+    obj_source: &Value,
+) -> Option<ShellError> {
+    match column_path_tried {
+        PathMember {
+            unspanned: UnspannedPathMember::String(column),
+            ..
+        } => {
+            let primary_label = format!("There isn't a column named '{}'", &column);
+
+            if let Some(suggestions) = did_you_mean(&obj_source, column_path_tried) {
+                Some(ShellError::labeled_error_with_secondary(
+                    "Unknown column",
+                    primary_label,
+                    column_path_tried.span,
+                    format!(
+                        "Perhaps you meant '{}'? Columns available: {}",
+                        suggestions[0].1,
+                        &obj_source.data_descriptors().join(",")
+                    ),
+                    column_path_tried.span.since(path_members_span),
+                ))
+            } else {
+                None
+            }
+        }
+        PathMember {
+            unspanned: UnspannedPathMember::Int(idx),
+            ..
+        } => Some(ShellError::labeled_error_with_secondary(
+            "No rows available",
+            format!("A row at '{}' can't be indexed.", &idx),
+            column_path_tried.span,
+            format!(
+                "Appears to contain columns. Columns available: {}",
+                columns.keys().join(",")
+            ),
+            column_path_tried.span.since(path_members_span),
+        )),
     }
 }
 

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -178,11 +178,7 @@ fn evaluator(by: ColumnPath) -> Box<dyn Fn(usize, &Value) -> Result<Value, Shell
     Box::new(move |_: usize, value: &Value| {
         let path = by.clone();
 
-        let eval = nu_value_ext::get_data_by_column_path(
-            value,
-            &path,
-            Box::new(move |(_, _, error)| error),
-        );
+        let eval = nu_value_ext::get_data_by_column_path(value, &path, move |_, _, error| error);
 
         match eval {
             Ok(with_value) => Ok(with_value),

--- a/crates/nu-cli/src/commands/select.rs
+++ b/crates/nu-cli/src/commands/select.rs
@@ -83,7 +83,7 @@ async fn select(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
             let fetcher = get_data_by_column_path(
                 &value,
                 &path,
-                Box::new(move |(obj_source, path_member_tried, error)| {
+                move |obj_source, path_member_tried, error| {
                     if let PathMember {
                         unspanned: UnspannedPathMember::String(column),
                         ..
@@ -98,7 +98,7 @@ async fn select(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
                     }
 
                     error
-                }),
+                },
             );
 
             let field = path.clone();

--- a/crates/nu-data/src/base.rs
+++ b/crates/nu-data/src/base.rs
@@ -190,8 +190,8 @@ mod tests {
 
     fn error_callback(
         reason: &'static str,
-    ) -> impl FnOnce((&Value, &PathMember, ShellError)) -> ShellError {
-        move |(_obj_source, _column_path_tried, _err)| ShellError::unimplemented(reason)
+    ) -> impl FnOnce(&Value, &PathMember, ShellError) -> ShellError {
+        move |_obj_source, _column_path_tried, _err| ShellError::unimplemented(reason)
     }
 
     fn column_path(paths: &[Value]) -> Result<Tagged<ColumnPathValue>, ShellError> {


### PR DESCRIPTION
Cleanup code in `get` and associated functions (and some users of the modified lower-level functions).

Split the get implementation into multiple smaller, more managable functions.
Removed some unneccessary `clones()` and vector splits.

There is still work to be done (mostly in the error generating functions), but I believe this is an improvement.

Some strange function choices were fixed as well (taking a tuple in a Fn, taking a Box<dyn FnOnce> instead of generics).