### PR TITLE
Fix Gitpod dev setup by rebuilding the dev image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,9 @@
 FROM gitpod/workspace-full
 
+# Gitpod will not rebuild Nushell's dev image unless *some* change is made to this Dockerfile.
+# To force a rebuild, simply increase this counter:
+ENV TRIGGER_REBUILD 1
+
 USER gitpod
 
 RUN sudo apt-get update && \
@@ -11,4 +15,4 @@ RUN sudo apt-get update && \
         rust-lldb \
     && sudo rm -rf /var/lib/apt/lists/*
 
-ENV RUST_LLDB=/usr/bin/lldb-8
+ENV RUST_LLDB=/usr/bin/lldb-11


### PR DESCRIPTION
Hello! 👋

Opening Nushell in Gitpod today, I noticed that it didn't work out-of-the-box -- there were a few Rust compilation errors displayed, and the `nu` binary wasn't available to be run.

Looking into it, I noticed that the used Rust version was quite old already. That's likely because Gitpod caches dev images, and never rebuilds them unless some characters change in the `.gitpod.Dockerfile` (and there haven't been changes in that file in a while).

Thankfully, it's a simple fix! 🚀 I've added a helpful comment with a counter that can simply be bumped every time the base image should be rebuilt.

You can test my Pull Request by opening it in Gitpod:

https://gitpod.io/#https://github.com/nushell/nushell/pull/2783

<img width="1440" alt="Screenshot 2020-12-08 at 17 20 32" src="https://user-images.githubusercontent.com/599268/101510099-c68eb780-3979-11eb-8f04-db3cecdecb3c.png">
