### PR TITLE
Flush out! lines, helps autoview

### DIFF
--- a/crates/nu-protocol/src/macros.rs
+++ b/crates/nu-protocol/src/macros.rs
@@ -4,7 +4,11 @@
 /// and stray printlns left by accident
 #[macro_export]
 macro_rules! out {
-    ($($tokens:tt)*) => { print!($($tokens)*) }
+    ($($tokens:tt)*) => {
+        use std::io::Write;
+        print!($($tokens)*);
+        let _ = std::io::stdout().flush();
+    }
 }
 
 /// Outputs to standard out with a newline added


### PR DESCRIPTION
This flushes our `out!` output macro, which helps `autoview` behave a bit better when you want to print out a value at a given position.