### PR TITLE
Update dependency rust-embed now that issue with its use of syn has been fixed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,7 +3179,6 @@ dependencies = [
  "nu_plugin_tree",
  "nu_plugin_xpath",
  "pretty_env_logger",
- "syn",
 ]
 
 [[package]]
@@ -4837,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "5.6.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213acf1bc5a6dfcd70b62db1e9a7d06325c0e73439c312fcb8599d456d9686ee"
+checksum = "abcb6e9589c2b7875dc4cdfecc6289ea75700a52976b52ef4443d7aad46f7397"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -4848,10 +4847,11 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "5.6.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7903c2cf599db8f310b392332f38367ca4acc84420fa1aee3536299f433c10d5"
+checksum = "ebc6a6c2785d73d8f0157d10a40223bbf0210f18aecb261d39b96802f9ccc69d"
 dependencies = [
+ "proc-macro2",
  "quote",
  "rust-embed-utils",
  "syn",
@@ -4860,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97655158074ccb2d2cfb1ccb4c956ef0f4054e43a2c1e71146d4991e6961e105"
+checksum = "2a512219132473ab0a77b52077059f1c47ce4af7fbdc94503e9862a34422876d"
 dependencies = [
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,6 @@ dependencies = [
  "nu-protocol",
  "nu-source",
  "nu-value-ext",
- "syn",
  "tui",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ futures = {version = "0.3.5", features = ["compat", "io-compat"]}
 itertools = "0.9.0"
 log = "0.4.11"
 pretty_env_logger = "0.4.0"
-syn = "=1.0.57"
 
 [dev-dependencies]
 dunce = "1.0.1"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -76,7 +76,7 @@ rand = "0.7.3"
 rayon = "1.4.0"
 regex = "1.3.9"
 roxmltree = "0.13.0"
-rust-embed = "5.6.0"
+rust-embed = "5.8.0"
 rustyline = {version = "6.3.0", optional = true}
 serde = {version = "1.0.115", features = ["derive"]}
 serde_bytes = "0.11.5"

--- a/crates/nu_plugin_chart/Cargo.toml
+++ b/crates/nu_plugin_chart/Cargo.toml
@@ -20,4 +20,3 @@ nu-value-ext = {path = "../nu-value-ext", version = "0.25.1"}
 
 crossterm = "0.19.0"
 tui = {version = "0.14.0", default-features = false, features = ["crossterm"]}
-syn = "=1.0.57"

--- a/samples/wasm/Cargo.toml
+++ b/samples/wasm/Cargo.toml
@@ -35,7 +35,6 @@ async-trait = "0.1.36"
 futures = {version = "0.3", features = ["compat", "io-compat"]}
 futures-util = "0.3.5"
 futures_codec = "0.4"
-syn = "=1.0.57"
 web-sys = {version = "0.3.14", features = ["console"]}
 
 [dev-dependencies]


### PR DESCRIPTION
I brought the `syn` issue to the attention of the `rust-embed` folks who fixed the issue in `rust-embed-impl`. See https://github.com/pyros2097/rust-embed/commit/05b1f43cbb7d626f0c55d9531c33dd8078d218f6 for the changes that were made for `rust-embed` version 5.8.0 that mean that `nu` no longer needs to pin the version of syn.