### PR TITLE
Error on bad row in column path

### DIFF
--- a/crates/nu-engine/src/evaluate/evaluator.rs
+++ b/crates/nu-engine/src/evaluate/evaluator.rs
@@ -172,8 +172,8 @@ pub async fn evaluate_baseline_expr(
                 let next = item.get_data_by_member(member);
 
                 match next {
-                    Err(err) => {
-                        if let UnspannedPathMember::String(_name) = &member.unspanned {
+                    Err(err) => match &member.unspanned {
+                        UnspannedPathMember::String(_name) => {
                             let possible_matches = did_you_mean(&item, member.as_string());
 
                             match possible_matches {
@@ -187,7 +187,14 @@ pub async fn evaluate_baseline_expr(
                                 None => return Err(err),
                             }
                         }
-                    }
+                        UnspannedPathMember::Int(_row) => {
+                            return Err(ShellError::labeled_error(
+                                "Unknown row",
+                                "unknown row",
+                                &member.span,
+                            ));
+                        }
+                    },
                     Ok(next) => {
                         item = next.clone().value.into_value(&tag);
                     }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -559,6 +559,18 @@ fn can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external() {
 }
 
 #[test]
+fn index_out_of_bounds() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            let foo = [1, 2, 3]; echo $foo.5
+        "#
+    );
+
+    assert!(actual.err.contains("unknown row"));
+}
+
+#[test]
 fn echoing_ranges() {
     let actual = nu!(
         cwd: ".",

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -571,6 +571,42 @@ fn index_out_of_bounds() {
 }
 
 #[test]
+fn index_row() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let foo = [[name]; [joe] [bob]]; echo $foo.1 | to json
+        "#
+    );
+
+    assert_eq!(actual.out, r#"{"name":"bob"}"#);
+}
+
+#[test]
+fn index_cell() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let foo = [[name]; [joe] [bob]]; echo $foo.name.1
+        "#
+    );
+
+    assert_eq!(actual.out, "bob");
+}
+
+#[test]
+fn index_cell_alt() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let foo = [[name]; [joe] [bob]]; echo $foo.1.name
+        "#
+    );
+
+    assert_eq!(actual.out, "bob");
+}
+
+#[test]
 fn echoing_ranges() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
This will let us now error if the row isn't a valid row:

```
let foo = [1, 2, 3]
echo $foo.5
```

Will now error