### PR TITLE
make Table, Autoview read in memory config.

### DIFF
--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -1,4 +1,4 @@
-use crate::commands::autoview::options::{ConfigExtensions, NuConfig as AutoViewConfiguration};
+use crate::commands::autoview::options::ConfigExtensions;
 use crate::prelude::*;
 use crate::primitive::get_color_config;
 use nu_data::value::format_leaf;
@@ -44,7 +44,7 @@ impl WholeStreamCommand for Command {
 }
 
 pub fn autoview(context: CommandArgs) -> Result<OutputStream, ShellError> {
-    let configuration = AutoViewConfiguration::new();
+    let configuration = context.configs.lock().global_config();
 
     let binary = context.scope.get_command("binaryview");
     let text = context.scope.get_command("textview");
@@ -213,7 +213,7 @@ pub fn autoview(context: CommandArgs) -> Result<OutputStream, ShellError> {
                                 ]);
                             }
 
-                            let color_hm = get_color_config();
+                            let color_hm = get_color_config(&configuration);
 
                             let table =
                                 nu_table::Table::new(vec![], entries, nu_table::Theme::compact());

--- a/crates/nu-command/src/commands/table/command.rs
+++ b/crates/nu-command/src/commands/table/command.rs
@@ -1,4 +1,4 @@
-use crate::commands::table::options::{ConfigExtensions, NuConfig as TableConfiguration};
+use crate::commands::table::options::{ConfigExtensions, NuConfig};
 use crate::prelude::*;
 use crate::primitive::get_color_config;
 use nu_data::value::{format_leaf, style_leaf};
@@ -41,13 +41,13 @@ impl WholeStreamCommand for Command {
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        table(TableConfiguration::new(), args)
+        table(args)
     }
 }
 
 pub fn from_list(
     values: &[Value],
-    configuration: &TableConfiguration,
+    configuration: &NuConfig,
     starting_idx: usize,
     color_hm: &HashMap<String, nu_ansi_term::Style>,
 ) -> nu_table::Table {
@@ -56,7 +56,13 @@ pub fn from_list(
         .into_iter()
         .map(|x| StyledString::new(x, header_style))
         .collect();
-    let entries = values_to_entries(values, &mut headers, configuration, starting_idx, &color_hm);
+    let entries = values_to_entries(
+        values,
+        &mut headers,
+        &configuration,
+        starting_idx,
+        &color_hm,
+    );
     nu_table::Table {
         headers,
         data: entries,
@@ -67,7 +73,7 @@ pub fn from_list(
 fn values_to_entries(
     values: &[Value],
     headers: &mut Vec<StyledString>,
-    configuration: &TableConfiguration,
+    configuration: &NuConfig,
     starting_idx: usize,
     color_hm: &HashMap<String, nu_ansi_term::Style>,
 ) -> Vec<Vec<StyledString>> {
@@ -158,8 +164,9 @@ fn values_to_entries(
     entries
 }
 
-fn table(configuration: TableConfiguration, args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn table(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let mut args = args.evaluate_once()?;
+    let configuration = args.configs.lock().global_config();
 
     // Ideally, get_color_config would get all the colors configured in the config.toml
     // and create a style based on those settings. However, there are few places where
@@ -167,7 +174,7 @@ fn table(configuration: TableConfiguration, args: CommandArgs) -> Result<OutputS
     // more than just color, it needs fg & bg color, bold, dimmed, italic, underline,
     // blink, reverse, hidden, strikethrough and most of those aren't available in the
     // config.toml.... yet.
-    let color_hm = get_color_config();
+    let color_hm = get_color_config(&configuration);
 
     let mut start_number = if let Some(f) = args.get_flag("start_number") {
         f?

--- a/crates/nu-data/src/primitive.rs
+++ b/crates/nu-data/src/primitive.rs
@@ -1,6 +1,6 @@
+use crate::config::NuConfig;
 use nu_ansi_term::{Color, Style};
 use nu_protocol::{hir::Number, Primitive, Value};
-use nu_source::Tag;
 use nu_table::{Alignment, TextStyle};
 use std::collections::HashMap;
 
@@ -121,7 +121,9 @@ fn update_hashmap(key: &str, val: &Value, hm: &mut HashMap<String, Style>) {
     }
 }
 
-pub fn get_color_config() -> HashMap<String, Style> {
+pub fn get_color_config(config: &NuConfig) -> HashMap<String, Style> {
+    let config = &config.vars;
+
     // create the hashmap
     let mut hm: HashMap<String, Style> = HashMap::new();
     // set some defaults
@@ -150,72 +152,70 @@ pub fn get_color_config() -> HashMap<String, Style> {
     );
 
     // populate hashmap from config values
-    if let Ok(config) = crate::config::config(Tag::unknown()) {
-        if let Some(primitive_color_vars) = config.get("color_config") {
-            for (key, value) in primitive_color_vars.row_entries() {
-                match key.as_ref() {
-                    "primitive_int" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_decimal" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_filesize" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_string" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_line" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_columnpath" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_pattern" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_boolean" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_date" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_duration" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_range" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_path" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "primitive_binary" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "separator_color" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "header_align" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "header_color" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "header_bold" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "header_style" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "index_color" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    "leading_trailing_space_bg" => {
-                        update_hashmap(&key, &value, &mut hm);
-                    }
-                    _ => (),
+    if let Some(primitive_color_vars) = config.get("color_config") {
+        for (key, value) in primitive_color_vars.row_entries() {
+            match key.as_ref() {
+                "primitive_int" => {
+                    update_hashmap(&key, &value, &mut hm);
                 }
+                "primitive_decimal" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_filesize" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_string" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_line" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_columnpath" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_pattern" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_boolean" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_date" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_duration" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_range" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_path" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "primitive_binary" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "separator_color" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "header_align" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "header_color" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "header_bold" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "header_style" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "index_color" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                "leading_trailing_space_bg" => {
+                    update_hashmap(&key, &value, &mut hm);
+                }
+                _ => (),
             }
         }
     }

--- a/crates/nu-engine/src/config_holder.rs
+++ b/crates/nu-engine/src/config_holder.rs
@@ -24,6 +24,13 @@ impl ConfigHolder {
         }
     }
 
+    pub fn global_config(&self) -> NuConfig {
+        match &self.global_config {
+            Some(config) => config.clone(),
+            None => NuConfig::default(),
+        }
+    }
+
     pub fn add_local_cfg(&mut self, cfg: NuConfig) {
         self.local_configs.push(cfg);
     }


### PR DESCRIPTION
Expanding on #3285, here we avoid any direct configuration reading from files and depend on in-memory configuration instead.