### PR TITLE
add heavy & none table border options

### DIFF
--- a/crates/nu-cli/src/commands/table/options.rs
+++ b/crates/nu-cli/src/commands/table/options.rs
@@ -59,6 +59,8 @@ pub fn table_mode(config: &NuConfig) -> nu_table::Theme {
             Ok(m) if m == "compact_double" => nu_table::Theme::compact_double(),
             Ok(m) if m == "rounded" => nu_table::Theme::rounded(),
             Ok(m) if m == "reinforced" => nu_table::Theme::reinforced(),
+            Ok(m) if m == "heavy" => nu_table::Theme::heavy(),
+            Ok(m) if m == "none" => nu_table::Theme::none(),
             _ => nu_table::Theme::compact(),
         })
 }

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -536,6 +536,66 @@ impl Theme {
             print_bottom_border: true,
         }
     }
+
+    #[allow(unused)]
+    pub fn heavy() -> Theme {
+        Theme {
+            top_left: '┏',
+            middle_left: '┣',
+            bottom_left: '┗',
+            top_center: '┳',
+            center: '╋',
+            bottom_center: '┻',
+            top_right: '┓',
+            middle_right: '┫',
+            bottom_right: '┛',
+            top_horizontal: '━',
+            middle_horizontal: '━',
+            bottom_horizontal: '━',
+
+            left_vertical: '┃',
+            center_vertical: '┃',
+            right_vertical: '┃',
+
+            separate_header: true,
+            separate_rows: false,
+
+            print_left_border: true,
+            print_right_border: true,
+            print_top_border: true,
+            print_bottom_border: true,
+        }
+    }
+    #[allow(unused)]
+    pub fn none() -> Theme {
+        Theme {
+            top_left: ' ',
+            middle_left: ' ',
+            bottom_left: ' ',
+            top_center: ' ',
+            center: ' ',
+            bottom_center: ' ',
+            top_right: ' ',
+            middle_right: ' ',
+            bottom_right: ' ',
+
+            top_horizontal: ' ',
+            middle_horizontal: ' ',
+            bottom_horizontal: ' ',
+
+            left_vertical: ' ',
+            center_vertical: ' ',
+            right_vertical: ' ',
+
+            separate_header: false,
+            separate_rows: false,
+
+            print_left_border: false,
+            print_right_border: false,
+            print_top_border: false,
+            print_bottom_border: false,
+        }
+    }
 }
 
 impl Table {


### PR DESCRIPTION
Added a couple more table framing options for fun.

None
![image](https://user-images.githubusercontent.com/343840/96642631-07f4d600-12ec-11eb-9e05-32480a78e5d7.png)

Heavy
![image](https://user-images.githubusercontent.com/343840/96642677-18a54c00-12ec-11eb-8cd4-208c2f5b8260.png)
