### PR TITLE
fix: deadlock when printing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Nu has early support for configuring the shell. You can refer to the book for a 
 To set one of these variables, you can use `config set`. For example:
 
 ```shell
-> config set edit_mode "vi"
+> config set line_editor.edit_mode "vi"
 > config set path $nu.path
 ```
 

--- a/crates/nu-command/src/script.rs
+++ b/crates/nu-command/src/script.rs
@@ -257,9 +257,7 @@ pub async fn run_script_standalone(
         }
 
         LineResult::Error(line, err) => {
-            context.with_host(|_host| {
-                print_err(err, &Text::from(line.clone()), &context);
-            });
+            print_err(err, &Text::from(line.clone()), &context);
 
             maybe_print_errors(&context, Text::from(line));
             if exit_on_error {


### PR DESCRIPTION
This would produce an error and lock up the shell during error printing
``` sh
echo "lxx" | save test.nu
source test.nu
```
The deadlock would occur because 
``` rust
context.with_host(|_host| {
    print_err(err, &Text::from(line.clone()), &context);
});
```
calls self.host.lock()

``` rust
pub fn with_host<T>(&self, block: impl FnOnce(&mut dyn Host) -> T) -> T {
    let mut host = self.host.lock();

    block(&mut *host)
}
```
and print_err interally calls the passed context again with ctx.host.lock()
``` rust
pub fn print_err(err: ShellError, source: &Text, ctx: &EvaluationContext) {
    ...
    let writer = ctx.host.lock().err_termcolor();
    ...
}
```
