### PR TITLE
Treat all the startup commands as a single script file

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -359,11 +359,12 @@ async fn run_startup_commands(
                 value: UntaggedValue::Table(pipelines),
                 ..
             } => {
+                let mut script_file = String::new();
                 for pipeline in pipelines {
-                    if let Ok(pipeline_string) = pipeline.as_string() {
-                        let _ = run_script_standalone(pipeline_string, false, context, false).await;
-                    }
+                    script_file.push_str(&pipeline.as_string()?);
+                    script_file.push('\n');
                 }
+                let _ = run_script_standalone(script_file, false, context, false).await;
             }
             _ => {
                 return Err(ShellError::untagged_runtime_error(


### PR DESCRIPTION
Glue all the lines from the startup array into a single script file and run that instead of running each individual line separately.