### PR TITLE
Getting ready for multiline scripts

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -392,52 +392,56 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             if let Some(prompt) = configuration.var("prompt") {
                 let prompt_line = prompt.as_string()?;
 
-                match nu_parser::lite_parse(&prompt_line, 0).map_err(ShellError::from) {
-                    Ok(result) => {
-                        let prompt_block = nu_parser::classify_block(&result, context.registry());
+                let (result, err) = nu_parser::lite_parse(&prompt_line, 0);
 
-                        let env = context.get_env();
+                if err.is_some() {
+                    use crate::git::current_branch;
+                    format!(
+                        "\x1b[32m{}{}\x1b[m> ",
+                        cwd,
+                        match current_branch() {
+                            Some(s) => format!("({})", s),
+                            None => "".to_string(),
+                        }
+                    )
+                } else {
+                    let prompt_block = nu_parser::classify_block(&result, context.registry());
 
-                        match run_block(
-                            &prompt_block.block,
-                            &mut context,
-                            InputStream::empty(),
-                            Scope::from_env(env),
-                        )
-                        .await
-                        {
-                            Ok(result) => match result.collect_string(Tag::unknown()).await {
-                                Ok(string_result) => {
-                                    let errors = context.get_errors();
-                                    context.maybe_print_errors(Text::from(prompt_line));
-                                    context.clear_errors();
+                    let env = context.get_env();
 
-                                    if !errors.is_empty() {
-                                        "> ".to_string()
-                                    } else {
-                                        string_result.item
-                                    }
-                                }
-                                Err(e) => {
-                                    crate::cli::print_err(e, &Text::from(prompt_line));
-                                    context.clear_errors();
+                    match run_block(
+                        &prompt_block.block,
+                        &mut context,
+                        InputStream::empty(),
+                        Scope::from_env(env),
+                    )
+                    .await
+                    {
+                        Ok(result) => match result.collect_string(Tag::unknown()).await {
+                            Ok(string_result) => {
+                                let errors = context.get_errors();
+                                context.maybe_print_errors(Text::from(prompt_line));
+                                context.clear_errors();
 
+                                if !errors.is_empty() {
                                     "> ".to_string()
+                                } else {
+                                    string_result.item
                                 }
-                            },
+                            }
                             Err(e) => {
                                 crate::cli::print_err(e, &Text::from(prompt_line));
                                 context.clear_errors();
 
                                 "> ".to_string()
                             }
-                        }
-                    }
-                    Err(e) => {
-                        crate::cli::print_err(e, &Text::from(prompt_line));
-                        context.clear_errors();
+                        },
+                        Err(e) => {
+                            crate::cli::print_err(e, &Text::from(prompt_line));
+                            context.clear_errors();
 
-                        "> ".to_string()
+                            "> ".to_string()
+                        }
                     }
                 }
             } else {
@@ -857,7 +861,10 @@ pub async fn parse_and_eval(line: &str, ctx: &mut EvaluationContext) -> Result<S
         line
     };
 
-    let lite_result = nu_parser::lite_parse(&line, 0)?;
+    let (lite_result, err) = nu_parser::lite_parse(&line, 0);
+    if let Some(err) = err {
+        return Err(err.into());
+    }
 
     // TODO ensure the command whose examples we're testing is actually in the pipeline
     let classified_block = nu_parser::classify_block(&lite_result, ctx.registry());
@@ -890,13 +897,11 @@ pub async fn process_line(
         let line = chomp_newline(line);
         ctx.raw_input = line.to_string();
 
-        let result = match nu_parser::lite_parse(&line, 0) {
-            Err(err) => {
-                return LineResult::Error(line.to_string(), err.into());
-            }
+        let (result, err) = nu_parser::lite_parse(&line, 0);
 
-            Ok(val) => val,
-        };
+        if let Some(err) = err {
+            return LineResult::Error(line.to_string(), err.into());
+        }
 
         debug!("=== Parsed ===");
         debug!("{:#?}", result);
@@ -1093,7 +1098,8 @@ pub fn print_err(err: ShellError, source: &Text) {
 mod tests {
     #[quickcheck]
     fn quickcheck_parse(data: String) -> bool {
-        if let Ok(lite_block) = nu_parser::lite_parse(&data, 0) {
+        let (lite_block, err) = nu_parser::lite_parse(&data, 0);
+        if err.is_none() {
             let context = crate::evaluation_context::EvaluationContext::basic().unwrap();
             let _ = nu_parser::classify_block(&lite_block, context.registry());
         }

--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -288,10 +288,7 @@ mod tests {
             registry: &dyn SignatureRegistry,
             pos: usize,
         ) -> Vec<LocationType> {
-            let lite_block = match lite_parse(line, 0) {
-                Ok(v) => v,
-                Err(e) => e.partial.expect("lite_parse result"),
-            };
+            let (lite_block, _) = lite_parse(line, 0);
 
             let block = classify_block(&lite_block, registry);
 

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -197,7 +197,10 @@ fn parse_line(line: &str, ctx: &mut EvaluationContext) -> Result<ClassifiedBlock
         line
     };
 
-    let lite_result = nu_parser::lite_parse(&line, 0)?;
+    let (lite_result, err) = nu_parser::lite_parse(&line, 0);
+    if let Some(err) = err {
+        return Err(err.into());
+    }
 
     // TODO ensure the command whose examples we're testing is actually in the pipeline
     let classified_block = nu_parser::classify_block(&lite_result, ctx.registry());

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -23,15 +23,10 @@ impl NuCompleter {
         use completion::engine::LocationType;
 
         let nu_context: &EvaluationContext = context.as_ref();
-        let lite_block = match nu_parser::lite_parse(line, 0) {
-            Ok(block) => Some(block),
-            Err(result) => result.partial,
-        };
+        let (lite_block, _) = nu_parser::lite_parse(line, 0);
 
-        let locations = lite_block
-            .map(|block| nu_parser::classify_block(&block, &nu_context.registry))
-            .map(|block| completion::engine::completion_location(line, &block.block, pos))
-            .unwrap_or_default();
+        let classified_block = nu_parser::classify_block(&lite_block, &nu_context.registry);
+        let locations = completion::engine::completion_location(line, &classified_block.block, pos);
 
         let matcher = nu_data::config::config(Tag::unknown())
             .ok()

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -121,10 +121,10 @@ impl rustyline::validate::Validator for NuValidator {
     ) -> rustyline::Result<rustyline::validate::ValidationResult> {
         let src = ctx.input();
 
-        let lite_result = nu_parser::lite_parse(src, 0);
+        let (_, err) = nu_parser::lite_parse(src, 0);
 
-        if let Err(err) = lite_result {
-            if let nu_errors::ParseErrorReason::Eof { .. } = err.cause.reason() {
+        if let Some(err) = err {
+            if let nu_errors::ParseErrorReason::Eof { .. } = err.reason() {
                 return Ok(rustyline::validate::ValidationResult::Incomplete);
             }
         }

--- a/crates/nu-cli/src/shell/painter.rs
+++ b/crates/nu-cli/src/shell/painter.rs
@@ -25,22 +25,21 @@ impl Painter {
         registry: &dyn SignatureRegistry,
         palette: &P,
     ) -> Cow<'l, str> {
-        let lite_block = nu_parser::lite_parse(line, 0);
+        let (lb, err) = nu_parser::lite_parse(line, 0);
 
-        match lite_block {
-            Err(_) => Cow::Borrowed(line),
-            Ok(lb) => {
-                let classified = nu_parser::classify_block(&lb, registry);
+        if err.is_some() {
+            Cow::Borrowed(line)
+        } else {
+            let classified = nu_parser::classify_block(&lb, registry);
 
-                let shapes = nu_parser::shapes(&classified.block);
-                let mut painter = Painter::new(line);
+            let shapes = nu_parser::shapes(&classified.block);
+            let mut painter = Painter::new(line);
 
-                for shape in shapes {
-                    painter.paint_shape(&shape, palette);
-                }
-
-                Cow::Owned(painter.into_string())
+            for shape in shapes {
+                painter.paint_shape(&shape, palette);
             }
+
+            Cow::Owned(painter.into_string())
         }
     }
 

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -1,19 +1,18 @@
-use std::fmt::Debug;
+// use std::fmt::Debug;
 
-/// A combination of an informative parse error, and what has been successfully parsed so far
-#[derive(Debug)]
-pub struct ParseError<T: Debug> {
-    /// An informative cause for this parse error
-    pub cause: nu_errors::ParseError,
+// A combination of an informative parse error, and what has been successfully parsed so far
+// #[derive(Debug)]
+// pub struct ParseError {
+//     /// An informative cause for this parse error
+//     pub cause: nu_errors::ParseError,
+//     // /// What has been successfully parsed, if anything
+//     // pub partial: Option<T>,
+// }
 
-    /// What has been successfully parsed, if anything
-    pub partial: Option<T>,
-}
+// pub type ParseResult<T> = Result<T, ParseError<T>>;
 
-pub type ParseResult<T> = Result<T, ParseError<T>>;
-
-impl<T: Debug> From<ParseError<T>> for nu_errors::ShellError {
-    fn from(e: ParseError<T>) -> Self {
-        e.cause.into()
-    }
-}
+// impl<T: Debug> From<ParseError<T>> for nu_errors::ShellError {
+//     fn from(e: ParseError<T>) -> Self {
+//         e.cause.into()
+//     }
+// }

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -5,7 +5,6 @@ mod path;
 mod shapes;
 mod signature;
 
-pub use errors::{ParseError, ParseResult};
 pub use lite_parse::{lite_parse, LiteBlock};
 pub use parse::{classify_block, garbage, parse_full_column_path};
 pub use path::expand_ndots;

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -65,6 +65,12 @@ pub struct LitePipeline {
     pub commands: Vec<LiteCommand>,
 }
 
+impl Default for LitePipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LitePipeline {
     pub fn new() -> Self {
         Self { commands: vec![] }
@@ -95,6 +101,12 @@ pub struct LiteGroup {
     pub pipelines: Vec<LitePipeline>,
 }
 
+impl Default for LiteGroup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LiteGroup {
     pub fn new() -> Self {
         Self { pipelines: vec![] }
@@ -123,6 +135,12 @@ impl LiteGroup {
 #[derive(Debug, Clone)]
 pub struct LiteBlock {
     pub block: Vec<LiteGroup>,
+}
+
+impl Default for LiteBlock {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LiteBlock {

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -3,27 +3,57 @@ use std::str::CharIndices;
 
 use nu_source::{Span, Spanned, SpannedItem};
 
-use crate::errors::{ParseError, ParseResult};
+use nu_errors::ParseError;
 
 type Input<'t> = Peekable<CharIndices<'t>>;
 
+#[derive(Debug)]
+pub struct Token {
+    pub contents: TokenContents,
+    pub span: Span,
+}
+impl Token {
+    pub fn new(contents: TokenContents, span: Span) -> Token {
+        Token { contents, span }
+    }
+}
+
+#[derive(Debug)]
+pub enum TokenContents {
+    Bare(String),
+    Pipe,
+    Semicolon,
+    EOL,
+}
+
 #[derive(Debug, Clone)]
 pub struct LiteCommand {
-    pub name: Spanned<String>,
-    pub args: Vec<Spanned<String>>,
+    pub parts: Vec<Spanned<String>>,
 }
 
 impl LiteCommand {
-    fn new(name: Spanned<String>) -> LiteCommand {
-        LiteCommand { name, args: vec![] }
+    fn new() -> LiteCommand {
+        LiteCommand { parts: vec![] }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.parts.is_empty()
+    }
+    pub fn push(&mut self, item: Spanned<String>) {
+        self.parts.push(item)
     }
 
     pub(crate) fn span(&self) -> Span {
-        let start = self.name.span.start();
-        let end = if let Some(x) = self.args.last() {
+        let start = if let Some(x) = self.parts.first() {
+            x.span.start()
+        } else {
+            0
+        };
+
+        let end = if let Some(x) = self.parts.last() {
             x.span.end()
         } else {
-            self.name.span.end()
+            0
         };
 
         Span::new(start, end)
@@ -36,9 +66,18 @@ pub struct LitePipeline {
 }
 
 impl LitePipeline {
+    pub fn new() -> Self {
+        Self { commands: vec![] }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+    pub fn push(&mut self, item: LiteCommand) {
+        self.commands.push(item)
+    }
     pub(crate) fn span(&self) -> Span {
         let start = if !self.commands.is_empty() {
-            self.commands[0].name.span.start()
+            self.commands[0].span().start()
         } else {
             0
         };
@@ -52,11 +91,50 @@ impl LitePipeline {
 }
 
 #[derive(Debug, Clone)]
+pub struct LiteGroup {
+    pub pipelines: Vec<LitePipeline>,
+}
+
+impl LiteGroup {
+    pub fn new() -> Self {
+        Self { pipelines: vec![] }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.pipelines.is_empty()
+    }
+    pub fn push(&mut self, item: LitePipeline) {
+        self.pipelines.push(item)
+    }
+    pub(crate) fn span(&self) -> Span {
+        let start = if !self.pipelines.is_empty() {
+            self.pipelines[0].span().start()
+        } else {
+            0
+        };
+
+        if let Some((last, _)) = self.pipelines[..].split_last() {
+            Span::new(start, last.span().end())
+        } else {
+            Span::new(start, 0)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct LiteBlock {
-    pub block: Vec<LitePipeline>,
+    pub block: Vec<LiteGroup>,
 }
 
 impl LiteBlock {
+    pub fn new() -> Self {
+        Self { block: vec![] }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.block.is_empty()
+    }
+    pub fn push(&mut self, item: LiteGroup) {
+        self.block.push(item)
+    }
     pub(crate) fn span(&self) -> Span {
         let start = if !self.block.is_empty() {
             self.block[0].span().start()
@@ -69,12 +147,6 @@ impl LiteBlock {
         } else {
             Span::new(start, 0)
         }
-    }
-}
-
-impl From<Spanned<String>> for LiteCommand {
-    fn from(v: Spanned<String>) -> LiteCommand {
-        LiteCommand::new(v)
     }
 }
 
@@ -105,9 +177,11 @@ impl From<BlockKind> for char {
     }
 }
 
-fn bare(src: &mut Input, span_offset: usize) -> ParseResult<Spanned<String>> {
-    skip_whitespace(src);
-
+/// Finds the extents of a bare (un-classified) token, returning the string with its associated span,
+/// along with any parse error that was discovered along the way.
+/// Bare tokens are unparsed content separated by spaces or a command separator (like pipe or semicolon)
+/// Bare tokens may be surrounded by quotes (single, double, or backtick) or braces (square, paren, curly)
+pub fn bare(src: &mut Input, span_offset: usize) -> (Spanned<String>, Option<ParseError>) {
     let mut bare = String::new();
     let start_offset = if let Some((pos, _)) = src.peek() {
         *pos
@@ -158,16 +232,13 @@ fn bare(src: &mut Input, span_offset: usize) -> ParseResult<Spanned<String>> {
 
     if let Some(block) = block_level.last() {
         let delim: char = (*block).into();
-        let cause = nu_errors::ParseError::unexpected_eof(delim.to_string(), span);
+        let cause = ParseError::unexpected_eof(delim.to_string(), span);
 
         while let Some(bk) = block_level.pop() {
             bare.push(bk.into());
         }
 
-        return Err(ParseError {
-            cause,
-            partial: Some(bare.spanned(span)),
-        });
+        return (bare.spanned(span), Some(cause));
     }
 
     if let Some(delimiter) = inside_quote {
@@ -176,133 +247,232 @@ fn bare(src: &mut Input, span_offset: usize) -> ParseResult<Spanned<String>> {
         // correct information from the non-lite parse.
         bare.push(delimiter);
 
-        return Err(ParseError {
-            cause: nu_errors::ParseError::unexpected_eof(delimiter.to_string(), span),
-            partial: Some(bare.spanned(span)),
-        });
+        return (
+            bare.spanned(span),
+            Some(ParseError::unexpected_eof(delimiter.to_string(), span)),
+        );
     }
 
     if bare.is_empty() {
-        return Err(ParseError {
-            cause: nu_errors::ParseError::unexpected_eof("command", span),
-            partial: Some(bare.spanned(span)),
-        });
+        return (
+            bare.spanned(span),
+            Some(ParseError::unexpected_eof("command".to_string(), span)),
+        );
     }
 
-    Ok(bare.spanned(span))
+    (bare.spanned(span), None)
 }
 
-fn command(src: &mut Input, span_offset: usize) -> ParseResult<LiteCommand> {
-    let mut cmd = match bare(src, span_offset) {
-        Ok(v) => LiteCommand::new(v),
-        Err(e) => {
-            return Err(ParseError {
-                cause: e.cause,
-                partial: e.partial.map(LiteCommand::new),
-            });
-        }
-    };
+/// Breaks the input string into a vector of tokens. This tokenization only tries to classify separators like
+/// semicolons, pipes, etc from external bare values (values that haven't been classified further)
+/// Takes in a string and and offset, which is used to offset the spans created (for when this function is used to parse inner strings)
+pub fn lex(input: &str, span_offset: usize) -> (Vec<Token>, Option<ParseError>) {
+    let mut char_indices = input.char_indices().peekable();
+    let mut error = None;
 
-    loop {
-        skip_whitespace(src);
+    let mut output = vec![];
 
-        if let Some((_, c)) = src.peek() {
-            // The first character tells us a lot about each argument
-            match c {
-                ';' => {
-                    // this is the end of the command and the end of the pipeline
-                    break;
-                }
-                '|' => {
-                    let _ = src.next();
-                    if let Some((pos, next_c)) = src.peek() {
-                        if *next_c == '|' {
-                            // this isn't actually a pipeline but a comparison
-                            let span = Span::new(pos - 1 + span_offset, pos + 1 + span_offset);
-                            cmd.args.push("||".to_string().spanned(span));
-                            let _ = src.next();
-                        } else {
-                            // this is the end of this command
-                            break;
-                        }
-                    } else {
-                        // this is the end of this command
-                        break;
-                    }
-                }
-                _ => {
-                    // basic argument
-                    match bare(src, span_offset) {
-                        Ok(v) => {
-                            cmd.args.push(v);
-                        }
-
-                        Err(e) => {
-                            if let Some(v) = e.partial {
-                                cmd.args.push(v);
-                            }
-
-                            return Err(ParseError {
-                                cause: e.cause,
-                                partial: Some(cmd),
-                            });
-                        }
-                    }
-                }
-            }
+    while let Some((idx, c)) = char_indices.peek() {
+        if *c == '|' {
+            let idx = *idx;
+            let _ = char_indices.next();
+            output.push(Token::new(
+                TokenContents::Pipe,
+                Span::new(span_offset + idx, span_offset + idx + 1),
+            ));
+        } else if *c == ';' {
+            let idx = *idx;
+            let _ = char_indices.next();
+            output.push(Token::new(
+                TokenContents::Semicolon,
+                Span::new(span_offset + idx, span_offset + idx + 1),
+            ));
+        } else if *c == '\n' || *c == '\r' {
+            let idx = *idx;
+            let _ = char_indices.next();
+            output.push(Token::new(
+                TokenContents::EOL,
+                Span::new(span_offset + idx, span_offset + idx + 1),
+            ));
+        } else if *c == ' ' || *c == '\t' {
+            let _ = char_indices.next();
         } else {
-            break;
+            let (result, err) = bare(&mut char_indices, span_offset);
+            if error.is_none() {
+                error = err;
+            }
+            let Spanned { item, span } = result;
+            output.push(Token::new(TokenContents::Bare(item), span));
         }
     }
 
-    Ok(cmd)
+    (output, error)
 }
 
-fn pipeline(src: &mut Input, span_offset: usize) -> ParseResult<LiteBlock> {
-    let mut block = vec![];
-    let mut commands = vec![];
+// fn command(src: &mut Input, span_offset: usize) -> (LiteCommand, Option<ParseError>) {
+//     let mut error = None;
 
-    skip_whitespace(src);
+//     let (v, err) = bare(src, span_offset);
+//     let cmd = LiteCommand::new();
+//     cmd.parts.push(v);
+//     if error.is_none() {
+//         error = err;
+//     }
 
-    while src.peek().is_some() {
-        // If there is content there, let's parse it
-        let cmd = match command(src, span_offset) {
-            Ok(v) => v,
-            Err(e) => {
-                if let Some(partial) = e.partial {
-                    commands.push(partial);
-                    block.push(LitePipeline { commands });
+//     loop {
+//         skip_whitespace(src);
+
+//         if let Some((_, c)) = src.peek() {
+//             // The first character tells us a lot about each argument
+//             match c {
+//                 ';' => {
+//                     // this is the end of the command and the end of the pipeline
+//                     break;
+//                 }
+//                 '|' => {
+//                     let _ = src.next();
+//                     if let Some((pos, next_c)) = src.peek() {
+//                         if *next_c == '|' {
+//                             // this isn't actually a pipeline but a comparison
+//                             let span = Span::new(pos - 1 + span_offset, pos + 1 + span_offset);
+//                             cmd.parts.push("||".to_string().spanned(span));
+//                             let _ = src.next();
+//                         } else {
+//                             // this is the end of this command
+//                             break;
+//                         }
+//                     } else {
+//                         // this is the end of this command
+//                         break;
+//                     }
+//                 }
+//                 _ => {
+//                     // basic argument
+//                     let (v, err) = bare(src, span_offset);
+//                     cmd.args.push(v);
+//                     if error.is_none() {
+//                         error = err;
+//                     }
+//                 }
+//             }
+//         } else {
+//             break;
+//         }
+//     }
+
+//     (cmd, None)
+// }
+
+// fn pipeline(src: &mut Input, span_offset: usize) -> (LiteGroup, Option<ParseError>) {
+//     let mut pipelines = vec![];
+//     let mut commands = vec![];
+//     let mut error = None;
+
+//     skip_whitespace(src);
+
+//     while src.peek().is_some() {
+//         // If there is content there, let's parse it
+//         let (v, err) = command(src, span_offset);
+
+//         if error.is_none() {
+//             error = err;
+//         }
+
+//         commands.push(v);
+//         skip_whitespace(src);
+
+//         if let Some((_, ';')) = src.peek() {
+//             let _ = src.next();
+
+//             if !commands.is_empty() {
+//                 pipelines.push(LitePipeline { commands });
+//                 commands = vec![];
+//             }
+//         }
+//     }
+
+//     if !commands.is_empty() {
+//         pipelines.push(LitePipeline { commands });
+//     }
+
+//     (LiteGroup { pipelines }, error)
+// }
+
+fn group(tokens: Vec<Token>) -> (LiteBlock, Option<ParseError>) {
+    let mut groups = vec![];
+    let mut group = LiteGroup::new();
+    let mut pipeline = LitePipeline::new();
+    let mut command = LiteCommand::new();
+
+    for token in tokens {
+        match token.contents {
+            TokenContents::EOL => {
+                if !command.is_empty() {
+                    pipeline.push(command);
+                    command = LiteCommand::new();
                 }
-
-                return Err(ParseError {
-                    cause: e.cause,
-                    partial: Some(LiteBlock { block }),
-                });
+                if !pipeline.is_empty() {
+                    group.push(pipeline);
+                    pipeline = LitePipeline::new();
+                }
+                if !group.is_empty() {
+                    groups.push(group);
+                    group = LiteGroup::new();
+                }
             }
-        };
+            TokenContents::Pipe => {
+                if !command.is_empty() {
+                    pipeline.push(command);
+                    command = LiteCommand::new();
+                } else {
+                    let mut block = LiteBlock::new();
+                    block.block = groups;
 
-        commands.push(cmd);
-        skip_whitespace(src);
-
-        if let Some((_, ';')) = src.peek() {
-            let _ = src.next();
-
-            if !commands.is_empty() {
-                block.push(LitePipeline { commands });
-                commands = vec![];
+                    return (
+                        block,
+                        Some(ParseError::extra_tokens(
+                            "|".to_string().spanned(token.span),
+                        )),
+                    );
+                }
+            }
+            TokenContents::Semicolon => {
+                if !command.is_empty() {
+                    pipeline.push(command);
+                    command = LiteCommand::new();
+                }
+                if !pipeline.is_empty() {
+                    group.push(pipeline);
+                    pipeline = LitePipeline::new();
+                }
+            }
+            TokenContents::Bare(bare) => {
+                command.push(bare.spanned(token.span));
             }
         }
     }
-
-    if !commands.is_empty() {
-        block.push(LitePipeline { commands });
+    if !command.is_empty() {
+        pipeline.push(command);
+    }
+    if !pipeline.is_empty() {
+        group.push(pipeline);
+    }
+    if !group.is_empty() {
+        groups.push(group);
     }
 
-    Ok(LiteBlock { block })
+    let mut block = LiteBlock::new();
+    block.block = groups;
+    (block, None)
 }
 
-pub fn lite_parse(src: &str, span_offset: usize) -> ParseResult<LiteBlock> {
-    pipeline(&mut src.char_indices().peekable(), span_offset)
+pub fn lite_parse(src: &str, span_offset: usize) -> (LiteBlock, Option<ParseError>) {
+    let (output, error) = lex(src, span_offset);
+    if error.is_some() {
+        return (LiteBlock::new(), error);
+    }
+
+    group(output)
 }
 
 #[cfg(test)]
@@ -321,8 +491,9 @@ mod tests {
             let input = "foo bar baz";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 3));
         }
 
@@ -331,8 +502,9 @@ mod tests {
             let input = "'foo bar' baz";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 9));
         }
 
@@ -341,8 +513,9 @@ mod tests {
             let input = "'foo\" bar' baz";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 10));
         }
 
@@ -351,8 +524,9 @@ mod tests {
             let input = "[foo bar] baz";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 9));
         }
 
@@ -361,8 +535,9 @@ mod tests {
             let input = "'foo 'bar baz";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 9));
         }
 
@@ -371,8 +546,9 @@ mod tests {
             let input = "''foo baz";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 5));
         }
 
@@ -381,8 +557,9 @@ mod tests {
             let input = "'' foo";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 2));
         }
 
@@ -391,8 +568,9 @@ mod tests {
             let input = " '' foo";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(1, 3));
         }
 
@@ -401,8 +579,9 @@ mod tests {
             let input = " 'foo' foo";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(1, 6));
         }
 
@@ -411,8 +590,9 @@ mod tests {
             let input = "[foo, bar]";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 10));
         }
 
@@ -421,8 +601,9 @@ mod tests {
             let input = "foo 'bar";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0).unwrap();
+            let (result, err) = bare(input, 0);
 
+            assert!(err.is_none());
             assert_eq!(result.span, span(0, 3));
         }
 
@@ -431,9 +612,9 @@ mod tests {
             let input = "'foo bar";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0);
+            let (result, err) = bare(input, 0);
 
-            assert_eq!(result.is_ok(), false);
+            assert!(err.is_some());
         }
 
         #[test]
@@ -441,9 +622,9 @@ mod tests {
             let input = "'bar";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0);
+            let (result, err) = bare(input, 0);
 
-            assert_eq!(result.is_ok(), false);
+            assert!(err.is_some());
         }
 
         #[test]
@@ -451,9 +632,9 @@ mod tests {
             let input = " 'bar";
 
             let input = &mut input.char_indices().peekable();
-            let result = bare(input, 0);
+            let (result, err) = bare(input, 0);
 
-            assert_eq!(result.is_ok(), false);
+            assert!(err.is_some());
         }
     }
 
@@ -462,7 +643,8 @@ mod tests {
 
         #[test]
         fn pipeline() {
-            let result = lite_parse("cmd1 | cmd2 ; deploy", 0).unwrap();
+            let (result, err) = lite_parse("cmd1 | cmd2 ; deploy", 0);
+            assert!(err.is_none());
             assert_eq!(result.span(), span(0, 20));
             assert_eq!(result.block[0].span(), span(0, 11));
             assert_eq!(result.block[1].span(), span(14, 20));
@@ -470,31 +652,49 @@ mod tests {
 
         #[test]
         fn simple_1() {
-            let result = lite_parse("foo", 0).unwrap();
+            let (result, err) = lite_parse("foo", 0);
+            assert!(err.is_none());
             assert_eq!(result.block.len(), 1);
-            assert_eq!(result.block[0].commands.len(), 1);
-            assert_eq!(result.block[0].commands[0].name.span, span(0, 3));
+            assert_eq!(result.block[0].pipelines.len(), 1);
+            assert_eq!(result.block[0].pipelines[0].commands.len(), 1);
+            assert_eq!(result.block[0].pipelines[0].commands[0].parts.len(), 1);
+            assert_eq!(
+                result.block[0].pipelines[0].commands[0].parts[0].span,
+                span(0, 3)
+            );
         }
 
         #[test]
         fn simple_offset() {
-            let result = lite_parse("foo", 10).unwrap();
-            assert_eq!(result.block.len(), 1);
-            assert_eq!(result.block[0].commands.len(), 1);
-            assert_eq!(result.block[0].commands[0].name.span, span(10, 13));
+            let (result, err) = lite_parse("foo", 10);
+            assert!(err.is_none());
+            assert_eq!(result.block[0].pipelines.len(), 1);
+            assert_eq!(result.block[0].pipelines[0].commands.len(), 1);
+            assert_eq!(result.block[0].pipelines[0].commands[0].parts.len(), 1);
+            assert_eq!(
+                result.block[0].pipelines[0].commands[0].parts[0].span,
+                span(10, 13)
+            );
         }
 
         #[test]
         fn incomplete_result() {
-            let result = lite_parse("my_command \"foo' --test", 10).unwrap_err();
-            assert!(matches!(result.cause.reason(), nu_errors::ParseErrorReason::Eof { .. }));
+            let (result, err) = lite_parse("my_command \"foo' --test", 10);
+            assert!(matches!(err.unwrap().reason(), nu_errors::ParseErrorReason::Eof { .. }));
 
-            let result = result.partial.unwrap();
             assert_eq!(result.block.len(), 1);
-            assert_eq!(result.block[0].commands.len(), 1);
-            assert_eq!(result.block[0].commands[0].name.item, "my_command");
-            assert_eq!(result.block[0].commands[0].args.len(), 1);
-            assert_eq!(result.block[0].commands[0].args[0].item, "\"foo' --test\"");
+            assert_eq!(result.block[0].pipelines.len(), 1);
+            assert_eq!(result.block[0].pipelines[0].commands.len(), 1);
+            assert_eq!(result.block[0].pipelines[0].commands[0].parts.len(), 2);
+
+            assert_eq!(
+                result.block[0].pipelines[0].commands[0].parts[0].item,
+                "my_command"
+            );
+            assert_eq!(
+                result.block[0].pipelines[0].commands[0].parts[1].item,
+                "\"foo' --test\""
+            );
         }
     }
 }

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -150,16 +150,6 @@ impl LiteBlock {
     }
 }
 
-fn skip_whitespace(src: &mut Input) {
-    while let Some((_, x)) = src.peek() {
-        if x.is_whitespace() {
-            let _ = src.next();
-        } else {
-            break;
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 enum BlockKind {
     Paren,
@@ -612,7 +602,7 @@ mod tests {
             let input = "'foo bar";
 
             let input = &mut input.char_indices().peekable();
-            let (result, err) = bare(input, 0);
+            let (_, err) = bare(input, 0);
 
             assert!(err.is_some());
         }
@@ -622,7 +612,7 @@ mod tests {
             let input = "'bar";
 
             let input = &mut input.char_indices().peekable();
-            let (result, err) = bare(input, 0);
+            let (_, err) = bare(input, 0);
 
             assert!(err.is_some());
         }
@@ -632,7 +622,7 @@ mod tests {
             let input = " 'bar";
 
             let input = &mut input.char_indices().peekable();
-            let (result, err) = bare(input, 0);
+            let (_, err) = bare(input, 0);
 
             assert!(err.is_some());
         }

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1543,6 +1543,9 @@ fn classify_pipeline(
 
     let mut iter = lite_pipeline.commands.iter().peekable();
     while let Some(lite_cmd) = iter.next() {
+        if lite_cmd.parts.is_empty() {
+            continue;
+        }
         if lite_cmd.parts[0].item.starts_with('^') {
             let name = lite_cmd.parts[0]
                 .clone()

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1406,7 +1406,7 @@ fn parse_internal_command(
     let mut named = NamedArguments::new();
     let mut positional = vec![];
     let mut error = None;
-    idx = idx + 1; // Start where the arguments begin
+    idx += 1; // Start where the arguments begin
 
     while idx < lite_cmd.parts.len() {
         if lite_cmd.parts[idx].item.starts_with('-') && lite_cmd.parts[idx].item.len() > 1 {


### PR DESCRIPTION
This is a bit of a refactor of the lite_parse to add a new stage called "groups", allowing us to separate individual lines from semicolon-separated groups, from pipelines.

The end result is that we should be able to parse a whole script file (soon) and get back a single parse entity that represents the script.