### PR TITLE
Remove it expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ We can pipeline this into a command that gets the contents of one of the columns
 Finally, we can use commands outside of Nu once we have the data we want:
 
 ```shell
-> open Cargo.toml | get package.version | echo $it
+> open Cargo.toml | get package.version 
 0.15.1
 ```
 

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -384,12 +384,9 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
 
                 match nu_parser::lite_parse(&prompt_line, 0).map_err(ShellError::from) {
                     Ok(result) => {
-                        let mut prompt_block =
-                            nu_parser::classify_block(&result, context.registry());
+                        let prompt_block = nu_parser::classify_block(&result, context.registry());
 
                         let env = context.get_env();
-
-                        prompt_block.block.expand_it_usage();
 
                         match run_block(
                             &prompt_block.block,
@@ -850,8 +847,7 @@ pub async fn parse_and_eval(line: &str, ctx: &mut EvaluationContext) -> Result<S
     let lite_result = nu_parser::lite_parse(&line, 0)?;
 
     // TODO ensure the command whose examples we're testing is actually in the pipeline
-    let mut classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
-    classified_block.block.expand_it_usage();
+    let classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
 
     let input_stream = InputStream::empty();
     let env = ctx.get_env();
@@ -892,7 +888,7 @@ pub async fn process_line(
         debug!("=== Parsed ===");
         debug!("{:#?}", result);
 
-        let mut classified_block = nu_parser::classify_block(&result, ctx.registry());
+        let classified_block = nu_parser::classify_block(&result, ctx.registry());
 
         debug!("{:#?}", classified_block);
         //println!("{:#?}", pipeline);
@@ -1008,8 +1004,6 @@ pub async fn process_line(
         } else {
             InputStream::empty()
         };
-
-        classified_block.block.expand_it_usage();
 
         trace!("{:#?}", classified_block);
         let env = ctx.get_env();

--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -219,33 +219,13 @@ fn spawn(
                         UntaggedValue::Primitive(Primitive::Nothing) => continue,
                         UntaggedValue::Primitive(Primitive::String(s))
                         | UntaggedValue::Primitive(Primitive::Line(s)) => {
-                            if let Err(e) = stdin_write.write(s.as_bytes()) {
-                                let message = format!("Unable to write to stdin (error = {})", e);
-
-                                let _ = stdin_write_tx.send(Ok(Value {
-                                    value: UntaggedValue::Error(ShellError::labeled_error(
-                                        message,
-                                        "application may have closed before completing pipeline",
-                                        &stdin_name_tag,
-                                    )),
-                                    tag: stdin_name_tag,
-                                }));
-                                return Err(());
+                            if stdin_write.write(s.as_bytes()).is_err() {
+                                break;
                             }
                         }
                         UntaggedValue::Primitive(Primitive::Binary(b)) => {
-                            if let Err(e) = stdin_write.write(b) {
-                                let message = format!("Unable to write to stdin (error = {})", e);
-
-                                let _ = stdin_write_tx.send(Ok(Value {
-                                    value: UntaggedValue::Error(ShellError::labeled_error(
-                                        message,
-                                        "application may have closed before completing pipeline",
-                                        &stdin_name_tag,
-                                    )),
-                                    tag: stdin_name_tag,
-                                }));
-                                return Err(());
+                            if stdin_write.write(b).is_err() {
+                                break;
                             }
                         }
                         unsupported => {

--- a/crates/nu-cli/src/commands/each/window.rs
+++ b/crates/nu-cli/src/commands/each/window.rs
@@ -56,7 +56,6 @@ impl WholeStreamCommand for EachWindow {
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
         let registry = registry.clone();
-        let head = Arc::new(raw_args.call_info.args.head.clone());
         let scope = raw_args.call_info.scope.clone();
         let context = Arc::new(EvaluationContext::from_raw(&raw_args, &registry));
         let (each_args, mut input): (EachWindowArgs, _) = raw_args.process(&registry).await?;
@@ -82,13 +81,12 @@ impl WholeStreamCommand for EachWindow {
 
                 let block = block.clone();
                 let scope = scope.clone();
-                let head = head.clone();
                 let context = context.clone();
                 let local_window = window.clone();
 
                 async move {
                     if i % stride == 0 {
-                        Some(run_block_on_vec(local_window, block, scope, head, context).await)
+                        Some(run_block_on_vec(local_window, block, scope, context).await)
                     } else {
                         None
                     }

--- a/crates/nu-cli/src/commands/group_by.rs
+++ b/crates/nu-cli/src/commands/group_by.rs
@@ -95,7 +95,6 @@ pub async fn group_by(
 ) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let registry = registry.clone();
-    let head = Arc::new(args.call_info.args.head.clone());
     let scope = args.call_info.scope.clone();
     let context = Arc::new(EvaluationContext::from_raw(&args, &registry));
     let (GroupByArgs { grouper }, input) = args.process(&registry).await?;
@@ -115,12 +114,9 @@ pub async fn group_by(
             for value in values.iter() {
                 let run = block.clone();
                 let scope = scope.clone();
-                let head = head.clone();
                 let context = context.clone();
 
-                match crate::commands::each::process_row(run, scope, head, context, value.clone())
-                    .await
-                {
+                match crate::commands::each::process_row(run, scope, context, value.clone()).await {
                     Ok(mut s) => {
                         let collection: Vec<Result<ReturnSuccess, ShellError>> =
                             s.drain_vec().await;

--- a/crates/nu-cli/src/commands/into_int.rs
+++ b/crates/nu-cli/src/commands/into_int.rs
@@ -37,7 +37,7 @@ impl WholeStreamCommand for IntoInt {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Convert filesize to integer",
-            example: "echo 1kb | into-int $it | = $it / 1024",
+            example: "into-int 1kb | each { = $it / 1024 }",
             result: Some(vec![UntaggedValue::int(1).into()]),
         }]
     }

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -70,8 +70,7 @@ fn parse_line(
     let lite_result = nu_parser::lite_parse(&line, 0)?;
 
     // TODO ensure the command whose examples we're testing is actually in the pipeline
-    let mut classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
-    classified_block.block.expand_it_usage();
+    let classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
     Ok(classified_block)
 }
 

--- a/crates/nu-cli/tests/commands/append.rs
+++ b/crates/nu-cli/tests/commands/append.rs
@@ -21,7 +21,7 @@ fn adds_a_row_to_the_end() {
                 | lines
                 | append "pollo loco"
                 | nth 3
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/cal.rs
+++ b/crates/nu-cli/tests/commands/cal.rs
@@ -71,7 +71,7 @@ fn cal_sees_pipeline_year() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1020 | cal --full-year $it | get monday | first 3 | to json
+        cal --full-year 1020 | get monday | first 3 | to json
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/cd.rs
+++ b/crates/nu-cli/tests/commands/cd.rs
@@ -10,7 +10,7 @@ fn filesystem_change_from_current_directory_using_relative_path() {
             cwd: dirs.root(),
             r#"
                 cd cd_test_1
-                pwd | echo $it
+                pwd 
             "#
         );
 
@@ -25,7 +25,7 @@ fn filesystem_change_from_current_directory_using_absolute_path() {
             cwd: dirs.test(),
             r#"
                 cd "{}"
-                pwd | echo $it
+                pwd 
             "#,
             dirs.formats()
         );
@@ -44,7 +44,7 @@ fn filesystem_switch_back_to_previous_working_directory() {
             r#"
                 cd {}
                 cd -
-                pwd | echo $it
+                pwd 
             "#,
             dirs.test()
         );
@@ -62,7 +62,7 @@ fn filesytem_change_from_current_directory_using_relative_path_and_dash() {
             cwd: dirs.test(),
             r#"
                 cd odin/-
-                pwd | echo $it
+                pwd 
             "#
         );
 
@@ -80,7 +80,7 @@ fn filesystem_change_current_directory_to_parent_directory() {
             cwd: dirs.test(),
             r#"
                 cd ..
-                pwd | echo $it
+                pwd 
             "#
         );
 
@@ -97,7 +97,7 @@ fn filesystem_change_current_directory_to_two_parents_up_using_multiple_dots() {
             cwd: dirs.test().join("foo/bar"),
             r#"
                 cd ...
-                pwd | echo $it
+                pwd 
             "#
         );
 
@@ -116,7 +116,7 @@ fn filesystem_change_current_directory_to_parent_directory_after_delete_cwd() {
                 rm {}/foo/bar
                 echo ","
                 cd ..
-                pwd | echo $it
+                pwd 
             "#,
             dirs.test()
         );
@@ -135,7 +135,7 @@ fn filesystem_change_to_home_directory() {
             cwd: dirs.test(),
             r#"
                 cd ~
-                pwd | echo $it
+                pwd 
             "#
         );
 
@@ -152,7 +152,7 @@ fn filesystem_change_to_a_directory_containing_spaces() {
             cwd: dirs.test(),
             r#"
                 cd "robalino turner katz"
-                pwd | echo $it
+                pwd 
             "#
         );
 
@@ -219,7 +219,7 @@ fn filesystem_change_directory_to_symlink_relative() {
             cwd: dirs.test().join("boo"),
             r#"
                 cd ../foo_link
-                pwd | echo $it
+                pwd 
             "#
         );
 
@@ -249,7 +249,7 @@ fn valuesystem_change_from_current_path_using_relative_path() {
             r#"
                 enter sample.toml
                 cd bin
-                pwd | echo $it
+                pwd 
                 exit
             "#
         );
@@ -283,7 +283,7 @@ fn valuesystem_change_from_current_path_using_absolute_path() {
                 enter sample.toml
                 cd bin
                 cd /dependencies
-                pwd | echo $it
+                pwd 
                 exit
             "#
         );
@@ -319,7 +319,7 @@ fn valuesystem_switch_back_to_previous_working_path() {
                 cd dependencies
                 cd /bin
                 cd -
-                pwd | echo $it
+                pwd 
                 exit
             "#
         );
@@ -353,7 +353,7 @@ fn valuesystem_change_from_current_path_using_relative_path_and_dash() {
                 cd package/-
                 cd /bin
                 cd -
-                pwd | echo $it
+                pwd 
                 exit
             "#
         );
@@ -380,7 +380,7 @@ fn valuesystem_change_current_path_to_parent_path() {
                 enter sample.toml
                 cd package/emberenios
                 cd ..
-                pwd | echo $it
+                pwd 
                 exit
             "#
         );
@@ -405,7 +405,7 @@ fn valuesystem_change_to_a_path_containing_spaces() {
             r#"
                 enter sample.toml
                 cd "pa que te"
-                pwd | echo $it
+                pwd 
                 exit
             "#
         );

--- a/crates/nu-cli/tests/commands/compact.rs
+++ b/crates/nu-cli/tests/commands/compact.rs
@@ -26,7 +26,7 @@ fn discards_rows_where_given_column_is_empty() {
                 | get amigos
                 | compact rusty_luck
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -43,7 +43,7 @@ fn discards_empty_rows_by_default() {
                 | from json
                 | compact
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/default.rs
+++ b/crates/nu-cli/tests/commands/default.rs
@@ -27,7 +27,7 @@ fn adds_row_data_if_column_missing() {
                 | default rusty_luck 1
                 | where rusty_luck == 1
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/drop.rs
+++ b/crates/nu-cli/tests/commands/drop.rs
@@ -4,7 +4,7 @@ use nu_test_support::{nu, pipeline};
 fn drop_rows() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"foo": 3}, {"foo": 8}, {"foo": 4}]' | from json | drop 2 | get foo | math sum | echo $it"#
+        r#"echo '[{"foo": 3}, {"foo": 8}, {"foo": 4}]' | from json | drop 2 | get foo | math sum "#
     );
 
     assert_eq!(actual.out, "3");

--- a/crates/nu-cli/tests/commands/each.rs
+++ b/crates/nu-cli/tests/commands/each.rs
@@ -5,7 +5,7 @@ fn each_works_separately() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3] | each { echo $it 10 | math sum } | to json | echo $it
+        echo [1 2 3] | each { echo $it 10 | math sum } | to json 
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/echo.rs
+++ b/crates/nu-cli/tests/commands/echo.rs
@@ -5,7 +5,7 @@ fn echo_range_is_lazy() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo 1..10000000000 | first 3 | echo $it | to json
+        echo 1..10000000000 | first 3  | to json
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/first.rs
+++ b/crates/nu-cli/tests/commands/first.rs
@@ -18,7 +18,7 @@ fn gets_first_rows_by_amount() {
                 ls
                 | first 3
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -42,7 +42,7 @@ fn gets_all_rows_if_amount_higher_than_all_rows() {
                 ls
                 | first 99
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -61,7 +61,7 @@ fn gets_first_row_when_no_amount_given() {
                 ls
                 | first
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/format.rs
+++ b/crates/nu-cli/tests/commands/format.rs
@@ -8,7 +8,7 @@ fn creates_the_resulting_string_from_the_given_fields() {
         open cargo_sample.toml
             | get package
             | format "{name} has license {license}"
-            | echo $it
+            
         "#
     ));
 
@@ -22,7 +22,7 @@ fn given_fields_can_be_column_paths() {
         r#"
         open cargo_sample.toml
             | format "{package.name} is {package.description}"
-            | echo $it
+            
         "#
     ));
 
@@ -36,7 +36,7 @@ fn can_use_variables() {
         r#"
         open cargo_sample.toml
             | format "{$it.package.name} is {$it.package.description}"
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/get.rs
+++ b/crates/nu-cli/tests/commands/get.rs
@@ -17,7 +17,7 @@ fn fetches_a_row() {
             r#"
                 open sample.toml
                 | get nu_party_venue
-                | echo $it
+                
             "#
         ));
 
@@ -44,7 +44,7 @@ fn fetches_by_index() {
             r#"
                 open sample.toml
                 | get package.authors.2
-                | echo $it
+                
             "#
         ));
 
@@ -67,7 +67,7 @@ fn fetches_by_column_path() {
             r#"
                 open sample.toml
                 | get package.name
-                | echo $it
+                
             "#
         ));
 
@@ -93,7 +93,7 @@ fn column_paths_are_either_double_quoted_or_regular_unquoted_words_separated_by_
                 open sample.toml
                 | get package."9999"
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -127,7 +127,7 @@ fn fetches_more_than_one_column_path() {
                 open sample.toml
                 | get fortune_tellers.2.name fortune_tellers.0.name fortune_tellers.1.name
                 | nth 2
-                | echo $it
+                
             "#
         ));
 
@@ -250,7 +250,7 @@ fn errors_fetching_by_index_out_of_bounds() {
 fn quoted_column_access() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"foo bar": {"baz": 4}}]' | from json | get "foo bar".baz | echo $it"#
+        r#"echo '[{"foo bar": {"baz": 4}}]' | from json | get "foo bar".baz "#
     );
 
     assert_eq!(actual.out, "4");

--- a/crates/nu-cli/tests/commands/group_by.rs
+++ b/crates/nu-cli/tests/commands/group_by.rs
@@ -22,7 +22,7 @@ fn groups() {
                 | group-by rusty_at
                 | get "10/11/2013"
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/histogram.rs
+++ b/crates/nu-cli/tests/commands/histogram.rs
@@ -22,7 +22,7 @@ fn summarizes_by_column_given() {
                 | histogram rusty_at countries
                 | where rusty_at == "Ecuador"
                 | get countries
-                | echo $it
+                
             "#
         ));
 
@@ -55,7 +55,7 @@ fn summarizes_by_values() {
                 | histogram
                 | where value == "Estados Unidos"
                 | get occurrences
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/insert.rs
+++ b/crates/nu-cli/tests/commands/insert.rs
@@ -8,7 +8,7 @@ fn sets_the_column_from_a_block_run_output() {
             open cargo_sample.toml
             | insert dev-dependencies.newdep "1"
             | get dev-dependencies.newdep
-            | echo $it
+            
         "#
     ));
 
@@ -24,7 +24,7 @@ fn sets_the_column_from_a_block_full_stream_output() {
             | insert content { open --raw cargo_sample.toml | lines | first 5 }
             | get content.1
             | str contains "nu"
-            | echo $it
+            
         "#
     ));
 
@@ -40,7 +40,7 @@ fn sets_the_column_from_an_invocation() {
             | insert content $(open --raw cargo_sample.toml | lines | first 5)
             | get content.1
             | str contains "nu"
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/into_int.rs
+++ b/crates/nu-cli/tests/commands/into_int.rs
@@ -1,23 +1,11 @@
 use nu_test_support::{nu, pipeline};
 
 #[test]
-fn into_int_filesize() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        into-int 1kb | = $it / 1024
-        "#
-    ));
-
-    assert!(actual.out.contains("1"));
-}
-
-#[test]
 fn into_int_int() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        into-int 1024 | = $it / 1024
+        into-int 1024 | each { = $it / 1024 }
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/is_empty.rs
+++ b/crates/nu-cli/tests/commands/is_empty.rs
@@ -23,7 +23,7 @@ fn adds_value_provided_if_column_is_empty() {
                 | empty? likes 1
                 | get likes
                 | math sum
-                | echo $it
+                
             "#
         ));
 
@@ -53,7 +53,7 @@ fn adds_value_provided_for_columns_that_are_empty() {
                 | empty? boost check 1
                 | get boost check
                 | math sum
-                | echo $it
+                
             "#
         ));
 
@@ -85,7 +85,7 @@ fn value_emptiness_check() {
                 | empty?
                 | where $it
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/keep/keep.rs
+++ b/crates/nu-cli/tests/commands/keep/keep.rs
@@ -23,7 +23,7 @@ fn rows() {
                 | keep 3
                 | get lucky_code
                 | math sum
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/keep/until.rs
+++ b/crates/nu-cli/tests/commands/keep/until.rs
@@ -43,7 +43,7 @@ fn condition_is_met() {
                 | str to-int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/keep/while_.rs
+++ b/crates/nu-cli/tests/commands/keep/while_.rs
@@ -42,7 +42,7 @@ fn condition_is_met() {
                 | str to-int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/last.rs
+++ b/crates/nu-cli/tests/commands/last.rs
@@ -6,7 +6,7 @@ use nu_test_support::{nu, pipeline};
 fn gets_the_last_row() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | sort-by name | last 1 | get name | str trim | echo $it"
+        "ls | sort-by name | last 1 | get name | str trim "
     );
 
     assert_eq!(actual.out, "utf16.ini");
@@ -28,7 +28,7 @@ fn gets_last_rows_by_amount() {
                 ls
                 | last 3
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -47,7 +47,7 @@ fn gets_last_row_when_no_amount_given() {
                 ls
                 | last
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/lines.rs
+++ b/crates/nu-cli/tests/commands/lines.rs
@@ -13,7 +13,7 @@ fn lines() {
             | split column "="
             | get Column1
             | str trim
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -16,7 +16,7 @@ fn lists_regular_files() {
             r#"
                 ls
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -39,7 +39,7 @@ fn lists_regular_files_using_asterisk_wildcard() {
             r#"
                 ls *.txt
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -62,7 +62,7 @@ fn lists_regular_files_using_question_mark_wildcard() {
             r#"
                 ls *.??.txt
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -90,9 +90,9 @@ fn lists_all_files_in_directories_from_stream() {
             cwd: dirs.test(), pipeline(
             r#"
                 echo dir_a dir_b
-                | ls $it
+                | each { ls $it }
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -110,7 +110,7 @@ fn does_not_fail_if_glob_matches_empty_directory() {
             r#"
                 ls dir_a
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -147,7 +147,7 @@ fn list_files_from_two_parents_up_using_multiple_dots() {
         let actual = nu!(
             cwd: dirs.test().join("foo/bar"),
             r#"
-                ls ... | count | echo $it
+                ls ... | count 
             "#
         );
 
@@ -171,7 +171,7 @@ fn lists_hidden_file_when_explicitly_specified() {
             r#"
                 ls .testdotfile
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -206,7 +206,7 @@ fn lists_all_hidden_files_when_glob_contains_dot() {
             r#"
                 ls **/.*
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -244,7 +244,7 @@ fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
             r#"
                 ls **/*
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -268,7 +268,7 @@ fn lists_files_including_starting_with_dot() {
             r#"
                 ls -a
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/math/avg.rs
+++ b/crates/nu-cli/tests/commands/math/avg.rs
@@ -8,7 +8,7 @@ fn can_average_numbers() {
              open sgml_description.json
              | get glossary.GlossDiv.GlossList.GlossEntry.Sections
              | math avg
-             | echo $it
+             
          "#
     ));
 
@@ -19,7 +19,7 @@ fn can_average_numbers() {
 fn can_average_bytes() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | sort-by name | skip 1 | first 2 | get size | math avg | format \"{$it}\" | echo $it"
+        "ls | sort-by name | skip 1 | first 2 | get size | math avg | format \"{$it}\" "
     );
 
     assert_eq!(actual.out, "1.6 KB");

--- a/crates/nu-cli/tests/commands/math/median.rs
+++ b/crates/nu-cli/tests/commands/math/median.rs
@@ -7,7 +7,7 @@ fn median_numbers_with_even_rows() {
         r#"
              echo [10 6 19 21 4]
              | math median
-             | echo $it
+             
          "#
     ));
 
@@ -21,7 +21,7 @@ fn median_numbers_with_odd_rows() {
         r#"
              echo [3 8 9 12 12 15]
              | math median
-             | echo $it
+             
          "#
     ));
 
@@ -35,7 +35,7 @@ fn median_mixed_numbers() {
         r#"
              echo [-11.5 -13.5 10]
              | math median
-             | echo $it
+             
          "#
     ));
 

--- a/crates/nu-cli/tests/commands/math/mod.rs
+++ b/crates/nu-cli/tests/commands/math/mod.rs
@@ -210,18 +210,6 @@ fn duration_math_with_negative() {
 }
 
 #[test]
-fn it_math() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            echo 1020 | = $it + 10
-        "#
-    ));
-
-    assert_eq!(actual.out, "1030");
-}
-
-#[test]
 fn compound_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-cli/tests/commands/math/sum.rs
+++ b/crates/nu-cli/tests/commands/math/sum.rs
@@ -26,7 +26,7 @@ fn all() {
                 | get meals
                 | get calories
                 | math sum
-                | echo $it
+                
             "#
         ));
 
@@ -36,7 +36,7 @@ fn all() {
 
 #[test]
 fn outputs_zero_with_no_input() {
-    let actual = nu!(cwd: ".", "math sum | echo $it");
+    let actual = nu!(cwd: ".", "math sum ");
 
     assert_eq!(actual.out, "0");
 }

--- a/crates/nu-cli/tests/commands/merge.rs
+++ b/crates/nu-cli/tests/commands/merge.rs
@@ -34,7 +34,7 @@ fn row() {
                 | where country in ["Guayaquil Ecuador" "New Zealand"]
                 | get luck
                 | math sum
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/mkdir.rs
+++ b/crates/nu-cli/tests/commands/mkdir.rs
@@ -71,7 +71,7 @@ fn show_created_paths() {
              r#"
                  mkdir -s dir_1 dir_2 dir_3
                  | count
-                 | echo $it
+                 
              "#
         ));
 

--- a/crates/nu-cli/tests/commands/move_/column.rs
+++ b/crates/nu-cli/tests/commands/move_/column.rs
@@ -27,7 +27,7 @@ fn moves_a_column_before() {
                 | get chars
                 | str trim
                 | str collect
-                | echo $it
+                
             "#
         ));
 
@@ -62,7 +62,7 @@ fn moves_columns_before() {
                 | get chars_2 chars_1
                 | str trim
                 | str collect
-                | echo $it
+                
             "#
         ));
 
@@ -98,7 +98,7 @@ fn moves_a_column_after() {
                 | get chars_1 chars_2
                 | str trim
                 | str collect
-                | echo $it
+                
             "#
         ));
 
@@ -132,7 +132,7 @@ fn moves_columns_after() {
                 | get
                 | nth 1 2
                 | str collect
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/nth.rs
+++ b/crates/nu-cli/tests/commands/nth.rs
@@ -10,7 +10,7 @@ fn selects_a_row() {
                 | sort-by name
                 | nth 0
                 | get name
-                | echo $it
+                
             "#
         ));
 
@@ -30,7 +30,7 @@ fn selects_many_rows() {
                 | get name
                 | nth 1 0
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/open.rs
+++ b/crates/nu-cli/tests/commands/open.rs
@@ -21,7 +21,7 @@ fn parses_csv() {
                 open nu.zion.csv
                 | where author == "Andres N. Robalino"
                 | get source
-                | echo $it
+                
             "#
         ));
 
@@ -59,7 +59,7 @@ fn parses_csv() {
 fn parses_bson() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open sample.bson | get root | nth 0 | get b | echo $it"
+        "open sample.bson | get root | nth 0 | get b "
     );
 
     assert_eq!(actual.out, "hello");
@@ -76,7 +76,7 @@ fn parses_more_bson_complexity() {
             | nth 6
             | get b
             | get '$binary_subtype'
-            | echo $it
+            
         "#
     ));
 
@@ -142,7 +142,7 @@ fn parses_sqlite() {
             | get table_values
             | nth 2
             | get x
-            | echo $it
+            
         "#
     ));
 
@@ -153,7 +153,7 @@ fn parses_sqlite() {
 fn parses_toml() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open cargo_sample.toml | get package.edition | echo $it"
+        "open cargo_sample.toml | get package.edition "
     );
 
     assert_eq!(actual.out, "2018");
@@ -167,7 +167,7 @@ fn parses_tsv() {
             open caco3_plastics.tsv
             | first 1
             | get origin
-            | echo $it
+            
         "#
     ));
 
@@ -181,7 +181,7 @@ fn parses_json() {
         r#"
             open sgml_description.json
             | get glossary.GlossDiv.GlossList.GlossEntry.GlossSee
-            | echo $it
+            
         "#
     ));
 
@@ -192,7 +192,7 @@ fn parses_json() {
 fn parses_xml() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open jonathan.xml | get rss.children.channel.children | get item.children | get link.children | echo $it"
+        "open jonathan.xml | get rss.children.channel.children | get item.children | get link.children.0"
     );
 
     assert_eq!(
@@ -205,7 +205,7 @@ fn parses_xml() {
 fn parses_ini() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open sample.ini | get SectionOne.integer | echo $it"
+        "open sample.ini | get SectionOne.integer "
     );
 
     assert_eq!(actual.out, "1234")
@@ -215,7 +215,7 @@ fn parses_ini() {
 fn parses_utf16_ini() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open utf16.ini | get '.ShellClassInfo' | get IconIndex | echo $it"
+        "open utf16.ini | get '.ShellClassInfo' | get IconIndex "
     );
 
     assert_eq!(actual.out, "-236")

--- a/crates/nu-cli/tests/commands/parse.rs
+++ b/crates/nu-cli/tests/commands/parse.rs
@@ -24,7 +24,7 @@ mod simple {
                     | lines
                     | each { echo $it | parse "{Name}={Value}" }
                     | nth 1
-                    | echo $it.Value
+                    | each { echo $it.Value }
                 "#
             ));
 
@@ -40,7 +40,7 @@ mod simple {
                 r#"
                     echo "{abc}123"
                     | parse "{{abc}{name}"
-                    | echo $it.name
+                    | each { echo $it.name }
                 "#
             ));
 
@@ -56,7 +56,7 @@ mod simple {
                 r#"
                     echo "(abc)123"
                     | parse "(abc){name}"
-                    | echo $it.name
+                    | each { echo $it.name }
                 "#
             ));
 
@@ -89,7 +89,7 @@ mod simple {
                 r#"
                     echo "(abc)123"
                     | parse "(abc){name"
-                    | echo $it.name
+                    | each { echo $it.name }
                 "#
             ));
 
@@ -123,7 +123,7 @@ mod regex {
                     | parse --regex "(?P<Hash>\w+) (?P<Message>.+) \(#(?P<PR>\d+)\)"
                     | nth 1
                     | get PR
-                    | echo $it
+                    
                 "#
             ));
 
@@ -143,7 +143,7 @@ mod regex {
                     | parse --regex "(\w+) (.+) \(#(\d+)\)"
                     | nth 1
                     | get Capture1
-                    | echo $it
+                    
                 "#
             ));
 
@@ -163,7 +163,7 @@ mod regex {
                     | parse --regex "(?P<Hash>\w+) (.+) \(#(?P<PR>\d+)\)"
                     | nth 1
                     | get Capture2
-                    | echo $it
+                    
                 "#
             ));
 
@@ -181,7 +181,7 @@ mod regex {
                 r#"
                     open nushell_git_log_oneline.txt
                     | parse --regex "(?P<Hash>\w+ unfinished capture group"
-                    | echo $it
+                    
                 "#
             ));
 

--- a/crates/nu-cli/tests/commands/prepend.rs
+++ b/crates/nu-cli/tests/commands/prepend.rs
@@ -21,7 +21,7 @@ fn adds_a_row_to_the_beginning() {
                 | lines
                 | prepend "pollo loco"
                 | nth 0
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/range.rs
+++ b/crates/nu-cli/tests/commands/range.rs
@@ -14,7 +14,7 @@ fn selects_a_row() {
                 | sort-by name
                 | range 0..0
                 | get name
-                | echo $it
+                
             "#
         ));
 
@@ -38,7 +38,7 @@ fn selects_some_rows() {
                 | get name
                 | range 1..2
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/reduce.rs
+++ b/crates/nu-cli/tests/commands/reduce.rs
@@ -54,7 +54,7 @@ fn reduce_numbered_example() {
         echo one longest three bar
         | reduce -n { if $(echo $it.item | str length) > $(echo $acc.item | str length) {echo $it} {echo $acc}}
         | get index
-        | echo $it
+        
         "#
         )
     );
@@ -74,7 +74,7 @@ fn folding_with_tables() {
             }
           }
         | math sum
-        | echo $it
+        
         "#
         )
     );

--- a/crates/nu-cli/tests/commands/rename.rs
+++ b/crates/nu-cli/tests/commands/rename.rs
@@ -24,7 +24,7 @@ fn changes_the_column_name() {
                 | rename mosqueteros
                 | get mosqueteros
                 | count
-                | echo $it
+                
                 "#
         ));
 
@@ -55,7 +55,7 @@ fn keeps_remaining_original_names_given_less_new_names_than_total_original_names
                 | rename mosqueteros
                 | get hit
                 | count
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/reverse.rs
+++ b/crates/nu-cli/tests/commands/reverse.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu;
 fn can_get_reverse_first() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | sort-by name | reverse | first 1 | get name | str trim | echo $it"
+        "ls | sort-by name | reverse | first 1 | get name | str trim "
     );
 
     assert_eq!(actual.out, "utf16.ini");

--- a/crates/nu-cli/tests/commands/select.rs
+++ b/crates/nu-cli/tests/commands/select.rs
@@ -22,7 +22,7 @@ fn regular_columns() {
                 | select rusty_at last_name
                 | nth 0
                 | get last_name
-                | echo $it
+                
             "#
         ));
 
@@ -65,7 +65,7 @@ fn complex_nested_columns() {
                 | select nu."0xATYKARNU" nu.committers.name nu.releases.version
                 | where "nu.releases.version" > "0.8"
                 | get "nu.releases.version"
-                | echo $it
+                
             "#
         ));
 
@@ -92,7 +92,7 @@ fn allows_if_given_unknown_column_name_is_missing() {
                 open los_tres_caballeros.csv
                 | select rrusty_at first_name
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/skip/until.rs
+++ b/crates/nu-cli/tests/commands/skip/until.rs
@@ -42,7 +42,7 @@ fn condition_is_met() {
                 | str to-int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/skip/while_.rs
+++ b/crates/nu-cli/tests/commands/skip/while_.rs
@@ -42,7 +42,7 @@ fn condition_is_met() {
                 | str to-int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                | echo $it
+                
                 "#
         ));
 

--- a/crates/nu-cli/tests/commands/sort_by.rs
+++ b/crates/nu-cli/tests/commands/sort_by.rs
@@ -15,7 +15,7 @@ fn by_column() {
             | first 1
             | get Column1
             | str trim
-            | echo $it
+            
         "#
     ));
 
@@ -37,7 +37,7 @@ fn by_invalid_column() {
             | first 1
             | get Column1
             | str trim
-            | echo $it
+            
         "#
     ));
 
@@ -73,7 +73,7 @@ fn sort_primitive_values() {
             | first 6
             | sort-by
             | first 1
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/split_by.rs
+++ b/crates/nu-cli/tests/commands/split_by.rs
@@ -23,7 +23,7 @@ fn splits() {
                 | split-by type
                 | get A."10/11/2013"
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/split_column.rs
+++ b/crates/nu-cli/tests/commands/split_column.rs
@@ -20,7 +20,7 @@ fn to_column() {
                 | str trim
                 | split column ","
                 | get Column2
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/split_row.rs
+++ b/crates/nu-cli/tests/commands/split_row.rs
@@ -20,7 +20,7 @@ fn to_row() {
                 | str trim
                 | split row ","
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/commands/str_/mod.rs
+++ b/crates/nu-cli/tests/commands/str_/mod.rs
@@ -17,7 +17,7 @@ fn trims() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "open sample.toml | str trim dependency.name | get dependency.name | echo $it"
+            "open sample.toml | str trim dependency.name | get dependency.name "
         );
 
         assert_eq!(actual.out, "nu");
@@ -50,7 +50,7 @@ fn capitalizes() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "open sample.toml | str capitalize dependency.name | get dependency.name | echo $it"
+            "open sample.toml | str capitalize dependency.name | get dependency.name "
         );
 
         assert_eq!(actual.out, "Nu");
@@ -70,7 +70,7 @@ fn downcases() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "open sample.toml | str downcase dependency.name | get dependency.name | echo $it"
+            "open sample.toml | str downcase dependency.name | get dependency.name "
         );
 
         assert_eq!(actual.out, "light");
@@ -90,7 +90,7 @@ fn upcases() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "open sample.toml | str upcase package.name | get package.name | echo $it"
+            "open sample.toml | str upcase package.name | get package.name "
         );
 
         assert_eq!(actual.out, "NUSHELL");
@@ -110,7 +110,7 @@ fn camelcases() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "open sample.toml | str camel-case dependency.name | get dependency.name | echo $it"
+            "open sample.toml | str camel-case dependency.name | get dependency.name "
         );
 
         assert_eq!(actual.out, "thisIsATest");
@@ -128,7 +128,7 @@ fn converts_to_int() {
             | rename number
             | where number == 1
             | get number
-            | echo $it
+            
         "#
     ));
 
@@ -167,7 +167,7 @@ fn sets() {
                  open sample.toml
                  | str set wykittenshell package.name
                  | get package.name
-                 | echo $it
+                 
              "#
         ));
 
@@ -192,7 +192,7 @@ fn find_and_replaces() {
                  open sample.toml
                  | str find-replace KATZ "5289" fortune.teller.phone
                  | get fortune.teller.phone
-                 | echo $it
+                 
              "#
         ));
 
@@ -217,7 +217,7 @@ fn find_and_replaces_without_passing_field() {
                  open sample.toml
                  | get fortune.teller.phone
                  | str find-replace KATZ "5289"
-                 | echo $it
+                 
              "#
         ));
 
@@ -242,7 +242,7 @@ fn substrings_the_input() {
                  open sample.toml
                  | str substring 6,14 fortune.teller.phone
                  | get fortune.teller.phone
-                 | echo $it
+                 
              "#
         ));
 
@@ -266,7 +266,7 @@ fn substring_errors_if_start_index_is_greater_than_end_index() {
             r#"
                  open sample.toml
                  | str substring 6,5 fortune.teller.phone
-                 | echo $it
+                 
              "#
         ));
 
@@ -293,7 +293,7 @@ fn substrings_the_input_and_returns_the_string_if_end_index_exceeds_length() {
                  open sample.toml
                  | str substring 0,999 package.name
                  | get package.name
-                 | echo $it
+                 
              "#
         ));
 
@@ -318,7 +318,7 @@ fn substrings_the_input_and_returns_blank_if_start_index_exceeds_length() {
                  open sample.toml
                  | str substring 50,999 package.name
                  | get package.name
-                 | echo $it
+                 
              "#
         ));
 
@@ -343,7 +343,7 @@ fn substrings_the_input_and_treats_start_index_as_zero_if_blank_start_index_give
                  open sample.toml
                  | str substring ,2 package.name
                  | get package.name
-                 | echo $it
+                 
              "#
         ));
 
@@ -368,7 +368,7 @@ fn substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given(
                  open sample.toml
                  | str substring 3, package.name
                  | get package.name
-                 | echo $it
+                 
              "#
         ));
 

--- a/crates/nu-cli/tests/commands/uniq.rs
+++ b/crates/nu-cli/tests/commands/uniq.rs
@@ -23,7 +23,7 @@ fn removes_duplicate_rows() {
                 open los_tres_caballeros.csv
                 | uniq
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -53,7 +53,7 @@ fn uniq_values() {
                 | select type
                 | uniq
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -118,7 +118,7 @@ fn nested_json_structures() {
                 open nested_json_structures.json
                 | uniq
                 | count
-                | echo $it
+                
             "#
         ));
         assert_eq!(actual.out, "3");
@@ -134,7 +134,7 @@ fn uniq_when_keys_out_of_order() {
             | from json
             | uniq
             | count
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/update.rs
+++ b/crates/nu-cli/tests/commands/update.rs
@@ -8,7 +8,7 @@ fn sets_the_column() {
             open cargo_sample.toml
             | update dev-dependencies.pretty_assertions "0.7.0"
             | get dev-dependencies.pretty_assertions
-            | echo $it
+            
         "#
     ));
 
@@ -24,7 +24,7 @@ fn sets_the_column_from_a_block_run_output() {
             open cargo_sample.toml
             | update dev-dependencies.pretty_assertions { open cargo_sample.toml | get dev-dependencies.pretty_assertions | inc --minor }
             | get dev-dependencies.pretty_assertions
-            | echo $it
+            
         "#
     ));
 
@@ -40,7 +40,7 @@ fn sets_the_column_from_a_block_full_stream_output() {
             | update content { open --raw cargo_sample.toml | lines | first 5 }
             | get content.1
             | str contains "nu"
-            | echo $it
+            
         "#
     ));
 
@@ -56,7 +56,7 @@ fn sets_the_column_from_an_invocation() {
             | update content $(open --raw cargo_sample.toml | lines | first 5)
             | get content.1
             | str contains "nu"
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/where_.rs
+++ b/crates/nu-cli/tests/commands/where_.rs
@@ -7,7 +7,7 @@ use nu_test_support::pipeline;
 fn filters_by_unit_size_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | where size > 1kb | sort-by size | get name | first 1 | str trim | echo $it"
+        "ls | where size > 1kb | sort-by size | get name | first 1 | str trim "
     );
 
     assert_eq!(actual.out, "cargo_sample.toml");
@@ -17,7 +17,7 @@ fn filters_by_unit_size_comparison() {
 fn filters_with_nothing_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from json | get foo | compact | where $it > 1 | math sum | echo $it"#
+        r#"echo '[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from json | get foo | compact | where $it > 1 | math sum "#
     );
 
     assert_eq!(actual.out, "7");
@@ -27,7 +27,7 @@ fn filters_with_nothing_comparison() {
 fn where_in_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name in ["foo"] | get size | math sum | echo $it"#
+        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name in ["foo"] | get size | math sum "#
     );
 
     assert_eq!(actual.out, "5");
@@ -37,7 +37,7 @@ fn where_in_table() {
 fn where_not_in_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name not-in ["foo"] | get size | math sum | echo $it"#
+        r#"echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name not-in ["foo"] | get size | math sum "#
     );
 
     assert_eq!(actual.out, "4");
@@ -55,7 +55,7 @@ fn explicit_block_condition() {
             | first 4
             | where {= $it.z > 4200}
             | get z
-            | echo $it
+            
         "#
     ));
 
@@ -74,7 +74,7 @@ fn binary_operator_comparisons() {
             | first 4
             | where z > 4200
             | get z
-            | echo $it
+            
         "#
     ));
 
@@ -89,7 +89,7 @@ fn binary_operator_comparisons() {
             | first 4
             | where z >= 4253
             | get z
-            | echo $it
+            
         "#
     ));
 
@@ -104,7 +104,7 @@ fn binary_operator_comparisons() {
             | first 4
             | where z < 10
             | get z
-            | echo $it
+            
         "#
     ));
 
@@ -119,7 +119,7 @@ fn binary_operator_comparisons() {
             | first 4
             | where z <= 1
             | get z
-            | echo $it
+            
         "#
     ));
 
@@ -134,7 +134,7 @@ fn binary_operator_comparisons() {
             | where z != 1
             | first 1
             | get z
-            | echo $it
+            
         "#
     ));
 
@@ -152,7 +152,7 @@ fn contains_operator() {
             | get table_values
             | where x =~ ell
             | count
-            | echo $it
+            
         "#
     ));
 
@@ -166,7 +166,7 @@ fn contains_operator() {
             | get table_values
             | where x !~ ell
             | count
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/commands/wrap.rs
+++ b/crates/nu-cli/tests/commands/wrap.rs
@@ -24,7 +24,7 @@ fn wrap_rows_into_a_row() {
                 | get caballeros
                 | nth 0
                 | get last_name
-                | echo $it
+                
             "#
         ));
 
@@ -54,7 +54,7 @@ fn wrap_rows_into_a_table() {
                 | wrap caballero
                 | nth 2
                 | get caballero
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/format_conversions/bson.rs
+++ b/crates/nu-cli/tests/format_conversions/bson.rs
@@ -10,7 +10,7 @@ fn table_to_bson_and_back_into_table() {
             | from bson
             | get root
             | get 1.b
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/format_conversions/csv.rs
+++ b/crates/nu-cli/tests/format_conversions/csv.rs
@@ -6,7 +6,7 @@ use nu_test_support::{nu, pipeline};
 fn table_to_csv_text_and_from_csv_text_back_into_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open caco3_plastics.csv | to csv | from csv | first 1 | get origin | echo $it"
+        "open caco3_plastics.csv | to csv | from csv | first 1 | get origin "
     );
 
     assert_eq!(actual.out, "SPAIN");
@@ -35,7 +35,7 @@ fn table_to_csv_text() {
                 | to csv
                 | lines
                 | nth 1
-                | echo $it
+                
             "#
         ));
 
@@ -66,7 +66,7 @@ fn table_to_csv_text_skipping_headers_after_conversion() {
                 | split column "," a b c d origin
                 | last 1
                 | to csv --headerless
-                | echo $it
+                
             "#
         ));
 
@@ -96,7 +96,7 @@ fn infers_types() {
                 open los_cuatro_mosqueteros.csv
                 | where rusty_luck > 0
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -124,7 +124,7 @@ fn from_csv_text_to_table() {
                 | from csv
                 | get rusty_luck
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -152,7 +152,7 @@ fn from_csv_text_with_separator_to_table() {
                 | from csv --separator ';'
                 | get rusty_luck
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -180,7 +180,7 @@ fn from_csv_text_with_tab_separator_to_table() {
                 | from csv --separator '\t'
                 | get rusty_luck
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -207,7 +207,7 @@ fn from_csv_text_skipping_headers_to_table() {
                 | from csv --headerless
                 | get Column3
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/format_conversions/eml.rs
+++ b/crates/nu-cli/tests/format_conversions/eml.rs
@@ -12,7 +12,7 @@ fn from_eml_get_to_field() {
             open sample.eml
             | get To
             | get Address
-            | echo $it
+            
         "#
         )
     );
@@ -26,7 +26,7 @@ fn from_eml_get_to_field() {
             open sample.eml
             | get To
             | get Name
-            | echo $it
+            
         "#
         )
     );
@@ -44,7 +44,7 @@ fn from_eml_get_replyto_field() {
             open sample.eml
             | get Reply-To
             | get Address
-            | echo $it
+            
         "#
         )
     );
@@ -58,7 +58,7 @@ fn from_eml_get_replyto_field() {
             open sample.eml
             | get Reply-To
             | get Name
-            | echo $it
+            
         "#
         )
     );
@@ -74,7 +74,7 @@ fn from_eml_get_subject_field() {
             r#"
             open sample.eml
             | get Subject
-            | echo $it
+            
         "#
         )
     );
@@ -90,7 +90,7 @@ fn from_eml_get_another_header_field() {
             r#"
             open sample.eml
             | get MIME-Version
-            | echo $it
+            
         "#
         )
     );

--- a/crates/nu-cli/tests/format_conversions/ics.rs
+++ b/crates/nu-cli/tests/format_conversions/ics.rs
@@ -49,7 +49,7 @@ fn infers_types() {
                 open calendar.ics
                 | get events
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -92,7 +92,7 @@ fn from_ics_text_to_table() {
                 | where name == "SUMMARY"
                 | first
                 | get value
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/format_conversions/json.rs
+++ b/crates/nu-cli/tests/format_conversions/json.rs
@@ -11,7 +11,7 @@ fn table_to_json_text_and_from_json_text_back_into_table() {
             | to json
             | from json
             | get glossary.GlossDiv.GlossList.GlossEntry.GlossSee
-            | echo $it
+            
         "#
     ));
 
@@ -37,7 +37,7 @@ fn from_json_text_to_table() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "open katz.txt | from json | get katz | get rusty_luck | count | echo $it"
+            "open katz.txt | from json | get katz | get rusty_luck | count "
         );
 
         assert_eq!(actual.out, "4");
@@ -64,7 +64,7 @@ fn from_json_text_recognizing_objects_independently_to_table() {
                 | from json -o
                 | where name == "GorbyPuff"
                 | get rusty_luck
-                | echo $it
+                
             "#
         ));
 
@@ -94,7 +94,7 @@ fn table_to_json_text() {
                 | from json
                 | nth 0
                 | get name
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/format_conversions/ods.rs
+++ b/crates/nu-cli/tests/format_conversions/ods.rs
@@ -9,7 +9,7 @@ fn from_ods_file_to_table() {
             | get SalesOrders
             | nth 4
             | get Column2
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/format_conversions/sqlite.rs
+++ b/crates/nu-cli/tests/format_conversions/sqlite.rs
@@ -13,7 +13,7 @@ fn table_to_sqlite_and_back_into_table() {
             | get table_values
             | nth 2
             | get x
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/format_conversions/ssv.rs
+++ b/crates/nu-cli/tests/format_conversions/ssv.rs
@@ -22,7 +22,7 @@ fn from_ssv_text_to_table() {
                 | from ssv
                 | nth 0
                 | get IP
-                | echo $it
+                
             "#
         ));
 
@@ -50,7 +50,7 @@ fn from_ssv_text_to_table_with_separator_specified() {
                 | from ssv --minimum-spaces 3
                 | nth 0
                 | get IP
-                | echo $it
+                
             "#
         ));
 
@@ -77,7 +77,7 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
                 | from ssv --headerless -a
                 | first
                 | get Column1
-                | echo $it
+                
             "#
         ));
 
@@ -88,7 +88,7 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
                 | from ssv --headerless
                 | first
                 | get Column1
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/format_conversions/toml.rs
+++ b/crates/nu-cli/tests/format_conversions/toml.rs
@@ -9,7 +9,7 @@ fn table_to_toml_text_and_from_toml_text_back_into_table() {
             | to toml
             | from toml
             | get package.name
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/format_conversions/tsv.rs
+++ b/crates/nu-cli/tests/format_conversions/tsv.rs
@@ -6,7 +6,7 @@ use nu_test_support::{nu, pipeline};
 fn table_to_tsv_text_and_from_tsv_text_back_into_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open caco3_plastics.tsv | to tsv | from tsv | first 1 | get origin | echo $it"
+        "open caco3_plastics.tsv | to tsv | from tsv | first 1 | get origin "
     );
 
     assert_eq!(actual.out, "SPAIN");
@@ -16,7 +16,7 @@ fn table_to_tsv_text_and_from_tsv_text_back_into_table() {
 fn table_to_tsv_text_and_from_tsv_text_back_into_table_using_csv_separator() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r"open caco3_plastics.tsv | to tsv | from csv --separator '\t' | first 1 | get origin | echo $it"
+        r"open caco3_plastics.tsv | to tsv | from csv --separator '\t' | first 1 | get origin "
     );
 
     assert_eq!(actual.out, "SPAIN");
@@ -44,7 +44,7 @@ fn table_to_tsv_text() {
                 | to tsv
                 | lines
                 | nth 1
-                | echo $it
+                
             "#
         ));
 
@@ -72,7 +72,7 @@ fn table_to_tsv_text_skipping_headers_after_conversion() {
                 | split column "\t" a b c d origin
                 | last 1
                 | to tsv --headerless
-                | echo $it
+                
             "#
         ));
 
@@ -100,7 +100,7 @@ fn from_tsv_text_to_table() {
                 | from tsv
                 | get rusty_luck
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -127,7 +127,7 @@ fn from_tsv_text_skipping_headers_to_table() {
                 | from tsv --headerless
                 | get Column3
                 | count
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/format_conversions/url.rs
+++ b/crates/nu-cli/tests/format_conversions/url.rs
@@ -9,7 +9,7 @@ fn can_encode_and_decode_urlencoding() {
                 | to url
                 | from url
                 | get cheese
-                | echo $it
+                
             "#
     ));
 

--- a/crates/nu-cli/tests/format_conversions/vcf.rs
+++ b/crates/nu-cli/tests/format_conversions/vcf.rs
@@ -36,7 +36,7 @@ fn infers_types() {
             r#"
                 open contacts.vcf
                 | count
-                | echo $it
+                
             "#
         ));
 
@@ -75,7 +75,7 @@ fn from_vcf_text_to_table() {
                 | where name == "EMAIL"
                 | first
                 | get value
-                | echo $it
+                
             "#
         ));
 

--- a/crates/nu-cli/tests/format_conversions/xlsx.rs
+++ b/crates/nu-cli/tests/format_conversions/xlsx.rs
@@ -9,7 +9,7 @@ fn from_excel_file_to_table() {
             | get SalesOrders
             | nth 4
             | get Column2
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/format_conversions/xml.rs
+++ b/crates/nu-cli/tests/format_conversions/xml.rs
@@ -9,7 +9,7 @@ fn table_to_xml_text_and_from_xml_text_back_into_table() {
             | to xml
             | from xml
             | get rss.children.channel.children.0.item.children.0.guid.attributes.isPermaLink
-            | echo $it
+            
         "#
     ));
 

--- a/crates/nu-cli/tests/format_conversions/yaml.rs
+++ b/crates/nu-cli/tests/format_conversions/yaml.rs
@@ -9,7 +9,7 @@ fn table_to_yaml_text_and_from_yaml_text_back_into_table() {
             | to yaml
             | from yaml
             | get environment.global.PROJECT_NAME
-            | echo $it
+            
         "#
     ));
 

--- a/docker/packaging/Dockerfile.ubuntu-bionic
+++ b/docker/packaging/Dockerfile.ubuntu-bionic
@@ -14,4 +14,4 @@ RUN rustc -Vv && cargo build --release && \
     debuild -b -us -uc -i && \
     dpkg -i ../nu_0.2.0-1_amd64.deb && \
     chsh -s /usr/bin/nu && \
-    echo 'ls | get name | echo $it' | /usr/bin/nu
+    echo 'ls | get name ' | /usr/bin/nu

--- a/tests/plugins/core_inc.rs
+++ b/tests/plugins/core_inc.rs
@@ -27,7 +27,7 @@ fn by_one_with_field_passed() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
-            "open sample.toml | inc package.edition | get package.edition | echo $it"
+            "open sample.toml | inc package.edition | get package.edition "
         );
 
         assert_eq!(actual.out, "2019");
@@ -47,7 +47,7 @@ fn by_one_with_no_field_passed() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
-            "open sample.toml | get package.contributors | inc | echo $it"
+            "open sample.toml | get package.contributors | inc "
         );
 
         assert_eq!(actual.out, "3");
@@ -67,7 +67,7 @@ fn semversion_major_inc() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
-            "open sample.toml | inc package.version -M | get package.version | echo $it"
+            "open sample.toml | inc package.version -M | get package.version "
         );
 
         assert_eq!(actual.out, "1.0.0");
@@ -87,7 +87,7 @@ fn semversion_minor_inc() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
-            "open sample.toml | inc package.version --minor | get package.version | echo $it"
+            "open sample.toml | inc package.version --minor | get package.version "
         );
 
         assert_eq!(actual.out, "0.2.0");
@@ -107,7 +107,7 @@ fn semversion_patch_inc() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
-            "open sample.toml | inc package.version --patch | get package.version | echo $it"
+            "open sample.toml | inc package.version --patch | get package.version "
         );
 
         assert_eq!(actual.out, "0.1.4");
@@ -127,7 +127,7 @@ fn semversion_without_passing_field() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
-            "open sample.toml | get package.version | inc --patch | echo $it"
+            "open sample.toml | get package.version | inc --patch "
         );
 
         assert_eq!(actual.out, "0.1.4");

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -53,7 +53,7 @@ fn automatically_change_directory_with_trailing_slash_and_same_name_as_command()
             cwd: dirs.test(),
             r#"
                 cd/
-                pwd | echo $it
+                pwd
             "#
         );
 
@@ -87,10 +87,8 @@ mod it_evaluation {
                 ls
                 | sort-by name
                 | get name
-                | nu --testbin cococo $it
-                | lines
+                | each { nu --testbin cococo $it | lines }
                 | nth 1
-                | echo $it
                 "#
             ));
 
@@ -114,10 +112,8 @@ mod it_evaluation {
             r#"
                 open nu_candies.txt
                 | lines
-                | nu --testbin chop $it
-                | lines
+                | each { nu --testbin chop $it | lines }
                 | nth 1
-                | echo $it
                 "#
             ));
 
@@ -139,8 +135,7 @@ mod it_evaluation {
                 cwd: dirs.test(), pipeline(
                 r#"
                     open sample.toml
-                    | nu --testbin cococo $it.nu_party_venue
-                    | echo $it
+                    | each { nu --testbin cococo $it.nu_party_venue }
                 "#
             ));
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -34,7 +34,7 @@ fn automatically_change_directory() {
             cwd: dirs.test(),
             r#"
                 autodir
-                pwd | echo $it
+                pwd 
             "#
         );
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -7,31 +7,14 @@ use nu_test_support::playground::Playground;
 
 #[test]
 fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
-    Playground::setup("internal_to_external_pipe_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "nu_times.csv",
-            r#"
-                name,rusty_luck,origin
-                Jason,1,Canada
-                Jonathan,1,New Zealand
-                Andrés,1,Ecuador
-                AndKitKatz,1,Estados Unidos
-            "#,
-        )]);
-
-        let actual = nu!(
-        cwd: dirs.test(), pipeline(
+    let actual = nu!(
+        cwd: ".",
         r#"
-            open nu_times.csv
-            | get origin
-            | each { ^echo $it | nu --testbin chop | lines }
-            | nth 2
-            "#
-        ));
+        echo [foo bar baz] | each { nu --testbin cococo $it | nu --testbin chop | lines } | nth 2
+        "#
+    );
 
-        // chop will remove the last escaped double quote from \"Estados Unidos\"
-        assert_eq!(actual.out, "Ecuado");
-    })
+    assert_eq!(actual.out, "ba");
 }
 
 #[cfg(feature = "directories-support")]
@@ -277,7 +260,7 @@ fn string_interpolation_with_it() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo "foo" | echo `{{$it}}`
+                    echo "foo" | each { echo `{{$it}}` }
             "#
     );
 
@@ -289,8 +272,8 @@ fn string_interpolation_with_column() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo '{"name": "bob"}' | from json | echo `{{name}} is cool`
-            "#
+            echo '{"name": "bob"}' | from json | each { echo `{{name}} is cool` }
+        "#
     );
 
     assert_eq!(actual.out, "bob is cool");
@@ -301,7 +284,7 @@ fn string_interpolation_with_column2() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo '{"name": "fred"}' | from json | echo `also {{name}} is cool`
+                    echo '{"name": "fred"}' | from json | each { echo `also {{name}} is cool` }
             "#
     );
 
@@ -313,7 +296,7 @@ fn string_interpolation_with_column3() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo '{"name": "sally"}' | from json | echo `also {{name}}`
+                    echo '{"name": "sally"}' | from json | each { echo `also {{name}}` }
             "#
     );
 
@@ -325,7 +308,7 @@ fn string_interpolation_with_it_column_path() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo '{"name": "sammie"}' | from json | echo `{{$it.name}}`
+                    echo '{"name": "sammie"}' | from json | each { echo `{{$it.name}}` }
         "#
     );
 
@@ -418,7 +401,7 @@ fn range_with_left_var() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo [[size]; [3]] | echo $it.size..10 | math sum
+        echo [[size]; [3]] | each { echo $it.size..10 } | math sum
         "#
     );
 
@@ -430,7 +413,7 @@ fn range_with_right_var() {
     let actual = nu!(
         cwd: ".",
         r#"
-        echo [[size]; [30]] | echo 4..$it.size | math sum
+        echo [[size]; [30]] | each { echo 4..$it.size } | math sum
         "#
     );
 


### PR DESCRIPTION
DRAFT

This PR removes it-expansion. We've had a few points of feedback that it can feel confusing to use it-expansion, as you don't ever get to see exactly what is being expanded or how. Instead, people have asked that `each` is required and that in Nu this is used to specifically point to when we're processing things a row at a time.

You can see the kinds of changes this causes by looking in the tests that were updated in this PR. Ignoring dropping the unnecessary `| echo $it` updates, you'll see the main set of updates. String interpolation and uses of $it including $it variable paths now will need `each` wrapping around them.

Unrelated, but part of PR: I fixed an issue with stdin into external commands. We can take this separately, but I wasn't able to pass the test suite reliably without it.