### PR TITLE
Simplifies 'if' to work on the available scope rather than a stream

### DIFF
--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -13,7 +13,7 @@ use num_bigint::BigInt;
 use crate::commands::classified::block::run_block;
 use crate::commands::command::CommandArgs;
 use crate::commands::{
-    whole_stream_command, BuildString, Command, Each, Echo, First, Get, Keep, Last, Nth,
+    whole_stream_command, BuildString, Command, Each, Echo, First, Get, Keep, Last, Nth, Set,
     StrCollect, WholeStreamCommand, Wrap,
 };
 use crate::evaluation_context::EvaluationContext;
@@ -40,6 +40,7 @@ pub fn test_examples(cmd: Command) -> Result<(), ShellError> {
         whole_stream_command(Each {}),
         whole_stream_command(Last {}),
         whole_stream_command(Nth {}),
+        whole_stream_command(Set {}),
         whole_stream_command(StrCollect),
         whole_stream_command(Wrap),
         cmd,
@@ -97,6 +98,7 @@ pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
         whole_stream_command(Get {}),
         whole_stream_command(Keep {}),
         whole_stream_command(Each {}),
+        whole_stream_command(Set {}),
         whole_stream_command(cmd),
         whole_stream_command(StrCollect),
         whole_stream_command(Wrap),
@@ -158,6 +160,7 @@ pub fn test_anchors(cmd: Command) -> Result<(), ShellError> {
         whole_stream_command(Each {}),
         whole_stream_command(Last {}),
         whole_stream_command(Nth {}),
+        whole_stream_command(Set {}),
         whole_stream_command(StrCollect),
         whole_stream_command(Wrap),
         cmd,

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -27,7 +27,7 @@ fn plugins_are_declared_with_wix() {
                 | wrap wix
             }
             | default wix _
-            | if $it.wix != $it.cargo { = 1 } { = 0 }
+            | each { if $it.wix != $it.cargo { = 1 } { = 0 } }
             | math sum
             "#
     ));


### PR DESCRIPTION
Previously, `if` worked like `while` and worked over a stream, setting `$it` to the value in the stream.

In practice, this feels awkward because you sometimes want to use the `$it` over what is in the scope outside of the `if`.

This PR simplifies `if` to just work against what's in the Scope rather than working over a stream.