### PR TITLE
Change ls to output path

### DIFF
--- a/crates/nu-cli/src/shell/filesystem_shell.rs
+++ b/crates/nu-cli/src/shell/filesystem_shell.rs
@@ -979,7 +979,7 @@ pub(crate) fn dir_entry_dict(
         )
     })?;
 
-    dict.insert_untagged("name", UntaggedValue::string(name));
+    dict.insert_untagged("name", UntaggedValue::path(name));
 
     if let Some(md) = metadata {
         dict.insert_untagged("type", get_file_type(md));

--- a/crates/nu-data/src/base.rs
+++ b/crates/nu-data/src/base.rs
@@ -152,6 +152,12 @@ pub fn coerce_compare_primitive(
         (Date(left), Date(right)) => CompareValues::Date(*left, *right),
         (Date(left), Duration(right)) => CompareValues::DateDuration(*left, right.clone()),
         (Boolean(left), Boolean(right)) => CompareValues::Booleans(*left, *right),
+        (Path(left), String(right)) => {
+            CompareValues::String(left.as_path().display().to_string(), right.clone())
+        }
+        (String(left), Path(right)) => {
+            CompareValues::String(left.clone(), right.as_path().display().to_string())
+        }
         _ => return Err((left.type_name(), right.type_name())),
     })
 }


### PR DESCRIPTION
This change allows the filenames of the output of `ls` to be stored as `UntaggedValue::path()` instead of string. Therefore, the names can be colored. Right now, a config setting such as `primitive_path = "yellow"` in the `[color_config]` section would make all the file names yellow.

![image](https://user-images.githubusercontent.com/343840/103179305-48bf1d00-4850-11eb-947d-e5d5a2ebe1a5.png)

Note: There may be a slowdown here that needs to be resolved.