### PR TITLE
Getting closer to multiline scripts

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -927,11 +927,12 @@ pub async fn process_script(
         // ...then change to this directory
         if cli_mode
             && classified_block.block.block.len() == 1
-            && classified_block.block.block[0].list.len() == 1
+            && classified_block.block.block[0].pipelines.len() == 1
+            && classified_block.block.block[0].pipelines[0].list.len() == 1
         {
             if let ClassifiedCommand::Internal(InternalCommand {
                 ref name, ref args, ..
-            }) = classified_block.block.block[0].list[0]
+            }) = classified_block.block.block[0].pipelines[0].list[0]
             {
                 let internal_name = name;
                 let name = args

--- a/crates/nu-cli/src/commands/benchmark.rs
+++ b/crates/nu-cli/src/commands/benchmark.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use heim::cpu::time;
 use nu_errors::ShellError;
 use nu_protocol::{
-    hir::{Block, ClassifiedCommand, Commands, InternalCommand},
+    hir::{Block, ClassifiedCommand, Group, InternalCommand, Pipeline},
     Dictionary, Scope, Signature, SyntaxShape, UntaggedValue, Value,
 };
 use rand::{
@@ -175,15 +175,19 @@ where
 
 fn add_implicit_autoview(mut block: Block) -> Block {
     if block.block.is_empty() {
-        block.push({
-            let mut commands = Commands::new(block.span);
-            commands.push(ClassifiedCommand::Internal(InternalCommand::new(
-                "autoview".to_string(),
-                block.span,
-                block.span,
-            )));
-            commands
-        });
+        let group = Group::new(
+            vec![{
+                let mut commands = Pipeline::new(block.span);
+                commands.push(ClassifiedCommand::Internal(InternalCommand::new(
+                    "autoview".to_string(),
+                    block.span,
+                    block.span,
+                )));
+                commands
+            }],
+            block.span,
+        );
+        block.push(group);
     }
     block
 }

--- a/crates/nu-cli/src/commands/if_.rs
+++ b/crates/nu-cli/src/commands/if_.rs
@@ -94,9 +94,9 @@ async fn if_command(
                 tag,
             ));
         }
