### PR TITLE
fix some misalignment errors

### DIFF
--- a/crates/nu_plugin_sys/Cargo.toml
+++ b/crates/nu_plugin_sys/Cargo.toml
@@ -10,12 +10,12 @@ version = "0.25.2"
 doctest = false
 
 [dependencies]
-nu-errors = {path = "../nu-errors", version = "0.25.2"}
-nu-plugin = {path = "../nu-plugin", version = "0.25.2"}
-nu-protocol = {path = "../nu-protocol", version = "0.25.2"}
-nu-source = {path = "../nu-source", version = "0.25.2"}
+nu-errors = { path = "../nu-errors", version = "0.25.2" }
+nu-plugin = { path = "../nu-plugin", version = "0.25.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.25.2" }
+nu-source = { path = "../nu-source", version = "0.25.2" }
 
-futures = {version = "0.3.5", features = ["compat", "io-compat"]}
+futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 futures-util = "0.3.5"
 num-bigint = "0.3.0"
 sysinfo = "0.15.9"


### PR DESCRIPTION
This fixes errors like this one, where one of the columns is misaligned
```
sys | get host
───┬─────────┬──────────┬───────────────┬───────────────────────┬────────────────
 # │  name   │ version  │   hostname    │        uptime         │    sessions
───┼─────────┼──────────┼───────────────┼───────────────────────┼────────────────
 0 │ Windows │ 6.2.9200 │ SOMEHOSTNAME │ 8day 23hr 13min 46sec │ [table 5 rows]
───┴─────────┴──────────┴───────────────┴───────────────────────┴────────────────
```
What I found was that some strings ended with a c style null string `\0`, so I wrapped all string returns with a function to remove that.