### PR TITLE
add config: prompt_color_enabled = true

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -218,11 +218,20 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             }
         };
 
-        let prompt = {
-            if let Ok(bytes) = strip_ansi_escapes::strip(&colored_prompt) {
-                String::from_utf8_lossy(&bytes).to_string()
-            } else {
-                "> ".to_string()
+        let config = config::config(Tag::unknown());
+        let prompt = match config
+            .unwrap_or_default()
+            .get("prompt_color_enabled")
+            .map(|s| s.value.is_true())
+            .unwrap_or(true)
+        {
+            true => colored_prompt.to_owned(),
+            false => {
+                if let Ok(bytes) = strip_ansi_escapes::strip(&colored_prompt) {
+                    String::from_utf8_lossy(&bytes).to_string()
+                } else {
+                    "> ".to_string()
+                }
             }
         };
 

--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -68,6 +68,7 @@ edit_mode = "emacs" # vi, emacs
 auto_add_history = true
 bell_style = "audible" # audible, none, visible
 color_mode = "enabled" # enabled, forced, disabled
+prompt_color_enabled = true
 tab_stop = 4
 
 [textview]


### PR DESCRIPTION
Currently if you want to disable colors (that are not customizable) in cli, you have to set `color_mode = "disabled"` in `line_editor` section of config.
But this also strips all colors from `prompt` (either default or custom).
I would like to keep the colors in my custom prompt value, regardless of `color_mode`.

To make it easier to switch on/off colors in prompt (default or custom) I added a new config parameter `prompt_color_enabled` which defaults to `true`.