### PR TITLE
Add aliased command to which output

### DIFF
--- a/crates/nu-cli/src/commands/which_.rs
+++ b/crates/nu-cli/src/commands/which_.rs
@@ -61,7 +61,15 @@ fn get_entries_in_aliases(scope: &Scope, name: &str, tag: Tag) -> Vec<Value> {
         .get_aliases_with_name(name)
         .unwrap_or_default()
         .into_iter()
-        .map(|_| create_entry!(name, "Nushell alias", tag.clone(), false))
+        .flatten()
+        .map(|alias| {
+            create_entry!(
+                name,
+                format!("Nushell alias: {}", alias.item),
+                tag.clone(),
+                false
+            )
+        })
         .collect::<Vec<_>>();
     trace!("Found {} aliases", aliases.len());
     aliases

--- a/crates/nu-cli/src/commands/which_.rs
+++ b/crates/nu-cli/src/commands/which_.rs
@@ -61,11 +61,17 @@ fn get_entries_in_aliases(scope: &Scope, name: &str, tag: Tag) -> Vec<Value> {
         .get_aliases_with_name(name)
         .unwrap_or_default()
         .into_iter()
-        .flatten()
+        .map(|spans| {
+            spans
+                .into_iter()
+                .map(|span| span.item)
+                .collect::<Vec<String>>()
+                .join(" ")
+        })
         .map(|alias| {
             create_entry!(
                 name,
-                format!("Nushell alias: {}", alias.item),
+                format!("Nushell alias: {}", alias),
                 tag.clone(),
                 false
             )

--- a/crates/nu-cli/tests/commands/which.rs
+++ b/crates/nu-cli/tests/commands/which.rs
@@ -17,7 +17,7 @@ fn which_alias_ls() {
         "alias ls = ls -a; which ls | get path | str trim"
     );
 
-    assert_eq!(actual.out, "Nushell alias");
+    assert_eq!(actual.out, "Nushell alias: ls -a");
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn correct_precedence_alias_def_custom() {
         "def ls [] {echo def}; alias ls = echo alias; which ls | get path | str trim"
     );
 
-    assert_eq!(actual.out, "Nushell alias");
+    assert_eq!(actual.out, "Nushell alias: echo alias");
 }
 
 #[test]


### PR DESCRIPTION
This is for issue #1713.

It seems that the others working on this issue dropped it. 

Old behaviour:
```
> alias s = { git status -sb }
> which s
───┬─────┬───────────────┬─────────
 # │ arg │     path      │ builtin
───┼─────┼───────────────┼─────────
 0 │ s   │ Nushell alias │ No
───┴─────┴───────────────┴─────────
```

New behaviour:
```
> alias s = { git status -sb }
> which s
───┬─────┬───────────────────────────────────┬─────────
 # │ arg │               path                │ builtin
───┼─────┼───────────────────────────────────┼─────────
 0 │ s   │ Nushell alias: { git status -sb } │ No
───┴─────┴───────────────────────────────────┴─────────
```

This is my first PR, so apologies if I've done something incorrect.