### PR TITLE
Use iterator chain instead of string concat.

### DIFF
--- a/crates/nu-cli/src/commands/lines.rs
+++ b/crates/nu-cli/src/commands/lines.rs
@@ -75,9 +75,9 @@ async fn lines(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
                 } => {
                     let mut leftover_string = leftover_string.lock();
 
-                    let st = (&*leftover_string).clone() + &st;
-
-                    let mut lines: Vec<String> = st.lines().map(|x| x.to_string()).collect();
+                    let lo_lines = (&*leftover_string).lines().map(|x| x.to_string());
+                    let st_lines = st.lines().map(|x| x.to_string());
+                    let mut lines: Vec<String> = lo_lines.chain(st_lines).collect();
 
                     leftover_string.clear();
 

--- a/crates/nu-cli/tests/commands/lines.rs
+++ b/crates/nu-cli/tests/commands/lines.rs
@@ -34,3 +34,18 @@ fn lines_proper_buffering() {
 
     assert_eq!(actual.out, "[8194,4]");
 }
+
+#[test]
+fn lines_multi_value_split() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open sample-simple.json
+            | get first second
+            | lines
+            | count
+        "#
+    ));
+
+    assert_eq!(actual.out, "6");
+}

--- a/tests/fixtures/formats/sample-simple.json
+++ b/tests/fixtures/formats/sample-simple.json
@@ -1,0 +1,4 @@
+{
+    "first": "first",
+    "second": "this\nshould\nbe\nseparate\nlines"
+}


### PR DESCRIPTION
This should fix #1470.
Previously strings from multiple rows were added together before being split, this changes it so they are  separately split and the results added together afterwards.
This should make behavior more consistent.

Before this commit:
```sh
open foo.json | get first second | lines
───┬───────────
 0 │ firstthis 
 1 │ should    
 2 │ be        
 3 │ separate  
 4 │ lines     
───┴───────────
```
After this commit:
```sh
open foo.json | get first second | lines
───┬──────────
 0 │ first    
 1 │ this     
 2 │ should   
 3 │ be       
 4 │ separate 
 5 │ lines    
───┴──────────
```

`foo.json`:
```json
{
  "first": "first",
  "second": "this\nshould\nbe\nseparate\nlines"
}
```

*Disclaimer*: I am not very familiar with this code base so I didn't test this very well.