### PR TITLE
Fix typos

### DIFF
--- a/crates/nu-cli/src/commands/benchmark.rs
+++ b/crates/nu-cli/src/commands/benchmark.rs
@@ -122,7 +122,7 @@ async fn benchmark(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
         benchmark_output(indexmap, output, passthrough, &tag, &mut context).await
     } else {
         Err(ShellError::untagged_runtime_error(
-            "Could not retreive CPU time",
+            "Could not retrieve CPU time",
         ))
     }
 }

--- a/crates/nu-cli/src/commands/format/format_filesize.rs
+++ b/crates/nu-cli/src/commands/format/format_filesize.rs
@@ -73,7 +73,7 @@ async fn process_row(
         match replace_for {
             Ok(s) => match convert_bytes_to_string_using_format(s, format) {
                 Ok(b) => OutputStream::one(ReturnSuccess::value(
-                    input.replace_data_at_column_path(&field, b).expect("Given that the existance check was already done, this souldn't trigger never"),
+                    input.replace_data_at_column_path(&field, b).expect("Given that the existence check was already done, this shouldn't trigger never"),
                 )),
                 Err(e) => OutputStream::one(Err(e)),
             },

--- a/crates/nu-cli/src/commands/histogram.rs
+++ b/crates/nu-cli/src/commands/histogram.rs
@@ -90,7 +90,7 @@ pub async fn histogram(args: CommandArgs) -> Result<OutputStream, ShellError> {
     } else if let Some((key, _)) = columns[0].split_last() {
         key.as_string()
     } else {
-        "frecuency".to_string()
+        "frequency".to_string()
     };
 
     let column = if let Some(ref column) = column_grouper {
@@ -149,7 +149,7 @@ pub async fn histogram(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     .ok_or_else(|| {
                         ShellError::labeled_error(
                             "Unable to load group labels",
-                            "unabled to load group labels",
+                            "unable to load group labels",
                             &name,
                         )
                     })?

--- a/crates/nu-cli/src/commands/math/ceil.rs
+++ b/crates/nu-cli/src/commands/math/ceil.rs
@@ -14,7 +14,7 @@ impl WholeStreamCommand for SubCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("math celi")
+        Signature::build("math ceil")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cli/src/commands/math/stddev.rs
+++ b/crates/nu-cli/src/commands/math/stddev.rs
@@ -120,7 +120,7 @@ pub fn compute_stddev(values: &[Value], n: usize, name: &Tag) -> Result<Value, S
         _ => {
             return Err(ShellError::labeled_error(
                 "Could not take square root of variance",
-                "error occured here",
+                "error occurred here",
                 name.span,
             ))
         }
@@ -129,7 +129,7 @@ pub fn compute_stddev(values: &[Value], n: usize, name: &Tag) -> Result<Value, S
         Some(stddev) => Ok(UntaggedValue::from(Primitive::Decimal(stddev)).into_value(name)),
         None => Err(ShellError::labeled_error(
             "Could not calculate stddev",
-            "error occured here",
+            "error occurred here",
             name.span,
         )),
     }

--- a/crates/nu-cli/src/commands/str_/find_replace.rs
+++ b/crates/nu-cli/src/commands/str_/find_replace.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for SubCommand {
                 SyntaxShape::ColumnPath,
                 "optionally find and replace text by column paths",
             )
-            .switch("all", "replace all occurences of find string", Some('a'))
+            .switch("all", "replace all occurrences of find string", Some('a'))
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cli/src/evaluate/scope.rs
+++ b/crates/nu-cli/src/evaluate/scope.rs
@@ -80,7 +80,7 @@ impl Scope {
     }
 
     pub fn get_vars(&self) -> IndexMap<String, Value> {
-        //FIXME: should this be an interator?
+        //FIXME: should this be an iterator?
         let mut output = IndexMap::new();
 
         for frame in self.frames.lock().iter().rev() {
@@ -93,7 +93,7 @@ impl Scope {
     }
 
     pub fn get_env_vars(&self) -> IndexMap<String, String> {
-        //FIXME: should this be an interator?
+        //FIXME: should this be an iterator?
         let mut output = IndexMap::new();
 
         for frame in self.frames.lock().iter().rev() {
@@ -242,7 +242,7 @@ impl ScopeFrame {
 
 // impl Scope {
 //     pub fn vars(&self) -> IndexMap<String, Value> {
-//         //FIXME: should this be an interator?
+//         //FIXME: should this be an iterator?
 
 //         let mut output = IndexMap::new();
 
@@ -262,7 +262,7 @@ impl ScopeFrame {
 //     }
 
 //     pub fn env(&self) -> IndexMap<String, String> {
-//         //FIXME: should this be an interator?
+//         //FIXME: should this be an iterator?
 
 //         let mut output = IndexMap::new();
 

--- a/crates/nu-cli/src/script.rs
+++ b/crates/nu-cli/src/script.rs
@@ -89,8 +89,8 @@ pub async fn process_script(
                 let name = args
                     .positional
                     .as_ref()
-                    .and_then(|potionals| {
-                        potionals.get(0).map(|e| {
+                    .and_then(|positionals| {
+                        positionals.get(0).map(|e| {
                             if let Expression::Literal(Literal::String(ref s)) = e.expr {
                                 &s
                             } else {

--- a/crates/nu-cli/src/shell/palette.rs
+++ b/crates/nu-cli/src/shell/palette.rs
@@ -265,7 +265,7 @@ impl ThemeColor {
         match character {
             b'0'..=b'9' => Ok(character - b'0'),
             b'a'..=b'z' => Ok(character - (b'a' - 10)),
-            _ => Err(E::custom(format!("invalid charater {}", character))),
+            _ => Err(E::custom(format!("invalid character {}", character))),
         }
     }
 }

--- a/crates/nu-cli/tests/commands/flatten.rs
+++ b/crates/nu-cli/tests/commands/flatten.rs
@@ -47,7 +47,7 @@ fn flatten_nested_tables() {
 }
 
 #[test]
-fn flatten_row_column_explictly() {
+fn flatten_row_column_explicitly() {
     Playground::setup("flatten_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "katz.json",
@@ -113,7 +113,7 @@ fn flatten_row_columns_having_same_column_names_flats_separately() {
 }
 
 #[test]
-fn flatten_table_columns_explictly() {
+fn flatten_table_columns_explicitly() {
     Playground::setup("flatten_test_3", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "katz.json",

--- a/crates/nu-cli/tests/commands/math/mod.rs
+++ b/crates/nu-cli/tests/commands/math/mod.rs
@@ -30,7 +30,7 @@ fn add() {
 }
 
 #[test]
-fn add_compount() {
+fn add_compound() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -159,7 +159,7 @@ impl PrettyDebug for FormatInlineShape {
             InlineShape::Bytesize(bytesize) => {
                 // get the config value, if it doesn't exist make it 'auto' so it works how it originally did
                 let filesize_format_var = crate::config::config(Tag::unknown())
-                    .expect("unabled to get the config.toml file")
+                    .expect("unable to get the config.toml file")
                     .get("filesize_format")
                     .map(|val| val.convert_to_string().to_ascii_lowercase())
                     .unwrap_or_else(|| "auto".to_string());

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1278,7 +1278,7 @@ pub fn parse_math_expression(
                     let (orig_left, left) =
                         working_exprs.pop().expect("This shouldn't be possible");
 
-                    // If we're in shorthand mode, we need to reparse the left-hand side if possibe
+                    // If we're in shorthand mode, we need to reparse the left-hand side if possible
                     let (left, err) = shorthand_reparse(left, orig_left, scope, shorthand_mode);
                     if error.is_none() {
                         error = err;

--- a/crates/nu-plugin/src/plugin.rs
+++ b/crates/nu-plugin/src/plugin.rs
@@ -5,7 +5,7 @@ use std::io;
 
 /// The `Plugin` trait defines the API which plugins may use to "hook" into nushell.
 pub trait Plugin {
-    /// The `config` method is used to configure a plguin's user interface / signature.
+    /// The `config` method is used to configure a plugin's user interface / signature.
     ///
     /// This is where the "name" of the plugin (ex `fetch`), description, any required/optional fields, and flags
     /// can be defined. This information will displayed in nushell when running help <plugin name>

--- a/crates/nu-protocol/src/value/column_path.rs
+++ b/crates/nu-protocol/src/value/column_path.rs
@@ -44,7 +44,7 @@ impl PrettyDebug for &PathMember {
     }
 }
 
-/// The fundamental path primitive to descrive how to navigate through a table to get to a sub-item. A path member can be either a word or a number. Words/strings are taken to mean
+/// The fundamental path primitive to describe how to navigate through a table to get to a sub-item. A path member can be either a word or a number. Words/strings are taken to mean
 /// a column name, and numbers are the row number. Taken together they describe which column or row to narrow to in order to get data.
 ///
 /// Rows must follow column names, they can't come first. eg) `foo.1` is valid where `1.foo` is not.

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -334,7 +334,7 @@ impl Tag {
         }
     }
 
-    /// Creates a `Tag` for the given `AnchorLocatrion` with unknown `Span` position.
+    /// Creates a `Tag` for the given `AnchorLocation` with unknown `Span` position.
     pub fn unknown_span(anchor: AnchorLocation) -> Tag {
         Tag {
             anchor: Some(anchor),
@@ -376,7 +376,7 @@ impl Tag {
     ///
     /// Both `Tag`s must share the same `AnchorLocation`.
     /// The resulting `Tag` will have a `Span` that starts from the current `Tag` and ends at `Span` of the given `Tag`.
-    /// Should the `None` variant be passed in, a new `Tag` with the same `Span` and `Anchorlocation` will be returned.
+    /// Should the `None` variant be passed in, a new `Tag` with the same `Span` and `AnchorLocation` will be returned.
     pub fn until_option(&self, other: Option<impl Into<Tag>>) -> Tag {
         match other {
             Some(other) => {

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -159,11 +159,11 @@ impl TextStyle {
         self.color_style.unwrap_or_default().is_strikethrough
     }
 
-    pub fn fg(&self, foregound: Color) -> TextStyle {
+    pub fn fg(&self, foreground: Color) -> TextStyle {
         TextStyle {
             alignment: self.alignment,
             color_style: Some(Style {
-                foreground: Some(foregound),
+                foreground: Some(foreground),
                 ..self.color_style.unwrap_or_default()
             }),
         }

--- a/crates/nu_plugin_chart/src/nu/bar.rs
+++ b/crates/nu_plugin_chart/src/nu/bar.rs
@@ -130,7 +130,7 @@ impl Plugin for SubCommand {
     fn config(&mut self) -> Result<Signature, ShellError> {
         Ok(Signature::build("chart bar")
             .desc("Bar charts")
-            .switch("acc", "accumuate values", Some('a'))
+            .switch("acc", "accumulate values", Some('a'))
             .optional(
                 "columns",
                 SyntaxShape::Any,

--- a/crates/nu_plugin_chart/src/nu/line.rs
+++ b/crates/nu_plugin_chart/src/nu/line.rs
@@ -128,7 +128,7 @@ impl Plugin for SubCommand {
     fn config(&mut self) -> Result<Signature, ShellError> {
         Ok(Signature::build("chart line")
             .desc("Line charts")
-            .switch("acc", "accumuate values", Some('a'))
+            .switch("acc", "accumulate values", Some('a'))
             .optional(
                 "columns",
                 SyntaxShape::Any,

--- a/crates/nu_plugin_ps/src/ps.rs
+++ b/crates/nu_plugin_ps/src/ps.rs
@@ -35,7 +35,7 @@ pub async fn ps(tag: Tag, long: bool) -> Result<Vec<Value>, ShellError> {
         .await
         .map_err(|_| {
             ShellError::labeled_error(
-                "Unabled to get process list",
+                "Unable to get process list",
                 "could not load process list",
                 tag.span,
             )

--- a/crates/nu_plugin_s3/src/nu/mod.rs
+++ b/crates/nu_plugin_s3/src/nu/mod.rs
@@ -18,13 +18,13 @@ impl Plugin for handler::Handler {
             .named(
                 "endpoint",
                 SyntaxShape::Any,
-                "the enpoint info for the S3 resource, i.g., s3.ap-northeast-1.amazonaws.com or 10.1.1.1",
+                "the endpoint info for the S3 resource, i.g., s3.ap-northeast-1.amazonaws.com or 10.1.1.1",
                 Some('e'),
             )
             .named(
                 "access_key",
                 SyntaxShape::Any,
-                "the accessy key when authenticating",
+                "the access key when authenticating",
                 Some('a'),
             )
             .named(

--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -117,7 +117,7 @@ async fn host(tag: Tag) -> Result<Value, ShellError> {
     // Sessions
     // note: the heim host module has nomenclature "users"
     let users = host::users().await.map_err(|_| {
-        ShellError::labeled_error("Unabled to get users", "could not load users", tag.span)
+        ShellError::labeled_error("Unable to get users", "could not load users", tag.span)
     })?;
 
     futures::pin_mut!(users);
@@ -141,7 +141,7 @@ async fn disks(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
     let mut output = vec![];
     let partitions = disk::partitions_physical().await.map_err(|_| {
         ShellError::labeled_error(
-            "Unabled to get disk list",
+            "Unable to get disk list",
             "could not load disk list",
             tag.span,
         )
@@ -301,7 +301,7 @@ async fn net(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
     let mut output = vec![];
     let io_counters = net::io_counters().await.map_err(|_| {
         ShellError::labeled_error(
-            "Unabled to get network device list",
+            "Unable to get network device list",
             "could not load network device list",
             tag.span,
         )

--- a/docs/commands/from-xml.md
+++ b/docs/commands/from-xml.md
@@ -1,6 +1,6 @@
 # from xml
 
-Parse text as `.xml` and create table. Use this when nushell cannot dertermine the input file extension.
+Parse text as `.xml` and create table. Use this when nushell cannot determine the input file extension.
 
 Syntax: `from xml`
 

--- a/docs/commands/touch.md
+++ b/docs/commands/touch.md
@@ -42,7 +42,7 @@ Create a file within an already existent folder.
 ──────────┴───────────
 ```
 
-Create three files at oince
+Create three files at once
 ```shell
 > touch a b c
 > ls


### PR DESCRIPTION
I was trying to get nushell work with with CLion's build system, when I noticed [this typo](https://github.com/nushell/nushell/pull/2841), then, shortly after, I decided to run the spellchecker on the entire project (sorry for the two separate PRs).  CLion found about 1,200 things it considered typos, most were not.  I sifted through them all and tried to correct the ones that seemed to be actual typos, while omitting certain things that are not typos.  I it is possible I missed something or made a bad call when deeming something not a typo, but this should be a good chunk to get most of them fixed.