### PR TITLE
add config "filesize_metric = true" for default formatting of filesize

### DIFF
--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -1,4 +1,5 @@
 filesize_format = "B" # can be b, kb, kib, mb, mib, gb, gib, etc
+filesize_metric = true # true => (KB, MB, GB), false => (KiB, MiB, GiB)
 skip_welcome_message = true
 disable_table_indexes = false
 nonzero_exit_errors = true


### PR DESCRIPTION
The default would be `filesize_metric = true` which is the current behavior (use KB, MB, GB in `ls` and `du`).
If  `filesize_metric = false` is set, KiB, MiG and GiB units are used.
This will not override `filesize_format` config param.
If `filesize_format` is set, `filesize_metric` is ignored.