### PR TITLE
Move filesize to use bigint

### DIFF
--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -174,6 +174,13 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
                         out!("{}", output);
                     }
                     Value {
+                        value: UntaggedValue::Primitive(Primitive::Filesize(_)),
+                        ..
+                    } => {
+                        let output = format_leaf(&x).plain_string(100_000);
+                        out!("{}", output);
+                    }
+                    Value {
                         value: UntaggedValue::Primitive(Primitive::Date(d)),
                         ..
                     } => {

--- a/crates/nu-command/src/commands/format/format_filesize.rs
+++ b/crates/nu-command/src/commands/format/format_filesize.rs
@@ -108,60 +108,70 @@ fn convert_bytes_to_string_using_format(
 ) -> Result<Value, ShellError> {
     match bytes.value {
         Primitive(Filesize(b)) => {
-            let byte = byte_unit::Byte::from_bytes(b as u128);
-            let value = match format.item().to_lowercase().as_str() {
-                "b" => Ok(UntaggedValue::string(b.to_formatted_string(&Locale::en))),
-                "kb" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::KB).to_string(),
-                )),
-                "kib" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::KiB).to_string(),
-                )),
-                "mb" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::MB).to_string(),
-                )),
-                "mib" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::MiB).to_string(),
-                )),
-                "gb" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::GB).to_string(),
-                )),
-                "gib" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::GiB).to_string(),
-                )),
-                "tb" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::TB).to_string(),
-                )),
-                "tib" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::TiB).to_string(),
-                )),
-                "pb" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::PB).to_string(),
-                )),
-                "pib" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::PiB).to_string(),
-                )),
-                "eb" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::EB).to_string(),
-                )),
-                "eib" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::EiB).to_string(),
-                )),
-                "zb" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::ZB).to_string(),
-                )),
-                "zib" => Ok(UntaggedValue::string(
-                    byte.get_adjusted_unit(byte_unit::ByteUnit::ZiB).to_string(),
-                )),
-                _ => Err(ShellError::labeled_error(
-                    format!("Invalid format code: {:}", format.item()),
-                    "invalid format",
-                    format.tag(),
-                )),
-            };
-            match value {
-                Ok(b) => Ok(Value { value: b, ..bytes }),
-                Err(e) => Err(e),
+            if let Some(value) = b.to_u128() {
+                let byte = byte_unit::Byte::from_bytes(value);
+                let value = match format.item().to_lowercase().as_str() {
+                    "b" => Ok(UntaggedValue::string(
+                        value.to_formatted_string(&Locale::en),
+                    )),
+                    "kb" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::KB).to_string(),
+                    )),
+                    "kib" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::KiB).to_string(),
+                    )),
+                    "mb" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::MB).to_string(),
+                    )),
+                    "mib" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::MiB).to_string(),
+                    )),
+                    "gb" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::GB).to_string(),
+                    )),
+                    "gib" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::GiB).to_string(),
+                    )),
+                    "tb" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::TB).to_string(),
+                    )),
+                    "tib" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::TiB).to_string(),
+                    )),
+                    "pb" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::PB).to_string(),
+                    )),
+                    "pib" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::PiB).to_string(),
+                    )),
+                    "eb" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::EB).to_string(),
+                    )),
+                    "eib" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::EiB).to_string(),
+                    )),
+                    "zb" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::ZB).to_string(),
+                    )),
+                    "zib" => Ok(UntaggedValue::string(
+                        byte.get_adjusted_unit(byte_unit::ByteUnit::ZiB).to_string(),
+                    )),
+                    _ => Err(ShellError::labeled_error(
+                        format!("Invalid format code: {:}", format.item()),
+                        "invalid format",
+                        format.tag(),
+                    )),
+                };
+                match value {
+                    Ok(b) => Ok(Value { value: b, ..bytes }),
+                    Err(e) => Err(e),
+                }
+            } else {
+                Err(ShellError::labeled_error(
+                    "Value too large to fit in 128 bits",
+                    "value too large to fit in format",
+                    format.span(),
+                ))
             }
         }
         _ => Err(ShellError::labeled_error(

--- a/crates/nu-command/src/commands/math/avg.rs
+++ b/crates/nu-command/src/commands/math/avg.rs
@@ -59,12 +59,9 @@ impl WholeStreamCommand for SubCommand {
 
 fn to_byte(value: &Value) -> Option<Value> {
     match &value.value {
-        UntaggedValue::Primitive(Primitive::Int(num)) => Some(
-            UntaggedValue::Primitive(Primitive::Filesize(convert_number_to_u64(&Number::Int(
-                num.clone(),
-            ))))
-            .into_untagged_value(),
-        ),
+        UntaggedValue::Primitive(Primitive::Int(num)) => {
+            Some(UntaggedValue::Primitive(Primitive::Filesize(num.clone())).into_untagged_value())
+        }
         _ => None,
     }
 }
@@ -95,7 +92,7 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                     Value {
                         value: UntaggedValue::Primitive(Primitive::Filesize(num)),
                         ..
-                    } => UntaggedValue::int(*num as usize).into_untagged_value(),
+                    } => UntaggedValue::int(num.clone()).into_untagged_value(),
                     other => other.clone(),
                 })
                 .collect::<Vec<_>>(),

