### PR TITLE
highlight trailing spaces in tables in darkgray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,6 +3363,7 @@ name = "nu-table"
 version = "0.24.1"
 dependencies = [
  "ansi_term 0.12.1",
+ "regex 1.4.2",
  "unicode-width",
 ]
 

--- a/crates/nu-data/src/primitive.rs
+++ b/crates/nu-data/src/primitive.rs
@@ -104,6 +104,7 @@ pub fn string_to_lookup_value(str_prim: &str) -> String {
         "header_bold" => "header_bold".to_string(),
         "header_style" => "header_style".to_string(),
         "index_color" => "index_color".to_string(),
+        "leading_trailing_space_bg" => "leading_trailing_space_bg".to_string(),
         _ => "Primitive::Nothing".to_string(),
     }
 }
@@ -143,6 +144,10 @@ pub fn get_color_config() -> HashMap<String, Style> {
     hm.insert("header_bold".to_string(), Color::Green.bold());
     hm.insert("header_style".to_string(), Style::default());
     hm.insert("index_color".to_string(), Color::Green.bold());
+    hm.insert(
+        "leading_trailing_space_bg".to_string(),
+        Style::default().on(Color::RGB(128, 128, 128)),
+    );
 
     // populate hashmap from config values
     if let Ok(config) = crate::config::config(Tag::unknown()) {
@@ -204,6 +209,9 @@ pub fn get_color_config() -> HashMap<String, Style> {
                         update_hashmap(&key, &value, &mut hm);
                     }
                     "index_color" => {
+                        update_hashmap(&key, &value, &mut hm);
+                    }
+                    "leading_trailing_space_bg" => {
                         update_hashmap(&key, &value, &mut hm);
                     }
                     _ => (),

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/main.rs"
 [dependencies]
 ansi_term = "0.12.1"
 unicode-width = "0.1.8"
+regex = "1.4.2"

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -778,7 +778,6 @@ impl WrappedTable {
         }
 
         println!("{}", output);
-        // println!("{:#?}", output);
     }
 
     fn print_cell_contents(&self, cells: &[WrappedCell], color_hm: &HashMap<String, Style>) {
@@ -804,7 +803,6 @@ impl WrappedTable {
                     let remainder = self.column_widths[column.0] - line.width;
                     output.push(' ');
 
-                    // println!("Column1: [{:?}]", column.1.style);
                     match column.1.style.alignment {
                         Alignment::Left => {
                             if let Some(color) = column.1.style.color_style {
@@ -869,7 +867,7 @@ impl WrappedTable {
         }
     }
 
-    fn new_print_table(&self, color_hm: &HashMap<String, Style>) {
+    fn print_table(&self, color_hm: &HashMap<String, Style>) {
         #[cfg(windows)]
         {
             let _ = ansi_term::enable_ansi_support();
@@ -1015,12 +1013,16 @@ pub fn draw_table(table: &Table, termwidth: usize, color_hm: &HashMap<String, St
     // This should give us the final max column width
     let max_column_width = column_space.max_width(termwidth);
 
-    let wrapped_table = wrap_cells(processed_table, max_column_width);
+    let wrapped_table = wrap_cells(processed_table, max_column_width, &color_hm);
 
-    wrapped_table.new_print_table(&color_hm);
+    wrapped_table.print_table(&color_hm);
 }
 
-fn wrap_cells(processed_table: ProcessedTable, max_column_width: usize) -> WrappedTable {
+fn wrap_cells(
+    processed_table: ProcessedTable,
+    max_column_width: usize,
+    color_hm: &HashMap<String, Style>,
+) -> WrappedTable {
     let mut column_widths = vec![
         0;
         std::cmp::max(
@@ -1041,7 +1043,8 @@ fn wrap_cells(processed_table: ProcessedTable, max_column_width: usize) -> Wrapp
         };
 
         for contents in header.1.contents.into_iter() {
-            let (mut lines, inner_max_width) = wrap(max_column_width, contents.into_iter());
+            let (mut lines, inner_max_width) =
+                wrap(max_column_width, contents.into_iter(), &color_hm);
             wrapped.lines.append(&mut lines);
             if inner_max_width > wrapped.max_width {
                 wrapped.max_width = inner_max_width;
@@ -1063,7 +1066,8 @@ fn wrap_cells(processed_table: ProcessedTable, max_column_width: usize) -> Wrapp
                 style: column.1.style,
             };
             for contents in column.1.contents.into_iter() {
-                let (mut lines, inner_max_width) = wrap(max_column_width, contents.into_iter());
+                let (mut lines, inner_max_width) =
+                    wrap(max_column_width, contents.into_iter(), &color_hm);
                 wrapped.lines.append(&mut lines);
                 if inner_max_width > wrapped.max_width {
                     wrapped.max_width = inner_max_width;

--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -233,11 +233,18 @@ pub fn wrap<'a>(
             current_max = current_line_width;
         }
 
-        // highlight trailing spaces so they stand out.
-        let re = regex::Regex::new(r"(?P<endsp>\s+)$").expect("error with regex");
-        if let Some(mat) = re.find(&current_line) {
-            let match_start = mat.start();
-            String::insert_str(&mut current_line, match_start, "\x1b[100m");
+        // highlight leading and trailing spaces so they stand out.
+        let re_leading =
+            regex::Regex::new(r"(?P<beginsp>^\s+)").expect("error with leading space regex");
+        if let Some(leading_match) = re_leading.find(&current_line.clone()) {
+            String::insert_str(&mut current_line, leading_match.end(), "\x1b[0m");
+            String::insert_str(&mut current_line, leading_match.start(), "\x1b[100m");
+        }
+
+        let re_trailing =
+            regex::Regex::new(r"(?P<endsp>\s+$)").expect("error with trailing space regex");
+        if let Some(trailing_match) = re_trailing.find(&current_line.clone()) {
+            String::insert_str(&mut current_line, trailing_match.start(), "\x1b[100m");
             current_line += "\x1b[0m";
         }
 

--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -233,6 +233,14 @@ pub fn wrap<'a>(
             current_max = current_line_width;
         }
 
+        // highlight trailing spaces so they stand out.
+        let re = regex::Regex::new(r"(?P<endsp>\s+)$").expect("error with regex");
+        if let Some(mat) = re.find(&current_line) {
+            let match_start = mat.start();
+            String::insert_str(&mut current_line, match_start, "\x1b[100m");
+            current_line += "\x1b[0m";
+        }
+
         output.push(WrappedLine {
             line: current_line,
             width: current_line_width,

--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -1,4 +1,6 @@
 use crate::table::TextStyle;
+use ansi_term::Style;
+use std::collections::HashMap;
 use std::{fmt::Display, iter::Iterator};
 use unicode_width::UnicodeWidthStr;
 
@@ -136,12 +138,18 @@ fn split_word<'a>(cell_width: usize, word: &'a str) -> Vec<Subline<'a>> {
 pub fn wrap<'a>(
     cell_width: usize,
     mut input: impl Iterator<Item = Subline<'a>>,
+    color_hm: &HashMap<String, Style>,
 ) -> (Vec<WrappedLine>, usize) {
     let mut lines = vec![];
     let mut current_line: Vec<Subline> = vec![];
     let mut current_width = 0;
     let mut first = true;
     let mut max_width = 0;
+    let lead_trail_space_bg_color = color_hm
+        .get("leading_trailing_space_bg")
+        .unwrap_or(&Style::default())
+        .to_owned();
+
     loop {
         match input.next() {
             Some(item) => {
@@ -234,17 +242,24 @@ pub fn wrap<'a>(
         }
 
         // highlight leading and trailing spaces so they stand out.
+        let mut bg_color_string = Style::default().prefix().to_string();
+        // right now config settings can only set foreground colors so, in this
+        // instance we take the foreground color and make it a background color
+        if let Some(bg) = lead_trail_space_bg_color.foreground {
+            bg_color_string = Style::default().on(bg).prefix().to_string()
+        };
+
         let re_leading =
             regex::Regex::new(r"(?P<beginsp>^\s+)").expect("error with leading space regex");
         if let Some(leading_match) = re_leading.find(&current_line.clone()) {
             String::insert_str(&mut current_line, leading_match.end(), "\x1b[0m");
-            String::insert_str(&mut current_line, leading_match.start(), "\x1b[100m");
+            String::insert_str(&mut current_line, leading_match.start(), &bg_color_string);
         }
 
         let re_trailing =
             regex::Regex::new(r"(?P<endsp>\s+$)").expect("error with trailing space regex");
         if let Some(trailing_match) = re_trailing.find(&current_line.clone()) {
-            String::insert_str(&mut current_line, trailing_match.start(), "\x1b[100m");
+            String::insert_str(&mut current_line, trailing_match.start(), &bg_color_string);
             current_line += "\x1b[0m";
         }
 

--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -53,6 +53,7 @@ header_align = "l" # left|l, right|r, center|c
 header_color = "c" # green|g, red|r, blue|u, black|b, yellow|y, purple|p, cyan|c, white|w
 header_bold = true
 index_color = "rd"
+leading_trailing_space_bg = "white"
 
 [line_editor]
 max_history_size = 100000


### PR DESCRIPTION
This PR highlights leading & trailing spaces in tables so that they're easier to see. I've been burnt several times trying to parse things only to find out later that the reason I couldn't parse things properly was because there were trailing spaces.

Trailing Spaces Example
`cargo search nu_plugin --limit 24 | lines | parse "{crate_name} = {version} #{description}" | skip 1`
![image](https://user-images.githubusercontent.com/343840/102406417-2572b300-3fb0-11eb-8859-faa2da7fea71.png)

Leading Spaces Example
`cargo search nu_plugin --limit 24 | lines | parse "{crate_name} ={version} #{description}" | skip 1`
![image](https://user-images.githubusercontent.com/343840/102502346-1e958000-4044-11eb-8195-d486644a0b76.png)

The color of the white space indicator is controlled by `leading_trailing_space_bg` in the `[color_config]` section of the `config.toml`