### PR TITLE
deserialize_struct: fix missing conversion from string to column path

### DIFF
--- a/crates/nu-engine/src/deserializer.rs
+++ b/crates/nu-engine/src/deserializer.rs
@@ -4,6 +4,7 @@ use nu_protocol::{
     hir::CapturedBlock, CallInfo, ColumnPath, Primitive, RangeInclusion, ShellTypeName,
     UntaggedValue, Value,
 };
+use nu_source::Span;
 use nu_source::{HasSpan, Spanned, SpannedItem, Tagged, TaggedItem};
 use nu_value_ext::ValueExt;
 use serde::de;
@@ -401,6 +402,13 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut ConfigDeserializer<'de> {
                     value: UntaggedValue::Primitive(Primitive::ColumnPath(path)),
                     ..
                 } => path,
+                Value {
+                    value: UntaggedValue::Primitive(Primitive::String(path)),
+                    ..
+                } => {
+                    let s = path.spanned(Span::unknown());
+                    ColumnPath::build(&s)
+                }
                 other => {
                     return Err(ShellError::type_error(
                         "column path",


### PR DESCRIPTION
We were not able to define a function that takes a column name as argument and passed it to another command.
Example:
```
def size2int-col [p] {
	format filesize $p B | str from $p | str find-replace -a ',' '' $p | str to-int $p
}

def size2int [] {
	size2int-col size
}

ls | size2int
```