### PR TITLE
Soft rest arguments column path cohersions.

### DIFF
--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -197,7 +197,7 @@ pub(crate) use from_xlsx::FromXLSX;
 pub(crate) use from_xml::FromXML;
 pub(crate) use from_yaml::FromYAML;
 pub(crate) use from_yaml::FromYML;
-pub(crate) use get::Get;
+pub(crate) use get::Command as Get;
 pub(crate) use group_by::Command as GroupBy;
 pub(crate) use group_by_date::GroupByDate;
 pub(crate) use hash_::{Hash, HashBase64};
@@ -299,7 +299,8 @@ mod tests {
             whole_stream_command(Move),
             whole_stream_command(Update),
             whole_stream_command(Empty),
-            //whole_stream_command(Select),
+            // whole_stream_command(Select),
+            // whole_stream_command(Get),
             // Str Command Suite
             whole_stream_command(Str),
             whole_stream_command(StrToDecimal),

--- a/crates/nu-command/src/utils/arguments.rs
+++ b/crates/nu-command/src/utils/arguments.rs
@@ -1,9 +1,15 @@
 use indexmap::IndexSet;
 use nu_errors::ShellError;
 use nu_protocol::{hir::CapturedBlock, ColumnPath, UntaggedValue, Value};
-use nu_source::Tagged;
 use nu_value_ext::ValueExt;
 
+/// Commands can be used in block form (passing a block) and
+/// in the majority of cases we are also interested in accepting
+/// column names along with it.
+///
+/// This aids with commands that take rest arguments
+/// that need to be column names and an optional block as last
+/// argument.
 pub fn arguments(
     rest: &mut Vec<Value>,
 ) -> Result<(Vec<ColumnPath>, Option<Box<CapturedBlock>>), ShellError> {
@@ -15,9 +21,14 @@ pub fn arguments(
     let mut default = None;
 
     for argument in columns.drain(..) {
-        let Tagged { item: path, .. } = argument.as_column_path()?;
-
-        column_paths.push(path);
+        match &argument.value {
+            UntaggedValue::Table(values) => {
+                column_paths.extend(collect_as_column_paths(&values)?);
+            }
+            _ => {
+                column_paths.push(argument.as_column_path()?.item);
+            }
+        }
     }
 
     match last_argument {
@@ -25,13 +36,77 @@ pub fn arguments(
             value: UntaggedValue::Block(call),
             ..
         }) => default = Some(call),
-        Some(other) => {
-            let Tagged { item: path, .. } = other.as_column_path()?;
-
-            column_paths.push(path);
-        }
+        Some(other) => match &other.value {
+            UntaggedValue::Table(values) => {
+                column_paths.extend(collect_as_column_paths(&values)?);
+            }
+            _ => {
+                column_paths.push(other.as_column_path()?.item);
+            }
+        },
         None => {}
     };
 
     Ok((column_paths, default))
+}
+
+fn collect_as_column_paths(values: &[Value]) -> Result<Vec<ColumnPath>, ShellError> {
+    let mut out = vec![];
+
+    for name in values {
+        out.push(name.as_column_path()?.item);
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::arguments;
+    use nu_test_support::value::*;
+    use nu_value_ext::ValueExt;
+
+    #[test]
+    fn arguments_test() -> Result<(), Box<dyn std::error::Error>> {
+        // cmd name
+        let arg1 = string("name");
+        let expected = string("name").as_column_path()?.item;
+
+        let (args, _) = arguments(&mut vec![arg1])?;
+
+        assert_eq!(args[0], expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn arguments_test_2() -> Result<(), Box<dyn std::error::Error>> {
+        // cmd name [type]
+        let arg1 = string("name");
+        let arg2 = table(&vec![string("type")]);
+
+        let expected = vec![
+            string("name").as_column_path()?.item,
+            string("type").as_column_path()?.item,
+        ];
+
+        assert_eq!(arguments(&mut vec![arg1, arg2])?.0, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn arguments_test_3() -> Result<(), Box<dyn std::error::Error>> {
+        // cmd [name type]
+        let arg1 = table(&vec![string("name"), string("type")]);
+
+        let expected = vec![
+            string("name").as_column_path()?.item,
+            string("type").as_column_path()?.item,
+        ];
+
+        assert_eq!(arguments(&mut vec![arg1])?.0, expected);
+
+        Ok(())
+    }
 }

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -210,7 +210,7 @@ fn parses_ini() {
 fn parses_utf16_ini() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open utf16.ini | get '.ShellClassInfo' | get IconIndex"
+        "open utf16.ini | rename info | get info | get IconIndex"
     );
 
     assert_eq!(actual.out, "-236")

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -55,8 +55,8 @@ fn complex_nested_columns() {
             r#"
                 open los_tres_caballeros.json
                 | select nu."0xATYKARNU" nu.committers.name nu.releases.version
-                | where "nu.releases.version" > "0.8"
-                | get "nu.releases.version"
+                | where nu_releases_version > "0.8"
+                | get nu_releases_version
             "#
         ));
 

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -628,16 +628,6 @@ pub fn replace_data_at_column_path(
 
 pub fn as_column_path(value: &Value) -> Result<Tagged<ColumnPath>, ShellError> {
     match &value.value {
-        UntaggedValue::Table(table) => {
-            let mut out: Vec<PathMember> = vec![];
-
-            for item in table {
-                out.push(as_path_member(item)?);
-            }
-
-            Ok(ColumnPath::new(out).tagged(&value.tag))
-        }
-
         UntaggedValue::Primitive(Primitive::String(s)) => {
             let s = s.to_string().spanned(value.tag.span);
 

--- a/crates/nu-value-ext/src/tests.rs
+++ b/crates/nu-value-ext/src/tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use nu_test_support::value::*;
+
+use indexmap::indexmap;
+
+#[test]
+fn forgiving_insertion_test_1() {
+    let field_path = column_path("crate.version").as_column_path().unwrap();
+
+    let version = string("nuno");
+
+    let value = UntaggedValue::row(indexmap! {
+        "package".into() =>
+            row(indexmap! {
+                "name".into()    =>     string("nu"),
+                "version".into() =>  string("0.20.0")
+            })
+    });
+
+    assert_eq!(
+        *value
+            .into_untagged_value()
+            .forgiving_insert_data_at_column_path(&field_path.item, version)
+            .unwrap()
+            .get_data_by_column_path(&field_path, Box::new(error_callback("crate.version")))
+            .unwrap(),
+        *string("nuno")
+    );
+}
+
+#[test]
+fn forgiving_insertion_test_2() {
+    let field_path = column_path("things.0").as_column_path().unwrap();
+
+    let version = string("arepas");
+
+    let value = UntaggedValue::row(indexmap! {
+        "pivot_mode".into() => string("never"),
+        "things".into() => table(&[string("frijoles de Andrés"), int(1)]),
+        "color_config".into() =>
+            row(indexmap! {
+                "header_align".into()    =>     string("left"),
+                "index_color".into() =>  string("cyan_bold")
+            })
+    });
+
+    assert_eq!(
+        *value
+            .into_untagged_value()
+            .forgiving_insert_data_at_column_path(&field_path.item, version)
+            .unwrap()
+            .get_data_by_column_path(&field_path, Box::new(error_callback("things.0")))
+            .unwrap(),
+        *string("arepas")
+    );
+}
+
+#[test]
+fn forgiving_insertion_test_3() {
+    let field_path = column_path("color_config.arepa_color")
+        .as_column_path()
+        .unwrap();
+    let pizza_path = column_path("things.0").as_column_path().unwrap();
+
+    let entry = string("amarillo");
+
+    let value = UntaggedValue::row(indexmap! {
+        "pivot_mode".into() => string("never"),
+        "things".into() => table(&[string("Arepas de Yehuda"), int(1)]),
+        "color_config".into() =>
+            row(indexmap! {
+                "header_align".into()    =>     string("left"),
+                "index_color".into() =>  string("cyan_bold")
+            })
+    });
+
+    assert_eq!(
+        *value
+            .clone()
+            .into_untagged_value()
+            .forgiving_insert_data_at_column_path(&field_path, entry.clone())
+            .unwrap()
+            .get_data_by_column_path(
+                &field_path.item,
+                Box::new(error_callback("color_config.arepa_color"))
+            )
+            .unwrap(),
+        *string("amarillo")
+    );
+
+    assert_eq!(
+        *value
+            .into_untagged_value()
+            .forgiving_insert_data_at_column_path(&field_path.item, entry)
+            .unwrap()
+            .get_data_by_column_path(&pizza_path, Box::new(error_callback("things.0")))
+            .unwrap(),
+        *string("Arepas de Yehuda")
+    );
+}
+
+#[test]
+fn get_row_data_by_key() {
+    let row = row(indexmap! {
+            "lines".to_string() => int(0),
+            "words".to_string() => int(7),
+    });
+    assert_eq!(
+        row.get_data_by_key("lines".spanned_unknown()).unwrap(),
+        int(0)
+    );
+    assert!(row.get_data_by_key("chars".spanned_unknown()).is_none());
+}
+
+#[test]
+fn get_table_data_by_key() {
+    let row1 = row(indexmap! {
+            "lines".to_string() => int(0),
+            "files".to_string() => int(10),
+    });
+
+    let row2 = row(indexmap! {
+            "files".to_string() => int(1)
+    });
+
+    let table_value = table(&[row1, row2]);
+    assert_eq!(
+        table_value
+            .get_data_by_key("files".spanned_unknown())
+            .unwrap(),
+        table(&[int(10), int(1)])
+    );
+    assert_eq!(
+        table_value
+            .get_data_by_key("chars".spanned_unknown())
+            .unwrap(),
+        table(&[nothing(), nothing()])
+    );
+}


### PR DESCRIPTION
Closes #2979 , #2985 and probably few more I can't find in issues logged.

A couple of things. `arguments` helper is applied in more places (`get` and `select`, to be exact, by changing their signature type to accept a `SyntaxShape::Any` rather than `SyntaxShape::ColumnPath` which allows passing it any value type that can be converted on runtime to a column path allowing things like invocations in the arguments. Originally extracted out from `empty?` command. 

This allows to convert the values passed to column path types and optionally determine if a block is passed at the end. This pattern (like `empty?`) is commonly showing up where you need to pass in columns to a command and you are interested also in having the command do a different behavior if also a block is passed to it.

With this is place, here are two examples. Given the [following source file](https://raw.githubusercontent.com/andrab/ecuacovid/master/datos_crudos/defunciones/por_fecha/provincias_por_dia.csv) having (at the time of this writing, `41` columns). The second command we just get the last 5 column names for demonstration purposes. This file also changes everyday (more columns).

```
> fetch "https://raw.githubusercontent.com/andrab/ecuacovid/master/datos_crudos/defunciones/por_fecha/provincias_por_dia.csv" | get | count
41

> fetch "https://raw.githubusercontent.com/andrab/ecuacovid/master/datos_crudos/defunciones/por_fecha/provincias_por_dia.csv" | get | last 5
───┬────────────
 0 │ 02/02/2021
 1 │ 03/02/2021
 2 │ 04/02/2021
 3 │ 05/02/2021
 4 │ 06/02/2021
───┴────────────
```

Say we are interested in selecting just the `provincia` column and some random columns from January, we can do, like so:

```
> fetch "https://raw.githubusercontent.com/andrab/ecuacovid/master/datos_crudos/defunciones/2020/por_fecha/lugar_provincias_por_dia.csv" | select provincia $(echo 1..5 | each { = `0{{$(random integer 1..10)}}/01/2021` }) | shuffle | first 5

───┬───────────┬────────────┬────────────┬────────────┬────────────┬────────────
 # │ provincia │ 09/01/2021 │ 03/01/2021 │ 05/01/2021 │ 06/01/2021 │ 07/01/2021
───┼───────────┼────────────┼────────────┼────────────┼────────────┼────────────
 0 │ Imbabura  │         45 │          6 │         35 │         58 │         22
 1 │ Loja      │         34 │         15 │          5 │         24 │          5
 2 │ Manabí    │         80 │          8 │         63 │         86 │        107
 3 │ Orellana  │          0 │          0 │          0 │          2 │          8
 4 │ Pichincha │        311 │         26 │        425 │        478 │        180
───┴───────────┴────────────┴────────────┴────────────┴────────────┴────────────
```

This means `select` can also take Table types (the output of the invocation in positional argument and converts them to column paths as well)

```
select provincia $(echo 1..5 | each { = `0{{$(random integer 1..10)}}/01/2021` })
```

The `get` command also supports it now.

