### PR TITLE
Use writer from host instead of always std::err

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -79,7 +79,7 @@ pub async fn run_script_file(
         syncer.sync_path_vars(ctx);
 
         if let Err(reason) = syncer.autoenv(ctx) {
-            print_err(reason, &Text::from(""));
+            print_err(reason, &Text::from(""), ctx);
         }
 
         let _ = register_plugins(ctx);
@@ -107,7 +107,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
         syncer.sync_path_vars(ctx);
 
         if let Err(reason) = syncer.autoenv(ctx) {
-            print_err(reason, &Text::from(""));
+            print_err(reason, &Text::from(""), ctx);
         }
 
         let _ = configure_ctrl_c(ctx);
@@ -199,14 +199,14 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
                                 }
                             }
                             Err(e) => {
-                                crate::cli::print_err(e, &Text::from(prompt_line));
+                                crate::cli::print_err(e, &Text::from(prompt_line), &context);
                                 context.clear_errors();
 
                                 "> ".to_string()
                             }
                         },
                         Err(e) => {
-                            crate::cli::print_err(e, &Text::from(prompt_line));
+                            crate::cli::print_err(e, &Text::from(prompt_line), &context);
                             context.clear_errors();
 
                             "> ".to_string()
@@ -274,7 +274,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             }
 
             if let Err(reason) = syncer.autoenv(ctx) {
-                print_err(reason, &Text::from(""));
+                print_err(reason, &Text::from(""), ctx);
             }
 
             let _ = configure_rustyline_editor(&mut rl, config);
@@ -296,9 +296,7 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
                 rl.add_history_entry(&line);
                 let _ = rl.save_history(&history_path);
 
-                context.with_host(|_host| {
-                    print_err(err, &Text::from(session_text.clone()));
-                });
+                print_err(err, &Text::from(session_text.clone()), &context);
 
                 maybe_print_errors(&context, Text::from(session_text.clone()));
             }

--- a/crates/nu-command/src/maybe_print_errors.rs
+++ b/crates/nu-command/src/maybe_print_errors.rs
@@ -9,7 +9,7 @@ pub fn maybe_print_errors(context: &EvaluationContext, source: Text) -> bool {
         let error = errors[0].clone();
         *errors = vec![];
 
-        crate::script::print_err(error, &source);
+        crate::script::print_err(error, &source, context);
         true
     } else {
         false

--- a/crates/nu-command/src/script.rs
+++ b/crates/nu-command/src/script.rs
@@ -33,15 +33,13 @@ fn chomp_newline(s: &str) -> &str {
     }
 }
 
-pub fn print_err(err: ShellError, source: &Text) {
+pub fn print_err(err: ShellError, source: &Text, ctx: &EvaluationContext) {
     if let Some(diag) = err.into_diagnostic() {
         let source = source.to_string();
         let mut files = codespan_reporting::files::SimpleFiles::new();
         files.add("shell", source);
 
-        let writer = codespan_reporting::term::termcolor::StandardStream::stderr(
-            codespan_reporting::term::termcolor::ColorChoice::Always,
-        );
+        let writer = ctx.host.lock().err_termcolor();
         let config = codespan_reporting::term::Config::default();
 
         let _ = std::panic::catch_unwind(move || {
@@ -260,7 +258,7 @@ pub async fn run_script_standalone(
 
         LineResult::Error(line, err) => {
             context.with_host(|_host| {
-                print_err(err, &Text::from(line.clone()));
+                print_err(err, &Text::from(line.clone()), &context);
             });
 
             maybe_print_errors(&context, Text::from(line));


### PR DESCRIPTION
This change might result in different behavior (probably depending on your terminal?), as current `print_error` uses `ColorChoice::Always` but `Host::err_termcolor` uses `ColorChoice::Auto`. However, not forcing coloring, if the terminal does not support it, might be better?

At least it works on my machine :)