### PR TITLE
nu_cli refactor in preparation for a crate called nu_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,18 +3157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-core-commands"
-version = "0.25.1"
-dependencies = [
- "async-trait",
- "eml-parser",
- "nu-errors",
- "nu-protocol",
- "nu-source",
- "serde 1.0.118",
-]
-
-[[package]]
 name = "nu-data"
 version = "0.25.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,6 +3221,7 @@ dependencies = [
  "serde 1.0.118",
  "serde_json",
  "tempfile",
+ "term_size",
  "termcolor",
  "umask",
  "users",

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -1,12 +1,12 @@
 use crate::commands::default_context::create_default_context;
 use crate::env::basic_host::BasicHost;
 use crate::line_editor::configure_ctrl_c;
+use nu_engine::basic_shell_manager;
 use nu_engine::run_block;
 use nu_engine::EvaluationContext;
-use nu_engine::{FilesystemShell, Scope, ShellManager};
+use nu_engine::Scope;
 use parking_lot::Mutex;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
 #[allow(unused_imports)]
@@ -85,13 +85,6 @@ pub fn maybe_print_errors(context: &EvaluationContext, source: Text) -> bool {
     }
 }
 
-pub fn basic_shell_manager() -> Result<ShellManager, Box<dyn Error>> {
-    Ok(ShellManager {
-        current_shell: Arc::new(AtomicUsize::new(0)),
-        shells: Arc::new(Mutex::new(vec![Box::new(FilesystemShell::basic()?)])),
-    })
-}
-
 pub fn basic_evaluation_context() -> Result<EvaluationContext, Box<dyn Error>> {
     Ok(EvaluationContext {
         scope: Scope::new(),
@@ -99,7 +92,7 @@ pub fn basic_evaluation_context() -> Result<EvaluationContext, Box<dyn Error>> {
         current_errors: Arc::new(Mutex::new(vec![])),
         ctrl_c: Arc::new(AtomicBool::new(false)),
         user_recently_used_autoenv_untrust: Arc::new(AtomicBool::new(false)),
-        shell_manager: crate::cli::basic_shell_manager()?,
+        shell_manager: basic_shell_manager::basic_shell_manager()?,
         windows_drives_previous_cwd: Arc::new(Mutex::new(std::collections::HashMap::new())),
     })
 }

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -1,13 +1,7 @@
 use crate::commands::default_context::create_default_context;
-use crate::env::basic_host::BasicHost;
 use crate::line_editor::configure_ctrl_c;
-use nu_engine::basic_shell_manager;
 use nu_engine::run_block;
 use nu_engine::EvaluationContext;
-use nu_engine::Scope;
-use parking_lot::Mutex;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
 #[allow(unused_imports)]
 pub(crate) use crate::script::{process_script, LineResult};
@@ -83,18 +77,6 @@ pub fn maybe_print_errors(context: &EvaluationContext, source: Text) -> bool {
     } else {
         false
     }
-}
-
-pub fn basic_evaluation_context() -> Result<EvaluationContext, Box<dyn Error>> {
-    Ok(EvaluationContext {
-        scope: Scope::new(),
-        host: Arc::new(parking_lot::Mutex::new(Box::new(BasicHost))),
-        current_errors: Arc::new(Mutex::new(vec![])),
-        ctrl_c: Arc::new(AtomicBool::new(false)),
-        user_recently_used_autoenv_untrust: Arc::new(AtomicBool::new(false)),
-        shell_manager: basic_shell_manager::basic_shell_manager()?,
-        windows_drives_previous_cwd: Arc::new(Mutex::new(std::collections::HashMap::new())),
-    })
 }
 
 pub async fn run_script_file(
@@ -438,13 +420,14 @@ pub async fn parse_and_eval(line: &str, ctx: &EvaluationContext) -> Result<Strin
 
 #[cfg(test)]
 mod tests {
+    use nu_engine::basic_evaluation_context;
 
     #[quickcheck]
     fn quickcheck_parse(data: String) -> bool {
         let (tokens, err) = nu_parser::lex(&data, 0);
         let (lite_block, err2) = nu_parser::block(tokens);
         if err.is_none() && err2.is_none() {
-            let context = crate::cli::basic_evaluation_context().unwrap();
+            let context = basic_evaluation_context().unwrap();
             let _ = nu_parser::classify_block(&lite_block, &context.scope);
         }
         true

--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -538,10 +538,11 @@ mod tests {
     #[cfg(feature = "which")]
     use futures::executor::block_on;
     #[cfg(feature = "which")]
+    use nu_engine::basic_evaluation_context;
+    #[cfg(feature = "which")]
     use nu_errors::ShellError;
     #[cfg(feature = "which")]
     use nu_test_support::commands::ExternalBuilder;
-
     // async fn read(mut stream: OutputStream) -> Option<Value> {
     //     match stream.try_next().await {
     //         Ok(val) => {

--- a/crates/nu-cli/src/commands/classified/external.rs
+++ b/crates/nu-cli/src/commands/classified/external.rs
@@ -561,8 +561,8 @@ mod tests {
         let cmd = ExternalBuilder::for_name("i_dont_exist.exe").build();
 
         let input = InputStream::empty();
-        let mut ctx = crate::cli::basic_evaluation_context()
-            .expect("There was a problem creating a basic context.");
+        let mut ctx =
+            basic_evaluation_context().expect("There was a problem creating a basic context.");
 
         assert!(
             run_external_command(cmd, &mut ctx, input, ExternalRedirection::Stdout)

--- a/crates/nu-cli/src/commands/default_context.rs
+++ b/crates/nu-cli/src/commands/default_context.rs
@@ -1,9 +1,10 @@
 use crate::prelude::*;
+use nu_engine::basic_evaluation_context;
 use nu_engine::whole_stream_command;
 use std::error::Error;
 
 pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Box<dyn Error>> {
-    let context = crate::cli::basic_evaluation_context()?;
+    let context = basic_evaluation_context()?;
 
     {
         use crate::commands::*;

--- a/crates/nu-cli/src/env.rs
+++ b/crates/nu-cli/src/env.rs
@@ -1,4 +1,3 @@
-pub(crate) mod basic_host;
 pub(crate) mod directory_specific_environment;
 pub(crate) mod environment;
 pub(crate) mod environment_syncer;

--- a/crates/nu-cli/src/env/environment_syncer.rs
+++ b/crates/nu-cli/src/env/environment_syncer.rs
@@ -155,6 +155,7 @@ mod tests {
     use super::EnvironmentSyncer;
     use indexmap::IndexMap;
     use nu_data::config::tests::FakeConfig;
+    use nu_engine::basic_evaluation_context;
     use nu_engine::Env;
     use nu_errors::ShellError;
     use nu_test_support::fs::Stub::FileWithContent;
@@ -170,7 +171,7 @@ mod tests {
     #[test]
     fn syncs_env_if_new_env_entry_is_added_to_an_existing_configuration() -> Result<(), ShellError>
     {
-        let mut ctx = crate::cli::basic_evaluation_context()?;
+        let mut ctx = basic_evaluation_context()?;
         ctx.host = Arc::new(Mutex::new(Box::new(nu_engine::FakeHost::new())));
 
         let mut expected = IndexMap::new();
@@ -273,7 +274,7 @@ mod tests {
     #[test]
     fn syncs_env_if_new_env_entry_in_session_is_not_in_configuration_file() -> Result<(), ShellError>
     {
-        let mut ctx = crate::cli::basic_evaluation_context()?;
+        let mut ctx = basic_evaluation_context()?;
         ctx.host = Arc::new(Mutex::new(Box::new(nu_engine::FakeHost::new())));
 
         let mut expected = IndexMap::new();
@@ -372,7 +373,7 @@ mod tests {
 
     #[test]
     fn nu_envs_have_higher_priority_and_does_not_get_overwritten() -> Result<(), ShellError> {
-        let mut ctx = crate::cli::basic_evaluation_context()?;
+        let mut ctx = basic_evaluation_context()?;
         ctx.host = Arc::new(Mutex::new(Box::new(nu_engine::FakeHost::new())));
 
         let mut expected = IndexMap::new();
@@ -448,7 +449,7 @@ mod tests {
     #[test]
     fn syncs_path_if_new_path_entry_in_session_is_not_in_configuration_file(
     ) -> Result<(), ShellError> {
-        let mut ctx = crate::cli::basic_evaluation_context()?;
+        let mut ctx = basic_evaluation_context()?;
         ctx.host = Arc::new(Mutex::new(Box::new(nu_engine::FakeHost::new())));
 
         let expected = std::env::join_paths(vec![
@@ -535,7 +536,7 @@ mod tests {
     #[test]
     fn nu_paths_have_higher_priority_and_new_paths_get_appended_to_the_end(
     ) -> Result<(), ShellError> {
-        let mut ctx = crate::cli::basic_evaluation_context()?;
+        let mut ctx = basic_evaluation_context()?;
         ctx.host = Arc::new(Mutex::new(Box::new(nu_engine::FakeHost::new())));
 
         let expected = std::env::join_paths(vec![

--- a/crates/nu-cli/src/examples.rs
+++ b/crates/nu-cli/src/examples.rs
@@ -1,3 +1,4 @@
+use nu_engine::basic_evaluation_context;
 use nu_errors::ShellError;
 use nu_parser::ParserScope;
 use nu_protocol::hir::ClassifiedBlock;
@@ -25,7 +26,7 @@ use serde::Deserialize;
 pub fn test_examples(cmd: Command) -> Result<(), ShellError> {
     let examples = cmd.examples();
 
-    let base_context = crate::cli::basic_evaluation_context()?;
+    let base_context = basic_evaluation_context()?;
 
     base_context.add_commands(vec![
         // Mocks
@@ -89,7 +90,7 @@ pub fn test_examples(cmd: Command) -> Result<(), ShellError> {
 pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
     let examples = cmd.examples();
 
-    let base_context = crate::cli::basic_evaluation_context()?;
+    let base_context = basic_evaluation_context()?;
 
     base_context.add_commands(vec![
         whole_stream_command(Echo {}),
@@ -145,7 +146,7 @@ pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
 pub fn test_anchors(cmd: Command) -> Result<(), ShellError> {
     let examples = cmd.examples();
 
-    let base_context = crate::cli::basic_evaluation_context()?;
+    let base_context = basic_evaluation_context()?;
 
     base_context.add_commands(vec![
         // Minimal restricted commands to aid in testing

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -39,6 +39,7 @@ serde = {version = "1.0.115", features = ["derive"]}
 serde_json = "1.0.57"
 tempfile = "3.1.0"
 termcolor = "1.1.0"
+term_size = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
 umask = "1.0.0"

--- a/crates/nu-engine/src/basic_evaluation_context.rs
+++ b/crates/nu-engine/src/basic_evaluation_context.rs
@@ -1,0 +1,20 @@
+use crate::basic_shell_manager;
+use crate::env::basic_host::BasicHost;
+use crate::EvaluationContext;
+use crate::Scope;
+use parking_lot::Mutex;
+use std::error::Error;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+pub fn basic_evaluation_context() -> Result<EvaluationContext, Box<dyn Error>> {
+    Ok(EvaluationContext {
+        scope: Scope::new(),
+        host: Arc::new(parking_lot::Mutex::new(Box::new(BasicHost))),
+        current_errors: Arc::new(Mutex::new(vec![])),
+        ctrl_c: Arc::new(AtomicBool::new(false)),
+        user_recently_used_autoenv_untrust: Arc::new(AtomicBool::new(false)),
+        shell_manager: basic_shell_manager::basic_shell_manager()?,
+        windows_drives_previous_cwd: Arc::new(Mutex::new(std::collections::HashMap::new())),
+    })
+}

--- a/crates/nu-engine/src/basic_shell_manager.rs
+++ b/crates/nu-engine/src/basic_shell_manager.rs
@@ -1,0 +1,14 @@
+use crate::filesystem::filesystem_shell::FilesystemShell;
+use crate::shell::shell_manager::ShellManager;
+
+use parking_lot::Mutex;
+use std::error::Error;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+pub fn basic_shell_manager() -> Result<ShellManager, Box<dyn Error>> {
+    Ok(ShellManager {
+        current_shell: Arc::new(AtomicUsize::new(0)),
+        shells: Arc::new(Mutex::new(vec![Box::new(FilesystemShell::basic()?)])),
+    })
+}

--- a/crates/nu-engine/src/env/basic_host.rs
+++ b/crates/nu-engine/src/env/basic_host.rs
@@ -1,4 +1,4 @@
-use nu_engine::Host;
+use crate::Host;
 use nu_protocol::{errln, outln};
 use std::ffi::OsString;
 

--- a/crates/nu-engine/src/env/mod.rs
+++ b/crates/nu-engine/src/env/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod basic_host;
 pub(crate) mod environment;
 pub(crate) mod host;

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod basic_shell_manager;
 mod call_info;
 mod command_args;
 pub mod deserializer;
@@ -13,6 +14,7 @@ pub mod plugin;
 pub mod shell;
 mod whole_stream_command;
 
+pub use crate::basic_shell_manager::basic_shell_manager;
 pub use crate::call_info::UnevaluatedCallInfo;
 pub use crate::command_args::{
     CommandArgs, EvaluatedCommandArgs, EvaluatedWholeStreamCommandArgs, RawCommandArgs,

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod basic_evaluation_context;
 pub mod basic_shell_manager;
 mod call_info;
 mod command_args;
@@ -14,6 +15,7 @@ pub mod plugin;
 pub mod shell;
 mod whole_stream_command;
 
+pub use crate::basic_evaluation_context::basic_evaluation_context;
 pub use crate::basic_shell_manager::basic_shell_manager;
 pub use crate::call_info::UnevaluatedCallInfo;
 pub use crate::command_args::{


### PR DESCRIPTION
getting the dependencies correct so that things will more easily move across to the crate nu_command...

move basic_shell_manager and basic_evaluation_context to nu_engine
