### PR TITLE
Exclude internal commands from 'help command'

### DIFF
--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -303,6 +303,11 @@ pub trait WholeStreamCommand: Send + Sync {
         false
     }
 
+    // Commands that are not meant to be run by users
+    fn is_internal(&self) -> bool {
+        false
+    }
+
     fn examples(&self) -> Vec<Example> {
         Vec::new()
     }
@@ -365,6 +370,10 @@ impl Command {
 
     pub fn is_binary(&self) -> bool {
         self.0.is_binary()
+    }
+
+    pub fn is_internal(&self) -> bool {
+        self.0.is_internal()
     }
 
     pub fn stream_command(&self) -> &dyn WholeStreamCommand {

--- a/crates/nu-cli/src/commands/run_external.rs
+++ b/crates/nu-cli/src/commands/run_external.rs
@@ -59,6 +59,10 @@ impl WholeStreamCommand for RunExternalCommand {
         }]
     }
 
+    fn is_internal(&self) -> bool {
+        true
+    }
+
     async fn run(
         &self,
         args: CommandArgs,


### PR DESCRIPTION
1. Exclude internal helper commands from 'help command'

There may be more internal commands that I'm missing here, can get them added here.

Closes #2567 

Note `run_external` does not display.
![image](https://user-images.githubusercontent.com/6572184/93650385-387ee280-f9c3-11ea-8682-52df5c0aa833.png)
