### PR TITLE
Refactor `to md` and Add Padding for Pretty Flag

### DIFF
--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -118,11 +118,13 @@ fn get_output_string(
 
         for i in 0..headers.len() {
             if pretty {
+                output_string.push_str(" ");
                 output_string.push_str(&get_padded_string(
                     headers[i].clone(),
                     column_width_vector[i],
                     ' ',
                 ));
+                output_string.push_str(" ");
             } else {
                 output_string.push_str(headers[i].as_str());
             }
@@ -135,11 +137,13 @@ fn get_output_string(
         #[allow(clippy::needless_range_loop)]
         for i in 0..headers.len() {
             if pretty {
+                output_string.push_str(" ");
                 output_string.push_str(&get_padded_string(
                     String::from("-"),
                     column_width_vector[i],
                     '-',
                 ));
+                output_string.push_str(" ");
             } else {
                 output_string.push_str("-");
             }
@@ -155,11 +159,13 @@ fn get_output_string(
 
         for i in 0..headers.len() {
             if pretty {
+                output_string.push_str(" ");
                 output_string.push_str(&get_padded_string(
                     row[i].clone(),
                     column_width_vector[i],
                     ' ',
                 ));
+                output_string.push_str(" ");
             } else {
                 output_string.push_str(row[i].as_str());
             }
@@ -173,11 +179,7 @@ fn get_output_string(
     output_string
 }
 
-fn get_padded_string(
-    text: String,
-    desired_length: usize,
-    padding_character: char,
-) -> String {
+fn get_padded_string(text: String, desired_length: usize, padding_character: char) -> String {
     format!(
         "{}{}",
         text,

--- a/crates/nu-cli/tests/format_conversions/markdown.rs
+++ b/crates/nu-cli/tests/format_conversions/markdown.rs
@@ -33,5 +33,5 @@ fn out_md_table_pretty() {
         "#
     ));
 
-    assert_eq!(actual.out, "|name  ||------||joseph|");
+    assert_eq!(actual.out, "| name   || ------ || joseph |");
 }


### PR DESCRIPTION
[In the last PR I opened for `to md`](https://github.com/nushell/nushell/pull/2640), I mentioned that I didn't quite like the fact that I had a lot of copy and pasting going on.  This PR fixes the copy and pasting.  In order to compute the final width of a column for the `-p` flag, you must run through the whole table and get the longest string for each column.  Then you have to go through the table again and pad each string.  There is some encoding going on in the `to md` command that I was doing twice for each string, but I corrected this by storing the encoded values into vector, to remove the encoding that was happening twice.

The second thing this PR does is adds a single space of padding to the left and right side of each column.  Here are couple of popular Markdown table formatting plugin:

1) For Atom, there is [Markdown Table Editor](https://atom.io/packages/markdown-table-editor), which formats Markdown tables to look like this:

<img width="492" alt="Screen Shot 2020-10-17 at 7 26 08 PM" src="https://user-images.githubusercontent.com/19867440/96355455-cb3c9b00-10af-11eb-80b9-ca359e93110d.png">

I used this package extensively

2) For VS Code, there is[ Markdown Table Formatter](https://marketplace.visualstudio.com/items?itemName=fcrespo82.markdown-table-formatter), which formats Markdown tables to look like this:

<img width="513" alt="Screen Shot 2020-10-17 at 7 25 52 PM" src="https://user-images.githubusercontent.com/19867440/96355474-063ece80-10b0-11eb-982d-1f228acae0a4.png">

Both of these tables are nearly identical, both have the padding on the sides of the columns, so I felt it would be good to add this to the `-p` flag on `to md`:

<img width="818" alt="Screen Shot 2020-10-17 at 7 37 44 PM" src="https://user-images.githubusercontent.com/19867440/96355492-3f773e80-10b0-11eb-85ce-e35e505a0c6d.png">
