### PR TITLE
fetch plugin - add support for the text/csv content-type

### DIFF
--- a/crates/nu_plugin_fetch/src/fetch.rs
+++ b/crates/nu_plugin_fetch/src/fetch.rs
@@ -190,6 +190,15 @@ async fn helper(
                         )
                         .into_value(tag),
                     )),
+                    (mime::TEXT, mime::CSV) => Ok((
+                        Some("csv".to_string()),
+                        UntaggedValue::string(
+                            r.body_string()
+                                .await
+                                .map_err(|e| generate_error("text", e, &span))?,
+                        )
+                        .into_value(tag),
+                    )),
                     (mime::TEXT, mime::PLAIN) => {
                         let path_extension = url::Url::parse(location)
                             .map_err(|_| {


### PR DESCRIPTION
Nu does not currently support `fetch` with content-type: text/csv. The expected behavior is for nu to download the file contents and display it as if a csv was opened via the file system.