### PR TITLE
Add script sourcing

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -108,6 +108,7 @@ pub(crate) mod size;
 pub(crate) mod skip;
 pub(crate) mod sleep;
 pub(crate) mod sort_by;
+pub(crate) mod source;
 pub(crate) mod split;
 pub(crate) mod split_by;
 pub(crate) mod str_;
@@ -255,6 +256,7 @@ pub(crate) use size::Size;
 pub(crate) use skip::{Skip, SkipUntil, SkipWhile};
 pub(crate) use sleep::Sleep;
 pub(crate) use sort_by::SortBy;
+pub(crate) use source::Source;
 pub(crate) use split::{Split, SplitChars, SplitColumn, SplitRow};
 pub(crate) use split_by::SplitBy;
 pub(crate) use str_::{

--- a/crates/nu-cli/src/commands/autoview/command.rs
+++ b/crates/nu-cli/src/commands/autoview/command.rs
@@ -35,7 +35,6 @@ impl WholeStreamCommand for Command {
             ctrl_c: args.ctrl_c,
             current_errors: args.current_errors,
             name: args.call_info.name_tag,
-            raw_input: args.raw_input,
         })
         .await
     }

--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -43,7 +43,6 @@ pub struct CommandArgs {
     pub call_info: UnevaluatedCallInfo,
     pub scope: Scope,
     pub input: InputStream,
-    pub raw_input: String,
 }
 
 #[derive(Getters, Clone)]
@@ -67,7 +66,6 @@ impl RawCommandArgs {
             call_info: self.call_info,
             scope: self.scope,
             input: input.into(),
-            raw_input: String::default(),
         }
     }
 }
@@ -116,7 +114,6 @@ pub struct RunnableContext {
     pub current_errors: Arc<Mutex<Vec<ShellError>>>,
     pub scope: Scope,
     pub name: Tag,
-    pub raw_input: String,
 }
 
 impl RunnableContext {

--- a/crates/nu-cli/src/commands/math/avg.rs
+++ b/crates/nu-cli/src/commands/math/avg.rs
@@ -38,7 +38,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             average,
         )

--- a/crates/nu-cli/src/commands/math/ceil.rs
+++ b/crates/nu-cli/src/commands/math/ceil.rs
@@ -31,7 +31,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             ceil_big_int,
             ceil_big_decimal,

--- a/crates/nu-cli/src/commands/math/floor.rs
+++ b/crates/nu-cli/src/commands/math/floor.rs
@@ -31,7 +31,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             floor_big_int,
             floor_big_decimal,

--- a/crates/nu-cli/src/commands/math/max.rs
+++ b/crates/nu-cli/src/commands/math/max.rs
@@ -31,7 +31,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             maximum,
         )

--- a/crates/nu-cli/src/commands/math/median.rs
+++ b/crates/nu-cli/src/commands/math/median.rs
@@ -35,7 +35,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             median,
         )

--- a/crates/nu-cli/src/commands/math/min.rs
+++ b/crates/nu-cli/src/commands/math/min.rs
@@ -31,7 +31,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             minimum,
         )

--- a/crates/nu-cli/src/commands/math/mode.rs
+++ b/crates/nu-cli/src/commands/math/mode.rs
@@ -31,7 +31,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             mode,
         )

--- a/crates/nu-cli/src/commands/math/product.rs
+++ b/crates/nu-cli/src/commands/math/product.rs
@@ -34,7 +34,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             product,
         )

--- a/crates/nu-cli/src/commands/math/sum.rs
+++ b/crates/nu-cli/src/commands/math/sum.rs
@@ -35,7 +35,6 @@ impl WholeStreamCommand for SubCommand {
                 ctrl_c: args.ctrl_c,
                 current_errors: args.current_errors,
                 name: args.call_info.name_tag,
-                raw_input: args.raw_input,
             },
             summation,
         )

--- a/crates/nu-cli/src/commands/run_external.rs
+++ b/crates/nu-cli/src/commands/run_external.rs
@@ -88,7 +88,6 @@ impl WholeStreamCommand for RunExternalCommand {
                 ctrl_c: args.ctrl_c.clone(),
                 current_errors: Arc::new(Mutex::new(vec![])),
                 windows_drives_previous_cwd: Arc::new(Mutex::new(std::collections::HashMap::new())),
-                raw_input: String::default(),
             }
         };
 

--- a/crates/nu-cli/src/commands/save.rs
+++ b/crates/nu-cli/src/commands/save.rs
@@ -165,7 +165,7 @@ async fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let host = raw_args.host.clone();
     let ctrl_c = raw_args.ctrl_c.clone();
     let current_errors = raw_args.current_errors.clone();
-    let mut shell_manager = raw_args.shell_manager.clone();
+    let shell_manager = raw_args.shell_manager.clone();
 
     let head = raw_args.call_info.args.head.clone();
     let (

--- a/crates/nu-cli/src/commands/source.rs
+++ b/crates/nu-cli/src/commands/source.rs
@@ -1,0 +1,48 @@
+use crate::commands::WholeStreamCommand;
+use crate::prelude::*;
+
+use nu_errors::ShellError;
+use nu_protocol::{CommandAction, ReturnSuccess, Signature, SyntaxShape};
+use nu_source::Tagged;
+
+pub struct Source;
+
+#[derive(Deserialize)]
+pub struct SourceArgs {
+    pub filename: Tagged<String>,
+}
+
+#[async_trait]
+impl WholeStreamCommand for Source {
+    fn name(&self) -> &str {
+        "source"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("source").required(
+            "filename",
+            SyntaxShape::String,
+            "the filepath to the script file to source",
+        )
+    }
+
+    fn usage(&self) -> &str {
+        "Runs a script file in the current context."
+    }
+
+    async fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        source(args).await
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![]
+    }
+}
+
+pub async fn source(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let (SourceArgs { filename }, _) = args.process().await?;
+
+    Ok(OutputStream::one(ReturnSuccess::action(
+        CommandAction::SourceScript(filename.item),
+    )))
+}

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -192,7 +192,7 @@ pub fn test_anchors(cmd: Command) -> Result<(), ShellError> {
 }
 
 /// Parse and run a nushell pipeline
