### PR TITLE
remove set from windows cmd_builtins

### DIFF
--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -464,7 +464,7 @@ pub fn did_find_command(#[allow(unused)] name: &str) -> bool {
             let cmd_builtins = [
                 "assoc", "break", "color", "copy", "date", "del", "dir", "dpath", "echo", "erase",
                 "for", "ftype", "md", "mkdir", "mklink", "move", "path", "ren", "rename", "rd",
-                "rmdir", "set", "start", "time", "title", "type", "ver", "verify", "vol",
+                "rmdir", "start", "time", "title", "type", "ver", "verify", "vol",
             ];
 
             cmd_builtins.contains(&name)


### PR DESCRIPTION
with `set` removed, if someone (like me) does `set x = 5` they'll get an error like this:

```
set fg = 5
error: Command not found
  ┌─ shell:2:1
  │
2 │ set fg = 5
  │ ^^^ command not found
```
