### PR TITLE
print string returned by draw_table, in autoview when pivot mode is on

### DIFF
--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -253,7 +253,7 @@ pub async fn autoview(context: RunnableContext) -> Result<OutputStream, ShellErr
                         let table =
                             nu_table::Table::new(vec![], entries, nu_table::Theme::compact());
 
-                        nu_table::draw_table(&table, term_width, &color_hm);
+                        println!("{}", nu_table::draw_table(&table, term_width, &color_hm));
                     }
                     Value {
                         value: UntaggedValue::Primitive(Primitive::Nothing),


### PR DESCRIPTION
Fixed bug introduced by #3088.

Previously draw_table printed directly, now it returns a string. Print this.