### PR TITLE
macos cli config dir change

### DIFF
--- a/Cargo.lock.orig
+++ b/Cargo.lock.orig
@@ -3180,6 +3180,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "nu-command"
 version = "0.25.2"
 dependencies = [
@@ -3200,6 +3201,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "derive-new",
+ "directories 3.0.1",
  "dirs 3.0.1",
  "dtparse",
  "dunce",
@@ -3282,6 +3284,21 @@ dependencies = [
 ]
 
 [[package]]
+||||||| constructed merge base
+name = "nu-core-commands"
+version = "0.25.2"
+dependencies = [
+ "async-trait",
+ "eml-parser",
+ "nu-errors",
+ "nu-protocol",
+ "nu-source",
+ "serde 1.0.118",
+]
+
+[[package]]
+=======
+>>>>>>> macos cli config dir change
 name = "nu-data"
 version = "0.25.2"
 dependencies = [

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -42,7 +42,7 @@ codespan-reporting = "0.11.0"
 csv = "1.1.3"
 ctrlc = {version = "3.1.6", optional = true}
 derive-new = "0.5.8"
-directories = {version = "3.0.1", optional = true}
+# directories = {version = "3.0.1", optional = true}
 dirs = {version = "3.0.1", optional = true}
 dtparse = "1.2.0"
 dunce = "1.0.1"
@@ -133,3 +133,4 @@ rich-benchmark = ["heim"]
 rustyline-support = ["rustyline"]
 stable = []
 trash-support = ["trash"]
+directories = []

--- a/crates/nu-cli/src/keybinding.rs
+++ b/crates/nu-cli/src/keybinding.rs
@@ -405,14 +405,10 @@ pub struct Keybinding {
 
 type Keybindings = Vec<Keybinding>;
 
-pub(crate) fn keybinding_path() -> Result<std::path::PathBuf, nu_errors::ShellError> {
-    nu_data::config::default_path_for(&Some(std::path::PathBuf::from("keybindings.yml")))
-}
-
 pub(crate) fn load_keybindings(
     rl: &mut rustyline::Editor<crate::shell::Helper>,
 ) -> Result<(), nu_errors::ShellError> {
-    let filename = keybinding_path()?;
+    let filename = nu_data::keybinding::keybinding_path()?;
     let contents = std::fs::read_to_string(filename);
 
     // Silently fail if there is no file there

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -41,7 +41,6 @@ codespan-reporting = "0.11.0"
 csv = "1.1.3"
 ctrlc = {version = "3.1.6", optional = true}
 derive-new = "0.5.8"
-directories = {version = "3.0.1", optional = true}
 dirs = {version = "3.0.1", optional = true}
 dtparse = "1.2.0"
 dunce = "1.0.1"
@@ -132,3 +131,4 @@ rich-benchmark = ["heim"]
 rustyline-support = ["rustyline"]
 stable = []
 trash-support = ["trash"]
+directories = []

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -16,7 +16,7 @@ byte-unit = "4.0.9"
 
 chrono = "0.4.15"
 derive-new = "0.5.8"
-directories = {version = "3.0.1", optional = true}
+etcetera = {version = "0.3.2", optional = true}
 dirs = {version = "3.0.1", optional = true}
 getset = "0.1.1"
 indexmap = {version = "1.6.0", features = ["serde-1"]}
@@ -38,3 +38,6 @@ nu-value-ext = {version = "0.25.2", path = "../nu-value-ext"}
 
 [target.'cfg(unix)'.dependencies]
 users = "0.10.0"
+
+[features]
+directories = ["etcetera"]

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -145,11 +145,17 @@ pub fn value_to_toml_value(v: &Value) -> Result<toml::Value, ShellError> {
 
 #[cfg(feature = "directories")]
 pub fn config_path() -> Result<PathBuf, ShellError> {
-    use directories::ProjectDirs;
+    use etcetera::app_strategy;
+    use etcetera::app_strategy::AppStrategy;
+    use etcetera::app_strategy::AppStrategyArgs;
 
-    let dir = ProjectDirs::from("org", "nushell", "nu")
-        .ok_or_else(|| ShellError::untagged_runtime_error("Couldn't find project directory"))?;
-    let path = ProjectDirs::config_dir(&dir).to_owned();
+    let strategy = app_strategy::choose_app_strategy(AppStrategyArgs {
+        top_level_domain: "org".to_string(),
+        author: "nushell".to_string(),
+        app_name: "nu".to_string(),
+    })
+    .map_err(|_| ShellError::untagged_runtime_error("Couldn't find config directory"))?;
+    let path = strategy.config_dir();
     std::fs::create_dir_all(&path).map_err(|err| {
         ShellError::untagged_runtime_error(&format!("Couldn't create {} path:\n{}", "config", err))
     })?;
@@ -181,11 +187,17 @@ pub fn default_path_for(file: &Option<PathBuf>) -> Result<PathBuf, ShellError> {
 
 #[cfg(feature = "directories")]
 pub fn user_data() -> Result<PathBuf, ShellError> {
-    use directories::ProjectDirs;
+    use etcetera::app_strategy;
+    use etcetera::app_strategy::AppStrategy;
+    use etcetera::app_strategy::AppStrategyArgs;
 
-    let dir = ProjectDirs::from("org", "nushell", "nu")
-        .ok_or_else(|| ShellError::untagged_runtime_error("Couldn't find project directory"))?;
-    let path = ProjectDirs::data_local_dir(&dir).to_owned();
+    let strategy = app_strategy::choose_app_strategy(AppStrategyArgs {
+        top_level_domain: "org".to_string(),
+        author: "nushell".to_string(),
+        app_name: "nu".to_string(),
+    })
+    .map_err(|_| ShellError::untagged_runtime_error("Couldn't find config directory"))?;
+    let path = strategy.data_dir();
     std::fs::create_dir_all(&path).map_err(|err| {
         ShellError::untagged_runtime_error(&format!(
             "Couldn't create {} path:\n{}",

--- a/crates/nu-data/src/keybinding.rs
+++ b/crates/nu-data/src/keybinding.rs
@@ -1,0 +1,3 @@
+pub fn keybinding_path() -> Result<std::path::PathBuf, nu_errors::ShellError> {
+    crate::config::default_path_for(&Some(std::path::PathBuf::from("keybindings.yml")))
+}

--- a/crates/nu-data/src/lib.rs
+++ b/crates/nu-data/src/lib.rs
@@ -2,6 +2,7 @@ pub mod base;
 pub mod command;
 pub mod config;
 pub mod dict;
+pub mod keybinding;
 pub mod primitive;
 pub mod types;
 pub mod utils;

--- a/crates/nu-engine/src/evaluate/variables.rs
+++ b/crates/nu-engine/src/evaluate/variables.rs
@@ -45,9 +45,9 @@ pub fn nu(env: &IndexMap<String, String>, tag: impl Into<Tag>) -> Result<Value, 
         UntaggedValue::filepath(config).into_value(&tag),
     );
 
-    #[cfg(feature = "rustyline-support")]
+    // #[cfg(feature = "rustyline-support")]
     {
-        let keybinding_path = crate::keybinding::keybinding_path()?;
+        let keybinding_path = nu_data::keybinding::keybinding_path()?;
         nu_dict.insert_value(
             "keybinding-path",
             UntaggedValue::filepath(keybinding_path).into_value(&tag),


### PR DESCRIPTION
Change to use `etcetera` instead of `directories` to resolve config and user data directories. This change uses the Xdg strategy on anything but windows and should only impact macOs users as the config location will change from `~/Library/Application Support/org.nushell.nu` to `~/.config/nu` which is more standard for cli tools on macOs.

Before:
```
┬────────────────────────────────────┬────────────────────────────────────────┬───────────────────────────────────
│            config-path             │            keybinding-path             │            history-path
┼────────────────────────────────────┼────────────────────────────────────────┼───────────────────────────────────
│ /Users/aras/Library/Application    │ /Users/aras/Library/Application        │ /Users/aras/Library/Application
│ Support/org.nushell.nu/config.toml │ Support/org.nushell.nu/keybindings.yml │ Support/org.nushell.nu/history.txt
┴────────────────────────────────────┴────────────────────────────────────────┴───────────────────────────────────
```

After:
```
┬────────────────────────────────────┬─────────────────────────────────────────
│            config-path             │              history-path
┼────────────────────────────────────┼─────────────────────────────────────────
│ /Users/aras/.config/nu/config.toml │ /Users/aras/.local/share/nu/history.txt
┴────────────────────────────────────┴─────────────────────────────────────────
```