### PR TITLE
help generate_docs | flatten crashes nushell

### DIFF
--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -1,0 +1,31 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn help_commands_count() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        help commands | count
+        "#
+    ));
+
+    let output = actual.out;
+    let output_int: i32 = output.parse().unwrap();
+    let is_positive = output_int.is_positive();
+    assert!(is_positive);
+}
+
+#[test]
+fn help_generate_docs_count() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        help generate_docs | flatten | count
+        "#
+    ));
+
+    let output = actual.out;
+    let output_int: i32 = output.parse().unwrap();
+    let is_positive = output_int.is_positive();
+    assert!(is_positive);
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -22,6 +22,7 @@ mod get;
 mod group_by;
 mod hash_;
 mod headers;
+mod help;
 mod histogram;
 mod insert;
 mod into_int;

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -67,10 +67,12 @@ pub fn generate_docs(scope: &Scope) -> Value {
         if name.contains(' ') {
             let split_name = name.split_whitespace().collect_vec();
             let parent_name = split_name.first().expect("Expected a parent command name");
-            let sub_names = cmap
-                .get_mut(*parent_name)
-                .expect("Expected a entry for parent");
-            sub_names.push(name.to_owned());
+            if cmap.contains_key(*parent_name) {
+                let sub_names = cmap
+                    .get_mut(*parent_name)
+                    .expect("Expected a entry for parent");
+                sub_names.push(name.to_owned());
+            }
         } else {
             cmap.insert(name.to_owned(), Vec::new());
         };


### PR DESCRIPTION

this fixes the case where the user would type

```
help generate_docs | flatten
```

and nushell would crash

closes #3094 

fix case where parent_name was {nu, term} and possibly others in the future by doing an extra test first to see if if the *parent_name key actually exists in cmap...
