### PR TITLE
update sysinfo due to breaking change with get_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5272,9 +5272,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.15.9"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de94457a09609f33fec5e7fceaf907488967c6c7c75d64da6a7ce6ffdb8b5abd"
+checksum = "dd024ccff6b09c6be38d41f168b7f3e132bac86338ee4b24fa485caf601ee158"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",

--- a/crates/nu_plugin_ps/Cargo.toml
+++ b/crates/nu_plugin_ps/Cargo.toml
@@ -19,6 +19,6 @@ num-bigint = "0.3.0"
 
 futures = {version = "0.3.5", features = ["compat", "io-compat"]}
 futures-timer = "3.0.2"
-sysinfo = "0.15.9"
+sysinfo = "0.15.11"
 
 [build-dependencies]

--- a/crates/nu_plugin_sys/Cargo.toml
+++ b/crates/nu_plugin_sys/Cargo.toml
@@ -18,6 +18,6 @@ nu-source = { path = "../nu-source", version = "0.26.0" }
 futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 futures-util = "0.3.5"
 num-bigint = "0.3.0"
-sysinfo = "0.15.9"
+sysinfo = "0.15.11"
 
 [build-dependencies]

--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -115,8 +115,17 @@ pub fn host(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
     if let Some(name) = sys.get_name() {
         dict.insert_untagged("name", UntaggedValue::string(trim_cstyle_null(name)));
     }
-    if let Some(version) = sys.get_version() {
-        dict.insert_untagged("version", UntaggedValue::string(trim_cstyle_null(version)));
+    if let Some(version) = sys.get_os_version() {
+        dict.insert_untagged(
+            "os version",
+            UntaggedValue::string(trim_cstyle_null(version)),
+        );
+    }
+    if let Some(version) = sys.get_kernel_version() {
+        dict.insert_untagged(
+            "kernel version",
+            UntaggedValue::string(trim_cstyle_null(version)),
+        );
     }
     if let Some(hostname) = sys.get_host_name() {
         dict.insert_untagged(


### PR DESCRIPTION
There was a breaking change in `sysinfo` where `get_version()` no longer works. They split it out into `get_os_version()` and `get_kernel_version()` so I put the two new ones in place.

```
Users/fdncred/Downloads/rust/forks/nushell<main> (50.4 °F 🌦️ ) ▶ sys | get host
╭───┬────────┬────────────┬────────────────┬─────────────────────────────────────┬──────────────────┬────────────────╮
│ # │ name   │ os version │ kernel version │ hostname                            │ uptime           │ sessions       │
├───┼────────┼────────────┼────────────────┼─────────────────────────────────────┼──────────────────┼────────────────┤
│ 0 │ Darwin │ 10.13.6    │ 17.7.0         │ xxxxxx-xxxxxxxxxx-MacBook-Pro.local │ 18hr 44min 31sec │ [table 4 rows] │
╰───┴────────┴────────────┴────────────────┴─────────────────────────────────────┴──────────────────┴────────────────╯
```