### PR TITLE
Avoid subtract overflow when no ending index given.

### DIFF
--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -159,12 +159,14 @@ fn action(input: &Value, options: &Substring, tag: impl Into<Tag>) -> Result<Val
                         "End must be greater than or equal to Start",
                         tag.span,
                     )),
-                    Ordering::Less => Ok(UntaggedValue::string(
+                    Ordering::Less => Ok(UntaggedValue::string(if end == isize::max_value() {
+                        s.chars().skip(start as usize).collect::<String>()
+                    } else {
                         s.chars()
                             .skip(start as usize)
                             .take((end - start) as usize)
-                            .collect::<String>(),
-                    )
+                            .collect::<String>()
+                    })
                     .into_value(tag)),
                 }
             } else {
@@ -330,6 +332,9 @@ mod tests {
             expectation("and", (0, -3)),
             expectation("andr", (0, -2)),
             expectation("andre", (0, -1)),
+            // str substring [ -4 , _ ]
+            // str substring   -4 ,
+            expectation("dres", (-4, isize::max_value())),
             expectation("", (0, -110)),
             expectation("", (6, 0)),
             expectation("", (6, -1)),


### PR DESCRIPTION
There are cases when we do `str substring -5,` or `str substring [-5, _]` to grab characters from the end of the string. When the command is called like this Nu uses as ending index an `isize` maxvalue and depending on the string we are sub stringing against, there are cases that a panic occurs due do subtraction overflows.

This PR fixes it.

NOTE: We need to check again behaviors we want depending on positive/negative values used as starting and ending indexes since the logic was changed here #2499 