### PR TITLE
Lift `return` out of `match` and `if`-`else` branches

### DIFF
--- a/crates/nu-command/src/commands/cal.rs
+++ b/crates/nu-command/src/commands/cal.rs
@@ -210,18 +210,16 @@ fn add_month_to_table(
 
     let month_helper = match month_helper_result {
         Ok(month_helper) => month_helper,
-        Err(()) => match args.get("full-year") {
-            Some(full_year_value) => {
-                return Err(get_invalid_year_shell_error(&full_year_value.tag()))
-            }
-            None => {
-                return Err(ShellError::labeled_error(
+        Err(()) => {
+            return match args.get("full-year") {
+                Some(full_year_value) => Err(get_invalid_year_shell_error(&full_year_value.tag())),
+                None => Err(ShellError::labeled_error(
                     "Issue parsing command",
                     "invalid command",
                     tag,
-                ))
+                )),
             }
-        },
+        }
     };
 
     let mut days_of_the_week = [

--- a/crates/nu-engine/src/evaluate/block.rs
+++ b/crates/nu-engine/src/evaluate/block.rs
@@ -153,7 +153,7 @@ async fn run_pipeline(
                     }
                 }
 
-                match &call.head.expr {
+                return match &call.head.expr {
                     Expression::Block(block) => {
                         ctx.scope.enter_scope();
                         for (param, value) in block.params.positional.iter().zip(args.iter()) {
@@ -163,7 +163,7 @@ async fn run_pipeline(
                         ctx.scope.exit_scope();
 
                         let result = result?;
-                        return Ok(result);
+                        Ok(result)
                     }
                     Expression::Variable(v, span) => {
                         if let Some(value) = ctx.scope.get_var(v) {
@@ -184,24 +184,24 @@ async fn run_pipeline(
                                     ctx.scope.exit_scope();
 
                                     let result = result?;
-                                    return Ok(result);
+                                    Ok(result)
                                 }
                                 _ => {
-                                    return Err(ShellError::labeled_error("Dynamic commands must start with a block (or variable pointing to a block)", "needs to be a block", call.head.span));
+                                    Err(ShellError::labeled_error("Dynamic commands must start with a block (or variable pointing to a block)", "needs to be a block", call.head.span))
                                 }
                             }
                         } else {
-                            return Err(ShellError::labeled_error(
+                            Err(ShellError::labeled_error(
                                 "Variable not found",
                                 "variable not found",
                                 span,
-                            ));
+                            ))
                         }
                     }
                     _ => {
-                        return Err(ShellError::labeled_error("Dynamic commands must start with a block (or variable pointing to a block)", "needs to be a block", call.head.span));
+                        Err(ShellError::labeled_error("Dynamic commands must start with a block (or variable pointing to a block)", "needs to be a block", call.head.span))
                     }
-                }
+                };
             }
 
             ClassifiedCommand::Expr(expr) => run_expression_block(&*expr, ctx).await?,

--- a/crates/nu-json/src/de.rs
+++ b/crates/nu-json/src/de.rs
@@ -661,10 +661,10 @@ where
             Some(b'}') => return Ok(None), // handled later for root
             Some(_) => {}
             None => {
-                if self.root {
-                    return Ok(None);
+                return if self.root {
+                    Ok(None)
                 } else {
-                    return Err(self.de.rdr.error(ErrorCode::EOFWhileParsingObject));
+                    Err(self.de.rdr.error(ErrorCode::EOFWhileParsingObject))
                 }
             }
         }

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1757,14 +1757,14 @@ fn parse_call(
         return (Some(ClassifiedCommand::Expr(Box::new(expr))), error);
     } else if lite_cmd.parts[0].item == "alias" {
         let error = parse_alias(&lite_cmd, scope);
-        if error.is_none() {
-            return (None, None);
+        return if error.is_none() {
+            (None, None)
         } else {
-            return (
+            (
                 Some(ClassifiedCommand::Expr(Box::new(garbage(lite_cmd.span())))),
                 error,
-            );
-        }
+            )
+        };
     } else if lite_cmd.parts[0].item == "source" {
         if lite_cmd.parts.len() != 2 {
             return (


### PR DESCRIPTION
This PR just cleans up a little code by moving the return statements out of the branches of `match` and `if`-`else` statements.  Doing so caused `rustfmt` to restructure some items, which is why the changes seem bigger than they really are.