### PR TITLE
Defer to bash completion, for external commands

### DIFF
--- a/crates/nu-cli/src/completion/bash.rs
+++ b/crates/nu-cli/src/completion/bash.rs
@@ -1,0 +1,51 @@
+use super::matchers::Matcher;
+use crate::completion::{Completer, CompletionContext, Suggestion};
+use nu_engine::EvaluationContext;
+use std::{
+    io::Read,
+    process::{Command, Stdio},
+};
+
+pub struct BashCompleter;
+
+impl BashCompleter {
+    fn complete_bash(&self, command: &str) -> Vec<Suggestion> {
+        // println!("complete_bash: {}", command);
+        //TODO: escape characters
+        let bash_command = format!(
+            "source ~/.config/nu/bash_completions.sh; get_bash_completions \"{}\"",
+            command
+        );
+        let child = Command::new("bash")
+            .args(&["-c", bash_command.as_str()])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("BashCompleter: Failed to spawn child process");
+        let mut stdout = child.stdout.unwrap();
+        let suggestions = &mut String::new();
+        let _strlen = stdout.read_to_string(suggestions);
+        let suggestions: Vec<Suggestion> = suggestions
+            .split('\n')
+            .map(|s| s.trim().to_string())
+            .map(|s| Suggestion {
+                display: s.clone(),
+                replacement: s,
+            })
+            .collect();
+
+        suggestions
+    }
+}
+
+impl Completer for BashCompleter {
+    fn complete(
+        &self,
+        ctx: &CompletionContext<'_>,
+        partial: &str,
+        _matcher: &dyn Matcher,
+    ) -> Vec<Suggestion> {
+        let _context: &EvaluationContext = ctx.as_ref();
+        self.complete_bash(partial)
+    }
+}

--- a/crates/nu-cli/src/completion/bash.rs
+++ b/crates/nu-cli/src/completion/bash.rs
@@ -22,7 +22,7 @@ impl BashCompleter {
             .stdout(Stdio::piped())
             .spawn()
             .expect("BashCompleter: Failed to spawn child process");
-        let mut stdout = child.stdout.unwrap();
+        let mut stdout = child.stdout.expect("Error opening bash stdout");
         let suggestions = &mut String::new();
         let _strlen = stdout.read_to_string(suggestions);
         let suggestions: Vec<Suggestion> = suggestions

--- a/crates/nu-cli/src/completion/bash/bash_completions.sh
+++ b/crates/nu-cli/src/completion/bash/bash_completions.sh
@@ -1,0 +1,46 @@
+# Sourced from: https://brbsix.github.io/2015/11/29/accessing-tab-completion-programmatically-in-bash/
+
+get_bash_completions(){
+    local completion COMP_CWORD COMP_LINE COMP_POINT COMP_WORDS COMPREPLY=()
+
+    # load bash-completion if necessary
+    declare -F _completion_loader &>/dev/null || {
+        source /usr/share/bash-completion/bash_completion
+    }
+
+    COMP_LINE=$*
+    COMP_POINT=${#COMP_LINE}
+
+    eval set -- "$@"
+
+    COMP_WORDS=("$@")
+
+    # add '' to COMP_WORDS if the last character of the command line is a space
+    [[ ${COMP_LINE[@]: -1} = ' ' ]] && COMP_WORDS+=('')
+
+    # index of the last word
+    COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
+
+    # determine completion function
+    completion=$(complete -p "$1" 2>/dev/null | awk '{print $(NF-1)}')
+
+    # run _completion_loader only if necessary
+    [[ -n $completion ]] || {
+
+        # load completion
+        _completion_loader "$1"
+
+        # detect completion
+        completion=$(complete -p "$1" 2>/dev/null | awk '{print $(NF-1)}')
+
+    }
+
+    # ensure completion was detected
+    [[ -n $completion ]] || return 1
+
+    # execute completion function
+    "$completion"
+
+    # print completions to stdout
+    printf '%s\n' "${COMPREPLY[@]}" | LC_ALL=C sort
+}

--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -335,11 +335,9 @@ mod tests {
         fn completes_external_command_names() {
             let registry: VecRegistry = Vec::new().into();
             let line = "echo 1 | echo 2";
-
-            assert_eq!(
-                completion_location(line, &registry, 10),
-                vec![LocationType::Command],
-            );
+            let completions = completion_location(line, &registry, 10);
+            println!("{:#?}", completions);
+            assert_eq!(completions, vec![LocationType::Command],);
         }
 
         #[test]

--- a/crates/nu-cli/src/completion/mod.rs
+++ b/crates/nu-cli/src/completion/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod bash;
 pub(crate) mod command;
 pub(crate) mod engine;
 pub(crate) mod flag;


### PR DESCRIPTION
This is a WIP, but essentially works for the simple case of a single command. Truly a horrible solution, but may be attractive for the fact it will work for a bunch of use cases, until nushell finds a better way.

I'm not sure if this is something you guys will want to incorporate, but perhaps may lead towards having a completion plugin engine, that something like this can hook into to perform truly heinous things in the name of usability!

Currently doesnt work for commands a the end of a series of pipelines: (bad example, but I'm not feeling creative enough right now):
```
ls -a | git stat<tab>
```

The bash script is assumed to currently be in .config/nu/bash_completions.sh. Will need to find where assets currently get unpacked, or something