### PR TITLE
Restore bigint/bigdecimal serialization.

### DIFF
--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -7,6 +7,8 @@ pub mod evaluate;
 pub mod iter;
 pub mod primitive;
 pub mod range;
+mod serde_bigdecimal;
+mod serde_bigint;
 
 use crate::hir;
 use crate::type_name::{ShellTypeName, SpannedTypeName};

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -1,6 +1,7 @@
 use crate::type_name::ShellTypeName;
 use crate::value::column_path::ColumnPath;
 use crate::value::range::{Range, RangeInclusion};
+use crate::value::{serde_bigdecimal, serde_bigint};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use nu_errors::{ExpectedRange, ShellError};
@@ -24,8 +25,10 @@ pub enum Primitive {
     /// An empty value
     Nothing,
     /// A "big int", an integer with arbitrarily large size (aka not limited to 64-bit)
+    #[serde(with = "serde_bigint")]
     Int(BigInt),
     /// A "big decimal", an decimal number with arbitrarily large size (aka not limited to 64-bit)
+    #[serde(with = "serde_bigdecimal")]
     Decimal(BigDecimal),
     /// A count in the number of bytes, used as a filesize
     Filesize(u64),
@@ -42,6 +45,7 @@ pub enum Primitive {
     /// A date value, in UTC
     Date(DateTime<Utc>),
     /// A count in the number of nanoseconds
+    #[serde(with = "serde_bigint")]
     Duration(BigInt),
     /// A range of values
     Range(Box<Range>),

--- a/crates/nu-protocol/src/value/serde_bigdecimal.rs
+++ b/crates/nu-protocol/src/value/serde_bigdecimal.rs
@@ -1,0 +1,26 @@
+use bigdecimal::BigDecimal;
+use num_traits::cast::FromPrimitive;
+use num_traits::cast::ToPrimitive;
+
+/// Enable big decimal serialization by providing a `serialize` function
+pub fn serialize<S>(big_decimal: &BigDecimal, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serde::Serialize::serialize(
+        &big_decimal
+            .to_f64()
+            .ok_or_else(|| serde::ser::Error::custom("expected a f64-sized bignum"))?,
+        serializer,
+    )
+}
+
+/// Enable big decimal deserialization by providing a `deserialize` function
+pub fn deserialize<'de, D>(deserializer: D) -> Result<BigDecimal, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let x: f64 = serde::Deserialize::deserialize(deserializer)?;
+    Ok(BigDecimal::from_f64(x)
+        .ok_or_else(|| serde::de::Error::custom("expected a f64-sized bigdecimal"))?)
+}

--- a/crates/nu-protocol/src/value/serde_bigint.rs
+++ b/crates/nu-protocol/src/value/serde_bigint.rs
@@ -1,0 +1,26 @@
+use num_bigint::BigInt;
+use num_traits::cast::FromPrimitive;
+use num_traits::cast::ToPrimitive;
+
+/// Enable big int serialization by providing a `serialize` function
+pub fn serialize<S>(big_int: &BigInt, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serde::Serialize::serialize(
+        &big_int
+            .to_i64()
+            .ok_or_else(|| serde::ser::Error::custom("expected a i64-sized bignum"))?,
+        serializer,
+    )
+}
+
+/// Enable big int deserialization by providing a `deserialize` function
+pub fn deserialize<'de, D>(deserializer: D) -> Result<BigInt, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let x: i64 = serde::Deserialize::deserialize(deserializer)?;
+    Ok(BigInt::from_i64(x)
+        .ok_or_else(|| serde::de::Error::custom("expected a i64-sized bignum"))?)
+}

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -234,7 +234,7 @@
                         </Component>
                         <Component Id='binary18' Guid='*' Win64='$(var.Win64)'>
                             <File
-                                Id='exe17'
+                                Id='exe18'
                                 Name='nu_plugin_extra_xpath.exe'
                                 DiskId='1'
                                 Source='target\$(var.Profile)\nu_plugin_extra_xpath.exe'
@@ -278,6 +278,7 @@
             <ComponentRef Id='binary15'/>
             <ComponentRef Id='binary16'/>
             <ComponentRef Id='binary17'/>
+            <ComponentRef Id='binary18'/>
 
             <Feature
                 Id='Environment'


### PR DESCRIPTION
Also fixing the `wix` manifest file. We bring back serialization and deserialization on `Value` for big int and big decimal since it faciliates plugins sending and receiving number's through json-rpc.