### PR TITLE
display boolean config options as true/false instead of Yes/No

### DIFF
--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -251,12 +251,12 @@ impl PrettyDebug for FormatInlineShape {
             InlineShape::GlobPattern(pattern) => DbgDocBldr::primitive(pattern),
             InlineShape::Boolean(boolean) => DbgDocBldr::primitive(
                 match (boolean, column) {
-                    (true, None) => "Yes",
-                    (false, None) => "No",
+                    (true, None) => "true",
+                    (false, None) => "false",
                     (true, Some(Column::String(s))) if !s.is_empty() => s,
                     (false, Some(Column::String(s))) if !s.is_empty() => "",
-                    (true, Some(_)) => "Yes",
-                    (false, Some(_)) => "No",
+                    (true, Some(_)) => "true",
+                    (false, Some(_)) => "false",
                 }
                 .to_owned(),
             ),

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -314,12 +314,12 @@ pub fn format_primitive(primitive: &Primitive, field_name: Option<&String>) -> S
             f
         }
         Primitive::Boolean(b) => match (b, field_name) {
-            (true, None) => "Yes",
-            (false, None) => "No",
+            (true, None) => "true",
+            (false, None) => "false",
             (true, Some(s)) if !s.is_empty() => s,
             (false, Some(s)) if !s.is_empty() => "",
-            (true, Some(_)) => "Yes",
-            (false, Some(_)) => "No",
+            (true, Some(_)) => "true",
+            (false, Some(_)) => "false",
         }
         .to_owned(),
         Primitive::Binary(_) => "<binary>".to_owned(),

--- a/docs/commands/empty.md
+++ b/docs/commands/empty.md
@@ -24,12 +24,12 @@ Given the following meals
 Show the empty contents
 ```shell
 > echo [[meal size]; [arepa small] [taco '']] | empty? meal size
-═══╦══════╦══════
- # ║ meal ║ size
-═══╬══════╬══════
- 0 ║ No   ║ No
- 1 ║ No   ║ Yes
-═══╩══════╩══════
+═══╦═══════╦═══════
+ # ║ meal  ║ size
+═══╬═══════╬═══════
+ 0 ║ false ║ false
+ 1 ║ false ║ true
+═══╩═══════╩═══════
 ```
 
 Let's assume we have a report of totals per day. For simplicity we show just for three days `2020/04/16`, `2020/07/10`, and `2020/11/16`. Like so

--- a/docs/commands/from-json.md
+++ b/docs/commands/from-json.md
@@ -27,6 +27,6 @@ Syntax: `from json {flags}`
 ━━━━━━━━━━━┯━━━━━━━━━┯━━━━━━━
  title     │ type    │ flags
 ───────────┼─────────┼───────
- from json │ command │ Yes
+ from json │ command │ true
 ━━━━━━━━━━━┷━━━━━━━━━┷━━━━━━━
 ```

--- a/docs/commands/which.md
+++ b/docs/commands/which.md
@@ -22,7 +22,7 @@ Usage:
 ─────────┬─────────────────
  arg     │ python
  path    │ /usr/bin/python
- builtin │ No
+ builtin │ false
 ─────────┴─────────────────
 ```
 
@@ -31,7 +31,7 @@ Usage:
 ─────────┬────────────────────────────
  arg     │ cargo
  path    │ /home/bob/.cargo/bin/cargo
- builtin │ No
+ builtin │ false
 ─────────┴────────────────────────────
 ```
 
@@ -42,7 +42,7 @@ Usage:
 ─────────┬──────────────────────────
  arg     │ ls
  path    │ nushell built-in command
- builtin │ Yes
+ builtin │ true
 ─────────┴──────────────────────────
 ```
 
@@ -51,7 +51,7 @@ Usage:
 ─────────┬──────────────────────────
  arg     │ which
  path    │ nushell built-in command
- builtin │ Yes
+ builtin │ true
 ─────────┴──────────────────────────
 ```
 
@@ -62,8 +62,8 @@ Passing the `all` flag identifies all instances of a command or binary
 ───┬─────┬──────────────────────────┬─────────
  # │ arg │ path                     │ builtin
 ───┼─────┼──────────────────────────┼─────────
- 0 │ ls  │ nushell built-in command │ Yes
- 1 │ ls  │ /bin/ls                  │ No
+ 0 │ ls  │ nushell built-in command │ true
+ 1 │ ls  │ /bin/ls                  │ false
 ───┴─────┴──────────────────────────┴─────────
 ```
 
@@ -76,7 +76,7 @@ Passing the `all` flag identifies all instances of a command or binary
 ─────────┬────────────────────────────────
  arg     │ ./foo
  path    │ /Users/josephlyons/Desktop/foo
- builtin │ No
+ builtin │ false
 ─────────┴────────────────────────────────
 ```
 
@@ -88,7 +88,7 @@ Passing the `all` flag identifies all instances of a command or binary
 ───┬─────┬───────────────┬─────────
  # │ arg │     path      │ builtin
 ───┼─────┼───────────────┼─────────
- 0 │ e   │ Nushell alias │ No
+ 0 │ e   │ Nushell alias │ false
 ───┴─────┴───────────────┴─────────
 ```
 
@@ -100,6 +100,6 @@ and custom commands
 ───┬──────────────┬────────────────────────┬─────────
  # │     arg      │          path          │ builtin
 ───┼──────────────┼────────────────────────┼─────────
- 0 │ my_cool_echo │ Nushell custom command │ No
+ 0 │ my_cool_echo │ Nushell custom command │ false
 ───┴──────────────┴────────────────────────┴─────────
 ```


### PR DESCRIPTION
Alleviates the second half of #3037 by displaying booleans as `true` or `false` instead of `Yes` or `No`.

At first glance this doesn't seem to break any tests (the pass/fail ratio after this change is the same as it was before).