### PR TITLE
Refactor/config commands

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -420,7 +420,7 @@ pub fn load_local_cfg_if_present(context: &EvaluationContext) {
 }
 
 fn load_cfg_as_global_cfg(context: &EvaluationContext, path: PathBuf) {
-    if let Err(err) = context.load_config(&ConfigPath::Global(path.clone())) {
+    if let Err(err) = context.load_config(&ConfigPath::Global(path)) {
         context.host.lock().print_err(err, &Text::from(""));
     }
 }

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -173,7 +173,7 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
         let _ = configure_rustyline_editor(&mut rl, cfg);
         let helper = Some(nu_line_editor_helper(&context, cfg));
         rl.set_helper(helper);
-        nu_data::config::path::history_path(cfg)
+        nu_data::config::path::history_path_or_default(cfg)
     } else {
         nu_data::config::path::default_history_path()
     };
@@ -422,13 +422,6 @@ pub fn load_local_cfg_if_present(context: &EvaluationContext) {
 fn load_cfg_as_global_cfg(context: &EvaluationContext, path: PathBuf) {
     if let Err(err) = context.load_config(&ConfigPath::Global(path.clone())) {
         context.host.lock().print_err(err, &Text::from(""));
-    } else {
-        //TODO current commands assume to find path to global cfg file under config-path
-        //TODO use newly introduced nuconfig::file_path instead
-        context.scope.add_var(
-            "config-path",
-            UntaggedValue::filepath(path).into_untagged_value(),
-        );
     }
 }
 

--- a/crates/nu-command/src/commands/config/clear.rs
+++ b/crates/nu-command/src/commands/config/clear.rs
@@ -42,12 +42,11 @@ pub fn clear(args: CommandArgs) -> Result<OutputStream, ShellError> {
             UntaggedValue::Row(global_cfg.vars.clone().into()).into_value(args.call_info.name_tag),
         )))
     } else {
-        Ok(
-            futures::stream::iter(vec![ReturnSuccess::value(UntaggedValue::Error(
-                crate::commands::config::err_no_global_cfg_present(),
-            ))])
-            .to_output_stream(),
-        )
+        Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
+            crate::commands::config::err_no_global_cfg_present(),
+        ))]
+        .into_iter()
+        .to_output_stream())
     };
 
     result

--- a/crates/nu-command/src/commands/config/command.rs
+++ b/crates/nu-command/src/commands/config/command.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for Command {
             .to_output_stream())
         } else {
             Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
-                ShellError::untagged_runtime_error("No global config found!"),
+                crate::commands::config::err_no_global_cfg_present(),
             ))]
             .into_iter()
             .to_output_stream())

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -44,7 +44,7 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
 
