### PR TITLE
add support for timestamp-based time conversion by specifying timezone

### DIFF
--- a/crates/nu-command/src/commands/str_/to_datetime.rs
+++ b/crates/nu-command/src/commands/str_/to_datetime.rs
@@ -42,8 +42,7 @@ impl Zone {
         }
     }
     fn from_string(s: String) -> Self {
-        let l = s.to_lowercase();
-        match l.as_str() {
+        match s.to_lowercase().as_str() {
             "utc" | "u" => Self::Utc,
             "local" | "l" => Self::Local,
             _ => Self::Error,
@@ -151,19 +150,17 @@ async fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
             item: Zone::new(zone_offset),
             tag: _tag,
         })
-    } else {
-        if let Some(Tagged {
-            item: zone,
+    } else if let Some(Tagged {
+        item: zone,
+        tag: _tag,
+    }) = timezone
+    {
+        Some(Tagged {
+            item: Zone::from_string(zone),
             tag: _tag,
-        }) = timezone
-        {
-            Some(Tagged {
-                item: Zone::from_string(zone),
-                tag: _tag,
-            })
-        } else {
-            None
-        }
+        })
+    } else {
+        None
     };
 
     let format_options = if let Some(Tagged { item: fmt, .. }) = format {
@@ -287,7 +284,7 @@ mod tests {
     use super::ShellError;
     use super::{action, DatetimeFormat, SubCommand, Zone};
     use nu_protocol::{Primitive, UntaggedValue};
-    use nu_source::Tag;
+    use nu_source::{Tag, Tagged};
     use nu_test_support::value::string;
 
     #[test]

--- a/crates/nu-command/src/commands/str_/to_datetime.rs
+++ b/crates/nu-command/src/commands/str_/to_datetime.rs
@@ -337,9 +337,7 @@ mod tests {
     #[test]
     fn takes_timestamp() {
         let date_str = string("1614434140");
-        let timezone_option = Some(Tagged {
-            item: Zone::Local,
-        });
+        let timezone_option = Some(Tagged { item: Zone::Local });
         let actual = action(&date_str, &timezone_option, &None, Tag::unknown()).unwrap();
         match actual.value {
             UntaggedValue::Primitive(Primitive::Date(_)) => {}


### PR DESCRIPTION
add support for timestamp-based time conversion by specifying timezone or 'UTC/Local'
related Issue [#3205](https://github.com/nushell/nushell/issues/3205).