### PR TITLE
Fix defaulting alias var values

### DIFF
--- a/crates/nu-cli/tests/commands/alias.rs
+++ b/crates/nu-cli/tests/commands/alias.rs
@@ -17,6 +17,21 @@ fn alias_args_work() {
 }
 
 #[test]
+fn alias_missing_args_work() {
+    Playground::setup("append_test_1", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.root(),
+            r#"
+                alias double_echo [a b] {^echo $a $b}
+                double_echo bob
+            "#
+        );
+
+        assert_eq!(actual.out, "bob");
+    })
+}
+
+#[test]
 #[cfg(not(windows))]
 fn alias_parses_path_tilde() {
     let actual = nu!(


### PR DESCRIPTION
This adds back the ability to define more than parameters to an alias than you actually use in practice, defaulting each of the unused variables to nothing when used.

eg)

```
                alias double_echo [a b] {^echo $a $b}
                double_echo bob
```