--- a/crates/nu-command/src/commands/math/avg.rs
+++ b/crates/nu-command/src/commands/math/avg.rs
@@ -113,7 +113,7 @@ pub fn average(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
             value: UntaggedValue::Primitive(Primitive::Filesize(num)),
             ..
         } => {
-            let left = UntaggedValue::from(Primitive::Int(num.into()));
+            let left = UntaggedValue::from(Primitive::Int(num));
             let result = nu_data::value::compute_values(Operator::Divide, &left, &total_rows);
 
             match result {

--- a/crates/nu-command/src/commands/math/median.rs
+++ b/crates/nu-command/src/commands/math/median.rs
@@ -137,7 +137,7 @@ fn compute_average(values: &[Value], name: impl Into<Tag>) -> Result<Value, Shel
             value: UntaggedValue::Primitive(Primitive::Filesize(num)),
             ..
         } => {
-            let left = UntaggedValue::from(Primitive::Int(num.into()));
+            let left = UntaggedValue::from(Primitive::Int(num));
             let result = nu_data::value::compute_values(Operator::Divide, &left, &total_rows);
 
             match result {

--- a/crates/nu-command/src/commands/math/product.rs
+++ b/crates/nu-command/src/commands/math/product.rs
@@ -3,10 +3,7 @@ use crate::commands::math::utils::run_with_function;
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{
-    hir::{convert_number_to_u64, Number},
-    Primitive, Signature, UntaggedValue, Value,
-};
+use nu_protocol::{Primitive, Signature, UntaggedValue, Value};
 
 pub struct SubCommand;
 
@@ -51,12 +48,9 @@ impl WholeStreamCommand for SubCommand {
 
 fn to_byte(value: &Value) -> Option<Value> {
     match &value.value {
-        UntaggedValue::Primitive(Primitive::Int(num)) => Some(
-            UntaggedValue::Primitive(Primitive::Filesize(convert_number_to_u64(&Number::Int(
-                num.clone(),
-            ))))
-            .into_untagged_value(),
-        ),
+        UntaggedValue::Primitive(Primitive::Int(num)) => {
+            Some(UntaggedValue::Primitive(Primitive::Filesize(num.clone())).into_untagged_value())
+        }
         _ => None,
     }
 }
@@ -78,7 +72,7 @@ pub fn product(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                     Value {
                         value: UntaggedValue::Primitive(Primitive::Filesize(num)),
                         ..
-                    } => UntaggedValue::int(*num as usize).into_untagged_value(),
+                    } => UntaggedValue::int(num.clone()).into_untagged_value(),
                     other => other.clone(),
                 })
                 .collect::<Vec<_>>(),

--- a/crates/nu-command/src/commands/math/sum.rs
+++ b/crates/nu-command/src/commands/math/sum.rs
@@ -4,10 +4,7 @@ use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 
-use nu_protocol::{
-    hir::{convert_number_to_u64, Number},
-    Primitive, Signature, UntaggedValue, Value,
-};
+use nu_protocol::{Primitive, Signature, UntaggedValue, Value};
 
 pub struct SubCommand;
 
@@ -59,12 +56,9 @@ impl WholeStreamCommand for SubCommand {
 
 fn to_byte(value: &Value) -> Option<Value> {
     match &value.value {
-        UntaggedValue::Primitive(Primitive::Int(num)) => Some(
-            UntaggedValue::Primitive(Primitive::Filesize(convert_number_to_u64(&Number::Int(
-                num.clone(),
-            ))))
-            .into_untagged_value(),
-        ),
+        UntaggedValue::Primitive(Primitive::Int(num)) => {
+            Some(UntaggedValue::Primitive(Primitive::Filesize(num.clone())).into_untagged_value())
+        }
         _ => None,
     }
 }
@@ -90,7 +84,7 @@ pub fn summation(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                     Value {
                         value: UntaggedValue::Primitive(Primitive::Filesize(num)),
                         ..
-                    } => UntaggedValue::int(*num as usize).into_untagged_value(),
+                    } => UntaggedValue::int(num.clone()).into_untagged_value(),
                     other => other.clone(),
                 })
                 .collect::<Vec<_>>(),

--- a/crates/nu-command/src/commands/math/variance.rs
+++ b/crates/nu-command/src/commands/math/variance.rs
@@ -130,7 +130,7 @@ fn sum_of_squares(values: &[Value], name: &Tag) -> Result<Value, ShellError> {
                 value: UntaggedValue::Primitive(Primitive::Filesize(num)),
                 ..
             } => {
-                UntaggedValue::from(Primitive::Int(num.clone().into()))
+                UntaggedValue::from(Primitive::Int(num.clone()))
             },
             Value {
                 value: UntaggedValue::Primitive(num),

--- a/crates/nu-command/src/commands/to_delimited_data.rs
+++ b/crates/nu-command/src/commands/to_delimited_data.rs
@@ -116,7 +116,7 @@ pub fn clone_tagged_value(v: &Value) -> Value {
             UntaggedValue::Primitive(Primitive::FilePath(x.clone()))
         }
         UntaggedValue::Primitive(Primitive::Filesize(b)) => {
-            UntaggedValue::Primitive(Primitive::Filesize(*b))
+            UntaggedValue::Primitive(Primitive::Filesize(b.clone()))
         }
         UntaggedValue::Primitive(Primitive::Date(d)) => {
             UntaggedValue::Primitive(Primitive::Date(*d))

--- a/crates/nu-command/src/commands/to_toml.rs
+++ b/crates/nu-command/src/commands/to_toml.rs
@@ -40,7 +40,17 @@ impl WholeStreamCommand for ToTOML {
 fn helper(v: &Value) -> Result<toml::Value, ShellError> {
     Ok(match &v.value {
         UntaggedValue::Primitive(Primitive::Boolean(b)) => toml::Value::Boolean(*b),
-        UntaggedValue::Primitive(Primitive::Filesize(b)) => toml::Value::Integer(*b as i64),
+        UntaggedValue::Primitive(Primitive::Filesize(b)) => {
+            if let Some(value) = b.to_i64() {
+                toml::Value::Integer(value)
+            } else {
+                return Err(ShellError::labeled_error(
+                    "Value too large to write to toml",
+                    "value too large for toml",
+                    v.tag.span,
+                ));
+            }
+        }
         UntaggedValue::Primitive(Primitive::Duration(i)) => toml::Value::String(i.to_string()),
         UntaggedValue::Primitive(Primitive::Date(d)) => toml::Value::String(d.to_string()),
         UntaggedValue::Primitive(Primitive::EndOfStream) => {

--- a/crates/nu-data/src/base.rs
+++ b/crates/nu-data/src/base.rs
@@ -129,20 +129,18 @@ pub fn coerce_compare_primitive(
         (Int(left), Decimal(right)) => {
             CompareValues::Decimals(BigDecimal::zero() + left, right.clone())
         }
-        (Int(left), Filesize(right)) => CompareValues::Ints(left.clone(), BigInt::from(*right)),
+        (Int(left), Filesize(right)) => CompareValues::Ints(left.clone(), right.clone()),
         (Decimal(left), Decimal(right)) => CompareValues::Decimals(left.clone(), right.clone()),
         (Decimal(left), Int(right)) => {
             CompareValues::Decimals(left.clone(), BigDecimal::zero() + right)
         }
         (Decimal(left), Filesize(right)) => {
-            CompareValues::Decimals(left.clone(), BigDecimal::from(*right))
+            CompareValues::Decimals(left.clone(), BigDecimal::from(right.clone()))
         }
-        (Filesize(left), Filesize(right)) => {
-            CompareValues::Ints(BigInt::from(*left), BigInt::from(*right))
-        }
-        (Filesize(left), Int(right)) => CompareValues::Ints(BigInt::from(*left), right.clone()),
+        (Filesize(left), Filesize(right)) => CompareValues::Ints(left.clone(), right.clone()),
+        (Filesize(left), Int(right)) => CompareValues::Ints(left.clone(), right.clone()),
         (Filesize(left), Decimal(right)) => {
-            CompareValues::Decimals(BigDecimal::from(*left), right.clone())
+            CompareValues::Decimals(BigDecimal::from(left.clone()), right.clone())
         }
         (Nothing, Nothing) => CompareValues::Booleans(true, true),
         (String(left), String(right)) => CompareValues::String(left.clone(), right.clone()),

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -81,21 +81,12 @@ pub fn unsafe_compute_values(
     match (left, right) {
         (UntaggedValue::Primitive(lhs), UntaggedValue::Primitive(rhs)) => match (lhs, rhs) {
             (Primitive::Filesize(x), Primitive::Int(y)) => match operator {
-                Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
-                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Int(x - y))),
-                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Int(x * y))),
-                Operator::Divide => Ok(UntaggedValue::Primitive(Primitive::Decimal(
-                    bigdecimal::BigDecimal::from(*x) / bigdecimal::BigDecimal::from(y.clone()),
-                ))),
+                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Filesize(x * y))),
+                Operator::Divide => Ok(UntaggedValue::Primitive(Primitive::Filesize(x / y))),
                 _ => Err((left.type_name(), right.type_name())),
             },
             (Primitive::Int(x), Primitive::Filesize(y)) => match operator {
-                Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Int(x + y))),
-                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Int(x - y))),
-                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Int(x * y))),
-                Operator::Divide => Ok(UntaggedValue::Primitive(Primitive::Decimal(
-                    bigdecimal::BigDecimal::from(x.clone()) / bigdecimal::BigDecimal::from(*y),
-                ))),
+                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Filesize(x * y))),
                 _ => Err((left.type_name(), right.type_name())),
             },
             _ => Err((left.type_name(), right.type_name())),