-    let (Arguments { column_path }, _) = args.process().await?;
+    let (Arguments { column_path }, _) = args.process()?;
 
     let result = if let Some(global_cfg) = &ctx.configs.lock().global_config {
         let result = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -47,7 +47,7 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let (Arguments { column_path }, _) = args.process().await?;
 
     let result = if let Some(global_cfg) = &ctx.configs.lock().global_config {
-        let result = UntaggedValue::row(global_cfg.vars.clone().into()).into_value(&name);
+        let result = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);
         let value = crate::commands::get::get_column_path(&column_path, &result)?;
         Ok(match value {
             Value {

--- a/crates/nu-command/src/commands/config/mod.rs
+++ b/crates/nu-command/src/commands/config/mod.rs
@@ -13,3 +13,9 @@ pub use path::SubCommand as ConfigPath;
 pub use remove::SubCommand as ConfigRemove;
 pub use set::SubCommand as ConfigSet;
 pub use set_into::SubCommand as ConfigSetInto;
+
+use nu_errors::ShellError;
+
+pub fn err_no_global_cfg_present() -> ShellError {
+    ShellError::untagged_runtime_error("No global config found!")
+}

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -43,7 +43,7 @@ impl WholeStreamCommand for SubCommand {
 
 pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let ctx = EvaluationContext::from_args(&args);
-    let (Arguments { remove }, _) = args.process().await?;
+    let (Arguments { remove }, _) = args.process()?;
 
     let key = remove.to_string();
 
@@ -52,7 +52,7 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
             global_cfg.vars.swap_remove(&key);
             global_cfg.write()?;
             ctx.reload_config(global_cfg)?;
-            Ok(futures::stream::iter(vec![ReturnSuccess::value(
+            Ok(vec![ReturnSuccess::value(
                 UntaggedValue::row(global_cfg.vars.clone()).into_value(remove.tag()),
             )]
             .into_iter()

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -51,8 +51,8 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
         if global_cfg.vars.contains_key(&key) {
             global_cfg.vars.swap_remove(&key);
             global_cfg.write()?;
-
-            Ok(vec![ReturnSuccess::value(
+            ctx.reload_config(global_cfg)?;
+            Ok(futures::stream::iter(vec![ReturnSuccess::value(
                 UntaggedValue::row(global_cfg.vars.clone()).into_value(remove.tag()),
             )]
             .into_iter()

--- a/crates/nu-command/src/commands/config/set_into.rs
+++ b/crates/nu-command/src/commands/config/set_into.rs
@@ -1,9 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{
-    ConfigPath, Primitive, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value,
-};
+use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 
 pub struct SubCommand;
@@ -46,55 +44,44 @@ impl WholeStreamCommand for SubCommand {
 pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
-    let scope = args.scope.clone();
-    let (Arguments { set_into: v }, input) = args.process()?;
+    let (Arguments { set_into: v }, input) = args.process().await?;
 
-    let path = match scope.get_var("config-path") {
-        Some(Value {
-            value: UntaggedValue::Primitive(Primitive::FilePath(path)),
-            ..
-        }) => Some(path),
-        _ => nu_data::config::default_path().ok(),
-    };
-
-    let mut result = nu_data::config::read(&name, &path)?;
-
-    let rows: Vec<Value> = input.collect();
+    let rows: Vec<Value> = input.collect().await;
     let key = v.to_string();
 
-    Ok(if rows.is_empty() {
-        return Err(ShellError::labeled_error(
-            "No values given for set_into",
-            "needs value(s) from pipeline",
-            v.tag(),
-        ));
-    } else if rows.len() == 1 {
-        // A single value
-        let value = &rows[0];
+    let result = if let Some(global_cfg) = &mut ctx.configs.lock().global_config {
+        if rows.is_empty() {
+            return Err(ShellError::labeled_error(
+                "No values given for set_into",
+                "needs value(s) from pipeline",
+                v.tag(),
+            ));
+        } else if rows.len() == 1 {
+            // A single value
+            let value = &rows[0];
 
-        result.insert(key, value.clone());
+            global_cfg.vars.insert(key, value.clone());
+        } else {
+            // Take in the pipeline as a table
+            let value = UntaggedValue::Table(rows).into_value(name.clone());
 
-        config::write(&result, &path)?;
-        ctx.reload_config(&ConfigPath::Global(
-            path.expect("Global config path is always some"),
-        ))?;
+            global_cfg.vars.insert(key, value);
+        }
 
-        OutputStream::one(ReturnSuccess::value(
-            UntaggedValue::Row(result.into()).into_value(name),
-        ))
+        global_cfg.write()?;
+
+        ctx.reload_config(global_cfg)?;
+
+        Ok(OutputStream::one(ReturnSuccess::value(
+            UntaggedValue::row(global_cfg.vars.clone()).into_value(name),
+        )))
     } else {
-        // Take in the pipeline as a table
-        let value = UntaggedValue::Table(rows).into_value(name.clone());
+        Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
+            crate::commands::config::err_no_global_cfg_present(),
+        ))]
+        .into_iter()
+        .to_output_stream())
+    };
 
-        result.insert(key, value);
-
-        config::write(&result, &path)?;
-        ctx.reload_config(&ConfigPath::Global(
-            path.expect("Global config path is always some"),
-        ))?;
-
-        OutputStream::one(ReturnSuccess::value(
-            UntaggedValue::Row(result.into()).into_value(name),
-        ))
-    })
+    result
 }

--- a/crates/nu-command/src/commands/config/set_into.rs
+++ b/crates/nu-command/src/commands/config/set_into.rs
@@ -69,7 +69,6 @@ pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
 
         global_cfg.write()?;
-
         ctx.reload_config(global_cfg)?;
 
         Ok(OutputStream::one(ReturnSuccess::value(

--- a/crates/nu-command/src/commands/config/set_into.rs
+++ b/crates/nu-command/src/commands/config/set_into.rs
@@ -44,9 +44,9 @@ impl WholeStreamCommand for SubCommand {
 pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
-    let (Arguments { set_into: v }, input) = args.process().await?;
+    let (Arguments { set_into: v }, input) = args.process()?;
 
-    let rows: Vec<Value> = input.collect().await;
+    let rows: Vec<Value> = input.collect();
     let key = v.to_string();
 
     let result = if let Some(global_cfg) = &mut ctx.configs.lock().global_config {

--- a/crates/nu-command/tests/commands/config.rs
+++ b/crates/nu-command/tests/commands/config.rs
@@ -1,0 +1,138 @@
+use nu_test_support::fs::AbsolutePath;
+use nu_test_support::fs::Stub::FileWithContent;
+use nu_test_support::playground::{says, Playground};
+
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+
+#[test]
+fn clearing_config_clears_config() {
+    Playground::setup("environment_syncing_test_1", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("config.toml"));
+
+        nu.with_config(&file);
+        nu.with_files(vec![FileWithContent(
+            "config.toml",
+            r#"
+                skip_welcome_message = true
+            "#,
+        )]);
+
+        assert_that!(
+            nu.pipeline("config clear; config get skip_welcome_message"),
+            says().to_stdout("")
+        );
+        let config_contents = std::fs::read_to_string(file).expect("Could not read file");
+        assert!(config_contents.is_empty());
+    });
+}
+
+#[test]
+fn config_get_returns_value() {
+    Playground::setup("environment_syncing_test_1", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("config.toml"));
+
+        nu.with_config(&file);
+        nu.with_files(vec![FileWithContent(
+            "config.toml",
+            r#"
+                skip_welcome_message = true
+            "#,
+        )]);
+
+        assert_that!(
+            //Clears config
+            nu.pipeline("config get skip_welcome_message"),
+            says().to_stdout("true")
+        );
+    });
+}
+
+#[test]
+fn config_set_sets_value() {
+    Playground::setup("environment_syncing_test_1", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("config.toml"));
+
+        nu.with_config(&file);
+        nu.with_files(vec![FileWithContent(
+            "config.toml",
+            r#"
+                skip_welcome_message = true
+            "#,
+        )]);
+
+        assert_that!(
+            //Clears config
+            nu.pipeline("config set key value; config get key"),
+            says().to_stdout("value")
+        );
+        let config_contents = std::fs::read_to_string(file).expect("Could not read file");
+        assert!(config_contents.contains("key = \"value\""));
+    });
+}
+
+#[test]
+fn config_set_into_sets_value() {
+    Playground::setup("environment_syncing_test_1", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("config.toml"));
+
+        nu.with_config(&file);
+        nu.with_files(vec![FileWithContent(
+            "config.toml",
+            r#"
+                skip_welcome_message = true
+            "#,
+        )]);
+
+        assert_that!(
+            //Clears config
+            nu.pipeline("echo value | config set_into key; config get key"),
+            says().to_stdout("value")
+        );
+        let config_contents = std::fs::read_to_string(file).expect("Could not read file");
+        assert!(config_contents.contains("key = \"value\""));
+    });
+}
+
+#[test]
+fn config_rm_removes_value() {
+    Playground::setup("environment_syncing_test_1", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("config.toml"));
+
+        nu.with_config(&file);
+        nu.with_files(vec![FileWithContent(
+            "config.toml",
+            r#"
+                key = "value"
+                skip_welcome_message = true
+            "#,
+        )]);
+
+        assert_that!(
+            nu.pipeline("config remove key; config get key"),
+            says().to_stdout("")
+        );
+        let config_contents = std::fs::read_to_string(file).expect("Could not read file");
+        assert!(!config_contents.contains("key = \"value\""));
+    });
+}
+
+#[test]
+fn config_path_returns_correct_path() {
+    Playground::setup("environment_syncing_test_1", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("config.toml"));
+
+        nu.with_config(&file);
+        nu.with_files(vec![FileWithContent(
+            "config.toml",
+            r#"
+                skip_welcome_message = true
+            "#,
+        )]);
+
+        assert_that!(
+            nu.pipeline("config path"),
+            says().to_stdout(&file.inner.to_string_lossy().to_string())
+        );
+    });
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -4,6 +4,7 @@ mod append;
 mod cal;
 mod cd;
 mod compact;
+mod config;
 mod cp;
 mod def;
 mod default;

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -328,6 +328,6 @@ fn touch(path: &Path) -> io::Result<()> {
     }
 }
 
-pub fn cfg_path_to_scope_tag(cfg_path: &PathBuf) -> String {
+pub fn cfg_path_to_scope_tag(cfg_path: &Path) -> String {
     cfg_path.to_string_lossy().to_string()
 }

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -16,8 +16,8 @@ use indexmap::IndexMap;
 use log::trace;
 use nu_errors::{CoerceInto, ShellError};
 use nu_protocol::{
-    ConfigPath, Dictionary, Primitive, ShellTypeName, TaggedDictBuilder, UnspannedPathMember,
-    UntaggedValue, Value,
+    Dictionary, Primitive, ShellTypeName, TaggedDictBuilder, UnspannedPathMember, UntaggedValue,
+    Value,
 };
 use nu_source::{SpannedItem, Tag, TaggedItem};
 use std::fs::{self, OpenOptions};
@@ -328,6 +328,6 @@ fn touch(path: &Path) -> io::Result<()> {
     }
 }
 
-pub fn cfg_path_to_scope_tag(cfg_path: &ConfigPath) -> String {
-    cfg_path.get_path().to_string_lossy().to_string()
+pub fn cfg_path_to_scope_tag(cfg_path: &PathBuf) -> String {
+    cfg_path.to_string_lossy().to_string()
 }

--- a/crates/nu-data/src/config/nuconfig.rs
+++ b/crates/nu-data/src/config/nuconfig.rs
@@ -65,6 +65,7 @@ impl NuConfig {
         })
     }
 
+    /// Writes self.values under self.file_path
     pub fn write(&self) -> Result<(), ShellError> {
         write(&self.vars, &Some(self.file_path.clone()))
     }

--- a/crates/nu-data/src/config/nuconfig.rs
+++ b/crates/nu-data/src/config/nuconfig.rs
@@ -5,6 +5,8 @@ use nu_protocol::Value;
 use nu_source::Tag;
 use std::{fmt::Debug, path::PathBuf};
 
+use super::write;
+
 #[derive(Debug, Clone, Default)]
 pub struct NuConfig {
     pub vars: IndexMap<String, Value>,
@@ -61,6 +63,10 @@ impl NuConfig {
             vars,
             modified_at,
         })
+    }
+
+    pub fn write(&self) -> Result<(), ShellError> {
+        write(&self.vars, &Some(self.file_path.clone()))
     }
 
     pub fn new() -> NuConfig {

--- a/crates/nu-data/src/config/path.rs
+++ b/crates/nu-data/src/config/path.rs
@@ -1,5 +1,6 @@
-use crate::config::Conf;
 use std::path::PathBuf;
+
+use super::NuConfig;
 
 const DEFAULT_LOCATION: &str = "history.txt";
 
@@ -12,7 +13,19 @@ pub fn default_history_path() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from(DEFAULT_LOCATION))
 }
 
-pub fn history_path(config: &dyn Conf) -> PathBuf {
+/// Get history path of config, if present
+pub fn history_path(config: &NuConfig) -> Option<PathBuf> {
+    config
+        .var("history-path")
+        .map(|custom_path| match custom_path.as_string() {
+            Ok(path) => Some(PathBuf::from(path)),
+            Err(_) => None,
+        })
+        .flatten()
+}
+
+/// Get history path in config or default
+pub fn history_path_or_default(config: &NuConfig) -> PathBuf {
     let default_history_path = default_history_path();
 
     config.var("history-path").map_or(

--- a/crates/nu-data/src/config/path.rs
+++ b/crates/nu-data/src/config/path.rs
@@ -26,5 +26,5 @@ pub fn history_path(config: &NuConfig) -> Option<PathBuf> {
 
 /// Get history path in config or default
 pub fn history_path_or_default(config: &NuConfig) -> PathBuf {
-    history_path(config).unwrap_or_else(|| default_history_path())
+    history_path(config).unwrap_or_else(default_history_path)
 }

--- a/crates/nu-data/src/config/path.rs
+++ b/crates/nu-data/src/config/path.rs
@@ -26,13 +26,5 @@ pub fn history_path(config: &NuConfig) -> Option<PathBuf> {
 
 /// Get history path in config or default
 pub fn history_path_or_default(config: &NuConfig) -> PathBuf {
-    let default_history_path = default_history_path();
-
-    config.var("history-path").map_or(
-        default_history_path.clone(),
-        |custom_path| match custom_path.as_string() {
-            Ok(path) => PathBuf::from(path),
-            Err(_) => default_history_path,
-        },
-    )
+    history_path(config).unwrap_or_else(|| default_history_path())
 }

--- a/crates/nu-engine/src/evaluate/evaluator.rs
+++ b/crates/nu-engine/src/evaluate/evaluator.rs
@@ -230,7 +230,7 @@ fn evaluate_literal(literal: &hir::Literal, span: Span) -> Value {
 
 fn evaluate_reference(name: &str, ctx: &EvaluationContext, tag: Tag) -> Result<Value, ShellError> {
     match name {
-        "$nu" => crate::evaluate::variables::nu(&ctx.scope, tag),
+        "$nu" => crate::evaluate::variables::nu(&ctx.scope, tag, ctx),
 
         "$scope" => crate::evaluate::variables::scope(&ctx.scope.get_aliases(), tag),
 

--- a/crates/nu-engine/src/evaluate/variables.rs
+++ b/crates/nu-engine/src/evaluate/variables.rs
@@ -1,11 +1,15 @@
-use crate::evaluate::scope::Scope;
+use crate::{evaluate::scope::Scope, EvaluationContext};
 use indexmap::IndexMap;
-use nu_data::config::path::history_path;
+use nu_data::config::path::{default_history_path, history_path};
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, TaggedDictBuilder, UntaggedValue, Value};
+use nu_protocol::{TaggedDictBuilder, UntaggedValue, Value};
 use nu_source::{Spanned, Tag};
 
-pub fn nu(scope: &Scope, tag: impl Into<Tag>) -> Result<Value, ShellError> {
+pub fn nu(
+    scope: &Scope,
+    tag: impl Into<Tag>,
+    ctx: &EvaluationContext,
+) -> Result<Value, ShellError> {
     let env = &scope.get_env_vars();
     let tag = tag.into();
 
@@ -17,18 +21,33 @@ pub fn nu(scope: &Scope, tag: impl Into<Tag>) -> Result<Value, ShellError> {
             dict.insert_untagged(v.0, UntaggedValue::string(v.1));
         }
     }
+
     nu_dict.insert_value("env", dict.into_value());
 
-    let config_file = match scope.get_var("config-path") {
-        Some(Value {
-            value: UntaggedValue::Primitive(Primitive::FilePath(path)),
-            ..
-        }) => Some(path),
-        _ => None,
-    };
+    nu_dict.insert_value(
+        "history-path",
+        UntaggedValue::filepath(default_history_path()).into_value(&tag),
+    );
 
-    let config = nu_data::config::read(&tag, &config_file)?;
-    nu_dict.insert_value("config", UntaggedValue::row(config).into_value(&tag));
+    if let Some(global_cfg) = &ctx.configs.lock().global_config {
+        nu_dict.insert_value(
+            "config",
+            UntaggedValue::row(global_cfg.vars.clone()).into_value(&tag),
+        );
+
+        nu_dict.insert_value(
+            "config-path",
+            UntaggedValue::filepath(global_cfg.file_path.clone()).into_value(&tag),
+        );
+
+        // overwrite hist-path if present
+        if let Some(hist_path) = history_path(global_cfg) {
+            nu_dict.insert_value(
+                "history-path",
+                UntaggedValue::filepath(hist_path).into_value(&tag),
+            );
+        }
+    }
 
     let mut table = vec![];
     for v in env.iter() {
@@ -50,17 +69,6 @@ pub fn nu(scope: &Scope, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     let temp = std::env::temp_dir();
     nu_dict.insert_value("temp-dir", UntaggedValue::filepath(temp).into_value(&tag));
 
-    let config = if let Some(path) = config_file {
-        path
-    } else {
-        nu_data::config::default_path()?
-    };
-
-    nu_dict.insert_value(
-        "config-path",
-        UntaggedValue::filepath(config).into_value(&tag),
-    );
-
     #[cfg(feature = "rustyline-support")]
     {
         let keybinding_path = nu_data::keybinding::keybinding_path()?;
@@ -69,13 +77,6 @@ pub fn nu(scope: &Scope, tag: impl Into<Tag>) -> Result<Value, ShellError> {
             UntaggedValue::filepath(keybinding_path).into_value(&tag),
         );
     }
-
-    let config: Box<dyn nu_data::config::Conf> = Box::new(nu_data::config::NuConfig::new());
-    let history = history_path(&config);
-    nu_dict.insert_value(
-        "history-path",
-        UntaggedValue::filepath(history).into_value(&tag),
-    );
 
     Ok(nu_dict.into_value())
 }

--- a/crates/nu-test-support/src/fs.rs
+++ b/crates/nu-test-support/src/fs.rs
@@ -45,7 +45,7 @@ impl From<AbsoluteFile> for PathBuf {
 }
 
 pub struct AbsolutePath {
-    inner: PathBuf,
+    pub inner: PathBuf,
 }
 
 impl AbsolutePath {


### PR DESCRIPTION
The config commands used the variable "config-path". Now they use `ctx.configs` :)
I also removed all other occurrences of "config-path".

Edit: Oops, I duplicated some of the config tests. I didn't saw them . Can I move the existing config tests (which tests the config commands, and only those) to nu-command/tests/command/config.rs?