### PR TITLE
Handle inf/nan in delimited data

### DIFF
--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -197,13 +197,22 @@ impl UntaggedValue {
     pub fn decimal_from_float(f: f64, span: Span) -> UntaggedValue {
         let dec = BigDecimal::from_f64(f);
 
-        match dec {
-            Some(dec) => UntaggedValue::Primitive(Primitive::Decimal(dec)),
-            None => UntaggedValue::Error(ShellError::labeled_error(
-                "Can not convert f64 to big decimal",
-                "can not create decimal",
-                span,
-            )),
+        // BigDecimal doesn't have the concept of inf/NaN so handle manually
+        if f.is_sign_negative() && f.is_infinite() {
+            UntaggedValue::from("-inf")
+        } else if f.is_infinite() {
+            UntaggedValue::from("inf")
+        } else if f.is_nan() {
+            UntaggedValue::from("NaN")
+        } else {
+            match dec {
+                Some(dec) => UntaggedValue::Primitive(Primitive::Decimal(dec)),
+                None => UntaggedValue::Error(ShellError::labeled_error(
+                    "Can not convert f64 to big decimal",
+                    "can not create decimal",
+                    span,
+                )),
+            }
         }
     }
 
@@ -544,4 +553,29 @@ pub fn merge_descriptors(values: &[Value]) -> Vec<String> {
         }
     }
     ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decimal_from_float() {
+        assert_eq!(
+            UntaggedValue::from("inf"),
+            UntaggedValue::decimal_from_float(f64::INFINITY, Span::default())
+        );
+        assert_eq!(
+            UntaggedValue::from("-inf"),
+            UntaggedValue::decimal_from_float(f64::NEG_INFINITY, Span::default())
+        );
+        assert_eq!(
+            UntaggedValue::from("NaN"),
+            UntaggedValue::decimal_from_float(f64::NAN, Span::default())
+        );
+        assert_eq!(
+            UntaggedValue::from(5.5),
+            UntaggedValue::decimal_from_float(5.5, Span::default())
+        )
+    }
 }


### PR DESCRIPTION
1. Handle inf/nan in delimited data

I opted to handle this edge case manually. I think it would take a while to get it integrated directly into `BigDecimal`, but if it is ever does, we can revisit.

Closes #2400 

BEFORE:
```
> echo [[name, stars]; ['nu', inf]] | to csv | from csv
───┬──────┬───────
 # │ name │ stars
───┼──────┼───────
 0 │ nu   │ error
```

AFTER:
```
> echo [[name, stars]; ['nu', inf]] | to csv | from csv
───┬──────┬───────
 # │ name │ stars
───┼──────┼───────
 0 │ nu   │ inf
───┴──────┴───────
```