### PR TITLE
Move non-essential deps into specific crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,6 @@ name = "nu"
 version = "0.20.0"
 dependencies = [
  "clap",
- "crossterm",
  "ctrlc",
  "dunce",
  "futures 0.3.5",
@@ -2875,11 +2874,8 @@ dependencies = [
  "nu_plugin_to_sqlite",
  "nu_plugin_tree",
  "pretty_env_logger",
- "quick-xml 0.18.1",
- "semver 0.10.0",
  "serde 1.0.115",
  "toml",
- "url 2.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,20 +43,16 @@ nu_plugin_to_bson = {version = "0.20.0", path = "./crates/nu_plugin_to_bson", op
 nu_plugin_to_sqlite = {version = "0.20.0", path = "./crates/nu_plugin_to_sqlite", optional = true}
 nu_plugin_tree = {version = "0.20.0", path = "./crates/nu_plugin_tree", optional = true}
 
-crossterm = {version = "0.17", optional = true}
-semver = {version = "0.10.0", optional = true}
-url = {version = "2.1.1", optional = true}
-
+# Required to bootstrap the main binary
 clap = "2.33.3"
 ctrlc = "3.1.6"
-dunce = "1.0.1"
 futures = {version = "0.3.5", features = ["compat", "io-compat"]}
 log = "0.4.11"
 pretty_env_logger = "0.4.0"
-quick-xml = "0.18.1"
 
 [dev-dependencies]
 nu-test-support = {version = "0.20.0", path = "./crates/nu-test-support"}
+dunce = "1.0.1"
 
 [build-dependencies]
 serde = {version = "1.0.115", features = ["derive"]}
@@ -85,10 +81,10 @@ extra = ["default", "binaryview", "tree", "clipboard-cli", "trash-support", "sta
 stable = ["default"]
 
 # Default
-inc = ["semver", "nu_plugin_inc"]
+inc = ["nu_plugin_inc"]
 ps = ["nu_plugin_ps"]
 sys = ["nu_plugin_sys"]
-textview = ["crossterm", "url", "nu_plugin_textview"]
+textview = ["nu_plugin_textview"]
 
 # Stable
 binaryview = ["nu_plugin_binaryview"]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -64,6 +64,7 @@ pin-utils = "0.1.0"
 pretty-hex = "0.2.0"
 ptree = {version = "0.3.0", optional = true}
 query_interface = "0.3.5"
+quick-xml = "0.18.1"
 rand = "0.7.3"
 regex = "1.3.9"
 roxmltree = "0.13.0"
@@ -93,7 +94,6 @@ zip = {version = "0.5.7", optional = true}
 Inflector = "0.11"
 clipboard = {version = "0.5.0", optional = true}
 encoding_rs = "0.8.24"
-quick-xml = "0.18.1"
 rayon = "1.4.0"
 trash = {version = "1.1.1", optional = true}
 url = "2.1.1"


### PR DESCRIPTION
1. Move non-essential dependencies into specific crates

This will keep the base `Cargo.toml` to importing libraries needed for bootstrapping. Each specific crate can import their own libraries as needed.