### PR TITLE
Flatten rows containing same sub-table columns correctly.

### DIFF
--- a/crates/nu-cli/src/commands/flatten.rs
+++ b/crates/nu-cli/src/commands/flatten.rs
@@ -100,12 +100,20 @@ fn flat_value(
                 } = value
                 {
                     if column_requested.is_none() && !columns.is_empty() {
-                        out.insert_value(column, value.clone());
+                        if out.contains_key(&column) {
+                            out.insert_value(format!("{}_{}", column, column), value.clone());
+                        } else {
+                            out.insert_value(column, value.clone());
+                        }
                         continue;
                     }
 
                     for (k, v) in mapa.into_iter() {
-                        out.insert_value(k, v.clone());
+                        if out.contains_key(k) {
+                            out.insert_value(format!("{}_{}", column, k), v.clone());
+                        } else {
+                            out.insert_value(k, v.clone());
+                        }
                     }
                 } else if value.is_table() {
                     if tables_explicitly_flattened >= 1 && column_requested.is_some() {

--- a/crates/nu-cli/tests/commands/flatten.rs
+++ b/crates/nu-cli/tests/commands/flatten.rs
@@ -54,24 +54,16 @@ fn flatten_row_column_explictly() {
             r#"
                 [
                     {
-                        "origin": "Ecuador",
                         "people": {
                             "name": "Andres",
                             "meal": "arepa"
-                        },
-                        "code": { "id": 1, "references": 2},
-                        "tags": ["carbohydrate", "corn", "maiz"],
-                        "city": ["Guayaquil", "Samborondón"]
+                        }
                     },
                     {
-                        "origin": "USA",
                         "people": {
                             "name": "Katz",
                             "meal": "nurepa"
-                        },
-                        "code": { "id": 2, "references": 1},
-                        "tags": ["carbohydrate", "shell food", "amigos flavor"],
-                        "city": ["Oregon", "Brooklin"]
+                        }
                     }
                 ]
             "#,
@@ -87,30 +79,58 @@ fn flatten_row_column_explictly() {
 }
 
 #[test]
-fn flatten_table_columns_explictly() {
+fn flatten_row_columns_having_same_column_names_flats_separately() {
     Playground::setup("flatten_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "katz.json",
             r#"
                 [
                     {
-                        "origin": "Ecuador",
                         "people": {
                             "name": "Andres",
                             "meal": "arepa"
                         },
-                        "code": { "id": 1, "references": 2},
-                        "tags": ["carbohydrate", "corn", "maiz"],
-                        "city": ["Guayaquil", "Samborondón"]
+                        "city": [{"name": "Guayaquil"}, {"name": "Samborondón"}]
                     },
                     {
-                        "origin": "USA",
                         "people": {
                             "name": "Katz",
                             "meal": "nurepa"
                         },
-                        "code": { "id": 2, "references": 1},
-                        "tags": ["carbohydrate", "shell food", "amigos flavor"],
+                        "city": [{"name": "Oregon"}, {"name": "Brooklin"}]
+                    }
+                ]
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "open katz.json | flatten | flatten people city | get city_name | count"
+        );
+
+        assert_eq!(actual.out, "4");
+    })
+}
+
+#[test]
+fn flatten_table_columns_explictly() {
+    Playground::setup("flatten_test_3", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "katz.json",
+            r#"
+                [
+                    {
+                        "people": {
+                            "name": "Andres",
+                            "meal": "arepa"
+                        },
+                        "city": ["Guayaquil", "Samborondón"]
+                    },
+                    {
+                        "people": {
+                            "name": "Katz",
+                            "meal": "nurepa"
+                        },
                         "city": ["Oregon", "Brooklin"]
                     }
                 ]
@@ -128,28 +148,24 @@ fn flatten_table_columns_explictly() {
 
 #[test]
 fn flatten_more_than_one_column_that_are_subtables_not_supported() {
-    Playground::setup("flatten_test_3", |dirs, sandbox| {
+    Playground::setup("flatten_test_4", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "katz.json",
             r#"
                 [
                     {
-                        "origin": "Ecuador",
                         "people": {
                             "name": "Andres",
                             "meal": "arepa"
-                        },
-                        "code": { "id": 1, "references": 2},
+                        }
                         "tags": ["carbohydrate", "corn", "maiz"],
                         "city": ["Guayaquil", "Samborondón"]
                     },
                     {
-                        "origin": "USA",
                         "people": {
                             "name": "Katz",
                             "meal": "nurepa"
                         },
-                        "code": { "id": 2, "references": 1},
                         "tags": ["carbohydrate", "shell food", "amigos flavor"],
                         "city": ["Oregon", "Brooklin"]
                     }

--- a/crates/nu-protocol/src/value/dict.rs
+++ b/crates/nu-protocol/src/value/dict.rs
@@ -252,6 +252,11 @@ impl TaggedDictBuilder {
     pub fn is_empty(&self) -> bool {
         self.dict.is_empty()
     }
+
+    /// Checks if given key exists
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.dict.contains_key(key)
+    }
 }
 
 impl From<TaggedDictBuilder> for Value {


### PR DESCRIPTION
Given the following `andras.json` document:

```
[
   {
    "people": {
      "name": "Andres",
      "meal": "arepa"
     },
     "city": [{"name": "Guayaquil"}, {"name": "Samborondón"}]
   },
   {
    "people": {
      "name": "Katz",
      "meal": "nurepa"
    },
     "city": [{"name": "Oregon"}, {"name": "Brooklin"}]
   }
]
```

Opening and flattening the `city` column we get:

```
> open andras.json | flatten city
═══╦═════════════════╦════════════
 # ║ people          ║ city
═══╬═════════════════╬════════════
 0 ║ [row name meal] ║ [row name]
 1 ║ [row name meal] ║ [row name]
 2 ║ [row name meal] ║ [row name]
 3 ║ [row name meal] ║ [row name]
═══╩═════════════════╩════════════
```

Without this PR, doing another flatten on table above `open andras.json | flatten city | flatten` it will flatten both columns (`people` and `city`) but, since the column `people` has an inner row column called `name` as well as the column `city` with a column called `name`... it will keep just one, behavior we don't want. With this PR, Nu notices it and the secondary flattened column with have it's name as `[original_inner_column]` like so (in this case, `city_name`):

```
> open andras.json | flatten city | flatten
═══╦════════╦════════╦═════════════
 # ║ name   ║ meal   ║ city_name
═══╬════════╬════════╬═════════════
 0 ║ Andres ║ arepa  ║ Guayaquil
 1 ║ Andres ║ arepa  ║ Samborondón
 2 ║ Katz   ║ nurepa ║ Oregon
 3 ║ Katz   ║ nurepa ║ Brooklin
═══╩════════╩════════╩═════════════
```