### PR TITLE
Use equality assert macros

### DIFF
--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -65,7 +65,7 @@ fn multiple_reports_of_multiple_alias() {
     );
 
     let count: i32 = actual.out.parse().unwrap();
-    assert!(count == 2);
+    assert_eq!(count, 2);
 }
 
 #[ignore]
@@ -77,7 +77,7 @@ fn multiple_reports_of_multiple_defs() {
     );
 
     let count: i32 = actual.out.parse().unwrap();
-    assert!(count == 2);
+    assert_eq!(count, 2);
 }
 
 //Fails due to ParserScope::add_definition
@@ -92,5 +92,5 @@ fn def_only_seen_once() {
     );
     //count is 2. One custom_command (def) one built in ("wrongly" added)
     let count: i32 = actual.out.parse().unwrap();
-    assert!(count == 1);
+    assert_eq!(count, 1);
 }

--- a/crates/nu-engine/src/deserializer.rs
+++ b/crates/nu-engine/src/deserializer.rs
@@ -602,8 +602,8 @@ mod tests {
         let tuple = type_name::<()>();
         let tagged_tuple = type_name::<Tagged<()>>();
         let tagged_value = type_name::<Value>();
-        assert!(tuple != tagged_tuple);
-        assert!(tuple != tagged_value);
-        assert!(tagged_tuple != tagged_value);
+        assert_ne!(tuple, tagged_tuple);
+        assert_ne!(tuple, tagged_value);
+        assert_ne!(tagged_tuple, tagged_value);
     }
 }


### PR DESCRIPTION
Instead of using a generic `assert` macro, these can be replaced with built-in `assert_eq` and `assert_ne` macros.