### PR TITLE
Don't print description in help if none exists

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -127,8 +127,11 @@ pub fn get_documentation(
     let signature = cmd.signature();
     let mut long_desc = String::new();
 
-    long_desc.push_str(&cmd.usage());
-    long_desc.push('\n');
+    let usage = &cmd.usage();
+    if !usage.is_empty() {
+        long_desc.push_str(usage);
+        long_desc.push_str("\n\n");
+    }
 
     let mut subcommands = vec![];
     if !config.no_subcommands {
@@ -168,7 +171,7 @@ pub fn get_documentation(
         one_liner.push_str("{flags} ");
     }
 
-    long_desc.push_str(&format!("\nUsage:\n  > {}\n", one_liner));
+    long_desc.push_str(&format!("Usage:\n  > {}\n", one_liner));
 
     if !subcommands.is_empty() {
         long_desc.push_str("\nSubcommands:\n");


### PR DESCRIPTION
This fixes #2912.

On a side note, is there any reason why this method is named `usage`? The method returns the description of the command, not the usage text.