### PR TITLE
Source path including tilda

### DIFF
--- a/crates/nu-command/src/commands/source.rs
+++ b/crates/nu-command/src/commands/source.rs
@@ -2,9 +2,9 @@ use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 
 use nu_errors::ShellError;
+use nu_parser::expand_path;
 use nu_protocol::{Signature, SyntaxShape};
 use nu_source::Tagged;
-use nu_parser::expand_path;
 
 pub struct Source;
 

--- a/crates/nu-command/src/commands/source.rs
+++ b/crates/nu-command/src/commands/source.rs
@@ -4,6 +4,7 @@ use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape};
 use nu_source::Tagged;
+use nu_parser::expand_path;
 
 pub struct Source;
 
@@ -46,7 +47,7 @@ pub async fn source(args: CommandArgs) -> Result<OutputStream, ShellError> {
     // Note: this is a special case for setting the context from a command
     // In this case, if we don't set it now, we'll lose the scope that this
     // variable should be set into.
-    let contents = std::fs::read_to_string(&filename.item);
+    let contents = std::fs::read_to_string(expand_path(&filename.item).into_owned());
     match contents {
         Ok(contents) => {
             let result = crate::script::run_script_standalone(contents, true, &ctx, false).await;

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -15,6 +15,7 @@ pub use lex::lexer::{lex, parse_block};
 pub use lex::tokens::{LiteBlock, LiteCommand, LiteGroup, LitePipeline};
 pub use parse::{classify_block, garbage, parse, parse_full_column_path, parse_math_expression};
 pub use path::expand_ndots;
+pub use path::expand_path;
 pub use scope::ParserScope;
 pub use shapes::shapes;
 pub use signature::{Signature, SignatureRegistry};

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1788,7 +1788,9 @@ fn parse_call(
                 )),
             );
         }
-        if let Ok(contents) = std::fs::read_to_string(expand_path(&lite_cmd.parts[1].item).into_owned()) {
+        if let Ok(contents) =
+            std::fs::read_to_string(expand_path(&lite_cmd.parts[1].item).into_owned())
+        {
             let _ = parse(&contents, 0, scope);
         } else {
             return (

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1788,7 +1788,7 @@ fn parse_call(
                 )),
             );
         }
-        if let Ok(contents) = std::fs::read_to_string(&lite_cmd.parts[1].item) {
+        if let Ok(contents) = std::fs::read_to_string(expand_path(&lite_cmd.parts[1].item).into_owned()) {
             let _ = parse(&contents, 0, scope);
         } else {
             return (


### PR DESCRIPTION
Fix #2881.

"source" command uses "srd::fs::read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String>" to read the contents but this function cannot handle the path with tilda.
"crate::path::expand_path" can convert the path with tilda into the one without tilda representing the same path, so when using "read_to_string", the argument should be converted through "crate::path::expand_path".