### PR TITLE
Tighten how input streams handle nothing, and related

### DIFF
--- a/crates/nu-cli/src/commands/do_.rs
+++ b/crates/nu-cli/src/commands/do_.rs
@@ -2,9 +2,7 @@ use crate::commands::classified::block::run_block;
 use crate::commands::WholeStreamCommand;
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{
-    hir::CapturedBlock, hir::ExternalRedirection, ReturnSuccess, Signature, SyntaxShape, Value,
-};
+use nu_protocol::{hir::CapturedBlock, hir::ExternalRedirection, Signature, SyntaxShape, Value};
 
 pub struct Do;
 
@@ -48,7 +46,7 @@ impl WholeStreamCommand for Do {
             Example {
                 description: "Run the block and ignore errors",
                 example: r#"do -i { thisisnotarealcommand }"#,
-                result: Some(vec![Value::nothing()]),
+                result: Some(vec![]),
             },
         ]
     }
@@ -98,7 +96,7 @@ async fn do_(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                 context.clear_errors();
                 Ok(futures::stream::iter(output).to_output_stream())
             }
-            Err(_) => Ok(OutputStream::one(ReturnSuccess::value(Value::nothing()))),
+            Err(_) => Ok(OutputStream::empty()),
         }
     } else {
         result.map(|x| x.to_output_stream())

--- a/crates/nu-cli/src/commands/math/sum.rs
+++ b/crates/nu-cli/src/commands/math/sum.rs
@@ -73,7 +73,11 @@ pub fn summation(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
     let sum = reducer_for(Reduce::Summation);
 
     let first = values.get(0).ok_or_else(|| {
-        ShellError::unexpected("Cannot perform aggregate math operation on empty data")
+        ShellError::labeled_error(
+            "Cannot perform aggregate math operation on empty data",
+            "expected input",
+            name.span,
+        )
     })?;
 
     match first {

--- a/crates/nu-cli/tests/commands/math/sum.rs
+++ b/crates/nu-cli/tests/commands/math/sum.rs
@@ -34,13 +34,6 @@ fn all() {
 }
 
 #[test]
-fn outputs_zero_with_no_input() {
-    let actual = nu!(cwd: ".", "math sum");
-
-    assert_eq!(actual.out, "0");
-}
-
-#[test]
 #[allow(clippy::unreadable_literal)]
 #[allow(clippy::float_cmp)]
 fn compute_sum_of_individual_row() -> Result<(), String> {

--- a/crates/nu-cli/tests/commands/reduce.rs
+++ b/crates/nu-cli/tests/commands/reduce.rs
@@ -103,5 +103,5 @@ fn error_reduce_empty() {
         )
     );
 
-    assert!(actual.err.contains("empty input"));
+    assert!(actual.err.contains("needs input"));
 }

--- a/crates/nu-stream/src/input.rs
+++ b/crates/nu-stream/src/input.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use futures::stream::{iter, once};
+use futures::stream::iter;
 use nu_errors::ShellError;
 use nu_protocol::{Primitive, Type, UntaggedValue, Value};
 use nu_source::{PrettyDebug, Tag, Tagged, TaggedItem};
@@ -14,7 +14,7 @@ pub struct InputStream {
 impl InputStream {
     pub fn empty() -> InputStream {
         InputStream {
-            values: once(async { UntaggedValue::nothing().into_untagged_value() }).boxed(),
+            values: futures::stream::empty().boxed(),
             empty: true,
         }
     }


### PR DESCRIPTION
This tighens how input streams work, so they no longer have a Nothing value in them by default. Instead, you need to call `.is_empty()` to change the logic of your command based on if there's a value there. Fixed up a few commands that were leaning on this logic.

This should also allow us to not accidentally iterate over that Nothing value, which cleans up some `each` use cases.