### PR TITLE
Add global mode to str trim

### DIFF
--- a/crates/nu-cli/src/commands/str_/trim/mod.rs
+++ b/crates/nu-cli/src/commands/str_/trim/mod.rs
@@ -8,6 +8,7 @@ use nu_protocol::ShellTypeName;
 use nu_protocol::{ColumnPath, Primitive, ReturnSuccess, UntaggedValue, Value};
 use nu_source::{Tag, Tagged};
 use nu_value_ext::ValueExt;
+use std::iter::FromIterator;
 
 pub use trim_both_ends::SubCommand as Trim;
 pub use trim_left::SubCommand as TrimLeft;
@@ -38,14 +39,22 @@ where
     Ok(input
         .map(move |v| {
             if column_paths.is_empty() {
-                ReturnSuccess::value(action(&v, v.tag(), to_trim, &trim_operation)?)
+                ReturnSuccess::value(action(
+                    &v,
+                    v.tag(),
+                    to_trim,
+                    &trim_operation,
+                    ActionMode::Global,
+                )?)
             } else {
                 let mut ret = v;
 
                 for path in &column_paths {
                     ret = ret.swap_data_by_column_path(
                         path,
-                        Box::new(move |old| action(old, old.tag(), to_trim, &trim_operation)),
+                        Box::new(move |old| {
+                            action(old, old.tag(), to_trim, &trim_operation, ActionMode::Local)
+                        }),
                     )?;
                 }
 
@@ -55,27 +64,63 @@ where
         .to_output_stream())
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum ActionMode {
+    Local,
+    Global,
+}
+
 pub fn action<F>(
     input: &Value,
     tag: impl Into<Tag>,
     char_: Option<char>,
     trim_operation: &F,
+    mode: ActionMode,
 ) -> Result<Value, ShellError>
 where
     F: Fn(&str, Option<char>) -> String + Send + Sync + 'static,
 {
+    let tag = tag.into();
     match &input.value {
         UntaggedValue::Primitive(Primitive::Line(s))
         | UntaggedValue::Primitive(Primitive::String(s)) => {
             Ok(UntaggedValue::string(trim_operation(s, char_)).into_value(tag))
         }
-        other => {
-            let got = format!("got {}", other.type_name());
-            Err(ShellError::labeled_error(
-                "value is not string",
-                got,
-                tag.into().span,
-            ))
-        }
+        other => match mode {
+            ActionMode::Global => match other {
+                UntaggedValue::Row(dictionary) => {
+                    let results: Result<Vec<(String, Value)>, ShellError> = dictionary
+                        .entries()
+                        .iter()
+                        .map(|(k, v)| -> Result<_, ShellError> {
+                            Ok((
+                                k.clone(),
+                                action(&v, tag.clone(), char_, trim_operation, mode)?,
+                            ))
+                        })
+                        .collect();
+                    let indexmap = IndexMap::from_iter(results?);
+                    Ok(UntaggedValue::Row(indexmap.into()).into_value(tag))
+                }
+                UntaggedValue::Table(values) => {
+                    let values: Result<Vec<Value>, ShellError> = values
+                        .iter()
+                        .map(|v| -> Result<_, ShellError> {
+                            Ok(action(v, tag.clone(), char_, trim_operation, mode)?)
+                        })
+                        .collect();
+                    Ok(UntaggedValue::Table(values?).into_value(tag))
+                }
+                _ => Ok(input.clone()),
+            },
+            ActionMode::Local => {
+                let got = format!("got {}", other.type_name());
+                Err(ShellError::labeled_error(
+                    "value is not string",
+                    got,
+                    tag.span,
+                ))
+            }
+        },
     }
 }

--- a/crates/nu-cli/src/commands/str_/trim/trim_both_ends.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_both_ends.rs
@@ -63,7 +63,7 @@ fn trim(s: &str, char_: Option<char>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{trim, SubCommand};
-    use crate::commands::str_::trim::action;
+    use crate::commands::str_::trim::{action, ActionMode};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
@@ -79,7 +79,7 @@ mod tests {
         let word = string("andres ");
         let expected = string("andres");
 
-        let actual = action(&word, Tag::unknown(), None, &trim).unwrap();
+        let actual = action(&word, Tag::unknown(), None, &trim, ActionMode::Local).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -88,7 +88,7 @@ mod tests {
         let word = string("!#andres#!");
         let expected = string("#andres#");
 
-        let actual = action(&word, Tag::unknown(), Some('!'), &trim).unwrap();
+        let actual = action(&word, Tag::unknown(), Some('!'), &trim, ActionMode::Local).unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-cli/src/commands/str_/trim/trim_both_ends.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_both_ends.rs
@@ -64,7 +64,10 @@ fn trim(s: &str, char_: Option<char>) -> String {
 mod tests {
     use super::{trim, SubCommand};
     use crate::commands::str_::trim::{action, ActionMode};
-    use nu_plugin::test_helpers::value::string;
+    use nu_plugin::{
+        row,
+        test_helpers::value::{int, string, table},
+    };
     use nu_source::Tag;
 
     #[test]
@@ -80,6 +83,42 @@ mod tests {
         let expected = string("andres");
 
         let actual = action(&word, Tag::unknown(), None, &trim, ActionMode::Local).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn trims_global() {
+        let word = string(" global   ");
+        let expected = string("global");
+
+        let actual = action(&word, Tag::unknown(), None, &trim, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_ignores_numbers() {
+        let number = int(2020);
+        let expected = int(2020);
+
+        let actual = action(&number, Tag::unknown(), None, &trim, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_row() {
+        let row = row!["a".to_string() => string("    c "), " b ".to_string() => string("  d   ")];
+        let expected = row!["a".to_string() => string("c"), " b ".to_string() => string("d")];
+
+        let actual = action(&row, Tag::unknown(), None, &trim, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_table() {
+        let row = table(&[string("  a  "), int(65), string(" d")]);
+        let expected = table(&[string("a"), int(65), string("d")]);
+
+        let actual = action(&row, Tag::unknown(), None, &trim, ActionMode::Global).unwrap();
         assert_eq!(actual, expected);
     }
 

--- a/crates/nu-cli/src/commands/str_/trim/trim_left.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_left.rs
@@ -65,7 +65,10 @@ fn trim_left(s: &str, char_: Option<char>) -> String {
 mod tests {
     use super::{trim_left, SubCommand};
     use crate::commands::str_::trim::{action, ActionMode};
-    use nu_plugin::test_helpers::value::string;
+    use nu_plugin::{
+        row,
+        test_helpers::value::{int, string, table},
+    };
     use nu_source::Tag;
 
     #[test]
@@ -83,6 +86,50 @@ mod tests {
         let actual = action(&word, Tag::unknown(), None, &trim_left, ActionMode::Local).unwrap();
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn trims_left_global() {
+        let word = string(" global   ");
+        let expected = string("global   ");
+
+        let actual = action(&word, Tag::unknown(), None, &trim_left, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_left_ignores_numbers() {
+        let number = int(2020);
+        let expected = int(2020);
+
+        let actual = action(
+            &number,
+            Tag::unknown(),
+            None,
+            &trim_left,
+            ActionMode::Global,
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_left_row() {
+        let row = row!["a".to_string() => string("    c "), " b ".to_string() => string("  d   ")];
+        let expected = row!["a".to_string() => string("c "), " b ".to_string() => string("d   ")];
+
+        let actual = action(&row, Tag::unknown(), None, &trim_left, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_left_table() {
+        let row = table(&[string("  a  "), int(65), string(" d")]);
+        let expected = table(&[string("a  "), int(65), string("d")]);
+
+        let actual = action(&row, Tag::unknown(), None, &trim_left, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
     #[test]
     fn trims_custom_chars_from_left() {
         let word = string("!!! andres !!!");

--- a/crates/nu-cli/src/commands/str_/trim/trim_left.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_left.rs
@@ -64,7 +64,7 @@ fn trim_left(s: &str, char_: Option<char>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{trim_left, SubCommand};
-    use crate::commands::str_::trim::action;
+    use crate::commands::str_::trim::{action, ActionMode};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
@@ -80,7 +80,7 @@ mod tests {
         let word = string(" andres ");
         let expected = string("andres ");
 
-        let actual = action(&word, Tag::unknown(), None, &trim_left).unwrap();
+        let actual = action(&word, Tag::unknown(), None, &trim_left, ActionMode::Local).unwrap();
         assert_eq!(actual, expected);
     }
     #[test]
@@ -88,7 +88,14 @@ mod tests {
         let word = string("!!! andres !!!");
         let expected = string(" andres !!!");
 
-        let actual = action(&word, Tag::unknown(), Some('!'), &trim_left).unwrap();
+        let actual = action(
+            &word,
+            Tag::unknown(),
+            Some('!'),
+            &trim_left,
+            ActionMode::Local,
+        )
+        .unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-cli/src/commands/str_/trim/trim_right.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_right.rs
@@ -64,7 +64,7 @@ fn trim_right(s: &str, char_: Option<char>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{trim_right, SubCommand};
-    use crate::commands::str_::trim::action;
+    use crate::commands::str_::trim::{action, ActionMode};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
@@ -80,7 +80,7 @@ mod tests {
         let word = string(" andres ");
         let expected = string(" andres");
 
-        let actual = action(&word, Tag::unknown(), None, &trim_right).unwrap();
+        let actual = action(&word, Tag::unknown(), None, &trim_right, ActionMode::Local).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -89,7 +89,14 @@ mod tests {
         let word = string("#@! andres !@#");
         let expected = string("#@! andres !@");
 
-        let actual = action(&word, Tag::unknown(), Some('#'), &trim_right).unwrap();
+        let actual = action(
+            &word,
+            Tag::unknown(),
+            Some('#'),
+            &trim_right,
+            ActionMode::Local,
+        )
+        .unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-cli/src/commands/str_/trim/trim_right.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_right.rs
@@ -65,7 +65,10 @@ fn trim_right(s: &str, char_: Option<char>) -> String {
 mod tests {
     use super::{trim_right, SubCommand};
     use crate::commands::str_::trim::{action, ActionMode};
-    use nu_plugin::test_helpers::value::string;
+    use nu_plugin::{
+        row,
+        test_helpers::value::{int, string, table},
+    };
     use nu_source::Tag;
 
     #[test]
@@ -81,6 +84,49 @@ mod tests {
         let expected = string(" andres");
 
         let actual = action(&word, Tag::unknown(), None, &trim_right, ActionMode::Local).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn trims_right_global() {
+        let word = string(" global   ");
+        let expected = string(" global");
+
+        let actual = action(&word, Tag::unknown(), None, &trim_right, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_right_ignores_numbers() {
+        let number = int(2020);
+        let expected = int(2020);
+
+        let actual = action(
+            &number,
+            Tag::unknown(),
+            None,
+            &trim_right,
+            ActionMode::Global,
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_row() {
+        let row = row!["a".to_string() => string("    c "), " b ".to_string() => string("  d   ")];
+        let expected = row!["a".to_string() => string("    c"), " b ".to_string() => string("  d")];
+
+        let actual = action(&row, Tag::unknown(), None, &trim_right, ActionMode::Global).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn global_trim_table() {
+        let row = table(&[string("  a  "), int(65), string(" d")]);
+        let expected = table(&[string("  a"), int(65), string(" d")]);
+
+        let actual = action(&row, Tag::unknown(), None, &trim_right, ActionMode::Global).unwrap();
         assert_eq!(actual, expected);
     }
 

--- a/crates/nu-plugin/src/test_helpers.rs
+++ b/crates/nu-plugin/src/test_helpers.rs
@@ -206,9 +206,9 @@ pub mod value {
     #[macro_export]
     macro_rules! row {
         ($( $key: expr => $val: expr ),*) => {{
-             let mut map = indexmap::IndexMap::new();
+             let mut map = ::indexmap::IndexMap::new();
              $( map.insert($key, $val); )*
-             UntaggedValue::row(map).into_untagged_value()
+             ::nu_protocol::UntaggedValue::row(map).into_untagged_value()
         }}
     }
 }


### PR DESCRIPTION
Solves #2564

The global mode allows skipping non-string values,
and processes rows and tables as well.