### PR TITLE
Add in parameter inference for blocks

### DIFF
--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -231,6 +231,7 @@ fn spawn(
                             }
                         }
                         unsupported => {
+                            println!("Unsupported: {:?}", unsupported);
                             let _ = stdin_write_tx.send(Ok(Value {
                                 value: UntaggedValue::Error(ShellError::labeled_error(
                                     format!(

--- a/crates/nu-cli/src/commands/each/command.rs
+++ b/crates/nu-cli/src/commands/each/command.rs
@@ -6,8 +6,7 @@ use crate::prelude::*;
 use futures::stream::once;
 use nu_errors::ShellError;
 use nu_protocol::{
-    hir::Block, hir::Expression, hir::SpannedExpression, hir::Synthetic, Scope, Signature,
-    SyntaxShape, TaggedDictBuilder, UntaggedValue, Value,
+    hir::Block, Scope, Signature, SyntaxShape, TaggedDictBuilder, UntaggedValue, Value,
 };
 use nu_source::Tagged;
 
@@ -73,34 +72,36 @@ impl WholeStreamCommand for Each {
     }
 }
 
-fn is_expanded_it_usage(head: &SpannedExpression) -> bool {
-    matches!(&*head, SpannedExpression {
-        expr: Expression::Synthetic(Synthetic::String(s)),
-        ..
-    } if s == "expanded-each")
-}
-
 pub async fn process_row(
     block: Arc<Block>,
     scope: Arc<Scope>,
-    head: Arc<Box<SpannedExpression>>,
     mut context: Arc<EvaluationContext>,
     input: Value,
 ) -> Result<OutputStream, ShellError> {
     let input_clone = input.clone();
-    let input_stream = if is_expanded_it_usage(&head) {
+    // When we process a row, we need to know whether the block wants to have the contents of the row as
+    // a parameter to the block (so it gets assigned to a variable that can be used inside the block) or
+    // if it wants the contents as as an input stream
+    let params = block.params();
+
+    let input_stream = if !params.is_empty() {
         InputStream::empty()
     } else {
         once(async { Ok(input_clone) }).to_input_stream()
     };
-    Ok(run_block(
-        &block,
-        Arc::make_mut(&mut context),
-        input_stream,
-        Scope::append_var(scope, "$it", input),
+
+    let scope = if !params.is_empty() {
+        // FIXME: add check for more than parameter, once that's supported
+        Scope::append_var(scope, params[0].clone(), input)
+    } else {
+        scope
+    };
+
+    Ok(
+        run_block(&block, Arc::make_mut(&mut context), input_stream, scope)
+            .await?
+            .to_output_stream(),
     )
-    .await?
-    .to_output_stream())
 }
 
 pub(crate) fn make_indexed_item(index: usize, item: Value) -> Value {
@@ -116,7 +117,6 @@ async fn each(
     registry: &CommandRegistry,
 ) -> Result<OutputStream, ShellError> {
     let registry = registry.clone();
-    let head = Arc::new(raw_args.call_info.args.head.clone());
     let scope = raw_args.call_info.scope.clone();
     let context = Arc::new(EvaluationContext::from_raw(&raw_args, &registry));
     let (each_args, input): (EachArgs, _) = raw_args.process(&registry).await?;
@@ -128,12 +128,11 @@ async fn each(
             .then(move |input| {
                 let block = block.clone();
                 let scope = scope.clone();
-                let head = head.clone();
                 let context = context.clone();
                 let row = make_indexed_item(input.0, input.1);
 
                 async {
-                    match process_row(block, scope, head, context, row).await {
+                    match process_row(block, scope, context, row).await {
                         Ok(s) => s,
                         Err(e) => OutputStream::one(Err(e)),
                     }
@@ -146,11 +145,10 @@ async fn each(
             .then(move |input| {
                 let block = block.clone();
                 let scope = scope.clone();
-                let head = head.clone();
                 let context = context.clone();
 
                 async {
-                    match process_row(block, scope, head, context, input).await {
+                    match process_row(block, scope, context, input).await {
                         Ok(s) => s,
                         Err(e) => OutputStream::one(Err(e)),
                     }

--- a/crates/nu-cli/src/commands/each/window.rs
+++ b/crates/nu-cli/src/commands/each/window.rs
@@ -56,7 +56,6 @@ impl WholeStreamCommand for EachWindow {
         registry: &CommandRegistry,
     ) -> Result<OutputStream, ShellError> {
         let registry = registry.clone();
-        let head = Arc::new(raw_args.call_info.args.head.clone());
         let scope = raw_args.call_info.scope.clone();
         let context = Arc::new(EvaluationContext::from_raw(&raw_args, &registry));
         let (each_args, mut input): (EachWindowArgs, _) = raw_args.process(&registry).await?;
@@ -82,13 +81,12 @@ impl WholeStreamCommand for EachWindow {
 
                 let block = block.clone();
                 let scope = scope.clone();
-                let head = head.clone();
                 let context = context.clone();
                 let local_window = window.clone();
 
                 async move {
                     if i % stride == 0 {
-                        Some(run_block_on_vec(local_window, block, scope, head, context).await)
+                        Some(run_block_on_vec(local_window, block, scope, context).await)
                     } else {
                         None
                     }

--- a/crates/nu-cli/src/commands/group_by.rs
+++ b/crates/nu-cli/src/commands/group_by.rs
@@ -139,7 +139,6 @@ pub async fn group_by(
 ) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let registry = registry.clone();
-    let head = Arc::new(args.call_info.args.head.clone());
     let scope = args.call_info.scope.clone();
     let context = Arc::new(EvaluationContext::from_raw(&args, &registry));
     let (Arguments { grouper }, input) = args.process(&registry).await?;
@@ -159,12 +158,9 @@ pub async fn group_by(
             for value in values.iter() {
                 let run = block.clone();
                 let scope = scope.clone();
-                let head = head.clone();
                 let context = context.clone();
 
-                match crate::commands::each::process_row(run, scope, head, context, value.clone())
-                    .await
-                {
+                match crate::commands::each::process_row(run, scope, context, value.clone()).await {
                     Ok(mut s) => {
                         let collection: Vec<Result<ReturnSuccess, ShellError>> =
                             s.drain_vec().await;

--- a/crates/nu-cli/tests/commands/each.rs
+++ b/crates/nu-cli/tests/commands/each.rs
@@ -47,3 +47,27 @@ fn each_window_stride() {
 
     assert_eq!(actual.out, "[[1,2,3],[3,4,5]]");
 }
+
+#[test]
+fn each_no_args_in_block() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        echo [[foo bar]; [a b] [c d] [e f]] | each { to json } | nth 1 | str collect
+        "#
+    ));
+
+    assert_eq!(actual.out, r#"{"foo":"c","bar":"d"}"#);
+}
+
+#[test]
+fn each_implicit_it_in_block() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        echo [[foo bar]; [a b] [c d] [e f]] | each { nu --testbin cococo $it.foo }
+        "#
+    ));
+
+    assert_eq!(actual.out, "ace");
+}

--- a/crates/nu-data/src/base.rs
+++ b/crates/nu-data/src/base.rs
@@ -11,7 +11,6 @@ use nu_source::{Span, Tag};
 use nu_value_ext::ValueExt;
 use num_bigint::BigInt;
 use num_traits::Zero;
-use query_interface::{interfaces, vtable_for, ObjectHash};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, new, Serialize)]
@@ -20,14 +19,6 @@ pub struct Operation {
     pub(crate) operator: hir::Operator,
     pub(crate) right: Value,
 }
-
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, new)]
-pub struct Block {
-    pub(crate) commands: hir::Commands,
-    pub(crate) tag: Tag,
-}
-
-interfaces!(Block: dyn ObjectHash);
 
 #[derive(Serialize, Deserialize)]
 pub enum Switch {

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -991,14 +991,14 @@ mod tests {
     #[test]
     fn test_string_to_string_value_create_tag_extension() {
         let end = "a_string".to_string().len();
-        let the_tag = Tag {
+        let tag = Tag {
             anchor: None,
             span: Span::new(0, end),
         };
 
         let expected = Value {
             value: UntaggedValue::Primitive(Primitive::String("a_string".to_string())),
-            tag: the_tag.clone(),
+            tag,
         };
 
         assert_eq!(


### PR DESCRIPTION
This adds parameter inference into blocks. We use this in `each` to know whether the values being passed to the block should be passed as arguments given to the block or as an input stream the block consumes.

Fixes #2705 