### PR TITLE
feat: make echo ls | source work

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1670,38 +1670,6 @@ fn parse_call(
                 error,
             );
         }
-    } else if lite_cmd.parts[0].item == "source" {
-        if lite_cmd.parts.len() != 2 {
-            return (
-                None,
-                Some(ParseError::argument_error(
-                    lite_cmd.parts[0].clone(),
-                    ArgumentError::MissingMandatoryPositional("a path for sourcing".into()),
-                )),
-            );
-        }
-        if lite_cmd.parts[1].item.starts_with('$') {
-            return (
-                None,
-                Some(ParseError::mismatch(
-                    "a filepath constant",
-                    lite_cmd.parts[1].clone(),
-                )),
-            );
-        }
-        if let Ok(contents) =
-            std::fs::read_to_string(expand_path(&lite_cmd.parts[1].item).into_owned())
-        {
-            let _ = parse(&contents, 0, scope);
-        } else {
-            return (
-                None,
-                Some(ParseError::mismatch(
-                    "a filepath to a source file",
-                    lite_cmd.parts[1].clone(),
-                )),
-            );
-        }
     } else if lite_cmd.parts.len() > 1 {
         // Check if it's a sub-command
         if let Some(signature) = scope.get_signature(&format!(


### PR DESCRIPTION
Purpose
This would enable the use case of   #2812 #2804
``` sh
some_program --config nushell | source # or
echo "some code to test the source commands behaviour programatically" | source
```
While I am at it I should probably add some tests for the `source` command. 
Can someone give me some guidance on where to put them?

The `nu-parser` had some special-casing around the `source` command, this would interfere with `source.rs`. 
This prevented `source -h` from working
I removed the special casing and now `source.rs` is responsible for itself.
The one issue I noticed is, that previously
``` sh
let TEST = 'path'
source $TEST 
```
wasn't permitted. Now after the special casing in `parse.rs` is removed` source.rs` accepts this. 
Are there reasons that this rejection should be replicated in `source.rs`?