### PR TITLE
Ensure selection of columns are done once per column

### DIFF
--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -245,7 +245,7 @@ pub(crate) use reverse::Reverse;
 pub(crate) use rm::Remove;
 pub(crate) use run_external::RunExternalCommand;
 pub(crate) use save::Save;
-pub(crate) use select::Select;
+pub(crate) use select::Command as Select;
 pub(crate) use seq::Seq;
 pub(crate) use seq_dates::SeqDates;
 pub(crate) use shells::Shells;
@@ -299,6 +299,7 @@ mod tests {
             whole_stream_command(Move),
             whole_stream_command(Update),
             whole_stream_command(Empty),
+            //whole_stream_command(Select),
             // Str Command Suite
             whole_stream_command(Str),
             whole_stream_command(StrToDecimal),

--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -70,7 +70,7 @@ impl WholeStreamCommand for Benchmark {
 
 async fn benchmark(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tag = raw_args.call_info.args.span;
-    let mut context = EvaluationContext::from_raw(&raw_args);
+    let mut context = EvaluationContext::from_args(&raw_args);
     let scope = raw_args.scope.clone();
     let (BenchmarkArgs { block, passthrough }, input) = raw_args.process().await?;
 

--- a/crates/nu-command/src/commands/do_.rs
+++ b/crates/nu-command/src/commands/do_.rs
@@ -55,7 +55,7 @@ impl WholeStreamCommand for Do {
 async fn do_(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let external_redirection = raw_args.call_info.args.external_redirection;
 
-    let context = EvaluationContext::from_raw(&raw_args);
+    let context = EvaluationContext::from_args(&raw_args);
     let (
         DoArgs {
             ignore_errors,

--- a/crates/nu-command/src/commands/each/command.rs
+++ b/crates/nu-command/src/commands/each/command.rs
@@ -111,7 +111,7 @@ pub(crate) fn make_indexed_item(index: usize, item: Value) -> Value {
 }
 
 async fn each(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let context = Arc::new(EvaluationContext::from_raw(&raw_args));
+    let context = Arc::new(EvaluationContext::from_args(&raw_args));
 
     let (each_args, input): (EachArgs, _) = raw_args.process().await?;
     let block = Arc::new(Box::new(each_args.block));

--- a/crates/nu-command/src/commands/each/group.rs
+++ b/crates/nu-command/src/commands/each/group.rs
@@ -46,7 +46,7 @@ impl WholeStreamCommand for EachGroup {
     }
 
     async fn run(&self, raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-        let context = Arc::new(EvaluationContext::from_raw(&raw_args));
+        let context = Arc::new(EvaluationContext::from_args(&raw_args));
         let (each_args, input): (EachGroupArgs, _) = raw_args.process().await?;
         let block = Arc::new(Box::new(each_args.block));
 

--- a/crates/nu-command/src/commands/each/window.rs
+++ b/crates/nu-command/src/commands/each/window.rs
@@ -51,7 +51,7 @@ impl WholeStreamCommand for EachWindow {
     }
 
     async fn run(&self, raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-        let context = Arc::new(EvaluationContext::from_raw(&raw_args));
+        let context = Arc::new(EvaluationContext::from_args(&raw_args));
         let (each_args, mut input): (EachWindowArgs, _) = raw_args.process().await?;
         let block = Arc::new(Box::new(each_args.block));
 

--- a/crates/nu-command/src/commands/group_by.rs
+++ b/crates/nu-command/src/commands/group_by.rs
@@ -130,7 +130,7 @@ enum Grouper {
 
 pub async fn group_by(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
-    let context = Arc::new(EvaluationContext::from_raw(&args));
+    let context = Arc::new(EvaluationContext::from_args(&args));
     let (Arguments { grouper }, input) = args.process().await?;
 
     let values: Vec<Value> = input.collect().await;

--- a/crates/nu-command/src/commands/if_.rs
+++ b/crates/nu-command/src/commands/if_.rs
@@ -66,7 +66,7 @@ impl WholeStreamCommand for If {
 }
 async fn if_command(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tag = raw_args.call_info.name_tag.clone();
-    let context = Arc::new(EvaluationContext::from_raw(&raw_args));
+    let context = Arc::new(EvaluationContext::from_args(&raw_args));
 
     let (
         IfArgs {

--- a/crates/nu-command/src/commands/insert.rs
+++ b/crates/nu-command/src/commands/insert.rs
@@ -154,7 +154,7 @@ async fn process_row(
 }
 
 async fn insert(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let context = Arc::new(EvaluationContext::from_raw(&raw_args));
+    let context = Arc::new(EvaluationContext::from_args(&raw_args));
     let (Arguments { column, value }, input) = raw_args.process().await?;
     let value = Arc::new(value);
     let column = Arc::new(column);

--- a/crates/nu-command/src/commands/merge.rs
+++ b/crates/nu-command/src/commands/merge.rs
@@ -47,7 +47,7 @@ impl WholeStreamCommand for Merge {
 }
 
 async fn merge(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let context = EvaluationContext::from_raw(&raw_args);
+    let context = EvaluationContext::from_args(&raw_args);
     let name_tag = raw_args.call_info.name_tag.clone();
     let (merge_args, input): (MergeArgs, _) = raw_args.process().await?;
     let block = merge_args.block;

--- a/crates/nu-command/src/commands/reduce.rs
+++ b/crates/nu-command/src/commands/reduce.rs
@@ -95,7 +95,7 @@ async fn process_row(
 
 async fn reduce(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let span = raw_args.call_info.name_tag.span;
-    let context = Arc::new(EvaluationContext::from_raw(&raw_args));
+    let context = Arc::new(EvaluationContext::from_args(&raw_args));
     let (reduce_args, mut input): (ReduceArgs, _) = raw_args.process().await?;
     let block = Arc::new(reduce_args.block);
     let (ioffset, start) = if !input.is_empty() {

--- a/crates/nu-command/src/commands/update.rs
+++ b/crates/nu-command/src/commands/update.rs
@@ -174,7 +174,7 @@ async fn process_row(
 
 async fn update(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name_tag = Arc::new(raw_args.call_info.name_tag.clone());
-    let context = Arc::new(EvaluationContext::from_raw(&raw_args));
+    let context = Arc::new(EvaluationContext::from_args(&raw_args));
     let (Arguments { field, replacement }, input) = raw_args.process().await?;
     let replacement = Arc::new(replacement);
     let field = Arc::new(field);

--- a/crates/nu-command/src/commands/where_.rs
+++ b/crates/nu-command/src/commands/where_.rs
@@ -61,7 +61,7 @@ impl WholeStreamCommand for Where {
     }
 }
 async fn where_command(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let ctx = Arc::new(EvaluationContext::from_raw(&raw_args));
+    let ctx = Arc::new(EvaluationContext::from_args(&raw_args));
     let tag = raw_args.call_info.name_tag.clone();
     let (WhereArgs { block }, input) = raw_args.process().await?;
     let condition = {

--- a/crates/nu-command/src/commands/with_env.rs
+++ b/crates/nu-command/src/commands/with_env.rs
@@ -69,7 +69,7 @@ impl WholeStreamCommand for WithEnv {
 }
 
 async fn with_env(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let context = EvaluationContext::from_raw(&raw_args);
+    let context = EvaluationContext::from_args(&raw_args);
     let (WithEnvArgs { variable, block }, input) = raw_args.process().await?;
 
     let mut env = IndexMap::new();

--- a/crates/nu-command/src/utils.rs
+++ b/crates/nu-command/src/utils.rs
@@ -1,2 +1,3 @@
+pub mod arguments;
 pub mod suggestions;
 pub mod test_bins;

--- a/crates/nu-command/src/utils/arguments.rs
+++ b/crates/nu-command/src/utils/arguments.rs
@@ -1,0 +1,37 @@
+use indexmap::IndexSet;
+use nu_errors::ShellError;
+use nu_protocol::{hir::CapturedBlock, ColumnPath, UntaggedValue, Value};
+use nu_source::Tagged;
+use nu_value_ext::ValueExt;
+
+pub fn arguments(
+    rest: &mut Vec<Value>,
+) -> Result<(Vec<ColumnPath>, Option<Box<CapturedBlock>>), ShellError> {
+    let last_argument = rest.pop();
+
+    let mut columns: IndexSet<_> = rest.iter().collect();
+    let mut column_paths = vec![];
+
+    let mut default = None;
+
+    for argument in columns.drain(..) {
+        let Tagged { item: path, .. } = argument.as_column_path()?;
+
+        column_paths.push(path);
+    }
+
+    match last_argument {
+        Some(Value {
+            value: UntaggedValue::Block(call),
+            ..
+        }) => default = Some(call),
+        Some(other) => {
+            let Tagged { item: path, .. } = other.as_column_path()?;
+
+            column_paths.push(path);
+        }
+        None => {}
+    };
+
+    Ok((column_paths, default))
+}

--- a/crates/nu-engine/src/evaluation_context.rs
+++ b/crates/nu-engine/src/evaluation_context.rs
@@ -27,18 +27,6 @@ pub struct EvaluationContext {
 }
 
 impl EvaluationContext {
-    pub fn from_raw(raw_args: &CommandArgs) -> EvaluationContext {
-        EvaluationContext {
-            scope: raw_args.scope.clone(),
-            host: raw_args.host.clone(),
-            current_errors: raw_args.current_errors.clone(),
-            ctrl_c: raw_args.ctrl_c.clone(),
-            shell_manager: raw_args.shell_manager.clone(),
-            user_recently_used_autoenv_untrust: Arc::new(AtomicBool::new(false)),
-            windows_drives_previous_cwd: Arc::new(Mutex::new(std::collections::HashMap::new())),
-        }
-    }
-
     pub fn from_args(args: &CommandArgs) -> EvaluationContext {
         EvaluationContext {
             scope: args.scope.clone(),


### PR DESCRIPTION
In Discord we learned about unexpected behavior if `select` is passed repeated name columns (Ex: `... | select name modified name`), here, we make sure the just one time per column is considered.

Also a bit of clean up and some refactoring.