### PR TITLE
Fix bug #2921

### DIFF
--- a/crates/nu-engine/tests/evaluate/invocation.rs
+++ b/crates/nu-engine/tests/evaluate/invocation.rs
@@ -1,0 +1,13 @@
+use nu_test_support::nu;
+
+#[test]
+fn test_parse_invocation_with_range() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let foo = 3
+        echo $(echo 1..$foo | each { echo $it }) | to json
+        "#
+    );
+    assert_eq!(actual.out, "[1,2,3]")
+}

--- a/crates/nu-engine/tests/evaluate/mod.rs
+++ b/crates/nu-engine/tests/evaluate/mod.rs
@@ -1,1 +1,2 @@
+mod invocation;
 mod operator;

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -446,6 +446,8 @@ fn parse_dollar_expr(
         //Return invocation
         trace!("Parsing invocation expression");
         parse_invocation(lite_arg, scope)
+    } else if lite_arg.item.contains("..") {
+        parse_range(lite_arg, scope)
     } else if lite_arg.item.contains('.') {
         trace!("Parsing path expression");
         parse_full_column_path(lite_arg, scope)
@@ -742,7 +744,7 @@ fn parse_arg(
     scope: &dyn ParserScope,
     lite_arg: &Spanned<String>,
 ) -> (SpannedExpression, Option<ParseError>) {
-    if lite_arg.item.starts_with('$') && parse_range(lite_arg, scope).1.is_some() {
+    if lite_arg.item.starts_with('$') {
         return parse_dollar_expr(&lite_arg, scope);
     }
 


### PR DESCRIPTION
Moving whether a range should be parsed further back, giving e.G. parsing of invocations precedence fixes the bug.
