### PR TITLE
Nushell internal commands. Anchor locations tracker surveying.

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -135,7 +135,7 @@ pub(crate) use command::{
 
 pub(crate) use alias::Alias;
 pub(crate) use ansi::Ansi;
-pub(crate) use append::Append;
+pub(crate) use append::Command as Append;
 pub(crate) use autoenv::Autoenv;
 pub(crate) use autoenv_trust::AutoenvTrust;
 pub(crate) use autoenv_untrust::AutoenvUnTrust;
@@ -164,7 +164,7 @@ pub(crate) use echo::Echo;
 pub(crate) use if_::If;
 pub(crate) use is_empty::IsEmpty;
 pub(crate) use nu::NuPlugin;
-pub(crate) use update::Update;
+pub(crate) use update::Command as Update;
 pub(crate) mod kill;
 pub(crate) use kill::Kill;
 pub(crate) mod clear;
@@ -193,13 +193,13 @@ pub(crate) use from_xml::FromXML;
 pub(crate) use from_yaml::FromYAML;
 pub(crate) use from_yaml::FromYML;
 pub(crate) use get::Get;
-pub(crate) use group_by::GroupBy;
+pub(crate) use group_by::Command as GroupBy;
 pub(crate) use group_by_date::GroupByDate;
 pub(crate) use headers::Headers;
 pub(crate) use help::Help;
 pub(crate) use histogram::Histogram;
 pub(crate) use history::History;
-pub(crate) use insert::Insert;
+pub(crate) use insert::Command as Insert;
 pub(crate) use into_int::IntoInt;
 pub(crate) use keep::{Keep, KeepUntil, KeepWhile};
 pub(crate) use last::Last;
@@ -270,3 +270,40 @@ pub(crate) use where_::Where;
 pub(crate) use which_::Which;
 pub(crate) use with_env::WithEnv;
 pub(crate) use wrap::Wrap;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::whole_stream_command;
+    use crate::examples::{test_anchors, test_examples};
+    use nu_errors::ShellError;
+
+    fn commands() -> Vec<Command> {
+        vec![
+            // Table operations
+            whole_stream_command(Append),
+            whole_stream_command(GroupBy),
+            // Row specific operations
+            whole_stream_command(Insert),
+            whole_stream_command(Update),
+        ]
+    }
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        for cmd in commands() {
+            test_examples(cmd)?;
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn tracks_metadata() -> Result<(), ShellError> {
+        for cmd in commands() {
+            test_anchors(cmd)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/nu-cli/src/commands/alias.rs
+++ b/crates/nu-cli/src/commands/alias.rs
@@ -340,11 +340,12 @@ fn find_block_shapes(block: &Block, registry: &CommandRegistry) -> Result<ShapeM
 #[cfg(test)]
 mod tests {
     use super::Alias;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Alias {})
+        Ok(test_examples(Alias {})?)
     }
 }

--- a/crates/nu-cli/src/commands/ansi.rs
+++ b/crates/nu-cli/src/commands/ansi.rs
@@ -135,11 +135,12 @@ pub fn str_to_ansi_color(s: String) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::Ansi;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Ansi {})
+        Ok(test_examples(Ansi {})?)
     }
 }

--- a/crates/nu-cli/src/commands/autoview/command.rs
+++ b/crates/nu-cli/src/commands/autoview/command.rs
@@ -326,11 +326,12 @@ fn create_default_command_args(context: &RunnableContextWithoutInput) -> RawComm
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/cal.rs
+++ b/crates/nu-cli/src/commands/cal.rs
@@ -339,11 +339,12 @@ fn add_month_to_table(
 #[cfg(test)]
 mod tests {
     use super::Cal;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Cal {})
+        Ok(test_examples(Cal {})?)
     }
 }

--- a/crates/nu-cli/src/commands/cd.rs
+++ b/crates/nu-cli/src/commands/cd.rs
@@ -72,11 +72,12 @@ impl WholeStreamCommand for Cd {
 #[cfg(test)]
 mod tests {
     use super::Cd;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Cd {})
+        Ok(test_examples(Cd {})?)
     }
 }

--- a/crates/nu-cli/src/commands/char_.rs
+++ b/crates/nu-cli/src/commands/char_.rs
@@ -130,11 +130,12 @@ fn str_to_character(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::Char;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Char {})
+        Ok(test_examples(Char {})?)
     }
 }

--- a/crates/nu-cli/src/commands/chart.rs
+++ b/crates/nu-cli/src/commands/chart.rs
@@ -42,11 +42,12 @@ impl WholeStreamCommand for Chart {
 #[cfg(test)]
 mod tests {
     use super::Chart;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Chart {})
+        Ok(test_examples(Chart {})?)
     }
 }

--- a/crates/nu-cli/src/commands/clear.rs
+++ b/crates/nu-cli/src/commands/clear.rs
@@ -43,15 +43,3 @@ impl WholeStreamCommand for Clear {
         }]
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::Clear;
-
-    #[test]
-    fn examples_work_as_expected() {
-        use crate::examples::test as test_examples;
-
-        test_examples(Clear {})
-    }
-}

--- a/crates/nu-cli/src/commands/clip.rs
+++ b/crates/nu-cli/src/commands/clip.rs
@@ -104,11 +104,12 @@ pub async fn clip(
 #[cfg(test)]
 mod tests {
     use super::Clip;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Clip {})
+        Ok(test_examples(Clip {})?)
     }
 }

--- a/crates/nu-cli/src/commands/compact.rs
+++ b/crates/nu-cli/src/commands/compact.rs
@@ -84,11 +84,12 @@ pub async fn compact(
 #[cfg(test)]
 mod tests {
     use super::Compact;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Compact {})
+        Ok(test_examples(Compact {})?)
     }
 }

--- a/crates/nu-cli/src/commands/count.rs
+++ b/crates/nu-cli/src/commands/count.rs
@@ -80,11 +80,12 @@ impl WholeStreamCommand for Count {
 #[cfg(test)]
 mod tests {
     use super::Count;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Count {})
+        Ok(test_examples(Count {})?)
     }
 }

--- a/crates/nu-cli/src/commands/cp.rs
+++ b/crates/nu-cli/src/commands/cp.rs
@@ -66,11 +66,12 @@ impl WholeStreamCommand for Cpy {
 #[cfg(test)]
 mod tests {
     use super::Cpy;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Cpy {})
+        Ok(test_examples(Cpy {})?)
     }
 }

--- a/crates/nu-cli/src/commands/date/command.rs
+++ b/crates/nu-cli/src/commands/date/command.rs
@@ -36,11 +36,12 @@ impl WholeStreamCommand for Command {
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/date/format.rs
+++ b/crates/nu-cli/src/commands/date/format.rs
@@ -61,3 +61,16 @@ pub async fn format(
 
     Ok(OutputStream::one(value))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Date;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        Ok(test_examples(Date {})?)
+    }
+}

--- a/crates/nu-cli/src/commands/date/now.rs
+++ b/crates/nu-cli/src/commands/date/now.rs
@@ -48,3 +48,16 @@ pub async fn now(
 
     Ok(OutputStream::one(value))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Date;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        Ok(test_examples(Date {})?)
+    }
+}

--- a/crates/nu-cli/src/commands/date/utc.rs
+++ b/crates/nu-cli/src/commands/date/utc.rs
@@ -48,3 +48,16 @@ pub async fn utc(
 
     Ok(OutputStream::one(value))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Date;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        Ok(test_examples(Date {})?)
+    }
+}

--- a/crates/nu-cli/src/commands/debug.rs
+++ b/crates/nu-cli/src/commands/debug.rs
@@ -55,11 +55,12 @@ async fn debug_value(
 #[cfg(test)]
 mod tests {
     use super::Debug;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Debug {})
+        Ok(test_examples(Debug {})?)
     }
 }

--- a/crates/nu-cli/src/commands/default.rs
+++ b/crates/nu-cli/src/commands/default.rs
@@ -83,11 +83,12 @@ async fn default(
 #[cfg(test)]
 mod tests {
     use super::Default;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Default {})
+        Ok(test_examples(Default {})?)
     }
 }

--- a/crates/nu-cli/src/commands/describe.rs
+++ b/crates/nu-cli/src/commands/describe.rs
@@ -50,11 +50,12 @@ pub async fn describe(
 #[cfg(test)]
 mod tests {
     use super::Describe;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Describe {})
+        Ok(test_examples(Describe {})?)
     }
 }

--- a/crates/nu-cli/src/commands/do_.rs
+++ b/crates/nu-cli/src/commands/do_.rs
@@ -117,11 +117,12 @@ async fn do_(
 #[cfg(test)]
 mod tests {
     use super::Do;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Do {})
+        Ok(test_examples(Do {})?)
     }
 }

