### PR TITLE
Temporarily(?) switch from heim+uom to sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,17 +159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ca4f8ff117c37c278a2f7415ce9be55560b846b5bc4412aaa5d29c1c3dae2"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-global-executor"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,49 +192,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-mutex"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-net"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de475c85affe184648202401d7622afb32f0f74e02192857d0201a16defbe5"
-dependencies = [
- "async-io",
- "blocking",
- "fastrand",
- "futures-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8cea09c1fb10a317d1b5af8024eeba256d6554763e85ecd90ff8df31c7bbda"
-dependencies = [
- "async-io",
- "blocking",
- "cfg-if 0.1.10",
- "event-listener",
- "futures-lite",
- "once_cell",
- "signal-hook",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -400,23 +352,6 @@ dependencies = [
  "syntect",
  "unicode-width",
  "wild",
-]
-
-[[package]]
-name = "battery"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b624268937c0e0a3edb7c27843f9e547c320d730c610d3b8e6e8e95b2026e4"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation 0.7.0",
- "lazycell",
- "libc",
- "mach",
- "nix 0.19.1",
- "num-traits 0.2.14",
- "uom",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -822,29 +757,13 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
- "core-foundation-sys 0.8.2",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -859,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.1",
+ "core-foundation",
  "foreign-types",
  "libc",
 ]
@@ -1107,7 +1026,7 @@ version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
 dependencies = [
- "nix 0.18.0",
+ "nix",
  "winapi 0.3.9",
 ]
 
@@ -1140,26 +1059,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "darwin-libproc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc629b7cf42586fee31dae31f9ab73fa5ff5f0170016aa61be5fcbc12a90c516"
-dependencies = [
- "darwin-libproc-sys",
- "libc",
- "memchr",
-]
-
-[[package]]
-name = "darwin-libproc-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0aa083b94c54aa4cfd9bbfd37856714c139d1dc511af80270558c7ba3b4816"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1323,6 +1222,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -2018,174 +1923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heim"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a653442b9bdd11a77d3753a60443c60c4437d3acac8e6c3d4a6a9acd7cceed"
-dependencies = [
- "heim-common",
- "heim-cpu",
- "heim-disk",
- "heim-host",
- "heim-memory",
- "heim-net",
- "heim-process",
- "heim-runtime",
- "heim-sensors",
-]
-
-[[package]]
-name = "heim-common"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767e6e47cf88abe7c9a5ebb4df82f180d30d9c0ba0269b6d166482461765834"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation 0.9.1",
- "futures-core",
- "futures-util",
- "lazy_static 1.4.0",
- "libc",
- "mach",
- "nix 0.19.1",
- "pin-utils",
- "uom",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "heim-cpu"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba5fb13a3b90581d22b4edf99e87c54316444622ae123d36816a227a7caa6df"
-dependencies = [
- "cfg-if 1.0.0",
- "futures 0.3.8",
- "glob",
- "heim-common",
- "heim-runtime",
- "lazy_static 1.4.0",
- "libc",
- "mach",
- "ntapi",
- "smol",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "heim-disk"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75603ff3868851c04954ee86bf610a6bd45be2732a0e81c35fd72b2b90fa4718"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "core-foundation 0.9.1",
- "heim-common",
- "heim-runtime",
- "libc",
- "mach",
- "widestring",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "heim-host"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abf6cd02bc4f6e6aa31a7f80702a2d0e574f4f2c6156a93c3550eb036304722"
-dependencies = [
- "cfg-if 1.0.0",
- "heim-common",
- "heim-runtime",
- "lazy_static 1.4.0",
- "libc",
- "log 0.4.11",
- "mach",
- "ntapi",
- "platforms",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "heim-memory"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa81bccc5e81ab0c68f520ecba5cb42817bacabfc6120160de886754ad0e3e1"
-dependencies = [
- "cfg-if 1.0.0",
- "heim-common",
- "heim-runtime",
- "lazy_static 1.4.0",
- "libc",
- "mach",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "heim-net"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13afa5e9b71c813c1e087bb27f51ae87d3a6d68a2bdd045bae4322dfae4948b"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "heim-common",
- "heim-runtime",
- "libc",
- "macaddr",
- "nix 0.19.1",
-]
-
-[[package]]
-name = "heim-process"
-version = "0.1.1-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386870aac75d29b817fe709f1ef4303553e0af369e3c71d04beceeb50ae2cf39"
-dependencies = [
- "async-trait",
- "cfg-if 1.0.0",
- "darwin-libproc",
- "futures 0.3.8",
- "heim-common",
- "heim-cpu",
- "heim-host",
- "heim-net",
- "heim-runtime",
- "lazy_static 1.4.0",
- "libc",
- "mach",
- "memchr",
- "ntapi",
- "ordered-float 2.0.1",
- "smol",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "heim-runtime"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ec7e5238c8f0dd0cc60914d31a5a7aadd4cde74c966a76c1caed1f5224e9b8"
-dependencies = [
- "futures 0.3.8",
- "futures-timer",
- "once_cell",
- "smol",
-]
-
-[[package]]
-name = "heim-sensors"
-version = "0.1.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82de7f0784d3b0c53f2e8875c63f430bf6718b03ec8ddce905c12887031158f5"
-dependencies = [
- "cfg-if 1.0.0",
- "heim-common",
- "heim-runtime",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,21 +2443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "macaddr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,18 +2711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,7 +2818,6 @@ dependencies = [
  "futures_codec",
  "getset",
  "glob",
- "heim",
  "htmlescape",
  "ical",
  "ichwh",
@@ -3169,7 +2878,6 @@ dependencies = [
  "trash",
  "umask",
  "unicode-segmentation",
- "uom",
  "url",
  "users",
  "uuid",
@@ -3211,7 +2919,6 @@ dependencies = [
  "futures_codec",
  "getset",
  "glob",
- "heim",
  "htmlescape",
  "ical",
  "ichwh",
@@ -3271,7 +2978,6 @@ dependencies = [
  "trash",
  "umask",
  "unicode-segmentation",
- "uom",
  "url",
  "users",
  "uuid",
@@ -3620,12 +3326,12 @@ version = "0.25.2"
 dependencies = [
  "futures 0.3.8",
  "futures-timer",
- "heim",
  "nu-errors",
  "nu-plugin",
  "nu-protocol",
  "nu-source",
  "num-bigint 0.3.1",
+ "sysinfo",
 ]
 
 [[package]]
@@ -3669,15 +3375,14 @@ dependencies = [
 name = "nu_plugin_sys"
 version = "0.25.2"
 dependencies = [
- "battery",
  "futures 0.3.8",
  "futures-util",
- "heim",
  "nu-errors",
  "nu-plugin",
  "nu-protocol",
  "nu-source",
  "num-bigint 0.3.1",
+ "sysinfo",
 ]
 
 [[package]]
@@ -4001,15 +3706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
-dependencies = [
- "num-traits 0.2.14",
-]
-
-[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4238,12 +3934,6 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "platforms"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc77a3fc329982cbf3ea772aa265b742a550998bad65747c630406ee52dac425"
 
 [[package]]
 name = "plist"
@@ -4873,7 +4563,7 @@ dependencies = [
  "libc",
  "log 0.4.11",
  "memchr",
- "nix 0.18.0",
+ "nix",
  "scopeguard",
  "unicode-segmentation",
  "unicode-width",
@@ -4967,8 +4657,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.1",
- "core-foundation-sys 0.8.2",
+ "core-foundation",
+ "core-foundation-sys",
  "libc",
  "security-framework-sys",
 ]
@@ -4979,7 +4669,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
- "core-foundation-sys 0.8.2",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -5079,7 +4769,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 dependencies = [
- "ordered-float 1.1.1",
+ "ordered-float",
  "serde 1.0.118",
 ]
 
@@ -5309,24 +4999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
 
 [[package]]
-name = "smol"
-version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf3b5351f3e783c1d79ab5fc604eeed8b8ae9abd36b166e8b87a089efd85e4"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-net",
- "async-process",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5508,6 +5180,23 @@ dependencies = [
  "serde_json",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.15.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de94457a09609f33fec5e7fceaf907488967c6c7c75d64da6a7ce6ffdb8b5abd"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6122,17 +5811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "uom"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e76503e636584f1e10b9b3b9498538279561adcef5412927ba00c2b32c4ce5ed"
-dependencies = [
- "num-rational 0.3.2",
- "num-traits 0.2.14",
- "typenum",
-]
-
-[[package]]
 name = "url"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6410,12 +6088,6 @@ dependencies = [
  "libc",
  "thiserror",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "wild"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ nu-test-support = {version = "0.25.2", path = "./crates/nu-test-support"}
 ctrlc-support = ["nu-cli/ctrlc", "nu-command/ctrlc"]
 directories-support = ["nu-cli/directories", "nu-cli/dirs", "nu-command/directories", "nu-command/dirs", "nu-data/directories", "nu-data/dirs", "nu-engine/dirs"]
 ptree-support = ["nu-cli/ptree", "nu-command/ptree"]
-rich-benchmark = ["nu-cli/rich-benchmark", "nu-command/rich-benchmark"]
 rustyline-support = ["nu-cli/rustyline-support", "nu-command/rustyline-support"]
 term-support = ["nu-cli/term", "nu-command/term"]
 uuid-support = ["nu-cli/uuid_crate", "nu-command/uuid_crate"]
@@ -87,7 +86,6 @@ default = [
   "match",
   "post",
   "fetch",
-  "rich-benchmark",
   "zip-support",
 ]
 extra = ["default", "binaryview", "tree", "clipboard-cli", "trash-support", "start", "bson", "sqlite", "s3", "chart", "xpath", "selector"]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -55,7 +55,6 @@ futures-util = "0.3.8"
 futures_codec = "0.4.1"
 getset = "0.1.1"
 glob = "0.3.0"
-heim = { version = "0.1.0-rc.1", optional = true }
 htmlescape = "0.3.1"
 ical = "0.7.0"
 ichwh = { version = "0.3.4", optional = true }
@@ -98,7 +97,6 @@ titlecase = "1.0"
 toml = "0.5.6"
 trash = { version = "1.2.0", optional = true }
 unicode-segmentation = "1.6.0"
-uom = { version = "0.30.0", features = ["f64", "try-from"] }
 url = "2.1.1"
 uuid_crate = { package = "uuid", version = "0.8.1", features = ["v4"], optional = true }
 which = { version = "4.0.2", optional = true }
@@ -130,7 +128,6 @@ quickcheck_macros = "0.9.1"
 [features]
 default = ["shadow-rs"]
 clipboard-cli = ["arboard"]
-rich-benchmark = ["heim"]
 rustyline-support = ["rustyline", "nu-engine/rustyline-support"]
 stable = []
 trash-support = ["trash"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -54,7 +54,6 @@ futures-util = "0.3.8"
 futures_codec = "0.4.1"
 getset = "0.1.1"
 glob = "0.3.0"
-heim = { version = "0.1.0-rc.1", optional = true }
 htmlescape = "0.3.1"
 ical = "0.7.0"
 ichwh = { version = "0.3.4", optional = true }
@@ -97,7 +96,6 @@ titlecase = "1.0"
 toml = "0.5.6"
 trash = { version = "1.2.0", optional = true }
 unicode-segmentation = "1.6.0"
-uom = { version = "0.30.0", features = ["f64", "try-from"] }
 url = "2.1.1"
 uuid_crate = { package = "uuid", version = "0.8.1", features = ["v4"], optional = true }
 which = { version = "4.0.2", optional = true }
@@ -127,7 +125,6 @@ quickcheck_macros = "0.9.1"
 
 [features]
 clipboard-cli = ["arboard"]
-rich-benchmark = ["heim"]
 rustyline-support = ["rustyline"]
 stable = []
 trash-support = ["trash"]

--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-#[cfg(feature = "rich-benchmark")]
-use heim::cpu::time;
+// #[cfg(feature = "rich-benchmark")]
+// use heim::cpu::time;
 use nu_engine::run_block;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
@@ -81,22 +81,22 @@ async fn benchmark(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let start_time = Instant::now();
 
-    #[cfg(feature = "rich-benchmark")]
-    let start = time().await;
+    // #[cfg(feature = "rich-benchmark")]
+    // let start = time().await;
 
     context.scope.enter_scope();
     let result = run_block(&block.block, &context, input).await;
     context.scope.exit_scope();
     let output = result?.into_vec().await;
 
-    #[cfg(feature = "rich-benchmark")]
-    let end = time().await;
+    // #[cfg(feature = "rich-benchmark")]
+    // let end = time().await;
 
     let end_time = Instant::now();
     context.clear_errors();
 
     // return basic runtime
-    #[cfg(not(feature = "rich-benchmark"))]
+    //#[cfg(not(feature = "rich-benchmark"))]
     {
         let mut indexmap = IndexMap::with_capacity(1);
 
@@ -105,28 +105,29 @@ async fn benchmark(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
         benchmark_output(indexmap, output, passthrough, &tag, &mut context).await
     }
     // return advanced stats
-    #[cfg(feature = "rich-benchmark")]
-    if let (Ok(start), Ok(end)) = (start, end) {
-        let mut indexmap = IndexMap::with_capacity(4);
+    // #[cfg(feature = "rich-benchmark")]
+    // if let (Ok(start), Ok(end)) = (start, end) {
+    //     let mut indexmap = IndexMap::with_capacity(4);
 
-        let real_time = into_big_int(end_time - start_time);
-        indexmap.insert("real time".to_string(), real_time);
+    //     let real_time = into_big_int(end_time - start_time);
+    //     indexmap.insert("real time".to_string(), real_time);
 
-        let user_time = into_big_int(end.user() - start.user());
-        indexmap.insert("user time".to_string(), user_time);
+    //     let user_time = into_big_int(end.user() - start.user());
+    //     indexmap.insert("user time".to_string(), user_time);
 
-        let system_time = into_big_int(end.system() - start.system());
-        indexmap.insert("system time".to_string(), system_time);
+    //     let system_time = into_big_int(end.system() - start.system());
+    //     indexmap.insert("system time".to_string(), system_time);
 
-        let idle_time = into_big_int(end.idle() - start.idle());
-        indexmap.insert("idle time".to_string(), idle_time);
+    //     let idle_time = into_big_int(end.idle() - start.idle());
+    //     indexmap.insert("idle time".to_string(), idle_time);
 
-        benchmark_output(indexmap, output, passthrough, &tag, &mut context).await
-    } else {
-        Err(ShellError::untagged_runtime_error(
-            "Could not retrieve CPU time",
-        ))
-    }
+    //     benchmark_output(indexmap, output, passthrough, &tag, &mut context).await
+    // } else {
+    //     Err(ShellError::untagged_runtime_error(
+    //         "Could not retrieve CPU time",
+    //     ))
+    // }
+    
 }
 
 async fn benchmark_output<T, Output>(

--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -127,7 +127,6 @@ async fn benchmark(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     //         "Could not retrieve CPU time",
     //     ))
     // }
-    
 }
 
 async fn benchmark_output<T, Output>(

--- a/crates/nu-command/src/commands/version.rs
+++ b/crates/nu-command/src/commands/version.rs
@@ -170,10 +170,10 @@ fn features_enabled() -> Vec<String> {
         names.push("ptree".to_string());
     }
 
-    #[cfg(feature = "rich-benchmark")]
-    {
-        names.push("rich-benchmark".to_string());
-    }
+    // #[cfg(feature = "rich-benchmark")]
+    // {
+    //     names.push("rich-benchmark".to_string());
+    // }
 
     #[cfg(feature = "rustyline-support")]
     {

--- a/crates/nu-plugin/src/jsonrpc.rs
+++ b/crates/nu-plugin/src/jsonrpc.rs
@@ -1,5 +1,6 @@
 use nu_protocol::{outln, CallInfo, Value};
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JsonRpc<T> {
@@ -22,10 +23,16 @@ pub fn send_response<T: Serialize>(result: T) {
     let response = JsonRpc::new("response", result);
     let response_raw = serde_json::to_string(&response);
 
+    let mut stdout = std::io::stdout();
+
     match response_raw {
-        Ok(response) => outln!("{}", response),
-        Err(err) => outln!("{}", err),
-    }
+        Ok(response) => {
+            let _ = writeln!(stdout, "{}", response);
+        }
+        Err(err) => {
+            let _ = writeln!(stdout, "{}", err);
+        }
+    };
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/nu_plugin_ps/Cargo.toml
+++ b/crates/nu_plugin_ps/Cargo.toml
@@ -19,10 +19,6 @@ num-bigint = "0.3.0"
 
 futures = {version = "0.3.5", features = ["compat", "io-compat"]}
 futures-timer = "3.0.2"
-
-[dependencies.heim]
-default-features = false
-features = ["process"]
-version = "0.1.0-rc.1"
+sysinfo = "0.15.9"
 
 [build-dependencies]

--- a/crates/nu_plugin_ps/src/ps.rs
+++ b/crates/nu_plugin_ps/src/ps.rs
@@ -1,6 +1,4 @@
 use futures::{StreamExt, TryStreamExt};
-use heim::process::{self as process, Process, ProcessResult};
-use heim::units::{information, ratio, time, Ratio};
 use std::usize;
 
 use nu_errors::ShellError;
@@ -20,89 +18,89 @@ impl Ps {
     }
 }
 
-async fn usage(process: Process) -> ProcessResult<(process::Process, Ratio, process::Memory)> {
-    let usage_1 = process.cpu_usage().await?;
-    futures_timer::Delay::new(Duration::from_millis(100)).await;
-    let usage_2 = process.cpu_usage().await?;
+// async fn usage(process: Process) -> ProcessResult<(process::Process, Ratio, process::Memory)> {
+//     let usage_1 = process.cpu_usage().await?;
+//     futures_timer::Delay::new(Duration::from_millis(100)).await;
+//     let usage_2 = process.cpu_usage().await?;
 
-    let memory = process.memory().await?;
+//     let memory = process.memory().await?;
 
-    Ok((process, usage_2 - usage_1, memory))
-}
+//     Ok((process, usage_2 - usage_1, memory))
+// }
 
 pub async fn ps(tag: Tag, long: bool) -> Result<Vec<Value>, ShellError> {
-    let processes = process::processes()
-        .await
-        .map_err(|_| {
-            ShellError::labeled_error(
-                "Unable to get process list",
-                "could not load process list",
-                tag.span,
-            )
-        })?
-        .map_ok(|process| {
-            // Note that there is no `.await` here,
-            // as we want to pass the returned future
-            // into the `.try_buffer_unordered`.
-            usage(process)
-        })
-        .try_buffer_unordered(usize::MAX);
-    futures::pin_mut!(processes);
+    // let processes = process::processes()
+    //     .await
+    //     .map_err(|_| {
+    //         ShellError::labeled_error(
+    //             "Unable to get process list",
+    //             "could not load process list",
+    //             tag.span,
+    //         )
+    //     })?
+    //     .map_ok(|process| {
+    //         // Note that there is no `.await` here,
+    //         // as we want to pass the returned future
+    //         // into the `.try_buffer_unordered`.
+    //         usage(process)
+    //     })
+    //     .try_buffer_unordered(usize::MAX);
+    // futures::pin_mut!(processes);
 
-    let mut output = vec![];
-    while let Some(res) = processes.next().await {
-        if let Ok((process, usage, memory)) = res {
-            let mut dict = TaggedDictBuilder::new(&tag);
-            dict.insert_untagged("pid", UntaggedValue::int(process.pid()));
-            if let Ok(name) = process.name().await {
-                dict.insert_untagged("name", UntaggedValue::string(name));
-            }
-            if let Ok(status) = process.status().await {
-                dict.insert_untagged("status", UntaggedValue::string(format!("{:?}", status)));
-            }
-            dict.insert_untagged(
-                "cpu",
-                UntaggedValue::decimal_from_float(usage.get::<ratio::percent>() as f64, tag.span),
-            );
-            dict.insert_untagged(
-                "mem",
-                UntaggedValue::filesize(memory.rss().get::<information::byte>()),
-            );
-            dict.insert_untagged(
-                "virtual",
-                UntaggedValue::filesize(memory.vms().get::<information::byte>()),
-            );
-            if long {
-                if let Ok(cpu_time) = process.cpu_time().await {
-                    let user_time = cpu_time.user().get::<time::nanosecond>().round() as i64;
-                    let system_time = cpu_time.system().get::<time::nanosecond>().round() as i64;
+    // let mut output = vec![];
+    // while let Some(res) = processes.next().await {
+    //     if let Ok((process, usage, memory)) = res {
+    //         let mut dict = TaggedDictBuilder::new(&tag);
+    //         dict.insert_untagged("pid", UntaggedValue::int(process.pid()));
+    //         if let Ok(name) = process.name().await {
+    //             dict.insert_untagged("name", UntaggedValue::string(name));
+    //         }
+    //         if let Ok(status) = process.status().await {
+    //             dict.insert_untagged("status", UntaggedValue::string(format!("{:?}", status)));
+    //         }
+    //         dict.insert_untagged(
+    //             "cpu",
+    //             UntaggedValue::decimal_from_float(usage.get::<ratio::percent>() as f64, tag.span),
+    //         );
+    //         dict.insert_untagged(
+    //             "mem",
+    //             UntaggedValue::filesize(memory.rss().get::<information::byte>()),
+    //         );
+    //         dict.insert_untagged(
+    //             "virtual",
+    //             UntaggedValue::filesize(memory.vms().get::<information::byte>()),
+    //         );
+    //         if long {
+    //             if let Ok(cpu_time) = process.cpu_time().await {
+    //                 let user_time = cpu_time.user().get::<time::nanosecond>().round() as i64;
+    //                 let system_time = cpu_time.system().get::<time::nanosecond>().round() as i64;
 
-                    dict.insert_untagged(
-                        "cpu_time",
-                        UntaggedValue::duration(BigInt::from(user_time + system_time)),
-                    )
-                }
-                if let Ok(parent_pid) = process.parent_pid().await {
-                    dict.insert_untagged("parent", UntaggedValue::int(parent_pid))
-                }
+    //                 dict.insert_untagged(
+    //                     "cpu_time",
+    //                     UntaggedValue::duration(BigInt::from(user_time + system_time)),
+    //                 )
+    //             }
+    //             if let Ok(parent_pid) = process.parent_pid().await {
+    //                 dict.insert_untagged("parent", UntaggedValue::int(parent_pid))
+    //             }
 
-                if let Ok(exe) = process.exe().await {
-                    dict.insert_untagged("exe", UntaggedValue::string(exe.to_string_lossy()))
-                }
+    //             if let Ok(exe) = process.exe().await {
+    //                 dict.insert_untagged("exe", UntaggedValue::string(exe.to_string_lossy()))
+    //             }
 
-                #[cfg(not(windows))]
-                {
-                    if let Ok(command) = process.command().await {
-                        dict.insert_untagged(
-                            "command",
-                            UntaggedValue::string(command.to_os_string().to_string_lossy()),
-                        );
-                    }
-                }
-            }
-            output.push(dict.into_value());
-        }
-    }
-
+    //             #[cfg(not(windows))]
+    //             {
+    //                 if let Ok(command) = process.command().await {
+    //                     dict.insert_untagged(
+    //                         "command",
+    //                         UntaggedValue::string(command.to_os_string().to_string_lossy()),
+    //                     );
+    //                 }
+    //             }
+    //         }
+    //         output.push(dict.into_value());
+    //     }
+    // }
+    let output = vec![];
     Ok(output)
 }

--- a/crates/nu_plugin_ps/src/ps.rs
+++ b/crates/nu_plugin_ps/src/ps.rs
@@ -12,16 +12,6 @@ impl Ps {
     }
 }
 
-// async fn usage(process: Process) -> ProcessResult<(process::Process, Ratio, process::Memory)> {
-//     let usage_1 = process.cpu_usage().await?;
-//     futures_timer::Delay::new(Duration::from_millis(100)).await;
-//     let usage_2 = process.cpu_usage().await?;
-
-//     let memory = process.memory().await?;
-
-//     Ok((process, usage_2 - usage_1, memory))
-// }
-
 pub async fn ps(tag: Tag, long: bool) -> Result<Vec<Value>, ShellError> {
     let mut sys = System::new_all();
     sys.refresh_all();
@@ -59,77 +49,5 @@ pub async fn ps(tag: Tag, long: bool) -> Result<Vec<Value>, ShellError> {
         output.push(dict.into_value());
     }
 
-    // let processes = process::processes()
-    //     .await
-    //     .map_err(|_| {
-    //         ShellError::labeled_error(
-    //             "Unable to get process list",
-    //             "could not load process list",
-    //             tag.span,
-    //         )
-    //     })?
-    //     .map_ok(|process| {
-    //         // Note that there is no `.await` here,
-    //         // as we want to pass the returned future
-    //         // into the `.try_buffer_unordered`.
-    //         usage(process)
-    //     })
-    //     .try_buffer_unordered(usize::MAX);
-    // futures::pin_mut!(processes);
-
-    // let mut output = vec![];
-    // while let Some(res) = processes.next().await {
-    //     if let Ok((process, usage, memory)) = res {
-    //         let mut dict = TaggedDictBuilder::new(&tag);
-    //         dict.insert_untagged("pid", UntaggedValue::int(process.pid()));
-    //         if let Ok(name) = process.name().await {
-    //             dict.insert_untagged("name", UntaggedValue::string(name));
-    //         }
-    //         if let Ok(status) = process.status().await {
-    //             dict.insert_untagged("status", UntaggedValue::string(format!("{:?}", status)));
-    //         }
-    //         dict.insert_untagged(
-    //             "cpu",
-    //             UntaggedValue::decimal_from_float(usage.get::<ratio::percent>() as f64, tag.span),
-    //         );
-    //         dict.insert_untagged(
-    //             "mem",
-    //             UntaggedValue::filesize(memory.rss().get::<information::byte>()),
-    //         );
-    //         dict.insert_untagged(
-    //             "virtual",
-    //             UntaggedValue::filesize(memory.vms().get::<information::byte>()),
-    //         );
-    //         if long {
-    //             if let Ok(cpu_time) = process.cpu_time().await {
-    //                 let user_time = cpu_time.user().get::<time::nanosecond>().round() as i64;
-    //                 let system_time = cpu_time.system().get::<time::nanosecond>().round() as i64;
-
-    //                 dict.insert_untagged(
-    //                     "cpu_time",
-    //                     UntaggedValue::duration(BigInt::from(user_time + system_time)),
-    //                 )
-    //             }
-    //             if let Ok(parent_pid) = process.parent_pid().await {
-    //                 dict.insert_untagged("parent", UntaggedValue::int(parent_pid))
-    //             }
-
-    //             if let Ok(exe) = process.exe().await {
-    //                 dict.insert_untagged("exe", UntaggedValue::string(exe.to_string_lossy()))
-    //             }
-
-    //             #[cfg(not(windows))]
-    //             {
-    //                 if let Ok(command) = process.command().await {
-    //                     dict.insert_untagged(
-    //                         "command",
-    //                         UntaggedValue::string(command.to_os_string().to_string_lossy()),
-    //                     );
-    //                 }
-    //             }
-    //         }
-    //         output.push(dict.into_value());
-    //     }
-    // }
     Ok(output)
 }

--- a/crates/nu_plugin_sys/Cargo.toml
+++ b/crates/nu_plugin_sys/Cargo.toml
@@ -15,15 +15,9 @@ nu-plugin = {path = "../nu-plugin", version = "0.25.2"}
 nu-protocol = {path = "../nu-protocol", version = "0.25.2"}
 nu-source = {path = "../nu-source", version = "0.25.2"}
 
-battery = "0.7.6"
 futures = {version = "0.3.5", features = ["compat", "io-compat"]}
 futures-util = "0.3.5"
 num-bigint = "0.3.0"
-
-[dependencies.heim]
-default-features = false
-version = "0.1.0-beta.3"
-
-features = ["host", "cpu", "memory", "disk", "net", "sensors"]
+sysinfo = "0.15.9"
 
 [build-dependencies]

--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -187,7 +187,7 @@ pub async fn sysinfo(tag: Tag) -> Vec<Value> {
     if let Some(temp) = temp(&mut sys, tag.clone()) {
         sysinfo.insert_value("temp", temp);
     }
-    if let Some(net) = net(&mut sys, tag.clone()) {
+    if let Some(net) = net(&mut sys, tag) {
         sysinfo.insert_value("net", net);
     }
 

--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -1,11 +1,10 @@
 use futures_util::StreamExt;
-use heim::units::{frequency, information, thermodynamic_temperature, time};
-use heim::{disk, host, memory, net, sensors};
 use nu_errors::ShellError;
 use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
 use nu_source::Tag;
 use num_bigint::BigInt;
 use std::ffi::OsStr;
+use sysinfo::{NetworkExt, NetworksExt, ProcessExt, System, SystemExt, DiskExt};
 
 #[derive(Default)]
 pub struct Sys;
@@ -16,353 +15,377 @@ impl Sys {
     }
 }
 
-async fn cpu(tag: Tag) -> Option<Value> {
-    let span = tag.span;
-    match futures::future::try_join(heim::cpu::logical_count(), heim::cpu::frequency()).await {
-        Ok((num_cpu, cpu_speed)) => {
-            let mut cpu_idx = TaggedDictBuilder::with_capacity(tag, 4);
-            cpu_idx.insert_untagged("cores", UntaggedValue::int(num_cpu));
+// async fn cpu(tag: Tag) -> Option<Value> {
+//     let span = tag.span;
+//     match futures::future::try_join(heim::cpu::logical_count(), heim::cpu::frequency()).await {
+//         Ok((num_cpu, cpu_speed)) => {
+//             let mut cpu_idx = TaggedDictBuilder::with_capacity(tag, 4);
+//             cpu_idx.insert_untagged("cores", UntaggedValue::int(num_cpu));
 
-            let current_speed =
-                (cpu_speed.current().get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0)
-                    .round()
-                    / 100.0;
-            cpu_idx.insert_untagged(
-                "current ghz",
-                UntaggedValue::decimal_from_float(current_speed, span),
-            );
+//             let current_speed =
+//                 (cpu_speed.current().get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0)
+//                     .round()
+//                     / 100.0;
+//             cpu_idx.insert_untagged(
+//                 "current ghz",
+//                 UntaggedValue::decimal_from_float(current_speed, span),
+//             );
 
-            if let Some(min_speed) = cpu_speed.min() {
-                let min_speed =
-                    (min_speed.get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0).round()
-                        / 100.0;
-                cpu_idx.insert_untagged(
-                    "min ghz",
-                    UntaggedValue::decimal_from_float(min_speed, span),
-                );
-            }
+//             if let Some(min_speed) = cpu_speed.min() {
+//                 let min_speed =
+//                     (min_speed.get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0).round()
+//                         / 100.0;
+//                 cpu_idx.insert_untagged(
+//                     "min ghz",
+//                     UntaggedValue::decimal_from_float(min_speed, span),
+//                 );
+//             }
 
-            if let Some(max_speed) = cpu_speed.max() {
-                let max_speed =
-                    (max_speed.get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0).round()
-                        / 100.0;
-                cpu_idx.insert_untagged(
-                    "max ghz",
-                    UntaggedValue::decimal_from_float(max_speed, span),
-                );
-            }
+//             if let Some(max_speed) = cpu_speed.max() {
+//                 let max_speed =
+//                     (max_speed.get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0).round()
+//                         / 100.0;
+//                 cpu_idx.insert_untagged(
+//                     "max ghz",
+//                     UntaggedValue::decimal_from_float(max_speed, span),
+//                 );
+//             }
 
-            Some(cpu_idx.into_value())
-        }
-        Err(_) => None,
-    }
-}
+//             Some(cpu_idx.into_value())
+//         }
+//         Err(_) => None,
+//     }
+// }
 
-async fn mem(tag: Tag) -> Value {
-    let mut dict = TaggedDictBuilder::with_capacity(tag, 4);
+// async fn mem(tag: Tag) -> Value {
+//     let mut dict = TaggedDictBuilder::with_capacity(tag, 4);
 
-    let (memory_result, swap_result) =
-        futures::future::join(memory::memory(), memory::swap()).await;
+//     let (memory_result, swap_result) =
+//         futures::future::join(memory::memory(), memory::swap()).await;
 
-    if let Ok(memory) = memory_result {
-        dict.insert_untagged(
-            "total",
-            UntaggedValue::filesize(memory.total().get::<information::byte>()),
-        );
-        dict.insert_untagged(
-            "free",
-            UntaggedValue::filesize(memory.free().get::<information::byte>()),
-        );
-    }
+//     if let Ok(memory) = memory_result {
+//         dict.insert_untagged(
+//             "total",
+//             UntaggedValue::filesize(memory.total().get::<information::byte>()),
+//         );
+//         dict.insert_untagged(
+//             "free",
+//             UntaggedValue::filesize(memory.free().get::<information::byte>()),
+//         );
+//     }
 
-    if let Ok(swap) = swap_result {
-        dict.insert_untagged(
-            "swap total",
-            UntaggedValue::filesize(swap.total().get::<information::byte>()),
-        );
-        dict.insert_untagged(
-            "swap free",
-            UntaggedValue::filesize(swap.free().get::<information::byte>()),
-        );
-    }
+//     if let Ok(swap) = swap_result {
+//         dict.insert_untagged(
+//             "swap total",
+//             UntaggedValue::filesize(swap.total().get::<information::byte>()),
+//         );
+//         dict.insert_untagged(
+//             "swap free",
+//             UntaggedValue::filesize(swap.free().get::<information::byte>()),
+//         );
+//     }
 
-    dict.into_value()
-}
+//     dict.into_value()
+// }
 
-async fn host(tag: Tag) -> Result<Value, ShellError> {
-    let mut dict = TaggedDictBuilder::with_capacity(&tag, 6);
+// async fn host(tag: Tag) -> Result<Value, ShellError> {
+//     let mut dict = TaggedDictBuilder::with_capacity(&tag, 6);
 
-    let (platform_result, uptime_result) =
-        futures::future::join(host::platform(), host::uptime()).await;
+//     let (platform_result, uptime_result) =
+//         futures::future::join(host::platform(), host::uptime()).await;
 
-    // OS
-    if let Ok(platform) = platform_result {
-        dict.insert_untagged("name", UntaggedValue::string(platform.system()));
-        dict.insert_untagged("release", UntaggedValue::string(platform.release()));
-        dict.insert_untagged("version", UntaggedValue::string(platform.version()));
-        dict.insert_untagged("hostname", UntaggedValue::string(platform.hostname()));
-        dict.insert_untagged(
-            "arch",
-            UntaggedValue::string(platform.architecture().as_str()),
-        );
-    }
+//     // OS
+//     if let Ok(platform) = platform_result {
+//         dict.insert_untagged("name", UntaggedValue::string(platform.system()));
+//         dict.insert_untagged("release", UntaggedValue::string(platform.release()));
+//         dict.insert_untagged("version", UntaggedValue::string(platform.version()));
+//         dict.insert_untagged("hostname", UntaggedValue::string(platform.hostname()));
+//         dict.insert_untagged(
+//             "arch",
+//             UntaggedValue::string(platform.architecture().as_str()),
+//         );
+//     }
 
-    // Uptime
-    if let Ok(uptime) = uptime_result {
-        let uptime = uptime.get::<time::nanosecond>().round() as i64;
+//     // Uptime
+//     if let Ok(uptime) = uptime_result {
+//         let uptime = uptime.get::<time::nanosecond>().round() as i64;
 
-        dict.insert_untagged("uptime", UntaggedValue::duration(BigInt::from(uptime)));
-    }
+//         dict.insert_untagged("uptime", UntaggedValue::duration(BigInt::from(uptime)));
+//     }
 
-    // Sessions
-    // note: the heim host module has nomenclature "users"
-    let users = host::users().await.map_err(|_| {
-        ShellError::labeled_error("Unable to get users", "could not load users", tag.span)
-    })?;
+//     // Sessions
+//     // note: the heim host module has nomenclature "users"
+//     let users = host::users().await.map_err(|_| {
+//         ShellError::labeled_error("Unable to get users", "could not load users", tag.span)
+//     })?;
 
-    futures::pin_mut!(users);
+//     futures::pin_mut!(users);
 
-    let mut user_vec = vec![];
-    while let Some(user) = users.next().await {
-        if let Ok(user) = user {
-            user_vec.push(Value {
-                value: UntaggedValue::string(user.username()),
-                tag: tag.clone(),
-            });
-        }
-    }
-    let user_list = UntaggedValue::Table(user_vec);
-    dict.insert_untagged("sessions", user_list);
+//     let mut user_vec = vec![];
+//     while let Some(user) = users.next().await {
+//         if let Ok(user) = user {
+//             user_vec.push(Value {
+//                 value: UntaggedValue::string(user.username()),
+//                 tag: tag.clone(),
+//             });
+//         }
+//     }
+//     let user_list = UntaggedValue::Table(user_vec);
+//     dict.insert_untagged("sessions", user_list);
 
-    Ok(dict.into_value())
-}
+//     Ok(dict.into_value())
+// }
 
-async fn disks(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
+// async fn disks(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
+//     let mut output = vec![];
+//     let partitions = disk::partitions_physical().await.map_err(|_| {
+//         ShellError::labeled_error(
+//             "Unable to get disk list",
+//             "could not load disk list",
+//             tag.span,
+//         )
+//     })?;
+
+//     futures::pin_mut!(partitions);
+
+//     while let Some(part) = partitions.next().await {
+//         if let Ok(part) = part {
+//             let mut dict = TaggedDictBuilder::with_capacity(&tag, 6);
+//             dict.insert_untagged(
+//                 "device",
+//                 UntaggedValue::string(
+//                     part.device()
+//                         .unwrap_or_else(|| OsStr::new("N/A"))
+//                         .to_string_lossy(),
+//                 ),
+//             );
+
+//             dict.insert_untagged("type", UntaggedValue::string(part.file_system().as_str()));
+//             dict.insert_untagged(
+//                 "mount",
+//                 UntaggedValue::string(part.mount_point().to_string_lossy()),
+//             );
+
+//             if let Ok(usage) = disk::usage(part.mount_point().to_path_buf()).await {
+//                 dict.insert_untagged(
+//                     "total",
+//                     UntaggedValue::filesize(usage.total().get::<information::byte>()),
+//                 );
+//                 dict.insert_untagged(
+//                     "used",
+//                     UntaggedValue::filesize(usage.used().get::<information::byte>()),
+//                 );
+//                 dict.insert_untagged(
+//                     "free",
+//                     UntaggedValue::filesize(usage.free().get::<information::byte>()),
+//                 );
+//             }
+
+//             output.push(dict.into_value());
+//         }
+//     }
+
+//     if !output.is_empty() {
+//         Ok(Some(UntaggedValue::Table(output)))
+//     } else {
+//         Ok(None)
+//     }
+// }
+
+// async fn battery(tag: Tag) -> Option<UntaggedValue> {
+//     let mut output = vec![];
+//     let span = tag.span;
+
+//     if let Ok(manager) = battery::Manager::new() {
+//         if let Ok(batteries) = manager.batteries() {
+//             for battery in batteries {
+//                 if let Ok(battery) = battery {
+//                     let mut dict = TaggedDictBuilder::new(&tag);
+//                     if let Some(vendor) = battery.vendor() {
+//                         dict.insert_untagged("vendor", UntaggedValue::string(vendor));
+//                     }
+//                     if let Some(model) = battery.model() {
+//                         dict.insert_untagged("model", UntaggedValue::string(model));
+//                     }
+//                     if let Some(cycles) = battery.cycle_count() {
+//                         dict.insert_untagged("cycles", UntaggedValue::int(cycles));
+//                     }
+//                     if let Some(time_to_full) = battery.time_to_full() {
+//                         dict.insert_untagged(
+//                             "mins to full",
+//                             UntaggedValue::decimal_from_float(
+//                                 time_to_full.get::<battery::units::time::minute>() as f64,
+//                                 span,
+//                             ),
+//                         );
+//                     }
+//                     if let Some(time_to_empty) = battery.time_to_empty() {
+//                         dict.insert_untagged(
+//                             "mins to empty",
+//                             UntaggedValue::decimal_from_float(
+//                                 time_to_empty.get::<battery::units::time::minute>() as f64,
+//                                 span,
+//                             ),
+//                         );
+//                     }
+//                     output.push(dict.into_value());
+//                 }
+//             }
+//         }
+//     }
+
+//     if !output.is_empty() {
+//         Some(UntaggedValue::Table(output))
+//     } else {
+//         None
+//     }
+// }
+
+// async fn temp(tag: Tag) -> Option<UntaggedValue> {
+//     let mut output = vec![];
+//     let span = tag.span;
+
+//     let sensors = sensors::temperatures();
+
+//     futures::pin_mut!(sensors);
+
+//     while let Some(sensor) = sensors.next().await {
+//         if let Ok(sensor) = sensor {
+//             let mut dict = TaggedDictBuilder::new(&tag);
+//             dict.insert_untagged("unit", UntaggedValue::string(sensor.unit()));
+//             if let Some(label) = sensor.label() {
+//                 dict.insert_untagged("label", UntaggedValue::string(label));
+//             }
+//             dict.insert_untagged(
+//                 "temp",
+//                 UntaggedValue::decimal_from_float(
+//                     sensor
+//                         .current()
+//                         .get::<thermodynamic_temperature::degree_celsius>()
+//                         as f64,
+//                     span,
+//                 ),
+//             );
+//             if let Some(high) = sensor.high() {
+//                 dict.insert_untagged(
+//                     "high",
+//                     UntaggedValue::decimal_from_float(
+//                         high.get::<thermodynamic_temperature::degree_celsius>() as f64,
+//                         span,
+//                     ),
+//                 );
+//             }
+//             if let Some(critical) = sensor.critical() {
+//                 dict.insert_untagged(
+//                     "critical",
+//                     UntaggedValue::decimal_from_float(
+//                         critical.get::<thermodynamic_temperature::degree_celsius>() as f64,
+//                         span,
+//                     ),
+//                 );
+//             }
+
+//             output.push(dict.into_value());
+//         }
+//     }
+
+//     if !output.is_empty() {
+//         Some(UntaggedValue::Table(output))
+//     } else {
+//         None
+//     }
+// }
+
+// async fn net(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
+//     let mut output = vec![];
+//     let io_counters = net::io_counters().await.map_err(|_| {
+//         ShellError::labeled_error(
+//             "Unable to get network device list",
+//             "could not load network device list",
+//             tag.span,
+//         )
+//     })?;
+
+//     futures::pin_mut!(io_counters);
+
+//     while let Some(nic) = io_counters.next().await {
+//         if let Ok(nic) = nic {
+//             let mut network_idx = TaggedDictBuilder::with_capacity(&tag, 3);
+//             network_idx.insert_untagged("name", UntaggedValue::string(nic.interface()));
+//             network_idx.insert_untagged(
+//                 "sent",
+//                 UntaggedValue::filesize(nic.bytes_sent().get::<information::byte>()),
+//             );
+//             network_idx.insert_untagged(
+//                 "recv",
+//                 UntaggedValue::filesize(nic.bytes_recv().get::<information::byte>()),
+//             );
+//             output.push(network_idx.into_value());
+//         }
+//     }
+//     if !output.is_empty() {
+//         Ok(Some(UntaggedValue::Table(output)))
+//     } else {
+//         Ok(None)
+//     }
+// }
+
+pub fn disks(sys: &System, tag: Tag) -> Option<UntaggedValue> {
     let mut output = vec![];
-    let partitions = disk::partitions_physical().await.map_err(|_| {
-        ShellError::labeled_error(
-            "Unable to get disk list",
-            "could not load disk list",
-            tag.span,
-        )
-    })?;
-
-    futures::pin_mut!(partitions);
-
-    while let Some(part) = partitions.next().await {
-        if let Ok(part) = part {
-            let mut dict = TaggedDictBuilder::with_capacity(&tag, 6);
-            dict.insert_untagged(
-                "device",
-                UntaggedValue::string(
-                    part.device()
-                        .unwrap_or_else(|| OsStr::new("N/A"))
-                        .to_string_lossy(),
-                ),
-            );
-
-            dict.insert_untagged("type", UntaggedValue::string(part.file_system().as_str()));
-            dict.insert_untagged(
-                "mount",
-                UntaggedValue::string(part.mount_point().to_string_lossy()),
-            );
-
-            if let Ok(usage) = disk::usage(part.mount_point().to_path_buf()).await {
-                dict.insert_untagged(
-                    "total",
-                    UntaggedValue::filesize(usage.total().get::<information::byte>()),
-                );
-                dict.insert_untagged(
-                    "used",
-                    UntaggedValue::filesize(usage.used().get::<information::byte>()),
-                );
-                dict.insert_untagged(
-                    "free",
-                    UntaggedValue::filesize(usage.free().get::<information::byte>()),
-                );
-            }
-
-            output.push(dict.into_value());
-        }
+    for disk in sys.get_disks() {
+        let mut dict = TaggedDictBuilder::new(&tag);
+        dict.insert_untagged(
+            "device",
+            UntaggedValue::string(
+                disk.get_name()
+                    .to_string_lossy(),
+            ),
+        );
+        output.push(dict.into_value());
     }
-
-    if !output.is_empty() {
-        Ok(Some(UntaggedValue::Table(output)))
-    } else {
-        Ok(None)
-    }
-}
-
-async fn battery(tag: Tag) -> Option<UntaggedValue> {
-    let mut output = vec![];
-    let span = tag.span;
-
-    if let Ok(manager) = battery::Manager::new() {
-        if let Ok(batteries) = manager.batteries() {
-            for battery in batteries {
-                if let Ok(battery) = battery {
-                    let mut dict = TaggedDictBuilder::new(&tag);
-                    if let Some(vendor) = battery.vendor() {
-                        dict.insert_untagged("vendor", UntaggedValue::string(vendor));
-                    }
-                    if let Some(model) = battery.model() {
-                        dict.insert_untagged("model", UntaggedValue::string(model));
-                    }
-                    if let Some(cycles) = battery.cycle_count() {
-                        dict.insert_untagged("cycles", UntaggedValue::int(cycles));
-                    }
-                    if let Some(time_to_full) = battery.time_to_full() {
-                        dict.insert_untagged(
-                            "mins to full",
-                            UntaggedValue::decimal_from_float(
-                                time_to_full.get::<battery::units::time::minute>() as f64,
-                                span,
-                            ),
-                        );
-                    }
-                    if let Some(time_to_empty) = battery.time_to_empty() {
-                        dict.insert_untagged(
-                            "mins to empty",
-                            UntaggedValue::decimal_from_float(
-                                time_to_empty.get::<battery::units::time::minute>() as f64,
-                                span,
-                            ),
-                        );
-                    }
-                    output.push(dict.into_value());
-                }
-            }
-        }
-    }
-
     if !output.is_empty() {
         Some(UntaggedValue::Table(output))
     } else {
         None
-    }
-}
-
-async fn temp(tag: Tag) -> Option<UntaggedValue> {
-    let mut output = vec![];
-    let span = tag.span;
-
-    let sensors = sensors::temperatures();
-
-    futures::pin_mut!(sensors);
-
-    while let Some(sensor) = sensors.next().await {
-        if let Ok(sensor) = sensor {
-            let mut dict = TaggedDictBuilder::new(&tag);
-            dict.insert_untagged("unit", UntaggedValue::string(sensor.unit()));
-            if let Some(label) = sensor.label() {
-                dict.insert_untagged("label", UntaggedValue::string(label));
-            }
-            dict.insert_untagged(
-                "temp",
-                UntaggedValue::decimal_from_float(
-                    sensor
-                        .current()
-                        .get::<thermodynamic_temperature::degree_celsius>()
-                        as f64,
-                    span,
-                ),
-            );
-            if let Some(high) = sensor.high() {
-                dict.insert_untagged(
-                    "high",
-                    UntaggedValue::decimal_from_float(
-                        high.get::<thermodynamic_temperature::degree_celsius>() as f64,
-                        span,
-                    ),
-                );
-            }
-            if let Some(critical) = sensor.critical() {
-                dict.insert_untagged(
-                    "critical",
-                    UntaggedValue::decimal_from_float(
-                        critical.get::<thermodynamic_temperature::degree_celsius>() as f64,
-                        span,
-                    ),
-                );
-            }
-
-            output.push(dict.into_value());
-        }
-    }
-
-    if !output.is_empty() {
-        Some(UntaggedValue::Table(output))
-    } else {
-        None
-    }
-}
-
-async fn net(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
-    let mut output = vec![];
-    let io_counters = net::io_counters().await.map_err(|_| {
-        ShellError::labeled_error(
-            "Unable to get network device list",
-            "could not load network device list",
-            tag.span,
-        )
-    })?;
-
-    futures::pin_mut!(io_counters);
-
-    while let Some(nic) = io_counters.next().await {
-        if let Ok(nic) = nic {
-            let mut network_idx = TaggedDictBuilder::with_capacity(&tag, 3);
-            network_idx.insert_untagged("name", UntaggedValue::string(nic.interface()));
-            network_idx.insert_untagged(
-                "sent",
-                UntaggedValue::filesize(nic.bytes_sent().get::<information::byte>()),
-            );
-            network_idx.insert_untagged(
-                "recv",
-                UntaggedValue::filesize(nic.bytes_recv().get::<information::byte>()),
-            );
-            output.push(network_idx.into_value());
-        }
-    }
-    if !output.is_empty() {
-        Ok(Some(UntaggedValue::Table(output)))
-    } else {
-        Ok(None)
     }
 }
 
 pub async fn sysinfo(tag: Tag) -> Vec<Value> {
-    let mut sysinfo = TaggedDictBuilder::with_capacity(&tag, 7);
+    let mut sys = System::new_all();
+    sys.refresh_disks();
 
-    let (host, cpu, disks, memory, temp) = futures::future::join5(
-        host(tag.clone()),
-        cpu(tag.clone()),
-        disks(tag.clone()),
-        mem(tag.clone()),
-        temp(tag.clone()),
-    )
-    .await;
-    let (net, battery) = futures::future::join(net(tag.clone()), battery(tag.clone())).await;
+    let mut sysinfo = TaggedDictBuilder::with_capacity(&tag, 6);
 
-    if let Ok(host) = host {
-        sysinfo.insert_value("host", host);
+    //let host = host(tag, &sys);
+    // let (host, cpu, disks, memory, temp) = futures::future::join5(
+    //     host(tag.clone()),
+    //     cpu(tag.clone()),
+    //     disks(tag.clone()),
+    //     mem(tag.clone()),
+    //     temp(tag.clone()),
+    // )
+    // .await;
+    // let (net, battery) = futures::future::join(net(tag.clone()), battery(tag.clone())).await;
+
+    if let Some(disks) = disks(&sys, tag.clone()) {
+        sysinfo.insert_value("disks", disks);
     }
-    if let Some(cpu) = cpu {
-        sysinfo.insert_value("cpu", cpu);
-    }
-    if let Ok(Some(disks)) = disks {
-        sysinfo.insert_untagged("disks", disks);
-    }
-    sysinfo.insert_value("mem", memory);
-    if let Some(temp) = temp {
-        sysinfo.insert_untagged("temp", temp);
-    }
-    if let Ok(Some(net)) = net {
-        sysinfo.insert_untagged("net", net);
-    }
-    if let Some(battery) = battery {
-        sysinfo.insert_untagged("battery", battery);
-    }
+    // if let Some(cpu) = cpu {
+    //     sysinfo.insert_value("cpu", cpu);
+    // }
+    // if let Ok(Some(disks)) = disks {
+    //     sysinfo.insert_untagged("disks", disks);
+    // }
+    // sysinfo.insert_value("mem", memory);
+    // if let Some(temp) = temp {
+    //     sysinfo.insert_untagged("temp", temp);
+    // }
+    // if let Ok(Some(net)) = net {
+    //     sysinfo.insert_untagged("net", net);
+    // }
+    // if let Some(battery) = battery {
+    //     sysinfo.insert_untagged("battery", battery);
+    // }
 
     vec![sysinfo.into_value()]
 }

--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -1,10 +1,6 @@
-use futures_util::StreamExt;
-use nu_errors::ShellError;
 use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
 use nu_source::Tag;
-use num_bigint::BigInt;
-use std::ffi::OsStr;
-use sysinfo::{NetworkExt, NetworksExt, ProcessExt, System, SystemExt, DiskExt};
+use sysinfo::{ComponentExt, DiskExt, NetworkExt, ProcessorExt, System, SystemExt, UserExt};
 
 #[derive(Default)]
 pub struct Sys;
@@ -15,332 +11,153 @@ impl Sys {
     }
 }
 
-// async fn cpu(tag: Tag) -> Option<Value> {
-//     let span = tag.span;
-//     match futures::future::try_join(heim::cpu::logical_count(), heim::cpu::frequency()).await {
-//         Ok((num_cpu, cpu_speed)) => {
-//             let mut cpu_idx = TaggedDictBuilder::with_capacity(tag, 4);
-//             cpu_idx.insert_untagged("cores", UntaggedValue::int(num_cpu));
+pub fn disks(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
+    sys.refresh_disks();
 
-//             let current_speed =
-//                 (cpu_speed.current().get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0)
-//                     .round()
-//                     / 100.0;
-//             cpu_idx.insert_untagged(
-//                 "current ghz",
-//                 UntaggedValue::decimal_from_float(current_speed, span),
-//             );
-
-//             if let Some(min_speed) = cpu_speed.min() {
-//                 let min_speed =
-//                     (min_speed.get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0).round()
-//                         / 100.0;
-//                 cpu_idx.insert_untagged(
-//                     "min ghz",
-//                     UntaggedValue::decimal_from_float(min_speed, span),
-//                 );
-//             }
-
-//             if let Some(max_speed) = cpu_speed.max() {
-//                 let max_speed =
-//                     (max_speed.get::<frequency::hertz>() as f64 / 1_000_000_000.0 * 100.0).round()
-//                         / 100.0;
-//                 cpu_idx.insert_untagged(
-//                     "max ghz",
-//                     UntaggedValue::decimal_from_float(max_speed, span),
-//                 );
-//             }
-
-//             Some(cpu_idx.into_value())
-//         }
-//         Err(_) => None,
-//     }
-// }
-
-// async fn mem(tag: Tag) -> Value {
-//     let mut dict = TaggedDictBuilder::with_capacity(tag, 4);
-
-//     let (memory_result, swap_result) =
-//         futures::future::join(memory::memory(), memory::swap()).await;
-
-//     if let Ok(memory) = memory_result {
-//         dict.insert_untagged(
-//             "total",
-//             UntaggedValue::filesize(memory.total().get::<information::byte>()),
-//         );
-//         dict.insert_untagged(
-//             "free",
-//             UntaggedValue::filesize(memory.free().get::<information::byte>()),
-//         );
-//     }
-
-//     if let Ok(swap) = swap_result {
-//         dict.insert_untagged(
-//             "swap total",
-//             UntaggedValue::filesize(swap.total().get::<information::byte>()),
-//         );
-//         dict.insert_untagged(
-//             "swap free",
-//             UntaggedValue::filesize(swap.free().get::<information::byte>()),
-//         );
-//     }
-
-//     dict.into_value()
-// }
-
-// async fn host(tag: Tag) -> Result<Value, ShellError> {
-//     let mut dict = TaggedDictBuilder::with_capacity(&tag, 6);
-
-//     let (platform_result, uptime_result) =
-//         futures::future::join(host::platform(), host::uptime()).await;
-
-//     // OS
-//     if let Ok(platform) = platform_result {
-//         dict.insert_untagged("name", UntaggedValue::string(platform.system()));
-//         dict.insert_untagged("release", UntaggedValue::string(platform.release()));
-//         dict.insert_untagged("version", UntaggedValue::string(platform.version()));
-//         dict.insert_untagged("hostname", UntaggedValue::string(platform.hostname()));
-//         dict.insert_untagged(
-//             "arch",
-//             UntaggedValue::string(platform.architecture().as_str()),
-//         );
-//     }
-
-//     // Uptime
-//     if let Ok(uptime) = uptime_result {
-//         let uptime = uptime.get::<time::nanosecond>().round() as i64;
-
-//         dict.insert_untagged("uptime", UntaggedValue::duration(BigInt::from(uptime)));
-//     }
-
-//     // Sessions
-//     // note: the heim host module has nomenclature "users"
-//     let users = host::users().await.map_err(|_| {
-//         ShellError::labeled_error("Unable to get users", "could not load users", tag.span)
-//     })?;
-
-//     futures::pin_mut!(users);
-
-//     let mut user_vec = vec![];
-//     while let Some(user) = users.next().await {
-//         if let Ok(user) = user {
-//             user_vec.push(Value {
-//                 value: UntaggedValue::string(user.username()),
-//                 tag: tag.clone(),
-//             });
-//         }
-//     }
-//     let user_list = UntaggedValue::Table(user_vec);
-//     dict.insert_untagged("sessions", user_list);
-
-//     Ok(dict.into_value())
-// }
-
-// async fn disks(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
-//     let mut output = vec![];
-//     let partitions = disk::partitions_physical().await.map_err(|_| {
-//         ShellError::labeled_error(
-//             "Unable to get disk list",
-//             "could not load disk list",
-//             tag.span,
-//         )
-//     })?;
-
-//     futures::pin_mut!(partitions);
-
-//     while let Some(part) = partitions.next().await {
-//         if let Ok(part) = part {
-//             let mut dict = TaggedDictBuilder::with_capacity(&tag, 6);
-//             dict.insert_untagged(
-//                 "device",
-//                 UntaggedValue::string(
-//                     part.device()
-//                         .unwrap_or_else(|| OsStr::new("N/A"))
-//                         .to_string_lossy(),
-//                 ),
-//             );
-
-//             dict.insert_untagged("type", UntaggedValue::string(part.file_system().as_str()));
-//             dict.insert_untagged(
-//                 "mount",
-//                 UntaggedValue::string(part.mount_point().to_string_lossy()),
-//             );
-
-//             if let Ok(usage) = disk::usage(part.mount_point().to_path_buf()).await {
-//                 dict.insert_untagged(
-//                     "total",
-//                     UntaggedValue::filesize(usage.total().get::<information::byte>()),
-//                 );
-//                 dict.insert_untagged(
-//                     "used",
-//                     UntaggedValue::filesize(usage.used().get::<information::byte>()),
-//                 );
-//                 dict.insert_untagged(
-//                     "free",
-//                     UntaggedValue::filesize(usage.free().get::<information::byte>()),
-//                 );
-//             }
-
-//             output.push(dict.into_value());
-//         }
-//     }
-
-//     if !output.is_empty() {
-//         Ok(Some(UntaggedValue::Table(output)))
-//     } else {
-//         Ok(None)
-//     }
-// }
-
-// async fn battery(tag: Tag) -> Option<UntaggedValue> {
-//     let mut output = vec![];
-//     let span = tag.span;
-
-//     if let Ok(manager) = battery::Manager::new() {
-//         if let Ok(batteries) = manager.batteries() {
-//             for battery in batteries {
-//                 if let Ok(battery) = battery {
-//                     let mut dict = TaggedDictBuilder::new(&tag);
-//                     if let Some(vendor) = battery.vendor() {
-//                         dict.insert_untagged("vendor", UntaggedValue::string(vendor));
-//                     }
-//                     if let Some(model) = battery.model() {
-//                         dict.insert_untagged("model", UntaggedValue::string(model));
-//                     }
-//                     if let Some(cycles) = battery.cycle_count() {
-//                         dict.insert_untagged("cycles", UntaggedValue::int(cycles));
-//                     }
-//                     if let Some(time_to_full) = battery.time_to_full() {
-//                         dict.insert_untagged(
-//                             "mins to full",
-//                             UntaggedValue::decimal_from_float(
-//                                 time_to_full.get::<battery::units::time::minute>() as f64,
-//                                 span,
-//                             ),
-//                         );
-//                     }
-//                     if let Some(time_to_empty) = battery.time_to_empty() {
-//                         dict.insert_untagged(
-//                             "mins to empty",
-//                             UntaggedValue::decimal_from_float(
-//                                 time_to_empty.get::<battery::units::time::minute>() as f64,
-//                                 span,
-//                             ),
-//                         );
-//                     }
-//                     output.push(dict.into_value());
-//                 }
-//             }
-//         }
-//     }
-
-//     if !output.is_empty() {
-//         Some(UntaggedValue::Table(output))
-//     } else {
-//         None
-//     }
-// }
-
-// async fn temp(tag: Tag) -> Option<UntaggedValue> {
-//     let mut output = vec![];
-//     let span = tag.span;
-
-//     let sensors = sensors::temperatures();
-
-//     futures::pin_mut!(sensors);
-
-//     while let Some(sensor) = sensors.next().await {
-//         if let Ok(sensor) = sensor {
-//             let mut dict = TaggedDictBuilder::new(&tag);
-//             dict.insert_untagged("unit", UntaggedValue::string(sensor.unit()));
-//             if let Some(label) = sensor.label() {
-//                 dict.insert_untagged("label", UntaggedValue::string(label));
-//             }
-//             dict.insert_untagged(
-//                 "temp",
-//                 UntaggedValue::decimal_from_float(
-//                     sensor
-//                         .current()
-//                         .get::<thermodynamic_temperature::degree_celsius>()
-//                         as f64,
-//                     span,
-//                 ),
-//             );
-//             if let Some(high) = sensor.high() {
-//                 dict.insert_untagged(
-//                     "high",
-//                     UntaggedValue::decimal_from_float(
-//                         high.get::<thermodynamic_temperature::degree_celsius>() as f64,
-//                         span,
-//                     ),
-//                 );
-//             }
-//             if let Some(critical) = sensor.critical() {
-//                 dict.insert_untagged(
-//                     "critical",
-//                     UntaggedValue::decimal_from_float(
-//                         critical.get::<thermodynamic_temperature::degree_celsius>() as f64,
-//                         span,
-//                     ),
-//                 );
-//             }
-
-//             output.push(dict.into_value());
-//         }
-//     }
-
-//     if !output.is_empty() {
-//         Some(UntaggedValue::Table(output))
-//     } else {
-//         None
-//     }
-// }
-
-// async fn net(tag: Tag) -> Result<Option<UntaggedValue>, ShellError> {
-//     let mut output = vec![];
-//     let io_counters = net::io_counters().await.map_err(|_| {
-//         ShellError::labeled_error(
-//             "Unable to get network device list",
-//             "could not load network device list",
-//             tag.span,
-//         )
-//     })?;
-
-//     futures::pin_mut!(io_counters);
-
-//     while let Some(nic) = io_counters.next().await {
-//         if let Ok(nic) = nic {
-//             let mut network_idx = TaggedDictBuilder::with_capacity(&tag, 3);
-//             network_idx.insert_untagged("name", UntaggedValue::string(nic.interface()));
-//             network_idx.insert_untagged(
-//                 "sent",
-//                 UntaggedValue::filesize(nic.bytes_sent().get::<information::byte>()),
-//             );
-//             network_idx.insert_untagged(
-//                 "recv",
-//                 UntaggedValue::filesize(nic.bytes_recv().get::<information::byte>()),
-//             );
-//             output.push(network_idx.into_value());
-//         }
-//     }
-//     if !output.is_empty() {
-//         Ok(Some(UntaggedValue::Table(output)))
-//     } else {
-//         Ok(None)
-//     }
-// }
-
-pub fn disks(sys: &System, tag: Tag) -> Option<UntaggedValue> {
     let mut output = vec![];
     for disk in sys.get_disks() {
         let mut dict = TaggedDictBuilder::new(&tag);
         dict.insert_untagged(
             "device",
-            UntaggedValue::string(
-                disk.get_name()
-                    .to_string_lossy(),
-            ),
+            UntaggedValue::string(disk.get_name().to_string_lossy()),
         );
+        dict.insert_untagged(
+            "type",
+            UntaggedValue::string(String::from_utf8_lossy(disk.get_file_system())),
+        );
+        dict.insert_untagged("mount", UntaggedValue::filepath(disk.get_mount_point()));
+        dict.insert_untagged("total", UntaggedValue::filesize(disk.get_total_space()));
+        dict.insert_untagged("free", UntaggedValue::filesize(disk.get_available_space()));
+        output.push(dict.into_value());
+    }
+    if !output.is_empty() {
+        Some(UntaggedValue::Table(output))
+    } else {
+        None
+    }
+}
+
+pub fn net(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
+    sys.refresh_networks();
+
+    let mut output = vec![];
+    for (iface, data) in sys.get_networks() {
+        let mut dict = TaggedDictBuilder::new(&tag);
+        dict.insert_untagged("name", UntaggedValue::string(iface));
+        dict.insert_untagged(
+            "sent",
+            UntaggedValue::filesize(data.get_total_transmitted()),
+        );
+        dict.insert_untagged("recv", UntaggedValue::filesize(data.get_total_received()));
+
+        output.push(dict.into_value());
+    }
+    if !output.is_empty() {
+        Some(UntaggedValue::Table(output))
+    } else {
+        None
+    }
+}
+
+pub fn cpu(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
+    sys.refresh_cpu();
+
+    let mut output = vec![];
+    for cpu in sys.get_processors() {
+        let mut dict = TaggedDictBuilder::new(&tag);
+        dict.insert_untagged("name", UntaggedValue::string(cpu.get_name()));
+        dict.insert_untagged("brand", UntaggedValue::string(cpu.get_brand()));
+        dict.insert_untagged("freq", UntaggedValue::int(cpu.get_frequency()));
+
+        output.push(dict.into_value());
+    }
+    if !output.is_empty() {
+        Some(UntaggedValue::Table(output))
+    } else {
+        None
+    }
+}
+
+pub fn mem(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
+    sys.refresh_memory();
+
+    let mut dict = TaggedDictBuilder::new(tag);
+    let total_mem = sys.get_total_memory();
+    let free_mem = sys.get_free_memory();
+    let total_swap = sys.get_total_swap();
+    let free_swap = sys.get_free_swap();
+
+    dict.insert_untagged("total", UntaggedValue::filesize(total_mem));
+    dict.insert_untagged("free", UntaggedValue::filesize(free_mem));
+    dict.insert_untagged("swap total", UntaggedValue::filesize(total_swap));
+    dict.insert_untagged("swap free", UntaggedValue::filesize(free_swap));
+
+    Some(dict.into_untagged_value())
+}
+
+pub fn host(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
+    sys.refresh_users_list();
+
+    let mut dict = TaggedDictBuilder::new(&tag);
+    if let Some(name) = sys.get_name() {
+        dict.insert_untagged("name", UntaggedValue::string(name));
+    }
+    if let Some(version) = sys.get_version() {
+        dict.insert_untagged("version", UntaggedValue::string(version));
+    }
+    if let Some(hostname) = sys.get_host_name() {
+        dict.insert_untagged("hostname", UntaggedValue::string(hostname));
+    }
+    dict.insert_untagged(
+        "uptime",
+        UntaggedValue::duration(1000000000 * sys.get_uptime()),
+    );
+
+    let mut users = vec![];
+    for user in sys.get_users() {
+        let mut user_dict = TaggedDictBuilder::new(&tag);
+        user_dict.insert_untagged("name", UntaggedValue::string(user.get_name()));
+
+        let mut groups = vec![];
+        for group in user.get_groups() {
+            groups.push(UntaggedValue::string(group).into_value(&tag));
+        }
+        user_dict.insert_untagged("groups", UntaggedValue::Table(groups));
+
+        users.push(user_dict.into_value());
+    }
+    if !users.is_empty() {
+        dict.insert_untagged("sessions", UntaggedValue::Table(users));
+    }
+
+    Some(dict.into_untagged_value())
+}
+
+pub fn temp(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
+    sys.refresh_components();
+    sys.refresh_components_list();
+
+    let mut output = vec![];
+
+    for component in sys.get_components() {
+        let mut dict = TaggedDictBuilder::new(&tag);
+
+        dict.insert_untagged("unit", UntaggedValue::string(component.get_label()));
+        dict.insert_untagged(
+            "temp",
+            UntaggedValue::decimal_from_float(component.get_temperature() as f64, tag.span),
+        );
+        dict.insert_untagged(
+            "high",
+            UntaggedValue::decimal_from_float(component.get_max() as f64, tag.span),
+        );
+
+        if let Some(critical) = component.get_critical() {
+            dict.insert_untagged(
+                "critical",
+                UntaggedValue::decimal_from_float(critical as f64, tag.span),
+            );
+        }
         output.push(dict.into_value());
     }
     if !output.is_empty() {
@@ -352,40 +169,27 @@ pub fn disks(sys: &System, tag: Tag) -> Option<UntaggedValue> {
 
 pub async fn sysinfo(tag: Tag) -> Vec<Value> {
     let mut sys = System::new_all();
-    sys.refresh_disks();
 
     let mut sysinfo = TaggedDictBuilder::with_capacity(&tag, 6);
 
-    //let host = host(tag, &sys);
-    // let (host, cpu, disks, memory, temp) = futures::future::join5(
-    //     host(tag.clone()),
-    //     cpu(tag.clone()),
-    //     disks(tag.clone()),
-    //     mem(tag.clone()),
-    //     temp(tag.clone()),
-    // )
-    // .await;
-    // let (net, battery) = futures::future::join(net(tag.clone()), battery(tag.clone())).await;
-
-    if let Some(disks) = disks(&sys, tag.clone()) {
+    if let Some(host) = host(&mut sys, tag.clone()) {
+        sysinfo.insert_value("host", host);
+    }
+    if let Some(cpus) = cpu(&mut sys, tag.clone()) {
+        sysinfo.insert_value("cpu", cpus);
+    }
+    if let Some(disks) = disks(&mut sys, tag.clone()) {
         sysinfo.insert_value("disks", disks);
     }
-    // if let Some(cpu) = cpu {
-    //     sysinfo.insert_value("cpu", cpu);
-    // }
-    // if let Ok(Some(disks)) = disks {
-    //     sysinfo.insert_untagged("disks", disks);
-    // }
-    // sysinfo.insert_value("mem", memory);
-    // if let Some(temp) = temp {
-    //     sysinfo.insert_untagged("temp", temp);
-    // }
-    // if let Ok(Some(net)) = net {
-    //     sysinfo.insert_untagged("net", net);
-    // }
-    // if let Some(battery) = battery {
-    //     sysinfo.insert_untagged("battery", battery);
-    // }
+    if let Some(mem) = mem(&mut sys, tag.clone()) {
+        sysinfo.insert_value("mem", mem);
+    }
+    if let Some(temp) = temp(&mut sys, tag.clone()) {
+        sysinfo.insert_value("temp", temp);
+    }
+    if let Some(net) = net(&mut sys, tag.clone()) {
+        sysinfo.insert_value("net", net);
+    }
 
     vec![sysinfo.into_value()]
 }


### PR DESCRIPTION
This moves us onto using sysinfo instead of heim+uom. There are a few changes as a result:

* There aren't 1:1 equivalents for heim in sysinfo, which means some of the features we used to have aren't supported. Notably now missing: battery info, some of the system info fields, and maybe 1(?) of the ps fields.

* The reported processor memory usage differs. I noticed that current `nu` also differs from other process monitor tools I use, so perhaps different apps just count sizes differently.

* We also lose the fancy `benchmark` output because it relied on uom.

Performance between the two seems relatively similar.

Compile times improve noticeably. Here's a before/after `cargo bloat` run (in total, a `cargo build --all --features=extra` build drops from 5 mins 30 sec to 5 mins for me):

## Before
```
  Time Crate
61.78s nu_command
40.93s uom
 9.85s syn
 8.95s nu_engine
 8.10s nu
 7.59s clap
```
## After 
```
  Time Crate
72.37s nu_command
10.75s nu_engine
10.61s syn
 8.65s nu_protocol
 8.54s clap
 8.42s nu
 8.31s nu_plugin
```