### PR TITLE
Bump Rustyline to 7.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,31 +1252,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-dependencies = [
- "libc",
- "redox_users",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
 dependencies = [
  "libc",
  "redox_users",
@@ -1560,6 +1539,16 @@ checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4826,16 +4815,18 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "6.3.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
+checksum = "1a5f54deba50e65ee4cf786dbc37e8b3c63bdccccbcf9d3a8a9fd0c1bb7e1984"
 dependencies = [
- "cfg-if 0.1.10",
- "dirs-next",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "dirs 3.0.1",
+ "fs2",
  "libc",
  "log 0.4.11",
  "memchr",
- "nix 0.18.0",
+ "nix 0.19.0",
  "scopeguard",
  "unicode-segmentation",
  "unicode-width",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -75,7 +75,7 @@ rayon = "1.4.0"
 regex = "1.3.9"
 roxmltree = "0.13.0"
 rust-embed = "5.6.0"
-rustyline = {version = "6.3.0", optional = true}
+rustyline = {version = "7.0.0", optional = true}
 serde = {version = "1.0.115", features = ["derive"]}
 serde_bytes = "0.11.5"
 serde_ini = "0.2.0"

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -18,12 +18,13 @@ use rustyline::{
     config::Configurer,
     config::{ColorMode, CompletionType, Config},
     error::ReadlineError,
-    At, Cmd, Editor, KeyPress, Movement, Word,
+    At, Cmd, Editor, Movement, Word,
 };
 use std::error::Error;
 use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
+use rustyline::Modifiers;
 
 pub fn search_paths() -> Vec<std::path::PathBuf> {
     use std::env;
@@ -678,16 +679,25 @@ fn default_rustyline_editor_configuration() -> Editor<Helper> {
 
     // add key bindings to move over a whole word with Ctrl+ArrowLeft and Ctrl+ArrowRight
     rl.bind_sequence(
-        KeyPress::ControlLeft,
+        rustyline::KeyEvent {
+            0: rustyline::KeyCode::Left,
+            1: Modifiers::CTRL,
+        },
         Cmd::Move(Movement::BackwardWord(1, Word::Vi)),
     );
     rl.bind_sequence(
-        KeyPress::ControlRight,
+        rustyline::KeyEvent {
+            0: rustyline::KeyCode::Right,
+            1: Modifiers::CTRL,
+        },
         Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)),
     );
 
     // workaround for multiline-paste hang in rustyline (see https://github.com/kkawakam/rustyline/issues/202)
-    rl.bind_sequence(KeyPress::BracketedPasteStart, rustyline::Cmd::Noop);
+    rl.bind_sequence(rustyline::KeyEvent {
+        0: rustyline::KeyCode::BracketedPasteStart,
+        1: Modifiers::CTRL,
+    }, rustyline::Cmd::Noop);
 
     // Let's set the defaults up front and then override them later if the user indicates
     // defaults taken from here https://github.com/kkawakam/rustyline/blob/2fe886c9576c1ea13ca0e5808053ad491a6fe049/src/config.rs#L150-L167

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -1,18 +1,18 @@
 use crate::commands::classified::block::run_block;
 use crate::commands::classified::maybe_text_codec::{MaybeTextCodec, StringOrBinary};
 use crate::evaluation_context::EvaluationContext;
+#[cfg(feature = "rustyline-support")]
+use crate::keybinding::{convert_keyevent, KeyEvent};
 use crate::path::canonicalize;
 use crate::prelude::*;
 #[cfg(feature = "rustyline-support")]
 use crate::shell::Helper;
 use crate::EnvironmentSyncer;
 use futures_codec::FramedRead;
+use log::{debug, trace};
 use nu_errors::ShellError;
 use nu_protocol::hir::{ClassifiedCommand, Expression, InternalCommand, Literal, NamedArguments};
 use nu_protocol::{Primitive, ReturnSuccess, Scope, UntaggedValue, Value};
-
-use log::{debug, trace};
-use rustyline::Modifiers;
 #[cfg(feature = "rustyline-support")]
 use rustyline::{
     self,
@@ -679,26 +679,17 @@ fn default_rustyline_editor_configuration() -> Editor<Helper> {
 
     // add key bindings to move over a whole word with Ctrl+ArrowLeft and Ctrl+ArrowRight
     rl.bind_sequence(
-        rustyline::KeyEvent {
-            0: rustyline::KeyCode::Left,
-            1: Modifiers::CTRL,
-        },
+        convert_keyevent(KeyEvent::ControlLeft),
         Cmd::Move(Movement::BackwardWord(1, Word::Vi)),
     );
     rl.bind_sequence(
-        rustyline::KeyEvent {
-            0: rustyline::KeyCode::Right,
-            1: Modifiers::CTRL,
-        },
+        convert_keyevent(KeyEvent::ControlRight),
         Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)),
     );
 
     // workaround for multiline-paste hang in rustyline (see https://github.com/kkawakam/rustyline/issues/202)
     rl.bind_sequence(
-        rustyline::KeyEvent {
-            0: rustyline::KeyCode::BracketedPasteStart,
-            1: Modifiers::NONE,
-        },
+        convert_keyevent(KeyEvent::BracketedPasteStart),
         rustyline::Cmd::Noop,
     );
 

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -504,7 +504,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
         match line {
             LineResult::Success(line) => {
                 rl.add_history_entry(&line);
-                let _ = rl.save_history(&history_path);
+                let _ = rl.append_history(&history_path);
                 context.maybe_print_errors(Text::from(line));
             }
 
@@ -514,7 +514,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             }
 
             LineResult::Error(line, err) => {
-                rl.add_history_entry(&line);
+                rl.append_history(&line);
                 let _ = rl.save_history(&history_path);
 
                 context.with_host(|_host| {

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -504,8 +504,8 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
 
         match line {
             LineResult::Success(line) => {
-                rl.add_history_entry(&line);
-                let _ = rl.append_history(&history_path);
+                let _ = rl.add_history_entry(&line);
+                let _ = rl.save_history(&history_path);
                 context.maybe_print_errors(Text::from(line));
             }
 
@@ -515,7 +515,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             }
 
             LineResult::Error(line, err) => {
-                rl.append_history(&line);
+                let _ = rl.add_history_entry(&line);
                 let _ = rl.save_history(&history_path);
 
                 context.with_host(|_host| {

--- a/crates/nu-cli/src/keybinding.rs
+++ b/crates/nu-cli/src/keybinding.rs
@@ -3,57 +3,59 @@ use serde::{Deserialize, Serialize};
 
 pub fn convert_keyevent(key_event: KeyEvent) -> rustyline::KeyEvent {
     match key_event {
-        KeyEvent::UnknownEscSeq => convert_to_key_event(rustyline::KeyCode::UnknownEscSeq, None),
-        KeyEvent::Backspace => convert_to_key_event(rustyline::KeyCode::Backspace, None),
-        KeyEvent::BackTab => convert_to_key_event(rustyline::KeyCode::BackTab, None),
+        KeyEvent::UnknownEscSeq => convert_to_rl_keyevent(rustyline::KeyCode::UnknownEscSeq, None),
+        KeyEvent::Backspace => convert_to_rl_keyevent(rustyline::KeyCode::Backspace, None),
+        KeyEvent::BackTab => convert_to_rl_keyevent(rustyline::KeyCode::BackTab, None),
         KeyEvent::BracketedPasteStart => {
-            convert_to_key_event(rustyline::KeyCode::BracketedPasteStart, None)
+            convert_to_rl_keyevent(rustyline::KeyCode::BracketedPasteStart, None)
         }
         KeyEvent::BracketedPasteEnd => {
-            convert_to_key_event(rustyline::KeyCode::BracketedPasteEnd, None)
+            convert_to_rl_keyevent(rustyline::KeyCode::BracketedPasteEnd, None)
         }
-        KeyEvent::Char(c) => convert_to_key_event(rustyline::KeyCode::Char(c), None),
+        KeyEvent::Char(c) => convert_to_rl_keyevent(rustyline::KeyCode::Char(c), None),
         KeyEvent::ControlDown => {
-            convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::CTRL))
+            convert_to_rl_keyevent(rustyline::KeyCode::Down, Some(Modifiers::CTRL))
         }
         KeyEvent::ControlLeft => {
-            convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::CTRL))
+            convert_to_rl_keyevent(rustyline::KeyCode::Left, Some(Modifiers::CTRL))
         }
         KeyEvent::ControlRight => {
-            convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::CTRL))
+            convert_to_rl_keyevent(rustyline::KeyCode::Right, Some(Modifiers::CTRL))
         }
-        KeyEvent::ControlUp => convert_to_key_event(rustyline::KeyCode::Up, Some(Modifiers::CTRL)),
+        KeyEvent::ControlUp => {
+            convert_to_rl_keyevent(rustyline::KeyCode::Up, Some(Modifiers::CTRL))
+        }
         KeyEvent::Ctrl(c) => rustyline::KeyEvent::ctrl(c),
-        KeyEvent::Delete => convert_to_key_event(rustyline::KeyCode::Delete, None),
-        KeyEvent::Down => convert_to_key_event(rustyline::KeyCode::Down, None),
-        KeyEvent::End => convert_to_key_event(rustyline::KeyCode::End, None),
-        KeyEvent::Enter => convert_to_key_event(rustyline::KeyCode::Enter, None),
-        KeyEvent::Esc => convert_to_key_event(rustyline::KeyCode::Esc, None),
-        KeyEvent::F(u) => convert_to_key_event(rustyline::KeyCode::F(u), None),
-        KeyEvent::Home => convert_to_key_event(rustyline::KeyCode::Home, None),
-        KeyEvent::Insert => convert_to_key_event(rustyline::KeyCode::Insert, None),
-        KeyEvent::Left => convert_to_key_event(rustyline::KeyCode::Left, None),
+        KeyEvent::Delete => convert_to_rl_keyevent(rustyline::KeyCode::Delete, None),
+        KeyEvent::Down => convert_to_rl_keyevent(rustyline::KeyCode::Down, None),
+        KeyEvent::End => convert_to_rl_keyevent(rustyline::KeyCode::End, None),
+        KeyEvent::Enter => convert_to_rl_keyevent(rustyline::KeyCode::Enter, None),
+        KeyEvent::Esc => convert_to_rl_keyevent(rustyline::KeyCode::Esc, None),
+        KeyEvent::F(u) => convert_to_rl_keyevent(rustyline::KeyCode::F(u), None),
+        KeyEvent::Home => convert_to_rl_keyevent(rustyline::KeyCode::Home, None),
+        KeyEvent::Insert => convert_to_rl_keyevent(rustyline::KeyCode::Insert, None),
+        KeyEvent::Left => convert_to_rl_keyevent(rustyline::KeyCode::Left, None),
         KeyEvent::Meta(c) => rustyline::KeyEvent::new(c, Modifiers::NONE),
-        KeyEvent::Null => convert_to_key_event(rustyline::KeyCode::Null, None),
-        KeyEvent::PageDown => convert_to_key_event(rustyline::KeyCode::PageDown, None),
-        KeyEvent::PageUp => convert_to_key_event(rustyline::KeyCode::PageUp, None),
-        KeyEvent::Right => convert_to_key_event(rustyline::KeyCode::Right, None),
+        KeyEvent::Null => convert_to_rl_keyevent(rustyline::KeyCode::Null, None),
+        KeyEvent::PageDown => convert_to_rl_keyevent(rustyline::KeyCode::PageDown, None),
+        KeyEvent::PageUp => convert_to_rl_keyevent(rustyline::KeyCode::PageUp, None),
+        KeyEvent::Right => convert_to_rl_keyevent(rustyline::KeyCode::Right, None),
         KeyEvent::ShiftDown => {
-            convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::SHIFT))
+            convert_to_rl_keyevent(rustyline::KeyCode::Down, Some(Modifiers::SHIFT))
         }
         KeyEvent::ShiftLeft => {
-            convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::SHIFT))
+            convert_to_rl_keyevent(rustyline::KeyCode::Left, Some(Modifiers::SHIFT))
         }
         KeyEvent::ShiftRight => {
-            convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::SHIFT))
+            convert_to_rl_keyevent(rustyline::KeyCode::Right, Some(Modifiers::SHIFT))
         }