-fn parse_line(line: &str, ctx: &mut EvaluationContext) -> Result<ClassifiedBlock, ShellError> {
+fn parse_line(line: &str, ctx: &EvaluationContext) -> Result<ClassifiedBlock, ShellError> {
     //FIXME: do we still need this?
     let line = if let Some(line) = line.strip_suffix('\n') {
         line

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -26,7 +26,7 @@ use serde::Deserialize;
 pub fn test_examples(cmd: Command) -> Result<(), ShellError> {
     let examples = cmd.examples();
 
-    let mut base_context = EvaluationContext::basic()?;
+    let base_context = EvaluationContext::basic()?;
 
     base_context.add_commands(vec![
         // Mocks
@@ -89,7 +89,7 @@ pub fn test_examples(cmd: Command) -> Result<(), ShellError> {
 pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
     let examples = cmd.examples();
 
-    let mut base_context = EvaluationContext::basic()?;
+    let base_context = EvaluationContext::basic()?;
 
     base_context.add_commands(vec![
         whole_stream_command(Echo {}),
@@ -144,7 +144,7 @@ pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
 pub fn test_anchors(cmd: Command) -> Result<(), ShellError> {
     let examples = cmd.examples();
 
-    let mut base_context = EvaluationContext::basic()?;
+    let base_context = EvaluationContext::basic()?;
 
     base_context.add_commands(vec![
         // Minimal restricted commands to aid in testing

--- a/crates/nu-cli/src/shell/shell_manager.rs
+++ b/crates/nu-cli/src/shell/shell_manager.rs
@@ -33,7 +33,7 @@ impl ShellManager {
         })
     }
 
-    pub fn insert_at_current(&mut self, shell: Box<dyn Shell + Send>) {
+    pub fn insert_at_current(&self, shell: Box<dyn Shell + Send>) {
         self.shells.lock().push(shell);
         self.current_shell
             .store(self.shells.lock().len() - 1, Ordering::SeqCst);
@@ -44,7 +44,7 @@ impl ShellManager {
         self.current_shell.load(Ordering::SeqCst)
     }
 
-    pub fn remove_at_current(&mut self) {
+    pub fn remove_at_current(&self) {
         {
             let mut shells = self.shells.lock();
             if shells.len() > 0 {
@@ -78,7 +78,7 @@ impl ShellManager {
         env[self.current_shell()].pwd(args)
     }
 
-    pub fn set_path(&mut self, path: String) {
+    pub fn set_path(&self, path: String) {
         self.shells.lock()[self.current_shell()].set_path(path)
     }
 
@@ -93,7 +93,7 @@ impl ShellManager {
     }
 
     pub fn save(
-        &mut self,
+        &self,
         full_path: &PathBuf,
         save_data: &[u8],
         name: Span,
@@ -101,7 +101,7 @@ impl ShellManager {
         self.shells.lock()[self.current_shell()].save(full_path, save_data, name)
     }
 
-    pub fn next(&mut self) {
+    pub fn next(&self) {
         {
             let shell_len = self.shells.lock().len();
             if self.current_shell() == (shell_len - 1) {
@@ -114,7 +114,7 @@ impl ShellManager {
         self.set_path(self.path())
     }
 
-    pub fn prev(&mut self) {
+    pub fn prev(&self) {
         {
             let shell_len = self.shells.lock().len();
             if self.current_shell() == 0 {

--- a/crates/nu-protocol/src/return_value.rs
+++ b/crates/nu-protocol/src/return_value.rs
@@ -26,6 +26,8 @@ pub enum CommandAction {
     AddEnvVariable(String, String),
     /// Add plugins from path given
     AddPlugins(String),
+    /// Run the given script in the current context (given filename)
+    SourceScript(String),
     /// Go to the previous shell in the shell ring buffer
     PreviousShell,
     /// Go to the next shell in the shell ring buffer
@@ -49,6 +51,7 @@ impl PrettyDebug for CommandAction {
             CommandAction::EnterHelpShell(v) => b::typed("enter help shell", v.pretty()),
             CommandAction::AddVariable(..) => b::description("add variable"),
             CommandAction::AddEnvVariable(..) => b::description("add environment variable"),
+            CommandAction::SourceScript(..) => b::description("source script"),
             CommandAction::AddPlugins(..) => b::description("add plugins"),
             CommandAction::PreviousShell => b::description("previous shell"),
             CommandAction::NextShell => b::description("next shell"),


### PR DESCRIPTION
Needed to break for the night, but since this is working I'll put up the PR.

Needs a test case. Will write an issue to remind me to circle back and add the test once I learn how to do that.

This allows you to `source` a script file, which then runs that script file in the current context. This lets you add definitions, env vars, and more into the current context that are defined in the script file.

We may evolve this as we add modules, but just wanted to at least reach some more bash parity, and then we can decide how to proceed from there.