### PR TITLE
Table paging release

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -38,6 +38,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 chrono-tz = "0.5.3"
 clap = "2.33.3"
 codespan-reporting = "0.11.0"
+crossterm = { version = "0.19.0", optional = true }
 csv = "1.1.3"
 ctrlc = { version = "3.1.7", optional = true }
 derive-new = "0.5.8"
@@ -131,5 +132,5 @@ stable = []
 trash-support = ["trash"]
 directories = ["directories-next"]
 dirs = ["dirs-next"]
-table-pager = ["minus"]
+table-pager = ["minus", "crossterm"]
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -63,7 +63,7 @@ itertools = "0.10.0"
 lazy_static = "1.*"
 log = "0.4.14"
 meval = "0.2.0"
-minus = { optional = true, features = ["async_std_lib", "search"], git = "https://github.com/rezural/minus", branch = "nushell" }
+minus = { optional = true, features = ["async_std_lib", "search"], git = "https://github.com/arijit79/minus", branch = "main" }
 num-bigint = { version = "0.3.1", features = ["serde"] }
 num-format = { version = "0.4.0", features = ["with-num-bigint"] }
 num-traits = "0.2.14"

--- a/crates/nu-command/src/commands/table/command.rs
+++ b/crates/nu-command/src/commands/table/command.rs
@@ -198,7 +198,7 @@ async fn table(
         .set_exit_strategy(ExitStrategy::PagerQuit)
         .set_searchable(true)
         .set_page_if_havent_overflowed(false)
-        .set_input_handler(Box::new(input_handling::NushellMinusInputHandler {}))
+        .set_input_handler(Box::new(input_handling::MinusInputHandler {}))
         .finish();
 
     let stream_data = async {
@@ -314,9 +314,9 @@ async fn table(
 mod input_handling {
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
     use minus::{InputEvent, InputHandler, LineNumbers, SearchMode};
-    pub struct NushellMinusInputHandler;
+    pub struct MinusInputHandler;
 
-    impl InputHandler for NushellMinusInputHandler {
+    impl InputHandler for MinusInputHandler {
         fn handle_input(
             &self,
             ev: Event,
@@ -331,13 +331,13 @@ mod input_handling {
                     code: KeyCode::Up,
                     modifiers: KeyModifiers::NONE,
                 }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(1))),
-        
+
                 // Scroll down by one.
                 Event::Key(KeyEvent {
                     code: KeyCode::Down,
                     modifiers: KeyModifiers::NONE,
                 }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
-        
+
                 // Mouse scroll up/down
                 Event::Mouse(MouseEvent {
                     kind: MouseEventKind::ScrollUp,
@@ -357,7 +357,7 @@ mod input_handling {
                     code: KeyCode::End,
                     modifiers: KeyModifiers::NONE,
                 }) => Some(InputEvent::UpdateUpperMark(usize::MAX)),
-        
+
                 // Page Up/Down
                 Event::Key(KeyEvent {
                     code: KeyCode::PageUp,
@@ -371,7 +371,7 @@ mod input_handling {
                 }) => Some(InputEvent::UpdateUpperMark(
                     upper_mark.saturating_add(rows - 1),
                 )),
-        
+
                 // Resize event from the terminal.
                 Event::Resize(_, height) => Some(InputEvent::UpdateRows(height as usize)),
                 // Switch line number display.

--- a/crates/nu-command/src/commands/table/command.rs
+++ b/crates/nu-command/src/commands/table/command.rs
@@ -198,6 +198,7 @@ async fn table(
         .set_exit_strategy(ExitStrategy::PagerQuit)
         .set_searchable(true)
         .set_page_if_havent_overflowed(false)
+        .set_input_handler(Box::new(input_handling::NushellMinusInputHandler {}))
         .finish();
 
     let stream_data = async {
@@ -307,6 +308,114 @@ async fn table(
         .map_err(|_| ShellError::untagged_runtime_error("Error streaming data"))?;
 
     Ok(OutputStream::empty())
+}
+
+#[cfg(feature = "table-pager")]
+mod input_handling {
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+    use minus::{InputEvent, InputHandler, LineNumbers, SearchMode};
+    pub struct NushellMinusInputHandler;
+
+    impl InputHandler for NushellMinusInputHandler {
+        fn handle_input(
+            &self,
+            ev: Event,
+            upper_mark: usize,
+            search_mode: SearchMode,
+            ln: LineNumbers,
+            rows: usize,
+        ) -> Option<InputEvent> {
+            match ev {
+                // Scroll up by one.
+                Event::Key(KeyEvent {
+                    code: KeyCode::Up,
+                    modifiers: KeyModifiers::NONE,
+                }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(1))),
+        
+                // Scroll down by one.
+                Event::Key(KeyEvent {
+                    code: KeyCode::Down,
+                    modifiers: KeyModifiers::NONE,
+                }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(1))),
+        
+                // Mouse scroll up/down
+                Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::ScrollUp,
+                    ..
+                }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_sub(5))),
+                Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::ScrollDown,
+                    ..
+                }) => Some(InputEvent::UpdateUpperMark(upper_mark.saturating_add(5))),
+                // Go to top.
+                Event::Key(KeyEvent {
+                    code: KeyCode::Home,
+                    modifiers: KeyModifiers::NONE,
+                }) => Some(InputEvent::UpdateUpperMark(0)),
+                // Go to bottom.
+                Event::Key(KeyEvent {
+                    code: KeyCode::End,
+                    modifiers: KeyModifiers::NONE,
+                }) => Some(InputEvent::UpdateUpperMark(usize::MAX)),
+        
+                // Page Up/Down
+                Event::Key(KeyEvent {
+                    code: KeyCode::PageUp,
+                    modifiers: KeyModifiers::NONE,
+                }) => Some(InputEvent::UpdateUpperMark(
+                    upper_mark.saturating_sub(rows - 1),
+                )),
+                Event::Key(KeyEvent {
+                    code: KeyCode::PageDown,
+                    modifiers: KeyModifiers::NONE,
+                }) => Some(InputEvent::UpdateUpperMark(
+                    upper_mark.saturating_add(rows - 1),
+                )),
+        
+                // Resize event from the terminal.
+                Event::Resize(_, height) => Some(InputEvent::UpdateRows(height as usize)),
+                // Switch line number display.
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('l'),
+                    modifiers: KeyModifiers::CONTROL,
+                }) => Some(InputEvent::UpdateLineNumber(!ln)),
+                // Quit.
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('q'),
+                    modifiers: KeyModifiers::NONE,
+                })
+                | Event::Key(KeyEvent {
+                    code: KeyCode::Char('c'),
+                    modifiers: KeyModifiers::CONTROL,
+                }) => Some(InputEvent::Exit),
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('/'),
+                    modifiers: KeyModifiers::NONE,
+                }) => Some(InputEvent::Search(SearchMode::Unknown)),
+                Event::Key(KeyEvent {
+                    code: KeyCode::Down,
+                    modifiers: KeyModifiers::CONTROL,
+                }) => {
+                    if search_mode == SearchMode::Unknown {
+                        Some(InputEvent::NextMatch)
+                    } else {
+                        None
+                    }
+                }
+                Event::Key(KeyEvent {
+                    code: KeyCode::Up,
+                    modifiers: KeyModifiers::CONTROL,
+                }) => {
+                    if search_mode == SearchMode::Unknown {
+                        Some(InputEvent::PrevMatch)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/table/command.rs
+++ b/crates/nu-command/src/commands/table/command.rs
@@ -385,6 +385,14 @@ mod input_handling {
                     modifiers: KeyModifiers::NONE,
                 })
                 | Event::Key(KeyEvent {
+                    code: KeyCode::Char('Q'),
+                    modifiers: KeyModifiers::SHIFT,
+                })
+                | Event::Key(KeyEvent {
+                    code: KeyCode::Esc,
+                    modifiers: KeyModifiers::NONE,
+                })
+                | Event::Key(KeyEvent {
                     code: KeyCode::Char('c'),
                     modifiers: KeyModifiers::CONTROL,
                 }) => Some(InputEvent::Exit),


### PR DESCRIPTION
This contains the last changes required to run off minus without using a branch.

It is currently pointing to the main branch of minus, once the release of minus from @arijit79 is pushed, then we can update Cargo.toml.

It also has some changes to respond to 'Q', and ESC to quit the pager. This is kind of unrelated, but I'll bundle it here, unless you want me to pull it out into a separate PR.

Thanks