### PR TITLE
Add passing of named arguments if alias is exactly one command

### DIFF
--- a/crates/nu-cli/tests/commands/alias.rs
+++ b/crates/nu-cli/tests/commands/alias.rs
@@ -331,4 +331,18 @@ mod tests {
         );
         assert!(actual.out.contains("nushell_alias_test"));
     }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn alias_with_passing_of_named_arg() {
+        let actual = nu!(
+            cwd: ".",
+            r#"
+            touch /tmp/.nushell_alias_with_arg_test
+            alias l [x] { ls $x }
+            l -a /tmp | to json
+        "#
+        );
+        assert!(actual.out.contains(".nushell_alias_with_arg_test"));
+    }
 }


### PR DESCRIPTION
This commit adds the ability to pass flags to aliased commands.

To not get controversial here, this commit only adds the new behaviour if the aliased command is exactly 1 internal nushell command.
When multiple commands are aliased as 1, the design of passing of flags is not trivial. Please see the start of https://github.com/nushell/nushell/pull/2486#issuecomment-687097862 for reference. From a technical point of view, passing of flags to different commands is possible.

Related issue: #1633 