### PR TITLE
Refactor arguments of path subcommands & Add path join subcommand

### DIFF
--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -230,7 +230,7 @@ pub(crate) use open::Open;
 pub(crate) use parse::Parse;
 pub(crate) use path::{
     PathBasename, PathCommand, PathDirname, PathExists, PathExpand, PathExtension, PathFilestem,
-    PathType,
+    PathJoin, PathType,
 };
 pub(crate) use pivot::Pivot;
 pub(crate) use prepend::Prepend;

--- a/crates/nu-command/src/commands/default_context.rs
+++ b/crates/nu-command/src/commands/default_context.rs
@@ -235,6 +235,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(PathExpand),
             whole_stream_command(PathExtension),
             whole_stream_command(PathFilestem),
+            whole_stream_command(PathJoin),
             whole_stream_command(PathType),
             // Url
             whole_stream_command(UrlCommand),

--- a/crates/nu-command/src/commands/path/exists.rs
+++ b/crates/nu-command/src/commands/path/exists.rs
@@ -1,4 +1,4 @@
-use super::{operate, DefaultArguments};
+use super::{operate, PathSubcommandArguments};
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
@@ -10,6 +10,12 @@ pub struct PathExists;
 #[derive(Deserialize)]
 struct PathExistsArguments {
     rest: Vec<ColumnPath>,
+}
+
+impl PathSubcommandArguments for PathExistsArguments {
+    fn get_column_paths(&self) -> &Vec<ColumnPath> {
+        &self.rest
+    }
 }
 
 #[async_trait]
@@ -30,13 +36,7 @@ impl WholeStreamCommand for PathExists {
     async fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathExistsArguments { rest }, input) = args.process().await?;
-        let args = Arc::new(DefaultArguments {
-            replace: None,
-            prefix: None,
-            suffix: None,
-            num_levels: None,
-            paths: rest,
-        });
+        let args = Arc::new(PathExistsArguments { rest });
         operate(input, &action, tag.span, args).await
     }
 
@@ -59,7 +59,7 @@ impl WholeStreamCommand for PathExists {
     }
 }
 
-fn action(path: &Path, _args: Arc<DefaultArguments>) -> UntaggedValue {
+fn action(path: &Path, _args: &PathExistsArguments) -> UntaggedValue {
     UntaggedValue::boolean(path.exists())
 }
 

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -1,4 +1,4 @@
-use super::{operate, DefaultArguments};
+use super::{operate, PathSubcommandArguments};
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
@@ -10,6 +10,12 @@ pub struct PathExpand;
 #[derive(Deserialize)]
 struct PathExpandArguments {
     rest: Vec<ColumnPath>,
+}
+
+impl PathSubcommandArguments for PathExpandArguments {
+    fn get_column_paths(&self) -> &Vec<ColumnPath> {
+        &self.rest
+    }
 }
 
 #[async_trait]
@@ -30,13 +36,7 @@ impl WholeStreamCommand for PathExpand {
     async fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathExpandArguments { rest }, input) = args.process().await?;
-        let args = Arc::new(DefaultArguments {
-            replace: None,
-            prefix: None,
-            suffix: None,
-            num_levels: None,
-            paths: rest,
-        });
+        let args = Arc::new(PathExpandArguments { rest });
         operate(input, &action, tag.span, args).await
     }
 
@@ -61,7 +61,7 @@ impl WholeStreamCommand for PathExpand {
     }
 }
 
-fn action(path: &Path, _args: Arc<DefaultArguments>) -> UntaggedValue {
+fn action(path: &Path, _args: &PathExpandArguments) -> UntaggedValue {
     let ps = path.to_string_lossy();
     let expanded = shellexpand::tilde(&ps);
     let path: &Path = expanded.as_ref().as_ref();

--- a/crates/nu-command/src/commands/path/join.rs
+++ b/crates/nu-command/src/commands/path/join.rs
@@ -1,0 +1,84 @@
+use super::{operate, PathSubcommandArguments};
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{ColumnPath, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_source::Tagged;
+use std::path::Path;
+
+pub struct PathJoin;
+
+#[derive(Deserialize)]
+struct PathJoinArguments {
+    path: Tagged<String>,
+    rest: Vec<ColumnPath>,
+}
+
+impl PathSubcommandArguments for PathJoinArguments {
+    fn get_column_paths(&self) -> &Vec<ColumnPath> {
+        &self.rest
+    }
+}
+
+#[async_trait]
+impl WholeStreamCommand for PathJoin {
+    fn name(&self) -> &str {
+        "path join"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("path join")
+            .required("path", SyntaxShape::String, "Path to join the input path")
+            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+    }
+
+    fn usage(&self) -> &str {
+        "Joins an input path with another path"
+    }
+
+    async fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        let tag = args.call_info.name_tag.clone();
+        let (PathJoinArguments { path, rest }, input) = args.process().await?;
+        let args = Arc::new(PathJoinArguments { path, rest });
+        operate(input, &action, tag.span, args).await
+    }
+
+    #[cfg(windows)]
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Append a filename to a path",
+            example: "echo 'C:\\Users\\viking' | path join spam.txt",
+            result: Some(vec![Value::from(UntaggedValue::filepath(
+                "C:\\Users\\viking\\spam.txt",
+            ))]),
+        }]
+    }
+
+    #[cfg(not(windows))]
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Append a filename to a path",
+            example: "echo '/home/viking' | path join spam.txt",
+            result: Some(vec![Value::from(UntaggedValue::filepath(
+                "/home/viking/spam.txt",
+            ))]),
+        }]
+    }
+}
+
+fn action(path: &Path, args: &PathJoinArguments) -> UntaggedValue {
+    UntaggedValue::filepath(path.join(&args.path.item))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathJoin;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        test_examples(PathJoin {})
+    }
+}

