### PR TITLE
Output error when ls into a file without permission

### DIFF
--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -249,7 +249,7 @@ fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
 fn fails_with_ls_to_dir_without_permission() {
     Playground::setup("ls_test_1", |dirs, sandbox| {
         sandbox.within("dir_a").with_files(vec![
-            EmptyFile("yehuda.10.txt"),
+            EmptyFile("yehuda.11.txt"),
             EmptyFile("jonathan.10.txt"),
         ]);
 

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -245,6 +245,26 @@ fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
 }
 
 #[test]
+#[cfg(unix)]
+fn fails_with_ls_to_dir_without_permission() {
+    Playground::setup("ls_test_1", |dirs, sandbox| {
+        sandbox.within("dir_a")
+        .with_files(vec![
+            EmptyFile("yehuda.10.txt"),
+            EmptyFile("jonathan.10.txt"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                chmod 000 dir_a; ls dir_a
+            "#
+        ));
+        assert!(actual.err.contains("The permissions of 0 do not allow access for this user"));
+    })
+}
+
+#[test]
 fn lists_files_including_starting_with_dot() {
     Playground::setup("ls_test_9", |dirs, sandbox| {
         sandbox.with_files(vec![

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -248,8 +248,7 @@ fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
 #[cfg(unix)]
 fn fails_with_ls_to_dir_without_permission() {
     Playground::setup("ls_test_1", |dirs, sandbox| {
-        sandbox.within("dir_a")
-        .with_files(vec![
+        sandbox.within("dir_a").with_files(vec![
             EmptyFile("yehuda.10.txt"),
             EmptyFile("jonathan.10.txt"),
         ]);
@@ -260,7 +259,9 @@ fn fails_with_ls_to_dir_without_permission() {
                 chmod 000 dir_a; ls dir_a
             "#
         ));
-        assert!(actual.err.contains("The permissions of 0 do not allow access for this user"));
+        assert!(actual
+            .err
+            .contains("The permissions of 0 do not allow access for this user"));
     })
 }
 

--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -114,7 +114,7 @@ impl Shell for FilesystemShell {
                             "The permissions of {:o} do not allow access for this user",
                             p.metadata()
                                 .expect(
-                                    "this shouldnt be called since we already know there is a dir"
+                                    "this shouldn't be called since we already know there is a dir"
                                 )
                                 .permissions()
                                 .mode()

--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -108,6 +108,26 @@ impl Shell for FilesystemShell {
                 let p_tag = p.tag;
                 let mut p = p.item;
                 if p.is_dir() {
+                    if permission_denied(&p) {
+                        #[cfg(unix)]
+                        let error_msg = format!(
+                            "The permissions of {:o} do not allow access for this user",
+                            p.metadata()
+                                .expect(
+                                    "this shouldnt be called since we already know there is a dir"
+                                )
+                                .permissions()
+                                .mode()
+                                & 0o0777
+                        );
+                        #[cfg(not(unix))]
+                        let error_msg = String::from("Permission denied");
+                        return Err(ShellError::labeled_error(
+                            "Permission denied",
+                            error_msg,
+                            &p_tag,
+                        ));
+                    }
                     if is_empty_dir(&p) {
                         return Ok(OutputStream::empty());
                     }
@@ -854,6 +874,13 @@ fn is_empty_dir(dir: impl AsRef<Path>) -> bool {
     match dir.as_ref().read_dir() {
         Err(_) => true,
         Ok(mut s) => s.next().is_none(),
+    }
+}
+
+fn permission_denied(dir: impl AsRef<Path>) -> bool {
+    match dir.as_ref().read_dir() {
+        Err(e) => matches!(e.kind(), std::io::ErrorKind::PermissionDenied),
+        Ok(_) => false,
     }
 }
 


### PR DESCRIPTION
Fixes #3157

- Old behavior
```
    ls file_without_permission
    (Empty line)
```
- New behavior on unix systems
```
    ls file_without_permission
    
    error: Permission denied
   ┌─ shell:2:4
   │
 2 │ ls file_without_permission
   │    ^^^^^^^^^^^^^^^^^^^^^^^ The permissions of XXX do not allow access for this user

```
The XXX being the permissions bits in octagonal notation(Ex: 700)
- New behavior on Windows
```
    ls file_without_permission
    
    error: Permission denied
   ┌─ shell:2:4
   │
 2 │ ls file_without_permission
   │    ^^^^^^^^^^^^^^^^^^^^^^^ Permission denied

```
And that's pretty much it, couldn't make a test since i don't know how to use the playground to create a file with another user and with specific permissions, but if anyone knows and can point me out, i would gladly do it