### PR TITLE
Add example for update command

### DIFF
--- a/crates/nu-cli/src/commands/rename.rs
+++ b/crates/nu-cli/src/commands/rename.rs
@@ -1,6 +1,6 @@
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
-use indexmap::IndexMap;
+use indexmap::indexmap;
 use nu_errors::ShellError;
 use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
@@ -45,13 +45,22 @@ impl WholeStreamCommand for Rename {
         vec![
             Example {
                 description: "Rename a column",
-                example: r#"echo "{a: 1, b: 2, c: 3}" | from json | rename my_column"#,
-                result: None,
+                example: "echo [[a, b]; [1, 2]] | rename my_column",
+                result: Some(vec![UntaggedValue::row(indexmap! {
+                        "my_column".to_string() => UntaggedValue::int(1).into(),
+                        "b".to_string() => UntaggedValue::int(2).into(),
+                })
+                .into()]),
             },
             Example {
                 description: "Rename many columns",
-                example: r#"echo "{a: 1, b: 2, c: 3}" | from json | rename spam eggs cars"#,
-                result: None,
+                example: "echo [[a, b, c]; [1, 2, 3]] | rename eggs ham bacon",
+                result: Some(vec![UntaggedValue::row(indexmap! {
+                        "eggs".to_string() => UntaggedValue::int(1).into(),
+                        "ham".to_string() => UntaggedValue::int(2).into(),
+                        "bacon".to_string() => UntaggedValue::int(3).into(),
+                })
+                .into()]),
             },
         ]
     }

--- a/crates/nu-cli/src/commands/update.rs
+++ b/crates/nu-cli/src/commands/update.rs
@@ -2,6 +2,7 @@ use crate::command_registry::CommandRegistry;
 use crate::commands::classified::block::run_block;
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
+use indexmap::indexmap;
 use nu_errors::ShellError;
 use nu_protocol::{
     ColumnPath, Primitive, ReturnSuccess, Scope, Signature, SyntaxShape, UntaggedValue, Value,
@@ -48,6 +49,18 @@ impl WholeStreamCommand for Update {
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
         update(args, registry).await
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Update a column value",
+            example: "echo [[a, b]; [1, 2]] | update a 'nu'",
+            result: Some(vec![UntaggedValue::row(indexmap! {
+                    "a".to_string() => Value::from("nu"),
+                    "b".to_string() => UntaggedValue::int(2).into(),
+            })
+            .into()]),
+        }]
     }
 }
 

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -49,3 +49,12 @@ Updates an existing column on a table. First parameter is the column to update a
  1 │ X │ filesystem │ /
 ━━━┷━━━┷━━━━━━━━━━━━┷━━━━━━
 ```
+
+Collect all the values of a nested column and join them together
+```shell
+> version | update features {get features | str collect ', '}
+───┬─────────┬──────────────────────────────────────────┬───────────────────────────
+ # │ version │               commit_hash                │         features
+───┼─────────┼──────────────────────────────────────────┼───────────────────────────
+ 0 │ 0.20.0  │ fdab3368094e938c390f1e5a7892a42da45add3e │ default, clipboard, trash
+───┴─────────┴──────────────────────────────────────────┴───────────────────────────


### PR DESCRIPTION
Closes #2518 

1. Add more docs and an example for `update`
1. Add test cases for `rename` examples

```
Examples:
  Update a column value
  > echo "{a: 1, b: 2}" | from json | update a 'nu
```