### PR TITLE
hopefully fixes the coercion error when comparing $nothing to $var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 [[package]]
 name = "minus"
 version = "3.2.0"
-source = "git+https://github.com/rezural/minus?branch=add-finished-callback#b943ed5c9143924ca1f871e4911a82c2e784001a"
+source = "git+https://github.com/arijit79/minus?branch=main#eadb315644dcc051a0a3a7d4739bd59dfb37f0bd"
 dependencies = [
  "async-std",
  "crossterm 0.19.0",
@@ -3322,6 +3322,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "codespan-reporting",
+ "crossterm 0.19.0",
  "csv",
  "ctrlc",
  "derive-new",

--- a/crates/nu-data/src/base.rs
+++ b/crates/nu-data/src/base.rs
@@ -147,6 +147,8 @@ pub fn coerce_compare_primitive(
         (Date(left), Date(right)) => CompareValues::Date(*left, *right),
         (Date(left), Duration(right)) => CompareValues::DateDuration(*left, right.clone()),
         (Boolean(left), Boolean(right)) => CompareValues::Booleans(*left, *right),
+        (Boolean(left), Nothing) => CompareValues::Booleans(*left, false),
+        (Nothing, Boolean(right)) => CompareValues::Booleans(false, *right),
         (FilePath(left), String(right)) => {
             CompareValues::String(left.as_path().display().to_string(), right.clone())
         }


### PR DESCRIPTION
Fixes this situation.
```
# This checks the -f switch to see if it was supplied
# and tests the new $nothing variable
def nada [
    --flat(-f)
] {
    if $flat == $nothing {
        echo $true
    } {
        echo $false
    }
}
```
`nada -f`
```
error: Coercion error
  ┌─ shell:4:1       
  │
4 │ 
  │   nothing        
  │ 
  │ boolean
```
now it returns this
```
nada -f
false

nada
true
```