### PR TITLE
fix: prompt does not find external commands #3134

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -214,6 +214,9 @@ pub async fn cli(mut context: EvaluationContext, options: Options) -> Result<(),
     // Give ourselves a scope to work in
     context.scope.enter_scope();
 
+    let env = context.get_env();
+    context.scope.add_env_to_base(env);
+
     let history_path = nu_engine::history_path(&configuration);
     let _ = rl.load_history(&history_path);
 


### PR DESCRIPTION
The initial setup-commands of nushell were executed without loading environment variables.
This resulted in the PATH not being available at this point until an external command was run once, which resulted in env_vars being added
``` rust
// crates/nu-cli/src/cli.rs +268
// didn't have access to env_vars until an external command was executed which resulted in env_vars being added
let run_result = run_block(&prompt_block, &context, InputStream::empty()).await;
```
I added code that the env gets added to the context before entering the loop.