### PR TITLE
Add random chars command

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -266,6 +266,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(RandomUUID),
             whole_stream_command(RandomInteger),
             whole_stream_command(RandomDecimal),
+            whole_stream_command(RandomChars),
             // Path
             whole_stream_command(PathBasename),
             whole_stream_command(PathCommand),

--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -232,7 +232,9 @@ pub(crate) use prev::Previous;
 pub(crate) use pwd::Pwd;
 #[cfg(feature = "uuid_crate")]
 pub(crate) use random::RandomUUID;
-pub(crate) use random::{Random, RandomBool, RandomDecimal, RandomDice, RandomInteger};
+pub(crate) use random::{
+    Random, RandomBool, RandomChars, RandomDecimal, RandomDice, RandomInteger,
+};
 pub(crate) use range::Range;
 pub(crate) use reduce::Reduce;
 pub(crate) use reject::Reject;

--- a/crates/nu-cli/src/commands/random/chars.rs
+++ b/crates/nu-cli/src/commands/random/chars.rs
@@ -1,0 +1,89 @@
+use crate::commands::WholeStreamCommand;
+use crate::prelude::*;
+use nu_errors::ShellError;
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
+use nu_source::Tagged;
+use rand::distributions::Alphanumeric;
+use rand::prelude::{thread_rng, Rng};
+
+pub struct SubCommand;
+
+#[derive(Deserialize)]
+pub struct CharsArgs {
+    length: Option<Tagged<u32>>,
+}
+
+const DEFAULT_CHARS_LENGTH: u32 = 25;
+
+#[async_trait]
+impl WholeStreamCommand for SubCommand {
+    fn name(&self) -> &str {
+        "random chars"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("random chars").named(
+            "length",
+            SyntaxShape::Int,
+            "Number of chars",
+            Some('l'),
+        )
+    }
+
+    fn usage(&self) -> &str {
+        "Generate random chars"
+    }
+
+    async fn run(
+        &self,
+        args: CommandArgs,
+        registry: &CommandRegistry,
+    ) -> Result<OutputStream, ShellError> {
+        chars(args, registry).await
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Generate random chars",
+                example: "random chars",
+                result: None,
+            },
+            Example {
+                description: "Generate random chars with specified length",
+                example: "random chars -l 20",
+                result: None,
+            },
+        ]
+    }
+}
+
+pub async fn chars(
+    args: CommandArgs,
+    registry: &CommandRegistry,
+) -> Result<OutputStream, ShellError> {
+    let (CharsArgs { length }, _) = args.process(&registry).await?;
+
+    let chars_length = length.map_or(DEFAULT_CHARS_LENGTH, |l| l.item);
+
+    let random_string: String = thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(chars_length as usize)
+        .collect();
+
+    let result = UntaggedValue::string(random_string);
+    Ok(OutputStream::one(ReturnSuccess::value(result)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShellError;
+    use super::SubCommand;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        Ok(test_examples(SubCommand {})?)
+    }
+}

--- a/crates/nu-cli/src/commands/random/mod.rs
+++ b/crates/nu-cli/src/commands/random/mod.rs
@@ -1,6 +1,7 @@
 pub mod command;
 
 pub mod bool;
+pub mod chars;
 pub mod decimal;
 pub mod dice;
 pub mod integer;
@@ -10,6 +11,7 @@ pub mod uuid;
 pub use command::Command as Random;
 
 pub use self::bool::SubCommand as RandomBool;
+pub use chars::SubCommand as RandomChars;
 pub use decimal::SubCommand as RandomDecimal;
 pub use dice::SubCommand as RandomDice;
 pub use integer::SubCommand as RandomInteger;

--- a/crates/nu-cli/tests/commands/random/chars.rs
+++ b/crates/nu-cli/tests/commands/random/chars.rs
@@ -1,0 +1,14 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn generates_chars_of_specified_length() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        random chars -l 15 | size | get chars
+        "#
+    ));
+
+    let result = actual.out;
+    assert_eq!(result, "15");
+}

--- a/crates/nu-cli/tests/commands/random/mod.rs
+++ b/crates/nu-cli/tests/commands/random/mod.rs
@@ -1,4 +1,5 @@
 mod bool;
+mod chars;
 mod decimal;
 mod dice;
 mod integer;

--- a/docs/commands/random.md
+++ b/docs/commands/random.md
@@ -119,3 +119,10 @@ true
 > random integer 100000..200000
 173400
 ```
+
+### chars Examples
+Generate a random password of length 15
+```shell
+> random chars -l 15
+fWBSbE7QtaoJGeo
+```


### PR DESCRIPTION
I wanted to generate a random password and thought it would be fun to do it in `nushell`, hence the creation of a `random chars` command. 

It generates random alphanumeric characters, default size of 25, could eventually be enhanced to take customized char sets.

Examples:
```
> random chars -l 15
zqqUb3MfsndIxfD
> random chars
2YfjKZbZJ5WpAZIWtreoFwd4b
```