### PR TITLE
Reload global config automatically if changed

### DIFF
--- a/crates/nu-engine/src/evaluate/scope.rs
+++ b/crates/nu-engine/src/evaluate/scope.rs
@@ -300,21 +300,19 @@ impl Scope {
         })
     }
 
-    pub fn update_frame_with_tag(&self, frame: ScopeFrame, tag: &str) -> Result<(), ShellError> {
+    /// Update frame with tag `tag` by applying function `f` on the frame
+    /// Returns true if tag was found, false otherwise
+    pub fn update_frame_with_tag(&self, tag: &str, f: impl FnOnce(&mut ScopeFrame)) -> bool {
         let mut frames = self.frames.lock();
         let tag = Some(tag);
-        for f in frames.iter_mut().rev() {
-            if f.tag.as_deref() == tag {
-                *f = frame;
-                return Ok(());
+        for frame in frames.iter_mut().rev() {
+            if frame.tag.as_deref() == tag {
+                f(frame);
+                return true;
             }
         }
 
-        // Frame not found, return err
-        Err(ShellError::untagged_runtime_error(format!(
-            "Can't update frame with tag {:?}. No such frame present!",
-            tag
-        )))
+        false
     }
 }
 

--- a/crates/nu-engine/src/evaluation_context.rs
+++ b/crates/nu-engine/src/evaluation_context.rs
@@ -1,9 +1,9 @@
-use crate::evaluate::scope::{Scope, ScopeFrame};
+use crate::env::{basic_host::BasicHost, host::Host};
+use crate::evaluate::scope::Scope;
 use crate::shell::shell_manager::ShellManager;
 use crate::whole_stream_command::Command;
 use crate::{call_info::UnevaluatedCallInfo, config_holder::ConfigHolder};
 use crate::{command_args::CommandArgs, script};
-use crate::{env::basic_host::BasicHost, Host};
 use indexmap::IndexMap;
 use log::trace;
 use nu_data::config::{self, Conf, NuConfig};
@@ -264,15 +264,14 @@ impl EvaluationContext {
             .transpose()?;
 
         let tag = config::cfg_path_to_scope_tag(&cfg.file_path);
-        let mut frame = ScopeFrame::with_tag(tag.clone());
 
-        frame.env = cfg.env_map();
-        if let Some(path) = joined_paths {
-            frame.env.insert(NATIVE_PATH_ENV_VAR.to_string(), path);
-        }
-        frame.exitscripts = exit_scripts;
-
-        self.scope.update_frame_with_tag(frame, &tag)?;
+        self.scope.update_frame_with_tag(&tag, |frame| {
+            frame.env = cfg.env_map();
+            if let Some(path) = joined_paths {
+                frame.env.insert(NATIVE_PATH_ENV_VAR.to_string(), path);
+            }
+            frame.exitscripts = exit_scripts;
+        });
 
         Ok(())
     }

--- a/tests/shell/environment/configuration.rs
+++ b/tests/shell/environment/configuration.rs
@@ -142,7 +142,6 @@ fn removes_config_values() {
 }
 
 #[test]
-#[ignore = "This test is reproduciable by hand and succeeds when run locally, but fails only for linux stable CI"]
 fn updates_config_even_if_config_changed_externally() {
     Playground::setup("updates_config_when_changed", |dirs, nu| {
         let file = AbsolutePath::new(dirs.test().join("config.toml"));
@@ -166,7 +165,7 @@ fn updates_config_even_if_config_changed_externally() {
 
         assert_that!(
             nu.pipeline("config get hi")
-                .and_then("do {rm config.toml ; = $noting}")
+                .and_then("do {rm config.toml; $noting}")
                 .and_then("cp config.toml.2 config.toml")
                 .and_then("config get hi"),
             says().to_stdout("hibye")

--- a/tests/shell/environment/configuration.rs
+++ b/tests/shell/environment/configuration.rs
@@ -140,3 +140,36 @@ fn removes_config_values() {
         assert!(file_contents(&file).is_empty());
     })
 }
+
+#[test]
+#[ignore = "This test is reproduciable by hand and succeeds when run locally, but fails only for linux stable CI"]
+fn updates_config_even_if_config_changed_externally() {
+    Playground::setup("updates_config_when_changed", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("config.toml"));
+
+        nu.with_config(&file);
+        nu.with_files(vec![
+            FileWithContent(
+                "config.toml",
+                r#"
+                skip_welcome_message = true
+                hi = "hi"
+                "#,
+            ),
+            FileWithContent(
+                "config.toml.2",
+                r#"
+                hi = "bye"
+                "#,
+            ),
+        ]);
+
+        assert_that!(
+            nu.pipeline("config get hi")
+                .and_then("do {rm config.toml ; = $noting}")
+                .and_then("cp config.toml.2 config.toml")
+                .and_then("config get hi"),
+            says().to_stdout("hibye")
+        );
+    })
+}


### PR DESCRIPTION
With this PR applied I can by hand verify that the .config/nu/config.toml config is reloaded automatically.
However the test (which is doing the same?) is failing.

```shell
[I] leo@pc ~/r/nushell (main)> cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/nu`
Welcome to Nushell 0.29.1 (type 'help' for more info)
/home/leo/repos/nushell(main)> cd /home/leo/.config/nu
/home/leo/.config/nu(master)> cat config.toml
            skip_welcome_message = false
/home/leo/.config/nu(master)> config get skip_welcome_message
false
/home/leo/.config/nu(master)> cat c
            skip_welcome_message = true
/home/leo/.config/nu(master)> mv c config.toml
/home/leo/.config/nu(master)> cat config.toml
            skip_welcome_message = true
/home/leo/.config/nu(master)> config get skip_welcome_message
true
/home/leo/.config/nu(master)> 
```