### PR TITLE
Tidy up crates in nu-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,11 +3058,9 @@ dependencies = [
 name = "nu-protocol"
 version = "0.20.0"
 dependencies = [
- "ansi_term 0.12.1",
  "bigdecimal",
  "byte-unit",
  "chrono",
- "codespan-reporting",
  "derive-new",
  "getset",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,7 +3064,6 @@ dependencies = [
  "derive-new",
  "getset",
  "indexmap",
- "itertools",
  "log 0.4.11",
  "natural",
  "nu-errors",

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -16,7 +16,6 @@ chrono = {version = "0.4.15", features = ["serde"]}
 derive-new = "0.5.8"
 getset = "0.1.1"
 indexmap = {version = "1.6.0", features = ["serde-1"]}
-itertools = "0.9.0"
 log = "0.4.11"
 natural = "0.5.0"
 nu-errors = {path = "../nu-errors", version = "0.20.0"}

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -10,11 +10,9 @@ version = "0.20.0"
 doctest = false
 
 [dependencies]
-ansi_term = "0.12.1"
 bigdecimal = {version = "0.2.0", features = ["serde"]}
 byte-unit = "4.0.9"
 chrono = {version = "0.4.15", features = ["serde"]}
-codespan-reporting = "0.9.5"
 derive-new = "0.5.8"
 getset = "0.1.1"
 indexmap = {version = "1.6.0", features = ["serde-1"]}

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -20,7 +20,6 @@ use bigdecimal::BigDecimal;
 use bigdecimal::FromPrimitive;
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
-use itertools::Itertools;
 use nu_errors::ShellError;
 use nu_source::{AnchorLocation, HasSpan, Span, Spanned, Tag};
 use num_bigint::BigInt;

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -15,7 +15,7 @@ use crate::value::dict::Dictionary;
 use crate::value::iter::{RowValueIter, TableValueIter};
 use crate::value::primitive::Primitive;
 use crate::value::range::{Range, RangeInclusion};
-use crate::{ColumnPath, PathMember, UnspannedPathMember};
+use crate::{ColumnPath, PathMember};
 use bigdecimal::BigDecimal;
 use bigdecimal::FromPrimitive;
 use chrono::{DateTime, Utc};
@@ -312,12 +312,10 @@ impl Value {
             UntaggedValue::Primitive(Primitive::Filesize(x)) => format!("{}", x),
             UntaggedValue::Primitive(Primitive::Path(x)) => format!("{}", x.display()),
             UntaggedValue::Primitive(Primitive::ColumnPath(path)) => {
-                let joined = path
+                let joined: String = path
                     .iter()
-                    .map(|member| match &member.unspanned {
-                        UnspannedPathMember::String(name) => name.to_string(),
-                        UnspannedPathMember::Int(n) => format!("{}", n),
-                    })
+                    .map(|member| member.as_string())
+                    .collect::<Vec<String>>()
                     .join(".");
 
                 if joined.contains(' ') {


### PR DESCRIPTION
Tidy up crates in nu-protocol

1. Removed unused crates in `nu-protocol`
2. I also opted to omit `itertools` as it was only used to `.join` a vector of strings, which is in the std library (see in the second commit), but maybe I am missing some other reason to keep it around.