### PR TITLE
support forward slash for directory completion in Windows

### DIFF
--- a/crates/nu-cli/src/completion/path.rs
+++ b/crates/nu-cli/src/completion/path.rs
@@ -15,7 +15,8 @@ pub struct PathSuggestion {
 impl PathCompleter {
     pub fn path_suggestions(&self, partial: &str, matcher: &dyn Matcher) -> Vec<PathSuggestion> {
         let expanded = nu_parser::expand_ndots(partial);
-        let expanded = expanded.as_ref();
+        let expanded = expanded.replace(std::path::is_separator, &SEP.to_string());
+        let expanded: &str = expanded.as_ref();
 
         let (base_dir_name, partial) = match expanded.rfind(SEP) {
             Some(pos) => expanded.split_at(pos + SEP.len_utf8()),

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -143,7 +143,7 @@ async fn maybe_autocd_dir<'a>(
     //   - the command name ends in a path separator, or
     //   - it's not a command on the path and no arguments were given.
     let name = &cmd.name;
-    let path_name = if name.ends_with(std::path::MAIN_SEPARATOR)
+    let path_name = if name.ends_with(std::path::is_separator)
         || (cmd.args.is_empty()
             && PathBuf::from(name).is_dir()
             && dunce::canonicalize(name).is_ok()


### PR DESCRIPTION
While the "main" path separator in Windows is the backslash, it supports the
forward slash as a separator too.
Add support for this so that the behavior is similar to the way Windows
PowerShell handles the forward slash: it is recognized as a separator,
and when using <tab> for path completion the slash is reversed.