### PR TITLE
New termsize command

### DIFF
--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -115,6 +115,7 @@ pub(crate) mod split_by;
 pub(crate) mod str_;
 pub(crate) mod table;
 pub(crate) mod tags;
+pub(crate) mod termsize;
 pub(crate) mod to;
 pub(crate) mod to_csv;
 pub(crate) mod to_html;
@@ -265,6 +266,7 @@ pub(crate) use str_::{
 };
 pub(crate) use table::Table;
 pub(crate) use tags::Tags;
+pub(crate) use termsize::TermSize;
 pub(crate) use to::To;
 pub(crate) use to_csv::ToCSV;
 pub(crate) use to_html::ToHTML;

--- a/crates/nu-command/src/commands/default_context.rs
+++ b/crates/nu-command/src/commands/default_context.rs
@@ -237,6 +237,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(UrlQuery),
             whole_stream_command(Seq),
             whole_stream_command(SeqDates),
+            whole_stream_command(TermSize),
         ]);
 
         #[cfg(feature = "clipboard-cli")]

--- a/crates/nu-command/src/commands/termsize.rs
+++ b/crates/nu-command/src/commands/termsize.rs
@@ -1,0 +1,64 @@
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{Signature, UntaggedValue};
+
+pub struct TermSize;
+
+#[derive(Deserialize, Clone)]
+pub struct TermSizeArgs {
+    wide: bool,
+    tall: bool,
+}
+
+#[async_trait]
+impl WholeStreamCommand for TermSize {
+    fn name(&self) -> &str {
+        "term size"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("term size")
+            .switch("wide", "Report only the width of the terminal", Some('w'))
+            .switch("tall", "Report only the height of the terminal", Some('t'))
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the terminal size as W H"
+    }
+
+    async fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        let tag = args.call_info.name_tag.clone();
+        let (TermSizeArgs { wide, tall }, _) = args.process().await?;
+
+        let size = term_size::dimensions();
+        match size {
+            Some((w, h)) => {
+                if wide == true && tall == false {
+                    Ok(OutputStream::one(
+                        UntaggedValue::string(format!("{}", w)).into_value(tag),
+                    ))
+                } else if wide == false && tall == true {
+                    Ok(OutputStream::one(
+                        UntaggedValue::string(format!("{}", h)).into_value(tag),
+                    ))
+                } else {
+                    Ok(OutputStream::one(
+                        UntaggedValue::string(format!("{} {}", w, h)).into_value(tag),
+                    ))
+                }
+            }
+            _ => Ok(OutputStream::one(
+                UntaggedValue::string(format!("0 0")).into_value(tag),
+            )),
+        }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Return the terminal size",
+            example: "term size",
+            result: None,
+        }]
+    }
+}

--- a/crates/nu-command/src/commands/termsize.rs
+++ b/crates/nu-command/src/commands/termsize.rs
@@ -1,7 +1,8 @@
 use crate::prelude::*;
+use indexmap::IndexMap;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Signature, UntaggedValue};
+use nu_protocol::{Dictionary, Signature, UntaggedValue};
 
 pub struct TermSize;
 
@@ -39,9 +40,11 @@ impl WholeStreamCommand for TermSize {
                 } else if !wide && tall {
                     Ok(OutputStream::one(UntaggedValue::int(h).into_value(tag)))
                 } else {
-                    Ok(OutputStream::one(
-                        UntaggedValue::string(format!("{} {}", w, h)).into_value(tag),
-                    ))
+                    let mut indexmap = IndexMap::with_capacity(2);
+                    indexmap.insert("width".to_string(), UntaggedValue::int(w).into_value(&tag));
+                    indexmap.insert("height".to_string(), UntaggedValue::int(h).into_value(&tag));
+                    let value = UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag);
+                    Ok(OutputStream::one(value))
                 }
             }
             _ => Ok(OutputStream::one(

--- a/crates/nu-command/src/commands/termsize.rs
+++ b/crates/nu-command/src/commands/termsize.rs
@@ -34,14 +34,10 @@ impl WholeStreamCommand for TermSize {
         let size = term_size::dimensions();
         match size {
             Some((w, h)) => {
-                if wide == true && tall == false {
-                    Ok(OutputStream::one(
-                        UntaggedValue::string(format!("{}", w)).into_value(tag),
-                    ))
-                } else if wide == false && tall == true {
-                    Ok(OutputStream::one(
-                        UntaggedValue::string(format!("{}", h)).into_value(tag),
-                    ))
+                if wide && !tall {
+                    Ok(OutputStream::one(UntaggedValue::int(w).into_value(tag)))
+                } else if !wide && tall {
+                    Ok(OutputStream::one(UntaggedValue::int(h).into_value(tag)))
                 } else {
                     Ok(OutputStream::one(
                         UntaggedValue::string(format!("{} {}", w, h)).into_value(tag),
@@ -49,16 +45,28 @@ impl WholeStreamCommand for TermSize {
                 }
             }
             _ => Ok(OutputStream::one(
-                UntaggedValue::string(format!("0 0")).into_value(tag),
+                UntaggedValue::string("0 0".to_string()).into_value(tag),
             )),
         }
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Return the terminal size",
-            example: "term size",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "Return the width height of the terminal as W H",
+                example: "term size",
+                result: None,
+            },
+            Example {
+                description: "Return the width of the terminal",
+                example: "term size -w",
+                result: None,
+            },
+            Example {
+                description: "Return the height (t for tall) of the terminal",
+                example: "term size -t",
+                result: None,
+            },
+        ]
     }
 }


### PR DESCRIPTION
```
term size -h
Returns the terminal size as W H

Usage:
  > term size {flags}

Flags:
  -h, --help: Display this help message
  -w, --wide: Report only the width of the terminal
  -t, --tall: Report only the height of the terminal

Examples:
  Return the width height of the terminal as W H
  > term size

  Return the width of the terminal
  > term size -w

  Return the height (t for tall) of the terminal
  > term size -t
```