### PR TITLE
Add status code argument to `exit` (#3131)

### DIFF
--- a/crates/nu-engine/src/evaluate/internal.rs
+++ b/crates/nu-engine/src/evaluate/internal.rs
@@ -62,7 +62,7 @@ pub(crate) async fn run_internal_command(
                                 context.shell_manager.set_path(path);
                                 InputStream::empty()
                             }
-                            CommandAction::Exit => std::process::exit(0), // TODO: save history.txt
+                            CommandAction::Exit(code) => std::process::exit(code), // TODO: save history.txt
                             CommandAction::Error(err) => {
                                 context.error(err);
                                 InputStream::empty()
@@ -213,10 +213,10 @@ pub(crate) async fn run_internal_command(
                                 context.shell_manager.next();
                                 InputStream::empty()
                             }
-                            CommandAction::LeaveShell => {
+                            CommandAction::LeaveShell(code) => {
                                 context.shell_manager.remove_at_current();
                                 if context.shell_manager.is_empty() {
-                                    std::process::exit(0); // TODO: save history.txt
+                                    std::process::exit(code); // TODO: save history.txt
                                 }
                                 InputStream::empty()
                             }

--- a/crates/nu-protocol/src/return_value.rs
+++ b/crates/nu-protocol/src/return_value.rs
@@ -9,7 +9,7 @@ pub enum CommandAction {
     /// Change to a new directory or path (in non-filesystem situations)
     ChangePath(String),
     /// Exit out of Nu
-    Exit,
+    Exit(i32),
     /// Display an error
     Error(ShellError),
     /// Enter a new shell at the given path
@@ -27,7 +27,7 @@ pub enum CommandAction {
     /// Go to the next shell in the shell ring buffer
     NextShell,
     /// Leave the current shell. If it's the last shell, exit out of Nu
-    LeaveShell,
+    LeaveShell(i32),
 }
 
 impl PrettyDebug for CommandAction {
@@ -37,7 +37,7 @@ impl PrettyDebug for CommandAction {
             CommandAction::ChangePath(path) => {
                 DbgDocBldr::typed("change path", DbgDocBldr::description(path))
             }
-            CommandAction::Exit => DbgDocBldr::description("exit"),
+            CommandAction::Exit(_) => DbgDocBldr::description("exit"),
             CommandAction::Error(_) => DbgDocBldr::error("error"),
             CommandAction::AutoConvert(_, extension) => {
                 DbgDocBldr::typed("auto convert", DbgDocBldr::description(extension))
@@ -50,7 +50,7 @@ impl PrettyDebug for CommandAction {
             CommandAction::AddPlugins(..) => DbgDocBldr::description("add plugins"),
             CommandAction::PreviousShell => DbgDocBldr::description("previous shell"),
             CommandAction::NextShell => DbgDocBldr::description("next shell"),
-            CommandAction::LeaveShell => DbgDocBldr::description("leave shell"),
+            CommandAction::LeaveShell(_) => DbgDocBldr::description("leave shell"),
         }
     }
 }

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -445,6 +445,14 @@ impl Value {
         }
     }
 
+    /// View the Value as signed 64-bit, if possible
+    pub fn as_i32(&self) -> Result<i32, ShellError> {
+        match &self.value {
+            UntaggedValue::Primitive(primitive) => primitive.as_i32(self.tag.span),
+            _ => Err(ShellError::type_error("integer", self.spanned_type_name())),
+        }
+    }
+
     /// View the Value as boolean, if possible
     pub fn as_bool(&self) -> Result<bool, ShellError> {
         match &self.value {

--- a/crates/nu-protocol/src/value/primitive.rs
+++ b/crates/nu-protocol/src/value/primitive.rs
@@ -107,6 +107,29 @@ impl Primitive {
         }
     }
 
+    pub fn as_i32(&self, span: Span) -> Result<i32, ShellError> {
+        match self {
+            Primitive::Int(int) => int.to_i32().ok_or_else(|| {
+                ShellError::range_error(
+                    ExpectedRange::I32,
+                    &format!("{}", int).spanned(span),
+                    "converting an integer into a signed 32-bit integer",
+                )
+            }),
+            Primitive::Decimal(decimal) => decimal.to_i32().ok_or_else(|| {
+                ShellError::range_error(
+                    ExpectedRange::I32,
+                    &format!("{}", decimal).spanned(span),
+                    "converting a decimal into a signed 32-bit integer",
+                )
+            }),
+            other => Err(ShellError::type_error(
+                "number",
+                other.type_name().spanned(span),
+            )),
+        }
+    }
+
     // FIXME: This is a bad name, but no other way to differentiate with our own Duration.
     pub fn into_chrono_duration(self, span: Span) -> Result<chrono::Duration, ShellError> {
         match self {


### PR DESCRIPTION
Fixes #3131.

Adds an optional positional argument to `exit` for a status code to return if the process exits. This can either happen if `--now` was passed, or if this was the only active shell. The code will be ignored if the process does not exit.

I had to modify CommandAction to store the status code being returned, which I'm worried might be an API breaking change, I'm not sure what the policy is here.

I had to add some extra utility functions for converting a bigint to an i32, which is the native input of `std::process::exit`.

This is my first time contributing to Nu, so let me know if I did anything wrong.

Example usage:
```
❯ exit 42
error: process didn't exit successfully: `target\debug\nu.exe` (exit code: 42)
❯ exit $(math eval '-1') # Negative numbers seem to parse as a flag instead, so I have to use this to write them.
error: process didn't exit successfully: `target\debug\nu.exe` (exit code: 0xffffffff)
```
