### PR TITLE
Allow config to work with column paths.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,7 @@ dependencies = [
  "nu-protocol",
  "nu-source",
  "nu-table",
+ "nu-test-support",
  "nu-value-ext",
  "num-bigint 0.3.0",
  "num-traits 0.2.12",
@@ -3116,12 +3117,16 @@ dependencies = [
 name = "nu-test-support"
 version = "0.20.0"
 dependencies = [
+ "chrono",
  "dunce",
  "getset",
  "glob",
  "indexmap",
+ "nu-errors",
  "nu-protocol",
  "nu-source",
+ "nu-value-ext",
+ "num-bigint 0.3.0",
  "tempfile",
 ]
 
@@ -3134,6 +3139,7 @@ dependencies = [
  "nu-errors",
  "nu-protocol",
  "nu-source",
+ "nu-test-support",
  "num-traits 0.2.12",
 ]
 

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -33,6 +33,7 @@ nu-protocol = {version = "0.20.0", path = "../nu-protocol"}
 nu-source = {version = "0.20.0", path = "../nu-source"}
 nu-table = {version = "0.20.0", path = "../nu-table"}
 nu-value-ext = {version = "0.20.0", path = "../nu-value-ext"}
+nu-test-support = {version = "0.20.0", path = "../nu-test-support"}
 
 [target.'cfg(unix)'.dependencies]
 users = "0.10.0"

--- a/crates/nu-data/src/base.rs
+++ b/crates/nu-data/src/base.rs
@@ -165,38 +165,13 @@ pub fn coerce_compare_primitive(
 }
 #[cfg(test)]
 mod tests {
-    use indexmap::{indexmap, IndexMap};
     use nu_errors::ShellError;
-    use nu_protocol::{ColumnPath as ColumnPathValue, PathMember, UntaggedValue, Value};
-    use nu_source::*;
-    use nu_value_ext::{as_column_path, ValueExt};
-    use num_bigint::BigInt;
+    use nu_protocol::UntaggedValue;
+    use nu_source::SpannedItem;
+    use nu_test_support::value::*;
+    use nu_value_ext::ValueExt;
 
-    fn string(input: impl Into<String>) -> Value {
-        crate::utils::helpers::string(input)
-    }
-
-    fn int(input: impl Into<BigInt>) -> Value {
-        crate::utils::helpers::int(input)
-    }
-
-    fn row(entries: IndexMap<String, Value>) -> Value {
-        crate::utils::helpers::row(entries)
-    }
-
-    fn table(list: &[Value]) -> Value {
-        crate::utils::helpers::table(list)
-    }
-
-    fn error_callback(
-        reason: &'static str,
-    ) -> impl FnOnce(&Value, &PathMember, ShellError) -> ShellError {
-        move |_obj_source, _column_path_tried, _err| ShellError::unimplemented(reason)
-    }
-
-    fn column_path(paths: &[Value]) -> Result<Tagged<ColumnPathValue>, ShellError> {
-        as_column_path(&table(paths))
-    }
+    use indexmap::indexmap;
 
     #[test]
     fn gets_matching_field_from_a_row() -> Result<(), ShellError> {

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -92,6 +92,11 @@ impl UntaggedValue {
         matches!(self, UntaggedValue::Table(_))
     }
 
+    /// Returns true if this value represents a row
+    pub fn is_row(&self) -> bool {
+        matches!(self, UntaggedValue::Row(_))
+    }
+
     /// Returns true if this value represents a string
     pub fn is_string(&self) -> bool {
         matches!(self, UntaggedValue::Primitive(Primitive::String(_)))

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -12,11 +12,15 @@ doctest = false
 [dependencies]
 nu-protocol = {path = "../nu-protocol", version = "0.20.0"}
 nu-source = {path = "../nu-source", version = "0.20.0"}
+nu-errors = {version = "0.20.0", path = "../nu-errors"}
+nu-value-ext = {version = "0.20.0", path = "../nu-value-ext"}
 
+chrono = "0.4.15"
 dunce = "1.0.1"
 getset = "0.1.1"
 glob = "0.3.0"
 indexmap = {version = "1.6.0", features = ["serde-1"]}
 tempfile = "3.1.0"
+num-bigint = {version = "0.3.0", features = ["serde"]}
 
 [build-dependencies]

--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod fs;
 pub mod macros;
 pub mod playground;
+pub mod value;
 
 pub fn pipeline(commands: &str) -> String {
     commands

--- a/crates/nu-test-support/src/value.rs
+++ b/crates/nu-test-support/src/value.rs
@@ -1,0 +1,50 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use indexmap::IndexMap;
+use nu_errors::ShellError;
+use nu_protocol::{ColumnPath, PathMember, Primitive, UntaggedValue, Value};
+use nu_source::{Span, Tagged, TaggedItem};
+use nu_value_ext::as_column_path;
+use num_bigint::BigInt;
+
+pub fn int(s: impl Into<BigInt>) -> Value {
+    UntaggedValue::int(s).into_untagged_value()
+}
+
+pub fn decimal_from_float(f: f64, span: Span) -> Value {
+    UntaggedValue::decimal_from_float(f, span).into_untagged_value()
+}
+
+pub fn string(input: impl Into<String>) -> Value {
+    UntaggedValue::string(input.into()).into_untagged_value()
+}
+
+pub fn row(entries: IndexMap<String, Value>) -> Value {
+    UntaggedValue::row(entries).into_untagged_value()
+}
+
+pub fn table(list: &[Value]) -> Value {
+    UntaggedValue::table(list).into_untagged_value()
+}
+
+pub fn date(input: impl Into<String>) -> Value {
+    let key = input.into().tagged_unknown();
+
+    let date = NaiveDate::parse_from_str(key.borrow_tagged().item, "%Y-%m-%d")
+        .expect("date from string failed");
+
+    UntaggedValue::Primitive(Primitive::Date(DateTime::<Utc>::from_utc(
+        date.and_hms(12, 34, 56),
+        Utc,
+    )))
+    .into_untagged_value()
+}
+
+pub fn column_path(paths: &[Value]) -> Result<Tagged<ColumnPath>, ShellError> {
+    as_column_path(&table(paths))
+}
+
+pub fn error_callback(
+    reason: &'static str,
+) -> impl FnOnce(&Value, &PathMember, ShellError) -> ShellError {
+    move |_obj_source, _column_path_tried, _err| ShellError::unimplemented(reason)
+}

--- a/crates/nu-value-ext/Cargo.toml
+++ b/crates/nu-value-ext/Cargo.toml
@@ -18,4 +18,5 @@ indexmap = {version = "1.6.0", features = ["serde-1"]}
 itertools = "0.9.0"
 num-traits = "0.2.12"
 
-[build-dependencies]
+[dev-dependencies]
+nu-test-support = {path = "../nu-test-support", version = "0.20.0"}


### PR DESCRIPTION
Nu has many commands that allow the nuño to customize behavior such
as UI and behavior. Today, coloring can be customized, the line editor,
and other things. The more options there are, the higher the complexity
in managing them.

To mitigate this Nu can store configuration options as nested properties.

But to add and edit them can be taxing. With column path support we can
work with them easier.