### PR TITLE
Revert tab completion changes

### DIFF
--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -51,27 +51,7 @@ impl rustyline::completion::Completer for Helper {
     }
 
     fn update(&self, line: &mut rustyline::line_buffer::LineBuffer, start: usize, elected: &str) {
-        let end = start
-            + match line
-                .as_str()
-                .chars()
-                .into_iter()
-                .skip(start)
-                .zip(elected.chars().into_iter())
-                .enumerate()
-                .find(|(_, (line, replace))| line != replace)
-            {
-                Some((index, (_, _))) => index,
-                None => line.pos(),
-            };
-
-        let mut end = end.max(line.pos());
-
-        let remaining = &line.as_str()[end..];
-        if remaining.starts_with('"') {
-            end += 1;
-        }
-
+        let end = line.pos();
         line.replace(start..end, elected)
     }
 }
@@ -165,6 +145,7 @@ fn vec_tag<T>(input: Vec<Tagged<T>>) -> Option<Tag> {
 
 impl rustyline::Helper for Helper {}
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -172,6 +153,7 @@ mod tests {
     use rustyline::completion::Completer;
     use rustyline::line_buffer::LineBuffer;
 
+    #[ignore]
     #[test]
     fn closing_quote_should_replaced() {
         let text = "cd \"folder with spaces\\subdirectory\\\"";
@@ -191,6 +173,7 @@ mod tests {
         );
     }
 
+    #[ignore]
     #[test]
     fn replacement_with_cursor_in_text() {
         let text = "cd \"folder with spaces\\subdirectory\\\"";

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -145,7 +145,6 @@ fn vec_tag<T>(input: Vec<Tagged<T>>) -> Option<Tag> {
 
 impl rustyline::Helper for Helper {}
 
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Undo changes for now.

Will need to look further into why replacements vary in behaviour, 

Closes #2928 