### PR TITLE
Improve some errors, streamline internal error handling

### DIFF
--- a/crates/nu-cli/src/commands/classified/internal.rs
+++ b/crates/nu-cli/src/commands/classified/internal.rs
@@ -53,12 +53,12 @@ pub(crate) async fn run_internal_command(
                         Ok(ReturnSuccess::Action(action)) => match action {
                             CommandAction::ChangePath(path) => {
                                 context.shell_manager.set_path(path);
-                                InputStream::from_stream(futures::stream::iter(vec![]))
+                                InputStream::empty()
                             }
                             CommandAction::Exit => std::process::exit(0), // TODO: save history.txt
                             CommandAction::Error(err) => {
                                 context.error(err.clone());
-                                InputStream::one(UntaggedValue::Error(err).into_untagged_value())
+                                InputStream::empty()
                             }
                             CommandAction::AutoConvert(tagged_contents, extension) => {
                                 let contents_tag = tagged_contents.tag.clone();
@@ -117,8 +117,8 @@ pub(crate) async fn run_internal_command(
 
                                             futures::stream::iter(output).to_input_stream()
                                         }
-                                        Err(e) => {
-                                            context.add_error(e);
+                                        Err(err) => {
+                                            context.error(err.clone());
                                             InputStream::empty()
                                         }
                                     }
@@ -138,9 +138,8 @@ pub(crate) async fn run_internal_command(
                                         ) {
                                             Ok(v) => v,
                                             Err(err) => {
-                                                return InputStream::one(
-                                                    UntaggedValue::Error(err).into_untagged_value(),
-                                                )
+                                                context.error(err.clone());
+                                                return InputStream::empty();
                                             }
                                         },
                                     ));
@@ -151,9 +150,8 @@ pub(crate) async fn run_internal_command(
                                         match HelpShell::index(&context.scope) {
                                             Ok(v) => v,
                                             Err(err) => {
-                                                return InputStream::one(
-                                                    UntaggedValue::Error(err).into_untagged_value(),
-                                                )
+                                                context.error(err.clone());
+                                                return InputStream::empty();
                                             }
                                         },
                                     ));
@@ -171,10 +169,8 @@ pub(crate) async fn run_internal_command(
                                     match FilesystemShell::with_location(location) {
                                         Ok(v) => v,
                                         Err(err) => {
-                                            return InputStream::one(
-                                                UntaggedValue::Error(err.into())
-                                                    .into_untagged_value(),
-                                            )
+                                            context.error(err.into());
+                                            return InputStream::empty();
                                         }
                                     },
                                 ));
@@ -198,12 +194,9 @@ pub(crate) async fn run_internal_command(
                                         .await;
 
                                         if let Err(err) = result {
-                                            return InputStream::one(
-                                                UntaggedValue::Error(err.into())
-                                                    .into_untagged_value(),
-                                            );
+                                            context.error(err.into());
                                         }
-                                        InputStream::from_stream(futures::stream::iter(vec![]))
+                                        InputStream::empty()
                                     }
                                     Err(_) => {
                                         context.error(ShellError::labeled_error(
@@ -212,7 +205,7 @@ pub(crate) async fn run_internal_command(
                                             filename.span(),
                                         ));
 
-                                        InputStream::from_stream(futures::stream::iter(vec![]))
+                                        InputStream::empty()
                                     }
                                 }
                             }
@@ -228,39 +221,37 @@ pub(crate) async fn run_internal_command(
                                                 .collect(),
                                         );
 
-                                        InputStream::from_stream(futures::stream::iter(vec![]))
+                                        InputStream::empty()
                                     }
                                     Err(reason) => {
                                         context.error(reason.clone());
-                                        InputStream::one(
-                                            UntaggedValue::Error(reason).into_untagged_value(),
-                                        )
+                                        InputStream::empty()
                                     }
                                 }
                             }
                             CommandAction::PreviousShell => {
                                 context.shell_manager.prev();
-                                InputStream::from_stream(futures::stream::iter(vec![]))
+                                InputStream::empty()
                             }
                             CommandAction::NextShell => {
                                 context.shell_manager.next();
-                                InputStream::from_stream(futures::stream::iter(vec![]))
+                                InputStream::empty()
                             }
                             CommandAction::LeaveShell => {
                                 context.shell_manager.remove_at_current();
                                 if context.shell_manager.is_empty() {
                                     std::process::exit(0); // TODO: save history.txt
                                 }
-                                InputStream::from_stream(futures::stream::iter(vec![]))
+                                InputStream::empty()
                             }
                         },
 
                         Ok(ReturnSuccess::Value(Value {
                             value: UntaggedValue::Error(err),
-                            tag,
+                            ..
                         })) => {
                             context.error(err.clone());
-                            InputStream::one(UntaggedValue::Error(err).into_value(tag))
+                            InputStream::empty()
                         }
 
                         Ok(ReturnSuccess::Value(v)) => InputStream::one(v),
@@ -281,7 +272,7 @@ pub(crate) async fn run_internal_command(
 
                         Err(err) => {
                             context.error(err.clone());
-                            InputStream::one(UntaggedValue::Error(err).into_untagged_value())
+                            InputStream::empty()
                         }
                     }
                 }

--- a/crates/nu-cli/src/commands/classified/internal.rs
+++ b/crates/nu-cli/src/commands/classified/internal.rs
@@ -57,7 +57,7 @@ pub(crate) async fn run_internal_command(
                             }
                             CommandAction::Exit => std::process::exit(0), // TODO: save history.txt
                             CommandAction::Error(err) => {
-                                context.error(err.clone());
+                                context.error(err);
                                 InputStream::empty()
                             }
                             CommandAction::AutoConvert(tagged_contents, extension) => {
@@ -118,7 +118,7 @@ pub(crate) async fn run_internal_command(
                                             futures::stream::iter(output).to_input_stream()
                                         }
                                         Err(err) => {
-                                            context.error(err.clone());
+                                            context.error(err);
                                             InputStream::empty()
                                         }
                                     }
