### PR TITLE
added pow operator, and filesize math

### DIFF
--- a/crates/nu-cli/src/types/deduction.rs
+++ b/crates/nu-cli/src/types/deduction.rs
@@ -257,6 +257,7 @@ fn get_result_shape_of(
             }
         }
         Operator::Modulo => SyntaxShape::Number,
+        Operator::Pow => SyntaxShape::Number,
     })
 }
 
@@ -860,7 +861,7 @@ impl VarSyntaxShapeDeductor {
                         }
                     }
                 }
-                Operator::Multiply | Operator::Divide => {
+                Operator::Multiply | Operator::Divide | Operator::Pow => {
                     if let Some(shape) = self.get_shape_of_binary_arg_or_insert_dependency(
                         (var, expr),
                         bin_spanned,

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -173,7 +173,7 @@ pub fn compute_values(
                         }
                         Ok(x % bigdecimal::BigDecimal::from(y.clone()))
                     }
-                    // leaving this hear for the hope that bigdecimal will one day support pow/powf/fpow
+                    // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
                     // Operator::Pow => {
                     //     let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
                     //     let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);

--- a/crates/nu-engine/src/evaluate/operator.rs
+++ b/crates/nu-engine/src/evaluate/operator.rs
@@ -25,6 +25,7 @@ pub fn apply_operator(
         Operator::Plus => value::compute_values(op, left, right),
         Operator::Minus => value::compute_values(op, left, right),
         Operator::Multiply => value::compute_values(op, left, right),
+        Operator::Pow => value::compute_values(op, left, right),
         Operator::Divide => value::compute_values(op, left, right).map(|res| match res {
             UntaggedValue::Error(_) => UntaggedValue::Error(ShellError::labeled_error(
                 "Evaluation error",

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -307,6 +307,7 @@ fn parse_operator(lite_arg: &Spanned<String>) -> (SpannedExpression, Option<Pars
         "mod" => Operator::Modulo,
         "&&" => Operator::And,
         "||" => Operator::Or,
+        "**" => Operator::Pow,
         _ => {
             return (
                 garbage(lite_arg.span),

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -656,7 +656,7 @@ impl SpannedExpression {
                 // Higher precedence binds tighter
 
                 match operator {
-                    Operator::Multiply | Operator::Divide | Operator::Modulo => 100,
+                    Operator::Multiply | Operator::Divide | Operator::Modulo | Operator::Pow => 100,
                     Operator::Plus | Operator::Minus => 90,
                     Operator::NotContains
                     | Operator::Contains
@@ -835,6 +835,7 @@ pub enum Operator {
     Modulo,
     And,
     Or,
+    Pow,
 }
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash, Deserialize, Serialize, new)]

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -656,7 +656,8 @@ impl SpannedExpression {
                 // Higher precedence binds tighter
 
                 match operator {
-                    Operator::Multiply | Operator::Divide | Operator::Modulo | Operator::Pow => 100,
+                    Operator::Pow => 100,
+                    Operator::Multiply | Operator::Divide | Operator::Modulo => 95,
                     Operator::Plus | Operator::Minus => 90,
                     Operator::NotContains
                     | Operator::Contains


### PR DESCRIPTION
Added `pow` as an operator like `**` so you can do:
```
echo $(= 2 ** 8)
256
```
or
```
echo $(= 2.1 ** 8)
378.2285936100001
```
or
```
echo $(= 2.0 ** 8.1)
274.374006409291
```

Added filesize math so things like this will work
```
C:\Users\user\source\repos\forks\nushell(main)
▶ ls | where name == 'Cargo.lock' | get size | each { = $it + 5 }
156538
 C:\Users\user\source\repos\forks\nushell(main)
▶ ls | where name == 'Cargo.lock' | get size | each { = $it * 5 }
782665
 C:\Users\user\source\repos\forks\nushell(main)
▶ ls | where name == 'Cargo.lock' | get size | each { = $it / 5 }
31306
 C:\Users\user\source\repos\forks\nushell(main)
▶ ls | where name == 'Cargo.lock' | get size | each { = $it - 5 }
156528
 C:\Users\user\source\repos\forks\nushell(main)
▶ ls | where name == 'Cargo.lock' | get size
╭───┬───────────╮
│ 0 │ 152.9 KiB │
╰───┴───────────╯

@jonathandturner can you please look at the `pow` work. There was some serious hackage to get it to behave since bigdecimal doesn't support pow.