### PR TITLE
`did_you_mean` returns the word matches only

### DIFF
--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -132,7 +132,7 @@ pub fn get_column_path(path: &ColumnPath, obj: &Value) -> Result<Value, ShellErr
         if let Some(suggestions) = did_you_mean(&obj_source, column_path_tried) {
             ShellError::labeled_error(
                 "Unknown column",
-                format!("did you mean '{}'?", suggestions[0].1),
+                format!("did you mean '{}'?", suggestions[0]),
                 column_path_tried.span.since(path_members_span),
             )
         } else {
@@ -156,7 +156,7 @@ pub fn get_column_path_from_table_error(
             let suggestions: IndexSet<_> = rows
                 .iter()
                 .filter_map(|r| did_you_mean(&r, &column_path_tried))
-                .map(|s| s[0].1.to_owned())
+                .map(|s| s[0].to_owned())
                 .collect();
             let mut existing_columns: IndexSet<_> = IndexSet::default();
             let mut names: Vec<String> = vec![];
@@ -239,7 +239,7 @@ pub fn get_column_from_row_error(
                     column_path_tried.span,
                     format!(
                         "Perhaps you meant '{}'? Columns available: {}",
-                        suggestions[0].1,
+                        suggestions[0],
                         &obj_source.data_descriptors().join(", ")
                     ),
                     column_path_tried.span.since(path_members_span),

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -239,7 +239,7 @@ where
                         let suggestions: IndexSet<_> = rows
                             .iter()
                             .filter_map(|r| nu_protocol::did_you_mean(&r, &column_path_tried))
-                            .map(|s| s[0].1.to_owned())
+                            .map(|s| s[0].to_owned())
                             .collect();
                         let mut existing_columns: IndexSet<_> = IndexSet::default();
                         let mut names: Vec<String> = vec![];
@@ -316,7 +316,7 @@ where
                                 column_path_tried.span,
                                 format!(
                                     "Perhaps you meant '{}'? Columns available: {}",
-                                    suggestions[0].1,
+                                    suggestions[0],
                                     &obj_source.data_descriptors().join(",")
                                 ),
                                 column_path_tried.span.since(path_members_span),
@@ -345,7 +345,7 @@ where
             if let Some(suggestions) = nu_protocol::did_you_mean(&obj_source, &column_path_tried) {
                 return ShellError::labeled_error(
                     "Unknown column",
-                    format!("did you mean '{}'?", suggestions[0].1),
+                    format!("did you mean '{}'?", suggestions[0]),
                     column_path_tried.span.since(path_members_span),
                 );
             }

--- a/crates/nu_plugin_inc/src/inc.rs
+++ b/crates/nu_plugin_inc/src/inc.rs
@@ -109,7 +109,7 @@ impl Inc {
                         ) {
                             Some(suggestions) => ShellError::labeled_error(
                                 "Unknown column",
-                                format!("did you mean '{}'?", suggestions[0].1),
+                                format!("did you mean '{}'?", suggestions[0]),
                                 span_for_spanned_list(fields.iter().map(|p| p.span)),
                             ),
                             None => ShellError::labeled_error(


### PR DESCRIPTION
1. Add unit tests for `did_you_mean`
2. The function now returns the word matches only, no need to leak edit distance outside the function IMO