### PR TITLE
added as_html switch so a selector can be passed to a selector

### DIFF
--- a/crates/nu_plugin_selector/src/selector.rs
+++ b/crates/nu_plugin_selector/src/selector.rs
@@ -6,6 +6,7 @@ use nu_source::{Tag, Tagged};
 pub struct Selector {
     pub query: String,
     pub tag: Tag,
+    pub as_html: bool,
 }
 
 impl Selector {
@@ -13,6 +14,7 @@ impl Selector {
         Selector {
             query: String::new(),
             tag: Tag::unknown(),
+            as_html: false,
         }
     }
 }
@@ -23,14 +25,19 @@ impl Default for Selector {
     }
 }
 
-pub fn begin_selector_query(raw: String, query: Tagged<&str>) -> Result<Vec<Value>, ShellError> {
-    execute_selector_query(raw, query.item.to_string(), query.tag())
+pub fn begin_selector_query(
+    input: String,
+    query: Tagged<&str>,
+    as_html: bool,
+) -> Result<Vec<Value>, ShellError> {
+    execute_selector_query(input, query.item.to_string(), query.tag(), as_html)
 }
 
 fn execute_selector_query(
     input_string: String,
     query_string: String,
     tag: impl Into<Tag>,
+    as_html: bool,
 ) -> Result<Vec<Value>, ShellError> {
     let _tag = tag.into();
     let mut ret = vec![];
@@ -48,10 +55,15 @@ fn execute_selector_query(
     //     ret.push(title_url.to_string_value_create_tag());
     // });
 
-    doc.nip(&query_string).iter().for_each(|athing| {
-        ret.push(athing.text().to_string().to_string_value_create_tag());
-    });
-
+    if as_html {
+        doc.nip(&query_string).iter().for_each(|athing| {
+            ret.push(athing.html().to_string().to_string_value_create_tag());
+        });
+    } else {
+        doc.nip(&query_string).iter().for_each(|athing| {
+            ret.push(athing.text().to_string().to_string_value_create_tag());
+        });
+    }
     Ok(ret)
 }
 


### PR DESCRIPTION
with the `--as_html` or `-a` parameter a selector can be passed into another selector.

```
fetch https://news.ycombinator.com | selector ".storylink, .score" -a | first 5
┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ 0 ┃ <a href="https://www.vice.com/en/article/xgzxvz/voters-overwhelmingly-back-community-broadband-in-chicago-and-denver" class="storylink">Voters Overwhelmingly Back Community ┃
┃   ┃ Broadband in Chicago and Denver</a>                                                                                                                                          ┃
┃ 1 ┃ <span class="score" id="score_25035499">438 points</span>                                                                                                                    ┃
┃ 2 ┃ <a href="https://openstartups.listt.xyz" class="storylink">100+ Startups that have hit more than $1K MRR in about 12-24 months</a>                                           ┃
┃ 3 ┃ <span class="score" id="score_25036526">60 points</span>                                                                                                                     ┃
┃ 4 ┃ <a href="https://thefuntastic.com/blog/why-rust-is-the-future-game-dev?" class="storylink">Why Rust Is the Future of Game Development</a>                                    ┃
┗━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

```
fetch https://news.ycombinator.com | selector ".storylink, .score" -a | first 5 | selector ".s
core"
┏━━━┳━━━━━━━━━━━━┓
┃ 0 ┃ 442 points ┃
┃ 1 ┃ 26 points  ┃
┗━━━┻━━━━━━━━━━━━┛
```

the idea is that, in the future, we'd be able to set output to a variable and then carve away at a big selector to produce the tablular output one needs.