### PR TITLE
Add better coloring for alias, and help

### DIFF
--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -4,6 +4,7 @@ pub(crate) mod macros;
 mod from_delimited_data;
 mod to_delimited_data;
 
+pub(crate) mod alias;
 pub(crate) mod ansi;
 pub(crate) mod append;
 pub(crate) mod args;
@@ -137,6 +138,7 @@ pub(crate) mod wrap;
 pub(crate) use autoview::Autoview;
 pub(crate) use cd::Cd;
 
+pub(crate) use alias::Alias;
 pub(crate) use ansi::Ansi;
 pub(crate) use append::Command as Append;
 pub(crate) use autoenv::Autoenv;

--- a/crates/nu-command/src/commands/alias.rs
+++ b/crates/nu-command/src/commands/alias.rs
@@ -1,0 +1,44 @@
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+
+use nu_errors::ShellError;
+use nu_protocol::{Signature, SyntaxShape, Value};
+use nu_source::Tagged;
+
+pub struct Alias;
+
+#[derive(Deserialize)]
+pub struct AliasArgs {
+    pub name: Tagged<String>,
+    pub equals: Tagged<String>,
+    pub rest: Vec<Tagged<Value>>,
+}
+
+#[async_trait]
+impl WholeStreamCommand for Alias {
+    fn name(&self) -> &str {
+        "alias"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("alias")
+            .required("name", SyntaxShape::String, "the name of the command")
+            .required("equals", SyntaxShape::String, "the equals sign")
+            .rest(SyntaxShape::Any, "the definition for the alias")
+    }
+
+    fn usage(&self) -> &str {
+        "Create an alias and set it to a definition."
+    }
+
+    async fn run(&self, _args: CommandArgs) -> Result<OutputStream, ShellError> {
+        // Currently, we don't do anything here because we should have already
+        // installed the definition as we entered the scope
+        // We just create a command so that we can get proper coloring
+        Ok(OutputStream::empty())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![]
+    }
+}

--- a/crates/nu-command/src/commands/default_context.rs
+++ b/crates/nu-command/src/commands/default_context.rs
@@ -15,6 +15,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(Let),
             whole_stream_command(LetEnv),
             whole_stream_command(Def),
+            whole_stream_command(Alias),
             whole_stream_command(Source),
             // System/file operations
             whole_stream_command(Exec),


### PR DESCRIPTION
This isn't quite the complete solution, but this at least gives a help text and a better coloring for the `alias` command.