### PR TITLE
Add var args to alias

### DIFF
--- a/crates/nu-cli/tests/commands/alias.rs
+++ b/crates/nu-cli/tests/commands/alias.rs
@@ -84,6 +84,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn alias_all_args_missing() {
         Playground::setup("append_test_1", |dirs, _| {
             let actual = nu!(

--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -66,7 +66,7 @@ For example, to edit your config file in `vi`, run:
 
 ## Var args
 
-It is possible to pass a variable amount of arguments, to a command expecting an arbitrary amount of arguments, by specifying a var arg as the last parameter in the alias definition.
+It is possible to pass a variable amount of arguments, to a command expecting an arbitrary amount of arguments, by using a var arg variable in exactly that place.
 
 Example 1:
 ```shell

--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -63,3 +63,22 @@ For example, to edit your config file in `vi`, run:
 ```shell
 > vi $(config path)
 ```
+
+## Var args
+
+It is possible to pass a variable amount of arguments, to a command expecting an arbitrary amount of arguments, by specifying a var arg as the last parameter in the alias definition.
+Example 1:
+```shell
+alias my_echo [msg...] { echo $msg }
+```
+Example 2:
+```shell
+alias my_kill [pid pids...] { kill $pid $pids }
+```
+
+Please note, that the variable $pid in the second example is necessary and already using the var arg $pids there won't work, as the signature of kill is: 
+```shell
+kill <int> ints...
+```
+Kill only expects an arbitrary amount of arguments in the second position.
+

--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -67,6 +67,7 @@ For example, to edit your config file in `vi`, run:
 ## Var args
 
 It is possible to pass a variable amount of arguments, to a command expecting an arbitrary amount of arguments, by specifying a var arg as the last parameter in the alias definition.
+
 Example 1:
 ```shell
 alias my_echo [msg...] { echo $msg }


### PR DESCRIPTION
This commit applied, adds the ability to pass a variable amount of arguments, to a command expecting an arbitrary amount of arguments, by using a var arg variable. Please see [alias.md](https://github.com/nushell/nushell/pull/2734/files#diff-b0a049dd35337305a7d21f57efb0445775fc800ab139bf14f73b8aca0b99d42fR67) for examples.
Related Issues: #1884 #1716 

The functionality introduced by #2631 is kept. However I think, that it is obsolete with var args. I am happy to discuss that.

Var args are made possible by changing the rest field of the signature for the new command to the type of the rest field of the command where the vararg variable is used. When the alias is run, every positional passed to the alias after the normal positional arguments expected by the alias is copied into the vararg variable.

Example
```shell
alias -i my_kill [pid pids...] {kill $pid $pids}
my_kill 1 38497 2983
```
$pids is used as the rest argument for the command kill. So my_kill's rest argument is the same as kill's rest argument. The rest type of the alias signature is changed appropriately. Now the alias gets invoked with the arguments: "1 38497 2983". The first argument (1) gets assigned to the variable $pid. All other arguments (the rest arguments 38497 2983) get assigned to $pids.

If no type deduction (-i is not passed to alias) is used, the rest argument / the type of the vararg is of type `SyntaxShape::Any`

I hope, I have made myself clear. I am happy to explain anything more in depth if necessary.