### PR TITLE
Obey precedence rules in which; Fix #2875

### DIFF
--- a/crates/nu-cli/src/evaluate/scope.rs
+++ b/crates/nu-cli/src/evaluate/scope.rs
@@ -31,6 +31,28 @@ impl Scope {
         None
     }
 
+    pub fn get_aliases_with_name(&self, name: &str) -> Option<Vec<Vec<Spanned<String>>>> {
+        Some(
+            self.frames
+                .lock()
+                .iter()
+                .rev()
+                .filter_map(|frame| frame.aliases.get(name).cloned())
+                .collect(),
+        )
+    }
+
+    pub fn get_custom_commands_with_name(&self, name: &str) -> Option<Vec<Block>> {
+        Some(
+            self.frames
+                .lock()
+                .iter()
+                .rev()
+                .filter_map(|frame| frame.custom_commands.get(name).cloned())
+                .collect(),
+        )
+    }
+
     pub fn add_command(&self, name: String, command: Command) {
         // Note: this is assumed to always be true, as there is always a global top frame
         if let Some(frame) = self.frames.lock().last_mut() {

--- a/crates/nu-cli/src/evaluate/scope.rs
+++ b/crates/nu-cli/src/evaluate/scope.rs
@@ -32,25 +32,34 @@ impl Scope {
     }
 
     pub fn get_aliases_with_name(&self, name: &str) -> Option<Vec<Vec<Spanned<String>>>> {
-        Some(
-            self.frames
-                .lock()
-                .iter()
-                .rev()
-                .filter_map(|frame| frame.aliases.get(name).cloned())
-                .collect(),
-        )
+        let aliases: Vec<_> = self
+            .frames
+            .lock()
+            .iter()
+            .rev()
+            .filter_map(|frame| frame.aliases.get(name).cloned())
+            .collect();
+        if aliases.is_empty() {
+            None
+        } else {
+            Some(aliases)
+        }
     }
 
     pub fn get_custom_commands_with_name(&self, name: &str) -> Option<Vec<Block>> {
-        Some(
-            self.frames
-                .lock()
-                .iter()
-                .rev()
-                .filter_map(|frame| frame.custom_commands.get(name).cloned())
-                .collect(),
-        )
+        let custom_commands: Vec<_> = self
+            .frames
+            .lock()
+            .iter()
+            .rev()
+            .filter_map(|frame| frame.custom_commands.get(name).cloned())
+            .collect();
+
+        if custom_commands.is_empty() {
+            None
+        } else {
+            Some(custom_commands)
+        }
     }
 
     pub fn add_command(&self, name: String, command: Command) {

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -55,5 +55,6 @@ mod touch;
 mod uniq;
 mod update;
 mod where_;
+mod which;
 mod with_env;
 mod wrap;

--- a/crates/nu-cli/tests/commands/which.rs
+++ b/crates/nu-cli/tests/commands/which.rs
@@ -1,0 +1,96 @@
+use nu_test_support::nu;
+
+#[test]
+fn which_ls() {
+    let actual = nu!(
+        cwd: ".",
+        "which ls | get path | str trim"
+    );
+
+    assert_eq!(actual.out, "Nushell built-in command");
+}
+
+#[test]
+fn which_alias_ls() {
+    let actual = nu!(
+        cwd: ".",
+        "alias ls = ls -a; which ls | get path | str trim"
+    );
+
+    assert_eq!(actual.out, "Nushell alias");
+}
+
+#[test]
+fn which_def_ls() {
+    let actual = nu!(
+        cwd: ".",
+        "def ls [] {echo def}; which ls | get path | str trim"
+    );
+
+    assert_eq!(actual.out, "Nushell custom command");
+}
+
+#[test]
+fn correct_precedence_alias_def_custom() {
+    let actual = nu!(
+        cwd: ".",
+        "def ls [] {echo def}; alias ls = echo alias; which ls | get path | str trim"
+    );
+
+    assert_eq!(actual.out, "Nushell alias");
+}
+
+#[test]
+fn multiple_reports_for_alias_def_custom() {
+    let actual = nu!(
+        cwd: ".",
+        "def ls [] {echo def}; alias ls = echo alias; which -a ls | count"
+    );
+
+    let count: i32 = actual.out.parse().unwrap();
+    assert!(count >= 3);
+}
+
+// `get_aliases_with_name` and `get_custom_commands_with_name` don't return the correct count of
+// values
+// I suspect this is due to the ScopeFrame getting discarded at '}' and the command is then
+// executed in the parent scope
+// See: parse_definition, line 2187 for reference.
+#[ignore]
+#[test]
+fn multiple_reports_of_multiple_alias() {
+    let actual = nu!(
+        cwd: ".",
+        "alias xaz = echo alias1; def helper [] {alias xaz = echo alias2; which -a xaz}; helper | count"
+    );
+
+    let count: i32 = actual.out.parse().unwrap();
+    assert!(count == 2);
+}
+
+#[ignore]
+#[test]
+fn multiple_reports_of_multiple_defs() {
+    let actual = nu!(
+        cwd: ".",
+        "def xaz [] {echo def1}; def helper [] { def xaz [] { echo def2 }; which -a xaz }; helper | count"
+    );
+
+    let count: i32 = actual.out.parse().unwrap();
+    assert!(count == 2);
+}
+
+//Fails due to ParserScope::add_definition
+// frame.custom_commands.insert(name.clone(), block.clone());
+// frame.commands.insert(name, whole_stream_command(block));
+#[ignore]
+#[test]
+fn def_only_seen_once() {
+    let actual = nu!(
+        cwd: ".",
+        "def xaz [] {echo def1}; which -a xaz | count"
+    );
+    //count is 2. One custom_command (def) one built in ("wrongly" added)
+    let count: i32 = actual.out.parse().unwrap();
+    assert!(count == 1);
+}


### PR DESCRIPTION
Before which did not obay the precedence of alias before def commands.
Furthermore, `which -a echo` would only report either an alias or a def command or an
internal command with the provided name. Not all.

With this commit applied its fixed :)

Example:
```shell
/home/leo/repos/nushell(fix/which_reports_wrong_usage)> def echo [] {^echo hi}
/home/leo/repos/nushell(fix/which_reports_wrong_usage)> echo
hi
/home/leo/repos/nushell(fix/which_reports_wrong_usage)> which -a echo
───┬──────┬──────────────────────────┬─────────
 # │ arg  │           path           │ builtin
───┼──────┼──────────────────────────┼─────────
 0 │ echo │ Nushell custom command   │ No
 1 │ echo │ Nushell built-in command │ Yes
 2 │ echo │ /usr/bin/echo            │ No
───┴──────┴──────────────────────────┴─────────
/home/leo/repos/nushell(fix/which_reports_wrong_usage)> alias echo = ^echo hi there
/home/leo/repos/nushell(fix/which_reports_wrong_usage)> echo
hi there
/home/leo/repos/nushell(fix/which_reports_wrong_usage)> which -a echo
───┬──────┬──────────────────────────┬─────────
 # │ arg  │           path           │ builtin
───┼──────┼──────────────────────────┼─────────
 0 │ echo │ Nushell alias            │ No
 1 │ echo │ Nushell custom command   │ No
 2 │ echo │ Nushell built-in command │ Yes
 3 │ echo │ /usr/bin/echo            │ No
───┴──────┴──────────────────────────┴─────────
```