### PR TITLE
nu-parser: fix parsing comments with unclosed ' " [] {} in functions

### DIFF
--- a/crates/nu-parser/src/lex/lexer.rs
+++ b/crates/nu-parser/src/lex/lexer.rs
@@ -68,6 +68,8 @@ pub fn baseline(src: &mut Input, span_offset: usize) -> (Spanned<String>, Option
     // closing quote.
     let mut quote_start: Option<char> = None;
 
+    let mut in_comment = false;
+
     // This Vec tracks paired delimiters
     let mut block_level: Vec<BlockKind> = vec![];
 
@@ -97,6 +99,20 @@ pub fn baseline(src: &mut Input, span_offset: usize) -> (Spanned<String>, Option
             // string, we're done with the current string.
             if Some(c) == quote_start {
                 quote_start = None;
+            }
+        } else if c == '#' {
+            if is_termination(&block_level, c) {
+                break;
+            }
+            in_comment = true;
+        } else if c == '\n' {
+            in_comment = false;
+            if is_termination(&block_level, c) {
+                break;
+            }
+        } else if in_comment {
+            if is_termination(&block_level, c) {
+                break;
             }
         } else if c == '\'' || c == '"' || c == '`' {
             // We encountered the opening quote of a string literal.

--- a/crates/nu-parser/src/lex/tests.rs
+++ b/crates/nu-parser/src/lex/tests.rs
@@ -132,6 +132,46 @@ def e [] {echo hi}
     }
 
     #[test]
+    fn def_comment_with_sinqle_quote() {
+        let input = r#"def f [] {
+	    	# shouldn't return error
+			echo hi
+		}"#;
+        let (_result, err) = lex(input, 0);
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn def_comment_with_double_quote() {
+        let input = r#"def f [] {
+	    	# should "not return error
+			echo hi
+		}"#;
+        let (_result, err) = lex(input, 0);
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn def_comment_with_bracks() {
+        let input = r#"def f [] {
+	    	# should not [return error
+			echo hi
+		}"#;
+        let (_result, err) = lex(input, 0);
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn def_comment_with_curly() {
+        let input = r#"def f [] {
+	    	# should not return {error
+			echo hi
+		}"#;
+        let (_result, err) = lex(input, 0);
+        assert!(err.is_none());
+    }
+
+    #[test]
     fn ignore_future() {
         let input = "foo 'bar";
 


### PR DESCRIPTION
This PR fixes the following bug:
Comments in functions can not include any of these characters `' " [ ] { }` unless they are closed (like they are not in comment)

Example:
```
def testfunc [] {
	# nu shouldn't process any syntax inside comments
}
```
Gives:
```
error: Unexpected end of input
    ┌─ shell:169:17
    │  
169 │   def testfunc [] {
    │ ╭─────────────────^
170 │ │     # nu shouldn't process any syntax inside comments
171 │ │ }
172 │ │ 
    │ ╰^ Expected }
```
