### PR TITLE
Add Tau constant to math eval

### DIFF
--- a/crates/nu-cli/src/commands/math/eval.rs
+++ b/crates/nu-cli/src/commands/math/eval.rs
@@ -91,7 +91,9 @@ pub async fn eval(
 }
 
 pub fn parse<T: Into<Tag>>(math_expression: &str, tag: T) -> Result<Value, String> {
-    match meval::eval_str(math_expression) {
+    let mut ctx = meval::Context::new();
+    ctx.var("tau", std::f64::consts::TAU);
+    match meval::eval_str_with_context(math_expression, &ctx) {
         Ok(num) if num.is_infinite() || num.is_nan() => Err("cannot represent result".to_string()),
         Ok(num) => Ok(UntaggedValue::from(Primitive::from(num)).into_value(tag)),
         Err(error) => Err(error.to_string().to_lowercase()),

--- a/crates/nu-cli/tests/commands/math/eval.rs
+++ b/crates/nu-cli/tests/commands/math/eval.rs
@@ -71,3 +71,15 @@ fn evaluates_pi() {
 
     assert!(actual.out.contains("3.14"));
 }
+
+#[test]
+fn evaluates_tau() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        math eval tau
+        "#
+    ));
+
+    assert!(actual.out.contains("6.28"));
+}


### PR DESCRIPTION
Adds Tau constant to math eval using `meval::Context`.

Also adds a test to match pi's.

Note: Tau ends up not being more precise than 2*pi.

Resolves: #2258