### PR TITLE
Refactor: Signature Parsing: Abstract common code into parsing primitives

### DIFF
--- a/crates/nu-errors/src/lib.rs
+++ b/crates/nu-errors/src/lib.rs
@@ -37,6 +37,7 @@ pub enum ParseErrorReason {
     },
 }
 
+pub type ParseWarning = ParseError;
 /// A newtype for `ParseErrorReason`
 #[derive(Debug, Clone, Getters, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub struct ParseError {

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -18,7 +18,7 @@ impl Token {
     }
 }
 
-#[derive(Debug, PartialEq, is_enum_variant)]
+#[derive(Clone, Debug, PartialEq, is_enum_variant)]
 pub enum TokenContents {
     /// A baseline token is an atomic chunk of source code. This means that the
     /// token contains the entirety of string literals, as well as the entirety

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -7,7 +7,7 @@ use nu_errors::ParseError;
 
 type Input<'t> = Peekable<CharIndices<'t>>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Token {
     pub contents: TokenContents,
     pub span: Span,

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate derive_is_enum_variant;
+#[macro_use]
+extern crate derive_new;
 
 mod errors;
 mod lex;

--- a/crates/nu-parser/src/parse/def.rs
+++ b/crates/nu-parser/src/parse/def.rs
@@ -12,6 +12,7 @@ use crate::ParserScope;
 
 use self::param_flag_list::parse_signature;
 
+mod lex_fixup;
 mod lib_code;
 mod param_flag_list;
 mod primitives;

--- a/crates/nu-parser/src/parse/def.rs
+++ b/crates/nu-parser/src/parse/def.rs
@@ -13,6 +13,9 @@ use crate::ParserScope;
 use self::param_flag_list::parse_signature;
 
 mod param_flag_list;
+mod parse_lib;
+mod primitives;
+mod tests;
 
 pub(crate) fn parse_definition(call: &LiteCommand, scope: &dyn ParserScope) -> Option<ParseError> {
     // A this point, we've already handled the prototype and put it into scope;

--- a/crates/nu-parser/src/parse/def.rs
+++ b/crates/nu-parser/src/parse/def.rs
@@ -12,8 +12,8 @@ use crate::ParserScope;
 
 use self::param_flag_list::parse_signature;
 
+mod lib_code;
 mod param_flag_list;
-mod parse_lib;
 mod primitives;
 mod tests;
 

--- a/crates/nu-parser/src/parse/def/lex_fixup.rs
+++ b/crates/nu-parser/src/parse/def/lex_fixup.rs
@@ -1,0 +1,90 @@
+use log::debug;
+use nu_source::Span;
+
+use crate::lex::{Token, TokenContents};
+
+//Currently the lexer does not split off baselines after existing text
+//Example --flag(-f) is lexed as one baseline token.
+//To properly parse the input, it is required that --flag and (-f) are 2 tokens.
+pub(crate) fn lex_split_shortflag_from_longflag(tokens: Vec<Token>) -> Vec<Token> {
+    let mut result = Vec::with_capacity(tokens.capacity());
+    for token in tokens {
+        let mut processed = false;
+        if let TokenContents::Baseline(base) = &token.contents {
+            if let Some(paren_start) = base.find('(') {
+                if paren_start != 0 {
+                    processed = true;
+                    //If token contains '(' and '(' is not the first char,
+                    //we split on '('
+                    //Example: Baseline(--flag(-f)) results in: [Baseline(--flag), Baseline((-f))]
+                    let paren_span_i = token.span.start() + paren_start;
+                    result.push(Token::new(
+                        TokenContents::Baseline(base[..paren_start].to_string()),
+                        Span::new(token.span.start(), paren_span_i),
+                    ));
+                    result.push(Token::new(
+                        TokenContents::Baseline(base[paren_start..].to_string()),
+                        Span::new(paren_span_i, token.span.end()),
+                    ));
+                }
+            }
+        }
+
+        if !processed {
+            result.push(token);
+        }
+    }
+    result
+}
+
+//Currently the lexer does not split baselines on ',' ':' '?'
+//The parameter list requires this. Therefore here is a hacky method doing this.
+pub(crate) fn lex_split_baseline_tokens_on(
+    tokens: Vec<Token>,
+    extra_baseline_terminal_tokens: &[char],
+) -> Vec<Token> {
+    debug!("Before lex fix up {:?}", tokens);
+    let make_new_token =
+        |token_new: String, token_new_end: usize, terminator_char: Option<char>| {
+            let end = token_new_end;
+            let start = end - token_new.len();
+
+            let mut result = vec![];
+            //Only add token if its not empty
+            if !token_new.is_empty() {
+                result.push(Token::new(
+                    TokenContents::Baseline(token_new),
+                    Span::new(start, end),
+                ));
+            }
+            //Insert terminator_char as baseline token
+            if let Some(ch) = terminator_char {
+                result.push(Token::new(
+                    TokenContents::Baseline(ch.to_string()),
+                    Span::new(end, end + 1),
+                ));
+            }
+
+            result
+        };
+    let mut result = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        match token.contents {
+            TokenContents::Baseline(base) => {
+                let token_offset = token.span.start();
+                let mut current = "".to_string();
+                for (i, c) in base.chars().enumerate() {
+                    if extra_baseline_terminal_tokens.contains(&c) {
+                        result.extend(make_new_token(current, i + token_offset, Some(c)));
+                        current = "".to_string();
+                    } else {
+                        current.push(c);
+                    }
+                }
+                result.extend(make_new_token(current, base.len() + token_offset, None));
+            }
+            _ => result.push(token),
+        }
+    }
+    result
+}

--- a/crates/nu-parser/src/parse/def/lib_code.rs
+++ b/crates/nu-parser/src/parse/def/lib_code.rs
@@ -1,0 +1,3 @@
+pub use self::parse_result::ParseResult;
+pub mod parse_lib;
+pub mod parse_result;

--- a/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
+++ b/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
@@ -145,12 +145,12 @@ impl<Value: CheckedParse> Parse for Maybe<Value> {
 }
 
 ///Parse First and then Second
-pub(crate) struct AndThen<First, Second> {
+pub(crate) struct And<First, Second> {
     _marker1: marker::PhantomData<*const First>,
     _marker2: marker::PhantomData<*const Second>,
 }
 
-impl<First: CheckedParse, Second: CheckedParse> Parse for AndThen<First, Second> {
+impl<First: CheckedParse, Second: CheckedParse> Parse for And<First, Second> {
     type Output = (First::Output, Second::Output);
 
     fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
@@ -173,7 +173,7 @@ impl<First: CheckedParse, Second: CheckedParse> Parse for AndThen<First, Second>
 }
 
 //Always Checked because accepts only checked
-impl<T1: CheckedParse, T2: CheckedParse> CheckedParse for AndThen<T1, T2> {}
+impl<T1: CheckedParse, T2: CheckedParse> CheckedParse for And<T1, T2> {}
 
 pub(crate) struct IfSuccessThen<Try, AndThen> {
     _marker1: marker::PhantomData<*const Try>,

--- a/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
+++ b/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
@@ -3,7 +3,7 @@ use std::marker;
 
 use crate::{lex::Token, parse::util::token_to_spanned_string};
 use nu_errors::ParseError;
-use nu_source::{Span, Spanned, SpannedItem};
+use nu_source::Span;
 
 use super::ParseResult;
 
@@ -315,7 +315,7 @@ pub(crate) struct WithSpan<Parser: CheckedParse> {
 impl<Parser: CheckedParse> CheckedParse for WithSpan<Parser> {}
 
 impl<Parser: CheckedParse> Parse for WithSpan<Parser> {
-    type Output = Spanned<Parser::Output>;
+    type Output = (Span, Parser::Output);
 
     fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
         let i_before = i;
@@ -331,7 +331,7 @@ impl<Parser: CheckedParse> Parse for WithSpan<Parser> {
             Span::unknown()
         };
 
-        ParseResult::new(value.spanned(span), i, err)
+        ParseResult::new((span, value), i, err)
     }
 
     fn display_name() -> String {
@@ -339,6 +339,6 @@ impl<Parser: CheckedParse> Parse for WithSpan<Parser> {
     }
 
     fn default_error_value() -> Self::Output {
-        Parser::default_error_value().spanned_unknown()
+        (Span::unknown(), Parser::default_error_value())
     }
 }

--- a/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
+++ b/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
@@ -144,7 +144,13 @@ impl<P1: CheckedParse, P2: CheckedParse> Parse for And2<P1, P2> {
     fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
         let p1 = P1::parse(tokens, i);
         let p2 = P2::parse(tokens, p1.i);
-        ParseResult::new((p1.value, p2.value), p2.i, p1.err.or(p2.err))
+
+        let err = [p1.err, p2.err]
+            .iter()
+            .find(|e| e.is_some())
+            .cloned()
+            .unwrap_or(None);
+        ParseResult::new((p1.value, p2.value), p2.i, err)
     }
 
     fn display_name() -> String {
@@ -172,11 +178,13 @@ impl<P1: CheckedParse, P2: CheckedParse, P3: CheckedParse> Parse for And3<P1, P2
         let p1 = P1::parse(tokens, i);
         let p2 = P2::parse(tokens, p1.i);
         let p3 = P3::parse(tokens, p2.i);
-        ParseResult::new(
-            (p1.value, p2.value, p3.value),
-            p3.i,
-            p1.err.or(p2.err.or(p3.err)),
-        )
+
+        let err = [p1.err, p2.err, p3.err]
+            .iter()
+            .find(|e| e.is_some())
+            .cloned()
+            .unwrap_or(None);
+        ParseResult::new((p1.value, p2.value, p3.value), p3.i, err)
     }
 
     fn display_name() -> String {
@@ -215,11 +223,13 @@ impl<P1: CheckedParse, P2: CheckedParse, P3: CheckedParse, P4: CheckedParse> Par
         let p2 = P2::parse(tokens, p1.i);
         let p3 = P3::parse(tokens, p2.i);
         let p4 = P4::parse(tokens, p3.i);
-        ParseResult::new(
-            (p1.value, p2.value, p3.value, p4.value),
-            p4.i,
-            p1.err.or(p2.err.or(p3.err.or(p4.err))),
-        )
+
+        let err = [p1.err, p2.err, p3.err, p4.err]
+            .iter()
+            .find(|e| e.is_some())
+            .cloned()
+            .unwrap_or(None);
+        ParseResult::new((p1.value, p2.value, p3.value, p4.value), p4.i, err)
     }
 
     fn display_name() -> String {
@@ -322,7 +332,7 @@ impl<Parser: CheckedParse> Parse for WithSpan<Parser> {
         let ParseResult { value, i, err } = Parser::parse(tokens, i);
         let i_after = i;
 
-        let span = if tokens.len() > 0 {
+        let span = if !tokens.is_empty() {
             //Clamp indices to make sure we never access out of bounds
             let i_before = num_traits::clamp(i_before, 0, tokens.len() - 1);
             let i_after = num_traits::clamp(i_after, 0, tokens.len() - 1);

--- a/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
+++ b/crates/nu-parser/src/parse/def/lib_code/parse_lib.rs
@@ -142,9 +142,9 @@ impl<P1: CheckedParse, P2: CheckedParse> Parse for And2<P1, P2> {
     type Output = (P1::Output, P2::Output);
 
     fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
-        let _1 = P1::parse(tokens, i);
-        let _2 = P2::parse(tokens, _1.i);
-        ParseResult::new((_1.value, _2.value), _2.i, _1.err.or(_2.err))
+        let p1 = P1::parse(tokens, i);
+        let p2 = P2::parse(tokens, p1.i);
+        ParseResult::new((p1.value, p2.value), p2.i, p1.err.or(p2.err))
     }
 
     fn display_name() -> String {
@@ -169,13 +169,13 @@ impl<P1: CheckedParse, P2: CheckedParse, P3: CheckedParse> Parse for And3<P1, P2
     type Output = (P1::Output, P2::Output, P3::Output);
 
     fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
-        let _1 = P1::parse(tokens, i);
-        let _2 = P2::parse(tokens, _1.i);
-        let _3 = P3::parse(tokens, _2.i);
+        let p1 = P1::parse(tokens, i);
+        let p2 = P2::parse(tokens, p1.i);
+        let p3 = P3::parse(tokens, p2.i);
         ParseResult::new(
-            (_1.value, _2.value, _3.value),
-            _3.i,
-            _1.err.or(_2.err.or(_3.err)),
+            (p1.value, p2.value, p3.value),
+            p3.i,
+            p1.err.or(p2.err.or(p3.err)),
         )
     }
 
@@ -211,14 +211,14 @@ impl<P1: CheckedParse, P2: CheckedParse, P3: CheckedParse, P4: CheckedParse> Par
     type Output = (P1::Output, P2::Output, P3::Output, P4::Output);
 
     fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
-        let _1 = P1::parse(tokens, i);
-        let _2 = P2::parse(tokens, _1.i);
-        let _3 = P3::parse(tokens, _2.i);
-        let _4 = P4::parse(tokens, _3.i);
+        let p1 = P1::parse(tokens, i);
+        let p2 = P2::parse(tokens, p1.i);
+        let p3 = P3::parse(tokens, p2.i);
+        let p4 = P4::parse(tokens, p3.i);
         ParseResult::new(
-            (_1.value, _2.value, _3.value, _4.value),
-            _4.i,
-            _1.err.or(_2.err.or(_3.err.or(_4.err))),
+            (p1.value, p2.value, p3.value, p4.value),
+            p4.i,
+            p1.err.or(p2.err.or(p3.err.or(p4.err))),
         )
     }
 

--- a/crates/nu-parser/src/parse/def/lib_code/parse_result.rs
+++ b/crates/nu-parser/src/parse/def/lib_code/parse_result.rs
@@ -1,20 +1,35 @@
-use nu_errors::ParseError;
+use nu_errors::{ParseError, ParseWarning};
 
 #[derive(new)]
 pub struct ParseResult<Value> {
     pub value: Value,
     pub i: usize,
     pub err: Option<ParseError>,
+    pub warnings: Vec<ParseWarning>,
+}
+
+impl<Value> From<(Value, usize, Option<ParseError>, Vec<ParseWarning>)> for ParseResult<Value> {
+    fn from(
+        (value, i, err, warnings): (Value, usize, Option<ParseError>, Vec<ParseWarning>),
+    ) -> Self {
+        Self::new(value, i, err, warnings)
+    }
 }
 
 impl<Value> From<(Value, usize, Option<ParseError>)> for ParseResult<Value> {
     fn from((value, i, err): (Value, usize, Option<ParseError>)) -> Self {
-        Self { value, i, err }
+        Self::new(value, i, err, vec![])
     }
 }
 
-impl<Value> From<ParseResult<Value>> for (Value, usize, Option<ParseError>) {
+impl<Value> From<(Value, usize)> for ParseResult<Value> {
+    fn from((value, i): (Value, usize)) -> Self {
+        Self::new(value, i, None, vec![])
+    }
+}
+
+impl<Value> From<ParseResult<Value>> for (Value, usize, Option<ParseError>, Vec<ParseWarning>) {
     fn from(result: ParseResult<Value>) -> Self {
-        (result.value, result.i, result.err)
+        (result.value, result.i, result.err, result.warnings)
     }
 }

--- a/crates/nu-parser/src/parse/def/lib_code/parse_result.rs
+++ b/crates/nu-parser/src/parse/def/lib_code/parse_result.rs
@@ -1,0 +1,20 @@
+use nu_errors::ParseError;
+
+#[derive(new)]
+pub struct ParseResult<Value> {
+    pub value: Value,
+    pub i: usize,
+    pub err: Option<ParseError>,
+}
+
+impl<Value> From<ParseResult<Value>> for (Value, usize, Option<ParseError>) {
+    fn from(result: ParseResult<Value>) -> Self {
+        (result.value, result.i, result.err)
+    }
+}
+
+impl<Value> From<(Value, usize, Option<ParseError>)> for ParseResult<Value> {
+    fn from((value, i, err): (Value, usize, Option<ParseError>)) -> Self {
+        Self { value, i, err }
+    }
+}

--- a/crates/nu-parser/src/parse/def/lib_code/parse_result.rs
+++ b/crates/nu-parser/src/parse/def/lib_code/parse_result.rs
@@ -7,14 +7,14 @@ pub struct ParseResult<Value> {
     pub err: Option<ParseError>,
 }
 
-impl<Value> From<ParseResult<Value>> for (Value, usize, Option<ParseError>) {
-    fn from(result: ParseResult<Value>) -> Self {
-        (result.value, result.i, result.err)
-    }
-}
-
 impl<Value> From<(Value, usize, Option<ParseError>)> for ParseResult<Value> {
     fn from((value, i, err): (Value, usize, Option<ParseError>)) -> Self {
         Self { value, i, err }
+    }
+}
+
+impl<Value> From<ParseResult<Value>> for (Value, usize, Option<ParseError>) {
+    fn from(result: ParseResult<Value>) -> Self {
+        (result.value, result.i, result.err)
     }
 }

--- a/crates/nu-parser/src/parse/def/param_flag_list.rs
+++ b/crates/nu-parser/src/parse/def/param_flag_list.rs
@@ -75,7 +75,7 @@ pub(crate) fn parse_signature(
         if tokens[i].contents.is_eol() {
             //Skip leading eol
             i += 1;
-        } else if is_flag(&tokens[i]) {
+        } else if Flag::tokens_are_begin(&tokens, i) {
             let ParseResult {
                 value: flag,
                 i: i_new,
@@ -85,7 +85,7 @@ pub(crate) fn parse_signature(
             err = err.or(error);
             i = i_new;
             flags.push(flag);
-        } else if can_be_rest(&tokens[i]) {
+        } else if Rest::tokens_are_begin(&tokens, i) {
             let ParseResult {
                 value: rest_,
                 i: i_new,

--- a/crates/nu-parser/src/parse/def/param_flag_list.rs
+++ b/crates/nu-parser/src/parse/def/param_flag_list.rs
@@ -15,13 +15,18 @@ use log::debug;
 
 use crate::{
     lex::{lex, Token, TokenContents},
-    parse::util::token_to_spanned_string,
+    parse::def::parse_lib::{AndThen, Expect, IfSuccessThen, Maybe, Parse},
 };
 use nu_errors::ParseError;
 use nu_protocol::{NamedType, PositionalType, Signature, SyntaxShape};
-use nu_source::{Span, Spanned, SpannedItem};
+use nu_source::{Span, Spanned};
 
-pub fn parse_signature(
+use super::primitives::{
+    Comma, Comment, DoublePoint, FlagName, FlagShortName, OptionalModifier, ParameterName,
+    RestName, Shape, EOL,
+};
+
+pub(crate) fn parse_signature(
     name: &str,
     signature_vec: &Spanned<String>,
 ) -> (Signature, Option<ParseError>) {
@@ -66,19 +71,19 @@ pub fn parse_signature(
             //Skip leading eol
             i += 1;
         } else if is_flag(&tokens[i]) {
-            let (flag, advanced_by, error) = parse_flag(&tokens[i..], signature_vec);
+            let (flag, i_new, error) = Flag::parse_debug(&tokens, i);
             err = err.or(error);
-            i += advanced_by;
+            i = i_new;
             flags.push(flag);
         } else if is_rest(&tokens[i]) {
-            let (rest_, advanced_by, error) = parse_rest(&tokens[i..], signature_vec);
+            let (rest_, i_new, error) = Rest::parse_debug(&tokens, i);
             err = err.or(error);
-            i += advanced_by;
-            rest = rest_;
+            i = i_new;
+            rest = Some(rest_);
         } else {
-            let (parameter, advanced_by, error) = parse_parameter(&tokens[i..], signature_vec);
+            let (parameter, i_new, error) = Parameter::parse_debug(&tokens, i);
             err = err.or(error);
-            i += advanced_by;
+            i = i_new;
             parameters.push(parameter);
         }
     }
@@ -89,431 +94,137 @@ pub fn parse_signature(
     (signature, err)
 }
 
-fn parse_parameter(
-    tokens: &[Token],
-    tokens_as_str: &Spanned<String>,
-) -> (Parameter, usize, Option<ParseError>) {
-    if tokens.is_empty() {
-        //TODO fix span
-        return (
-            Parameter::error(),
-            0,
-            Some(ParseError::unexpected_eof("parameter", tokens_as_str.span)),
-        );
-    }
+impl Parse for Parameter {
+    type Output = Parameter;
 
-    let mut err: Option<ParseError> = None;
-    let mut i = 0;
-    let mut type_ = SyntaxShape::Any;
-    let mut comment = None;
-    let mut optional = false;
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        // let i_start = i;
 
-    let (name, error) = parse_param_name(&tokens[0]);
-    i += 1;
-    err = err.or(error);
+        let ((name, (optional, (type_, comment))), i, err) = AndThen::<
+            Expect<ParameterName>,
+            AndThen<Maybe<OptionalModifier>, AndThen<OptionalType, ItemEnd>>,
+        >::parse(tokens, i);
 
-    if i < tokens.len() {
-        let (parsed_opt_modifier, advanced_by) =
-            parse_optional_parameter_optional_modifier(&tokens[i]);
-        optional = parsed_opt_modifier;
-        i += advanced_by;
-    }
+        // let i_end = i;
 
-    if i < tokens.len() {
-        let (parsed_type_, advanced_by, error) = parse_optional_type(&tokens[i..]);
-        type_ = parsed_type_.unwrap_or(SyntaxShape::Any);
-        err = err.or(error);
-        i += advanced_by;
-    }
+        let type_ = type_.unwrap_or(SyntaxShape::Any);
+        // let span = tokens[i_start].span.until(tokens[i_end - 1].span);
+        let span = Span::unknown();
 
-    if i < tokens.len() {
-        let (comment_text, advanced_by, error) = parse_signature_item_end(&tokens[i..]);
-        comment = comment_text;
-        i += advanced_by;
-        err = err.or(error);
-    }
-
-    let pos_type = if optional {
-        PositionalType::optional(&name.item, type_)
-    } else {
-        PositionalType::mandatory(&name.item, type_)
-    };
-
-    let parameter = Parameter::new(pos_type, comment, name.span);
-
-    debug!(
-        "Parsed parameter: {} with shape {:?}",
-        parameter.pos_type.name(),
-        parameter.pos_type.syntax_type()
-    );
-
-    (parameter, i, err)
-}
-
-fn parse_flag(
-    tokens: &[Token],
-    tokens_as_str: &Spanned<String>,
-) -> (Flag, usize, Option<ParseError>) {
-    if tokens.is_empty() {
-        return (
-            Flag::error(),
-            0,
-            Some(ParseError::unexpected_eof("parameter", tokens_as_str.span)),
-        );
-    }
-
-    let mut err: Option<ParseError> = None;
-    let mut i = 0;
-    let mut shortform = None;
-    let mut type_ = None;
-    let mut comment = None;
-
-    let (name, error) = parse_flag_name(&tokens[0]);
-    err = err.or(error);
-    i += 1;
-
-    if i < tokens.len() {
-        let (parsed_shortform, advanced_by, error) = parse_flag_optional_shortform(&tokens[i..]);
-        shortform = parsed_shortform;
-        i += advanced_by;
-        err = err.or(error);
-    }
-
-    if i < tokens.len() {
-        let (parsed_type, advanced_by, error) = parse_optional_type(&tokens[i..]);
-        type_ = parsed_type;
-        i += advanced_by;
-        err = err.or(error);
-    }
-
-    if i < tokens.len() {
-        let (parsed_comment, advanced_by, error) = parse_signature_item_end(&tokens[i..]);
-        comment = parsed_comment;
-        i += advanced_by;
-        err = err.or(error);
-    }
-
-    //If no type is given, the flag is a switch. Otherwise its optional
-    //Example:
-    //--verbose(-v) # Switch
-    //--output(-o): path # Optional flag
-    let named_type = if let Some(shape) = type_ {
-        NamedType::Optional(shortform, shape)
-    } else {
-        NamedType::Switch(shortform)
-    };
-
-    let flag = Flag::new(name.item.clone(), named_type, comment, name.span);
-
-    debug!("Parsed flag: {:?}", flag);
-    (flag, i, err)
-}
-
-fn parse_rest(
-    tokens: &[Token],
-    tokens_as_str: &Spanned<String>,
-) -> (
-    Option<(SyntaxShape, Description)>,
-    usize,
-    Option<ParseError>,
-) {
-    if tokens.is_empty() {
-        return (
-            None,
-            0,
-            Some(ParseError::unexpected_eof(
-                "rest argument",
-                tokens_as_str.span,
-            )),
-        );
-    }
-
-    let mut err = None;
-    let mut i = 0;
-    let mut type_ = SyntaxShape::Any;
-    let mut comment = "".to_string();
-
-    let error = parse_rest_name(&tokens[i]);
-    err = err.or(error);
-    i += 1;
-
-    if i < tokens.len() {
-        let (parsed_type, advanced_by, error) = parse_optional_type(&tokens[i..]);
-        err = err.or(error);
-        i += advanced_by;
-        type_ = parsed_type.unwrap_or(SyntaxShape::Any);
-    }
-
-    if i < tokens.len() {
-        let (parsed_comment, advanced_by) = parse_optional_comment(&tokens[i..]);
-        i += advanced_by;
-        comment = parsed_comment.unwrap_or_else(|| "".to_string());
-    }
-
-    return (Some((type_, comment)), i, err);
-
-    fn parse_rest_name(name_token: &Token) -> Option<ParseError> {
-        return if let TokenContents::Baseline(name) = &name_token.contents {
-            if !name.starts_with("...") {
-                parse_rest_name_err(name_token)
-            } else if !name.starts_with("...rest") {
-                Some(ParseError::mismatch(
-                    "rest argument name to be 'rest'",
-                    token_to_spanned_string(name_token),
-                ))
-            } else {
-                None
-            }
+        let pos_type = if optional.is_some() {
+            PositionalType::optional(&name, type_)
         } else {
-            parse_rest_name_err(name_token)
+            PositionalType::mandatory(&name, type_)
         };
 
-        fn parse_rest_name_err(token: &Token) -> Option<ParseError> {
-            Some(ParseError::mismatch(
-                "...rest",
-                token_to_spanned_string(token),
-            ))
-        }
+        let parameter = Parameter::new(pos_type, comment, span);
+
+        debug!(
+            "Parsed parameter: {} with shape {:?}",
+            parameter.pos_type.name(),
+            parameter.pos_type.syntax_type()
+        );
+
+        (parameter, i, err)
+    }
+
+    fn display_name() -> String {
+        "parameter item".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        Parameter::error()
     }
 }
 
-fn parse_type(type_: &Spanned<String>) -> (SyntaxShape, Option<ParseError>) {
-    debug!("Parsing type {:?}", type_);
-    match type_.item.as_str() {
-        "int" => (SyntaxShape::Int, None),
-        "string" => (SyntaxShape::String, None),
-        "path" => (SyntaxShape::FilePath, None),
-        "table" => (SyntaxShape::Table, None),
-        "unit" => (SyntaxShape::Unit, None),
-        "number" => (SyntaxShape::Number, None),
-        "pattern" => (SyntaxShape::GlobPattern, None),
-        "range" => (SyntaxShape::Range, None),
-        "block" => (SyntaxShape::Block, None),
-        "any" => (SyntaxShape::Any, None),
-        _ => (
-            SyntaxShape::Any,
-            Some(ParseError::mismatch("type", type_.clone())),
-        ),
-    }
-}
+impl Parse for Flag {
+    type Output = Flag;
 
-fn parse_type_token(type_: &Token) -> (SyntaxShape, Option<ParseError>) {
-    match &type_.contents {
-        TokenContents::Baseline(type_str) => parse_type(&type_str.clone().spanned(type_.span)),
-        _ => (
-            SyntaxShape::Any,
-            Some(ParseError::mismatch(
-                "type",
-                type_.contents.to_string().spanned(type_.span),
-            )),
-        ),
-    }
-}
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        // let i_start = i;
 
-fn parse_param_name(token: &Token) -> (Spanned<String>, Option<ParseError>) {
-    if let TokenContents::Baseline(name) = &token.contents {
-        let name = name.clone().spanned(token.span);
-        (name, None)
-    } else {
-        (
-            "InternalError".to_string().spanned(token.span),
-            Some(ParseError::mismatch(
-                "parameter name",
-                token_to_spanned_string(token),
-            )),
-        )
-    }
-}
+        let ((name, (shortform, (type_, comment))), i, err) = AndThen::<
+            Expect<FlagName>,
+            AndThen<Maybe<FlagShortName>, AndThen<OptionalType, ItemEnd>>,
+        >::parse(tokens, i);
 
-fn parse_optional_comment(tokens: &[Token]) -> (Option<String>, usize) {
-    let mut comment_text = None;
-    let mut i: usize = 0;
-    if i < tokens.len() {
-        if let TokenContents::Comment(comment) = &tokens[i].contents {
-            comment_text = Some(comment.trim().to_string());
-            i += 1;
-        }
-    }
-    (comment_text, i)
-}
+        // let i_end = i;
+        // let span = tokens[i_start].span.until(tokens[i_end - 1].span);
+        let span = Span::unknown();
 
-fn parse_optional_type(tokens: &[Token]) -> (Option<SyntaxShape>, usize, Option<ParseError>) {
-    fn is_double_point(token: &Token) -> bool {
-        is_baseline_token_matching(token, ":")
-    }
-    let mut err = None;
-    let mut type_ = None;
-    let mut i: usize = 0;
-    //Check if a type has to follow
-    if i < tokens.len() && is_double_point(&tokens[i]) {
-        //Type has to follow
-        if i + 1 == tokens.len() {
-            err = err.or_else(|| Some(ParseError::unexpected_eof("type", tokens[i].span)));
+        //If no type is given, the flag is a switch. Otherwise its optional
+        //Example:
+        //--verbose(-v) # Switch
+        //--output(-o): path # Optional flag
+        let named_type = if let Some(shape) = type_ {
+            NamedType::Optional(shortform, shape)
         } else {
-            //Jump over <:>
-            i += 1;
-            let (shape, error) = parse_type_token(&tokens[i]);
-            err = err.or(error);
-            type_ = Some(shape);
-            i += 1;
-        }
+            NamedType::Switch(shortform)
+        };
+
+        let flag = Flag::new(name, named_type, comment, span);
+
+        debug!("Parsed flag: {:?}", flag);
+        (flag, i, err)
     }
-    (type_, i, err)
+
+    fn display_name() -> String {
+        "Flag item".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        Flag::error()
+    }
 }
 
-///Parse token if it is a modifier to make
-fn parse_optional_parameter_optional_modifier(token: &Token) -> (bool, usize) {
-    fn is_questionmark(token: &Token) -> bool {
-        is_baseline_token_matching(token, "?")
+struct Rest;
+impl Parse for Rest {
+    type Output = (SyntaxShape, Description);
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let ((_, (type_, comment)), i, err) =
+            AndThen::<Expect<RestName>, AndThen<OptionalType, ItemEnd>>::parse(tokens, i);
+
+        return (
+            (
+                type_.unwrap_or(SyntaxShape::Any),
+                comment.unwrap_or("".to_string()),
+            ),
+            i,
+            err,
+        );
     }
-    if is_questionmark(token) {
-        (true, 1)
-    } else {
-        (false, 0)
+
+    fn display_name() -> String {
+        "Rest item".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        (SyntaxShape::Any, "".to_string())
     }
 }
 
 ///Parses the end of a flag or a parameter
+///Return value is Option<Comment>
 ///   (<,>)? (#Comment)? (<eol>)?
-fn parse_signature_item_end(tokens: &[Token]) -> (Option<String>, usize, Option<ParseError>) {
-    if tokens.is_empty() {
-        //If no more tokens, parameter/flag doesn't need ',' or comment to be properly finished
-        return (None, 0, None);
+type ItemEnd = Option<Description>;
+impl Parse for ItemEnd {
+    //Item end Output is optional Comment
+    type Output = Option<Description>;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let ((_, (comment, _)), i, err) =
+            AndThen::<Maybe<Comma>, AndThen<Maybe<Comment>, Maybe<EOL>>>::parse(tokens, i);
+
+        (comment, i, err)
     }
 
-    let mut i = 0;
-    let err = None;
-    let (parsed_comma, advanced_by) = parse_comma(&tokens[i..]);
-    i += advanced_by;
-    let (comment, advanced_by) = parse_optional_comment(&tokens[i..]);
-    i += advanced_by;
-    let (parsed_eol, advanced_by) = parse_eol(&tokens[i..]);
-    i += advanced_by;
-
-    debug!(
-        "Parsed comma {} and parsed eol {}",
-        parsed_comma, parsed_eol
-    );
-    ////Separating flags/parameters is optional.
-    ////If this should change, the below code would raise a warning whenever 2 parameters/flags are
-    ////not delmited by <,> or <eol>
-    //if there is next item, but it's not comma, then it must be Optional(#Comment) + <eof>
-    //let parsed_delimiter = parsed_comma || parsed_eol;
-    //if !parsed_delimiter && i < tokens.len() {
-    //    //If not parsed , or eol but more tokens are comming
-    //    err = err.or(Some(ParseError::mismatch(
-    //        "Newline or ','",
-    //        (token[i-1].to_string() + token[i].to_string()).spanned(token[i-1].span.until(token[i].span))
-    //    )));
-    //}
-
-    (comment, i, err)
-}
-
-fn parse_flag_name(token: &Token) -> (Spanned<String>, Option<ParseError>) {
-    if let TokenContents::Baseline(name) = &token.contents {
-        if !name.starts_with("--") {
-            (
-                name.clone().spanned(token.span),
-                Some(ParseError::mismatch(
-                    "longform of a flag (Starting with --)",
-                    token_to_spanned_string(token),
-                )),
-            )
-        } else {
-            //Discard preceding --
-            let name = name[2..].to_string();
-            (name.spanned(token.span), None)
-        }
-    } else {
-        (
-            "".to_string().spanned_unknown(),
-            Some(ParseError::mismatch(
-                "longform of a flag (Starting with --)",
-                token_to_spanned_string(token),
-            )),
-        )
-    }
-}
-
-fn parse_flag_optional_shortform(tokens: &[Token]) -> (Option<char>, usize, Option<ParseError>) {
-    if tokens.is_empty() {
-        return (None, 0, None);
+    fn display_name() -> String {
+        "item end".to_string()
     }
 
-    let token = &tokens[0];
-    return if let TokenContents::Baseline(shortform) = &token.contents {
-        let mut chars = shortform.chars();
-        match (chars.next(), chars.next_back()) {
-            (Some('('), Some(')')) => {
-                let mut err = None;
-
-                let flag_span = Span::new(
-                    token.span.start() + 1, //Skip '('
-                    token.span.end() - 1,   // Skip ')'
-                );
-
-                let c: String = chars.collect();
-                let dash_count = c.chars().take_while(|c| *c == '-').count();
-                err = err
-                    .or_else(|| err_on_too_many_dashes(dash_count, c.clone().spanned(flag_span)));
-                let name = &c[dash_count..];
-                err = err.or_else(|| err_on_name_too_long(name, c.clone().spanned(flag_span)));
-                let c = name.chars().next();
-
-                (c, 1, err)
-            }
-            _ => (None, 0, None),
-        }
-    } else {
-        (None, 0, None)
-    };
-
-    fn err_on_too_many_dashes(dash_count: usize, actual: Spanned<String>) -> Option<ParseError> {
-        match dash_count {
-            0 => {
-                //If no starting -
-                Some(ParseError::mismatch("Shortflag starting with '-'", actual))
-            }
-            1 => None,
-            _ => {
-                //If --
-                Some(ParseError::mismatch(
-                    "Shortflag starting with a single '-'",
-                    actual,
-                ))
-            }
-        }
-    }
-
-    fn err_on_name_too_long(name: &str, actual: Spanned<String>) -> Option<ParseError> {
-        if name.len() != 1 {
-            Some(ParseError::mismatch(
-                "Shortflag of exactly 1 character",
-                actual,
-            ))
-        } else {
-            None
-        }
-    }
-}
-
-fn parse_eol(tokens: &[Token]) -> (bool, usize) {
-    if !tokens.is_empty() && tokens[0].contents.is_eol() {
-        (true, 1)
-    } else {
-        (false, 0)
-    }
-}
-
-fn parse_comma(tokens: &[Token]) -> (bool, usize) {
-    fn is_comma(token: &Token) -> bool {
-        is_baseline_token_matching(token, ",")
-    }
-    if !tokens.is_empty() && is_comma(&tokens[0]) {
-        (true, 1)
-    } else {
-        (false, 0)
+    fn default_error_value() -> Self::Output {
+        None
     }
 }
 
@@ -559,17 +270,10 @@ fn to_signature(
     sign
 }
 
-fn is_baseline_token_matching(token: &Token, string: &str) -> bool {
-    match &token.contents {
-        TokenContents::Baseline(base) => base == string,
-        _ => false,
-    }
-}
-
 //Currently the lexer does not split off baselines after existing text
 //Example --flag(-f) is lexed as one baseline token.
 //To properly parse the input, it is required that --flag and (-f) are 2 tokens.
-fn lex_split_shortflag_from_longflag(tokens: Vec<Token>) -> Vec<Token> {
+pub(crate) fn lex_split_shortflag_from_longflag(tokens: Vec<Token>) -> Vec<Token> {
     let mut result = Vec::with_capacity(tokens.capacity());
     for token in tokens {
         let mut processed = false;
@@ -601,7 +305,7 @@ fn lex_split_shortflag_from_longflag(tokens: Vec<Token>) -> Vec<Token> {
 }
 //Currently the lexer does not split baselines on ',' ':' '?'
 //The parameter list requires this. Therefore here is a hacky method doing this.
-fn lex_split_baseline_tokens_on(
+pub(crate) fn lex_split_baseline_tokens_on(
     tokens: Vec<Token>,
     extra_baseline_terminal_tokens: &[char],
 ) -> Vec<Token> {
@@ -681,7 +385,7 @@ impl Parameter {
 }
 
 #[derive(Clone, Debug)]
-struct Flag {
+pub(crate) struct Flag {
     pub long_name: String,
     pub named_type: NamedType,
     pub desc: Option<Description>,
@@ -716,366 +420,24 @@ impl Flag {
     }
 }
 
-mod tests {
-    #[allow(unused_imports)]
-    use super::*;
-    #[allow(unused_imports)]
-    use nu_test_support::nu;
+struct OptionalType {}
+impl Parse for OptionalType {
+    type Output = Option<SyntaxShape>;
 
-    #[test]
-    fn simple_def_with_params() {
-        let name = "my_func";
-        let sign = "[param1?: int, param2: string]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 27)));
-        assert!(err.is_none());
-        assert_eq!(
-            sign.positional,
-            vec![
-                (
-                    PositionalType::Optional("param1".into(), SyntaxShape::Int),
-                    "".into()
-                ),
-                (
-                    PositionalType::Mandatory("param2".into(), SyntaxShape::String),
-                    "".into()
-                ),
-            ]
-        );
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let (values, i_new, err) = IfSuccessThen::<DoublePoint, Shape>::parse(tokens, i);
+        if let Some((_, shape)) = values {
+            (Some(shape), i_new, err)
+        } else {
+            (None, i, None)
+        }
     }
 
-    #[test]
-    fn simple_def_with_optional_param_without_type() {
-        let name = "my_func";
-        let sign = "[param1 ?, param2?]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 27)));
-        assert!(err.is_none());
-        assert_eq!(
-            sign.positional,
-            vec![
-                (
-                    PositionalType::Optional("param1".into(), SyntaxShape::Any),
-                    "".into()
-                ),
-                (
-                    PositionalType::Optional("param2".into(), SyntaxShape::Any),
-                    "".into()
-                ),
-            ]
-        );
+    fn display_name() -> String {
+        "type".to_string()
     }
 
-    #[test]
-    fn simple_def_with_params_with_comment() {
-        let name = "my_func";
-        let sign = "[
-        param1:path # My first param
-        param2:number # My second param
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 64)));
-        assert!(err.is_none());
-        assert_eq!(
-            sign.positional,
-            vec![
-                (
-                    PositionalType::Mandatory("param1".into(), SyntaxShape::FilePath),
-                    "My first param".into()
-                ),
-                (
-                    PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
-                    "My second param".into()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn simple_def_with_params_without_type() {
-        let name = "my_func";
-        let sign = "[
-        param1 # My first param
-        param2:number # My second param
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 0)));
-        assert!(err.is_none());
-        assert_eq!(
-            sign.positional,
-            vec![
-                (
-                    PositionalType::Mandatory("param1".into(), SyntaxShape::Any),
-                    "My first param".into()
-                ),
-                (
-                    PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
-                    "My second param".into()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn oddly_but_correct_written_params() {
-        let name = "my_func";
-        let sign = "[
-        param1 :int         #      param1
-
-        param2 : number # My second param
-
-
-        param4, param5:path  ,  param6 # param6
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 0)));
-        assert!(err.is_none());
-        assert_eq!(
-            sign.positional,
-            vec![
-                (
-                    PositionalType::Mandatory("param1".into(), SyntaxShape::Int),
-                    "param1".into()
-                ),
-                (
-                    PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
-                    "My second param".into()
-                ),
-                (
-                    PositionalType::Mandatory("param4".into(), SyntaxShape::Any),
-                    "".into()
-                ),
-                (
-                    PositionalType::Mandatory("param5".into(), SyntaxShape::FilePath),
-                    "".into()
-                ),
-                (
-                    PositionalType::Mandatory("param6".into(), SyntaxShape::Any),
-                    "param6".into()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn err_wrong_type() {
-        let actual = nu!(
-            cwd: ".",
-            "def f [ param1:strig ] { echo hi }"
-        );
-        assert!(actual.err.contains("type"));
-    }
-
-    //For what ever reason, this gets reported as not used
-    #[allow(dead_code)]
-    fn assert_signature_has_flag(sign: &Signature, name: &str, type_: NamedType, comment: &str) {
-        assert_eq!(
-            Some((type_, comment.to_string())),
-            sign.named.get(name).cloned()
-        );
-    }
-
-    #[test]
-    fn simple_def_with_only_flags() {
-        let name = "my_func";
-        let sign = "[
-        --list (-l) : path  # First flag
-        --verbose : number # Second flag
-        --all(-a) # My switch
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_signature_has_flag(
-            &sign,
-            "list",
-            NamedType::Optional(Some('l'), SyntaxShape::FilePath),
-            "First flag",
-        );
-        assert_signature_has_flag(
-            &sign,
-            "verbose",
-            NamedType::Optional(None, SyntaxShape::Number),
-            "Second flag",
-        );
-        assert_signature_has_flag(&sign, "all", NamedType::Switch(Some('a')), "My switch");
-    }
-
-    #[test]
-    fn simple_def_with_params_and_flags() {
-        let name = "my_func";
-        let sign = "[
-        --list (-l) : path  # First flag
-        param1, param2:table # Param2 Doc
-        --verbose # Second flag
-        param3 : number,
-        --flag3 # Third flag
-        param4 ?: table # Optional Param
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_signature_has_flag(
-            &sign,
-            "list",
-            NamedType::Optional(Some('l'), SyntaxShape::FilePath),
-            "First flag",
-        );
-        assert_signature_has_flag(&sign, "verbose", NamedType::Switch(None), "Second flag");
-        assert_signature_has_flag(&sign, "flag3", NamedType::Switch(None), "Third flag");
-        assert_eq!(
-            sign.positional,
-            vec![
-                (
-                    PositionalType::Mandatory("param1".into(), SyntaxShape::Any),
-                    "".into()
-                ),
-                (
-                    PositionalType::Mandatory("param2".into(), SyntaxShape::Table),
-                    "Param2 Doc".into()
-                ),
-                (
-                    PositionalType::Mandatory("param3".into(), SyntaxShape::Number),
-                    "".into()
-                ),
-                (
-                    PositionalType::Optional("param4".into(), SyntaxShape::Table),
-                    "Optional Param".into()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn simple_def_with_parameters_and_flags_no_delimiter() {
-        let name = "my_func";
-        let sign = "[ param1:int param2
-            --force (-f) param3 # Param3
-            ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_signature_has_flag(&sign, "force", NamedType::Switch(Some('f')), "");
-        assert_eq!(
-            sign.positional,
-            // --list (-l) : path  # First flag
-            // param1, param2:table # Param2 Doc
-            // --verbose # Second flag
-            // param3 : number,
-            // --flag3 # Third flag
-            vec![
-                (
-                    PositionalType::Mandatory("param1".into(), SyntaxShape::Int),
-                    "".into()
-                ),
-                (
-                    PositionalType::Mandatory("param2".into(), SyntaxShape::Any),
-                    "".into()
-                ),
-                (
-                    PositionalType::Mandatory("param3".into(), SyntaxShape::Any),
-                    "Param3".into()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn simple_example_signature() {
-        let name = "my_func";
-        let sign = "[
-        d:int          # The required d parameter
-        --x (-x):string # The all powerful x flag
-        --y (-y):int    # The accompanying y flag
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_signature_has_flag(
-            &sign,
-            "x",
-            NamedType::Optional(Some('x'), SyntaxShape::String),
-            "The all powerful x flag",
-        );
-        assert_signature_has_flag(
-            &sign,
-            "y",
-            NamedType::Optional(Some('y'), SyntaxShape::Int),
-            "The accompanying y flag",
-        );
-        assert_eq!(
-            sign.positional,
-            vec![(
-                PositionalType::Mandatory("d".into(), SyntaxShape::Int),
-                "The required d parameter".into()
-            )]
-        );
-    }
-
-    #[test]
-    fn flag_withouth_space_between_longname_shortname() {
-        let name = "my_func";
-        let sign = "[
-        --xxx(-x):string # The all powerful x flag
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_signature_has_flag(
-            &sign,
-            "xxx",
-            NamedType::Optional(Some('x'), SyntaxShape::String),
-            "The all powerful x flag",
-        );
-    }
-
-    #[test]
-    fn simple_def_with_rest_arg() {
-        let name = "my_func";
-        let sign = "[ ...rest]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_eq!(
-            sign.rest_positional,
-            Some((SyntaxShape::Any, "".to_string()))
-        );
-    }
-
-    #[test]
-    fn simple_def_with_rest_arg_with_type_and_comment() {
-        let name = "my_func";
-        let sign = "[ ...rest:path # My super cool rest arg]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_eq!(
-            sign.rest_positional,
-            Some((SyntaxShape::FilePath, "My super cool rest arg".to_string()))
-        );
-    }
-
-    #[test]
-    fn simple_def_with_param_flag_and_rest() {
-        let name = "my_func";
-        let sign = "[
-        d:string          # The required d parameter
-        --xxx(-x)         # The all powerful x flag
-        --yyy (-y):int    #    The accompanying y flag
-        ...rest:table # Another rest
-        ]";
-        let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
-        assert!(err.is_none());
-        assert_signature_has_flag(
-            &sign,
-            "xxx",
-            NamedType::Switch(Some('x')),
-            "The all powerful x flag",
-        );
-        assert_signature_has_flag(
-            &sign,
-            "yyy",
-            NamedType::Optional(Some('y'), SyntaxShape::Int),
-            "The accompanying y flag",
-        );
-        assert_eq!(
-            sign.positional,
-            vec![(
-                PositionalType::Mandatory("d".into(), SyntaxShape::String),
-                "The required d parameter".into()
-            )]
-        );
-        assert_eq!(
-            sign.rest_positional,
-            Some((SyntaxShape::Table, "Another rest".to_string()))
-        );
+    fn default_error_value() -> Self::Output {
+        Some(SyntaxShape::Any)
     }
 }

--- a/crates/nu-parser/src/parse/def/param_flag_list.rs
+++ b/crates/nu-parser/src/parse/def/param_flag_list.rs
@@ -211,6 +211,14 @@ impl Parse for Flag {
         "flag item".to_string()
     }
 
+    fn tokens_are_begin(tokens: &[Token], i: usize) -> bool {
+        if let TokenContents::Baseline(item) = &tokens[i].contents {
+            item.starts_with('-')
+        } else {
+            false
+        }
+    }
+
     fn default_error_value() -> Self::Output {
         Flag::new(
             "Error".to_string(),
@@ -243,6 +251,14 @@ impl Parse for Rest {
             err,
             warnings,
         )
+    }
+
+    fn tokens_are_begin(tokens: &[Token], i: usize) -> bool {
+        if let TokenContents::Baseline(item) = &tokens[i].contents {
+            item.starts_with("...")
+        } else {
+            false
+        }
     }
 
     fn display_name() -> String {
@@ -308,22 +324,6 @@ impl Parse for OptionalType {
 
     fn default_error_value() -> Self::Output {
         Some(SyntaxShape::Any)
-    }
-}
-
-///Returns true if token potentially represents rest argument
-fn can_be_rest(token: &Token) -> bool {
-    match &token.contents {
-        TokenContents::Baseline(item) => item.starts_with("..."),
-        _ => false,
-    }
-}
-
-///True for short or longform flags. False otherwise
-fn is_flag(token: &Token) -> bool {
-    match &token.contents {
-        TokenContents::Baseline(item) => item.starts_with('-'),
-        _ => false,
     }
 }
 

--- a/crates/nu-parser/src/parse/def/param_flag_list.rs
+++ b/crates/nu-parser/src/parse/def/param_flag_list.rs
@@ -230,7 +230,7 @@ impl Parse for Rest {
         ParseResult::new(
             (
                 type_.unwrap_or(SyntaxShape::Any),
-                comment.unwrap_or("".to_string()),
+                comment.unwrap_or_else(String::new),
             ),
             i,
             err,
@@ -242,7 +242,7 @@ impl Parse for Rest {
     }
 
     fn default_error_value() -> Self::Output {
-        (SyntaxShape::Any, "".to_string())
+        (SyntaxShape::Any, String::new())
     }
 }
 
@@ -328,13 +328,13 @@ fn to_signature(
     for param in params.into_iter() {
         // pub positional: Vec<(PositionalType, Description)>,
         sign.positional
-            .push((param.pos_type, param.desc.unwrap_or_else(|| "".to_string())));
+            .push((param.pos_type, param.desc.unwrap_or_else(String::new)));
     }
 
     for flag in flags.into_iter() {
         sign.named.insert(
             flag.long_name,
-            (flag.named_type, flag.desc.unwrap_or_else(|| "".to_string())),
+            (flag.named_type, flag.desc.unwrap_or_else(String::new)),
         );
     }
 

--- a/crates/nu-parser/src/parse/def/param_flag_list.rs
+++ b/crates/nu-parser/src/parse/def/param_flag_list.rs
@@ -180,11 +180,10 @@ impl Parse for Flag {
         let ParseResult {
             value: ((span, (name, shortform, type_)), comment),
             i,
-            err
-        } = And2::
-            <WithSpan<And3<FlagName, Maybe<FlagShortName>, OptionalType>>,
-            ItemEnd>
-                ::parse(tokens, i);
+            err,
+        } = And2::<WithSpan<And3<FlagName, Maybe<FlagShortName>, OptionalType>>, ItemEnd>::parse(
+            tokens, i,
+        );
 
         //If no type is given, the flag is a switch. Otherwise its optional
         //Example:

--- a/crates/nu-parser/src/parse/def/param_flag_list.rs
+++ b/crates/nu-parser/src/parse/def/param_flag_list.rs
@@ -15,7 +15,7 @@ use log::debug;
 
 use crate::{
     lex::{lex, Token, TokenContents},
-    parse::def::lib_code::parse_lib::{AndThen, CheckedParse, IfSuccessThen, Maybe, Parse},
+    parse::def::lib_code::parse_lib::{And, CheckedParse, IfSuccessThen, Maybe, Parse},
 };
 use nu_errors::ParseError;
 use nu_protocol::{NamedType, PositionalType, Signature, SyntaxShape};
@@ -120,10 +120,9 @@ impl Parse for Parameter {
             value: (name, (optional, (type_, comment))),
             i,
             err,
-        } = AndThen::<
-            ParameterName,
-            AndThen<Maybe<OptionalModifier>, AndThen<OptionalType, ItemEnd>>,
-        >::parse(tokens, i);
+        } = And::<ParameterName, And<Maybe<OptionalModifier>, And<OptionalType, ItemEnd>>>::parse(
+            tokens, i,
+        );
 
         // let i_end = i;
 
@@ -164,10 +163,13 @@ impl Parse for Flag {
     fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
         // let i_start = i;
 
-        let ParseResult{value: (name, (shortform, (type_, comment))), i, err } = AndThen::<
-            FlagName,
-            AndThen<Maybe<FlagShortName>, AndThen<OptionalType, ItemEnd>>,
-        >::parse(tokens, i);
+        let ParseResult {
+            value: (name, (shortform, (type_, comment))),
+            i,
+            err,
+        } = And::<FlagName, And<Maybe<FlagShortName>, And<OptionalType, ItemEnd>>>::parse(
+            tokens, i,
+        );
 
         // let i_end = i;
         // let span = tokens[i_start].span.until(tokens[i_end - 1].span);
@@ -208,7 +210,7 @@ impl Parse for Rest {
             value: (_, (type_, comment)),
             i,
             err,
-        } = AndThen::<RestName, AndThen<OptionalType, ItemEnd>>::parse(tokens, i);
+        } = And::<RestName, And<OptionalType, ItemEnd>>::parse(tokens, i);
 
         ParseResult::new(
             (
@@ -243,7 +245,7 @@ impl Parse for ItemEnd {
             value: (_, (comment, _)),
             i,
             err,
-        } = AndThen::<Maybe<Comma>, AndThen<Maybe<Comment>, Maybe<EOL>>>::parse(tokens, i);
+        } = And::<Maybe<Comma>, And<Maybe<Comment>, Maybe<EOL>>>::parse(tokens, i);
 
         ParseResult::new(comment, i, err)
     }

--- a/crates/nu-parser/src/parse/def/parse_lib.rs
+++ b/crates/nu-parser/src/parse/def/parse_lib.rs
@@ -1,0 +1,196 @@
+use log::debug;
+use std::marker;
+
+use crate::{lex::Token, parse::util::token_to_spanned_string};
+use nu_errors::ParseError;
+use nu_source::Span;
+
+pub(crate) trait Parse {
+    type Output;
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>);
+
+    fn parse_debug(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let tokens_str = if i < tokens.len() {
+            format!(
+                "{:?}",
+                &tokens[i..]
+                    .iter()
+                    .map(|t| t.contents.clone())
+                    .collect::<Vec<_>>()
+            )
+        } else {
+            "[]".to_owned()
+        };
+        debug!(
+            r#"Parsing: {:?}
+            Tokens: {:?}"#,
+            Self::display_name(),
+            tokens_str
+        );
+
+        Self::parse(tokens, i)
+    }
+
+    fn display_name() -> String;
+    fn default_error_value() -> Self::Output;
+
+    fn mismatch_error(token: &Token) -> Option<ParseError> {
+        Some(ParseError::mismatch(
+            Self::display_name(),
+            token_to_spanned_string(token),
+        ))
+    }
+
+    fn mismatch_default_return(
+        token: &Token,
+        i: usize,
+    ) -> (Self::Output, usize, Option<ParseError>) {
+        (Self::default_error_value(), i, Self::mismatch_error(token))
+    }
+}
+
+// #[macro_export]
+// macro_rules! parse_struct {
+//     // (cwd: $cwd:expr, $path:expr, $($part:expr),*) => {{
+//     (name: $name:ident, $($x:ident),*) => {
+//             struct $name <
+//             $(
+//                 $x,
+//             )*
+//                 > {
+//                 $(
+//                     $x: marker::PhantomData<$x>,
+//                 )*
+//         }
+//     };
+// }
+
+// parse_struct!(name: Test, A, B);
+pub(crate) struct Expect<Value> {
+    _marker: marker::PhantomData<*const Value>,
+}
+
+impl<Value: Parse> Parse for Expect<Value> {
+    type Output = Value::Output;
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if i < tokens.len() {
+            debug!(
+                "Expect<{:?}> {:?} {:?}",
+                Value::display_name(),
+                &tokens[i..],
+                i
+            );
+            //Okay let underlying value parse tokens
+            Value::parse_debug(tokens, i)
+        } else {
+            debug!("Expect<{:?}> but no tokens", Value::display_name(),);
+            //No tokens are present --> Error out
+            let last_span = if let Some(last_token) = tokens.last() {
+                last_token.span
+            } else {
+                Span::unknown()
+            };
+
+            (
+                Value::default_error_value(),
+                i,
+                Some(ParseError::unexpected_eof(Value::display_name(), last_span)),
+            )
+        }
+    }
+
+    fn display_name() -> String {
+        Value::display_name()
+    }
+
+    fn default_error_value() -> Value::Output {
+        Value::default_error_value()
+    }
+}
+
+pub(crate) struct Maybe<Value> {
+    _marker: marker::PhantomData<*const Value>,
+}
+
+impl<Value: Parse> Parse for Maybe<Value> {
+    type Output = Option<Value::Output>;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if i < tokens.len() {
+            debug!("Parsing Maybe<{:?}>", Value::display_name());
+            //Okay can safely slice tokens
+            let (v, new_i, error) = Value::parse_debug(tokens, i);
+            //Okay we couldn't parse it
+            if error.is_some() {
+                (None, i, None)
+            } else {
+                (Some(v), new_i, error)
+            }
+        } else {
+            debug!("Maybe<{:?}> not present", Value::display_name());
+            //If tokens is empty we can't parse it so its None
+            (None, i, None)
+        }
+    }
+
+    fn display_name() -> String {
+        Value::display_name() + "?"
+    }
+
+    fn default_error_value() -> Self::Output {
+        Some(Value::default_error_value())
+    }
+}
+
+///Parse First and then Second
+pub(crate) struct AndThen<First, Second> {
+    _marker1: marker::PhantomData<*const First>,
+    _marker2: marker::PhantomData<*const Second>,
+}
+
+impl<First: Parse, Second: Parse> Parse for AndThen<First, Second> {
+    type Output = (First::Output, Second::Output);
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let (first, i, err_first) = First::parse(tokens, i);
+        let (second, i, err_second) = Second::parse(tokens, i);
+        ((first, second), i, err_first.or(err_second))
+    }
+
+    fn display_name() -> String {
+        First::display_name() + " >> " + &Second::display_name()
+    }
+
+    fn default_error_value() -> Self::Output {
+        (First::default_error_value(), Second::default_error_value())
+    }
+}
+
+pub(crate) struct IfSuccessThen<Maybe, AndThen> {
+    _marker1: marker::PhantomData<*const Maybe>,
+    _marker2: marker::PhantomData<*const AndThen>,
+}
+
+impl<Try: Parse, AndThen: Parse> Parse for IfSuccessThen<Try, AndThen> {
+    type Output = Option<(Try::Output, AndThen::Output)>;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let (try_, new_i, err_try) = Maybe::<Try>::parse(tokens, i);
+        if let Some(try_v) = try_ {
+            //Succeeded at parsing Maybe. Now AndThen has to follow
+            let (and_then, new_i, err_second) = Expect::<AndThen>::parse(tokens, new_i);
+            (Some((try_v, and_then)), new_i, err_try.or(err_second))
+        } else {
+            //Okay Couldn't parse Try
+            (None, i, None)
+        }
+    }
+
+    fn display_name() -> String {
+        "(".to_string() + &Try::display_name() + " >> " + &AndThen::display_name() + ")?"
+    }
+
+    fn default_error_value() -> Self::Output {
+        Some((Try::default_error_value(), AndThen::default_error_value()))
+    }
+}

--- a/crates/nu-parser/src/parse/def/primitives.rs
+++ b/crates/nu-parser/src/parse/def/primitives.rs
@@ -3,42 +3,40 @@ use crate::{
     parse::def::parse_lib::Parse,
     parse::util::token_to_spanned_string,
 };
-use log::debug;
 use nu_errors::ParseError;
 use nu_protocol::SyntaxShape;
 use nu_source::{Span, Spanned, SpannedItem};
 
-fn parse_type(type_: &Spanned<String>) -> (SyntaxShape, Option<ParseError>) {
-    debug!("Parsing type {:?}", type_);
-    match type_.item.as_str() {
-        "int" => (SyntaxShape::Int, None),
-        "string" => (SyntaxShape::String, None),
-        "path" => (SyntaxShape::FilePath, None),
-        "table" => (SyntaxShape::Table, None),
-        "unit" => (SyntaxShape::Unit, None),
-        "number" => (SyntaxShape::Number, None),
-        "pattern" => (SyntaxShape::GlobPattern, None),
-        "range" => (SyntaxShape::Range, None),
-        "block" => (SyntaxShape::Block, None),
-        "any" => (SyntaxShape::Any, None),
-        _ => (
-            SyntaxShape::Any,
-            Some(ParseError::mismatch("type", type_.clone())),
-        ),
-    }
-}
+use super::parse_lib::Expect;
 
-///Better use Type!
+///Better use Type
 ///Type parses (: shape)?
-pub(crate) struct Shape;
-impl Parse for Shape {
+pub(crate) struct ShapeUnchecked;
+pub(crate) type Shape = Expect<ShapeUnchecked>;
+impl Parse for ShapeUnchecked {
     type Output = SyntaxShape;
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
         let shape_token = &tokens[i];
         match &shape_token.contents {
             TokenContents::Baseline(type_str) => {
-                let (shape, err) = parse_type(&type_str.clone().spanned(shape_token.span));
+                let (shape, err) = match type_str.as_str() {
+                    "int" => (SyntaxShape::Int, None),
+                    "string" => (SyntaxShape::String, None),
+                    "path" => (SyntaxShape::FilePath, None),
+                    "table" => (SyntaxShape::Table, None),
+                    "unit" => (SyntaxShape::Unit, None),
+                    "number" => (SyntaxShape::Number, None),
+                    "pattern" => (SyntaxShape::GlobPattern, None),
+                    "range" => (SyntaxShape::Range, None),
+                    "block" => (SyntaxShape::Block, None),
+                    "any" => (SyntaxShape::Any, None),
+                    _ => (
+                        Self::default_error_value(),
+                        Self::mismatch_error(shape_token),
+                    ),
+                };
+
                 (shape, i + 1, err)
             }
             _ => Self::mismatch_default_return(shape_token, i),
@@ -54,8 +52,9 @@ impl Parse for Shape {
     }
 }
 
-pub(crate) struct DoublePoint {}
-impl Parse for DoublePoint {
+pub(crate) struct DoublePointUnchecked {}
+pub(crate) type DoublePoint = Expect<DoublePointUnchecked>;
+impl Parse for DoublePointUnchecked {
     type Output = ();
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -75,8 +74,9 @@ impl Parse for DoublePoint {
     }
 }
 
-pub(crate) struct Comma {}
-impl Parse for Comma {
+pub(crate) struct CommaUnchecked {}
+pub(crate) type Comma = Expect<CommaUnchecked>;
+impl Parse for CommaUnchecked {
     type Output = ();
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -96,8 +96,9 @@ impl Parse for Comma {
     }
 }
 
-pub(crate) struct EOL {}
-impl Parse for EOL {
+pub(crate) struct EOLUnchecked {}
+pub(crate) type EOL = Expect<EOLUnchecked>;
+impl Parse for EOLUnchecked {
     type Output = ();
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -117,8 +118,9 @@ impl Parse for EOL {
     }
 }
 
-pub(crate) struct Comment {}
-impl Parse for Comment {
+pub(crate) struct CommentUnchecked {}
+pub(crate) type Comment = Expect<CommentUnchecked>;
+impl Parse for CommentUnchecked {
     type Output = String;
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -139,8 +141,9 @@ impl Parse for Comment {
     }
 }
 
-pub(crate) struct OptionalModifier {}
-impl Parse for OptionalModifier {
+pub(crate) struct OptionalModifierUnchecked {}
+pub(crate) type OptionalModifier = Expect<OptionalModifierUnchecked>;
+impl Parse for OptionalModifierUnchecked {
     type Output = ();
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -160,8 +163,10 @@ impl Parse for OptionalModifier {
     }
 }
 
-pub(crate) struct ParameterName {}
-impl Parse for ParameterName {
+pub(crate) struct ParameterNameUnchecked {}
+pub(crate) type ParameterName = Expect<ParameterNameUnchecked>;
+
+impl Parse for ParameterNameUnchecked {
     type Output = String;
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -181,8 +186,9 @@ impl Parse for ParameterName {
     }
 }
 
-pub(crate) struct FlagName {}
-impl Parse for FlagName {
+pub(crate) struct FlagNameUnchecked {}
+pub(crate) type FlagName = Expect<FlagNameUnchecked>;
+impl Parse for FlagNameUnchecked {
     type Output = String;
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -217,8 +223,9 @@ impl Parse for FlagName {
     }
 }
 
-pub(crate) struct FlagShortName {}
-impl Parse for FlagShortName {
+pub(crate) struct FlagShortNameUnchecked {}
+pub(crate) type FlagShortName = Expect<FlagShortNameUnchecked>;
+impl Parse for FlagShortNameUnchecked {
     type Output = char;
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
@@ -292,8 +299,9 @@ impl Parse for FlagShortName {
     }
 }
 
-pub(crate) struct RestName {}
-impl Parse for RestName {
+pub(crate) struct RestNameUnchecked {}
+pub(crate) type RestName = Expect<RestNameUnchecked>;
+impl Parse for RestNameUnchecked {
     type Output = bool;
 
     fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {

--- a/crates/nu-parser/src/parse/def/primitives.rs
+++ b/crates/nu-parser/src/parse/def/primitives.rs
@@ -1,0 +1,338 @@
+use crate::{
+    lex::{Token, TokenContents},
+    parse::def::parse_lib::Parse,
+    parse::util::token_to_spanned_string,
+};
+use log::debug;
+use nu_errors::ParseError;
+use nu_protocol::SyntaxShape;
+use nu_source::{Span, Spanned, SpannedItem};
+
+fn parse_type(type_: &Spanned<String>) -> (SyntaxShape, Option<ParseError>) {
+    debug!("Parsing type {:?}", type_);
+    match type_.item.as_str() {
+        "int" => (SyntaxShape::Int, None),
+        "string" => (SyntaxShape::String, None),
+        "path" => (SyntaxShape::FilePath, None),
+        "table" => (SyntaxShape::Table, None),
+        "unit" => (SyntaxShape::Unit, None),
+        "number" => (SyntaxShape::Number, None),
+        "pattern" => (SyntaxShape::GlobPattern, None),
+        "range" => (SyntaxShape::Range, None),
+        "block" => (SyntaxShape::Block, None),
+        "any" => (SyntaxShape::Any, None),
+        _ => (
+            SyntaxShape::Any,
+            Some(ParseError::mismatch("type", type_.clone())),
+        ),
+    }
+}
+
+///Better use Type!
+///Type parses (: shape)?
+pub(crate) struct Shape;
+impl Parse for Shape {
+    type Output = SyntaxShape;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let shape_token = &tokens[i];
+        match &shape_token.contents {
+            TokenContents::Baseline(type_str) => {
+                let (shape, err) = parse_type(&type_str.clone().spanned(shape_token.span));
+                (shape, i + 1, err)
+            }
+            _ => Self::mismatch_default_return(shape_token, i),
+        }
+    }
+
+    fn display_name() -> String {
+        "type".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        SyntaxShape::Any
+    }
+}
+
+pub(crate) struct DoublePoint {}
+impl Parse for DoublePoint {
+    type Output = ();
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if is_baseline_token_matching(&tokens[i], ":") {
+            ((), i + 1, None)
+        } else {
+            Self::mismatch_default_return(&tokens[i], i)
+        }
+    }
+
+    fn display_name() -> String {
+        ":".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        ()
+    }
+}
+
+pub(crate) struct Comma {}
+impl Parse for Comma {
+    type Output = ();
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if is_baseline_token_matching(&tokens[i], ",") {
+            ((), i + 1, None)
+        } else {
+            Self::mismatch_default_return(&tokens[i], i)
+        }
+    }
+
+    fn display_name() -> String {
+        ",".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        ()
+    }
+}
+
+pub(crate) struct EOL {}
+impl Parse for EOL {
+    type Output = ();
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if tokens[i].contents.is_eol() {
+            ((), i + 1, None)
+        } else {
+            Self::mismatch_default_return(&tokens[i], i)
+        }
+    }
+
+    fn display_name() -> String {
+        "\\n".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        ()
+    }
+}
+
+pub(crate) struct Comment {}
+impl Parse for Comment {
+    type Output = String;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if let TokenContents::Comment(comment) = &tokens[i].contents {
+            let comment_text = comment.trim().to_string();
+            (comment_text, i + 1, None)
+        } else {
+            Self::mismatch_default_return(&tokens[i], i)
+        }
+    }
+
+    fn display_name() -> String {
+        "#Comment".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        "".to_string()
+    }
+}
+
+pub(crate) struct OptionalModifier {}
+impl Parse for OptionalModifier {
+    type Output = ();
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if is_baseline_token_matching(&tokens[i], "?") {
+            ((), i + 1, None)
+        } else {
+            Self::mismatch_default_return(&tokens[i], i)
+        }
+    }
+
+    fn display_name() -> String {
+        "optional modifier keyword".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        ()
+    }
+}
+
+pub(crate) struct ParameterName {}
+impl Parse for ParameterName {
+    type Output = String;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        if let TokenContents::Baseline(name) = &tokens[i].contents {
+            (name.clone(), i + 1, None)
+        } else {
+            Self::mismatch_default_return(&tokens[i], i)
+        }
+    }
+
+    fn display_name() -> String {
+        "parameter name".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        "InternalError".to_string()
+    }
+}
+
+pub(crate) struct FlagName {}
+impl Parse for FlagName {
+    type Output = String;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let flag_token = &tokens[i];
+        if let TokenContents::Baseline(name) = &flag_token.contents {
+            if !name.starts_with("--") {
+                (
+                    //Okay return name as flag name eventhough it does not start with --
+                    name.clone(),
+                    i + 1,
+                    Some(ParseError::mismatch(
+                        "longform of a flag (Starting with --)",
+                        token_to_spanned_string(flag_token),
+                    )),
+                )
+            } else {
+                //Discard preceding --
+                let name = name[2..].to_string();
+                (name.clone(), i + 1, None)
+            }
+        } else {
+            Self::mismatch_default_return(flag_token, i)
+        }
+    }
+
+    fn display_name() -> String {
+        "flag name".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        "InternalError".to_string()
+    }
+}
+
+pub(crate) struct FlagShortName {}
+impl Parse for FlagShortName {
+    type Output = char;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let flag_token = &tokens[i];
+        return if let TokenContents::Baseline(shortform) = &flag_token.contents {
+            let mut chars = shortform.chars();
+            match (chars.next(), chars.next_back()) {
+                (Some('('), Some(')')) => {
+                    let mut err = None;
+
+                    let flag_span = Span::new(
+                        flag_token.span.start() + 1, //Skip '('
+                        flag_token.span.end() - 1,   // Skip ')'
+                    );
+
+                    let c: String = chars.collect();
+                    let dash_count = c.chars().take_while(|c| *c == '-').count();
+                    err = err.or_else(|| {
+                        err_on_too_many_dashes(dash_count, c.clone().spanned(flag_span))
+                    });
+                    let name = &c[dash_count..];
+                    err = err.or_else(|| err_on_name_too_long(name, c.clone().spanned(flag_span)));
+                    let c = name.chars().next();
+
+                    (c.unwrap_or(Self::default_error_value()), i + 1, err)
+                }
+                _ => Self::mismatch_default_return(flag_token, i),
+            }
+        } else {
+            Self::mismatch_default_return(flag_token, i)
+        };
+
+        fn err_on_too_many_dashes(
+            dash_count: usize,
+            actual: Spanned<String>,
+        ) -> Option<ParseError> {
+            match dash_count {
+                0 => {
+                    //If no starting -
+                    Some(ParseError::mismatch("Shortflag starting with '-'", actual))
+                }
+                1 => None,
+                _ => {
+                    //If --
+                    Some(ParseError::mismatch(
+                        "Shortflag starting with a single '-'",
+                        actual,
+                    ))
+                }
+            }
+        }
+
+        fn err_on_name_too_long(name: &str, actual: Spanned<String>) -> Option<ParseError> {
+            if name.len() != 1 {
+                Some(ParseError::mismatch(
+                    "Shortflag of exactly 1 character",
+                    actual,
+                ))
+            } else {
+                None
+            }
+        }
+    }
+
+    fn display_name() -> String {
+        "flag shortname".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        'E'
+    }
+}
+
+pub(crate) struct RestName {}
+impl Parse for RestName {
+    type Output = bool;
+
+    fn parse(tokens: &[Token], i: usize) -> (Self::Output, usize, Option<ParseError>) {
+        let name_token = &tokens[i];
+        return if let TokenContents::Baseline(name) = &name_token.contents {
+            if !name.starts_with("...") {
+                //Don't parse this token as rest token
+                Self::mismatch_default_return(name_token, i)
+            } else if !name.starts_with("...rest") || name.len() != "...rest".len() {
+                //Okay accept this as rest, but give user warning
+                (true, i + 1, rest_name_must_be_rest_error(name_token))
+            } else {
+                //Okay correct name
+                (true, i + 1, None)
+            }
+        } else {
+            Self::mismatch_default_return(name_token, i)
+        };
+
+        fn rest_name_must_be_rest_error(token: &Token) -> Option<ParseError> {
+            Some(ParseError::mismatch(
+                "rest argument name to be 'rest'",
+                token_to_spanned_string(token),
+            ))
+        }
+    }
+
+    fn display_name() -> String {
+        "rest name".to_string()
+    }
+
+    fn default_error_value() -> Self::Output {
+        false
+    }
+}
+
+fn is_baseline_token_matching(token: &Token, string: &str) -> bool {
+    match &token.contents {
+        TokenContents::Baseline(base) => base == string,
+        _ => false,
+    }
+}

--- a/crates/nu-parser/src/parse/def/primitives.rs
+++ b/crates/nu-parser/src/parse/def/primitives.rs
@@ -69,9 +69,7 @@ impl Parse for DoublePointUnchecked {
         ":".to_string()
     }
 
-    fn default_error_value() -> Self::Output {
-        ()
-    }
+    fn default_error_value() -> Self::Output {}
 }
 
 pub(crate) struct CommaUnchecked {}
@@ -91,9 +89,7 @@ impl Parse for CommaUnchecked {
         ",".to_string()
     }
 
-    fn default_error_value() -> Self::Output {
-        ()
-    }
+    fn default_error_value() -> Self::Output {}
 }
 
 pub(crate) struct EOLUnchecked {}
@@ -113,9 +109,7 @@ impl Parse for EOLUnchecked {
         "\\n".to_string()
     }
 
-    fn default_error_value() -> Self::Output {
-        ()
-    }
+    fn default_error_value() -> Self::Output {}
 }
 
 pub(crate) struct CommentUnchecked {}
@@ -158,9 +152,7 @@ impl Parse for OptionalModifierUnchecked {
         "optional modifier keyword".to_string()
     }
 
-    fn default_error_value() -> Self::Output {
-        ()
-    }
+    fn default_error_value() -> Self::Output {}
 }
 
 pub(crate) struct ParameterNameUnchecked {}
@@ -207,7 +199,7 @@ impl Parse for FlagNameUnchecked {
             } else {
                 //Discard preceding --
                 let name = name[2..].to_string();
-                ParseResult::new(name.clone(), i + 1, None)
+                ParseResult::new(name, i + 1, None)
             }
         } else {
             Self::mismatch_default_return(flag_token, i)
@@ -248,9 +240,12 @@ impl Parse for FlagShortNameUnchecked {
                     });
                     let name = &c[dash_count..];
                     err = err.or_else(|| err_on_name_too_long(name, c.clone().spanned(flag_span)));
-                    let c = name.chars().next();
+                    let c = name
+                        .chars()
+                        .next()
+                        .unwrap_or_else(Self::default_error_value);
 
-                    ParseResult::new(c.unwrap_or(Self::default_error_value()), i + 1, err)
+                    ParseResult::new(c, i + 1, err)
                 }
                 _ => Self::mismatch_default_return(flag_token, i),
             }

--- a/crates/nu-parser/src/parse/def/primitives.rs
+++ b/crates/nu-parser/src/parse/def/primitives.rs
@@ -11,8 +11,6 @@ use super::lib_code::{
     ParseResult,
 };
 
-///Better use Type
-///Type parses (: shape)?
 pub(crate) struct ShapeUnchecked;
 pub(crate) type Shape = Expect<ShapeUnchecked>;
 impl Parse for ShapeUnchecked {

--- a/crates/nu-parser/src/parse/def/tests.rs
+++ b/crates/nu-parser/src/parse/def/tests.rs
@@ -1,9 +1,11 @@
 #[allow(unused_imports)]
+use super::lex_fixup::{lex_split_baseline_tokens_on, lex_split_shortflag_from_longflag};
+#[allow(unused_imports)]
 use super::lib_code::parse_lib::Parse;
 #[allow(unused_imports)]
 use super::lib_code::ParseResult;
 #[allow(unused_imports)]
-use super::param_flag_list::{lex_split_baseline_tokens_on, lex_split_shortflag_from_longflag};
+use super::param_flag_list::{};
 #[allow(unused_imports)]
 use super::param_flag_list::{parse_signature, Flag};
 #[allow(unused_imports)]
@@ -166,6 +168,15 @@ fn err_wrong_type() {
         "def f [ param1:strig ] { echo hi }"
     );
     assert!(actual.err.contains("type"));
+}
+
+#[test]
+fn err_wrong_dash_count() {
+    let actual = nu!(
+        cwd: ".",
+        "def f [ --flag(--f)] { echo hi }"
+    );
+    assert!(actual.err.contains(""));
 }
 
 //For what ever reason, this gets reported as not used

--- a/crates/nu-parser/src/parse/def/tests.rs
+++ b/crates/nu-parser/src/parse/def/tests.rs
@@ -1,0 +1,384 @@
+#[allow(unused_imports)]
+use super::param_flag_list::{lex_split_baseline_tokens_on, lex_split_shortflag_from_longflag};
+#[allow(unused_imports)]
+use super::param_flag_list::{parse_signature, Flag};
+#[allow(unused_imports)]
+use super::{parse_lib::Parse, primitives::FlagShortName};
+#[allow(unused_imports)]
+use crate::lex;
+#[allow(unused_imports)]
+use nu_protocol::{NamedType, PositionalType, Signature, SyntaxShape};
+#[allow(unused_imports)]
+use nu_source::{Span, Spanned, SpannedItem};
+#[allow(unused_imports)]
+use nu_test_support::nu;
+
+#[test]
+fn parse_flag_shortname() {
+    let (tokens, _) = lex("--flag(-f)", 0);
+    let tokens = lex_split_baseline_tokens_on(tokens, &[',', ':', '?']);
+    let tokens = lex_split_shortflag_from_longflag(tokens);
+    let (f, i, err) = Flag::parse(&tokens, 0);
+    assert_eq!("flag", &f.long_name);
+    assert_eq!(Some('f'), f.named_type.get_short());
+    assert_eq!(2, i);
+    assert!(err.is_none());
+}
+
+#[test]
+fn simple_def_with_params() {
+    let name = "my_func";
+    let sign = "[param1?: int, param2: string]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 27)));
+    assert!(err.is_none());
+    assert_eq!(
+        sign.positional,
+        vec![
+            (
+                PositionalType::Optional("param1".into(), SyntaxShape::Int),
+                "".into()
+            ),
+            (
+                PositionalType::Mandatory("param2".into(), SyntaxShape::String),
+                "".into()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn simple_def_with_optional_param_without_type() {
+    let name = "my_func";
+    let sign = "[param1 ?, param2?]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 27)));
+    assert!(err.is_none());
+    assert_eq!(
+        sign.positional,
+        vec![
+            (
+                PositionalType::Optional("param1".into(), SyntaxShape::Any),
+                "".into()
+            ),
+            (
+                PositionalType::Optional("param2".into(), SyntaxShape::Any),
+                "".into()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn simple_def_with_params_with_comment() {
+    let name = "my_func";
+    let sign = "[
+        param1:path # My first param
+        param2:number # My second param
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 64)));
+    assert!(err.is_none());
+    assert_eq!(
+        sign.positional,
+        vec![
+            (
+                PositionalType::Mandatory("param1".into(), SyntaxShape::FilePath),
+                "My first param".into()
+            ),
+            (
+                PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
+                "My second param".into()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn simple_def_with_params_without_and_with_type() {
+    let name = "my_func";
+    let sign = "[
+        param1 # My first param
+        param2:number # My second param
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 0)));
+    assert!(err.is_none());
+    assert_eq!(
+        sign.positional,
+        vec![
+            (
+                PositionalType::Mandatory("param1".into(), SyntaxShape::Any),
+                "My first param".into()
+            ),
+            (
+                PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
+                "My second param".into()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn oddly_but_correct_written_params() {
+    let name = "my_func";
+    let sign = "[
+        param1 :int         #      param1
+
+        param2 : number # My second param
+
+
+        param4, param5:path  ,  param6 # param6
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned(Span::new(0, 0)));
+    assert!(err.is_none());
+    assert_eq!(
+        sign.positional,
+        vec![
+            (
+                PositionalType::Mandatory("param1".into(), SyntaxShape::Int),
+                "param1".into()
+            ),
+            (
+                PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
+                "My second param".into()
+            ),
+            (
+                PositionalType::Mandatory("param4".into(), SyntaxShape::Any),
+                "".into()
+            ),
+            (
+                PositionalType::Mandatory("param5".into(), SyntaxShape::FilePath),
+                "".into()
+            ),
+            (
+                PositionalType::Mandatory("param6".into(), SyntaxShape::Any),
+                "param6".into()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn err_wrong_type() {
+    let actual = nu!(
+        cwd: ".",
+        "def f [ param1:strig ] { echo hi }"
+    );
+    assert!(actual.err.contains("type"));
+}
+
+//For what ever reason, this gets reported as not used
+#[allow(dead_code)]
+fn assert_signature_has_flag(sign: &Signature, name: &str, type_: NamedType, comment: &str) {
+    assert_eq!(
+        Some((type_, comment.to_string())),
+        sign.named.get(name).cloned()
+    );
+}
+
+#[test]
+fn simple_def_with_only_flags() {
+    let name = "my_func";
+    let sign = "[
+        --list (-l) : path  # First flag
+        --verbose : number # Second flag
+        --all(-a) # My switch
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_signature_has_flag(
+        &sign,
+        "list",
+        NamedType::Optional(Some('l'), SyntaxShape::FilePath),
+        "First flag",
+    );
+    assert_signature_has_flag(
+        &sign,
+        "verbose",
+        NamedType::Optional(None, SyntaxShape::Number),
+        "Second flag",
+    );
+    assert_signature_has_flag(&sign, "all", NamedType::Switch(Some('a')), "My switch");
+}
+
+#[test]
+fn simple_def_with_params_and_flags() {
+    let name = "my_func";
+    let sign = "[
+        --list (-l) : path  # First flag
+        param1, param2:table # Param2 Doc
+        --verbose # Second flag
+        param3 : number,
+        --flag3 # Third flag
+        param4 ?: table # Optional Param
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_signature_has_flag(
+        &sign,
+        "list",
+        NamedType::Optional(Some('l'), SyntaxShape::FilePath),
+        "First flag",
+    );
+    assert_signature_has_flag(&sign, "verbose", NamedType::Switch(None), "Second flag");
+    assert_signature_has_flag(&sign, "verbose", NamedType::Switch(None), "Second flag");
+    assert_signature_has_flag(&sign, "flag3", NamedType::Switch(None), "Third flag");
+    assert_eq!(
+        sign.positional,
+        vec![
+            (
+                PositionalType::Mandatory("param1".into(), SyntaxShape::Any),
+                "".into()
+            ),
+            (
+                PositionalType::Mandatory("param2".into(), SyntaxShape::Table),
+                "Param2 Doc".into()
+            ),
+            (
+                PositionalType::Mandatory("param3".into(), SyntaxShape::Number),
+                "".into()
+            ),
+            (
+                PositionalType::Optional("param4".into(), SyntaxShape::Table),
+                "Optional Param".into()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn simple_def_with_parameters_and_flags_no_delimiter() {
+    let name = "my_func";
+    let sign = "[ param1:int param2
+            --force (-f) param3 # Param3
+            ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_signature_has_flag(&sign, "force", NamedType::Switch(Some('f')), "");
+    assert_eq!(
+        sign.positional,
+        // --list (-l) : path  # First flag
+        // param1, param2:table # Param2 Doc
+        // --verbose # Second flag
+        // param3 : number,
+        // --flag3 # Third flag
+        vec![
+            (
+                PositionalType::Mandatory("param1".into(), SyntaxShape::Int),
+                "".into()
+            ),
+            (
+                PositionalType::Mandatory("param2".into(), SyntaxShape::Any),
+                "".into()
+            ),
+            (
+                PositionalType::Mandatory("param3".into(), SyntaxShape::Any),
+                "Param3".into()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn simple_example_signature() {
+    let name = "my_func";
+    let sign = "[
+        d:int          # The required d parameter
+        --x (-x):string # The all powerful x flag
+        --y (-y):int    # The accompanying y flag
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_signature_has_flag(
+        &sign,
+        "x",
+        NamedType::Optional(Some('x'), SyntaxShape::String),
+        "The all powerful x flag",
+    );
+    assert_signature_has_flag(
+        &sign,
+        "y",
+        NamedType::Optional(Some('y'), SyntaxShape::Int),
+        "The accompanying y flag",
+    );
+    assert_eq!(
+        sign.positional,
+        vec![(
+            PositionalType::Mandatory("d".into(), SyntaxShape::Int),
+            "The required d parameter".into()
+        )]
+    );
+}
+
+#[test]
+fn flag_withouth_space_between_longname_shortname() {
+    let name = "my_func";
+    let sign = "[
+        --xxx(-x):string # The all powerful x flag
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_signature_has_flag(
+        &sign,
+        "xxx",
+        NamedType::Optional(Some('x'), SyntaxShape::String),
+        "The all powerful x flag",
+    );
+}
+
+#[test]
+fn simple_def_with_rest_arg() {
+    let name = "my_func";
+    let sign = "[ ...rest]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_eq!(
+        sign.rest_positional,
+        Some((SyntaxShape::Any, "".to_string()))
+    );
+}
+
+#[test]
+fn simple_def_with_rest_arg_with_type_and_comment() {
+    let name = "my_func";
+    let sign = "[ ...rest:path # My super cool rest arg]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_eq!(
+        sign.rest_positional,
+        Some((SyntaxShape::FilePath, "My super cool rest arg".to_string()))
+    );
+}
+
+#[test]
+fn simple_def_with_param_flag_and_rest() {
+    let name = "my_func";
+    let sign = "[
+        d:string          # The required d parameter
+        --xxx(-x)         # The all powerful x flag
+        --yyy (-y):int    #    The accompanying y flag
+        ...rest:table # Another rest
+        ]";
+    let (sign, err) = parse_signature(name, &sign.to_string().spanned_unknown());
+    assert!(err.is_none());
+    assert_signature_has_flag(
+        &sign,
+        "xxx",
+        NamedType::Switch(Some('x')),
+        "The all powerful x flag",
+    );
+    assert_signature_has_flag(
+        &sign,
+        "yyy",
+        NamedType::Optional(Some('y'), SyntaxShape::Int),
+        "The accompanying y flag",
+    );
+    assert_eq!(
+        sign.positional,
+        vec![(
+            PositionalType::Mandatory("d".into(), SyntaxShape::String),
+            "The required d parameter".into()
+        )]
+    );
+    assert_eq!(
+        sign.rest_positional,
+        Some((SyntaxShape::Table, "Another rest".to_string()))
+    );
+}

--- a/crates/nu-parser/src/parse/def/tests.rs
+++ b/crates/nu-parser/src/parse/def/tests.rs
@@ -1,9 +1,13 @@
 #[allow(unused_imports)]
+use super::lib_code::parse_lib::Parse;
+#[allow(unused_imports)]
+use super::lib_code::ParseResult;
+#[allow(unused_imports)]
 use super::param_flag_list::{lex_split_baseline_tokens_on, lex_split_shortflag_from_longflag};
 #[allow(unused_imports)]
 use super::param_flag_list::{parse_signature, Flag};
 #[allow(unused_imports)]
-use super::{parse_lib::Parse, primitives::FlagShortName};
+use super::primitives::FlagShortName;
 #[allow(unused_imports)]
 use crate::lex;
 #[allow(unused_imports)]
@@ -18,9 +22,9 @@ fn parse_flag_shortname() {
     let (tokens, _) = lex("--flag(-f)", 0);
     let tokens = lex_split_baseline_tokens_on(tokens, &[',', ':', '?']);
     let tokens = lex_split_shortflag_from_longflag(tokens);
-    let (f, i, err) = Flag::parse(&tokens, 0);
-    assert_eq!("flag", &f.long_name);
-    assert_eq!(Some('f'), f.named_type.get_short());
+    let ParseResult { value, i, err } = Flag::parse(&tokens, 0);
+    assert_eq!("flag", &value.long_name);
+    assert_eq!(Some('f'), value.named_type.get_short());
     assert_eq!(2, i);
     assert!(err.is_none());
 }

--- a/crates/nu-parser/src/parse/def/tests.rs
+++ b/crates/nu-parser/src/parse/def/tests.rs
@@ -24,11 +24,17 @@ fn parse_flag_shortname() {
     let (tokens, _) = lex("--flag(-f)", 0);
     let tokens = lex_split_baseline_tokens_on(tokens, &[',', ':', '?']);
     let tokens = lex_split_shortflag_from_longflag(tokens);
-    let ParseResult { value, i, err } = Flag::parse(&tokens, 0);
+    let ParseResult {
+        value,
+        i,
+        err,
+        warnings,
+    } = Flag::parse(&tokens, 0);
     assert_eq!("flag", &value.long_name);
     assert_eq!(Some('f'), value.named_type.get_short());
     assert_eq!(2, i);
     assert!(err.is_none());
+    assert!(warnings.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
When I have written the parsing functions for the signature of a def command, I noticed patterns I do over and over. This draft introduces
 1. modular parsing abstractions which combined together, help writing parsing functions with less boilerplate.
 2. Changes the old signature-parse functions to use the new abstractions

Example before:
```rust
    if tokens.is_empty() {
        ... //error out
    }

    //Declare state
    let mut ...
    let mut ...

    //Parse first
    let (name, error) = parse_flag_name(&tokens[0]);
    //Don't forget to accumulate the error
    err = err.or(error);

    //Parse second
    let (shortform, advanced_by, error) = parse_flag_optional_shortform(&tokens[i..]);
    //Don't forget i
    i += advanced_by;
    err = err.or(error);

    //Parse third
    let (type_, advanced_by, error) = parse_optional_type(&tokens[i..]);
    let type_ = type_.unwrap_or(SyntaxShape::Any);
    err = err.or(error);
    i += advanced_by;

    //Parse fourth
    let (comment, advanced_by, error) = parse_signature_item_end(&tokens[i..]);
    i += advanced_by;
    err = err.or(error);

    //Okay finaly do the job
    let named_type = if ... {...} else{ ... }
    let flag = Flag::new(
        name.item.clone(),
        named_type,
        comment,
        name.span,
    );

    debug!("Parsed flag: {:?}", flag);
    (flag, i, err)

```

Now:
```rust
impl Parse for Flag {
    type Output = Flag;

    fn parse(tokens: &[Token], i: usize) -> ParseResult<Self::Output> {
        let ParseResult {
        //Result holds value with all values a flag can have
            value: ((span, (name, shortform, type_)), comment),
            i,
            err
        } = 
        //Parse 2 things:
        And2::
        //1.: Spanned<FlagName + Maybe<FlagShortName> + OptionalType>
            <WithSpan<And3<FlagName, Maybe<FlagShortName>, OptionalType>>,
        //2.: ItemEnd
            ItemEnd>
                ::parse(tokens, i);

        //Okay, transform individual pieces to flag
        let named_type = if ... {...} else {...}

        let flag = Flag::new(name, named_type, comment, span);
        debug!("Parsed flag: {:?}", flag);

        ParseResult::new(flag, i, err)
    }
    ...
}
```
All of the abstraction code still misses documentation. If there is a general interest moving towards this approach, I will do the missing work.