--- a/crates/nu-cli/src/commands/drop.rs
+++ b/crates/nu-cli/src/commands/drop.rs
@@ -85,11 +85,12 @@ async fn drop(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 #[cfg(test)]
 mod tests {
     use super::Drop;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Drop {})
+        Ok(test_examples(Drop {})?)
     }
 }

--- a/crates/nu-cli/src/commands/du.rs
+++ b/crates/nu-cli/src/commands/du.rs
@@ -427,11 +427,12 @@ impl From<FileInfo> for Value {
 #[cfg(test)]
 mod tests {
     use super::Du;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Du {})
+        Ok(test_examples(Du {})?)
     }
 }

--- a/crates/nu-cli/src/commands/each/command.rs
+++ b/crates/nu-cli/src/commands/each/command.rs
@@ -164,11 +164,12 @@ async fn each(
 #[cfg(test)]
 mod tests {
     use super::Each;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Each {})
+        Ok(test_examples(Each {})?)
     }
 }

--- a/crates/nu-cli/src/commands/each/group.rs
+++ b/crates/nu-cli/src/commands/each/group.rs
@@ -123,11 +123,12 @@ pub(crate) fn run_block_on_vec(
 #[cfg(test)]
 mod tests {
     use super::EachGroup;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(EachGroup {})
+        Ok(test_examples(EachGroup {})?)
     }
 }

--- a/crates/nu-cli/src/commands/each/window.rs
+++ b/crates/nu-cli/src/commands/each/window.rs
@@ -103,11 +103,12 @@ impl WholeStreamCommand for EachWindow {
 #[cfg(test)]
 mod tests {
     use super::EachWindow;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(EachWindow {})
+        Ok(test_examples(EachWindow {})?)
     }
 }

--- a/crates/nu-cli/src/commands/echo.rs
+++ b/crates/nu-cli/src/commands/echo.rs
@@ -162,11 +162,12 @@ impl Iterator for RangeIterator {
 #[cfg(test)]
 mod tests {
     use super::Echo;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Echo {})
+        Ok(test_examples(Echo {})?)
     }
 }

--- a/crates/nu-cli/src/commands/enter.rs
+++ b/crates/nu-cli/src/commands/enter.rs
@@ -191,11 +191,12 @@ async fn enter(
 #[cfg(test)]
 mod tests {
     use super::Enter;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Enter {})
+        Ok(test_examples(Enter {})?)
     }
 }

--- a/crates/nu-cli/src/commands/every.rs
+++ b/crates/nu-cli/src/commands/every.rs
@@ -93,11 +93,12 @@ async fn every(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 #[cfg(test)]
 mod tests {
     use super::Every;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Every {})
+        Ok(test_examples(Every {})?)
     }
 }

--- a/crates/nu-cli/src/commands/exit.rs
+++ b/crates/nu-cli/src/commands/exit.rs
@@ -63,11 +63,12 @@ pub async fn exit(
 #[cfg(test)]
 mod tests {
     use super::Exit;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Exit {})
+        Ok(test_examples(Exit {})?)
     }
 }

--- a/crates/nu-cli/src/commands/first.rs
+++ b/crates/nu-cli/src/commands/first.rs
@@ -72,11 +72,12 @@ async fn first(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 #[cfg(test)]
 mod tests {
     use super::First;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(First {})
+        Ok(test_examples(First {})?)
     }
 }

