### PR TITLE
Add var name to error message

### DIFF
--- a/crates/nu-engine/src/evaluate/evaluator.rs
+++ b/crates/nu-engine/src/evaluate/evaluator.rs
@@ -264,7 +264,7 @@ fn evaluate_reference(name: &str, ctx: &EvaluationContext, tag: Tag) -> Result<V
             Some(v) => Ok(v),
             None => Err(ShellError::labeled_error(
                 "Variable not in scope",
-                "unknown variable",
+                format!("unknown variable: {}", x),
                 tag.span,
             )),
         },


### PR DESCRIPTION
After applying this PR.
```nu
error: Variable not in scope
  ┌─ shell:1:17
  │
1 │ construct_prompt
  │                   unknown variable: $dir
```
Not perfect, but one small step forwards
