### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Thanks to all the people who already contributed!
 <a href="https://github.com/nushell/nushell/graphs/contributors">
   <img src="https://contributors-img.web.app/image?repo=nushell/nushell" />
 </a>
+
 ## License
 
 The project is made available under the MIT license. See the `LICENSE` file for more information.


### PR DESCRIPTION
I just noticed a small issue in the README, the last section was not being properly formatted due to a missing empty line.


## Before

![image](https://user-images.githubusercontent.com/249335/106544650-acd79f80-64e6-11eb-8061-7cb550c28bcc.png)

## After

![image](https://user-images.githubusercontent.com/249335/106544828-f6c08580-64e6-11eb-9612-031f131a138e.png)

