### PR TITLE
chart tweaks for windows

### DIFF
--- a/crates/nu_plugin_chart/src/chart.rs
+++ b/crates/nu_plugin_chart/src/chart.rs
@@ -123,7 +123,7 @@ impl<'a> BarChart<'a> {
         ui.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .margin(2)
+                .margin(0)
                 .constraints([Constraint::Percentage(100)].as_ref())
                 .split(f.size());
 
@@ -134,6 +134,7 @@ impl<'a> BarChart<'a> {
                 .bar_style(Style::default().fg(Color::Green))
                 .value_style(
                     Style::default()
+                        .fg(Color::Black)
                         .bg(Color::Green)
                         .add_modifier(Modifier::BOLD),
                 );


### PR DESCRIPTION
* I changed the border to be 0 instead of 2 so there's more screen real estate for the chart.
* I also changed the fg color of the chart values to black. in windows, whatever the default was, isn't visible. So, I changed it to something high contracts.
* Alas, there's no opportunity to change the color of the bars like having red, green, blue all in the same chart. if we wanted to do that we'd have to do a PR to tui-rs.
* We might want to think about removing the chart title altogether as I'm not sure it provides much benefit - or we could make it a parameter
* We might want to think about removing the borders altogether - i'm not sure we need framing - but i left it because these points are kind of end-user specific i think