-        KeyEvent::ShiftUp => convert_to_key_event(rustyline::KeyCode::Up, Some(Modifiers::SHIFT)),
-        KeyEvent::Tab => convert_to_key_event(rustyline::KeyCode::Tab, None),
-        KeyEvent::Up => convert_to_key_event(rustyline::KeyCode::Up, None),
+        KeyEvent::ShiftUp => convert_to_rl_keyevent(rustyline::KeyCode::Up, Some(Modifiers::SHIFT)),
+        KeyEvent::Tab => convert_to_rl_keyevent(rustyline::KeyCode::Tab, None),
+        KeyEvent::Up => convert_to_rl_keyevent(rustyline::KeyCode::Up, None),
     }
 }
 
-fn convert_to_key_event(key_event: KeyCode, modifier: Option<Modifiers>) -> rustyline::KeyEvent {
+fn convert_to_rl_keyevent(key_event: KeyCode, modifier: Option<Modifiers>) -> rustyline::KeyEvent {
     rustyline::KeyEvent {
         0: key_event,
         1: modifier.unwrap_or(Modifiers::NONE),

--- a/crates/nu-cli/src/keybinding.rs
+++ b/crates/nu-cli/src/keybinding.rs
@@ -1,38 +1,46 @@
 use serde::{Deserialize, Serialize};
+use rustyline::{KeyCode, Modifiers};
 
-fn convert_keypress(keypress: KeyPress) -> rustyline::KeyPress {
+fn convert_keypress(keypress: KeyEvent) -> rustyline::KeyEvent {
     match keypress {
-        KeyPress::UnknownEscSeq => rustyline::KeyPress::UnknownEscSeq,
-        KeyPress::Backspace => rustyline::KeyPress::Backspace,
-        KeyPress::BackTab => rustyline::KeyPress::BackTab,
-        KeyPress::BracketedPasteStart => rustyline::KeyPress::BracketedPasteStart,
-        KeyPress::BracketedPasteEnd => rustyline::KeyPress::BracketedPasteEnd,
-        KeyPress::Char(c) => rustyline::KeyPress::Char(c),
-        KeyPress::ControlDown => rustyline::KeyPress::ControlDown,
-        KeyPress::ControlLeft => rustyline::KeyPress::ControlLeft,
-        KeyPress::ControlRight => rustyline::KeyPress::ControlRight,
-        KeyPress::ControlUp => rustyline::KeyPress::ControlUp,
-        KeyPress::Ctrl(c) => rustyline::KeyPress::Ctrl(c),
-        KeyPress::Delete => rustyline::KeyPress::Delete,
-        KeyPress::Down => rustyline::KeyPress::Down,
-        KeyPress::End => rustyline::KeyPress::End,
-        KeyPress::Enter => rustyline::KeyPress::Enter,
-        KeyPress::Esc => rustyline::KeyPress::Esc,
-        KeyPress::F(u) => rustyline::KeyPress::F(u),
-        KeyPress::Home => rustyline::KeyPress::Home,
-        KeyPress::Insert => rustyline::KeyPress::Insert,
-        KeyPress::Left => rustyline::KeyPress::Left,
-        KeyPress::Meta(c) => rustyline::KeyPress::Meta(c),
-        KeyPress::Null => rustyline::KeyPress::Null,
-        KeyPress::PageDown => rustyline::KeyPress::PageDown,
-        KeyPress::PageUp => rustyline::KeyPress::PageUp,
-        KeyPress::Right => rustyline::KeyPress::Right,
-        KeyPress::ShiftDown => rustyline::KeyPress::ShiftDown,
-        KeyPress::ShiftLeft => rustyline::KeyPress::ShiftLeft,
-        KeyPress::ShiftRight => rustyline::KeyPress::ShiftRight,
-        KeyPress::ShiftUp => rustyline::KeyPress::ShiftUp,
-        KeyPress::Tab => rustyline::KeyPress::Tab,
-        KeyPress::Up => rustyline::KeyPress::Up,
+        KeyEvent::UnknownEscSeq => convert_to_key_event(rustyline::KeyCode::UnknownEscSeq, None),
+        KeyEvent::Backspace => convert_to_key_event(rustyline::KeyCode::Backspace, None),
+        KeyEvent::BackTab => convert_to_key_event(rustyline::KeyCode::BackTab, None),
+        KeyEvent::BracketedPasteStart => convert_to_key_event(rustyline::KeyCode::BracketedPasteStart, None),
+        KeyEvent::BracketedPasteEnd => convert_to_key_event(rustyline::KeyCode::BracketedPasteEnd, None),
+        KeyEvent::Char(c) => convert_to_key_event(rustyline::KeyCode::Char(c), None),
+        KeyEvent::ControlDown => convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::CTRL)),
+        KeyEvent::ControlLeft => convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::CTRL)),
+        KeyEvent::ControlRight => convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::CTRL)),
+        KeyEvent::ControlUp => convert_to_key_event(rustyline::KeyCode::Up, Some(Modifiers::CTRL)),
+        KeyEvent::Ctrl(c) => rustyline::KeyEvent::ctrl(c),
+        KeyEvent::Delete => convert_to_key_event(rustyline::KeyCode::Delete, None),
+        KeyEvent::Down => convert_to_key_event(rustyline::KeyCode::Down, None),
+        KeyEvent::End => convert_to_key_event(rustyline::KeyCode::End, None),
+        KeyEvent::Enter => convert_to_key_event(rustyline::KeyCode::Enter, None),
+        KeyEvent::Esc => convert_to_key_event(rustyline::KeyCode::Esc, None),
+        KeyEvent::F(u) => convert_to_key_event(rustyline::KeyCode::F(u), None),
+        KeyEvent::Home => convert_to_key_event(rustyline::KeyCode::Home, None),
+        KeyEvent::Insert => convert_to_key_event(rustyline::KeyCode::Insert, None),
+        KeyEvent::Left => convert_to_key_event(rustyline::KeyCode::Left, None),
+        KeyEvent::Meta(c) => rustyline::KeyEvent::new(c, Modifiers::NONE),
+        KeyEvent::Null => convert_to_key_event(rustyline::KeyCode::Null, None),
+        KeyEvent::PageDown => convert_to_key_event(rustyline::KeyCode::PageDown, None),
+        KeyEvent::PageUp => convert_to_key_event(rustyline::KeyCode::PageUp, None),
+        KeyEvent::Right => convert_to_key_event(rustyline::KeyCode::Right, None),
+        KeyEvent::ShiftDown => convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::SHIFT)),
+        KeyEvent::ShiftLeft => convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::SHIFT)),
+        KeyEvent::ShiftRight => convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::SHIFT)),
+        KeyEvent::ShiftUp => convert_to_key_event(rustyline::KeyCode::Up, Some(Modifiers::SHIFT)),
+        KeyEvent::Tab => convert_to_key_event(rustyline::KeyCode::Tab, None),
+        KeyEvent::Up => convert_to_key_event(rustyline::KeyCode::Up, None),
+    }
+}
+
+fn convert_to_key_event(key_event: KeyCode, modifier: Option<Modifiers>) -> rustyline::KeyEvent {
+    rustyline::KeyEvent {
+        0: key_event,
+        1: modifier.unwrap_or(Modifiers::NONE)
     }
 }
 
