### PR TITLE
Parse mid-line comments

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -280,10 +280,11 @@ pub fn bare(src: &mut Input, span_offset: usize) -> (Spanned<String>, Option<Par
 }
 
 fn skip_comment(input: &mut Input) {
-    for (_, c) in input {
-        if c == '\n' || c == '\r' {
+    while let Some((_, c)) = input.peek() {
+        if *c == '\n' || *c == '\r' {
             break;
         }
+        input.next();
     }
 }
 


### PR DESCRIPTION
This will allow mid-line comments like this:

```
bar 100 # this is a comment
def bar [x] { foo $x }
def foo [y] { echo $y }
```