### PR TITLE
fix: unicode byte counting error #3150

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -388,7 +388,7 @@ fn parse_invocation(
         .item
         .chars()
         .skip(2)
-        .take(lite_arg.item.len() - 3)
+        .take(lite_arg.item.chars().count() - 3)
         .collect();
 
     // We haven't done much with the inner string, so let's go ahead and work with it


### PR DESCRIPTION
This bug occurs because of a character/byte counting error.
In this case nu mixes counting chars and bytes. 
In `crates/nu-parser/src/parse.rs +387 `the commented line is the original which counts bytes.
The new line counts the chars. This should prevent breakage while handling chars > 1 byte. 
``` rust
    let string: String = lite_arg
        .item
        .chars()
        .skip(2)
        .take(lite_arg.item.chars().count() - 3)
        // .take(lite_arg.item.len() - 3)
        .collect();

```