### PR TITLE
parser/split long short flags

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -669,19 +669,6 @@ mod tests {
     mod bare {
         use super::*;
 
-        #[ignore = "result is Token::baseline(\"--flag(-f)\")"]
-        #[test]
-        fn lex_flag() {
-            let input = "--flag(-f)";
-
-            let (result, err) = lex(input, 0);
-
-            assert_eq!("", format!("{:?}", result));
-            assert!(err.is_none());
-            assert_eq!(result[0].span, span(0, 6));
-            assert_eq!(result[1].span, span(7, 9));
-        }
-
         #[test]
         fn simple_1() {
             let input = "foo bar baz";


### PR DESCRIPTION
The parser now recognizes the longname and shortname of a flag regardless whether a space is between them or not.

Example:
```shell
def my-command [--flag(-f) : string] { echo hi } #No space between --flag and (-f)
help my-command
...
  -f, --flag <any> 
...
```
