### PR TITLE
Add comments to next LiteCommand

### DIFF
--- a/crates/nu-cli/src/commands/command.rs
+++ b/crates/nu-cli/src/commands/command.rs
@@ -250,7 +250,7 @@ impl WholeStreamCommand for Block {
     }
 
     fn usage(&self) -> &str {
-        ""
+        &self.params.usage
     }
 
     async fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/crates/nu-cli/tests/commands/def.rs
+++ b/crates/nu-cli/tests/commands/def.rs
@@ -1,0 +1,19 @@
+use nu_test_support::nu;
+use nu_test_support::playground::Playground;
+use std::fs;
+#[test]
+fn def_with_comment() {
+    Playground::setup("def_with_comment", |dirs, _| {
+        let data = r#"
+#My echo
+def e [arg] {echo $arg}
+            "#;
+        fs::write(dirs.root().join("def_test"), data).expect("Unable to write file");
+        let actual = nu!(
+            cwd: dirs.root(),
+            "source def_test; help e | to json"
+        );
+
+        assert!(actual.out.contains("My echo\\n\\n"));
+    });
+}

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -7,6 +7,7 @@ mod cd;
 mod compact;
 mod count;
 mod cp;
+mod def;
 mod default;
 mod drop;
 mod each;

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -2161,7 +2161,11 @@ fn parse_definition(call: &LiteCommand, scope: &dyn ParserScope) -> Option<Parse
         }
 
         let name = trim_quotes(&call.parts[1].item);
-        let (signature, err) = parse_signature(&name, &call.parts[2], scope);
+        let (mut signature, err) = parse_signature(&name, &call.parts[2], scope);
+
+        //Add commands comments to signature usage
+        signature.usage = call.comments_joined();
+
         if err.is_some() {
             return err;
         };


### PR DESCRIPTION
This commit applied adds comments preceding a command to the LiteCommands new
field `comments`.

This can be usefull for example when defining a function with `def`. Nushell
could pick up the comments and display them when the user types `help my_def_func`.

Example
```shell
#My echo
#It's much better :)
def my_echo [arg] { echo $arg }
```
The LiteCommand `def` will now contain the comments `My echo` and `It's much
better :)`.

The comment is not associated with the next command if there is a (or multiple) newline
between them.
Example
```shell
#Happy new year

echo 42
```

This new functionality is similar to DocStrings. One might introduce a special
notation for such DocStrings, so that the parser can differentiate better
between discardable comments and usefull documentation.