### PR TITLE
helps table columns align a little bit better

### DIFF
--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -57,7 +57,15 @@ pub fn split_sublines(input: &str) -> Vec<Vec<Subline>> {
             line.split_terminator(' ')
                 .map(|x| Subline {
                     subline: x,
-                    width: UnicodeWidthStr::width(x),
+                    width: {
+                        // We've tried UnicodeWidthStr::width(x), UnicodeSegmentation::graphemes(x, true).count()
+                        // and x.chars().count() with all types of combinations. Currently, it appears that
+                        // getting the max of char count and unicode width seems to produce the best layout.
+                        // However, it's not perfect.
+                        let c = x.chars().count();
+                        let u = UnicodeWidthStr::width(x);
+                        std::cmp::max(c, u)
+                    },
                 })
                 .collect::<Vec<_>>()
         })


### PR DESCRIPTION
i tested this using an emoji json file linked below. Here are some results.
Before
![image](https://user-images.githubusercontent.com/343840/99433324-fbf03a00-28d2-11eb-892e-f4b68c08e9c2.png)
After
![image](https://user-images.githubusercontent.com/343840/99433460-28a45180-28d3-11eb-87a3-7884f21162ca.png)

But it doesn't appear to work when the difference is more than 1. I'm not sure why. You'd think `max` would take care of alignment but I'm guessing that all columns aren't calculated during a collection but they stream in one by one and therefore this doesn't work. But that's just a guess.

`echo [ [name, icon]; ['Clear', $(char sun)] ['Clouds', $(char clouds)] ['Rain', $(char rain)] ['Fog', $(char fog)] ['Mist', $(char mist)] ['Haze', $(char haze)] ['Snow', $(char snow)] ['Thunderstorm', $(char thunderstorm)] ] `

But it still looks better than previously.
Before
![image](https://user-images.githubusercontent.com/343840/99433797-98b2d780-28d3-11eb-8b95-8c4d720224a1.png)

After
![image](https://user-images.githubusercontent.com/343840/99433704-7ae57280-28d3-11eb-8068-908237a50335.png)





[emoji json file](https://github.com/nushell/nushell/files/5555527/e.zip)

