### PR TITLE
Remove the line primitive

### DIFF
--- a/crates/nu-cli/src/commands/autoview/command.rs
+++ b/crates/nu-cli/src/commands/autoview/command.rs
@@ -134,29 +134,6 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
                         out!("{}", s);
                     }
                     Value {
-                        value: UntaggedValue::Primitive(Primitive::Line(ref s)),
-                        tag: Tag { anchor, span },
-                    } if anchor.is_some() => {
-                        if let Some(text) = text {
-                            let mut stream = VecDeque::new();
-                            stream.push_back(
-                                UntaggedValue::string(s).into_value(Tag { anchor, span }),
-                            );
-                            let command_args =
-                                create_default_command_args(&context).with_input(stream);
-                            let result = text.run(command_args).await?;
-                            result.collect::<Vec<_>>().await;
-                        } else {
-                            out!("{}\n", s);
-                        }
-                    }
-                    Value {
-                        value: UntaggedValue::Primitive(Primitive::Line(s)),
-                        ..
-                    } => {
-                        out!("{}\n", s);
-                    }
-                    Value {
                         value: UntaggedValue::Primitive(Primitive::Path(s)),
                         ..
                     } => {

--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -221,8 +221,7 @@ fn spawn(
                 for value in block_on_stream(input) {
                     match &value.value {
                         UntaggedValue::Primitive(Primitive::Nothing) => continue,
-                        UntaggedValue::Primitive(Primitive::String(s))
-                        | UntaggedValue::Primitive(Primitive::Line(s)) => {
+                        UntaggedValue::Primitive(Primitive::String(s)) => {
                             if stdin_write.write(s.as_bytes()).is_err() {
                                 // Other side has closed, so exit
                                 return Ok(());

--- a/crates/nu-cli/src/commands/hash_/base64_.rs
+++ b/crates/nu-cli/src/commands/hash_/base64_.rs
@@ -164,8 +164,7 @@ fn action(
     tag: impl Into<Tag>,
 ) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let base64_config_enum: base64::Config = if &base64_config.character_set == "standard" {
                 base64::STANDARD
             } else if &base64_config.character_set == "standard-no-padding" {

--- a/crates/nu-cli/src/commands/lines.rs
+++ b/crates/nu-cli/src/commands/lines.rs
@@ -63,10 +63,6 @@ async fn lines(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 Value {
                     value: UntaggedValue::Primitive(Primitive::String(st)),
                     ..
-                }
-                | Value {
-                    value: UntaggedValue::Primitive(Primitive::Line(st)),
-                    ..
                 } => {
                     let mut leftover_string = leftover_string.lock();
 
@@ -84,7 +80,9 @@ async fn lines(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
                     let success_lines: Vec<_> = lines
                         .iter()
-                        .map(|x| ReturnSuccess::value(UntaggedValue::line(x).into_untagged_value()))
+                        .map(|x| {
+                            ReturnSuccess::value(UntaggedValue::string(x).into_untagged_value())
+                        })
                         .collect();
 
                     futures::stream::iter(success_lines)

--- a/crates/nu-cli/src/commands/path/mod.rs
+++ b/crates/nu-cli/src/commands/path/mod.rs
@@ -47,8 +47,7 @@ where
 {
     let v = match &v.value {
         UntaggedValue::Primitive(Primitive::Path(buf)) => action(buf, args).into_value(v.tag()),
-        UntaggedValue::Primitive(Primitive::String(s))
-        | UntaggedValue::Primitive(Primitive::Line(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             action(s.as_ref(), args).into_value(v.tag())
         }
         other => {

--- a/crates/nu-cli/src/commands/str_/capitalize.rs
+++ b/crates/nu-cli/src/commands/str_/capitalize.rs
@@ -72,8 +72,7 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let mut capitalized = String::new();
 
             for (idx, character) in s.chars().enumerate() {

--- a/crates/nu-cli/src/commands/str_/case/mod.rs
+++ b/crates/nu-cli/src/commands/str_/case/mod.rs
@@ -61,8 +61,7 @@ where
     F: Fn(&str) -> String + Send + Sync + 'static,
 {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             Ok(UntaggedValue::string(case_operation(s)).into_value(tag))
         }
         other => {

--- a/crates/nu-cli/src/commands/str_/contains.rs
+++ b/crates/nu-cli/src/commands/str_/contains.rs
@@ -96,8 +96,7 @@ fn action(
     tag: impl Into<Tag>,
 ) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let contains = if insensitive {
                 s.to_lowercase().find(&pattern.to_lowercase()).is_some()
             } else {

--- a/crates/nu-cli/src/commands/str_/downcase.rs
+++ b/crates/nu-cli/src/commands/str_/downcase.rs
@@ -72,8 +72,7 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             Ok(UntaggedValue::string(s.to_ascii_lowercase()).into_value(tag))
         }
         other => {

--- a/crates/nu-cli/src/commands/str_/ends_with.rs
+++ b/crates/nu-cli/src/commands/str_/ends_with.rs
@@ -75,8 +75,7 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let ends_with = s.ends_with(pattern);
             Ok(UntaggedValue::boolean(ends_with).into_value(tag))
         }

--- a/crates/nu-cli/src/commands/str_/find_replace.rs
+++ b/crates/nu-cli/src/commands/str_/find_replace.rs
@@ -105,8 +105,7 @@ fn action(
     all: bool,
 ) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let find = &options.0;
             let replacement = &options.1;
 

--- a/crates/nu-cli/src/commands/str_/index_of.rs
+++ b/crates/nu-cli/src/commands/str_/index_of.rs
@@ -137,8 +137,7 @@ fn action(
 ) -> Result<Value, ShellError> {
     let r = process_range(&input, &range)?;
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let start_index = r.0 as usize;
             let end_index = r.1 as usize;
 
@@ -169,15 +168,13 @@ fn action(
 
 fn process_range(input: &Value, range: &Value) -> Result<IndexOfOptionalBounds, ShellError> {
     let input_len = match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => s.len(),
+        UntaggedValue::Primitive(Primitive::String(s)) => s.len(),
         _ => 0,
     };
     let min_index_str = String::from("0");
     let max_index_str = input_len.to_string();
     let r = match &range.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let indexes: Vec<&str> = s.split(',').collect();
 
             let start_index = indexes.get(0).unwrap_or(&&min_index_str[..]).to_string();

--- a/crates/nu-cli/src/commands/str_/lpad.rs
+++ b/crates/nu-cli/src/commands/str_/lpad.rs
@@ -111,8 +111,7 @@ fn action(
     tag: impl Into<Tag>,
 ) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             if length < s.len() {
                 Ok(UntaggedValue::string(&s[0..length]).into_value(tag))
             } else {

--- a/crates/nu-cli/src/commands/str_/rpad.rs
+++ b/crates/nu-cli/src/commands/str_/rpad.rs
@@ -111,8 +111,7 @@ fn action(
     tag: impl Into<Tag>,
 ) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             if length < s.len() {
                 Ok(UntaggedValue::string(&s[0..length]).into_value(tag))
             } else {

--- a/crates/nu-cli/src/commands/str_/starts_with.rs
+++ b/crates/nu-cli/src/commands/str_/starts_with.rs
@@ -75,8 +75,7 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let starts_with = s.starts_with(pattern);
             Ok(UntaggedValue::boolean(starts_with).into_value(tag))
         }

--- a/crates/nu-cli/src/commands/str_/substring.rs
+++ b/crates/nu-cli/src/commands/str_/substring.rs
@@ -122,8 +122,7 @@ fn action(input: &Value, options: &Substring, tag: impl Into<Tag>) -> Result<Val
     let tag = tag.into();
 
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let len: isize = s.len().try_into().map_err(|_| {
                 ShellError::labeled_error(
                     "could not perform substring",

--- a/crates/nu-cli/src/commands/str_/to_datetime.rs
+++ b/crates/nu-cli/src/commands/str_/to_datetime.rs
@@ -109,8 +109,7 @@ fn action(
     tag: impl Into<Tag>,
 ) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let out = match options {
                 Some(dt) => match DateTime::parse_from_str(s, &dt.0) {
                     Ok(d) => UntaggedValue::date(d),

--- a/crates/nu-cli/src/commands/str_/to_decimal.rs
+++ b/crates/nu-cli/src/commands/str_/to_decimal.rs
@@ -75,8 +75,7 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let other = s.trim();
             let out = match BigDecimal::from_str(other) {
                 Ok(v) => UntaggedValue::decimal(v),

--- a/crates/nu-cli/src/commands/str_/to_integer.rs
+++ b/crates/nu-cli/src/commands/str_/to_integer.rs
@@ -97,8 +97,7 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn action(input: &Value, tag: impl Into<Tag>, radix: u32) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             let trimmed = s.trim();
 
             let out = match trimmed {

--- a/crates/nu-cli/src/commands/str_/trim/mod.rs
+++ b/crates/nu-cli/src/commands/str_/trim/mod.rs
@@ -80,8 +80,7 @@ where
 {
     let tag = tag.into();
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             Ok(UntaggedValue::string(trim_operation(s, char_)).into_value(tag))
         }
         other => match mode {

--- a/crates/nu-cli/src/commands/str_/upcase.rs
+++ b/crates/nu-cli/src/commands/str_/upcase.rs
@@ -72,8 +72,7 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     match &input.value {
-        UntaggedValue::Primitive(Primitive::Line(s))
-        | UntaggedValue::Primitive(Primitive::String(s)) => {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
             Ok(UntaggedValue::string(s.to_ascii_uppercase()).into_value(tag))
         }
         other => {

--- a/crates/nu-cli/src/commands/to_delimited_data.rs
+++ b/crates/nu-cli/src/commands/to_delimited_data.rs
@@ -133,7 +133,6 @@ pub fn clone_tagged_value(v: &Value) -> Value {
 fn to_string_tagged_value(v: &Value) -> Result<String, ShellError> {
     match &v.value {
         UntaggedValue::Primitive(Primitive::String(_))
-        | UntaggedValue::Primitive(Primitive::Line(_))
         | UntaggedValue::Primitive(Primitive::Filesize(_))
         | UntaggedValue::Primitive(Primitive::Boolean(_))
         | UntaggedValue::Primitive(Primitive::Decimal(_))

--- a/crates/nu-cli/src/commands/to_json.rs
+++ b/crates/nu-cli/src/commands/to_json.rs
@@ -98,7 +98,6 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
         UntaggedValue::Primitive(Primitive::Nothing) => serde_json::Value::Null,
         UntaggedValue::Primitive(Primitive::Pattern(s)) => serde_json::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::String(s)) => serde_json::Value::String(s.clone()),
-        UntaggedValue::Primitive(Primitive::Line(s)) => serde_json::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::ColumnPath(path)) => serde_json::Value::Array(
             path.iter()
                 .map(|x| match &x.unspanned {

--- a/crates/nu-cli/src/commands/to_toml.rs
+++ b/crates/nu-cli/src/commands/to_toml.rs
@@ -60,7 +60,6 @@ fn helper(v: &Value) -> Result<toml::Value, ShellError> {
         }
         UntaggedValue::Primitive(Primitive::Pattern(s)) => toml::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::String(s)) => toml::Value::String(s.clone()),
-        UntaggedValue::Primitive(Primitive::Line(s)) => toml::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::Path(s)) => {
             toml::Value::String(s.display().to_string())
         }

--- a/crates/nu-cli/src/commands/to_yaml.rs
+++ b/crates/nu-cli/src/commands/to_yaml.rs
@@ -60,7 +60,6 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
         UntaggedValue::Primitive(Primitive::Nothing) => serde_yaml::Value::Null,
         UntaggedValue::Primitive(Primitive::Pattern(s)) => serde_yaml::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::String(s)) => serde_yaml::Value::String(s.clone()),
-        UntaggedValue::Primitive(Primitive::Line(s)) => serde_yaml::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::ColumnPath(path)) => {
             let mut out = vec![];
 

--- a/crates/nu-cli/src/commands/url_/mod.rs
+++ b/crates/nu-cli/src/commands/url_/mod.rs
@@ -26,8 +26,7 @@ where
 {
     let a = |url| UntaggedValue::string(action(url));
     let v = match &v.value {
-        UntaggedValue::Primitive(Primitive::String(s))
-        | UntaggedValue::Primitive(Primitive::Line(s)) => match Url::parse(s) {
+        UntaggedValue::Primitive(Primitive::String(s)) => match Url::parse(s) {
             Ok(url) => a(&url).into_value(v.tag()),
             Err(_) => UntaggedValue::string("").into_value(v.tag()),
         },

--- a/crates/nu-cli/src/evaluate/operator.rs
+++ b/crates/nu-cli/src/evaluate/operator.rs
@@ -63,18 +63,6 @@ fn string_contains(
             UntaggedValue::Primitive(Primitive::String(l)),
             UntaggedValue::Primitive(Primitive::String(r)),
         ) => Ok(l.contains(r)),
-        (
-            UntaggedValue::Primitive(Primitive::Line(l)),
-            UntaggedValue::Primitive(Primitive::String(r)),
-        ) => Ok(l.contains(r)),
-        (
-            UntaggedValue::Primitive(Primitive::String(l)),
-            UntaggedValue::Primitive(Primitive::Line(r)),
-        ) => Ok(l.contains(r)),
-        (
-            UntaggedValue::Primitive(Primitive::Line(l)),
-            UntaggedValue::Primitive(Primitive::Line(r)),
-        ) => Ok(l.contains(r)),
         _ => Err((left.type_name(), right.type_name())),
     }
 }

--- a/crates/nu-cli/tests/commands/lines.rs
+++ b/crates/nu-cli/tests/commands/lines.rs
@@ -31,7 +31,7 @@ fn lines_proper_buffering() {
         "#
     ));
 
-    assert_eq!(actual.out, "[8194,4]");
+    assert_eq!(actual.out, "[8193,3]");
 }
 
 #[test]

--- a/crates/nu-data/src/base.rs
+++ b/crates/nu-data/src/base.rs
@@ -146,9 +146,6 @@ pub fn coerce_compare_primitive(
         }
         (Nothing, Nothing) => CompareValues::Booleans(true, true),
         (String(left), String(right)) => CompareValues::String(left.clone(), right.clone()),
-        (Line(left), String(right)) => CompareValues::String(left.clone(), right.clone()),
-        (String(left), Line(right)) => CompareValues::String(left.clone(), right.clone()),
-        (Line(left), Line(right)) => CompareValues::String(left.clone(), right.clone()),
         (Date(left), Date(right)) => CompareValues::Date(*left, *right),
         (Date(left), Duration(right)) => CompareValues::DateDuration(*left, right.clone()),
         (Boolean(left), Boolean(right)) => CompareValues::Booleans(*left, *right),

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -71,7 +71,6 @@ impl InlineShape {
             Primitive::Decimal(decimal) => InlineShape::Decimal(decimal.clone()),
             Primitive::Filesize(bytesize) => InlineShape::Bytesize(*bytesize),
             Primitive::String(string) => InlineShape::String(string.clone()),
-            Primitive::Line(string) => InlineShape::Line(string.clone()),
             Primitive::ColumnPath(path) => InlineShape::ColumnPath(path.clone()),
             Primitive::Pattern(pattern) => InlineShape::Pattern(pattern.clone()),
             Primitive::Boolean(boolean) => InlineShape::Boolean(*boolean),

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -83,7 +83,6 @@ fn helper(v: &Value) -> Result<toml::Value, ShellError> {
         }
         UntaggedValue::Primitive(Primitive::Pattern(s)) => toml::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::String(s)) => toml::Value::String(s.clone()),
-        UntaggedValue::Primitive(Primitive::Line(s)) => toml::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::Path(s)) => {
             toml::Value::String(s.display().to_string())
         }

--- a/crates/nu-data/src/types.rs
+++ b/crates/nu-data/src/types.rs
@@ -81,10 +81,6 @@ impl ExtractType for String {
                 value: UntaggedValue::Primitive(Primitive::String(string)),
                 ..
             } => Ok(string.clone()),
-            Value {
-                value: UntaggedValue::Primitive(Primitive::Line(string)),
-                ..
-            } => Ok(string.clone()),
             other => Err(ShellError::type_error("String", other.spanned_type_name())),
         }
     }

--- a/crates/nu-protocol/src/type_shape.rs
+++ b/crates/nu-protocol/src/type_shape.rs
@@ -140,7 +140,6 @@ impl Type {
             Primitive::Decimal(_) => Type::Decimal,
             Primitive::Filesize(_) => Type::Filesize,
             Primitive::String(_) => Type::String,
-            Primitive::Line(_) => Type::Line,
             Primitive::ColumnPath(_) => Type::ColumnPath,
             Primitive::Pattern(_) => Type::Pattern,
             Primitive::Boolean(_) => Type::Boolean,

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -162,11 +162,6 @@ impl UntaggedValue {
         UntaggedValue::Primitive(Primitive::String(s.into()))
     }
 
-    /// Helper for creating line values
-    pub fn line(s: impl Into<String>) -> UntaggedValue {
-        UntaggedValue::Primitive(Primitive::Line(s.into()))
-    }
-
     /// Helper for creating column-path values
     pub fn column_path(s: &str, span: Span) -> UntaggedValue {
         let s = s.to_string().spanned(span);
@@ -317,7 +312,6 @@ impl Value {
     pub fn as_string(&self) -> Result<String, ShellError> {
         match &self.value {
             UntaggedValue::Primitive(Primitive::String(string)) => Ok(string.clone()),
-            UntaggedValue::Primitive(Primitive::Line(line)) => Ok(line.clone() + "\n"),
             UntaggedValue::Primitive(Primitive::Path(path)) => {
                 Ok(path.to_string_lossy().to_string())
             }
@@ -584,8 +578,6 @@ pub trait StringExt {
     fn to_string_untagged_value(&self) -> UntaggedValue;
     fn to_string_value(&self, tag: Tag) -> Value;
     fn to_string_value_create_tag(&self) -> Value;
-    fn to_line_value(&self, tag: Tag) -> Value;
-    fn to_line_untagged_value(&self) -> UntaggedValue;
     fn to_column_path_value(&self, tag: Tag) -> Value;
     fn to_column_path_untagged_value(&self, span: Span) -> UntaggedValue;
     fn to_pattern_value(&self, tag: Tag) -> Value;
@@ -613,17 +605,6 @@ impl StringExt for String {
 
     fn to_string_untagged_value(&self) -> UntaggedValue {
         UntaggedValue::string(self)
-    }
-
-    fn to_line_value(&self, the_tag: Tag) -> Value {
-        Value {
-            value: UntaggedValue::Primitive(Primitive::Line(self.to_string())),
-            tag: the_tag,
-        }
-    }
-
-    fn to_line_untagged_value(&self) -> UntaggedValue {
-        UntaggedValue::line(self)
     }
 
     fn to_column_path_value(&self, the_tag: Tag) -> Value {
@@ -656,8 +637,6 @@ pub trait StrExt {
     fn to_str_untagged_value(&self) -> UntaggedValue;
     fn to_str_value(&self, tag: Tag) -> Value;
     fn to_str_value_create_tag(&self) -> Value;
-    fn to_line_value(&self, tag: Tag) -> Value;
-    fn to_line_untagged_value(&self) -> UntaggedValue;
     fn to_column_path_value(&self, tag: Tag) -> Value;
     fn to_column_path_untagged_value(&self, span: Span) -> UntaggedValue;
     fn to_pattern_value(&self, tag: Tag) -> Value;
@@ -685,17 +664,6 @@ impl StrExt for &str {
 
     fn to_str_untagged_value(&self) -> UntaggedValue {
         UntaggedValue::string(*self)
-    }
-
-    fn to_line_value(&self, the_tag: Tag) -> Value {
-        Value {
-            value: UntaggedValue::Primitive(Primitive::Line(self.to_string())),
-            tag: the_tag,
-        }
-    }
-
-    fn to_line_untagged_value(&self) -> UntaggedValue {
-        UntaggedValue::line(*self)
     }
 
     fn to_column_path_value(&self, the_tag: Tag) -> Value {
@@ -1013,12 +981,6 @@ mod tests {
             "a_string".to_string().to_string_value_create_tag(),
             expected
         );
-    }
-
-    #[test]
-    fn test_string_to_line_untagged_value() {
-        let a_line = r"this is some line\n";
-        assert_eq!(a_line.to_line_untagged_value(), UntaggedValue::line(a_line));
     }
 
     #[test]

--- a/crates/nu-protocol/src/value/debug.rs
+++ b/crates/nu-protocol/src/value/debug.rs
@@ -35,7 +35,6 @@ impl PrettyType for Primitive {
             Primitive::Decimal(_) => ty("decimal"),
             Primitive::Filesize(_) => ty("filesize"),
             Primitive::String(_) => ty("string"),
-            Primitive::Line(_) => ty("line"),
             Primitive::ColumnPath(_) => ty("column-path"),
             Primitive::Pattern(_) => ty("pattern"),
             Primitive::Boolean(_) => ty("boolean"),
@@ -73,7 +72,6 @@ impl PrettyDebug for Primitive {
             }
             Primitive::Filesize(bytes) => primitive_doc(bytes, "filesize"),
             Primitive::String(string) => prim(string),
-            Primitive::Line(string) => prim(string),
             Primitive::ColumnPath(path) => path.pretty(),
             Primitive::Pattern(pattern) => primitive_doc(pattern, "pattern"),
             Primitive::Boolean(boolean) => match boolean {

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -34,8 +34,6 @@ pub enum Primitive {
     Filesize(u64),
     /// A string value
     String(String),
-    /// A string value with an implied carriage return (or cr/lf) ending
-    Line(String),
     /// A path to travel to reach a value in a table
     ColumnPath(ColumnPath),
     /// A glob pattern, eg foo*
@@ -235,7 +233,6 @@ impl ShellTypeName for Primitive {
             Primitive::Decimal(_) => "decimal",
             Primitive::Filesize(_) => "filesize(in bytes)",
             Primitive::String(_) => "string",
-            Primitive::Line(_) => "line",
             Primitive::ColumnPath(_) => "column path",
             Primitive::Pattern(_) => "pattern",
             Primitive::Boolean(_) => "boolean",
@@ -294,7 +291,6 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
         ),
         Primitive::Pattern(s) => s.to_string(),
         Primitive::String(s) => s.to_owned(),
-        Primitive::Line(s) => s.to_owned(),
         Primitive::ColumnPath(p) => {
             let mut members = p.iter();
             let mut f = String::new();

--- a/crates/nu-stream/src/input.rs
+++ b/crates/nu-stream/src/input.rs
@@ -61,13 +61,6 @@ impl InputStream {
                     bytes.extend_from_slice(&s.into_bytes());
                 }
                 Some(Value {
-                    value: UntaggedValue::Primitive(Primitive::Line(s)),
-                    tag: value_t,
-                }) => {
-                    value_tag = value_t;
-                    bytes.extend_from_slice(&s.into_bytes());
-                }
-                Some(Value {
                     value: UntaggedValue::Primitive(Primitive::Binary(b)),
                     tag: value_t,
                 }) => {

--- a/crates/nu_plugin_post/src/post.rs
+++ b/crates/nu_plugin_post/src/post.rs
@@ -380,7 +380,6 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
         UntaggedValue::Primitive(Primitive::Nothing) => serde_json::Value::Null,
         UntaggedValue::Primitive(Primitive::Pattern(s)) => serde_json::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::String(s)) => serde_json::Value::String(s.clone()),
-        UntaggedValue::Primitive(Primitive::Line(s)) => serde_json::Value::String(s.clone()),
         UntaggedValue::Primitive(Primitive::ColumnPath(path)) => serde_json::Value::Array(
             path.iter()
                 .map(|x| match &x.unspanned {

--- a/crates/nu_plugin_to_bson/src/to_bson.rs
+++ b/crates/nu_plugin_to_bson/src/to_bson.rs
@@ -46,7 +46,6 @@ pub fn value_to_bson_value(v: &Value) -> Result<Bson, ShellError> {
         }
         UntaggedValue::Primitive(Primitive::Nothing) => Bson::Null,
         UntaggedValue::Primitive(Primitive::String(s)) => Bson::String(s.clone()),
-        UntaggedValue::Primitive(Primitive::Line(s)) => Bson::String(s.clone()),
         UntaggedValue::Primitive(Primitive::ColumnPath(path)) => Bson::Array(
             path.iter()
                 .map(|x| match &x.unspanned {

--- a/crates/nu_plugin_to_sqlite/src/to_sqlite.rs
+++ b/crates/nu_plugin_to_sqlite/src/to_sqlite.rs
@@ -47,7 +47,6 @@ fn nu_value_to_sqlite_string(v: Value) -> String {
             Primitive::Filesize(u) => format!("{}", u),
             Primitive::Pattern(s) => format!("'{}'", s.replace("'", "''")),
             Primitive::String(s) => format!("'{}'", s.replace("'", "''")),
-            Primitive::Line(s) => format!("'{}'", s.replace("'", "''")),
             Primitive::Boolean(true) => "1".into(),
             Primitive::Boolean(_) => "0".into(),
             Primitive::Date(d) => format!("'{}'", d),


### PR DESCRIPTION
This removes the line primitive. Now that we support `char newline`, it's easier to recreate newlines. It also turns out that the original separation of string into string and line turned into far too much complication and confusion.

Now, you can use `lines` to parse through input from an external and then `each` on the values, and they work more like you'd expect