### PR TITLE
Change error message; Add docs

### DIFF
--- a/crates/nu-parser/src/parse/def/param_flag_list.rs
+++ b/crates/nu-parser/src/parse/def/param_flag_list.rs
@@ -200,6 +200,12 @@ fn parse_type_token(type_: &Token) -> (SyntaxShape, Option<ParseError>) {
 }
 
 fn parse_param_name(token: &Token) -> (Spanned<String>, Option<ParseError>) {
+    fn error_mismatch_found_type(token: &Token) -> ParseError {
+        let found = "type ".to_string() + &token.contents.to_string();
+        let found = found.spanned(token.span);
+        ParseError::mismatch("parameter name", found)
+    }
+
     match &token.contents {
         TokenContents::Baseline(name) => {
             //Make sure user didn't enter type
@@ -213,21 +219,12 @@ fn parse_param_name(token: &Token) -> (Spanned<String>, Option<ParseError>) {
                 //Okay not a type. Just return name
                 (name, None)
             } else {
-                (
-                    name,
-                    Some(ParseError::mismatch(
-                        "parameter name",
-                        token_to_spanned_string(token),
-                    )),
-                )
+                (name, Some(error_mismatch_found_type(token)))
             }
         }
         _ => (
             "Internal Error".to_string().spanned(token.span),
-            Some(ParseError::mismatch(
-                "parameter name",
-                token_to_spanned_string(token),
-            )),
+            Some(error_mismatch_found_type(token)),
         ),
     }
 }

--- a/docs/commands/def.md
+++ b/docs/commands/def.md
@@ -1,0 +1,17 @@
+# def
+
+Use `def` to create a custom command.
+
+## Examples
+
+```
+> def my_command [] { echo hi nu }
+> my_command
+hi nu
+```
+
+```
+> def my_command [adjective: string, num: int] { echo $adjective $num meet nu }
+> my_command nice 2
+nice 2 meet nu
+```


### PR DESCRIPTION
The error message before
```shell
/home/leo/repos/nushell(main)> def my_command [adjective:string, int:int] {echo $adjective $int meet nu}
error: Type Error
  ┌─ shell:2:35
  │
2 │ def my_command [adjective:string, int:int] {echo $adjective $int meet nu}
  │                                   ^^^ Expected parameter name, found int
                                                                       ^^^^

```

The error message now
```shell
/home/leo/repos/nushell(main)> def my_command [adjective:string, int:int] {echo $adjective $int meet nu}
error: Type Error
  ┌─ shell:1:35
  │
1 │ def my_command [adjective:string, int:int] {echo $adjective $int meet nu}
  │                                   ^^^ Expected parameter name, found type int
                                                                       ^^^^^^^^

```

Also added documentation for the def command.