### PR TITLE
parser/add rest args to def

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -160,7 +160,7 @@ pub fn get_documentation(
     }
 
     if signature.rest_positional.is_some() {
-        one_liner.push_str(" ...args");
+        one_liner.push_str("...args ");
     }
 
     if !subcommands.is_empty() {

--- a/crates/nu-source/src/meta.rs
+++ b/crates/nu-source/src/meta.rs
@@ -48,13 +48,17 @@ impl Spanned<String> {
     ) -> impl Iterator<Item = &'a str> {
         items.map(|item| &item.item[..])
     }
-}
 
-impl Spanned<String> {
     /// Borrows the contained String
     pub fn borrow_spanned(&self) -> Spanned<&str> {
         let span = self.span;
         self.item[..].spanned(span)
+    }
+
+    pub fn slice_spanned(&self, span: impl Into<Span>) -> Spanned<&str> {
+        let span = span.into();
+        let item = &self.item[span.start()..span.end()];
+        item.spanned(span)
     }
 }
 


### PR DESCRIPTION
This PR applied adds the ability to define the rest parameter of a def
command. It does not implement the functionality to expand the rest argument in
a user defined def function.

The rest argument has to be exactly worded "...rest".

Example after this PR is applied:

file test.nu
```shell
def my_command [
    ...rest:int # My rest arg
] {
    echo 1 2 3
}
```

```shell
> source test.nu
> my_command -h
Usage:
  > my_command ...args {flags}

Parameters:
  ...args: My rest arg

Flags:
  -h, --help: Display this help message
```

