### PR TITLE
inode added to ls -l

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -942,6 +942,7 @@ pub(crate) fn dir_entry_dict(
                 "type",
                 "target",
                 "num_links",
+                "inode",
                 "readonly",
                 "mode",
                 "uid",
@@ -1018,6 +1019,9 @@ pub(crate) fn dir_entry_dict(
 
                 let nlinks = md.nlink();
                 dict.insert_untagged("num_links", UntaggedValue::string(nlinks.to_string()));
+
+                let inode = md.ino();
+                dict.insert_untagged("inode", UntaggedValue::string(inode.to_string()));
 
                 if let Some(user) = users::get_user_by_uid(md.uid()) {
                     dict.insert_untagged(

--- a/crates/nu-cli/tests/commands/ls.rs
+++ b/crates/nu-cli/tests/commands/ls.rs
@@ -298,6 +298,7 @@ fn list_all_columns() {
                         "type",
                         "target",
                         "num_links",
+                        "inode",
                         "readonly",
                         "mode",
                         "uid",


### PR DESCRIPTION
This might fix #2301 since I've added inode and links in recent PRs. At this point, we have most `stat` metadata in the `ls -l` command.

1. inode added to ls -l

![image](https://user-images.githubusercontent.com/6572184/97603820-0a30f180-19ca-11eb-83ff-0482a09a1523.png)
