### PR TITLE
Fix trash functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,7 @@ dependencies = [
  "tempfile",
  "term_size",
  "termcolor",
+ "trash",
  "umask",
  "users",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ s3 = ["nu_plugin_s3"]
 selector = ["nu_plugin_selector"]
 sqlite = ["nu_plugin_from_sqlite", "nu_plugin_to_sqlite"]
 start = ["nu_plugin_start"]
-trash-support = ["nu-cli/trash-support", "nu-command/trash-support"]
+trash-support = ["nu-cli/trash-support", "nu-command/trash-support", "nu-engine/trash-support"]
 tree = ["nu_plugin_tree"]
 xpath = ["nu_plugin_xpath"]
 #This is disabled in extra for now

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -17,6 +17,7 @@ nu-stream = { version = "0.27.2", path = "../nu-stream" }
 nu-value-ext = { version = "0.27.2", path = "../nu-value-ext" }
 nu-ansi-term = { version = "0.27.2", path = "../nu-ansi-term" }
 
+trash = { version = "1.3.0", optional = true }
 async-recursion = "0.3.2"
 async-trait = "0.1.42"
 bytes = "0.5.6"
@@ -52,3 +53,4 @@ nu-test-support = { version = "0.27.2", path = "../nu-test-support" }
 [features]
 rustyline-support = []
 dirs = ["dirs-next"]
+trash-support = ["trash"]

--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -609,7 +609,7 @@ impl Shell for FilesystemShell {
                         let result;
                         #[cfg(feature = "trash-support")]
                         {
-                            let rm_always_trash = config::config(Tag::unknown())?
+                            let rm_always_trash = nu_data::config::config(Tag::unknown())?
                                 .get("rm_always_trash")
                                 .map(|val| val.is_true())
                                 .unwrap_or(false);


### PR DESCRIPTION
For now the trash doesn't work because the trash-support flag isn't enabled in nu-engine
crate, so make it work by adding this flag.

Signed-off-by: Tw <wei.tan@intel.com>