### PR TITLE
Fix let-env

### DIFF
--- a/crates/nu-command/src/script.rs
+++ b/crates/nu-command/src/script.rs
@@ -184,7 +184,7 @@ pub async fn process_script(
         trace!("{:#?}", block);
         let env = ctx.get_env();
 
-        ctx.scope.add_env(env);
+        ctx.scope.add_env_to_base(env);
         let result = run_block(&block, ctx, input_stream).await;
         match result {
             Ok(input) => {

--- a/crates/nu-engine/src/evaluate/scope.rs
+++ b/crates/nu-engine/src/evaluate/scope.rs
@@ -186,6 +186,12 @@ impl Scope {
             frame.env.extend(env_vars)
         }
     }
+
+    pub fn add_env_to_base(&self, env_vars: IndexMap<String, String>) {
+        if let Some(frame) = self.frames.lock().first_mut() {
+            frame.env.extend(env_vars)
+        }
+    }
 }
 
 impl ParserScope for Scope {

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -220,50 +220,50 @@ fn autoenv() {
     })
 }
 
-// #[cfg(feature = "which")]
-// #[test]
-// fn nu_let_env_overwrites() {
-//     Playground::setup("syncs_env_test_1", |dirs, sandbox| {
-//         sandbox.with_files(vec![FileWithContent(
-//             "configuration.toml",
-//             r#"
-//             [env]
-//             SHELL = "/usr/bin/you_already_made_the_nu_choice"
-//         "#,
-//         )]);
+#[cfg(feature = "which")]
+#[test]
+fn nu_let_env_overwrites() {
+    Playground::setup("syncs_env_test_1", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent(
+            "configuration.toml",
+            r#"
+            [env]
+            SHELL = "/usr/bin/you_already_made_the_nu_choice"
+        "#,
+        )]);
 
-//         let mut file = dirs.test().clone();
-//         file.push("configuration.toml");
+        let mut file = dirs.test().clone();
+        file.push("configuration.toml");
 
-//         let fake_config = FakeConfig::new(&file);
-//         let mut actual = EnvironmentSyncer::new();
-//         actual.set_config(Box::new(fake_config));
+        let fake_config = FakeConfig::new(&file);
+        let mut actual = EnvironmentSyncer::new();
+        actual.set_config(Box::new(fake_config));
 
-//         // Here, the environment variables from the current session
-//         // are cleared since we will load and set them from the
-//         // configuration file (if any)
-//         actual.clear_env_vars(&mut ctx);
+        // Here, the environment variables from the current session
+        // are cleared since we will load and set them from the
+        // configuration file (if any)
+        actual.clear_env_vars(&mut ctx);
 
-//         // Nu loads the environment variables from the configuration file (if any)
-//         actual.load_environment();
+        // Nu loads the environment variables from the configuration file (if any)
+        actual.load_environment();
 
-//         // By this point, Nu has already loaded the environment variables
-//         // stored in the configuration file. Before continuing we check
-//         // if any new environment variables have been added from the ones loaded
-//         // in the configuration file.
-//         //
-//         // Nu sees the missing "USER" variable and accounts for it.
-//         actual.sync_env_vars(&mut ctx);
+        // By this point, Nu has already loaded the environment variables
+        // stored in the configuration file. Before continuing we check
+        // if any new environment variables have been added from the ones loaded
+        // in the configuration file.
+        //
+        // Nu sees the missing "USER" variable and accounts for it.
+        actual.sync_env_vars(&mut ctx);
 
-//         let actual = nu!(
-//             cwd: dirs.test(),
-//             r#"let-env SHELL = bob
-//             echo $nu.env.SHELL
-//             "#
-//         );
-//         assert!(actual.out.ends_with("set_in_foo"))
-//     });
-// }
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"let-env SHELL = bob
+            echo $nu.env.SHELL
+            "#
+        );
+        assert!(actual.out.ends_with("set_in_foo"))
+    });
+}
 
 #[test]
 fn invocation_properly_redirects() {


### PR DESCRIPTION
With this, `let-env` is allowed to overwrite an environment variable that's already been set.