### PR TITLE
Simplify run_block slightly

### DIFF
--- a/crates/nu-cli/src/commands/classified/block.rs
+++ b/crates/nu-cli/src/commands/classified/block.rs
@@ -50,7 +50,9 @@ pub async fn run_block(
                                 ctx.clear_errors();
                                 return Err(err.clone());
                             }
-                            if ctx.ctrl_c.load(Ordering::SeqCst) {}
+                            if ctx.ctrl_c.load(Ordering::SeqCst) {
+                                return Ok(InputStream::empty());
+                            }
                         }
                         Ok(None) => {
                             if let Some(err) = ctx.get_errors().get(0) {
@@ -83,7 +85,14 @@ pub async fn run_block(
                                 ctx.clear_errors();
                                 return Err(err.clone());
                             }
-                            if ctx.ctrl_c.load(Ordering::SeqCst) {}
+                            if ctx.ctrl_c.load(Ordering::SeqCst) {
+                                // This early return doesn't return the result
+                                // we have so far, but breaking out of this loop
+                                // causes lifetime issues. A future contribution
+                                // could attempt to return the current output.
+                                // https://github.com/nushell/nushell/pull/2830#discussion_r550319687
+                                return Ok(InputStream::empty());
+                            }
                         }
                         Ok(None) => {
                             if let Some(err) = ctx.get_errors().get(0) {

--- a/crates/nu-cli/src/commands/classified/block.rs
+++ b/crates/nu-cli/src/commands/classified/block.rs
@@ -40,30 +40,25 @@ pub async fn run_block(
                             inp,
                         )
                         .await?;
-                    loop {
-                        match output_stream.try_next().await {
-                            Ok(Some(ReturnSuccess::Value(Value {
-                                value: UntaggedValue::Error(e),
-                                ..
-                            }))) => return Err(e),
-                            Ok(Some(_item)) => {
-                                if let Some(err) = ctx.get_errors().get(0) {
-                                    ctx.clear_errors();
-                                    return Err(err.clone());
-                                }
-                                if ctx.ctrl_c.load(Ordering::SeqCst) {
-                                    break;
-                                }
+                    match output_stream.try_next().await {
+                        Ok(Some(ReturnSuccess::Value(Value {
+                            value: UntaggedValue::Error(e),
+                            ..
+                        }))) => return Err(e),
+                        Ok(Some(_item)) => {
+                            if let Some(err) = ctx.get_errors().get(0) {
+                                ctx.clear_errors();
+                                return Err(err.clone());
                             }
-                            Ok(None) => {
-                                if let Some(err) = ctx.get_errors().get(0) {
-                                    ctx.clear_errors();
-                                    return Err(err.clone());
-                                }
-                                break;
-                            }
-                            Err(e) => return Err(e),
+                            if ctx.ctrl_c.load(Ordering::SeqCst) {}
                         }
+                        Ok(None) => {
+                            if let Some(err) = ctx.get_errors().get(0) {
+                                ctx.clear_errors();
+                                return Err(err.clone());
+                            }
+                        }
+                        Err(e) => return Err(e),
                     }
                 }
             }
@@ -78,30 +73,25 @@ pub async fn run_block(
                 Ok(inp) => {
                     let mut output_stream = inp.to_output_stream();
 
-                    loop {
-                        match output_stream.try_next().await {
-                            Ok(Some(ReturnSuccess::Value(Value {
-                                value: UntaggedValue::Error(e),
-                                ..
-                            }))) => return Err(e),
-                            Ok(Some(_item)) => {
-                                if let Some(err) = ctx.get_errors().get(0) {
-                                    ctx.clear_errors();
-                                    return Err(err.clone());
-                                }
-                                if ctx.ctrl_c.load(Ordering::SeqCst) {
-                                    break;
-                                }
+                    match output_stream.try_next().await {
+                        Ok(Some(ReturnSuccess::Value(Value {
+                            value: UntaggedValue::Error(e),
+                            ..
+                        }))) => return Err(e),
+                        Ok(Some(_item)) => {
+                            if let Some(err) = ctx.get_errors().get(0) {
+                                ctx.clear_errors();
+                                return Err(err.clone());
                             }
-                            Ok(None) => {
-                                if let Some(err) = ctx.get_errors().get(0) {
-                                    ctx.clear_errors();
-                                    return Err(err.clone());
-                                }
-                                break;
-                            }
-                            Err(e) => return Err(e),
+                            if ctx.ctrl_c.load(Ordering::SeqCst) {}
                         }
+                        Ok(None) => {
+                            if let Some(err) = ctx.get_errors().get(0) {
+                                ctx.clear_errors();
+                                return Err(err.clone());
+                            }
+                        }
+                        Err(e) => return Err(e),
                     }
                 }
                 Err(e) => {


### PR DESCRIPTION
Not sure if these sorts of tweaky changes are helpful, or more work to review — totally fine to close if the latter.

I was reading through `run_block` as discussed on Discourse — and it seems to have a couple of loops that never loop, so removed them here.