### PR TITLE
Add space between column suggestions

### DIFF
--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -190,7 +190,7 @@ pub fn get_column_path_from_table_error(
                             .map(|x| x.to_owned())
                             .collect::<Vec<String>>()
                             .join(","),
-                        names.join(",")
+                        names.join(", ")
                     ),
                     column_path_tried.span.since(path_members_span),
                 )
@@ -240,7 +240,7 @@ pub fn get_column_from_row_error(
                     format!(
                         "Perhaps you meant '{}'? Columns available: {}",
                         suggestions[0].1,
-                        &obj_source.data_descriptors().join(",")
+                        &obj_source.data_descriptors().join(", ")
                     ),
                     column_path_tried.span.since(path_members_span),
                 ))
@@ -257,7 +257,7 @@ pub fn get_column_from_row_error(
             column_path_tried.span,
             format!(
                 "Appears to contain columns. Columns available: {}",
-                columns.keys().join(",")
+                columns.keys().join(", ")
             ),
             column_path_tried.span.since(path_members_span),
         )),

--- a/crates/nu-cli/tests/commands/get.rs
+++ b/crates/nu-cli/tests/commands/get.rs
@@ -143,6 +143,8 @@ fn errors_fetching_by_column_not_present() {
             r#"
                 [taconushell]
                 sentence_words = ["Yo", "quiero", "taconushell"]
+                [pizzanushell]
+                sentence-words = ["I", "want", "pizza"]
             "#,
         )]);
 
@@ -165,7 +167,13 @@ fn errors_fetching_by_column_not_present() {
         assert!(
             actual.err.contains("Perhaps you meant 'taconushell'?"),
             format!("actual: {:?}", actual.err)
-        )
+        );
+        assert!(
+            actual
+                .err
+                .contains("Columns available: pizzanushell, taconushell"),
+            format!("actual: {:?}", actual.err)
+        );
     })
 }
 

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -273,7 +273,7 @@ where
                                         .map(|x| x.to_owned())
                                         .collect::<Vec<String>>()
                                         .join(","),
-                                    names.join(",")
+                                    names.join(", ")
                                 ),
                                 column_path_tried.span.since(path_members_span),
                             );


### PR DESCRIPTION
1. Adds a space between column suggestions, makes it easier to read

```
> help commands | get a
error: Unknown column
  ┌─ shell:1:21
  │
1 │ help commands | get a
  │                     ^
  │                     │
  │                     There isn't a column named 'a'
  │                     Perhaps you meant 'name'? Columns available: name, description, subcommands
```