### PR TITLE
move keybinding_path to nu-data

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -130,6 +130,6 @@ quickcheck_macros = "0.9.1"
 [features]
 clipboard-cli = ["arboard"]
 rich-benchmark = ["heim"]
-rustyline-support = ["rustyline"]
+rustyline-support = ["rustyline", "nu-engine/rustyline-support"]
 stable = []
 trash-support = ["trash"]

--- a/crates/nu-cli/src/keybinding.rs
+++ b/crates/nu-cli/src/keybinding.rs
@@ -405,14 +405,10 @@ pub struct Keybinding {
 
 type Keybindings = Vec<Keybinding>;
 
-pub(crate) fn keybinding_path() -> Result<std::path::PathBuf, nu_errors::ShellError> {
-    nu_data::config::default_path_for(&Some(std::path::PathBuf::from("keybindings.yml")))
-}
-
 pub(crate) fn load_keybindings(
     rl: &mut rustyline::Editor<crate::shell::Helper>,
 ) -> Result<(), nu_errors::ShellError> {
-    let filename = keybinding_path()?;
+    let filename = nu_data::keybinding::keybinding_path()?;
     let contents = std::fs::read_to_string(filename);
 
     // Silently fail if there is no file there

--- a/crates/nu-data/src/keybinding.rs
+++ b/crates/nu-data/src/keybinding.rs
@@ -1,0 +1,3 @@
+pub fn keybinding_path() -> Result<std::path::PathBuf, nu_errors::ShellError> {
+    crate::config::default_path_for(&Some(std::path::PathBuf::from("keybindings.yml")))
+}

--- a/crates/nu-data/src/lib.rs
+++ b/crates/nu-data/src/lib.rs
@@ -2,6 +2,7 @@ pub mod base;
 pub mod command;
 pub mod config;
 pub mod dict;
+pub mod keybinding;
 pub mod primitive;
 pub mod types;
 pub mod utils;

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -48,3 +48,6 @@ users = "0.10.0"
 
 [dev-dependencies]
 nu-test-support = {version = "0.25.2", path = "../nu-test-support"}
+
+[features]
+rustyline-support = []

--- a/crates/nu-engine/src/evaluate/variables.rs
+++ b/crates/nu-engine/src/evaluate/variables.rs
@@ -47,7 +47,7 @@ pub fn nu(env: &IndexMap<String, String>, tag: impl Into<Tag>) -> Result<Value, 
 
     #[cfg(feature = "rustyline-support")]
     {
-        let keybinding_path = crate::keybinding::keybinding_path()?;
+        let keybinding_path = nu_data::keybinding::keybinding_path()?;
         nu_dict.insert_value(
             "keybinding-path",
             UntaggedValue::filepath(keybinding_path).into_value(&tag),


### PR DESCRIPTION
Fix for `keybinding-path` missing on `$nu` after some code shuffling.

