### PR TITLE
Fix `to md` errors

### DIFF
--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -193,7 +193,7 @@ fn get_output_string(
 }
 
 fn get_padded_string(text: String, desired_length: usize, padding_character: char) -> String {
-    let repeat_lenght = if (desired_length as i32 - text.len() as i32) < 0 {
+    let repeat_length = if text.len() > desired_length {
         0
     } else {
         desired_length - text.len()
@@ -202,7 +202,7 @@ fn get_padded_string(text: String, desired_length: usize, padding_character: cha
     format!(
         "{}{}",
         text,
-        padding_character.to_string().repeat(repeat_lenght)
+        padding_character.to_string().repeat(repeat_length)
     )
 }
 

--- a/crates/nu-cli/src/commands/to_md.rs
+++ b/crates/nu-cli/src/commands/to_md.rs
@@ -70,6 +70,8 @@ async fn to_md(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
             column_widths.push(escaped_header_string.len());
             escaped_headers.push(escaped_header_string);
         }
+    } else {
+        column_widths = vec![0; headers.len()]
     }
 
     let mut escaped_rows: Vec<Vec<String>> = Vec::new();
@@ -101,7 +103,15 @@ async fn to_md(args: CommandArgs, registry: &CommandRegistry) -> Result<OutputSt
         escaped_rows.push(escaped_row);
     }
 
-    let output_string = get_output_string(&escaped_headers, &escaped_rows, &column_widths, pretty);
+    let output_string = if (column_widths.is_empty() || column_widths.iter().all(|x| *x == 0))
+        && escaped_rows.is_empty()
+    {
+        String::from("")
+    } else {
+        get_output_string(&escaped_headers, &escaped_rows, &column_widths, pretty)
+            .trim()
+            .to_string()
+    };
 
     Ok(OutputStream::one(ReturnSuccess::value(
         UntaggedValue::string(output_string).into_value(name_tag),
@@ -183,12 +193,16 @@ fn get_output_string(
 }
 
 fn get_padded_string(text: String, desired_length: usize, padding_character: char) -> String {
+    let repeat_lenght = if (desired_length as i32 - text.len() as i32) < 0 {
+        0
+    } else {
+        desired_length - text.len()
+    };
+
     format!(
         "{}{}",
         text,
-        padding_character
-            .to_string()
-            .repeat(desired_length - text.len())
+        padding_character.to_string().repeat(repeat_lenght)
     )
 }
 

--- a/crates/nu-cli/tests/format_conversions/markdown.rs
+++ b/crates/nu-cli/tests/format_conversions/markdown.rs
@@ -1,7 +1,31 @@
 use nu_test_support::{nu, pipeline};
 
 #[test]
-fn out_md_simple() {
+fn md_empty() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            echo "{}" | from json | to md
+        "#
+    ));
+
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn md_empty_pretty() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            echo "{}" | from json | to md -p
+        "#
+    ));
+
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn md_simple() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
@@ -13,7 +37,19 @@ fn out_md_simple() {
 }
 
 #[test]
-fn out_md_table() {
+fn md_simple_pretty() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            echo 3 | to md -p
+        "#
+    ));
+
+    assert_eq!(actual.out, "3");
+}
+
+#[test]
+fn md_table() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
@@ -25,7 +61,7 @@ fn out_md_table() {
 }
 
 #[test]
-fn out_md_table_pretty() {
+fn md_table_pretty() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"


### PR DESCRIPTION
There are a few bugs in `to md`:

1. If you try to use `to md -p` on an empty table, such as `echo "{}" | from json | to md -p`, or anything that results in an empty table, Nushell crashes with:

`thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', crates/nu-cli/src/commands/to_md.rs:168:75
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace`

2. The same thing happens if you try to run `to md -p` on a table that is just a single value output, such as `random bool | to md -p`

<img width="1154" alt="Screen Shot 2020-11-05 at 1 28 55 AM" src="https://user-images.githubusercontent.com/19867440/98205515-4c948a00-1f06-11eb-8853-e65195a37763.png">

This PR keeps Nushell from crashing - nothing is printed out if a table is empty, regardless of whether you use `-p` or not and only the single value is printed in the second case, regardless of whether or not you use `-p`.

<img width="1018" alt="Screen Shot 2020-11-05 at 1 27 16 AM" src="https://user-images.githubusercontent.com/19867440/98205405-19ea9180-1f06-11eb-858d-7b4512c79906.png">

I added tests to pin down this behavior