### PR TITLE
refactor parser: rename method pub fn block to parse_block

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -412,7 +412,7 @@ mod tests {
     #[quickcheck]
     fn quickcheck_parse(data: String) -> bool {
         let (tokens, err) = nu_parser::lex(&data, 0);
-        let (lite_block, err2) = nu_parser::block(tokens);
+        let (lite_block, err2) = nu_parser::parse_block(tokens);
         if err.is_none() && err2.is_none() {
             let context = basic_evaluation_context().unwrap();
             let _ = nu_parser::classify_block(&lite_block, &context.scope);

--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -256,7 +256,7 @@ pub fn completion_location(line: &str, block: &Block, pos: usize) -> Vec<Complet
 mod tests {
     use super::*;
 
-    use nu_parser::{block, classify_block, lex, ParserScope};
+    use nu_parser::{classify_block, lex, parse_block, ParserScope};
     use nu_protocol::{Signature, SyntaxShape};
 
     #[derive(Clone, Debug)]
@@ -307,7 +307,7 @@ mod tests {
             pos: usize,
         ) -> Vec<LocationType> {
             let (tokens, _) = lex(line, 0);
-            let (lite_block, _) = block(tokens);
+            let (lite_block, _) = parse_block(tokens);
 
             scope.enter_scope();
             let (block, _) = classify_block(&lite_block, scope);

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -119,7 +119,7 @@ impl rustyline::validate::Validator for NuValidator {
             }
         }
 
-        let (_, err) = nu_parser::block(tokens);
+        let (_, err) = nu_parser::parse_block(tokens);
 
         if let Some(err) = err {
             if let nu_errors::ParseErrorReason::Eof { .. } = err.reason() {

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -215,7 +215,7 @@ fn parse_line(line: &str, ctx: &EvaluationContext) -> Result<ClassifiedBlock, Sh
     if let Some(err) = err {
         return Err(err.into());
     }
-    let (lite_result, err) = nu_parser::block(lite_result);
+    let (lite_result, err) = nu_parser::parse_block(lite_result);
     if let Some(err) = err {
         return Err(err.into());
     }

--- a/crates/nu-parser/src/lex/lexer.rs
+++ b/crates/nu-parser/src/lex/lexer.rs
@@ -332,7 +332,7 @@ impl BlockParser {
 }
 
 /// Try to parse a list of tokens into a block.
-pub fn block(tokens: Vec<Token>) -> (LiteBlock, Option<ParseError>) {
+pub fn parse_block(tokens: Vec<Token>) -> (LiteBlock, Option<ParseError>) {
     let mut parser = BlockParser::default();
 
     let mut tokens = tokens.iter().peekable();

--- a/crates/nu-parser/src/lex/tests.rs
+++ b/crates/nu-parser/src/lex/tests.rs
@@ -177,7 +177,7 @@ mod lite_parse {
     fn pipeline() {
         let (result, err) = lex("cmd1 | cmd2 ; deploy", 0);
         assert!(err.is_none());
-        let (result, err) = block(result);
+        let (result, err) = parse_block(result);
         assert!(err.is_none());
         assert_eq!(result.span(), span(0, 20));
         assert_eq!(result.block[0].pipelines[0].span(), span(0, 11));
@@ -188,7 +188,7 @@ mod lite_parse {
     fn simple_1() {
         let (result, err) = lex("foo", 0);
         assert!(err.is_none());
-        let (result, err) = block(result);
+        let (result, err) = parse_block(result);
         assert!(err.is_none());
         assert_eq!(result.block.len(), 1);
         assert_eq!(result.block[0].pipelines.len(), 1);
@@ -204,7 +204,7 @@ mod lite_parse {
     fn simple_offset() {
         let (result, err) = lex("foo", 10);
         assert!(err.is_none());
-        let (result, err) = block(result);
+        let (result, err) = parse_block(result);
         assert!(err.is_none());
         assert_eq!(result.block[0].pipelines.len(), 1);
         assert_eq!(result.block[0].pipelines[0].commands.len(), 1);
@@ -222,7 +222,7 @@ mod lite_parse {
             err.unwrap().reason(),
             nu_errors::ParseErrorReason::Eof { .. }
         ));
-        let (result, _) = block(result);
+        let (result, _) = parse_block(result);
 
         assert_eq!(result.block.len(), 1);
         assert_eq!(result.block[0].pipelines.len(), 1);
@@ -247,7 +247,7 @@ def my_echo [arg] { echo $arg }
         "#;
         let (result, err) = lex(code, 0);
         assert!(err.is_none());
-        let (result, err) = block(result);
+        let (result, err) = parse_block(result);
         assert!(err.is_none());
 
         assert_eq!(result.block.len(), 1);
@@ -281,7 +281,7 @@ echo 42
         let (result, err) = lex(code, 0);
         assert!(err.is_none());
         // assert_eq!(format!("{:?}", result), "");
-        let (result, err) = block(result);
+        let (result, err) = parse_block(result);
         assert!(err.is_none());
         assert_eq!(result.block.len(), 1);
         assert_eq!(result.block[0].pipelines.len(), 1);
@@ -301,7 +301,7 @@ echo 42
     let (result, err) = lex(code, 0);
     assert!(err.is_none());
     // assert_eq!(format!("{:?}", result), "");
-    let (result, err) = block(result);
+    let (result, err) = parse_block(result);
     assert!(err.is_none());
     assert_eq!(result.block.len(), 1);
     assert_eq!(result.block[0].pipelines.len(), 1);
@@ -335,7 +335,7 @@ echo 42
     let (result, err) = lex(code, 0);
     assert!(err.is_none());
     // assert_eq!(format!("{:?}", result), "");
-    let (result, err) = block(result);
+    let (result, err) = parse_block(result);
     assert!(err.is_none());
     assert_eq!(result.block.len(), 1);
     assert_eq!(result.block[0].pipelines.len(), 1);

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -11,7 +11,7 @@ mod scope;
 mod shapes;
 mod signature;
 
-pub use lex::lexer::{block, lex};
+pub use lex::lexer::{lex, parse_block};
 pub use lex::tokens::{LiteBlock, LiteCommand, LiteGroup, LitePipeline};
 pub use parse::{classify_block, garbage, parse, parse_full_column_path, parse_math_expression};
 pub use path::expand_ndots;

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -12,7 +12,7 @@ use nu_protocol::{NamedType, PositionalType, Signature, SyntaxShape, UnspannedPa
 use nu_source::{HasSpan, Span, Spanned, SpannedItem};
 use num_bigint::BigInt;
 
-use crate::lex::lexer::{block, lex};
+use crate::lex::lexer::{lex, parse_block};
 use crate::lex::tokens::{LiteBlock, LiteCommand, LitePipeline};
 use crate::path::expand_path;
 use crate::scope::ParserScope;
@@ -396,7 +396,7 @@ fn parse_invocation(
     if err.is_some() {
         return (garbage(lite_arg.span), err);
     };
-    let (lite_block, err) = block(tokens);
+    let (lite_block, err) = parse_block(tokens);
     if err.is_some() {
         return (garbage(lite_arg.span), err);
     };
@@ -702,7 +702,7 @@ fn parse_table(
         return (garbage(lite_inner.span()), err);
     }
 
-    let (lite_header, err) = block(tokens);
+    let (lite_header, err) = parse_block(tokens);
     if err.is_some() {
         return (garbage(lite_inner.span()), err);
     }
@@ -725,7 +725,7 @@ fn parse_table(
         if err.is_some() {
             return (garbage(arg.span), err);
         }
-        let (lite_cell, err) = block(tokens);
+        let (lite_cell, err) = parse_block(tokens);
         if err.is_some() {
             return (garbage(arg.span), err);
         }
@@ -856,7 +856,7 @@ fn parse_arg(
                         return (garbage(lite_arg.span), err);
                     }
 
-                    let (lite_block, err) = block(tokens);
+                    let (lite_block, err) = parse_block(tokens);
                     if err.is_some() {
                         return (garbage(lite_arg.span), err);
                     }
@@ -911,7 +911,7 @@ fn parse_arg(
                         return (garbage(lite_arg.span), err);
                     }
 
-                    let (lite_block, err) = block(tokens);
+                    let (lite_block, err) = parse_block(tokens);
                     if err.is_some() {
                         return (garbage(lite_arg.span), err);
                     }
@@ -1139,7 +1139,7 @@ fn parse_parenthesized_expression(
                 return (garbage(lite_arg.span), err);
             }
 
-            let (lite_block, err) = block(tokens);
+            let (lite_block, err) = parse_block(tokens);
             if err.is_some() {
                 return (garbage(lite_arg.span), err);
             }
@@ -2131,7 +2131,7 @@ pub fn parse(
     if error.is_some() {
         return (Block::basic(), error);
     }
-    let (lite_block, error) = block(output);
+    let (lite_block, error) = parse_block(output);
     if error.is_some() {
         return (Block::basic(), error);
     }

--- a/crates/nu-parser/src/parse/def.rs
+++ b/crates/nu-parser/src/parse/def.rs
@@ -9,7 +9,7 @@ use nu_protocol::hir::Block;
 use nu_source::{HasSpan, SpannedItem};
 
 //use crate::errors::{ParseError, ParseResult};
-use crate::lex::lexer::{block, lex};
+use crate::lex::lexer::{lex, parse_block};
 
 use crate::ParserScope;
 
@@ -56,7 +56,7 @@ pub(crate) fn parse_definition(call: &LiteCommand, scope: &dyn ParserScope) -> O
                 if err.is_some() {
                     return err;
                 };
-                let (lite_block, err) = block(tokens);
+                let (lite_block, err) = parse_block(tokens);
                 if err.is_some() {
                     return err;
                 };


### PR DESCRIPTION
This will make it clearer and more precise in the code exactly what this method is doing.  Previously discussed name re-change of this method is happening now that @wycats and @LhKipp first round of lexer and parser refactor work is completed.  This will also make it cleaner and clearer in the code as we move forward on a solution for issue #2972 