@@ -140,7 +148,7 @@ fn convert_cmd(cmd: Cmd) -> rustyline::Cmd {
     }
 }
 
-fn convert_keybinding(keybinding: Keybinding) -> (rustyline::KeyPress, rustyline::Cmd) {
+fn convert_keybinding(keybinding: Keybinding) -> (rustyline::KeyEvent, rustyline::Cmd) {
     (
         convert_keypress(keybinding.key),
         convert_cmd(keybinding.binding),
@@ -148,10 +156,10 @@ fn convert_keybinding(keybinding: Keybinding) -> (rustyline::KeyPress, rustyline
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum KeyPress {
+pub enum KeyEvent {
     /// Unsupported escape sequence (on unix platform)
     UnknownEscSeq,
-    /// ⌫ or `KeyPress::Ctrl('H')`
+    /// ⌫ or `KeyEvent::Ctrl('H')`
     Backspace,
     /// ⇤ (usually Shift-Tab)
     BackTab,
@@ -177,9 +185,9 @@ pub enum KeyPress {
     Down,
     /// ⇲
     End,
-    /// ↵ or `KeyPress::Ctrl('M')`
+    /// ↵ or `KeyEvent::Ctrl('M')`
     Enter,
-    /// Escape or `KeyPress::Ctrl('[')`
+    /// Escape or `KeyEvent::Ctrl('[')`
     Esc,
     /// Function key
     F(u8),
@@ -191,7 +199,7 @@ pub enum KeyPress {
     Left,
     /// Escape-char or Alt-char
     Meta(char),
-    /// `KeyPress::Char('\0')`
+    /// `KeyEvent::Char('\0')`
     Null,
     /// ⇟
     PageDown,
@@ -207,7 +215,7 @@ pub enum KeyPress {
     ShiftRight,
     /// Shift-↑
     ShiftUp,
-    /// ⇥ or `KeyPress::Ctrl('I')`
+    /// ⇥ or `KeyEvent::Ctrl('I')`
     Tab,
     /// ↑ arrow key
     Up,
@@ -399,7 +407,7 @@ pub type RepeatCount = usize;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Keybinding {
-    key: KeyPress,
+    key: KeyEvent,
     binding: Cmd,
 }
 

--- a/crates/nu-cli/src/keybinding.rs
+++ b/crates/nu-cli/src/keybinding.rs
@@ -105,7 +105,7 @@ fn convert_cmd(cmd: Cmd) -> rustyline::Cmd {
     match cmd {
         Cmd::Abort => rustyline::Cmd::Abort,
         Cmd::AcceptLine => rustyline::Cmd::AcceptLine,
-        Cmd::AcceptOrInsertLine => rustyline::Cmd::AcceptOrInsertLine,
+        Cmd::AcceptOrInsertLine => rustyline::Cmd::AcceptOrInsertLine { accept_in_the_middle: false },
         Cmd::BeginningOfHistory => rustyline::Cmd::BeginningOfHistory,
         Cmd::CapitalizeWord => rustyline::Cmd::CapitalizeWord,
         Cmd::ClearScreen => rustyline::Cmd::ClearScreen,

--- a/crates/nu-cli/src/keybinding.rs
+++ b/crates/nu-cli/src/keybinding.rs
@@ -1,17 +1,27 @@
-use serde::{Deserialize, Serialize};
 use rustyline::{KeyCode, Modifiers};
+use serde::{Deserialize, Serialize};
 
 fn convert_keypress(keypress: KeyEvent) -> rustyline::KeyEvent {
     match keypress {
         KeyEvent::UnknownEscSeq => convert_to_key_event(rustyline::KeyCode::UnknownEscSeq, None),
         KeyEvent::Backspace => convert_to_key_event(rustyline::KeyCode::Backspace, None),
         KeyEvent::BackTab => convert_to_key_event(rustyline::KeyCode::BackTab, None),
-        KeyEvent::BracketedPasteStart => convert_to_key_event(rustyline::KeyCode::BracketedPasteStart, None),
-        KeyEvent::BracketedPasteEnd => convert_to_key_event(rustyline::KeyCode::BracketedPasteEnd, None),
+        KeyEvent::BracketedPasteStart => {
+            convert_to_key_event(rustyline::KeyCode::BracketedPasteStart, None)
+        }
+        KeyEvent::BracketedPasteEnd => {
+            convert_to_key_event(rustyline::KeyCode::BracketedPasteEnd, None)
+        }
         KeyEvent::Char(c) => convert_to_key_event(rustyline::KeyCode::Char(c), None),
-        KeyEvent::ControlDown => convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::CTRL)),
-        KeyEvent::ControlLeft => convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::CTRL)),
-        KeyEvent::ControlRight => convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::CTRL)),
+        KeyEvent::ControlDown => {
+            convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::CTRL))
+        }
+        KeyEvent::ControlLeft => {
+            convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::CTRL))
+        }
+        KeyEvent::ControlRight => {
+            convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::CTRL))
+        }
         KeyEvent::ControlUp => convert_to_key_event(rustyline::KeyCode::Up, Some(Modifiers::CTRL)),
         KeyEvent::Ctrl(c) => rustyline::KeyEvent::ctrl(c),
         KeyEvent::Delete => convert_to_key_event(rustyline::KeyCode::Delete, None),
@@ -28,9 +38,15 @@ fn convert_keypress(keypress: KeyEvent) -> rustyline::KeyEvent {
         KeyEvent::PageDown => convert_to_key_event(rustyline::KeyCode::PageDown, None),
         KeyEvent::PageUp => convert_to_key_event(rustyline::KeyCode::PageUp, None),
         KeyEvent::Right => convert_to_key_event(rustyline::KeyCode::Right, None),
-        KeyEvent::ShiftDown => convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::SHIFT)),
-        KeyEvent::ShiftLeft => convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::SHIFT)),
-        KeyEvent::ShiftRight => convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::SHIFT)),
+        KeyEvent::ShiftDown => {
+            convert_to_key_event(rustyline::KeyCode::Down, Some(Modifiers::SHIFT))
+        }
+        KeyEvent::ShiftLeft => {
+            convert_to_key_event(rustyline::KeyCode::Left, Some(Modifiers::SHIFT))
+        }
+        KeyEvent::ShiftRight => {
+            convert_to_key_event(rustyline::KeyCode::Right, Some(Modifiers::SHIFT))
+        }
         KeyEvent::ShiftUp => convert_to_key_event(rustyline::KeyCode::Up, Some(Modifiers::SHIFT)),
         KeyEvent::Tab => convert_to_key_event(rustyline::KeyCode::Tab, None),
         KeyEvent::Up => convert_to_key_event(rustyline::KeyCode::Up, None),
