### PR TITLE
working for comparing filepath to string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,18 +3157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-core-commands"
-version = "0.25.1"
-dependencies = [
- "async-trait",
- "eml-parser",
- "nu-errors",
- "nu-protocol",
- "nu-source",
- "serde 1.0.118",
-]
-
-[[package]]
 name = "nu-data"
 version = "0.25.1"
 dependencies = [

--- a/crates/nu-engine/src/evaluate/operator.rs
+++ b/crates/nu-engine/src/evaluate/operator.rs
@@ -1,4 +1,4 @@
-use nu_data::value;
+use nu_data::{value, value::compare_values};
 use nu_errors::ShellError;
 use nu_protocol::hir::Operator;
 use nu_protocol::{Primitive, ShellTypeName, UntaggedValue, Value};
@@ -79,9 +79,15 @@ fn table_contains(
     left: &UntaggedValue,
     right: &UntaggedValue,
 ) -> Result<bool, (&'static str, &'static str)> {
-    let left = left.clone();
     match right {
-        UntaggedValue::Table(values) => Ok(values.iter().any(|x| x.value == left)),
+        UntaggedValue::Table(values) => {
+            Ok(values
+                .iter()
+                .any(|x| match compare_values(Operator::Equal, &left, &x.value) {
+                    Ok(coerced) => coerced,
+                    _ => false,
+                }))
+        }
         _ => Err((left.type_name(), right.type_name())),
     }
 }

--- a/crates/nu-engine/tests/evaluate/mod.rs
+++ b/crates/nu-engine/tests/evaluate/mod.rs
@@ -1,0 +1,1 @@
+mod operator;

--- a/crates/nu-engine/tests/evaluate/operator.rs
+++ b/crates/nu-engine/tests/evaluate/operator.rs
@@ -1,0 +1,38 @@
+use nu_test_support::fs::Stub::EmptyFile;
+use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn filter_ls_by_in_array() {
+    Playground::setup("filter_ls_by_1", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("jean-luc.cap"),
+            EmptyFile("riker.cmdr"),
+            EmptyFile("data.ltcmdr"),
+            EmptyFile("troi.ltcmdr"),
+            EmptyFile("worf.lt"),
+            EmptyFile("geordi.lt"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls | where name in ['data.ltcmdr', 'riker.cmdr'] | get name | to json
+            "#
+        ));
+
+        assert_eq!(actual.out, "[\"data.ltcmdr\",\"riker.cmdr\"]");
+    })
+}
+
+#[test]
+fn filter_json_with_in_array() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where size in [2] | get name
+        "#
+    ));
+
+    assert_eq!(actual.out, "foo");
+}

--- a/crates/nu-engine/tests/main.rs
+++ b/crates/nu-engine/tests/main.rs
@@ -1,0 +1,3 @@
+extern crate nu_test_support;
+
+mod evaluate;


### PR DESCRIPTION
I think this fixes the `in` `not-in` command. Here are two tests that I fixed.

```
echo '[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where size in [2]
```
and
```
ls | where name in ['src', 'README.md']
```