### PR TITLE
Support broad range of escape sequences

### DIFF
--- a/crates/nu-cli/src/commands/ansi.rs
+++ b/crates/nu-cli/src/commands/ansi.rs
@@ -75,6 +75,7 @@ following values:
     https://en.wikipedia.org/wiki/ANSI_escape_code
 
 OSC: '\x1b]' is not required for --osc parameter
+Example: echo [$(ansi -o '0') 'some title' $(char bel)] | str collect
 Format: #
     0 Set window title and icon name
     1 Set icon name
@@ -154,7 +155,7 @@ Format: #
                 }
                 //Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
                 // OCS's need to end with a bell '\x07' char
-                let output = format!("\x1b]{};\x07", o.item);
+                let output = format!("\x1b]{};", o.item);
                 return Ok(OutputStream::one(ReturnSuccess::value(
                     UntaggedValue::string(output).into_value(o.tag()),
                 )));

--- a/crates/nu-cli/src/commands/ansi.rs
+++ b/crates/nu-cli/src/commands/ansi.rs
@@ -112,7 +112,7 @@ Format: #
                     "Use ansi to color text (rb = red bold, gb = green bold, pb = purple bold)",
                 example: r#"echo [$(ansi -e '3;93;41m') Hello $(ansi reset) " " $(ansi gb) Nu " " $(ansi pb) World] | str collect"#,
                 result: Some(vec![Value::from(
-                    "\u{1b}[3;93;41mHello \u{1b}[1;32mNu \u{1b}[1;35mWorld",
+                    "\u{1b}[3;93;41mHello\u{1b}[0m \u{1b}[1;32mNu \u{1b}[1;35mWorld",
                 )]),
             },
         ]

--- a/crates/nu-cli/src/commands/ansi.rs
+++ b/crates/nu-cli/src/commands/ansi.rs
@@ -125,42 +125,36 @@ Format: #
     ) -> Result<OutputStream, ShellError> {
         let (AnsiArgs { color, escape, osc }, _) = args.process(&registry).await?;
 
-        match escape {
-            Some(e) => {
-                let esc_vec: Vec<char> = e.item.chars().collect();
-                if esc_vec[0] == '\\' {
-                    return Err(ShellError::labeled_error(
-                        "no need for escape characters",
-                        "no need for escape characters",
-                        e.tag(),
-                    ));
-                }
-                let output = format!("\x1b[{}", e.item);
-                return Ok(OutputStream::one(ReturnSuccess::value(
-                    UntaggedValue::string(output).into_value(e.tag()),
-                )));
+        if let Some(e) = escape {
+            let esc_vec: Vec<char> = e.item.chars().collect();
+            if esc_vec[0] == '\\' {
+                return Err(ShellError::labeled_error(
+                    "no need for escape characters",
+                    "no need for escape characters",
+                    e.tag(),
+                ));
             }
-            _ => (),
+            let output = format!("\x1b[{}", e.item);
+            return Ok(OutputStream::one(ReturnSuccess::value(
+                UntaggedValue::string(output).into_value(e.tag()),
+            )));
         }
 
-        match osc {
-            Some(o) => {
-                let osc_vec: Vec<char> = o.item.chars().collect();
-                if osc_vec[0] == '\\' {
-                    return Err(ShellError::labeled_error(
-                        "no need for escape characters",
-                        "no need for escape characters",
-                        o.tag(),
-                    ));
-                }
-                //Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
-                // OCS's need to end with a bell '\x07' char
-                let output = format!("\x1b]{};", o.item);
-                return Ok(OutputStream::one(ReturnSuccess::value(
-                    UntaggedValue::string(output).into_value(o.tag()),
-                )));
+        if let Some(o) = osc {
+            let osc_vec: Vec<char> = o.item.chars().collect();
+            if osc_vec[0] == '\\' {
+                return Err(ShellError::labeled_error(
+                    "no need for escape characters",
+                    "no need for escape characters",
+                    o.tag(),
+                ));
             }
-            _ => (),
+            //Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
+            // OCS's need to end with a bell '\x07' char
+            let output = format!("\x1b]{};", o.item);
+            return Ok(OutputStream::one(ReturnSuccess::value(
+                UntaggedValue::string(output).into_value(o.tag()),
+            )));
         }
 
         let color_string = color.as_string()?;


### PR DESCRIPTION
With this PR, nushell will allow a broad range of ansi escape sequences and operating system command (ocs) escape sequences. I've expanded the usage to help people learn more about ansi escape sequences. So, along with our standard `ansi green` functionality we can now pass escape sequences but without the escapes like `ansi -e 2;37;41m` for a dimmed white foreground on a red background. Hopefully this will allow users to be more creative with their prompts and other items.

another example: `echo [$(ansi -e '3;93;41m') Hello $(ansi reset) " " $(ansi gb) Nu " " $(ansi pb) World] | str collect`
![image](https://user-images.githubusercontent.com/343840/97740989-10999900-1ab0-11eb-90c6-0223e8d9815a.png)


```
ansi --help
Output ANSI codes to change color

For escape sequences:
Escape: '\x1b[' is not required for --escape parameter
Format: #(;#)m
Example: 1;31m for bold red or 2;37;41m for dimmed white fg with red bg
There can be multiple text formatting sequence numbers
separated by a ; and ending with an m where the # is of the
following values:
    attributes
    0    reset / normal display
    1    bold or increased intensity
    2    faint or decreased intensity
    3    italic on (non-mono font)
    4    underline on
    5    slow blink on
    6    fast blink on
    7    reverse video on
    8    nondisplayed (invisible) on
    9    strike-through on

    foreground/bright colors    background/bright colors
    30/90    black              40/100    black
    31/91    red                41/101    red
    32/92    green              42/102    green
    33/93    yellow             43/103    yellow
    34/94    blue               44/104    blue
    35/95    magenta            45/105    magenta
    36/96    cyan               46/106    cyan
    37/97    white              47/107    white
    https://en.wikipedia.org/wiki/ANSI_escape_code

OSC: '\x1b]' is not required for --osc parameter
Example: echo [$(ansi -o '0') 'some title' $(char bel)] | str collect
Format: #
    0 Set window title and icon name
    1 Set icon name
    2 Set window title
    4 Set/read color palette
    9 iTerm2 Grown notifications
    10 Set foreground color (x11 color spec)
    11 Set background color (x11 color spec)
    ... others

Usage:
  > ansi (color) {flags}

Parameters:
  (color) the name of the color to use or 'reset' to reset the color

Flags:
  -h, --help: Display this help message
  -e, --escape <any>: escape sequence without the escape character(s)
  -o, --osc <any>: operating system command (ocs) escape sequence without the escape character(s)

Examples:
  Change color to green
  > ansi green

  Reset the color
  > ansi reset

  Use ansi to color text (rb = red bold, gb = green bold, pb = purple bold)
  > echo [$(ansi rb) Hello " " $(ansi gb) Nu " " $(ansi pb) World] | str collect

  Use ansi to color text (rb = red bold, gb = green bold, pb = purple bold)
  > echo [$(ansi -e '3;93;41m') Hello $(ansi reset) " " $(ansi gb) Nu " " $(ansi pb) World] | str collect
```