@@ -138,7 +138,7 @@ pub(crate) async fn run_internal_command(
                                         ) {
                                             Ok(v) => v,
                                             Err(err) => {
-                                                context.error(err.clone());
+                                                context.error(err);
                                                 return InputStream::empty();
                                             }
                                         },
@@ -150,7 +150,7 @@ pub(crate) async fn run_internal_command(
                                         match HelpShell::index(&context.scope) {
                                             Ok(v) => v,
                                             Err(err) => {
-                                                context.error(err.clone());
+                                                context.error(err);
                                                 return InputStream::empty();
                                             }
                                         },
@@ -224,7 +224,7 @@ pub(crate) async fn run_internal_command(
                                         InputStream::empty()
                                     }
                                     Err(reason) => {
-                                        context.error(reason.clone());
+                                        context.error(reason);
                                         InputStream::empty()
                                     }
                                 }
@@ -250,7 +250,7 @@ pub(crate) async fn run_internal_command(
                             value: UntaggedValue::Error(err),
                             ..
                         })) => {
-                            context.error(err.clone());
+                            context.error(err);
                             InputStream::empty()
                         }
 
@@ -271,7 +271,7 @@ pub(crate) async fn run_internal_command(
                         }
 
                         Err(err) => {
-                            context.error(err.clone());
+                            context.error(err);
                             InputStream::empty()
                         }
                     }

--- a/crates/nu-cli/src/commands/enter.rs
+++ b/crates/nu-cli/src/commands/enter.rs
@@ -112,11 +112,12 @@ async fn enter(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
         let cwd = shell_manager.path();
 
         let full_path = std::path::PathBuf::from(cwd);
+        let span = location.span();
 
         let (file_extension, tagged_contents) = crate::commands::open::fetch(
             &full_path,
             &PathBuf::from(location_clone),
-            tag.span,
+            span,
             encoding,
         )
         .await?;

--- a/crates/nu-cli/src/commands/nu/plugin.rs
+++ b/crates/nu-cli/src/commands/nu/plugin.rs
@@ -42,7 +42,7 @@ impl WholeStreamCommand for SubCommand {
         vec![Example {
             description: "Load all plugins in the current directory",
             example: "nu plugin --load .",
-            result: Some(vec![]),
+            result: None,
         }]
     }
 

--- a/crates/nu-cli/src/evaluation_context.rs
+++ b/crates/nu-cli/src/evaluation_context.rs
@@ -74,10 +74,6 @@ impl EvaluationContext {
         self.current_errors.lock().clone()
     }
 
-    pub(crate) fn add_error(&self, err: ShellError) {
-        self.current_errors.lock().push(err);
-    }
-
     pub(crate) fn maybe_print_errors(&self, source: Text) -> bool {
         let errors = self.current_errors.clone();
         let mut errors = errors.lock();

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -49,7 +49,7 @@ pub fn test_examples(cmd: Command) -> Result<(), ShellError> {
     for sample_pipeline in examples {
         let mut ctx = base_context.clone();
 
-        let block = parse_line(sample_pipeline.example, &mut ctx)?;
+        let block = parse_line(sample_pipeline.example, &ctx)?;
 
         println!("{:#?}", block);
 
@@ -107,7 +107,7 @@ pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
     for sample_pipeline in examples {
         let mut ctx = base_context.clone();
 
-        let block = parse_line(sample_pipeline.example, &mut ctx)?;
+        let block = parse_line(sample_pipeline.example, &ctx)?;
 
         if let Some(expected) = &sample_pipeline.result {
             let result = block_on(evaluate_block(block, &mut ctx))?;
@@ -171,7 +171,7 @@ pub fn test_anchors(cmd: Command) -> Result<(), ShellError> {
 
         let mut ctx = base_context.clone();
 
-        let block = parse_line(&pipeline_with_anchor, &mut ctx)?;
+        let block = parse_line(&pipeline_with_anchor, &ctx)?;
         let result = block_on(evaluate_block(block, &mut ctx))?;
 
         ctx.with_errors(|reasons| reasons.iter().cloned().take(1).next())

--- a/crates/nu-cli/tests/commands/enter.rs
+++ b/crates/nu-cli/tests/commands/enter.rs
@@ -80,6 +80,6 @@ fn errors_if_file_not_found() {
             "enter i_dont_exist.csv"
         );
 
-        assert!(actual.err.contains("Cannot canonicalize"));
+        assert!(actual.err.contains("Cannot find file"));
     })
 }

--- a/crates/nu-cli/tests/commands/open.rs
+++ b/crates/nu-cli/tests/commands/open.rs
@@ -222,7 +222,7 @@ fn errors_if_file_not_found() {
         cwd: "tests/fixtures/formats",
         "open i_dont_exist.txt"
     );
-    let expected = "Cannot canonicalize";
+    let expected = "Cannot find file";
     assert!(
         actual.err.contains(expected),
         "Error:\n{}\ndoes not contain{}",


### PR DESCRIPTION
As a follow-up to https://github.com/nushell/nushell/pull/2836, I noticed that the internal error handler sometimes returns errors out via the InputStream and sometimes adds them to the context. I looked around and saw that the main mechanism is the context, which the internal handler uses if it sees an error. So I just convert all cases over to that style.

I also went ahead and fixed the "canonicalize" error to be a little easier to read.