### PR TITLE
Pin the syn version to avoid breaking change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,6 +3179,7 @@ dependencies = [
  "nu_plugin_tree",
  "nu_plugin_xpath",
  "pretty_env_logger",
+ "syn",
 ]
 
 [[package]]
@@ -5489,9 +5490,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.52"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1e438504729046a5cfae47f97c30d6d083c7d91d94603efdae3477fc070d4c"
+checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ nu_plugin_match = {version = "0.25.0", path = "./crates/nu_plugin_match", option
 nu_plugin_post = {version = "0.25.0", path = "./crates/nu_plugin_post", optional = true}
 nu_plugin_ps = {version = "0.25.0", path = "./crates/nu_plugin_ps", optional = true}
 nu_plugin_s3 = {version = "0.25.0", path = "./crates/nu_plugin_s3", optional = true}
+nu_plugin_selector = {version = "0.25.0", path = "./crates/nu_plugin_selector", optional = true}
 nu_plugin_start = {version = "0.25.0", path = "./crates/nu_plugin_start", optional = true}
 nu_plugin_sys = {version = "0.25.0", path = "./crates/nu_plugin_sys", optional = true}
 nu_plugin_textview = {version = "0.25.0", path = "./crates/nu_plugin_textview", optional = true}
@@ -44,15 +45,15 @@ nu_plugin_to_bson = {version = "0.25.0", path = "./crates/nu_plugin_to_bson", op
 nu_plugin_to_sqlite = {version = "0.25.0", path = "./crates/nu_plugin_to_sqlite", optional = true}
 nu_plugin_tree = {version = "0.25.0", path = "./crates/nu_plugin_tree", optional = true}
 nu_plugin_xpath = {version = "0.25.0", path = "./crates/nu_plugin_xpath", optional = true}
-nu_plugin_selector = {version = "0.25.0", path = "./crates/nu_plugin_selector", optional = true}
 
 # Required to bootstrap the main binary
 clap = "2.33.3"
 ctrlc = {version = "3.1.6", optional = true}
 futures = {version = "0.3.5", features = ["compat", "io-compat"]}
+itertools = "0.9.0"
 log = "0.4.11"
 pretty_env_logger = "0.4.0"
-itertools = "0.9.0"
+syn = "=1.0.57"
 
 [dev-dependencies]
 dunce = "1.0.1"
@@ -88,7 +89,7 @@ default = [
   "post",
   "fetch",
   "rich-benchmark",
-  "zip-support"
+  "zip-support",
 ]
 extra = ["default", "binaryview", "tree", "clipboard-cli", "trash-support", "start", "bson", "sqlite", "s3", "chart", "xpath", "selector"]
 stable = ["default"]
@@ -113,18 +114,18 @@ bson = ["nu_plugin_from_bson", "nu_plugin_to_bson"]
 chart = ["nu_plugin_chart"]
 clipboard-cli = ["nu-cli/clipboard-cli"]
 s3 = ["nu_plugin_s3"]
+selector = ["nu_plugin_selector"]
 sqlite = ["nu_plugin_from_sqlite", "nu_plugin_to_sqlite"]
 start = ["nu_plugin_start"]
 trash-support = ["nu-cli/trash-support"]
 tree = ["nu_plugin_tree"]
 xpath = ["nu_plugin_xpath"]
-selector = ["nu_plugin_selector"]
 
 [profile.release]
 #strip = "symbols" #Couldn't get working +nightly
-opt-level = 'z' #Optimize for size
-lto = true #Link Time Optimization
 codegen-units = 1 #Reduce parallel codegen units
+lto = true #Link Time Optimization
+opt-level = 'z' #Optimize for size
 
 # Core plugins that ship with `cargo install nu` by default
 # Currently, Cargo limits us to installing only one binary

--- a/samples/wasm/Cargo.toml
+++ b/samples/wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasm"
-version = "0.1.0"
 authors = ["Nu authors"]
 edition = "2018"
+name = "wasm"
+version = "0.1.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -17,14 +17,14 @@ wasm-bindgen = "0.2.63"
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = {version = "0.1.6", optional = true}
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default
 # allocator, however.
 #
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
+wee_alloc = {version = "0.4.5", optional = true}
 
 nu-cli = {path = "../../crates/nu-cli", default-features = false}
 nu-errors = {path = "../../crates/nu-errors", default-features = false}
@@ -35,8 +35,8 @@ async-trait = "0.1.36"
 futures = {version = "0.3", features = ["compat", "io-compat"]}
 futures-util = "0.3.5"
 futures_codec = "0.4"
+syn = "=1.0.57"
 web-sys = {version = "0.3.14", features = ["console"]}
-
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"


### PR DESCRIPTION
Looks like 1.0.58 has a breaking change, even though it's semver-compatible with what we've been using. Trying to fix it by pinning to 1.0.57