### PR TITLE
Improve tab completion behaviour

### DIFF
--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -51,7 +51,28 @@ impl rustyline::completion::Completer for Helper {
     }
 
     fn update(&self, line: &mut rustyline::line_buffer::LineBuffer, start: usize, elected: &str) {
-        let end = line.pos();
+        let end = start
+            + match line
+                .as_str()
+                .chars()
+                .into_iter()
+                .skip(start)
+                .zip(elected.chars().into_iter())
+                .enumerate()
+                .skip_while(|(_, (line, replace))| line == replace)
+                .next()
+            {
+                Some((index, (_, _))) => index,
+                None => line.pos(),
+            };
+
+        let mut end = end.max(line.pos());
+
+        let remaining = &line.as_str()[end..];
+        if remaining.starts_with('"') {
+            end += 1;
+        }
+
         line.replace(start..end, elected)
     }
 }

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -59,8 +59,7 @@ impl rustyline::completion::Completer for Helper {
                 .skip(start)
                 .zip(elected.chars().into_iter())
                 .enumerate()
-                .skip_while(|(_, (line, replace))| line == replace)
-                .next()
+                .find(|(_, (line, replace))| line != replace)
             {
                 Some((index, (_, _))) => index,
                 None => line.pos(),

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -164,3 +164,49 @@ fn vec_tag<T>(input: Vec<Tagged<T>>) -> Option<Tag> {
 }
 
 impl rustyline::Helper for Helper {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_engine::basic_evaluation_context;
+    use rustyline::completion::Completer;
+    use rustyline::line_buffer::LineBuffer;
+
+    #[test]
+    fn closing_quote_should_replaced() {
+        let text = "cd \"folder with spaces\\subdirectory\\\"";
+        let replacement = "\"folder with spaces\\subdirectory\\subsubdirectory\\\"";
+
+        let mut buffer = LineBuffer::with_capacity(256);
+        buffer.insert_str(0, text);
+        buffer.set_pos(text.len() - 1);
+
+        let helper = Helper::new(basic_evaluation_context().unwrap(), None);
+
+        helper.update(&mut buffer, "cd ".len(), &replacement);
+
+        assert_eq!(
+            buffer.as_str(),
+            "cd \"folder with spaces\\subdirectory\\subsubdirectory\\\""
+        );
+    }
+
+    #[test]
+    fn replacement_with_cursor_in_text() {
+        let text = "cd \"folder with spaces\\subdirectory\\\"";
+        let replacement = "\"folder with spaces\\subdirectory\\subsubdirectory\\\"";
+
+        let mut buffer = LineBuffer::with_capacity(256);
+        buffer.insert_str(0, text);
+        buffer.set_pos(text.len() - 30);
+
+        let helper = Helper::new(basic_evaluation_context().unwrap(), None);
+
+        helper.update(&mut buffer, "cd ".len(), &replacement);
+
+        assert_eq!(
+            buffer.as_str(),
+            "cd \"folder with spaces\\subdirectory\\subsubdirectory\\\""
+        );
+    }
+}


### PR DESCRIPTION
This fixes #2892 as well some improvements to tab completion when the cursor is located inside the quoted text.

The original issue showed that if the cursor was positioned on the closing quote then an 'extra' quote would be added. During testing I found that the root issue is that text is incorrectly replaced if the cursor is not located at the end of the text to be replaced.

Line contents:
```
 cd "Program Files (x86)\Adobe\Adobe Creative Cloud\"
                         ^
                         Position cursor here and use tab completion
```
Resulting Replacement:
```
cd "Program Files (x86)\Adobe\Adobe Creative Cloud\ACC\"Adobe Creative Cloud\"
```

The existing code incorrectly uses the cursor position to calculate how much text to replace rather than the length of the text to be replaced. The new code calculates the offset of the first differing character between the existing line text and the replacement text and uses that to ensure that text to the right of the cursor only contains new characters.