@@ -120,8 +111,12 @@ pub fn compute_values(
                 Ok(UntaggedValue::Primitive(Primitive::Filesize(result)))
             }
             (Primitive::Filesize(x), Primitive::Int(y)) => match operator {
-                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Int(x * y))),
-                Operator::Divide => Ok(UntaggedValue::Primitive(Primitive::Int(x / y))),
+                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Filesize(x * y))),
+                Operator::Divide => Ok(UntaggedValue::Primitive(Primitive::Filesize(x / y))),
+                _ => Err((left.type_name(), right.type_name())),
+            },
+            (Primitive::Int(x), Primitive::Filesize(y)) => match operator {
+                Operator::Multiply => Ok(UntaggedValue::Primitive(Primitive::Filesize(x * y))),
                 _ => Err((left.type_name(), right.type_name())),
             },
             (Primitive::Int(x), Primitive::Int(y)) => match operator {

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -631,8 +631,8 @@ impl Unit {
     }
 }
 
-pub fn filesize(size_in_bytes: u64) -> UntaggedValue {
-    UntaggedValue::Primitive(Primitive::Filesize(size_in_bytes))
+pub fn filesize(size_in_bytes: impl Into<BigInt>) -> UntaggedValue {
+    UntaggedValue::Primitive(Primitive::Filesize(size_in_bytes.into()))
 }
 
 pub fn duration(nanos: BigInt) -> UntaggedValue {

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -186,7 +186,7 @@ impl UntaggedValue {
     }
 
     /// Helper for creating filesize values
-    pub fn filesize(s: impl Into<u64>) -> UntaggedValue {
+    pub fn filesize(s: impl Into<BigInt>) -> UntaggedValue {
         UntaggedValue::Primitive(Primitive::Filesize(s.into()))
     }
 
@@ -713,7 +713,7 @@ impl U64Ext for u64 {
 
     fn to_filesize_value(&self, the_tag: Tag) -> Value {
         Value {
-            value: UntaggedValue::Primitive(Primitive::Filesize(*self)),
+            value: UntaggedValue::Primitive(Primitive::Filesize(BigInt::from(*self))),
             tag: the_tag,
         }
     }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -751,6 +751,53 @@ fn range_with_mixed_types() {
 }
 
 #[test]
+fn filesize_math() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        = 100 * 10kb
+        "#
+    );
+
+    assert_eq!(actual.out, "1.0 MB");
+}
+
+#[test]
+fn filesize_math2() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        = 100 / 10kb
+        "#
+    );
+
+    assert!(actual.err.contains("Coercion"));
+}
+
+#[test]
+fn filesize_math3() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        = 100kb / 10
+        "#
+    );
+
+    assert_eq!(actual.out, "10.2 KB");
+}
+#[test]
+fn filesize_math4() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        = 100kb * 5
+        "#
+    );
+
+    assert_eq!(actual.out, "512.0 KB");
+}
+
+#[test]
 fn exclusive_range_with_mixed_types() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
This moves filesize to bigint, so we can do math operations on filesizes better (and support the exabyte drives of the future :D)

I added a few more operations and cleaned up filesize display as well.