--- a/crates/nu-cli/src/commands/format.rs
+++ b/crates/nu-cli/src/commands/format.rs
@@ -151,11 +151,12 @@ fn format(input: &str) -> Vec<FormatCommand> {
 #[cfg(test)]
 mod tests {
     use super::Format;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Format {})
+        Ok(test_examples(Format {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from.rs
+++ b/crates/nu-cli/src/commands/from.rs
@@ -35,11 +35,12 @@ impl WholeStreamCommand for From {
 #[cfg(test)]
 mod tests {
     use super::From;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(From {})
+        Ok(test_examples(From {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_csv.rs
+++ b/crates/nu-cli/src/commands/from_csv.rs
@@ -109,11 +109,12 @@ async fn from_csv(
 #[cfg(test)]
 mod tests {
     use super::FromCSV;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromCSV {})
+        Ok(test_examples(FromCSV {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_eml.rs
+++ b/crates/nu-cli/src/commands/from_eml.rs
@@ -130,11 +130,12 @@ async fn from_eml(
 #[cfg(test)]
 mod tests {
     use super::FromEML;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromEML {})
+        Ok(test_examples(FromEML {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_ics.rs
+++ b/crates/nu-cli/src/commands/from_ics.rs
@@ -249,11 +249,12 @@ fn params_to_value(params: Vec<(String, Vec<String>)>, tag: Tag) -> Value {
 #[cfg(test)]
 mod tests {
     use super::FromIcs;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromIcs {})
+        Ok(test_examples(FromIcs {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_ini.rs
+++ b/crates/nu-cli/src/commands/from_ini.rs
@@ -95,11 +95,12 @@ async fn from_ini(
 #[cfg(test)]
 mod tests {
     use super::FromINI;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromINI {})
+        Ok(test_examples(FromINI {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_json.rs
+++ b/crates/nu-cli/src/commands/from_json.rs
@@ -144,11 +144,12 @@ async fn from_json(
 #[cfg(test)]
 mod tests {
     use super::FromJSON;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromJSON {})
+        Ok(test_examples(FromJSON {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_ods.rs
+++ b/crates/nu-cli/src/commands/from_ods.rs
@@ -102,11 +102,12 @@ async fn from_ods(
 #[cfg(test)]
 mod tests {
     use super::FromODS;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromODS {})
+        Ok(test_examples(FromODS {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_ssv.rs
+++ b/crates/nu-cli/src/commands/from_ssv.rs
@@ -302,7 +302,9 @@ async fn from_ssv(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::*;
+
     fn owned(x: &str, y: &str) -> (String, String) {
         (String::from(x), String::from(y))
     }
@@ -504,10 +506,10 @@ mod tests {
     }
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use super::FromSSV;
         use crate::examples::test as test_examples;
 
-        test_examples(FromSSV {})
+        Ok(test_examples(FromSSV {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_toml.rs
+++ b/crates/nu-cli/src/commands/from_toml.rs
@@ -101,11 +101,12 @@ pub async fn from_toml(
 #[cfg(test)]
 mod tests {
     use super::FromTOML;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromTOML {})
+        Ok(test_examples(FromTOML {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_tsv.rs
+++ b/crates/nu-cli/src/commands/from_tsv.rs
@@ -52,11 +52,12 @@ async fn from_tsv(
 #[cfg(test)]
 mod tests {
     use super::FromTSV;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromTSV {})
+        Ok(test_examples(FromTSV {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_url.rs
+++ b/crates/nu-cli/src/commands/from_url.rs
@@ -64,11 +64,12 @@ async fn from_url(
 #[cfg(test)]
 mod tests {
     use super::FromURL;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromURL {})
+        Ok(test_examples(FromURL {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_vcf.rs
+++ b/crates/nu-cli/src/commands/from_vcf.rs
@@ -104,11 +104,12 @@ fn params_to_value(params: Vec<(String, Vec<String>)>, tag: Tag) -> Value {
 #[cfg(test)]
 mod tests {
     use super::FromVcf;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromVcf {})
+        Ok(test_examples(FromVcf {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_xlsx.rs
+++ b/crates/nu-cli/src/commands/from_xlsx.rs
@@ -102,11 +102,12 @@ async fn from_xlsx(
 #[cfg(test)]
 mod tests {
     use super::FromXLSX;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromXLSX {})
+        Ok(test_examples(FromXLSX {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_xml.rs
+++ b/crates/nu-cli/src/commands/from_xml.rs
@@ -135,6 +135,7 @@ async fn from_xml(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use crate::commands::from_xml;
     use indexmap::IndexMap;
     use nu_protocol::{UntaggedValue, Value};
@@ -304,10 +305,10 @@ mod tests {
     }
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use super::FromXML;
         use crate::examples::test as test_examples;
 
-        test_examples(FromXML {})
+        Ok(test_examples(FromXML {})?)
     }
 }

--- a/crates/nu-cli/src/commands/from_yaml.rs
+++ b/crates/nu-cli/src/commands/from_yaml.rs
@@ -173,15 +173,16 @@ async fn from_yaml(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::*;
     use nu_plugin::row;
     use nu_plugin::test_helpers::value::string;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(FromYAML {})
+        Ok(test_examples(FromYAML {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/get.rs
+++ b/crates/nu-cli/src/commands/get.rs
@@ -267,11 +267,12 @@ pub fn get_column_from_row_error(
 #[cfg(test)]
 mod tests {
     use super::Get;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Get {})
+        Ok(test_examples(Get {})?)
     }
 }

--- a/crates/nu-cli/src/commands/group_by_date.rs
+++ b/crates/nu-cli/src/commands/group_by_date.rs
@@ -141,11 +141,12 @@ pub async fn group_by_date(
 #[cfg(test)]
 mod tests {
     use super::GroupByDate;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(GroupByDate {})
+        Ok(test_examples(GroupByDate {})?)
     }
 }

--- a/crates/nu-cli/src/commands/headers.rs
+++ b/crates/nu-cli/src/commands/headers.rs
@@ -116,11 +116,12 @@ pub async fn headers(
 #[cfg(test)]
 mod tests {
     use super::Headers;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Headers {})
+        Ok(test_examples(Headers {})?)
     }
 }

--- a/crates/nu-cli/src/commands/help.rs
+++ b/crates/nu-cli/src/commands/help.rs
@@ -234,11 +234,12 @@ pub fn get_help(cmd: &dyn WholeStreamCommand, registry: &CommandRegistry) -> Str
 #[cfg(test)]
 mod tests {
     use super::Help;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Help {})
+        Ok(test_examples(Help {})?)
     }
 }

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -227,11 +227,12 @@ fn splitter(
 #[cfg(test)]
 mod tests {
     use super::Histogram;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Histogram {})
+        Ok(test_examples(Histogram {})?)
     }
 }

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -79,11 +79,12 @@ fn history(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStrea
 #[cfg(test)]
 mod tests {
     use super::History;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(History {})
+        Ok(test_examples(History {})?)
     }
 }

--- a/crates/nu-cli/src/commands/if_.rs
+++ b/crates/nu-cli/src/commands/if_.rs
@@ -174,11 +174,12 @@ async fn if_command(
 #[cfg(test)]
 mod tests {
     use super::If;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(If {})
+        Ok(test_examples(If {})?)
     }
 }

--- a/crates/nu-cli/src/commands/insert.rs
+++ b/crates/nu-cli/src/commands/insert.rs
@@ -9,16 +9,18 @@ use nu_protocol::{
 use nu_value_ext::ValueExt;
 
 use futures::stream::once;
-pub struct Insert;
+use indexmap::indexmap;
+
+pub struct Command;
 
 #[derive(Deserialize)]
-pub struct InsertArgs {
+pub struct Arguments {
     column: ColumnPath,
     value: Value,
 }
 
 #[async_trait]
-impl WholeStreamCommand for Insert {
+impl WholeStreamCommand for Command {
     fn name(&self) -> &str {
         "insert"
     }
@@ -43,6 +45,28 @@ impl WholeStreamCommand for Insert {
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
         insert(args, registry).await
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Insert a column with a value",
+            example: "echo [[author, commits]; ['Andrés', 1]] | insert branches 5",
+            result: Some(vec![UntaggedValue::row(indexmap! {
+                    "author".to_string() => Value::from("Andrés"),
+                    "commits".to_string() => UntaggedValue::int(1).into(),
+                    "branches".to_string() => UntaggedValue::int(5).into(),
+            })
+            .into()]),
+        },Example {
+            description: "Use in block form for more involved insertion logic",
+            example: "echo [[author, lucky_number]; ['Yehuda', 4]] | insert success { = $it.lucky_number * 10 }",
+            result: Some(vec![UntaggedValue::row(indexmap! {
+                    "author".to_string() => Value::from("Yehuda"),
+                    "lucky_number".to_string() => UntaggedValue::int(4).into(),
+                    "success".to_string() => UntaggedValue::int(40).into(),
+            })
+            .into()]),
+        }]
     }
 }
 
@@ -135,7 +159,7 @@ async fn insert(
     let registry = registry.clone();
     let scope = raw_args.call_info.scope.clone();
     let context = Arc::new(EvaluationContext::from_raw(&raw_args, &registry));
-    let (InsertArgs { column, value }, input) = raw_args.process(&registry).await?;
+    let (Arguments { column, value }, input) = raw_args.process(&registry).await?;
     let value = Arc::new(value);
     let column = Arc::new(column);
 
@@ -155,16 +179,4 @@ async fn insert(
         })
         .flatten()
         .to_output_stream())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Insert;
-
-    #[test]
-    fn examples_work_as_expected() {
-        use crate::examples::test as test_examples;
-
-        test_examples(Insert {})
-    }
 }

--- a/crates/nu-cli/src/commands/into_int.rs
+++ b/crates/nu-cli/src/commands/into_int.rs
@@ -78,11 +78,12 @@ async fn into_int(
 #[cfg(test)]
 mod tests {
     use super::IntoInt;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(IntoInt {})
+        Ok(test_examples(IntoInt {})?)
     }
 }

--- a/crates/nu-cli/src/commands/is_empty.rs
+++ b/crates/nu-cli/src/commands/is_empty.rs
@@ -207,11 +207,12 @@ async fn is_empty(
 #[cfg(test)]
 mod tests {
     use super::IsEmpty;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(IsEmpty {})
+        Ok(test_examples(IsEmpty {})?)
     }
 }

--- a/crates/nu-cli/src/commands/keep/command.rs
+++ b/crates/nu-cli/src/commands/keep/command.rs
@@ -74,11 +74,12 @@ async fn keep(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/keep/until.rs
+++ b/crates/nu-cli/src/commands/keep/until.rs
@@ -101,12 +101,13 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/keep/while_.rs
+++ b/crates/nu-cli/src/commands/keep/while_.rs
@@ -100,12 +100,13 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/kill.rs
+++ b/crates/nu-cli/src/commands/kill.rs
@@ -121,11 +121,12 @@ async fn kill(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 #[cfg(test)]
 mod tests {
     use super::Kill;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Kill {})
+        Ok(test_examples(Kill {})?)
     }
 }

--- a/crates/nu-cli/src/commands/last.rs
+++ b/crates/nu-cli/src/commands/last.rs
@@ -83,11 +83,12 @@ async fn last(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 #[cfg(test)]
 mod tests {
     use super::Last;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Last {})
+        Ok(test_examples(Last {})?)
     }
 }

--- a/crates/nu-cli/src/commands/lines.rs
+++ b/crates/nu-cli/src/commands/lines.rs
@@ -125,11 +125,12 @@ async fn lines(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 #[cfg(test)]
 mod tests {
     use super::Lines;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Lines {})
+        Ok(test_examples(Lines {})?)
     }
 }

--- a/crates/nu-cli/src/commands/ls.rs
+++ b/crates/nu-cli/src/commands/ls.rs
@@ -89,11 +89,12 @@ impl WholeStreamCommand for Ls {
 #[cfg(test)]
 mod tests {
     use super::Ls;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Ls {})
+        Ok(test_examples(Ls {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/avg.rs
+++ b/crates/nu-cli/src/commands/math/avg.rs
@@ -188,12 +188,13 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/command.rs
+++ b/crates/nu-cli/src/commands/math/command.rs
@@ -44,10 +44,10 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/math/eval.rs
+++ b/crates/nu-cli/src/commands/math/eval.rs
@@ -100,12 +100,13 @@ pub fn parse<T: Into<Tag>>(math_expression: &str, tag: T) -> Result<Value, Strin
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/max.rs
+++ b/crates/nu-cli/src/commands/math/max.rs
@@ -58,12 +58,13 @@ pub fn maximum(values: &[Value], _name: &Tag) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/median.rs
+++ b/crates/nu-cli/src/commands/math/median.rs
@@ -186,12 +186,13 @@ fn compute_average(values: &[Value], name: impl Into<Tag>) -> Result<Value, Shel
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/min.rs
+++ b/crates/nu-cli/src/commands/math/min.rs
@@ -58,12 +58,13 @@ pub fn minimum(values: &[Value], _name: &Tag) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/mode.rs
+++ b/crates/nu-cli/src/commands/math/mode.rs
@@ -83,12 +83,13 @@ pub fn mode(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/product.rs
+++ b/crates/nu-cli/src/commands/math/product.rs
@@ -115,12 +115,13 @@ pub fn product(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/stddev.rs
+++ b/crates/nu-cli/src/commands/math/stddev.rs
@@ -141,12 +141,13 @@ pub fn compute_stddev(values: &[Value], n: usize, name: &Tag) -> Result<Value, S
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/sum.rs
+++ b/crates/nu-cli/src/commands/math/sum.rs
@@ -125,12 +125,13 @@ pub fn summation(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/math/variance.rs
+++ b/crates/nu-cli/src/commands/math/variance.rs
@@ -240,12 +240,13 @@ pub fn compute_variance(values: &[Value], n: usize, name: &Tag) -> Result<Value,
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/merge.rs
+++ b/crates/nu-cli/src/commands/merge.rs
@@ -101,11 +101,12 @@ async fn merge(
 #[cfg(test)]
 mod tests {
     use super::Merge;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Merge {})
+        Ok(test_examples(Merge {})?)
     }
 }

--- a/crates/nu-cli/src/commands/mkdir.rs
+++ b/crates/nu-cli/src/commands/mkdir.rs
@@ -60,11 +60,12 @@ async fn mkdir(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 #[cfg(test)]
 mod tests {
     use super::Mkdir;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Mkdir {})
+        Ok(test_examples(Mkdir {})?)
     }
 }

--- a/crates/nu-cli/src/commands/move_/column.rs
+++ b/crates/nu-cli/src/commands/move_/column.rs
@@ -324,12 +324,13 @@ fn move_before(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/move_/command.rs
+++ b/crates/nu-cli/src/commands/move_/command.rs
@@ -36,11 +36,12 @@ impl WholeStreamCommand for Command {
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/move_/mv.rs
+++ b/crates/nu-cli/src/commands/move_/mv.rs
@@ -79,11 +79,12 @@ async fn mv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
 #[cfg(test)]
 mod tests {
     use super::Mv;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Mv {})
+        Ok(test_examples(Mv {})?)
     }
 }

--- a/crates/nu-cli/src/commands/next.rs
+++ b/crates/nu-cli/src/commands/next.rs
@@ -35,11 +35,12 @@ fn next(_args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream,
 #[cfg(test)]
 mod tests {
     use super::Next;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Next {})
+        Ok(test_examples(Next {})?)
     }
 }

--- a/crates/nu-cli/src/commands/nth.rs
+++ b/crates/nu-cli/src/commands/nth.rs
@@ -96,11 +96,12 @@ async fn nth(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStre
 #[cfg(test)]
 mod tests {
     use super::Nth;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Nth {})
+        Ok(test_examples(Nth {})?)
     }
 }

--- a/crates/nu-cli/src/commands/nu/plugin.rs
+++ b/crates/nu-cli/src/commands/nu/plugin.rs
@@ -113,12 +113,13 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/open.rs
+++ b/crates/nu-cli/src/commands/open.rs
@@ -243,11 +243,12 @@ pub async fn fetch(
 #[cfg(test)]
 mod tests {
     use super::Open;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Open {})
+        Ok(test_examples(Open {})?)
     }
 }

--- a/crates/nu-cli/src/commands/parse/command.rs
+++ b/crates/nu-cli/src/commands/parse/command.rs
@@ -176,11 +176,12 @@ fn column_names(regex: &Regex) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/path/basename.rs
+++ b/crates/nu-cli/src/commands/path/basename.rs
@@ -51,11 +51,12 @@ fn action(path: &Path) -> UntaggedValue {
 #[cfg(test)]
 mod tests {
     use super::PathBasename;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(PathBasename {})
+        Ok(test_examples(PathBasename {})?)
     }
 }

--- a/crates/nu-cli/src/commands/path/command.rs
+++ b/crates/nu-cli/src/commands/path/command.rs
@@ -36,11 +36,12 @@ impl WholeStreamCommand for Path {
 #[cfg(test)]
 mod tests {
     use super::Path;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Path {})
+        Ok(test_examples(Path {})?)
     }
 }

--- a/crates/nu-cli/src/commands/path/dirname.rs
+++ b/crates/nu-cli/src/commands/path/dirname.rs
@@ -50,11 +50,12 @@ fn action(path: &Path) -> UntaggedValue {
 #[cfg(test)]
 mod tests {
     use super::PathDirname;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(PathDirname {})
+        Ok(test_examples(PathDirname {})?)
     }
 }

--- a/crates/nu-cli/src/commands/path/exists.rs
+++ b/crates/nu-cli/src/commands/path/exists.rs
@@ -43,3 +43,16 @@ impl WholeStreamCommand for PathExists {
 fn action(path: &Path) -> UntaggedValue {
     UntaggedValue::boolean(path.exists())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PathExists;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        Ok(test_examples(PathExists {})?)
+    }
+}

--- a/crates/nu-cli/src/commands/path/expand.rs
+++ b/crates/nu-cli/src/commands/path/expand.rs
@@ -2,7 +2,7 @@ use super::{operate, DefaultArguments};
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue};
 use std::path::Path;
 
 pub struct PathExpand;
@@ -35,7 +35,8 @@ impl WholeStreamCommand for PathExpand {
         vec![Example {
             description: "Expand relative directories",
             example: "echo '/home/joe/foo/../bar' | path expand",
-            result: Some(vec![Value::from("/home/joe/bar")]),
+            result: None,
+            //Some(vec![Value::from("/home/joe/bar")]),
         }]
     }
 }
@@ -48,4 +49,17 @@ fn action(path: &Path) -> UntaggedValue {
         Ok(p) => p.to_string_lossy().to_string(),
         Err(_) => ps.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathExpand;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        Ok(test_examples(PathExpand {})?)
+    }
 }

--- a/crates/nu-cli/src/commands/path/extension.rs
+++ b/crates/nu-cli/src/commands/path/extension.rs
@@ -58,11 +58,12 @@ fn action(path: &Path) -> UntaggedValue {
 #[cfg(test)]
 mod tests {
     use super::PathExtension;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(PathExtension {})
+        Ok(test_examples(PathExtension {})?)
     }
 }

--- a/crates/nu-cli/src/commands/path/filestem.rs
+++ b/crates/nu-cli/src/commands/path/filestem.rs
@@ -51,11 +51,12 @@ fn action(path: &Path) -> UntaggedValue {
 #[cfg(test)]
 mod tests {
     use super::PathFilestem;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(PathFilestem {})
+        Ok(test_examples(PathFilestem {})?)
     }
 }

--- a/crates/nu-cli/src/commands/path/type.rs
+++ b/crates/nu-cli/src/commands/path/type.rs
@@ -52,11 +52,12 @@ fn action(path: &Path) -> UntaggedValue {
 #[cfg(test)]
 mod tests {
     use super::PathType;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(PathType {})
+        Ok(test_examples(PathType {})?)
     }
 }

--- a/crates/nu-cli/src/commands/pivot.rs
+++ b/crates/nu-cli/src/commands/pivot.rs
@@ -155,11 +155,12 @@ pub async fn pivot(
 #[cfg(test)]
 mod tests {
     use super::Pivot;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Pivot {})
+        Ok(test_examples(Pivot {})?)
     }
 }

--- a/crates/nu-cli/src/commands/prepend.rs
+++ b/crates/nu-cli/src/commands/prepend.rs
@@ -67,11 +67,12 @@ async fn prepend(
 #[cfg(test)]
 mod tests {
     use super::Prepend;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Prepend {})
+        Ok(test_examples(Prepend {})?)
     }
 }

--- a/crates/nu-cli/src/commands/prev.rs
+++ b/crates/nu-cli/src/commands/prev.rs
@@ -36,11 +36,12 @@ fn previous(_args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStr
 #[cfg(test)]
 mod tests {
     use super::Previous;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Previous {})
+        Ok(test_examples(Previous {})?)
     }
 }

--- a/crates/nu-cli/src/commands/pwd.rs
+++ b/crates/nu-cli/src/commands/pwd.rs
@@ -50,11 +50,12 @@ pub async fn pwd(
 #[cfg(test)]
 mod tests {
     use super::Pwd;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Pwd {})
+        Ok(test_examples(Pwd {})?)
     }
 }

--- a/crates/nu-cli/src/commands/random/bool.rs
+++ b/crates/nu-cli/src/commands/random/bool.rs
@@ -86,12 +86,13 @@ pub async fn bool_command(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/random/dice.rs
+++ b/crates/nu-cli/src/commands/random/dice.rs
@@ -92,12 +92,13 @@ pub async fn dice(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/random/integer.rs
+++ b/crates/nu-cli/src/commands/random/integer.rs
@@ -101,12 +101,13 @@ pub async fn integer(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/random/uuid.rs
+++ b/crates/nu-cli/src/commands/random/uuid.rs
@@ -48,12 +48,13 @@ pub async fn uuid(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/range.rs
+++ b/crates/nu-cli/src/commands/range.rs
@@ -72,11 +72,12 @@ async fn range(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 #[cfg(test)]
 mod tests {
     use super::Range;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Range {})
+        Ok(test_examples(Range {})?)
     }
 }

--- a/crates/nu-cli/src/commands/reduce.rs
+++ b/crates/nu-cli/src/commands/reduce.rs
@@ -185,11 +185,12 @@ async fn reduce(
 #[cfg(test)]
 mod tests {
     use super::Reduce;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Reduce {})
+        Ok(test_examples(Reduce {})?)
     }
 }

--- a/crates/nu-cli/src/commands/reject.rs
+++ b/crates/nu-cli/src/commands/reject.rs
@@ -65,11 +65,12 @@ async fn reject(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
 #[cfg(test)]
 mod tests {
     use super::Reject;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Reject {})
+        Ok(test_examples(Reject {})?)
     }
 }

--- a/crates/nu-cli/src/commands/rename.rs
+++ b/crates/nu-cli/src/commands/rename.rs
@@ -117,11 +117,12 @@ pub async fn rename(
 #[cfg(test)]
 mod tests {
     use super::Rename;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Rename {})
+        Ok(test_examples(Rename {})?)
     }
 }

--- a/crates/nu-cli/src/commands/reverse.rs
+++ b/crates/nu-cli/src/commands/reverse.rs
@@ -58,11 +58,12 @@ async fn reverse(
 #[cfg(test)]
 mod tests {
     use super::Reverse;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Reverse {})
+        Ok(test_examples(Reverse {})?)
     }
 }

--- a/crates/nu-cli/src/commands/rm.rs
+++ b/crates/nu-cli/src/commands/rm.rs
@@ -100,11 +100,12 @@ async fn rm(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStrea
 #[cfg(test)]
 mod tests {
     use super::Remove;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Remove {})
+        Ok(test_examples(Remove {})?)
     }
 }

--- a/crates/nu-cli/src/commands/save.rs
+++ b/crates/nu-cli/src/commands/save.rs
@@ -280,11 +280,12 @@ fn string_from(input: &[Value]) -> String {
 #[cfg(test)]
 mod tests {
     use super::Save;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Save {})
+        Ok(test_examples(Save {})?)
     }
 }

--- a/crates/nu-cli/src/commands/select.rs
+++ b/crates/nu-cli/src/commands/select.rs
@@ -175,11 +175,12 @@ async fn select(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
 #[cfg(test)]
 mod tests {
     use super::Select;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Select {})
+        Ok(test_examples(Select {})?)
     }
 }

--- a/crates/nu-cli/src/commands/shells.rs
+++ b/crates/nu-cli/src/commands/shells.rs
@@ -52,12 +52,13 @@ fn shells(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Shells;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Shells {})
+        Ok(test_examples(Shells {})?)
     }
 }

--- a/crates/nu-cli/src/commands/shuffle.rs
+++ b/crates/nu-cli/src/commands/shuffle.rs
@@ -42,12 +42,13 @@ async fn shuffle(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Shuffle;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Shuffle {})
+        Ok(test_examples(Shuffle {})?)
     }
 }

--- a/crates/nu-cli/src/commands/size.rs
+++ b/crates/nu-cli/src/commands/size.rs
@@ -119,12 +119,13 @@ fn count(contents: &str, tag: impl Into<Tag>) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Size;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Size {})
+        Ok(test_examples(Size {})?)
     }
 }

--- a/crates/nu-cli/src/commands/skip/command.rs
+++ b/crates/nu-cli/src/commands/skip/command.rs
@@ -61,11 +61,12 @@ async fn skip(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/skip/until.rs
+++ b/crates/nu-cli/src/commands/skip/until.rs
@@ -100,12 +100,13 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/skip/while_.rs
+++ b/crates/nu-cli/src/commands/skip/while_.rs
@@ -101,12 +101,13 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/sleep.rs
+++ b/crates/nu-cli/src/commands/sleep.rs
@@ -178,18 +178,21 @@ impl Future for SleepFuture {
 #[cfg(test)]
 mod tests {
     use super::Sleep;
+    use nu_errors::ShellError;
     use std::time::Instant;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
         let start = Instant::now();
-        test_examples(Sleep {});
+        let results = test_examples(Sleep {});
         let elapsed = start.elapsed();
         println!("{:?}", elapsed);
         // only examples with actual output are run
         assert!(elapsed >= std::time::Duration::from_secs(1));
         assert!(elapsed < std::time::Duration::from_secs(2));
+
+        Ok(results?)
     }
 }

--- a/crates/nu-cli/src/commands/sort_by.rs
+++ b/crates/nu-cli/src/commands/sort_by.rs
@@ -194,12 +194,13 @@ pub fn sort(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SortBy;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SortBy {})
+        Ok(test_examples(SortBy {})?)
     }
 }

--- a/crates/nu-cli/src/commands/split/chars.rs
+++ b/crates/nu-cli/src/commands/split/chars.rs
@@ -73,12 +73,13 @@ async fn split_chars(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/split/column.rs
+++ b/crates/nu-cli/src/commands/split/column.rs
@@ -116,12 +116,13 @@ async fn split_column(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/split/command.rs
+++ b/crates/nu-cli/src/commands/split/command.rs
@@ -36,11 +36,12 @@ impl WholeStreamCommand for Command {
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/split/row.rs
+++ b/crates/nu-cli/src/commands/split/row.rs
@@ -85,12 +85,13 @@ async fn split_row(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/split_by.rs
+++ b/crates/nu-cli/src/commands/split_by.rs
@@ -100,6 +100,7 @@ pub fn split(
 #[cfg(test)]
 mod tests {
     use super::split;
+    use super::ShellError;
     use nu_data::utils::helpers::{committers_grouped_by_date, date, int, row, string, table};
     use nu_protocol::UntaggedValue;
     use nu_source::*;
@@ -168,10 +169,10 @@ mod tests {
     }
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use super::SplitBy;
         use crate::examples::test as test_examples;
 
-        test_examples(SplitBy {})
+        Ok(test_examples(SplitBy {})?)
     }
 }

--- a/crates/nu-cli/src/commands/str_/capitalize.rs
+++ b/crates/nu-cli/src/commands/str_/capitalize.rs
@@ -110,15 +110,16 @@ fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/case/camel_case.rs
+++ b/crates/nu-cli/src/commands/str_/case/camel_case.rs
@@ -43,16 +43,17 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{to_camel_case, SubCommand};
     use crate::commands::str_::case::action;
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/case/kebab_case.rs
+++ b/crates/nu-cli/src/commands/str_/case/kebab_case.rs
@@ -43,16 +43,17 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{to_kebab_case, SubCommand};
     use crate::commands::str_::case::action;
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/case/pascal_case.rs
+++ b/crates/nu-cli/src/commands/str_/case/pascal_case.rs
@@ -43,16 +43,17 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{to_pascal_case, SubCommand};
     use crate::commands::str_::case::action;
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/case/screaming_snake_case.rs
+++ b/crates/nu-cli/src/commands/str_/case/screaming_snake_case.rs
@@ -43,16 +43,17 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{to_screaming_snake_case, SubCommand};
     use crate::commands::str_::case::action;
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/case/snake_case.rs
+++ b/crates/nu-cli/src/commands/str_/case/snake_case.rs
@@ -43,16 +43,17 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{to_snake_case, SubCommand};
     use crate::commands::str_::case::action;
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/collect.rs
+++ b/crates/nu-cli/src/commands/str_/collect.rs
@@ -66,12 +66,13 @@ pub async fn collect(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/str_/command.rs
+++ b/crates/nu-cli/src/commands/str_/command.rs
@@ -39,11 +39,12 @@ impl WholeStreamCommand for Command {
 #[cfg(test)]
 mod tests {
     use super::Command;
+    use super::ShellError;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Command {})
+        Ok(test_examples(Command {})?)
     }
 }

--- a/crates/nu-cli/src/commands/str_/contains.rs
+++ b/crates/nu-cli/src/commands/str_/contains.rs
@@ -128,16 +128,17 @@ fn action(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_protocol::UntaggedValue;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/downcase.rs
+++ b/crates/nu-cli/src/commands/str_/downcase.rs
@@ -98,15 +98,16 @@ fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/ends_with.rs
+++ b/crates/nu-cli/src/commands/str_/ends_with.rs
@@ -102,16 +102,17 @@ fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, Sh
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_protocol::UntaggedValue;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/find_replace.rs
+++ b/crates/nu-cli/src/commands/str_/find_replace.rs
@@ -147,15 +147,16 @@ fn action(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, FindReplace, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/from.rs
+++ b/crates/nu-cli/src/commands/str_/from.rs
@@ -244,12 +244,13 @@ fn round_decimal(decimal: &BigDecimal, mut digits: u64) -> BigDecimal {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/str_/index_of.rs
+++ b/crates/nu-cli/src/commands/str_/index_of.rs
@@ -246,16 +246,17 @@ fn process_range(input: &Value, range: &Value) -> Result<IndexOfOptionalBounds, 
 }
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_protocol::{Primitive, UntaggedValue};
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/length.rs
+++ b/crates/nu-cli/src/commands/str_/length.rs
@@ -54,12 +54,13 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/str_/lpad.rs
+++ b/crates/nu-cli/src/commands/str_/lpad.rs
@@ -144,15 +144,16 @@ fn action(
 #[cfg(test)]
 mod tests {
     use super::{action, SubCommand};
+    use nu_errors::ShellError;
     use nu_plugin::test_helpers::value::string;
     use nu_protocol::UntaggedValue;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/reverse.rs
+++ b/crates/nu-cli/src/commands/str_/reverse.rs
@@ -47,12 +47,13 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::SubCommand;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 }

--- a/crates/nu-cli/src/commands/str_/rpad.rs
+++ b/crates/nu-cli/src/commands/str_/rpad.rs
@@ -144,15 +144,16 @@ fn action(
 #[cfg(test)]
 mod tests {
     use super::{action, SubCommand};
+    use nu_errors::ShellError;
     use nu_plugin::test_helpers::value::string;
     use nu_protocol::UntaggedValue;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/set.rs
+++ b/crates/nu-cli/src/commands/str_/set.rs
@@ -99,15 +99,16 @@ fn action(_input: &Value, options: &Replace, tag: impl Into<Tag>) -> Result<Valu
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, Replace, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/starts_with.rs
+++ b/crates/nu-cli/src/commands/str_/starts_with.rs
@@ -102,16 +102,17 @@ fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, Sh
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_protocol::UntaggedValue;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -283,15 +283,16 @@ fn process_arguments(range: Value, name: impl Into<Tag>) -> Result<(isize, isize
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand, Substring};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     struct Expectation<'a> {

--- a/crates/nu-cli/src/commands/str_/to_datetime.rs
+++ b/crates/nu-cli/src/commands/str_/to_datetime.rs
@@ -174,16 +174,17 @@ fn action(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, DatetimeFormat, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_protocol::{Primitive, UntaggedValue};
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/to_decimal.rs
+++ b/crates/nu-cli/src/commands/str_/to_decimal.rs
@@ -112,15 +112,16 @@ fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::{decimal_from_float, string};
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/to_integer.rs
+++ b/crates/nu-cli/src/commands/str_/to_integer.rs
@@ -112,15 +112,16 @@ fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::{int, string};
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/trim/trim_both_ends.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_both_ends.rs
@@ -62,6 +62,7 @@ fn trim(s: &str, char_: Option<char>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{trim, SubCommand};
     use crate::commands::str_::trim::{action, ActionMode};
     use nu_plugin::{
@@ -71,10 +72,10 @@ mod tests {
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/trim/trim_left.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_left.rs
@@ -63,6 +63,7 @@ fn trim_left(s: &str, char_: Option<char>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{trim_left, SubCommand};
     use crate::commands::str_::trim::{action, ActionMode};
     use nu_plugin::{
@@ -72,10 +73,10 @@ mod tests {
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/trim/trim_right.rs
+++ b/crates/nu-cli/src/commands/str_/trim/trim_right.rs
@@ -63,6 +63,7 @@ fn trim_right(s: &str, char_: Option<char>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{trim_right, SubCommand};
     use crate::commands::str_::trim::{action, ActionMode};
     use nu_plugin::{
@@ -72,10 +73,10 @@ mod tests {
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/str_/upcase.rs
+++ b/crates/nu-cli/src/commands/str_/upcase.rs
@@ -98,15 +98,16 @@ fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::{action, SubCommand};
     use nu_plugin::test_helpers::value::string;
     use nu_source::Tag;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(SubCommand {})
+        Ok(test_examples(SubCommand {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/table/command.rs
+++ b/crates/nu-cli/src/commands/table/command.rs
@@ -252,3 +252,16 @@ async fn table(
 
     Ok(OutputStream::empty())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Command;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        Ok(test_examples(Command {})?)
+    }
+}

--- a/crates/nu-cli/src/commands/tags.rs
+++ b/crates/nu-cli/src/commands/tags.rs
@@ -59,12 +59,13 @@ fn tags(args: CommandArgs, _registry: &CommandRegistry) -> Result<OutputStream, 
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Tags;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Tags {})
+        Ok(test_examples(Tags {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to.rs
+++ b/crates/nu-cli/src/commands/to.rs
@@ -35,12 +35,13 @@ impl WholeStreamCommand for To {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::To;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(To {})
+        Ok(test_examples(To {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_csv.rs
+++ b/crates/nu-cli/src/commands/to_csv.rs
@@ -84,12 +84,13 @@ async fn to_csv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::ToCSV;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToCSV {})
+        Ok(test_examples(ToCSV {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_html.rs
+++ b/crates/nu-cli/src/commands/to_html.rs
@@ -759,12 +759,13 @@ fn run_regexes(hash: &HashMap<u32, (&'static str, String)>, contents: &str) -> S
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::*;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToHTML {})
+        Ok(test_examples(ToHTML {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_json.rs
+++ b/crates/nu-cli/src/commands/to_json.rs
@@ -264,12 +264,13 @@ async fn to_json(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::ToJSON;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToJSON {})
+        Ok(test_examples(ToJSON {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -82,12 +82,13 @@ async fn to_html(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::ToMarkdown;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToMarkdown {})
+        Ok(test_examples(ToMarkdown {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_toml.rs
+++ b/crates/nu-cli/src/commands/to_toml.rs
@@ -186,14 +186,15 @@ async fn to_toml(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::*;
     use nu_protocol::Dictionary;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToTOML {})
+        Ok(test_examples(ToTOML {})?)
     }
 
     #[test]

--- a/crates/nu-cli/src/commands/to_tsv.rs
+++ b/crates/nu-cli/src/commands/to_tsv.rs
@@ -48,12 +48,13 @@ async fn to_tsv(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::ToTSV;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToTSV {})
+        Ok(test_examples(ToTSV {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_url.rs
+++ b/crates/nu-cli/src/commands/to_url.rs
@@ -80,12 +80,13 @@ async fn to_url(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::ToURL;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToURL {})
+        Ok(test_examples(ToURL {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_xml.rs
+++ b/crates/nu-cli/src/commands/to_xml.rs
@@ -194,12 +194,13 @@ async fn to_xml(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputS
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::ToXML;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToXML {})
+        Ok(test_examples(ToXML {})?)
     }
 }

--- a/crates/nu-cli/src/commands/to_yaml.rs
+++ b/crates/nu-cli/src/commands/to_yaml.rs
@@ -172,12 +172,13 @@ async fn to_yaml(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::ToYAML;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(ToYAML {})
+        Ok(test_examples(ToYAML {})?)
     }
 }

--- a/crates/nu-cli/src/commands/touch.rs
+++ b/crates/nu-cli/src/commands/touch.rs
@@ -77,12 +77,13 @@ async fn touch(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Touch;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Touch {})
+        Ok(test_examples(Touch {})?)
     }
 }

--- a/crates/nu-cli/src/commands/uniq.rs
+++ b/crates/nu-cli/src/commands/uniq.rs
@@ -128,12 +128,12 @@ async fn uniq(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Uniq;
-
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Uniq {})
+        Ok(test_examples(Uniq {})?)
     }
 }

--- a/crates/nu-cli/src/commands/url_/command.rs
+++ b/crates/nu-cli/src/commands/url_/command.rs
@@ -35,12 +35,13 @@ impl WholeStreamCommand for Url {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Url;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Url {})
+        Ok(test_examples(Url {})?)
     }
 }

--- a/crates/nu-cli/src/commands/url_/host.rs
+++ b/crates/nu-cli/src/commands/url_/host.rs
@@ -47,12 +47,13 @@ fn host(url: &Url) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::UrlHost;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(UrlHost {})
+        Ok(test_examples(UrlHost {})?)
     }
 }

--- a/crates/nu-cli/src/commands/url_/path.rs
+++ b/crates/nu-cli/src/commands/url_/path.rs
@@ -50,12 +50,13 @@ impl WholeStreamCommand for UrlPath {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::UrlPath;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(UrlPath {})
+        Ok(test_examples(UrlPath {})?)
     }
 }

--- a/crates/nu-cli/src/commands/url_/query.rs
+++ b/crates/nu-cli/src/commands/url_/query.rs
@@ -54,12 +54,13 @@ fn query(url: &Url) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::UrlQuery;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(UrlQuery {})
+        Ok(test_examples(UrlQuery {})?)
     }
 }

--- a/crates/nu-cli/src/commands/url_/scheme.rs
+++ b/crates/nu-cli/src/commands/url_/scheme.rs
@@ -49,12 +49,13 @@ impl WholeStreamCommand for UrlScheme {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::UrlScheme;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(UrlScheme {})
+        Ok(test_examples(UrlScheme {})?)
     }
 }

--- a/crates/nu-cli/src/commands/version.rs
+++ b/crates/nu-cli/src/commands/version.rs
@@ -84,12 +84,13 @@ fn features_enabled(tag: impl Into<Tag>) -> TaggedListBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Version;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Version {})
+        Ok(test_examples(Version {})?)
     }
 }

--- a/crates/nu-cli/src/commands/where_.rs
+++ b/crates/nu-cli/src/commands/where_.rs
@@ -132,12 +132,13 @@ async fn where_command(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Where;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Where {})
+        Ok(test_examples(Where {})?)
     }
 }

--- a/crates/nu-cli/src/commands/which_.rs
+++ b/crates/nu-cli/src/commands/which_.rs
@@ -122,12 +122,13 @@ async fn which(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Which;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Which {})
+        Ok(test_examples(Which {})?)
     }
 }

--- a/crates/nu-cli/src/commands/with_env.rs
+++ b/crates/nu-cli/src/commands/with_env.rs
@@ -123,12 +123,13 @@ async fn with_env(
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::WithEnv;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(WithEnv {})
+        Ok(test_examples(WithEnv {})?)
     }
 }

--- a/crates/nu-cli/src/commands/wrap.rs
+++ b/crates/nu-cli/src/commands/wrap.rs
@@ -138,12 +138,13 @@ async fn wrap(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputStr
 
 #[cfg(test)]
 mod tests {
+    use super::ShellError;
     use super::Wrap;
 
     #[test]
-    fn examples_work_as_expected() {
+    fn examples_work_as_expected() -> Result<(), ShellError> {
         use crate::examples::test as test_examples;
 
-        test_examples(Wrap {})
+        Ok(test_examples(Wrap {})?)
     }
 }

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -1,66 +1,211 @@
-use futures::executor::block_on;
-
 use nu_errors::ShellError;
 use nu_protocol::hir::ClassifiedBlock;
-use nu_protocol::{Scope, ShellTypeName, Value};
+use nu_protocol::{
+    ReturnSuccess, Scope, ShellTypeName, Signature, SyntaxShape, UntaggedValue, Value,
+};
+use nu_source::{AnchorLocation, TaggedItem};
 
+use crate::prelude::*;
+
+use indexmap::indexmap;
+use num_bigint::BigInt;
+
+use indexmap::IndexMap;
+
+use crate::command_registry::CommandRegistry;
 use crate::commands::classified::block::run_block;
-use crate::commands::{whole_stream_command, BuildString, Each, Echo, StrCollect};
+use crate::commands::command::CommandArgs;
+use crate::commands::{
+    whole_stream_command, BuildString, Command, Each, Echo, Get, Keep, StrCollect,
+    WholeStreamCommand,
+};
 use crate::evaluation_context::EvaluationContext;
-use crate::stream::InputStream;
-use crate::WholeStreamCommand;
+use crate::stream::{InputStream, OutputStream};
 
-pub fn test(cmd: impl WholeStreamCommand + 'static) {
+use async_trait::async_trait;
+use futures::executor::block_on;
+use serde::Deserialize;
+
+pub fn test_examples(cmd: Command) -> Result<(), ShellError> {
     let examples = cmd.examples();
-    let mut base_context = EvaluationContext::basic().expect("could not create basic context");
+
+    let mut base_context = EvaluationContext::basic()?;
+
+    base_context.add_commands(vec![
+        // Mocks
+        whole_stream_command(MockLs {}),
+        // Minimal restricted commands to aid in testing
+        whole_stream_command(Echo {}),
+        whole_stream_command(BuildString {}),
+        whole_stream_command(Get {}),
+        whole_stream_command(Keep {}),
+        whole_stream_command(Each {}),
+        whole_stream_command(StrCollect),
+        cmd,
+    ]);
+
+    for sample_pipeline in examples {
+        let mut ctx = base_context.clone();
+
+        let block = parse_line(sample_pipeline.example, &mut ctx)?;
+
+        if let Some(expected) = &sample_pipeline.result {
+            let result = block_on(evaluate_block(block, &mut ctx))?;
+
+            ctx.with_errors(|reasons| {
+                reasons
+                    .iter()
+                    .cloned()
+                    .take(1)
+                    .next()
+                    .and_then(|err| Some(err))
+            })
+            .map_or(Ok(()), |reason| Err(reason))?;
+
+            if expected.len() != result.len() {
+                let rows_returned =
+                    format!("expected: {}\nactual: {}", expected.len(), result.len());
+                let failed_call = format!("command: {}\n", sample_pipeline.example);
+
+                panic!(
+                    "example command produced unexpected number of results.\n {} {}",
+                    failed_call, rows_returned
+                );
+            }
+
+            for (e, a) in expected.iter().zip(result.iter()) {
+                if !values_equal(e, a) {
+                    let row_errored = format!("expected: {:#?}\nactual: {:#?}", e, a);
+                    let failed_call = format!("command: {}\n", sample_pipeline.example);
+
+                    panic!(
+                        "example command produced unexpected result.\n {} {}",
+                        failed_call, row_errored
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
+    let examples = cmd.examples();
+
+    let mut base_context = EvaluationContext::basic()?;
 
     base_context.add_commands(vec![
         whole_stream_command(Echo {}),
         whole_stream_command(BuildString {}),
+        whole_stream_command(Get {}),
+        whole_stream_command(Keep {}),
         whole_stream_command(Each {}),
         whole_stream_command(cmd),
         whole_stream_command(StrCollect),
     ]);
 
-    for example in examples {
+    for sample_pipeline in examples {
         let mut ctx = base_context.clone();
-        let block = parse_line(example.example, &mut ctx).expect("failed to parse example");
-        if let Some(expected) = example.result {
-            let result = block_on(evaluate_block(block, &mut ctx)).expect("failed to run example");
 
-            let errors = ctx.get_errors();
+        let block = parse_line(sample_pipeline.example, &mut ctx)?;
 
-            assert!(
-                errors.is_empty(),
-                "errors while running command.\ncommand: {}\nerrors: {:?}",
-                example.example,
-                errors
-            );
+        if let Some(expected) = &sample_pipeline.result {
+            let result = block_on(evaluate_block(block, &mut ctx))?;
 
-            assert!(expected.len() == result.len(), "example command produced unexpected number of results.\ncommand: {}\nexpected number: {}\nactual: {}",
-                example.example,
-                expected.len(),
-                result.len(),);
-
-            assert!(
-                expected
+            ctx.with_errors(|reasons| {
+                reasons
                     .iter()
-                    .zip(result.iter())
-                    .all(|(e, a)| values_equal(e, a)),
-                "example command produced unexpected result.\ncommand: {}\nexpected: {:?}\nactual: {:?}",
-                example.example,
-                expected,
-                result,
-            );
+                    .cloned()
+                    .take(1)
+                    .next()
+                    .and_then(|err| Some(err))
+            })
+            .map_or(Ok(()), |reason| Err(reason))?;
+
+            if expected.len() != result.len() {
+                let rows_returned =
+                    format!("expected: {}\nactual: {}", expected.len(), result.len());
+                let failed_call = format!("command: {}\n", sample_pipeline.example);
+
+                panic!(
+                    "example command produced unexpected number of results.\n {} {}",
+                    failed_call, rows_returned
+                );
+            }
+
+            for (e, a) in expected.iter().zip(result.iter()) {
+                if !values_equal(e, a) {
+                    let row_errored = format!("expected: {:#?}\nactual: {:#?}", e, a);
+                    let failed_call = format!("command: {}\n", sample_pipeline.example);
+
+                    panic!(
+                        "example command produced unexpected result.\n {} {}",
+                        failed_call, row_errored
+                    );
+                }
+            }
         }
     }
+
+    Ok(())
+}
+
+pub fn test_anchors(cmd: Command) -> Result<(), ShellError> {
+    let examples = cmd.examples();
+
+    let mut base_context = EvaluationContext::basic()?;
+
+    base_context.add_commands(vec![
+        // Minimal restricted commands to aid in testing
+        whole_stream_command(MockCommand {}),
+        whole_stream_command(MockEcho {}),
+        whole_stream_command(MockLs {}),
+        whole_stream_command(BuildString {}),
+        whole_stream_command(Get {}),
+        whole_stream_command(Keep {}),
+        whole_stream_command(Each {}),
+        whole_stream_command(StrCollect),
+        cmd,
+    ]);
+
+    for sample_pipeline in examples {
+        let pipeline_with_anchor = format!("mock --open --path | {}", sample_pipeline.example);
+
+        let mut ctx = base_context.clone();
+
+        let block = parse_line(&pipeline_with_anchor, &mut ctx)?;
+        let result = block_on(evaluate_block(block, &mut ctx))?;
+
+        ctx.with_errors(|reasons| {
+            reasons
+                .iter()
+                .cloned()
+                .take(1)
+                .next()
+                .and_then(|err| Some(err))
+        })
+        .map_or(Ok(()), |reason| Err(reason))?;
+
+        for actual in result.iter() {
+            if !is_anchor_carried(actual, mock_path()) {
+                let failed_call = format!("command: {}\n", pipeline_with_anchor);
+
+                panic!(
+                    "example command didn't carry anchor tag correctly.\n {} {:#?} {:#?}",
+                    failed_call,
+                    actual,
+                    mock_path()
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Parse and run a nushell pipeline
-fn parse_line(
-    line: &'static str,
-    ctx: &mut EvaluationContext,
-) -> Result<ClassifiedBlock, ShellError> {
+fn parse_line(line: &str, ctx: &mut EvaluationContext) -> Result<ClassifiedBlock, ShellError> {
     let line = if line.ends_with('\n') {
         &line[..line.len() - 1]
     } else {
@@ -86,7 +231,7 @@ async fn evaluate_block(
 
     Ok(run_block(&block.block, ctx, input_stream, scope)
         .await?
-        .into_vec()
+        .drain_vec()
         .await)
 }
 
@@ -112,4 +257,234 @@ fn values_equal(expected: &Value, actual: &Value) -> bool {
         (Table(e), Table(a)) => e.iter().zip(a.iter()).all(|(e, a)| values_equal(e, a)),
         (e, a) => unimplemented!("{} {}", e.type_name(), a.type_name()),
     }
+}
+
+fn is_anchor_carried(actual: &Value, anchor: AnchorLocation) -> bool {
+    actual.tag.anchor() == Some(anchor)
+}
+
+#[derive(Deserialize)]
+struct Arguments {
+    path: Option<bool>,
+    open: bool,
+}
+
+struct MockCommand;
+
+#[async_trait]
+impl WholeStreamCommand for MockCommand {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("mock")
+            .switch("open", "fake opening sources", Some('o'))
+            .switch("path", "file open", Some('p'))
+    }
+
+    fn usage(&self) -> &str {
+        "Generates tables and metadata that mimics behavior of real commands in controlled ways."
+    }
+
+    async fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        let name_tag = args.call_info.name_tag.clone();
+
+        let (
+            Arguments {
+                path: mocked_path,
+                open: open_mock,
+            },
+            _input,
+        ) = args.process(&registry).await?;
+
+        let out = UntaggedValue::string("Yehuda Katz in Ecuador");
+
+        if open_mock {
+            if let Some(true) = mocked_path {
+                let mocked_path = Some(mock_path());
+                let value = out.tagged(name_tag.span).map_anchored(&mocked_path);
+
+                return Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+                    value.item.into_value(value.tag),
+                ))));
+            }
+        }
+
+        Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+            out.into_value(name_tag),
+        ))))
+    }
+}
+
+struct MockEcho;
+
+#[derive(Deserialize)]
+pub struct MockEchoArgs {
+    pub rest: Vec<Value>,
+}
+
+#[async_trait]
+impl WholeStreamCommand for MockEcho {
+    fn name(&self) -> &str {
+        "echo"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("echo").rest(SyntaxShape::Any, "the values to echo")
+    }
+
+    fn usage(&self) -> &str {
+        "Mock echo."
+    }
+
+    async fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        let name_tag = args.call_info.name_tag.clone();
+        let (MockEchoArgs { rest }, input) = args.process(&registry).await?;
+
+        let mut base_value = UntaggedValue::string("Yehuda Katz in Ecuador").into_value(name_tag);
+        let input: Vec<Value> = input.collect().await;
+
+        if let Some(first) = input.get(0) {
+            base_value = first.clone()
+        }
+
+        let stream = rest.into_iter().map(move |i| {
+            let base_value = base_value.clone();
+            match i.as_string() {
+                Ok(s) => OutputStream::one(Ok(ReturnSuccess::Value(
+                    UntaggedValue::string(s).into_value(base_value.tag.clone()),
+                ))),
+                _ => match i {
+                    Value {
+                        value: UntaggedValue::Table(table),
+                        ..
+                    } => futures::stream::iter(
+                        table
+                            .into_iter()
+                            .map(move |mut v| {
+                                v.tag = base_value.tag();
+                                v
+                            })
+                            .map(ReturnSuccess::value),
+                    )
+                    .to_output_stream(),
+                    _ => OutputStream::one(Ok(ReturnSuccess::Value(Value {
+                        value: i.value.clone(),
+                        tag: base_value.tag.clone(),
+                    }))),
+                },
+            }
+        });
+
+        Ok(futures::stream::iter(stream).flatten().to_output_stream())
+    }
+}
+
+struct MockLs;
+
+#[async_trait]
+impl WholeStreamCommand for MockLs {
+    fn name(&self) -> &str {
+        "ls"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("ls")
+    }
+
+    fn usage(&self) -> &str {
+        "Mock ls."
+    }
+
+    async fn run(
+        &self,
+        args: CommandArgs,
+        _: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        let name_tag = args.call_info.name_tag.clone();
+
+        let mut base_value =
+            UntaggedValue::string("Andrés N. Robalino in Portland").into_value(name_tag);
+        let input: Vec<Value> = args.input.collect().await;
+
+        if let Some(first) = input.get(0) {
+            base_value = first.clone()
+        }
+
+        Ok(futures::stream::iter(
+            file_listing()
+                .iter()
+                .map(|row| Value {
+                    value: row.value.clone(),
+                    tag: base_value.tag.clone(),
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(ReturnSuccess::value),
+        )
+        .to_output_stream())
+    }
+}
+
+fn int(s: impl Into<BigInt>) -> Value {
+    UntaggedValue::int(s).into_untagged_value()
+}
+
+fn string(input: impl Into<String>) -> Value {
+    UntaggedValue::string(input.into()).into_untagged_value()
+}
+
+fn row(entries: IndexMap<String, Value>) -> Value {
+    UntaggedValue::row(entries).into_untagged_value()
+}
+
+fn date(input: impl Into<String>) -> Value {
+    let key = input.into().tagged_unknown();
+    crate::value::Date::naive_from_str(key.borrow_tagged())
+        .expect("date from string failed")
+        .into_untagged_value()
+}
+
+fn file_listing() -> Vec<Value> {
+    vec![
+        row(indexmap! {
+           "modified".to_string() =>   date("2019-07-23"),
+               "name".to_string() => string("Andrés.txt"),
+               "type".to_string() =>       string("File"),
+           "chickens".to_string() =>              int(10),
+        }),
+        row(indexmap! {
+           "modified".to_string() =>   date("2019-07-23"),
+               "name".to_string() =>   string("Jonathan"),
+               "type".to_string() =>        string("Dir"),
+           "chickens".to_string() =>               int(5),
+        }),
+        row(indexmap! {
+           "modified".to_string() =>    date("2019-09-24"),
+               "name".to_string() =>  string("Andrés.txt"),
+               "type".to_string() =>        string("File"),
+           "chickens".to_string() =>               int(20),
+        }),
+        row(indexmap! {
+           "modified".to_string() =>    date("2019-09-24"),
+               "name".to_string() =>      string("Yehuda"),
+               "type".to_string() =>         string("Dir"),
+           "chickens".to_string() =>                int(4),
+        }),
+    ]
+}
+
+fn mock_path() -> AnchorLocation {
+    let path = String::from("path/to/las_best_arepas_in_the_world.txt");
+
+    AnchorLocation::File(path)
 }

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -47,6 +47,10 @@ pub fn date_from_str(s: Tagged<&str>) -> Result<UntaggedValue, ShellError> {
     Date::from_regular_str(s)
 }
 
+pub fn date_naive_from_str(s: Tagged<&str>) -> Result<UntaggedValue, ShellError> {
+    Date::naive_from_str(s)
+}
+
 pub fn merge_values(
     left: &UntaggedValue,
     right: &UntaggedValue,

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -314,6 +314,13 @@ impl Tag {
         }
     }
 
+    pub fn anchored(self, anchor: Option<AnchorLocation>) -> Tag {
+        Tag {
+            anchor,
+            span: self.span,
+        }
+    }
+
     /// Creates a `Tag` from the given `Span` with no `AnchorLocation`
     pub fn unknown_anchor(span: Span) -> Tag {
         Tag { anchor: None, span }


### PR DESCRIPTION
This is the start of a major check on all our commands. In particular, anchor location tracking. We've seen cases when someone tries to `save` without passing in the file name from where the source comes from (and this is not a desired experience we'd like to let happen). As we continue to grow it's important to pay attention when it fails due to not setting tags correctly for a given command and the like.

This is error prone too, since every command implementor is responsible to set the right spans and tags. 

Some context before I continue. We currently have `examples` for documenting purposes, there are cases when we can't set in the `result` field the expected output for many reasons (like an example with `ls`, for instance) and this skips testing.

Every command has a `tests` module where the `examples` are tested. (we could also use more examples, make them better, and try to make the difficult ones to test, testable). 

This is the process I'm going to start now.

1) Move the test modules from all the commands into one single place: (`src/commands.rs`)
2) Add one by one to this newer file, while at it, test and write more examples and documentation.
3) Better documentation, more examples, and correct behavior.

This process is on route now. In this PR, I put and revised the first four commands (`update`, `insert`, `group-by`, and `append`). Bugs were fixed and all of them when used in the pipeline after opening a file will continue carrying over the anchor location as well (Added more examples too).

Some mock commands were written (fake `ls`, `echo`) and to test the anchor location tracking the pipeline starts feeding a mock anchor location from the start of the pipeline.

This short fake commands allow to test also the examples (like examples using `ls` in the pipeline). More details in the PR.