### PR TITLE
Do not store whitespace entries into history (#3019)

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -319,7 +319,7 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
 
         match line {
             LineResult::Success(line) => {
-                if options.save_history {
+                if options.save_history && !line.trim().is_empty() {
                     rl.add_history_entry(&line);
                     let _ = rl.save_history(&history_path);
                 }
@@ -334,7 +334,7 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
             }
 
             LineResult::Error(line, err) => {
-                if options.save_history {
+                if options.save_history && !line.trim().is_empty() {
                     rl.add_history_entry(&line);
                     let _ = rl.save_history(&history_path);
                 }


### PR DESCRIPTION
Before storing an entry into the history nushell will check if the entry consists only of whitespaces and if so, it does not store it in the history and this avoids  newline repetition when user is navigating in the history.

Fixes #3019 