### PR TITLE
fix: error Variable not in scope for a def parameter #2901

### DIFF
--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -1173,7 +1173,7 @@ impl Expression {
                     output.extend(item.get_free_variables(known_variables));
                 }
             }
-            Expression::Invocation(block) => {
+            Expression::Invocation(block) | Expression::Block(block) => {
                 output.extend(block.get_free_variables(known_variables));
             }
             Expression::Binary(binary) => {


### PR DESCRIPTION
The problem that resulted in a `variable not in scope` error originated in the way that
`hir::Expression::get_free_variables` operated. 
The match statement didn't handle `Expression::Block` cases and the catch-all `_` was empty. 
Someone that knows more about the workings of the `hir` should maybe look at this PR that it doesn't accidentally break something, or another match arm is missing because of some refactoring or something. 
The test that were present are still passing, and I added new tests to check for this particular issue. 
I hope that the way the tests are written isn't too brittle, so that it doesn't accidentally break in the future.
`Expression::Invocation(block)` and `Expression::Block(block) ` are now handled identically.

Related Issue #2901 