### PR TITLE
Tell Nu to look for hash's rest columns paths first.

### DIFF
--- a/crates/nu-cli/src/commands/hash_/base64_.rs
+++ b/crates/nu-cli/src/commands/hash_/base64_.rs
@@ -11,10 +11,10 @@ use base64::{decode_config, encode_config};
 
 #[derive(Deserialize)]
 pub struct Arguments {
+    pub rest: Vec<ColumnPath>,
     pub character_set: Option<Tagged<String>>,
     pub encode: Tagged<bool>,
     pub decode: Tagged<bool>,
-    pub rest: Vec<ColumnPath>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Fixes issue described in #2769 (re: `ls | hash base64 name type`) 

/c @notryanb 