### PR TITLE
Add support for custom subcommands

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -2154,7 +2154,7 @@ fn parse_definition(call: &LiteCommand, scope: &dyn ParserScope) -> Option<Parse
                 let (mut block, err) = classify_block(&lite_block, scope);
 
                 block.params = signature;
-                block.params.name = name.clone();
+                block.params.name = name;
 
                 scope.add_definition(block);
 

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -2130,7 +2130,7 @@ fn parse_definition(call: &LiteCommand, scope: &dyn ParserScope) -> Option<Parse
             return Some(ParseError::mismatch("definition", call.parts[0].clone()));
         }
 
-        let name = call.parts[1].item.clone();
+        let name = trim_quotes(&call.parts[1].item);
         let (signature, err) = parse_signature(&name, &call.parts[2], scope);
         if err.is_some() {
             return err;
@@ -2151,7 +2151,6 @@ fn parse_definition(call: &LiteCommand, scope: &dyn ParserScope) -> Option<Parse
                     return err;
                 };
 
-                let name = &call.parts[1].item;
                 let (mut block, err) = classify_block(&lite_block, scope);
 
                 block.params = signature;
@@ -2181,7 +2180,7 @@ fn parse_definition_prototype(call: &LiteCommand, scope: &dyn ParserScope) -> Op
         return Some(ParseError::mismatch("definition", call.parts[0].clone()));
     }
 
-    let name = call.parts[1].item.clone();
+    let name = trim_quotes(&call.parts[1].item);
     let (signature, error) = parse_signature(&name, &call.parts[2], scope);
     if err.is_none() {
         err = error;

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -369,6 +369,18 @@ fn run_custom_command_with_flag_missing() {
 }
 
 #[test]
+fn run_custom_subcommand() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        def "str double" [x] { echo $x $x | str collect }; str double bob
+        "#
+    );
+
+    assert_eq!(actual.out, "bobbob");
+}
+
+#[test]
 fn set_variable() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
This fixes a couple things, which enables adding custom subcommands now.

For example:
```
def "str double" [x] {
  echo $x $x | str collect
}
str double bob
```