### PR TITLE
Fix filesize "B" regression

### DIFF
--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -163,7 +163,7 @@ impl PrettyDebug for FormatInlineShape {
                     .get("filesize_format")
                     .map(|val| val.convert_to_string().to_ascii_lowercase())
                     .unwrap_or_else(|| "auto".to_string());
-                // if there is a value match it to one of the valid values for byte units
+                // if there is a value, match it to one of the valid values for byte units
                 let filesize_format = match filesize_format_var.as_str() {
                     "b" => (byte_unit::ByteUnit::B, ""),
                     "kb" => (byte_unit::ByteUnit::KB, ""),
@@ -194,7 +194,10 @@ impl PrettyDebug for FormatInlineShape {
                 match byte.get_unit() {
                     byte_unit::ByteUnit::B => {
                         let locale_byte = byte.get_value() as u64;
-                        (b::primitive(locale_byte.to_formatted_string(&Locale::en))).group()
+                        (b::primitive(locale_byte.to_formatted_string(&Locale::en))
+                            + b::space()
+                            + b::kind("B"))
+                        .group()
                     }
                     _ => b::primitive(byte.format(1)),
                 }


### PR DESCRIPTION
A small regression was introduced where the "B" on the file size was dropped.  Here is the 0.21 release:

<img width="666" alt="Screen Shot 2020-10-20 at 10 47 53 PM" src="https://user-images.githubusercontent.com/19867440/96667097-6343ba00-1326-11eb-86d7-ba13eb83abff.png">

Here is Nushell compiled from master today:

<img width="674" alt="Screen Shot 2020-10-20 at 10 47 37 PM" src="https://user-images.githubusercontent.com/19867440/96667118-6b9bf500-1326-11eb-90fe-22a0fddb5c8a.png">

This PR puts back the "B"