### PR TITLE
Move from using a Block to an Arc'd Block

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -233,7 +233,11 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
                 context.scope.enter_scope();
                 let (mut prompt_block, err) = nu_parser::parse(&prompt_line, 0, &context.scope);
 
-                prompt_block.set_redirect(ExternalRedirection::Stdout);
+                if let Some(block) =
+                    std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut prompt_block)
+                {
+                    block.set_redirect(ExternalRedirection::Stdout);
+                }
 
                 if err.is_some() {
                     context.scope.exit_scope();

--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -254,6 +254,8 @@ pub fn completion_location(line: &str, block: &Block, pos: usize) -> Vec<Complet
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     use nu_parser::{classify_block, lex, parse_block, ParserScope};
@@ -285,9 +287,9 @@ mod tests {
             todo!()
         }
 
-        fn add_definition(&self, _block: Block) {}
+        fn add_definition(&self, _block: Arc<Block>) {}
 
-        fn get_definitions(&self) -> Vec<Block> {
+        fn get_definitions(&self) -> Vec<Arc<Block>> {
             vec![]
         }
 

--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -166,21 +166,23 @@ where
     }
 }
 
-fn add_implicit_autoview(mut block: Block) -> Block {
-    if block.block.is_empty() {
-        let group = Group::new(
-            vec![{
-                let mut commands = Pipeline::new(block.span);
-                commands.push(ClassifiedCommand::Internal(InternalCommand::new(
-                    "autoview".to_string(),
-                    block.span,
-                    block.span,
-                )));
-                commands
-            }],
-            block.span,
-        );
-        block.push(group);
+fn add_implicit_autoview(mut block: Arc<Block>) -> Arc<Block> {
+    if let Some(block) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block) {
+        if block.block.is_empty() {
+            let group = Group::new(
+                vec![{
+                    let mut commands = Pipeline::new(block.span);
+                    commands.push(ClassifiedCommand::Internal(InternalCommand::new(
+                        "autoview".to_string(),
+                        block.span,
+                        block.span,
+                    )));
+                    commands
+                }],
+                block.span,
+            );
+            block.push(group);
+        }
     }
     block
 }

--- a/crates/nu-command/src/commands/do_.rs
+++ b/crates/nu-command/src/commands/do_.rs
@@ -81,7 +81,9 @@ fn do_(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
         x => x,
     };
 
-    block.block.set_redirect(block_redirection);
+    if let Some(block) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block.block) {
+        block.set_redirect(block_redirection);
+    }
     context.scope.enter_scope();
     let result = run_block(&block.block, &context, input);
     context.scope.exit_scope();

--- a/crates/nu-command/src/commands/with_env.rs
+++ b/crates/nu-command/src/commands/with_env.rs
@@ -78,7 +78,9 @@ fn with_env(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
         input,
     ) = raw_args.process()?;
 
-    block.block.set_redirect(redirection);
+    if let Some(block) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block.block) {
+        block.set_redirect(redirection);
+    }
 
     let mut env = IndexMap::new();
 

--- a/crates/nu-engine/src/evaluate/scope.rs
+++ b/crates/nu-engine/src/evaluate/scope.rs
@@ -61,7 +61,7 @@ impl Scope {
         }
     }
 
-    pub fn get_custom_commands_with_name(&self, name: &str) -> Option<Vec<Block>> {
+    pub fn get_custom_commands_with_name(&self, name: &str) -> Option<Vec<Arc<Block>>> {
         let custom_commands: Vec<_> = self
             .frames
             .lock()
@@ -307,7 +307,7 @@ impl ParserScope for Scope {
         self.get_command(name).is_some()
     }
 
-    fn add_definition(&self, block: Block) {
+    fn add_definition(&self, block: Arc<Block>) {
         if let Some(frame) = self.frames.lock().last_mut() {
             let name = block.params.name.clone();
             frame.custom_commands.insert(name.clone(), block.clone());
@@ -315,7 +315,7 @@ impl ParserScope for Scope {
         }
     }
 
-    fn get_definitions(&self) -> Vec<Block> {
+    fn get_definitions(&self) -> Vec<Arc<Block>> {
         let mut blocks = vec![];
         if let Some(frame) = self.frames.lock().last() {
             for (_, custom_command) in &frame.custom_commands {
@@ -356,7 +356,7 @@ pub struct ScopeFrame {
     pub vars: IndexMap<String, Value>,
     pub env: IndexMap<String, String>,
     pub commands: IndexMap<String, Command>,
-    pub custom_commands: IndexMap<String, Block>,
+    pub custom_commands: IndexMap<String, Arc<Block>>,
     pub aliases: IndexMap<String, Vec<Spanned<String>>>,
     ///Optional tag to better identify this scope frame later
     pub tag: Option<String>,

--- a/crates/nu-engine/src/whole_stream_command.rs
+++ b/crates/nu-engine/src/whole_stream_command.rs
@@ -44,7 +44,7 @@ pub trait WholeStreamCommand: Send + Sync {
 // implement a WholeStreamCommand
 #[allow(clippy::suspicious_else_formatting)]
 
-impl WholeStreamCommand for Block {
+impl WholeStreamCommand for Arc<Block> {
     fn name(&self) -> &str {
         &self.params.name
     }
@@ -61,7 +61,10 @@ impl WholeStreamCommand for Block {
         let call_info = args.call_info.clone();
 
         let mut block = self.clone();
-        block.set_redirect(call_info.args.external_redirection);
+
+        if let Some(block) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block) {
+            block.set_redirect(call_info.args.external_redirection);
+        }
 
         let ctx = EvaluationContext::from_args(&args);
         let evaluated = call_info.evaluate(&ctx)?;

--- a/crates/nu-parser/src/scope.rs
+++ b/crates/nu-parser/src/scope.rs
@@ -1,15 +1,15 @@
 use nu_protocol::hir::Block;
 use nu_source::Spanned;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 pub trait ParserScope: Debug {
     fn get_signature(&self, name: &str) -> Option<nu_protocol::Signature>;
 
     fn has_signature(&self, name: &str) -> bool;
 
-    fn add_definition(&self, block: Block);
+    fn add_definition(&self, block: Arc<Block>);
 
-    fn get_definitions(&self) -> Vec<Block>;
+    fn get_definitions(&self) -> Vec<Arc<Block>>;
 
     fn get_alias(&self, name: &str) -> Option<Vec<Spanned<String>>>;
 


### PR DESCRIPTION
This moves us from using a Block to using an Arc<Block>. The latter is far cheaper to clone.