-        match condition.block[0].list.get(0) {
-            Some(item) => match item {
-                ClassifiedCommand::Expr(expr) => expr.clone(),
+        match condition.block[0].pipelines.get(0) {
+            Some(item) => match item.list.get(0) {
+                Some(ClassifiedCommand::Expr(expr)) => expr.clone(),
                 _ => {
                     return Err(ShellError::labeled_error(
                         "Expected a condition",

--- a/crates/nu-cli/src/commands/keep/until.rs
+++ b/crates/nu-cli/src/commands/keep/until.rs
@@ -51,9 +51,9 @@ impl WholeStreamCommand for SubCommand {
                         tag,
                     ));
                 }
-                match block.block[0].list.get(0) {
-                    Some(item) => match item {
-                        ClassifiedCommand::Expr(expr) => expr.clone(),
+                match block.block[0].pipelines.get(0) {
+                    Some(item) => match item.list.get(0) {
+                        Some(ClassifiedCommand::Expr(expr)) => expr.clone(),
                         _ => {
                             return Err(ShellError::labeled_error(
                                 "Expected a condition",

--- a/crates/nu-cli/src/commands/keep/while_.rs
+++ b/crates/nu-cli/src/commands/keep/while_.rs
@@ -50,9 +50,9 @@ impl WholeStreamCommand for SubCommand {
                         tag,
                     ));
                 }
-                match block.block[0].list.get(0) {
-                    Some(item) => match item {
-                        ClassifiedCommand::Expr(expr) => expr.clone(),
+                match block.block[0].pipelines.get(0) {
+                    Some(item) => match item.list.get(0) {
+                        Some(ClassifiedCommand::Expr(expr)) => expr.clone(),
                         _ => {
                             return Err(ShellError::labeled_error(
                                 "Expected a condition",

--- a/crates/nu-cli/src/commands/skip/until.rs
+++ b/crates/nu-cli/src/commands/skip/until.rs
@@ -50,9 +50,9 @@ impl WholeStreamCommand for SubCommand {
                         tag,
                     ));
                 }
-                match block.block[0].list.get(0) {
-                    Some(item) => match item {
-                        ClassifiedCommand::Expr(expr) => expr.clone(),
+                match block.block[0].pipelines.get(0) {
+                    Some(item) => match item.list.get(0) {
+                        Some(ClassifiedCommand::Expr(expr)) => expr.clone(),
                         _ => {
                             return Err(ShellError::labeled_error(
                                 "Expected a condition",

--- a/crates/nu-cli/src/commands/skip/while_.rs
+++ b/crates/nu-cli/src/commands/skip/while_.rs
@@ -50,9 +50,9 @@ impl WholeStreamCommand for SubCommand {
                         tag,
                     ));
                 }
-                match block.block[0].list.get(0) {
-                    Some(item) => match item {
-                        ClassifiedCommand::Expr(expr) => expr.clone(),
+                match block.block[0].pipelines.get(0) {
+                    Some(item) => match item.list.get(0) {
+                        Some(ClassifiedCommand::Expr(expr)) => expr.clone(),
                         _ => {
                             return Err(ShellError::labeled_error(
                                 "Expected a condition",

--- a/crates/nu-cli/src/commands/where_.rs
+++ b/crates/nu-cli/src/commands/where_.rs
@@ -81,9 +81,9 @@ async fn where_command(
                 tag,
             ));
         }
-        match block.block[0].list.get(0) {
-            Some(item) => match item {
-                ClassifiedCommand::Expr(expr) => expr.clone(),
+        match block.block[0].pipelines.get(0) {
+            Some(item) => match item.list.get(0) {
+                Some(ClassifiedCommand::Expr(expr)) => expr.clone(),
                 _ => {
                     return Err(ShellError::labeled_error(
                         "Expected a condition",

--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -138,7 +138,7 @@ impl<'s> Flatten<'s> {
         result
     }
 
-    fn pipeline(&self, pipeline: &Commands) -> Vec<CompletionLocation> {
+    fn pipeline(&self, pipeline: &Pipeline) -> Vec<CompletionLocation> {
         let mut result = Vec::new();
 
         for command in &pipeline.list {
@@ -158,7 +158,11 @@ impl<'s> Flatten<'s> {
 
     /// Flattens the block into a Vec of completion locations
     pub fn completion_locations(&self, block: &Block) -> Vec<CompletionLocation> {
-        block.block.iter().flat_map(|v| self.pipeline(v)).collect()
+        block
+            .block
+            .iter()
+            .flat_map(|g| g.pipelines.iter().flat_map(|v| self.pipeline(v)))
+            .collect()
     }
 
     pub fn new(line: &'s str) -> Flatten<'s> {

--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -43,8 +43,8 @@ mod examples;
 pub use crate::cli::cli;
 
 pub use crate::cli::{
-    create_default_context, parse_and_eval, process_line, register_plugins,
-    run_pipeline_standalone, run_vec_of_pipelines, LineResult,
+    create_default_context, parse_and_eval, process_script, register_plugins, run_script_file,
+    run_script_standalone, LineResult,
 };
 pub use crate::command_registry::CommandRegistry;
 pub use crate::commands::command::{

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -123,11 +123,7 @@ impl LiteGroup {
             && !self.pipelines[0].commands.is_empty()
             && !self.pipelines[0].commands[0].parts.is_empty()
         {
-            if self.pipelines[0].commands[0].parts[0].item.starts_with('#') {
-                true
-            } else {
-                false
-            }
+            self.pipelines[0].commands[0].parts[0].item.starts_with('#')
         } else {
             false
         }

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -117,6 +117,21 @@ impl LiteGroup {
     pub fn push(&mut self, item: LitePipeline) {
         self.pipelines.push(item)
     }
+    pub fn is_comment(&self) -> bool {
+        if !self.is_empty()
+            && !self.pipelines[0].is_empty()
+            && !self.pipelines[0].commands.is_empty()
+            && !self.pipelines[0].commands[0].parts.is_empty()
+        {
+            if self.pipelines[0].commands[0].parts[0].item.starts_with('#') {
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
     pub(crate) fn span(&self) -> Span {
         let start = if !self.pipelines.is_empty() {
             self.pipelines[0].span().start()
@@ -348,7 +363,9 @@ fn group(tokens: Vec<Token>) -> (LiteBlock, Option<ParseError>) {
                     pipeline = LitePipeline::new();
                 }
                 if !group.is_empty() {
-                    groups.push(group);
+                    if !group.is_comment() {
+                        groups.push(group);
+                    }
                     group = LiteGroup::new();
                 }
             }
@@ -389,7 +406,7 @@ fn group(tokens: Vec<Token>) -> (LiteBlock, Option<ParseError>) {
     if !pipeline.is_empty() {
         group.push(pipeline);
     }
-    if !group.is_empty() {
+    if !group.is_empty() && !group.is_comment() {
         groups.push(group);
     }
 

--- a/crates/nu-parser/src/shapes.rs
+++ b/crates/nu-parser/src/shapes.rs
@@ -88,35 +88,39 @@ pub fn expression_to_flat_shape(e: &SpannedExpression) -> Vec<Spanned<FlatShape>
 pub fn shapes(commands: &Block) -> Vec<Spanned<FlatShape>> {
     let mut output = vec![];
 
-    for pipeline in &commands.block {
-        for command in &pipeline.list {
-            match command {
-                ClassifiedCommand::Internal(internal) => {
-                    output.append(&mut expression_to_flat_shape(&internal.args.head));
+    for group in &commands.block {
+        for pipeline in &group.pipelines {
+            for command in &pipeline.list {
+                match command {
+                    ClassifiedCommand::Internal(internal) => {
+                        output.append(&mut expression_to_flat_shape(&internal.args.head));
 
-                    if let Some(positionals) = &internal.args.positional {
-                        for positional_arg in positionals {
-                            output.append(&mut expression_to_flat_shape(positional_arg));
+                        if let Some(positionals) = &internal.args.positional {
+                            for positional_arg in positionals {
+                                output.append(&mut expression_to_flat_shape(positional_arg));
+                            }
                         }
-                    }
 
-                    if let Some(named) = &internal.args.named {
-                        for (_, named_arg) in named.iter() {
-                            match named_arg {
-                                NamedValue::PresentSwitch(span) => {
-                                    output.push(FlatShape::Flag.spanned(*span));
+                        if let Some(named) = &internal.args.named {
+                            for (_, named_arg) in named.iter() {
+                                match named_arg {
+                                    NamedValue::PresentSwitch(span) => {
+                                        output.push(FlatShape::Flag.spanned(*span));
+                                    }
+                                    NamedValue::Value(span, expr) => {
+                                        output.push(FlatShape::Flag.spanned(*span));
+                                        output.append(&mut expression_to_flat_shape(expr));
+                                    }
+                                    _ => {}
                                 }
-                                NamedValue::Value(span, expr) => {
-                                    output.push(FlatShape::Flag.spanned(*span));
-                                    output.append(&mut expression_to_flat_shape(expr));
-                                }
-                                _ => {}
                             }
                         }
                     }
+                    ClassifiedCommand::Expr(expr) => {
+                        output.append(&mut expression_to_flat_shape(expr))
+                    }
+                    _ => {}
                 }
-                ClassifiedCommand::Expr(expr) => output.append(&mut expression_to_flat_shape(expr)),
-                _ => {}
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use nu_cli::create_default_context;
 use nu_cli::utils::test_bins as binaries;
 use std::error::Error;
 use std::fs::File;
-use std::io::{prelude::*, BufReader};
+use std::io::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let matches = App::new("nushell")
@@ -124,9 +124,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     match matches.values_of("commands") {
         None => {}
         Some(values) => {
-            let pipelines: Vec<String> = values.map(|x| x.to_string()).collect();
-            futures::executor::block_on(nu_cli::run_vec_of_pipelines(
-                pipelines,
+            let script_text: String = values
+                .map(|x| x.to_string())
+                .collect::<Vec<String>>()
+                .join("\n");
+            futures::executor::block_on(nu_cli::run_script_file(
+                script_text,
                 matches.is_present("stdin"),
             ))?;
             return Ok(());
@@ -135,25 +138,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match matches.value_of("script") {
         Some(script) => {
-            let file = File::open(script)?;
-            let reader = BufReader::new(file);
-            let pipelines: Vec<String> = reader
-                .lines()
-                .filter_map(|x| {
-                    if let Ok(x) = x {
-                        if !x.starts_with('#') {
-                            Some(x)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+            let mut file = File::open(script)?;
+            let mut buffer = String::new();
+            file.read_to_string(&mut buffer)?;
 
-            futures::executor::block_on(nu_cli::run_vec_of_pipelines(
-                pipelines,
+            futures::executor::block_on(nu_cli::run_script_file(
+                buffer,
                 matches.is_present("stdin"),
             ))?;
             return Ok(());


### PR DESCRIPTION
With this we allow comments if the line starts with a `#` (though this algorithm may need to be tweeked since a group can span multiple lines and we don't want that)

It also moves the API to focusing on evaluating scripts instead of pipelines, so we take a step closer to evaluating a script of multiple groups.
