### PR TITLE
Fix 'ps -l' output when a process doesn't have a parent process.

### DIFF
--- a/crates/nu_plugin_ps/src/ps.rs
+++ b/crates/nu_plugin_ps/src/ps.rs
@@ -45,6 +45,8 @@ pub async fn ps(tag: Tag, long: bool) -> Result<Vec<Value>, ShellError> {
             if long {
                 if let Some(parent) = result.parent() {
                     dict.insert_untagged("parent", UntaggedValue::int(parent));
+                } else {
+                    dict.insert_untagged("parent", UntaggedValue::nothing());
                 }
                 dict.insert_untagged("exe", UntaggedValue::filepath(result.exe()));
                 dict.insert_untagged("command", UntaggedValue::string(result.cmd().join(" ")));


### PR DESCRIPTION
Before, ps would not insert a value if the process didn't have a parent, for example init and the kernel thread . Now, ps will insert an empty cell. This caused broken tables as some rows didn't have all the columns.

Example:
  Before:
```
> ps -l | sort-by parent | reverse

---snip---

 208 │  2180 │ rtkit-dae │ Sleep     │    0.0000 │   3.1 MB │ 629.9 GB │      1 │           │ /usr/lib/
     │       │ mon       │           │           │          │          │        │           │ rtkit-dae
     │       │           │           │           │          │          │        │           │ mon
 209 │  8308 │ bash      │ Sleep     │    0.0000 │   3.7 MB │  30.2 GB │      1 │ /usr/bin/ │ bash
     │       │           │           │           │          │          │        │ bash      │ /usr/bin/
     │       │           │           │           │          │          │        │           │ sway-laun
     │       │           │           │           │          │          │        │           │ cher-desk
     │       │           │           │           │          │          │        │           │ top
     │       │           │           │           │          │          │        │           │ run-deskt
     │       │           │           │           │          │          │        │           │ op
     │       │           │           │           │          │          │        │           │ /usr/shar
     │       │           │           │           │          │          │        │           │ e/applica
     │       │           │           │           │          │          │        │           │ tions/fir
     │       │           │           │           │          │          │        │           │ efox.desk
     │       │           │           │           │          │          │        │           │ top
─────┴───────┴───────────┴───────────┴───────────┴──────────┴──────────┴────────┴───────────┴────────────
─────┬─────┬──────┬────────┬────────┬─────────┬──────────┬─────┬────────────
  #  │ pid │ name │ status │  cpu   │   mem   │ virtual  │ exe │  command
─────┼─────┼──────┼────────┼────────┼─────────┼──────────┼─────┼────────────
 210 │   2 │      │ Sleep  │ 0.0000 │     0 B │      0 B │     │
 211 │   1 │ init │ Sleep  │ 0.0000 │ 10.9 MB │ 701.0 GB │     │ /sbin/init
─────┴─────┴──────┴────────┴────────┴─────────┴──────────┴─────┴────────────
```

After:
```
---snip---

 202 │  2112 │ kanshi    │ Sleep     │    0.0000 │ 736.0 KB │  10.7 GB │      1 │ /usr/bin/ │ kanshi
     │       │           │           │           │          │          │        │ kanshi    │
 203 │     1 │ init      │ Sleep     │    0.0000 │  10.9 MB │ 701.0 GB │        │           │ /sbin/ini
     │       │           │           │           │          │          │        │           │ t
 204 │     2 │           │ Sleep     │    0.0000 │      0 B │      0 B │        │           │
─────┴───────┴───────────┴───────────┴───────────┴──────────┴──────────┴────────┴───────────┴────────────
```