### PR TITLE
Stop nu panicks in math.round on a large decimal value(Most of the time)

### DIFF
--- a/crates/nu-command/src/commands/math/round.rs
+++ b/crates/nu-command/src/commands/math/round.rs
@@ -78,7 +78,10 @@ fn round_big_decimal(val: BigDecimal, precision: i64) -> Value {
     if precision > 0 {
         UntaggedValue::decimal(val.with_scale(precision + 1).round(precision)).into()
     } else {
-        let (rounded, _) = val.with_scale(precision + 1).round(precision).as_bigint_and_exponent();
+        let (rounded, _) = val
+            .with_scale(precision + 1)
+            .round(precision)
+            .as_bigint_and_exponent();
         UntaggedValue::int(rounded).into()
     }
 }

--- a/crates/nu-command/src/commands/math/round.rs
+++ b/crates/nu-command/src/commands/math/round.rs
@@ -76,9 +76,9 @@ fn round_big_int(val: BigInt) -> Value {
 
 fn round_big_decimal(val: BigDecimal, precision: i64) -> Value {
     if precision > 0 {
-        UntaggedValue::decimal(val.round(precision)).into()
+        UntaggedValue::decimal(val.with_scale(precision + 1).round(precision)).into()
     } else {
-        let (rounded, _) = val.round(precision).as_bigint_and_exponent();
+        let (rounded, _) = val.with_scale(precision + 1).round(precision).as_bigint_and_exponent();
         UntaggedValue::int(rounded).into()
     }
 }

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -1,6 +1,7 @@
 mod avg;
 mod eval;
 mod median;
+mod round;
 mod sum;
 
 use nu_test_support::{nu, pipeline};

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -14,7 +14,7 @@ fn can_round_very_large_numbers() {
 fn can_round_very_large_numbers_with_precision() {
     let actual = nu!(
         cwd: ".",
-        "echo 18.13725447800741422899276654867720123457878988 | math round -p 10"
+        "echo 18.13725447800741422899276654867720121457878988 | math round -p 10"
     );
 
     assert_eq!(actual.out, "18.137254478")

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -1,0 +1,21 @@
+use nu_test_support::nu;
+
+#[test]
+fn can_round_very_large_numbers() {
+    let actual = nu!(
+        cwd: ".",
+        "echo 18.1372544780074142289927665486772012345 | math round"
+    );
+
+    assert_eq!(actual.out, "18")
+}
+
+#[test]
+fn can_round_very_large_numbers_with_precision() {
+    let actual = nu!(
+        cwd: ".",
+        "echo 18.13725447800741422899276654867720123457878998 | math round -p 10"
+    );
+
+    assert_eq!(actual.out, "18.137254478")
+}

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -14,7 +14,7 @@ fn can_round_very_large_numbers() {
 fn can_round_very_large_numbers_with_precision() {
     let actual = nu!(
         cwd: ".",
-        "echo 18.13725447800741422899276654867720123457878998 | math round -p 10"
+        "echo 18.13725447800741422899276654867720123457878988 | math round -p 10"
     );
 
     assert_eq!(actual.out, "18.137254478")


### PR DESCRIPTION
Fixes #3130 

So basically the problem we have here is in the implementation of the round function inside BigDecimal, which we have here below, focus on the line with the arrows. Basically what bigdecimal does is remove the , in the number(Ex: 1,11 becomes 111) and fit that into a i128 number, except that if the number is too big for that the program crashes(thanks to the unwrap())
```
    /// Return number rounded to round_digits precision after the decimal point
    pub fn round(&self, round_digits: i64) -> BigDecimal {
        let (bigint, decimal_part_digits) = self.as_bigint_and_exponent();
        let need_to_round_digits = decimal_part_digits - round_digits;
        if round_digits >= 0 && need_to_round_digits <= 0 {
            return self.clone();
        }

        let mut number = bigint.to_i128().unwrap(); <<<<<<<<<<<
        ...
```
What i did was basically eliminate the numbers that were not needed for the computation(Ex: round 1.87 and round 1.8 give the same result, the 7 is not relevant when the precision is 0) so the "18.1372544780074142289927665486772012345" becomes "18.1" before the rounding and subsequent storing in the i128, if the precision needed as 2 the number that would actually be rounded would be "18.137". So currently the only way to crash because of this unwrap is if even after the scaling the number is still too big to be stored in a i128.
```
 echo 18.1372544780074142289927665486772012345 | math round -p 36
```
Will still crash. Below are some tests that i did with various numbers.
![image](https://user-images.githubusercontent.com/11317382/112773743-85e0aa00-900d-11eb-9526-1118131a9911.png)
