### PR TITLE
Precision (num digits) added to round cmd

### DIFF
--- a/crates/nu-cli/src/stream/input.rs
+++ b/crates/nu-cli/src/stream/input.rs
@@ -7,7 +7,7 @@ use nu_source::{Tagged, TaggedItem};
 pub struct InputStream {
     values: BoxStream<'static, Value>,
 
-    // Whether or not an empty stream was explicitly requeted via InputStream::empty
+    // Whether or not an empty stream was explicitly requested via InputStream::empty
     empty: bool,
 }
 


### PR DESCRIPTION
1. Add a precision option to the `round` command

```
/rust/nushell(round)> echo [1.555 2.333 -3.111] | math round
╭───┬────╮
│ 0 │  2 │
│ 1 │  2 │
│ 2 │ -3 │
╰───┴────╯
rust/nushell(round)> echo [1.555 2.333 -3.111] | math round -p 2
╭───┬─────────╮
│ 0 │  1.5600 │
│ 1 │  2.3300 │
│ 2 │ -3.1100 │
```