### PR TITLE
added .cargo/config.toml to build with bigger stack on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,6 @@
-# use LLD as linker on Windows because it is massively faster for full and incremental builds compared to default
+# use LLD as linker on Windows because it could be faster
+# for full and incremental builds compared to default
+
 [target.x86_64-pc-windows-msvc]
 #linker = "lld-link.exe"
 rustflags = ["-C", "link-args=-stack:10000000"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# use LLD as linker on Windows because it is massively faster for full and incremental builds compared to default
+[target.x86_64-pc-windows-msvc]
+#linker = "lld-link.exe"
+rustflags = ["-C", "link-args=-stack:10000000"]


### PR DESCRIPTION
added a config.toml file so we can build with a different stack size on windows. I went through a dozen or so sizes to get the smallest one.

the lld-link.exe is commented out right now because i'm not sure about it
```toml
# use LLD as linker on Windows because it could be faster
# for full and incremental builds compared to default

[target.x86_64-pc-windows-msvc]
#linker = "lld-link.exe"
rustflags = ["-C", "link-args=-stack:10000000"]
```