### PR TITLE
Revert "add config: prompt_color_enabled = true"

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -218,20 +218,11 @@ pub async fn cli(mut context: EvaluationContext) -> Result<(), Box<dyn Error>> {
             }
         };
 
-        let config = config::config(Tag::unknown());
-        let prompt = match config
-            .unwrap_or_default()
-            .get("prompt_color_enabled")
-            .map(|s| s.value.is_true())
-            .unwrap_or(true)
-        {
-            true => colored_prompt.to_owned(),
-            false => {
-                if let Ok(bytes) = strip_ansi_escapes::strip(&colored_prompt) {
-                    String::from_utf8_lossy(&bytes).to_string()
-                } else {
-                    "> ".to_string()
-                }
+        let prompt = {
+            if let Ok(bytes) = strip_ansi_escapes::strip(&colored_prompt) {
+                String::from_utf8_lossy(&bytes).to_string()
+            } else {
+                "> ".to_string()
             }
         };
 

--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -68,7 +68,6 @@ edit_mode = "emacs" # vi, emacs
 auto_add_history = true
 bell_style = "audible" # audible, none, visible
 color_mode = "enabled" # enabled, forced, disabled
-prompt_color_enabled = true
 tab_stop = 4
 
 [textview]


### PR DESCRIPTION
Reverts nushell/nushell#3115

Due to Windows Crash
![crash](https://user-images.githubusercontent.com/343840/109995063-8c605800-7cd3-11eb-9e4a-641b9a582de1.gif)

Then tried without config.toml
![no-crash](https://user-images.githubusercontent.com/343840/109995154-a7cb6300-7cd3-11eb-8cee-2f3483a8b643.gif)

Then half-way working but text was climbing up the screen
![text_going_up](https://user-images.githubusercontent.com/343840/109995214-b74aac00-7cd3-11eb-84bb-240e43f521e6.gif)