@@ -40,7 +56,7 @@ fn convert_keypress(keypress: KeyEvent) -> rustyline::KeyEvent {
 fn convert_to_key_event(key_event: KeyCode, modifier: Option<Modifiers>) -> rustyline::KeyEvent {
     rustyline::KeyEvent {
         0: key_event,
-        1: modifier.unwrap_or(Modifiers::NONE)
+        1: modifier.unwrap_or(Modifiers::NONE),
     }
 }
 
@@ -105,7 +121,9 @@ fn convert_cmd(cmd: Cmd) -> rustyline::Cmd {
     match cmd {
         Cmd::Abort => rustyline::Cmd::Abort,
         Cmd::AcceptLine => rustyline::Cmd::AcceptLine,
-        Cmd::AcceptOrInsertLine => rustyline::Cmd::AcceptOrInsertLine { accept_in_the_middle: false },
+        Cmd::AcceptOrInsertLine => rustyline::Cmd::AcceptOrInsertLine {
+            accept_in_the_middle: false,
+        },
         Cmd::BeginningOfHistory => rustyline::Cmd::BeginningOfHistory,
         Cmd::CapitalizeWord => rustyline::Cmd::CapitalizeWord,
         Cmd::ClearScreen => rustyline::Cmd::ClearScreen,

--- a/crates/nu-cli/src/keybinding.rs
+++ b/crates/nu-cli/src/keybinding.rs
@@ -1,8 +1,8 @@
 use rustyline::{KeyCode, Modifiers};
 use serde::{Deserialize, Serialize};
 
-fn convert_keypress(keypress: KeyEvent) -> rustyline::KeyEvent {
-    match keypress {
+pub fn convert_keyevent(key_event: KeyEvent) -> rustyline::KeyEvent {
+    match key_event {
         KeyEvent::UnknownEscSeq => convert_to_key_event(rustyline::KeyCode::UnknownEscSeq, None),
         KeyEvent::Backspace => convert_to_key_event(rustyline::KeyCode::Backspace, None),
         KeyEvent::BackTab => convert_to_key_event(rustyline::KeyCode::BackTab, None),
@@ -168,7 +168,7 @@ fn convert_cmd(cmd: Cmd) -> rustyline::Cmd {
 
 fn convert_keybinding(keybinding: Keybinding) -> (rustyline::KeyEvent, rustyline::Cmd) {
     (
-        convert_keypress(keybinding.key),
+        convert_keyevent(keybinding.key),
         convert_cmd(keybinding.binding),
     )
 }

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -62,6 +62,7 @@ impl rustyline::completion::Completer for Helper {
 }
 
 impl rustyline::hint::Hinter for Helper {
+    type Hint = String;
     fn hint(&self, line: &str, pos: usize, ctx: &rustyline::Context<'_>) -> Option<String> {
         self.hinter.as_ref().and_then(|h| h.hint(line, pos, &ctx))
     }

--- a/docs/sample_config/keybindings.yml
+++ b/docs/sample_config/keybindings.yml
@@ -74,7 +74,7 @@
     Enter:
   binding:
     AcceptLine:
-  
+
 # Next match from history
 - key:
     Down: #Down Arrow Key
@@ -150,7 +150,7 @@
   binding:
     Undo: 1
 
-#     KeyPress::UnknownEscSeq => Cmd::Noop,
+#     KeyEvent::UnknownEscSeq => Cmd::Noop,
 - key:
     UnknownEscSeq:
   binding:
@@ -161,7 +161,7 @@
 ##########################################################
 # /// Unsupported escape sequence (on unix platform)
 # UnknownEscSeq,
-# /// ⌫ or `KeyPress::Ctrl('H')`
+# /// ⌫ or `KeyEvent::Ctrl('H')`
 # Backspace,
 # /// ⇤ (usually Shift-Tab)
 # BackTab,
@@ -187,9 +187,9 @@
 # Down,
 # /// ⇲
 # End,
-# /// ↵ or `KeyPress::Ctrl('M')`
+# /// ↵ or `KeyEvent::Ctrl('M')`
 # Enter,
-# /// Escape or `KeyPress::Ctrl('[')`
+# /// Escape or `KeyEvent::Ctrl('[')`
 # Esc,
 # /// Function key
 # F(u8),
@@ -201,7 +201,7 @@
 # Left,
 # /// Escape-char or Alt-char
 # Meta(char),
-# /// `KeyPress::Char('\0')`
+# /// `KeyEvent::Char('\0')`
 # Null,
 # /// ⇟
 # PageDown,
@@ -217,7 +217,7 @@
 # ShiftRight,
 # /// Shift-↑
 # ShiftUp,
-# /// ⇥ or `KeyPress::Ctrl('I')`
+# /// ⇥ or `KeyEvent::Ctrl('I')`
 # Tab,
 # /// ↑ arrow key
 # Up,
@@ -330,7 +330,7 @@
 # BeforeEnd,
 # /// After end of word.
 # AfterEnd,
-    
+
 ##########################################################
 # Possible options for Anchor
 ##########################################################


### PR DESCRIPTION
There was a major version update to Rustyline -- bump up the dependency and fix breaking changes in order to stay aligned.

The biggest difference is that `KeyEvent` replaces `KeyPress` and adds modifiers to the key, like CTRL or SHIFT.

Moving forward, there may be opportunity to take advantage of new APIs like `append_history` which would be more performant than `save_history` when adding a single line to the history file.

https://github.com/kkawakam/rustyline/releases/tag/v7.0.0