### PR TITLE
Add height to host trait

### DIFF
--- a/crates/nu-engine/src/env/basic_host.rs
+++ b/crates/nu-engine/src/env/basic_host.rs
@@ -74,4 +74,9 @@ impl Host for BasicHost {
         term_width -= 1;
         term_width
     }
+
+    fn height(&self) -> usize {
+        let (_, term_height) = term_size::dimensions().unwrap_or((80, 20));
+        term_height
+    }
 }

--- a/crates/nu-engine/src/env/host.rs
+++ b/crates/nu-engine/src/env/host.rs
@@ -15,6 +15,7 @@ pub trait Host: Debug + Send {
     fn env_rm(&mut self, k: OsString);
 
     fn width(&self) -> usize;
+    fn height(&self) -> usize;
 }
 
 impl Host for Box<dyn Host> {
@@ -52,6 +53,10 @@ impl Host for Box<dyn Host> {
 
     fn width(&self) -> usize {
         (**self).width()
+    }
+
+    fn height(&self) -> usize {
+        (**self).height()
     }
 }
 
@@ -122,6 +127,10 @@ impl Host for FakeHost {
     }
 
     fn width(&self) -> usize {
+        1
+    }
+
+    fn height(&self) -> usize {
         1
     }
 }


### PR DESCRIPTION
add  a terminal height method to host trait and implementors,

The only questions is: this mimics the width method, by returning 1 less than what term-size returns.. is this desired?

Seems odd, but..