### PR TITLE
Adding coerce filesize functionality to math avg median

### DIFF
--- a/crates/nu-cli/src/commands/math/median.rs
+++ b/crates/nu-cli/src/commands/math/median.rs
@@ -54,6 +54,18 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
+fn to_byte(value: &Value) -> Option<Value> {
+    match &value.value {
+        UntaggedValue::Primitive(Primitive::Int(num)) => Some(
+            UntaggedValue::Primitive(Primitive::Filesize(convert_number_to_u64(&Number::Int(
+                num.clone(),
+            ))))
+            .into_untagged_value(),
+        ),
+        _ => None,
+    }
+}
+
 enum Pick {
     MedianAverage,
     Median,
@@ -129,7 +141,39 @@ fn compute_average(values: &[Value], name: impl Into<Tag>) -> Result<Value, Shel
         )
     })?;
     let total_rows = UntaggedValue::decimal(number);
-    let total = sum(UntaggedValue::int(0).into_untagged_value(), values.to_vec())?;
+
+    let are_bytes = values
+        .get(0)
+        .ok_or_else(|| {
+            ShellError::unexpected("Cannot perform aggregate math operation on empty data")
+        })?
+        .is_filesize();
+
+    let total = if are_bytes {
+        to_byte(&sum(
+            UntaggedValue::int(0).into_untagged_value(),
+            values
+                .to_vec()
+                .iter()
+                .map(|v| match v {
+                    Value {
+                        value: UntaggedValue::Primitive(Primitive::Filesize(num)),
+                        ..
+                    } => UntaggedValue::int(*num as usize).into_untagged_value(),
+                    other => other.clone(),
+                })
+                .collect::<Vec<_>>(),
+        )?)
+        .ok_or_else(|| {
+            ShellError::labeled_error(
+                "could not convert to big decimal",
+                "could not convert to big decimal",
+                &name.span,
+            )
+        })
+    } else {
+        sum(UntaggedValue::int(0).into_untagged_value(), values.to_vec())
+    }?;
 
     match total {
         Value {

--- a/crates/nu-cli/src/commands/math/reducers.rs
+++ b/crates/nu-cli/src/commands/math/reducers.rs
@@ -71,7 +71,7 @@ pub fn sum(data: Vec<Value>) -> Result<Value, ShellError> {
     // sum aggregator. Currently this is only handling, filesize,
     // and other types are defaulting to an integer.
     let mut acc = if first_value.is_filesize() {
-        UntaggedValue::filesize(0 as u64).into_untagged_value()
+        UntaggedValue::filesize(0u64).into_untagged_value()
     } else {
         UntaggedValue::int(0).into_untagged_value()
     };

--- a/crates/nu-cli/src/commands/math/reducers.rs
+++ b/crates/nu-cli/src/commands/math/reducers.rs
@@ -41,16 +41,18 @@ pub fn reducer_for(
     command: Reduce,
 ) -> Box<dyn Fn(Value, Vec<Value>) -> Result<Value, ShellError> + Send + Sync + 'static> {
     match command {
-        Reduce::Summation | Reduce::Default => Box::new(formula(
+        Reduce::Default => Box::new(formula(
             UntaggedValue::int(0).into_untagged_value(),
             Box::new(sum),
         )),
+        Reduce::Summation => Box::new(|_, values| sum(values)),
         Reduce::Minimum => Box::new(|_, values| min(values)),
         Reduce::Maximum => Box::new(|_, values| max(values)),
         Reduce::Product => Box::new(|_, values| product(values)),
     }
 }
 
+#[allow(dead_code)]
 pub enum Reduce {
     Summation,
     Minimum,
@@ -60,7 +62,20 @@ pub enum Reduce {
 }
 
 pub fn sum(data: Vec<Value>) -> Result<Value, ShellError> {
-    let mut acc = UntaggedValue::int(0).into_untagged_value();
+    let first_value = data
+        .get(0)
+        .ok_or_else(|| ShellError::unexpected(ERR_EMPTY_DATA))?;
+
+    // Generate the initial accumulator value, of the correct type for
+    // the incoming data, this will be used in conjunction with the
+    // sum aggregator. Currently this is only handling, filesize,
+    // and other types are defaulting to an integer.
+    let mut acc = if first_value.is_filesize() {
+        UntaggedValue::filesize(0 as u64).into_untagged_value()
+    } else {
+        UntaggedValue::int(0).into_untagged_value()
+    };
+
     for value in data {
         match value.value {
             UntaggedValue::Primitive(_) => {


### PR DESCRIPTION
This pull request addresses, #2819.
The median sub-command uses the average of the two middle values of a list, if the list that the median is being calculated for is even length.  However, this fails for even length `filesize`  type columns.  

Looking through the [median.rs](https://github.com/nushell/nushell/blob/main/crates/nu-cli/src/commands/math/median.rs) file compared to the [avg.rs](https://github.com/nushell/nushell/blob/main/crates/nu-cli/src/commands/math/avg.rs) file, it seems that the median command is not converting `filesize` type columns to a format that can be used in by the `Reduce::Summation` math reducer (from [reducers.rs](https://github.com/nushell/nushell/blob/main/crates/nu-cli/src/commands/math/reducers.rs)). I borrowed this functionality and added this to the median sub command.

This is my first pull request here, so let me know if I am missing something obvious or doing something wrong :)