### PR TITLE
Add option to invert match command selection

### DIFF
--- a/crates/nu_plugin_match/src/match_.rs
+++ b/crates/nu_plugin_match/src/match_.rs
@@ -3,6 +3,7 @@ use regex::Regex;
 pub struct Match {
     pub column: String,
     pub regex: Regex,
+    pub exclude: bool,
 }
 
 impl Match {
@@ -11,6 +12,7 @@ impl Match {
         Ok(Match {
             column: String::new(),
             regex: Regex::new("")?,
+            exclude: false,
         })
     }
 }

--- a/crates/nu_plugin_match/src/match_.rs
+++ b/crates/nu_plugin_match/src/match_.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 pub struct Match {
     pub column: String,
     pub regex: Regex,
-    pub exclude: bool,
+    pub invert: bool,
 }
 
 impl Match {
@@ -12,7 +12,7 @@ impl Match {
         Ok(Match {
             column: String::new(),
             regex: Regex::new("")?,
-            exclude: false,
+            invert: false,
         })
     }
 }

--- a/crates/nu_plugin_match/src/nu/mod.rs
+++ b/crates/nu_plugin_match/src/nu/mod.rs
@@ -24,11 +24,7 @@ impl Plugin for Match {
                 "dotall mode: allow a dot . to match newline character \\n",
                 Some('s'),
             )
-            .switch(
-                "invert",
-                "invert the match",
-                Some('v'),
-            )
+            .switch("invert", "invert the match", Some('v'))
             .filter())
     }
 

--- a/crates/nu_plugin_match/src/nu/mod.rs
+++ b/crates/nu_plugin_match/src/nu/mod.rs
@@ -24,6 +24,11 @@ impl Plugin for Match {
                 "dotall mode: allow a dot . to match newline character \\n",
                 Some('s'),
             )
+            .switch(
+                "exclude",
+                "exclude rows matching the regex instead of including them",
+                Some('x'),
+            )
             .filter())
     }
 
@@ -31,6 +36,7 @@ impl Plugin for Match {
         let insensitive = call_info.args.has("insensitive");
         let multiline = call_info.args.has("multiline");
         let dotall = call_info.args.has("dotall");
+        self.exclude = call_info.args.has("exclude");
         if let Some(args) = call_info.args.positional {
             match &args[0] {
                 Value {
@@ -72,7 +78,7 @@ impl Plugin for Match {
                     })?;
                 }
                 Value { tag, .. } => {
-                    return Err(ShellError::labeled_error(
+                return Err(ShellError::labeled_error(
                         "Unrecognized type in params",
                         "unexpected value",
                         tag,
@@ -113,7 +119,7 @@ impl Plugin for Match {
                 return Err(ShellError::labeled_error("Expected row", "value", tag));
             }
         }
-        if flag {
+        if flag ^ self.exclude {
             Ok(vec![Ok(ReturnSuccess::Value(input))])
         } else {
             Ok(vec![])

--- a/crates/nu_plugin_match/src/nu/mod.rs
+++ b/crates/nu_plugin_match/src/nu/mod.rs
@@ -25,9 +25,9 @@ impl Plugin for Match {
                 Some('s'),
             )
             .switch(
-                "exclude",
-                "exclude rows matching the regex instead of including them",
-                Some('x'),
+                "invert",
+                "invert the match",
+                Some('v'),
             )
             .filter())
     }
@@ -36,7 +36,7 @@ impl Plugin for Match {
         let insensitive = call_info.args.has("insensitive");
         let multiline = call_info.args.has("multiline");
         let dotall = call_info.args.has("dotall");
-        self.exclude = call_info.args.has("exclude");
+        self.invert = call_info.args.has("invert");
         if let Some(args) = call_info.args.positional {
             match &args[0] {
                 Value {
@@ -119,7 +119,7 @@ impl Plugin for Match {
                 return Err(ShellError::labeled_error("Expected row", "value", tag));
             }
         }
-        if flag ^ self.exclude {
+        if flag ^ self.invert {
             Ok(vec![Ok(ReturnSuccess::Value(input))])
         } else {
             Ok(vec![])

--- a/crates/nu_plugin_match/src/nu/mod.rs
+++ b/crates/nu_plugin_match/src/nu/mod.rs
@@ -78,7 +78,7 @@ impl Plugin for Match {
                     })?;
                 }
                 Value { tag, .. } => {
-                return Err(ShellError::labeled_error(
+                    return Err(ShellError::labeled_error(
                         "Unrecognized type in params",
                         "unexpected value",
                         tag,


### PR DESCRIPTION
Adds a new flag, `-x`, that excludes the matched rows instead of including them. 

I had to add a new field to the `Match` struct since I didn't figure out how to invert the match using just regex. I think you'd need lookahead which is not supported by Rust's regex.