--- a/crates/nu-command/src/commands/path/mod.rs
+++ b/crates/nu-command/src/commands/path/mod.rs
@@ -23,32 +23,21 @@ pub use extension::PathExtension;
 pub use filestem::PathFilestem;
 pub use r#type::PathType;
 
-#[derive(Deserialize)]
-struct DefaultArguments {
-    // used by basename, dirname, extension and filestem
-    replace: Option<String>,
-    // used by filestem
-    prefix: Option<String>,
-    suffix: Option<String>,
-    // used by dirname
-    num_levels: Option<u32>,
-    // used by all
-    paths: Vec<ColumnPath>,
+trait PathSubcommandArguments {
+    fn get_column_paths(&self) -> &Vec<ColumnPath>;
 }
 
-fn handle_value<F>(
-    action: &F,
-    v: &Value,
-    span: Span,
-    args: Arc<DefaultArguments>,
-) -> Result<Value, ShellError>
+fn handle_value<F, T>(action: &F, v: &Value, span: Span, args: Arc<T>) -> Result<Value, ShellError>
 where
-    F: Fn(&Path, Arc<DefaultArguments>) -> UntaggedValue + Send + 'static,
+    T: PathSubcommandArguments + Send + 'static,
+    F: Fn(&Path, &T) -> UntaggedValue + Send + 'static,
 {
     let v = match &v.value {
-        UntaggedValue::Primitive(Primitive::FilePath(buf)) => action(buf, args).into_value(v.tag()),
+        UntaggedValue::Primitive(Primitive::FilePath(buf)) => {
+            action(buf, &args).into_value(v.tag())
+        }
         UntaggedValue::Primitive(Primitive::String(s)) => {
-            action(s.as_ref(), args).into_value(v.tag())
+            action(s.as_ref(), &args).into_value(v.tag())
         }
         other => {
             let got = format!("got {}", other.type_name());
@@ -64,23 +53,24 @@ where
     Ok(v)
 }
 
-async fn operate<F>(
+async fn operate<F, T>(
     input: crate::InputStream,
     action: &'static F,
     span: Span,
-    args: Arc<DefaultArguments>,
+    args: Arc<T>,
 ) -> Result<OutputStream, ShellError>
 where
-    F: Fn(&Path, Arc<DefaultArguments>) -> UntaggedValue + Send + Sync + 'static,
+    T: PathSubcommandArguments + Send + Sync + 'static,
+    F: Fn(&Path, &T) -> UntaggedValue + Send + Sync + 'static,
 {
     Ok(input
         .map(move |v| {
-            if args.paths.is_empty() {
+            if args.get_column_paths().is_empty() {
                 ReturnSuccess::value(handle_value(&action, &v, span, Arc::clone(&args))?)
             } else {
                 let mut ret = v;
 
-                for path in &args.paths {
+                for path in args.get_column_paths() {
                     let cloned_args = Arc::clone(&args);
                     ret = ret.swap_data_by_column_path(
                         path,

--- a/crates/nu-command/src/commands/path/mod.rs
+++ b/crates/nu-command/src/commands/path/mod.rs
@@ -5,6 +5,7 @@ mod exists;
 mod expand;
 mod extension;
 mod filestem;
+mod join;
 mod r#type;
 
 use crate::prelude::*;
@@ -21,6 +22,7 @@ pub use exists::PathExists;
 pub use expand::PathExpand;
 pub use extension::PathExtension;
 pub use filestem::PathFilestem;
+pub use join::PathJoin;
 pub use r#type::PathType;
 
 trait PathSubcommandArguments {

--- a/crates/nu-command/tests/commands/path/join.rs
+++ b/crates/nu-command/tests/commands/path/join.rs
@@ -1,0 +1,45 @@
+use nu_test_support::{nu, pipeline};
+
+use super::join_path_sep;
+
+#[test]
+fn returns_path_joined_with_column_path() {
+    let actual = nu!(
+        cwd: "tests", pipeline(
+        r#"
+            echo [ [name]; [eggs] ]
+            | path join spam.txt name
+            | get name
+        "#
+    ));
+
+    let expected = join_path_sep(&["eggs", "spam.txt"]);
+    assert_eq!(actual.out, expected);
+}
+
+#[test]
+fn appends_slash_when_joined_with_empty_path() {
+    let actual = nu!(
+        cwd: "tests", pipeline(
+        r#"
+            echo "/some/dir"
+            | path join ''
+        "#
+    ));
+
+    let expected = join_path_sep(&["/some/dir", ""]);
+    assert_eq!(actual.out, expected);
+}
+
+#[test]
+fn returns_joined_path_when_joining_empty_path() {
+    let actual = nu!(
+        cwd: "tests", pipeline(
+        r#"
+            echo ""
+            | path join foo.txt
+        "#
+    ));
+
+    assert_eq!(actual.out, "foo.txt");
+}

--- a/crates/nu-command/tests/commands/path/mod.rs
+++ b/crates/nu-command/tests/commands/path/mod.rs
@@ -4,6 +4,7 @@ mod exists;
 mod expand;
 mod extension;
 mod filestem;
+mod join;
 mod type_;
 
 use std::path::MAIN_SEPARATOR;


### PR DESCRIPTION
1. I removed the ugly passing of `DefaultArguments` to all path subcommands. Now each subcommand has its own set of arguments which all implement a common trait so they can be handled with `operate` and `handle_value` functions.
2. There is a new `path join` subcommand. Pretty straightorward, just appends a path to an input path.