### PR TITLE
add "-0" as short for --headerless in "from" commands

### DIFF
--- a/crates/nu-command/src/commands/from_csv.rs
+++ b/crates/nu-command/src/commands/from_csv.rs
@@ -8,7 +8,7 @@ pub struct FromCSV;
 
 #[derive(Deserialize)]
 pub struct FromCSVArgs {
-    headerless: bool,
+    noheaders: bool,
     separator: Option<Value>,
 }
 
@@ -27,9 +27,9 @@ impl WholeStreamCommand for FromCSV {
                 Some('s'),
             )
             .switch(
-                "headerless",
+                "noheaders",
                 "don't treat the first row as column names",
-                None,
+                Some('n'),
             )
     }
 
@@ -50,7 +50,12 @@ impl WholeStreamCommand for FromCSV {
             },
             Example {
                 description: "Convert comma-separated data to a table, ignoring headers",
-                example: "open data.txt | from csv --headerless",
+                example: "open data.txt | from csv --noheaders",
+                result: None,
+            },
+            Example {
+                description: "Convert comma-separated data to a table, ignoring headers",
+                example: "open data.txt | from csv -0",
                 result: None,
             },
             Example {
@@ -67,7 +72,7 @@ async fn from_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let (
         FromCSVArgs {
-            headerless,
+            noheaders,
             separator,
         },
         input,
@@ -95,7 +100,7 @@ async fn from_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
         _ => ',',
     };
 
-    from_delimited_data(headerless, sep, "CSV", input, name).await
+    from_delimited_data(noheaders, sep, "CSV", input, name).await
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/from_csv.rs
+++ b/crates/nu-command/src/commands/from_csv.rs
@@ -55,7 +55,7 @@ impl WholeStreamCommand for FromCSV {
             },
             Example {
                 description: "Convert comma-separated data to a table, ignoring headers",
-                example: "open data.txt | from csv -0",
+                example: "open data.txt | from csv -n",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/commands/from_delimited_data.rs
+++ b/crates/nu-command/src/commands/from_delimited_data.rs
@@ -5,18 +5,18 @@ use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
 
 fn from_delimited_string_to_value(
     s: String,
-    headerless: bool,
+    noheaders: bool,
     separator: char,
     tag: impl Into<Tag>,
 ) -> Result<Value, csv::Error> {
     let mut reader = ReaderBuilder::new()
-        .has_headers(!headerless)
+        .has_headers(!noheaders)
         .delimiter(separator as u8)
         .from_reader(s.as_bytes());
     let tag = tag.into();
     let span = tag.span;
 
-    let headers = if headerless {
+    let headers = if noheaders {
         (1..=reader.headers()?.len())
             .map(|i| format!("Column{}", i))
             .collect::<Vec<String>>()
@@ -46,7 +46,7 @@ fn from_delimited_string_to_value(
 }
 
 pub async fn from_delimited_data(
-    headerless: bool,
+    noheaders: bool,
     sep: char,
     format_name: &'static str,
     input: InputStream,
@@ -56,7 +56,7 @@ pub async fn from_delimited_data(
     let concat_string = input.collect_string(name_tag.clone()).await?;
     let sample_lines = concat_string.item.lines().take(3).collect_vec().join("\n");
 
-    match from_delimited_string_to_value(concat_string.item, headerless, sep, name_tag.clone()) {
+    match from_delimited_string_to_value(concat_string.item, noheaders, sep, name_tag.clone()) {
         Ok(x) => match x {
             Value {
                 value: UntaggedValue::Table(list),

--- a/crates/nu-command/src/commands/from_ods.rs
+++ b/crates/nu-command/src/commands/from_ods.rs
@@ -10,7 +10,7 @@ pub struct FromODS;
 
 #[derive(Deserialize)]
 pub struct FromODSArgs {
-    headerless: bool,
+    noheaders: bool,
 }
 
 #[async_trait]
@@ -21,9 +21,9 @@ impl WholeStreamCommand for FromODS {
 
     fn signature(&self) -> Signature {
         Signature::build("from ods").switch(
-            "headerless",
+            "noheaders",
             "don't treat the first row as column names",
-            None,
+            Some('n'),
         )
     }
 
@@ -42,7 +42,7 @@ async fn from_ods(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let (
         FromODSArgs {
-            headerless: _headerless,
+            noheaders: _noheaders,
         },
         input,
     ) = args.process().await?;

--- a/crates/nu-command/src/commands/from_tsv.rs
+++ b/crates/nu-command/src/commands/from_tsv.rs
@@ -8,7 +8,7 @@ pub struct FromTSV;
 
 #[derive(Deserialize)]
 pub struct FromTSVArgs {
-    headerless: bool,
+    noheaders: bool,
 }
 
 #[async_trait]
@@ -19,9 +19,9 @@ impl WholeStreamCommand for FromTSV {
 
     fn signature(&self) -> Signature {
         Signature::build("from tsv").switch(
-            "headerless",
+            "noheaders",
             "don't treat the first row as column names",
-            None,
+            Some('n'),
         )
     }
 
@@ -36,9 +36,9 @@ impl WholeStreamCommand for FromTSV {
 
 async fn from_tsv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
-    let (FromTSVArgs { headerless }, input) = args.process().await?;
+    let (FromTSVArgs { noheaders }, input) = args.process().await?;
 
-    from_delimited_data(headerless, '\t', "TSV", input, name).await
+    from_delimited_data(noheaders, '\t', "TSV", input, name).await
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/from_xlsx.rs
+++ b/crates/nu-command/src/commands/from_xlsx.rs
@@ -10,7 +10,7 @@ pub struct FromXLSX;
 
 #[derive(Deserialize)]
 pub struct FromXLSXArgs {
-    headerless: bool,
+    noheaders: bool,
 }
 
 #[async_trait]
@@ -21,9 +21,9 @@ impl WholeStreamCommand for FromXLSX {
 
     fn signature(&self) -> Signature {
         Signature::build("from xlsx").switch(
-            "headerless",
+            "noheaders",
             "don't treat the first row as column names",
-            None,
+            Some('n'),
         )
     }
 
@@ -41,7 +41,7 @@ async fn from_xlsx(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let span = tag.span;
     let (
         FromXLSXArgs {
-            headerless: _headerless,
+            noheaders: _noheaders,
         },
         input,
     ) = args.process().await?;

--- a/crates/nu-command/src/commands/to_csv.rs
+++ b/crates/nu-command/src/commands/to_csv.rs
@@ -8,7 +8,7 @@ pub struct ToCSV;
 
 #[derive(Deserialize)]
 pub struct ToCSVArgs {
-    headerless: bool,
+    noheaders: bool,
     separator: Option<Value>,
 }
 
@@ -27,9 +27,9 @@ impl WholeStreamCommand for ToCSV {
                 Some('s'),
             )
             .switch(
-                "headerless",
+                "noheaders",
                 "do not output the columns names as the first row",
-                None,
+                Some('n'),
             )
     }
 
@@ -47,7 +47,7 @@ async fn to_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let (
         ToCSVArgs {
             separator,
-            headerless,
+            noheaders,
         },
         input,
     ) = args.process().await?;
@@ -74,7 +74,7 @@ async fn to_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
         _ => ',',
     };
 
-    to_delimited_data(headerless, sep, "CSV", input, name).await
+    to_delimited_data(noheaders, sep, "CSV", input, name).await
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_delimited_data.rs
+++ b/crates/nu-command/src/commands/to_delimited_data.rs
@@ -165,7 +165,7 @@ fn merge_descriptors(values: &[Value]) -> Vec<Spanned<String>> {
 }
 
 pub async fn to_delimited_data(
-    headerless: bool,
+    noheaders: bool,
     sep: char,
     format_name: &'static str,
     input: InputStream,
@@ -192,7 +192,7 @@ pub async fn to_delimited_data(
         futures::stream::iter(to_process_input.into_iter().map(move |value| {
             match from_value_to_delimited_string(&clone_tagged_value(&value), sep) {
                 Ok(mut x) => {
-                    if headerless {
+                    if noheaders {
                         if let Some(second_line) = x.find('\n') {
                             let start = second_line + 1;
                             x.replace_range(0..start, "");

--- a/crates/nu-command/src/commands/to_tsv.rs
+++ b/crates/nu-command/src/commands/to_tsv.rs
@@ -8,7 +8,7 @@ pub struct ToTSV;
 
 #[derive(Deserialize)]
 pub struct ToTSVArgs {
-    headerless: bool,
+    noheaders: bool,
 }
 
 #[async_trait]
@@ -19,9 +19,9 @@ impl WholeStreamCommand for ToTSV {
 
     fn signature(&self) -> Signature {
         Signature::build("to tsv").switch(
-            "headerless",
+            "noheaders",
             "do not output the column names as the first row",
-            None,
+            Some('n'),
         )
     }
 
@@ -36,9 +36,9 @@ impl WholeStreamCommand for ToTSV {
 
 async fn to_tsv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
-    let (ToTSVArgs { headerless }, input) = args.process().await?;
+    let (ToTSVArgs { noheaders }, input) = args.process().await?;
 
-    to_delimited_data(headerless, '\t', "TSV", input, name).await
+    to_delimited_data(noheaders, '\t', "TSV", input, name).await
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -64,7 +64,7 @@ fn table_to_csv_text_skipping_headers_after_conversion() {
                 | str trim
                 | split column "," a b c d origin
                 | last 1
-                | to csv --headerless
+                | to csv --noheaders
             "#
         ));
 
@@ -198,7 +198,7 @@ fn from_csv_text_skipping_headers_to_table() {
             cwd: dirs.test(), pipeline(
             r#"
                 open los_tres_amigos.txt
-                | from csv --headerless
+                | from csv --noheaders
                 | get Column3
                 | count
             "#

--- a/crates/nu-command/tests/format_conversions/ssv.rs
+++ b/crates/nu-command/tests/format_conversions/ssv.rs
@@ -72,7 +72,7 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
         cwd: dirs.test(), pipeline(
             r#"
                 open oc_get_svc.txt
-                | from ssv --headerless -a
+                | from ssv --noheaders -a
                 | first
                 | get Column1
             "#
@@ -82,7 +82,7 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
             cwd: dirs.test(), pipeline(
             r#"
                 open oc_get_svc.txt
-                | from ssv --headerless
+                | from ssv --noheaders
                 | first
                 | get Column1
                 

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -70,7 +70,7 @@ fn table_to_tsv_text_skipping_headers_after_conversion() {
                 | lines
                 | split column "\t" a b c d origin
                 | last 1
-                | to tsv --headerless
+                | to tsv --noheaders
             "#
         ));
 
@@ -121,7 +121,7 @@ fn from_tsv_text_skipping_headers_to_table() {
             cwd: dirs.test(), pipeline(
             r#"
                 open los_tres_amigos.txt
-                | from tsv --headerless
+                | from tsv --noheaders
                 | get Column3
                 | count
             "#


### PR DESCRIPTION
It's really hard to type `--headerless` 😄 
And we have to type at least `--hea` before pressing Tab, because we also have `--help`

If it was `--no-header`, we may have chosen `-n` as short flag (even though `-n` sometimes means number and sometimes `non-something`)

But I can't think of anything better than `-0` for `--headerless`.