### PR TITLE
added num-format to allow bytes to be formatted with commas.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,6 +3012,7 @@ dependencies = [
  "nu-test-support",
  "nu-value-ext",
  "num-bigint 0.3.0",
+ "num-format",
  "num-traits 0.2.12",
  "parking_lot 0.11.0",
  "query_interface",

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -23,6 +23,7 @@ indexmap = {version = "1.6.0", features = ["serde-1"]}
 log = "0.4.11"
 num-bigint = {version = "0.3.0", features = ["serde"]}
 num-traits = "0.2.12"
+num-format = "0.4.0"
 parking_lot = "0.11.0"
 query_interface = "0.3.5"
 serde = {version = "1.0.115", features = ["derive"]}

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -6,6 +6,7 @@ use nu_protocol::RangeInclusion;
 use nu_protocol::{format_primitive, ColumnPath, Dictionary, Primitive, UntaggedValue, Value};
 use nu_source::{b, DebugDocBuilder, PrettyDebug, Tag};
 use num_bigint::BigInt;
+use num_format::{Locale, ToFormattedString};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Debug;
@@ -192,8 +193,8 @@ impl PrettyDebug for FormatInlineShape {
 
                 match byte.get_unit() {
                     byte_unit::ByteUnit::B => {
-                        (b::primitive(format!("{}", byte.get_value())) + b::space() + b::kind("B"))
-                            .group()
+                        let locale_byte = byte.get_value() as u64;
+                        (b::primitive(locale_byte.to_formatted_string(&Locale::en))).group()
                     }
                     _ => b::primitive(byte.format(1)),
                 }


### PR DESCRIPTION
hard coded to commas right now. when locale is detectable we should switch it to whatever the locale separator is. to see this work add this to your config.toml file `filesize_format = "B"`