### PR TITLE
Display aliases and custom commands in which; fix #2810

### DIFF
--- a/crates/nu-cli/src/commands/which_.rs
+++ b/crates/nu-cli/src/commands/which_.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Which {
     }
 
     fn usage(&self) -> &str {
-        "Finds a program file."
+        "Finds a program file, alias or custom command."
     }
 
     async fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/docs/commands/which.md
+++ b/docs/commands/which.md
@@ -79,3 +79,27 @@ Passing the `all` flag identifies all instances of a command or binary
  builtin │ No
 ─────────┴────────────────────────────────
 ```
+
+`which` also identifies aliases
+
+```shell
+> alias e = echo
+> which e
+───┬─────┬───────────────┬─────────
+ # │ arg │     path      │ builtin
+───┼─────┼───────────────┼─────────
+ 0 │ e   │ Nushell alias │ No
+───┴─────┴───────────────┴─────────
+```
+
+and custom commands
+
+```shell
+> def my_cool_echo [arg] { echo $arg }
+> which my_cool_echo
+───┬──────────────┬────────────────────────┬─────────
+ # │     arg      │          path          │ builtin
+───┼──────────────┼────────────────────────┼─────────
+ 0 │ my_cool_echo │ Nushell custom command │ No
+───┴──────────────┴────────────────────────┴─────────
+```


### PR DESCRIPTION
Example output of nu after the commit is applied:

```shell
/home/leo/repos/nushell(feature/which_inspect_alias)> def docker-ps [] { docker ps --format '{{json .}}' | from json -o }
/home/leo/repos/nushell(feature/which_inspect_alias)> which docker-ps
───┬───────────┬────────────────────────┬─────────
 # │    arg    │          path          │ builtin
───┼───────────┼────────────────────────┼─────────
 0 │ docker-ps │ Nushell custom command │ No
───┴───────────┴────────────────────────┴─────────
/home/leo/repos/nushell(feature/which_inspect_alias)> alias d = gid pd
/home/leo/repos/nushell(feature/which_inspect_alias)> which d
───┬─────┬───────────────┬─────────
 # │ arg │     path      │ builtin
───┼─────┼───────────────┼─────────
 0 │ d   │ Nushell alias │ No
───┴─────┴───────────────┴─────────
```