### PR TITLE
History contains timestamp of invocation

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -24,6 +24,7 @@ use std::error::Error;
 use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
+use chrono::{DateTime, Local};
 
 pub fn search_paths() -> Vec<std::path::PathBuf> {
     use std::env;
@@ -500,7 +501,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
 
         match line {
             LineResult::Success(line) => {
-                rl.add_history_entry(&line);
+                add_history_entry_with_timestamp(&line);
                 let _ = rl.save_history(&history_path);
                 context.maybe_print_errors(Text::from(line));
             }
@@ -511,7 +512,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             }
 
             LineResult::Error(line, err) => {
-                rl.add_history_entry(&line);
+                add_history_entry_with_timestamp(&line);
                 let _ = rl.save_history(&history_path);
 
                 context.with_host(|_host| {
@@ -850,6 +851,12 @@ fn chomp_newline(s: &str) -> &str {
     } else {
         s
     }
+}
+
+fn add_history_entry_with_timestamp(line: &str) -> bool {
+    let local: DateTime<Local> = Local::now();
+    rl.add_history_entry(format!("#{}", local.timestamp()));
+    rl.add_history_entry(&line)
 }
 
 #[derive(Debug)]

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -501,7 +501,9 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
 
         match line {
             LineResult::Success(line) => {
-                add_history_entry_with_timestamp(&line);
+                let local: DateTime<Local> = Local::now();
+                rl.add_history_entry(format!("#{}", local.timestamp()));
+                rl.add_history_entry(&line);
                 let _ = rl.save_history(&history_path);
                 context.maybe_print_errors(Text::from(line));
             }
@@ -512,7 +514,9 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             }
 
             LineResult::Error(line, err) => {
-                add_history_entry_with_timestamp(&line);
+                let local: DateTime<Local> = Local::now();
+                rl.add_history_entry(format!("#{}", local.timestamp()));
+                rl.add_history_entry(&line);
                 let _ = rl.save_history(&history_path);
 
                 context.with_host(|_host| {
@@ -851,12 +855,6 @@ fn chomp_newline(s: &str) -> &str {
     } else {
         s
     }
-}
-
-fn add_history_entry_with_timestamp(line: &str) -> bool {
-    let local: DateTime<Local> = Local::now();
-    rl.add_history_entry(format!("#{}", local.timestamp()));
-    rl.add_history_entry(&line)
 }
 
 #[derive(Debug)]

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -96,14 +96,20 @@ async fn history(
                                     "command".to_string(),
                                     UntaggedValue::string(current_line).into_untagged_value(),
                                 );
-                                prev_was_timestamp = false;
                             }
                             Err(_) => {
-                                return Err(ShellError::unexpected(
-                                    "History timestamp is malformed",
-                                ))
+                                // Malformed timestamp found for this command, use current time as default
+                                map.insert(
+                                    "timestamp".to_string(),
+                                    UntaggedValue::date(chrono::Utc::now()).into_untagged_value(),
+                                );
+                                map.insert(
+                                    "command".to_string(),
+                                    UntaggedValue::string(current_line).into_untagged_value(),
+                                );
                             }
                         };
+                        prev_was_timestamp = false;
                     } else {
                         // Set the timestamp, if found
                         if current_line.starts_with('#') {

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -49,6 +49,26 @@ impl WholeStreamCommand for History {
         "Display command history."
     }
 
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "History of commands",
+                example: "history",
+                result: None,
+            },
+            Example {
+                description: "Commands within last day",
+                example: "history | where timestamp < 1day",
+                result: None,
+            },
+            Example {
+                description: "Clear out history entries",
+                example: "history --clear",
+                result: None,
+            },
+        ]
+    }
+
     async fn run(
         &self,
         args: CommandArgs,
@@ -76,7 +96,7 @@ async fn history(
         None => {
             if let Ok(file) = File::open(path) {
                 let mut prev_was_timestamp = false;
-                let mut prev_timestamp: String = String::from("");
+                let mut prev_timestamp = "".to_string();
                 let mut rows = VecDeque::new();
 
                 // Skips the first line, which is a Rustyline internal
@@ -113,7 +133,7 @@ async fn history(
                     } else {
                         // Set the timestamp, if found
                         if current_line.starts_with('#') {
-                            prev_timestamp = String::from(current_line.trim_start_matches('#'));
+                            prev_timestamp = current_line.trim_start_matches('#').to_string();
                             prev_was_timestamp = true;
                             continue;
                         } else {

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -86,22 +86,28 @@ async fn history(
 
                     // The previous line was a timestamp for the current command
                     if prev_was_timestamp {
-                        map.insert(
-                            "timestamp".to_string(),
-                            UntaggedValue::date(
-                                Utc.timestamp(prev_timestamp.parse::<i64>().unwrap(), 0),
-                            )
-                            .into_untagged_value(),
-                        );
-                        map.insert(
-                            "command".to_string(),
-                            UntaggedValue::string(current_line).into_untagged_value(),
-                        );
-                        prev_was_timestamp = false;
+                        match prev_timestamp.parse::<i64>() {
+                            Ok(ts) => {
+                                map.insert(
+                                    "timestamp".to_string(),
+                                    UntaggedValue::date(Utc.timestamp(ts, 0)).into_untagged_value(),
+                                );
+                                map.insert(
+                                    "command".to_string(),
+                                    UntaggedValue::string(current_line).into_untagged_value(),
+                                );
+                                prev_was_timestamp = false;
+                            }
+                            Err(_) => {
+                                return Err(ShellError::unexpected(
+                                    "History timestamp is malformed",
+                                ))
+                            }
+                        };
                     } else {
                         // Set the timestamp, if found
-                        if current_line.starts_with("#") {
-                            prev_timestamp = String::from(current_line.trim_start_matches("#"));
+                        if current_line.starts_with('#') {
+                            prev_timestamp = String::from(current_line.trim_start_matches('#'));
                             prev_was_timestamp = true;
                             continue;
                         } else {


### PR DESCRIPTION
Resolves #2735 

1. Adds the timestamp of when a command was run in the `history` command output

It uses the unix timestamp with a prefix of `#` to identify a timestamp. This is how bash does it, which seemed reasonable. 

Edge cases that will default to the current timestamp:
1. If a command starts with `#` for some reason
2. Older history entries (before this change) that don't have a corresponding timestamp

**Updated history text file format:**
![Screen Shot 2020-11-13 at 8 49 58 AM](https://user-images.githubusercontent.com/6572184/99129766-55025a00-25c3-11eb-85d1-7aedef35f035.png)

**Updated command:**
![Screen Shot 2020-11-13 at 7 01 45 AM](https://user-images.githubusercontent.com/6572184/99129768-5764b400-25c3-11eb-95ec-e378d54a9736.png)

Writing a test case was not possible since Rustyline isn't used in `nu!` tests, unfortunately
