### PR TITLE
Lines no longer treats a text buffer as a line

### DIFF
--- a/crates/nu-command/src/utils/test_bins.rs
+++ b/crates/nu-command/src/utils/test_bins.rs
@@ -17,6 +17,21 @@ pub fn nonu() {
     args().iter().skip(1).for_each(|arg| print!("{}", arg));
 }
 
+pub fn repeater() {
+    let mut stdout = io::stdout();
+    let args = args();
+    let mut args = args.iter().skip(1);
+    let letter = args.next().expect("needs a character to iterate");
+    let count = args.next().expect("need the number of times to iterate");
+
+    let count: u64 = count.parse().expect("can't convert count to number");
+
+    for _ in 0..count {
+        let _ = write!(stdout, "{}", letter);
+    }
+    let _ = stdout.flush();
+}
+
 pub fn iecho() {
     // println! panics if stdout gets closed, whereas writeln gives us an error
     let mut stdout = io::stdout();

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -46,5 +46,5 @@ fn lines_multi_value_split() {
         "#
     ));
 
-    assert_eq!(actual.out, "6");
+    assert_eq!(actual.out, "5");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .hidden(true)
                 .long("testbin")
                 .value_name("TESTBIN")
-                .possible_values(&["cococo", "iecho", "fail", "nonu", "chop"])
+                .possible_values(&["cococo", "iecho", "fail", "nonu", "chop", "repeater"])
                 .takes_value(true),
         )
         .arg(
@@ -77,6 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             "fail" => binaries::fail(),
             "nonu" => binaries::nonu(),
             "chop" => binaries::chop(),
+            "repeater" => binaries::repeater(),
             _ => unreachable!(),
         }
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -122,6 +122,17 @@ mod it_evaluation {
     }
 
     #[test]
+    fn can_properly_buffer_lines_externally() {
+        let actual = nu!(
+            cwd: ".",
+            r#"
+                nu --testbin repeater c 8197 | lines | count
+            "#
+        );
+
+        assert_eq!(actual.out, "1");
+    }
+    #[test]
     fn supports_fetching_given_a_column_path_to_it() {
         Playground::setup("it_argument_test_3", |dirs, sandbox| {
             sandbox.with_files(vec![FileWithContent(


### PR DESCRIPTION
Previously, `lines` assumed that a buffer of text by itself was a line unto itself. This doesn't really work, as you might be loading in a buffer that's larger than what MaybeTextCodec will split automatically.  As such, `lines` was incorrectly giving you one line every 8192 bytes.

With this fix, `lines` now will queue up as much text as needed to find the actual lines in the incoming text stream.

Fixes #2888 
