### PR TITLE
handle precision a tiny bit better than just hard coding to 4 decimal places

### DIFF
--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -249,7 +249,16 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
         }
         Primitive::Duration(duration) => format_duration(duration),
         Primitive::Int(i) => i.to_string(),
-        Primitive::Decimal(decimal) => format!("{:.4}", decimal),
+        Primitive::Decimal(decimal) => {
+            // TODO: We should really pass the precision in here instead of hard coding it
+            let decimal_string = decimal.to_string();
+            let decimal_places: Vec<&str> = decimal_string.split('.').collect();
+            if decimal_places.len() == 2 && decimal_places[1].len() > 4 {
+                format!("{:.4}", decimal)
+            } else {
+                format!("{}", decimal)
+            }
+        }
         Primitive::Range(range) => format!(
             "{}..{}{}",
             format_primitive(&range.from.0.item, None),


### PR DESCRIPTION
I noticed with the recent `round` with `precision` command we were getting output like this, which seemed odd.

```
echo [1.555 2.333 -3.111] | math round -p 2
┏━━━┳━━━━━━━━━┓
┃ 0 ┃  1.5600 ┃
┃ 1 ┃  2.3300 ┃
┃ 2 ┃ -3.1100 ┃
┗━━━┻━━━━━━━━━┛
```
Come to find out, thanks to @gillespiecd, we're hard coding decimals to 4 places. So, I just went in there and tweaked it a bit so that if it's less than 4, it displays appropriately.
```
echo [1.555 2.333 -3.111] | math round -p 2
┏━━━┳━━━━━━━┓
┃ 0 ┃  1.56 ┃
┃ 1 ┃  2.33 ┃
┃ 2 ┃ -3.11 ┃
┗━━━┻━━━━━━━┛
```

the downside to the `--precision` parameter is that you can't every go over `-p 4` because it's still hard coded.  We really need to be able to pass in the precision with decimals for proper display I think.