### PR TITLE
[wasi] Update time & instant crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2934,7 +2934,6 @@ dependencies = [
  "ical",
  "ichwh",
  "indexmap",
- "instant",
  "itertools",
  "log 0.4.11",
  "meval",
@@ -5212,11 +5211,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -5804,6 +5804,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -52,7 +52,6 @@ htmlescape = "0.3.1"
 ical = "0.6.0"
 ichwh = {version = "0.3.4", optional = true}
 indexmap = {version = "1.6.0", features = ["serde-1"]}
-instant = "0.1.7"
 itertools = "0.9.0"
 log = "0.4.11"
 meval = "0.2.0"

--- a/crates/nu-cli/src/env/host.rs
+++ b/crates/nu-cli/src/env/host.rs
@@ -126,9 +126,8 @@ impl Host for BasicHost {
     }
 
     fn width(&self) -> usize {
-        let (mut term_width, _) = term_size::dimensions().unwrap_or_else(|| (20, 20));
-        term_width -= 1;
-        std::cmp::max(term_width, 20)
+        let (term_width, _) = term_size::dimensions().unwrap_or_else(|| (80, 20));
+        term_width
     }
 }
 

--- a/crates/nu_plugin_textview/src/textview.rs
+++ b/crates/nu_plugin_textview/src/textview.rs
@@ -13,7 +13,7 @@ impl TextView {
 
 #[allow(clippy::cognitive_complexity)]
 pub fn view_text_value(value: &Value) {
-    let (mut term_width, _) = term_size::dimensions().unwrap_or_else(|| (20, 20));
+    let (mut term_width, _) = term_size::dimensions().unwrap_or_else(|| (80, 20));
     let mut tab_width: u64 = 4;
     let mut colored_output = true;
     let mut true_color = true;


### PR DESCRIPTION
In https://github.com/nushell/nushell/pull/2643 instant was updated by adding it as a hard dependency in Cargo.toml, but it's better to avoid it and only update in Cargo.lock via `cargo update -p ...`.

Additionally, updated `time` crate so that now some basic commands like `ls` work too, although formatting is pretty bad (probably because it can't get width of the terminal - maybe there is some sensible default value that could be used as a fallback?):

![image](https://user-images.githubusercontent.com/557590/95272083-61163180-0837-11eb-8c70-2cc9c1566b9d.png)

cc @jonathandturner 