### PR TITLE
Fix panic in str to-datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,9 +1207,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "dtparse"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9713da7ca51bcd8ecbaedbd6309110eb1ca930d2109ef595a125f84fa1bc608b"
+checksum = "13276c5dbd7f365e00efe6631242772fe6615e1899df84d1f6ce3ae7b48209f6"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -36,7 +36,7 @@ ctrlc = {version = "3.1.6", optional = true}
 derive-new = "0.5.8"
 directories = {version = "3.0.1", optional = true}
 dirs = {version = "3.0.1", optional = true}
-dtparse = "1.1.0"
+dtparse = "1.2.0"
 dunce = "1.0.1"
 eml-parser = "0.1.0"
 filesize = "0.2.0"


### PR DESCRIPTION
1. Handle panic in `str to-datetime`, the main culprit is that the `dtparse` crate was a little panic happy instead of returning `Result`. To fix, I patched `dtparse`, see https://github.com/bspeice/dtparse/issues/26.

Closes #2484 

A nice followup would be to include functionality for unix timestamps as a flag

Reproduce, no longer panics:

```
> echo "1566997680962280" | str to-datetime
error: could not parse as datetime
  ┌─ shell:1:6
  │
1 │ echo "1566997680962280" | str to-datetime
  │      ^^^^^^^^^^^^^^^^^^ ImpossibleTimestamp("Invalid date range given")
```