### PR TITLE
Split OutputStream into ActionStream/OutputStream

### DIFF
--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -30,7 +30,7 @@ pub use nu_data::config;
 pub use nu_data::dict::TaggedListBuilder;
 pub use nu_data::primitive;
 pub use nu_data::value;
-pub use nu_stream::{InputStream, InterruptibleStream, OutputStream};
+pub use nu_stream::{ActionStream, InputStream, InterruptibleStream};
 pub use nu_value_ext::ValueExt;
 pub use num_traits::cast::ToPrimitive;
 

--- a/crates/nu-cli/src/prelude.rs
+++ b/crates/nu-cli/src/prelude.rs
@@ -57,20 +57,3 @@ where
         }
     }
 }
-
-#[allow(clippy::clippy::wrong_self_convention)]
-pub trait ToOutputStream {
-    fn to_output_stream(self) -> ActionStream;
-}
-
-impl<T, U> ToOutputStream for T
-where
-    T: Iterator<Item = U> + Send + Sync + 'static,
-    U: Into<nu_protocol::ReturnValue>,
-{
-    fn to_output_stream(self) -> ActionStream {
-        ActionStream {
-            values: Box::new(self.map(|item| item.into())),
-        }
-    }
-}

--- a/crates/nu-cli/src/prelude.rs
+++ b/crates/nu-cli/src/prelude.rs
@@ -36,7 +36,7 @@ pub(crate) use nu_engine::Host;
 pub(crate) use nu_errors::ShellError;
 #[allow(unused_imports)]
 pub(crate) use nu_protocol::outln;
-pub(crate) use nu_stream::OutputStream;
+pub(crate) use nu_stream::ActionStream;
 #[allow(unused_imports)]
 pub(crate) use nu_value_ext::ValueExt;
 #[allow(unused_imports)]
@@ -44,15 +44,15 @@ pub(crate) use std::sync::atomic::Ordering;
 
 #[allow(clippy::clippy::wrong_self_convention)]
 pub trait FromInputStream {
-    fn from_input_stream(self) -> OutputStream;
+    fn from_input_stream(self) -> ActionStream;
 }
 
 impl<T> FromInputStream for T
 where
     T: Iterator<Item = nu_protocol::Value> + Send + Sync + 'static,
 {
-    fn from_input_stream(self) -> OutputStream {
-        OutputStream {
+    fn from_input_stream(self) -> ActionStream {
+        ActionStream {
             values: Box::new(self.map(nu_protocol::ReturnSuccess::value)),
         }
     }
@@ -60,7 +60,7 @@ where
 
 #[allow(clippy::clippy::wrong_self_convention)]
 pub trait ToOutputStream {
-    fn to_output_stream(self) -> OutputStream;
+    fn to_output_stream(self) -> ActionStream;
 }
 
 impl<T, U> ToOutputStream for T
@@ -68,8 +68,8 @@ where
     T: Iterator<Item = U> + Send + Sync + 'static,
     U: Into<nu_protocol::ReturnValue>,
 {
-    fn to_output_stream(self) -> OutputStream {
-        OutputStream {
+    fn to_output_stream(self) -> ActionStream {
+        ActionStream {
             values: Box::new(self.map(|item| item.into())),
         }
     }

--- a/crates/nu-command/src/commands/all.rs
+++ b/crates/nu-command/src/commands/all.rs
@@ -5,7 +5,7 @@ use nu_errors::ShellError;
 use nu_protocol::{
     hir::CapturedBlock, hir::ClassifiedCommand, Signature, SyntaxShape, UntaggedValue,
 };
-use nu_stream::ToOutputStreamWithActions;
+use nu_stream::ToActionStream;
 
 pub struct Command;
 
@@ -118,7 +118,7 @@ fn all(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 Err(e) => Err(e),
             }
         })?
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/all.rs
+++ b/crates/nu-command/src/commands/all.rs
@@ -5,6 +5,7 @@ use nu_errors::ShellError;
 use nu_protocol::{
     hir::CapturedBlock, hir::ClassifiedCommand, Signature, SyntaxShape, UntaggedValue,
 };
+use nu_stream::ToOutputStreamWithActions;
 
 pub struct Command;
 
@@ -30,7 +31,7 @@ impl WholeStreamCommand for Command {
         "Find if the table rows matches the condition."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         all(args)
     }
 
@@ -52,7 +53,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn all(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn all(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let ctx = Arc::new(EvaluationContext::from_args(&args));
     let tag = args.call_info.name_tag.clone();
     let (Arguments { block }, input) = args.process()?;
@@ -117,7 +118,7 @@ fn all(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 Err(e) => Err(e),
             }
         })?
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/ansi/command.rs
+++ b/crates/nu-command/src/commands/ansi/command.rs
@@ -112,7 +112,7 @@ Format: #
         ]
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let args = args.evaluate_once()?;
 
         let code: Option<Result<Tagged<String>, ShellError>> = args.opt(0);
@@ -130,7 +130,7 @@ Format: #
                 ));
             }
             let output = format!("\x1b[{}", e.item);
-            return Ok(OutputStream::one(ReturnSuccess::value(
+            return Ok(ActionStream::one(ReturnSuccess::value(
                 UntaggedValue::string(output).into_value(e.tag()),
             )));
         }
@@ -149,7 +149,7 @@ Format: #
             //Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
             // OCS's need to end with a bell '\x07' char
             let output = format!("\x1b]{};", o.item);
-            return Ok(OutputStream::one(ReturnSuccess::value(
+            return Ok(ActionStream::one(ReturnSuccess::value(
                 UntaggedValue::string(output).into_value(o.tag()),
             )));
         }
@@ -159,7 +159,7 @@ Format: #
             let ansi_code = str_to_ansi(&code.item);
 
             if let Some(output) = ansi_code {
-                Ok(OutputStream::one(ReturnSuccess::value(
+                Ok(ActionStream::one(ReturnSuccess::value(
                     UntaggedValue::string(output).into_value(code.tag()),
                 )))
             } else {

--- a/crates/nu-command/src/commands/ansi/strip.rs
+++ b/crates/nu-command/src/commands/ansi/strip.rs
@@ -65,7 +65,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/ansi/strip.rs
+++ b/crates/nu-command/src/commands/ansi/strip.rs
@@ -31,7 +31,7 @@ impl WholeStreamCommand for SubCommand {
         "strip ansi escape sequences from string"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -44,7 +44,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { rest }, input) = args.process()?;
     let column_paths: Vec<_> = rest;
 
@@ -65,7 +65,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/any.rs
+++ b/crates/nu-command/src/commands/any.rs
@@ -117,7 +117,7 @@ fn any(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 Err(e) => Err(e),
             }
         })?
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/any.rs
+++ b/crates/nu-command/src/commands/any.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for Command {
         "Find if the table rows matches the condition."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         any(args)
     }
 
@@ -52,7 +52,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn any(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn any(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let ctx = Arc::new(EvaluationContext::from_args(&args));
     let tag = args.call_info.name_tag.clone();
     let (Arguments { block }, input) = args.process()?;
@@ -117,7 +117,7 @@ fn any(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 Err(e) => Err(e),
             }
         })?
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/append.rs
+++ b/crates/nu-command/src/commands/append.rs
@@ -51,7 +51,7 @@ impl WholeStreamCommand for Command {
             .into_iter()
             .chain(vec![value])
             .map(ReturnSuccess::value)
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/commands/append.rs
+++ b/crates/nu-command/src/commands/append.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for Command {
         "Append a row to the table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let (Arguments { mut value }, input) = args.process()?;
 
         let input: Vec<Value> = input.collect();
@@ -51,7 +51,7 @@ impl WholeStreamCommand for Command {
             .into_iter()
             .chain(vec![value])
             .map(ReturnSuccess::value)
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/commands/autoenv.rs
+++ b/crates/nu-command/src/commands/autoenv.rs
@@ -25,8 +25,8 @@ The .nu-env file has the same format as your $HOME/nu/config.toml file. By loadi
     fn signature(&self) -> Signature {
         Signature::build("autoenv")
     }
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&Autoenv, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/autoenv_trust.rs
+++ b/crates/nu-command/src/commands/autoenv_trust.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for AutoenvTrust {
         "Trust a .nu-env file in the current or given directory"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let ctx = EvaluationContext::from_args(&args);
 
@@ -55,7 +55,7 @@ impl WholeStreamCommand for AutoenvTrust {
         })?;
         fs::write(config_path, tomlstr).expect("Couldn't write to toml file");
 
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(".nu-env trusted!").into_value(tag),
         )))
     }

--- a/crates/nu-command/src/commands/autoenv_untrust.rs
+++ b/crates/nu-command/src/commands/autoenv_untrust.rs
@@ -25,7 +25,7 @@ impl WholeStreamCommand for AutoenvUnTrust {
         "Untrust a .nu-env file in the current or given directory"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let ctx = EvaluationContext::from_args(&args);
         let file_to_untrust = match args.call_info.evaluate(&ctx)?.args.nth(0) {
@@ -79,7 +79,7 @@ impl WholeStreamCommand for AutoenvUnTrust {
         })?;
         fs::write(config_path, tomlstr).expect("Couldn't write to toml file");
 
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(".nu-env untrusted!").into_value(tag),
         )))
     }

--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -80,7 +80,7 @@ pub fn autoview(context: CommandArgs) -> Result<OutputStream, ShellError> {
                             );
                             let command_args =
                                 create_default_command_args(&context).with_input(stream);
-                            let result = text.run(command_args)?;
+                            let result = text.run_with_actions(command_args)?;
                             let _ = result.collect::<Vec<_>>();
                         } else {
                             out!("{}", s);
@@ -162,7 +162,7 @@ pub fn autoview(context: CommandArgs) -> Result<OutputStream, ShellError> {
                             stream.push_back(x);
                             let command_args =
                                 create_default_command_args(&context).with_input(stream);
-                            let result = binary.run(command_args)?;
+                            let result = binary.run_with_actions(command_args)?;
                             let _ = result.collect::<Vec<_>>();
                         } else {
                             use pretty_hex::*;
@@ -255,7 +255,7 @@ pub fn autoview(context: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     }
 
-    Ok(OutputStream::empty())
+    Ok(InputStream::empty())
 }
 
 fn create_default_command_args(context: &RunnableContextWithoutInput) -> RawCommandArgs {

--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -47,7 +47,7 @@ impl WholeStreamCommand for Benchmark {
         "Runs a block and returns the time it took to execute it."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         benchmark(args)
     }
 
@@ -67,7 +67,7 @@ impl WholeStreamCommand for Benchmark {
     }
 }
 
-fn benchmark(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn benchmark(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = raw_args.call_info.args.span;
     let mut context = EvaluationContext::from_args(&raw_args);
     let scope = raw_args.scope.clone();
@@ -134,10 +134,10 @@ fn benchmark_output<T, Output>(
     passthrough: Option<CapturedBlock>,
     tag: T,
     context: &mut EvaluationContext,
-) -> Result<OutputStream, ShellError>
+) -> Result<ActionStream, ShellError>
 where
     T: Into<Tag> + Copy,
-    Output: Into<OutputStream>,
+    Output: Into<ActionStream>,
 {
     let value = UntaggedValue::Row(Dictionary::from(
         indexmap
@@ -161,7 +161,7 @@ where
 
         Ok(block_output.into())
     } else {
-        let benchmark_output = OutputStream::one(value);
+        let benchmark_output = ActionStream::one(value);
         Ok(benchmark_output)
     }
 }

--- a/crates/nu-command/src/commands/build_string.rs
+++ b/crates/nu-command/src/commands/build_string.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for BuildString {
         "Builds a string from the arguments."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let rest: Vec<Value> = args.rest(0)?;
@@ -32,7 +32,7 @@ impl WholeStreamCommand for BuildString {
             output_string.push_str(&format_leaf(&r).plain_string(100_000))
         }
 
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(output_string).into_value(tag),
         )))
     }

--- a/crates/nu-command/src/commands/cal.rs
+++ b/crates/nu-command/src/commands/cal.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for Cal {
         "Display a calendar."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         cal(args)
     }
 
@@ -65,7 +65,7 @@ impl WholeStreamCommand for Cal {
     }
 }
 
-pub fn cal(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn cal(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let mut calendar_vec_deque = VecDeque::new();
     let tag = args.call_info.name_tag.clone();
@@ -101,7 +101,7 @@ pub fn cal(args: CommandArgs) -> Result<OutputStream, ShellError> {
         current_day_option,
     )?;
 
-    Ok(calendar_vec_deque.into_iter().to_output_stream())
+    Ok(calendar_vec_deque.into_iter().to_output_stream_with_actions())
 }
 
 fn get_invalid_year_shell_error(year_tag: &Tag) -> ShellError {

--- a/crates/nu-command/src/commands/cal.rs
+++ b/crates/nu-command/src/commands/cal.rs
@@ -101,9 +101,7 @@ pub fn cal(args: CommandArgs) -> Result<ActionStream, ShellError> {
         current_day_option,
     )?;
 
-    Ok(calendar_vec_deque
-        .into_iter()
-        .to_action_stream())
+    Ok(calendar_vec_deque.into_iter().to_action_stream())
 }
 
 fn get_invalid_year_shell_error(year_tag: &Tag) -> ShellError {

--- a/crates/nu-command/src/commands/cal.rs
+++ b/crates/nu-command/src/commands/cal.rs
@@ -103,7 +103,7 @@ pub fn cal(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     Ok(calendar_vec_deque
         .into_iter()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn get_invalid_year_shell_error(year_tag: &Tag) -> ShellError {

--- a/crates/nu-command/src/commands/cal.rs
+++ b/crates/nu-command/src/commands/cal.rs
@@ -101,7 +101,9 @@ pub fn cal(args: CommandArgs) -> Result<ActionStream, ShellError> {
         current_day_option,
     )?;
 
-    Ok(calendar_vec_deque.into_iter().to_output_stream_with_actions())
+    Ok(calendar_vec_deque
+        .into_iter()
+        .to_output_stream_with_actions())
 }
 
 fn get_invalid_year_shell_error(year_tag: &Tag) -> ShellError {

--- a/crates/nu-command/src/commands/cd.rs
+++ b/crates/nu-command/src/commands/cd.rs
@@ -24,7 +24,7 @@ impl WholeStreamCommand for Cd {
         "Change to a new path."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let name = args.call_info.name_tag.clone();
         let shell_manager = args.shell_manager.clone();
         let (args, _): (CdArgs, _) = args.process()?;

--- a/crates/nu-command/src/commands/char_.rs
+++ b/crates/nu-command/src/commands/char_.rs
@@ -57,7 +57,7 @@ impl WholeStreamCommand for Char {
         ]
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let args = args.evaluate_once()?;
 
         let name: Tagged<String> = args.req(0)?;
@@ -83,13 +83,13 @@ impl WholeStreamCommand for Char {
                         Err(e) => return Err(e),
                     }
                 }
-                Ok(OutputStream::one(ReturnSuccess::value(
+                Ok(ActionStream::one(ReturnSuccess::value(
                     UntaggedValue::string(multi_byte).into_value(name.tag),
                 )))
             } else {
                 let decoded_char = string_to_unicode_char(&name.item, &name.tag);
                 if let Ok(ch) = decoded_char {
-                    Ok(OutputStream::one(ReturnSuccess::value(
+                    Ok(ActionStream::one(ReturnSuccess::value(
                         UntaggedValue::string(ch).into_value(name.tag()),
                     )))
                 } else {
@@ -103,7 +103,7 @@ impl WholeStreamCommand for Char {
         } else {
             let special_character = str_to_character(&name.item);
             if let Some(output) = special_character {
-                Ok(OutputStream::one(ReturnSuccess::value(
+                Ok(ActionStream::one(ReturnSuccess::value(
                     UntaggedValue::string(output).into_value(name.tag()),
                 )))
             } else {

--- a/crates/nu-command/src/commands/chart.rs
+++ b/crates/nu-command/src/commands/chart.rs
@@ -19,14 +19,14 @@ impl WholeStreamCommand for Chart {
         "Displays charts."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         if args.scope.get_command("chart bar").is_none() {
             return Err(ShellError::untagged_runtime_error(
                 "nu_plugin_chart not installed.",
             ));
         }
 
-        Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+        Ok(ActionStream::one(Ok(ReturnSuccess::Value(
             UntaggedValue::string(get_full_help(&Chart, &args.scope)).into_value(Tag::unknown()),
         ))))
     }

--- a/crates/nu-command/src/commands/clear.rs
+++ b/crates/nu-command/src/commands/clear.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for Clear {
         "Clears the terminal."
     }
 
-    fn run(&self, _: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run(&self, _: CommandArgs) -> Result<InputStream, ShellError> {
         if cfg!(windows) {
             Command::new("cmd")
                 .args(&["/C", "cls"])
@@ -31,7 +31,7 @@ impl WholeStreamCommand for Clear {
                 .status()
                 .expect("failed to execute process");
         }
-        Ok(OutputStream::empty())
+        Ok(InputStream::empty())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/commands/clip.rs
+++ b/crates/nu-command/src/commands/clip.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for Clip {
         "Copy the contents of the pipeline to the copy/paste buffer."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         clip(args)
     }
 
@@ -41,9 +41,9 @@ impl WholeStreamCommand for Clip {
     }
 }
 
-pub fn clip(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn clip(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let input = args.input;
-    let name = args.call_info.name_tag.clone();
+    let name = args.call_info.name_tag;
     let values: Vec<Value> = input.collect();
 
     if let Ok(mut clip_context) = Clipboard::new() {
@@ -88,7 +88,7 @@ pub fn clip(args: CommandArgs) -> Result<OutputStream, ShellError> {
             name,
         ));
     }
-    Ok(OutputStream::empty())
+    Ok(ActionStream::empty())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/compact.rs
+++ b/crates/nu-command/src/commands/compact.rs
@@ -67,7 +67,7 @@ pub fn compact(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 }
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/compact.rs
+++ b/crates/nu-command/src/commands/compact.rs
@@ -25,7 +25,7 @@ impl WholeStreamCommand for Compact {
         "Creates a table with non-empty rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         compact(args)
     }
 
@@ -38,7 +38,7 @@ impl WholeStreamCommand for Compact {
     }
 }
 
-pub fn compact(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn compact(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (CompactArgs { rest: columns }, input) = args.process()?;
     Ok(input
         .filter_map(move |item| {
@@ -67,7 +67,7 @@ pub fn compact(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 }
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/config/clear.rs
+++ b/crates/nu-command/src/commands/config/clear.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for SubCommand {
         "clear the config"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         clear(args)
     }
 
@@ -31,14 +31,14 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn clear(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn clear(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let ctx = EvaluationContext::from_args(&args);
 
     let result = if let Some(global_cfg) = &mut args.configs.lock().global_config {
         global_cfg.vars.clear();
         global_cfg.write()?;
         ctx.reload_config(global_cfg)?;
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::Row(global_cfg.vars.clone().into()).into_value(args.call_info.name_tag),
         )))
     } else {
@@ -46,7 +46,7 @@ pub fn clear(args: CommandArgs) -> Result<OutputStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream())
+        .to_output_stream_with_actions())
     };
 
     result

--- a/crates/nu-command/src/commands/config/clear.rs
+++ b/crates/nu-command/src/commands/config/clear.rs
@@ -46,7 +46,7 @@ pub fn clear(args: CommandArgs) -> Result<ActionStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream_with_actions())
+        .to_action_stream())
     };
 
     result

--- a/crates/nu-command/src/commands/config/command.rs
+++ b/crates/nu-command/src/commands/config/command.rs
@@ -29,13 +29,13 @@ impl WholeStreamCommand for Command {
                 UntaggedValue::Row(result.into()).into_value(name),
             )]
             .into_iter()
-            .to_output_stream_with_actions())
+            .to_action_stream())
         } else {
             Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
                 crate::commands::config::err_no_global_cfg_present(),
             ))]
             .into_iter()
-            .to_output_stream_with_actions())
+            .to_action_stream())
         }
     }
 }

--- a/crates/nu-command/src/commands/config/command.rs
+++ b/crates/nu-command/src/commands/config/command.rs
@@ -3,7 +3,7 @@ use nu_engine::CommandArgs;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
-use nu_stream::OutputStream;
+use nu_stream::ActionStream;
 
 pub struct Command;
 
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Command {
         "Configuration management."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let name = args.call_info.name_tag;
 
         if let Some(global_cfg) = &args.configs.lock().global_config {
@@ -29,13 +29,13 @@ impl WholeStreamCommand for Command {
                 UntaggedValue::Row(result.into()).into_value(name),
             )]
             .into_iter()
-            .to_output_stream())
+            .to_output_stream_with_actions())
         } else {
             Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
                 crate::commands::config::err_no_global_cfg_present(),
             ))]
             .into_iter()
-            .to_output_stream())
+            .to_output_stream_with_actions())
         }
     }
 }

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -53,7 +53,7 @@ pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => list.into_iter().to_output_stream_with_actions(),
+            } => list.into_iter().to_action_stream(),
             x => ActionStream::one(ReturnSuccess::value(x)),
         })
     } else {
@@ -61,7 +61,7 @@ pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream_with_actions())
+        .to_action_stream())
     };
 
     result

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for SubCommand {
         "Gets a value from the config"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         get(args)
     }
 
@@ -40,7 +40,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
 
@@ -53,15 +53,15 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => list.into_iter().to_output_stream(),
-            x => OutputStream::one(ReturnSuccess::value(x)),
+            } => list.into_iter().to_output_stream_with_actions(),
+            x => ActionStream::one(ReturnSuccess::value(x)),
         })
     } else {
         Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream())
+        .to_output_stream_with_actions())
     };
 
     result

--- a/crates/nu-command/src/commands/config/path.rs
+++ b/crates/nu-command/src/commands/config/path.rs
@@ -41,6 +41,6 @@ pub fn path(args: CommandArgs) -> Result<ActionStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream_with_actions())
+        .to_action_stream())
     }
 }

--- a/crates/nu-command/src/commands/config/path.rs
+++ b/crates/nu-command/src/commands/config/path.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for SubCommand {
         "return the path to the config file"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         path(args)
     }
 
@@ -31,9 +31,9 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn path(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn path(args: CommandArgs) -> Result<ActionStream, ShellError> {
     if let Some(global_cfg) = &mut args.configs.lock().global_config {
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::Primitive(Primitive::FilePath(global_cfg.file_path.clone())),
         )))
     } else {
@@ -41,6 +41,6 @@ pub fn path(args: CommandArgs) -> Result<OutputStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream())
+        .to_output_stream_with_actions())
     }
 }

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for SubCommand {
         "Removes a value from the config"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         remove(args)
     }
 
@@ -41,7 +41,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn remove(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let ctx = EvaluationContext::from_args(&args);
     let (Arguments { remove }, _) = args.process()?;
 
@@ -56,7 +56,7 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 UntaggedValue::row(global_cfg.vars.clone()).into_value(remove.tag()),
             )]
             .into_iter()
-            .to_output_stream())
+            .to_output_stream_with_actions())
         } else {
             Err(ShellError::labeled_error(
                 "Key does not exist in config",
@@ -69,7 +69,7 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream())
+        .to_output_stream_with_actions())
     };
 
     result

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -56,7 +56,7 @@ pub fn remove(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 UntaggedValue::row(global_cfg.vars.clone()).into_value(remove.tag()),
             )]
             .into_iter()
-            .to_output_stream_with_actions())
+            .to_action_stream())
         } else {
             Err(ShellError::labeled_error(
                 "Key does not exist in config",
@@ -69,7 +69,7 @@ pub fn remove(args: CommandArgs) -> Result<ActionStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream_with_actions())
+        .to_action_stream())
     };
 
     result

--- a/crates/nu-command/src/commands/config/set.rs
+++ b/crates/nu-command/src/commands/config/set.rs
@@ -97,7 +97,7 @@ pub fn set(args: CommandArgs) -> Result<ActionStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream_with_actions())
+        .to_action_stream())
     };
 
     result

--- a/crates/nu-command/src/commands/config/set.rs
+++ b/crates/nu-command/src/commands/config/set.rs
@@ -26,7 +26,7 @@ impl WholeStreamCommand for SubCommand {
         "Sets a value in the config"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         set(args)
     }
 
@@ -56,7 +56,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn set(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn set(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
     let (
@@ -85,11 +85,11 @@ pub fn set(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 global_cfg.write()?;
                 ctx.reload_config(global_cfg)?;
 
-                Ok(OutputStream::one(ReturnSuccess::value(
+                Ok(ActionStream::one(ReturnSuccess::value(
                     UntaggedValue::row(global_cfg.vars.clone()).into_value(name),
                 )))
             }
-            Ok(_) => Ok(OutputStream::empty()),
+            Ok(_) => Ok(ActionStream::empty()),
             Err(reason) => Err(reason),
         }
     } else {
@@ -97,7 +97,7 @@ pub fn set(args: CommandArgs) -> Result<OutputStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream())
+        .to_output_stream_with_actions())
     };
 
     result

--- a/crates/nu-command/src/commands/config/set_into.rs
+++ b/crates/nu-command/src/commands/config/set_into.rs
@@ -79,7 +79,7 @@ pub fn set_into(args: CommandArgs) -> Result<ActionStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream_with_actions())
+        .to_action_stream())
     };
 
     result

--- a/crates/nu-command/src/commands/config/set_into.rs
+++ b/crates/nu-command/src/commands/config/set_into.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for SubCommand {
         "Sets a value in the config"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         set_into(args)
     }
 
@@ -41,7 +41,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn set_into(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
     let (Arguments { set_into: v }, input) = args.process()?;
@@ -71,7 +71,7 @@ pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
         global_cfg.write()?;
         ctx.reload_config(global_cfg)?;
 
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::row(global_cfg.vars.clone()).into_value(name),
         )))
     } else {
@@ -79,7 +79,7 @@ pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
             crate::commands::config::err_no_global_cfg_present(),
         ))]
         .into_iter()
-        .to_output_stream())
+        .to_output_stream_with_actions())
     };
 
     result

--- a/crates/nu-command/src/commands/cp.rs
+++ b/crates/nu-command/src/commands/cp.rs
@@ -25,7 +25,7 @@ impl WholeStreamCommand for Cpy {
         "Copy files."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let shell_manager = args.shell_manager.clone();
         let name = args.call_info.name_tag.clone();
         let (args, _) = args.process()?;

--- a/crates/nu-command/src/commands/date/command.rs
+++ b/crates/nu-command/src/commands/date/command.rs
@@ -18,8 +18,8 @@ impl WholeStreamCommand for Command {
         "Apply date function."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&Command, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/date/format.rs
+++ b/crates/nu-command/src/commands/date/format.rs
@@ -91,7 +91,7 @@ pub fn format(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 &tag,
             )),
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/format.rs
+++ b/crates/nu-command/src/commands/date/format.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for Date {
         "Format a given date using the given format string."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         format(args)
     }
 
@@ -50,7 +50,7 @@ impl WholeStreamCommand for Date {
     }
 }
 
-pub fn format(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn format(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let (FormatArgs { format, table }, input) = args.process()?;
 
@@ -91,7 +91,7 @@ pub fn format(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 &tag,
             )),
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/list_timezone.rs
+++ b/crates/nu-command/src/commands/date/list_timezone.rs
@@ -57,7 +57,7 @@ fn list_timezone(args: CommandArgs) -> Result<ActionStream, ShellError> {
         ))
     });
 
-    Ok(list.into_iter().to_output_stream_with_actions())
+    Ok(list.into_iter().to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/list_timezone.rs
+++ b/crates/nu-command/src/commands/date/list_timezone.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Date {
         "List supported time zones."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         list_timezone(args)
     }
 
@@ -40,7 +40,7 @@ impl WholeStreamCommand for Date {
     }
 }
 
-fn list_timezone(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn list_timezone(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.call_info.name_tag.clone();
 
@@ -57,7 +57,7 @@ fn list_timezone(args: CommandArgs) -> Result<OutputStream, ShellError> {
         ))
     });
 
-    Ok(list.into_iter().to_output_stream())
+    Ok(list.into_iter().to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/now.rs
+++ b/crates/nu-command/src/commands/date/now.rs
@@ -19,12 +19,12 @@ impl WholeStreamCommand for Date {
         "Get the current date."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         now(args)
     }
 }
 
-pub fn now(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn now(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.call_info.name_tag.clone();
 
@@ -32,7 +32,7 @@ pub fn now(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let value = UntaggedValue::date(now.with_timezone(now.offset())).into_value(&tag);
 
-    Ok(OutputStream::one(value))
+    Ok(ActionStream::one(value))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/to_table.rs
+++ b/crates/nu-command/src/commands/date/to_table.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Date {
         "Print the date in a structured table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_table(args)
     }
 
@@ -33,7 +33,7 @@ impl WholeStreamCommand for Date {
     }
 }
 
-fn to_table(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_table(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.call_info.name_tag.clone();
     let input = args.input;
@@ -87,7 +87,7 @@ fn to_table(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 &tag,
             )),
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/to_table.rs
+++ b/crates/nu-command/src/commands/date/to_table.rs
@@ -87,7 +87,7 @@ fn to_table(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 &tag,
             )),
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/to_timezone.rs
+++ b/crates/nu-command/src/commands/date/to_timezone.rs
@@ -85,7 +85,7 @@ fn to_timezone(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 &tag,
             )),
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn error_message(err: ParseErrorKind) -> &'static str {

--- a/crates/nu-command/src/commands/date/to_timezone.rs
+++ b/crates/nu-command/src/commands/date/to_timezone.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for Date {
         "Use 'date list-timezone' to list all supported time zones."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_timezone(args)
     }
 
@@ -58,7 +58,7 @@ impl WholeStreamCommand for Date {
     }
 }
 
-fn to_timezone(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_timezone(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let (DateToTimeZoneArgs { timezone }, input) = args.process()?;
 
@@ -85,7 +85,7 @@ fn to_timezone(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 &tag,
             )),
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn error_message(err: ParseErrorKind) -> &'static str {

--- a/crates/nu-command/src/commands/date/utc.rs
+++ b/crates/nu-command/src/commands/date/utc.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for Date {
         "return the current date in utc."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         utc(args)
     }
 }

--- a/crates/nu-command/src/commands/debug.rs
+++ b/crates/nu-command/src/commands/debug.rs
@@ -23,12 +23,12 @@ impl WholeStreamCommand for Debug {
         "Print the Rust debug representation of the values."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         debug_value(args)
     }
 }
 
-fn debug_value(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn debug_value(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (DebugArgs { raw }, input) = args.process()?;
     Ok(input
         .map(move |v| {
@@ -40,7 +40,7 @@ fn debug_value(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::debug_value(v)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/debug.rs
+++ b/crates/nu-command/src/commands/debug.rs
@@ -40,7 +40,7 @@ fn debug_value(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::debug_value(v)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/def.rs
+++ b/crates/nu-command/src/commands/def.rs
@@ -34,11 +34,11 @@ impl WholeStreamCommand for Def {
         "Create a command and set it to a definition."
     }
 
-    fn run(&self, _args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, _args: CommandArgs) -> Result<ActionStream, ShellError> {
         // Currently, we don't do anything here because we should have already
         // installed the definition as we entered the scope
         // We just create a command so that we can get proper coloring
-        Ok(OutputStream::empty())
+        Ok(ActionStream::empty())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/commands/default.rs
+++ b/crates/nu-command/src/commands/default.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for Default {
         "Sets a default row's column if missing."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         default(args)
     }
 
@@ -45,7 +45,7 @@ impl WholeStreamCommand for Default {
     }
 }
 
-fn default(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn default(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (DefaultArgs { column, value }, input) = args.process()?;
 
     Ok(input
@@ -67,7 +67,7 @@ fn default(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(item)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/default.rs
+++ b/crates/nu-command/src/commands/default.rs
@@ -67,7 +67,7 @@ fn default(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(item)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/describe.rs
+++ b/crates/nu-command/src/commands/describe.rs
@@ -22,12 +22,12 @@ impl WholeStreamCommand for Describe {
         "Describes the objects in the stream."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         describe(args)
     }
 }
 
-pub fn describe(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn describe(args: CommandArgs) -> Result<ActionStream, ShellError> {
     Ok(args
         .input
         .map(|row| {
@@ -36,7 +36,7 @@ pub fn describe(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 UntaggedValue::string(name).into_value(Tag::unknown_anchor(row.tag.span)),
             )
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/describe.rs
+++ b/crates/nu-command/src/commands/describe.rs
@@ -36,7 +36,7 @@ pub fn describe(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 UntaggedValue::string(name).into_value(Tag::unknown_anchor(row.tag.span)),
             )
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/do_.rs
+++ b/crates/nu-command/src/commands/do_.rs
@@ -96,12 +96,12 @@ fn do_(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
             Ok(mut stream) => {
                 let output = stream.drain_vec();
                 context.clear_errors();
-                Ok(output.into_iter().to_output_stream_with_actions())
+                Ok(output.into_iter().to_action_stream())
             }
             Err(_) => Ok(ActionStream::empty()),
         }
     } else {
-        result.map(|x| x.to_output_stream_with_actions())
+        result.map(|x| x.to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/do_.rs
+++ b/crates/nu-command/src/commands/do_.rs
@@ -31,7 +31,7 @@ impl WholeStreamCommand for Do {
         "Runs a block, optionally ignoring errors."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         do_(args)
     }
 
@@ -51,7 +51,7 @@ impl WholeStreamCommand for Do {
     }
 }
 
-fn do_(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn do_(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let external_redirection = raw_args.call_info.args.external_redirection;
 
     let context = EvaluationContext::from_args(&raw_args);
@@ -96,12 +96,12 @@ fn do_(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
             Ok(mut stream) => {
                 let output = stream.drain_vec();
                 context.clear_errors();
-                Ok(output.into_iter().to_output_stream())
+                Ok(output.into_iter().to_output_stream_with_actions())
             }
-            Err(_) => Ok(OutputStream::empty()),
+            Err(_) => Ok(ActionStream::empty()),
         }
     } else {
-        result.map(|x| x.to_output_stream())
+        result.map(|x| x.to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/drop/column.rs
+++ b/crates/nu-command/src/commands/drop/column.rs
@@ -29,7 +29,7 @@ impl WholeStreamCommand for SubCommand {
         "Remove the last number of columns. If you want to remove columns by name, try 'reject'."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         drop(args)
     }
 
@@ -47,7 +47,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn drop(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn drop(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { columns }, input) = args.process()?;
 
     let to_drop = if let Some(quantity) = columns {
@@ -69,7 +69,7 @@ fn drop(args: CommandArgs) -> Result<OutputStream, ShellError> {
             select_fields(&item, descs, item.tag())
         })
         .map(ReturnSuccess::value)
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/drop/column.rs
+++ b/crates/nu-command/src/commands/drop/column.rs
@@ -69,7 +69,7 @@ fn drop(args: CommandArgs) -> Result<ActionStream, ShellError> {
             select_fields(&item, descs, item.tag())
         })
         .map(ReturnSuccess::value)
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/drop/command.rs
+++ b/crates/nu-command/src/commands/drop/command.rs
@@ -62,7 +62,7 @@ fn drop(args: CommandArgs) -> Result<ActionStream, ShellError> {
     };
 
     Ok(if rows_to_drop == 0 {
-        v.into_iter().to_output_stream_with_actions()
+        v.into_iter().to_action_stream()
     } else {
         let k = if v.len() < rows_to_drop {
             0
@@ -72,6 +72,6 @@ fn drop(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
         let iter = v.into_iter().take(k);
 
-        iter.to_output_stream_with_actions()
+        iter.to_action_stream()
     })
 }

--- a/crates/nu-command/src/commands/drop/command.rs
+++ b/crates/nu-command/src/commands/drop/command.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for Command {
         "Remove the last number of rows or columns."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         drop(args)
     }
 
@@ -51,7 +51,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn drop(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn drop(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { rows }, input) = args.process()?;
     let v: Vec<_> = input.into_vec();
 
@@ -62,7 +62,7 @@ fn drop(args: CommandArgs) -> Result<OutputStream, ShellError> {
     };
 
     Ok(if rows_to_drop == 0 {
-        v.into_iter().to_output_stream()
+        v.into_iter().to_output_stream_with_actions()
     } else {
         let k = if v.len() < rows_to_drop {
             0
@@ -72,6 +72,6 @@ fn drop(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
         let iter = v.into_iter().take(k);
 
-        iter.to_output_stream()
+        iter.to_output_stream_with_actions()
     })
 }

--- a/crates/nu-command/src/commands/du.rs
+++ b/crates/nu-command/src/commands/du.rs
@@ -70,7 +70,7 @@ impl WholeStreamCommand for Du {
         "Find disk usage sizes of specified items."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         du(args)
     }
 
@@ -83,7 +83,7 @@ impl WholeStreamCommand for Du {
     }
 }
 
-fn du(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn du(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let ctrl_c = args.ctrl_c.clone();
     let ctrl_c_copy = ctrl_c.clone();
@@ -150,7 +150,7 @@ fn du(args: CommandArgs) -> Result<OutputStream, ShellError> {
             Err(e) => vec![Err(e)],
         })
         .interruptible(ctrl_c_copy)
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn glob_err_into(e: GlobError) -> ShellError {

--- a/crates/nu-command/src/commands/du.rs
+++ b/crates/nu-command/src/commands/du.rs
@@ -150,7 +150,7 @@ fn du(args: CommandArgs) -> Result<ActionStream, ShellError> {
             Err(e) => vec![Err(e)],
         })
         .interruptible(ctrl_c_copy)
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn glob_err_into(e: GlobError) -> ShellError {

--- a/crates/nu-command/src/commands/each/command.rs
+++ b/crates/nu-command/src/commands/each/command.rs
@@ -90,7 +90,7 @@ pub fn process_row(
 
     context.scope.exit_scope();
 
-    Ok(result?.to_output_stream())
+    result
 }
 
 pub(crate) fn make_indexed_item(index: usize, item: Value) -> Value {
@@ -121,7 +121,7 @@ fn each(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
 
                 match process_row(block, context, row) {
                     Ok(s) => s,
-                    Err(e) => OutputStream::one(Err(e)),
+                    Err(e) => OutputStream::one(Value::error(e)),
                 }
             })
             .flatten()
@@ -135,7 +135,7 @@ fn each(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
 
                 match process_row(block, context, input) {
                     Ok(s) => s,
-                    Err(e) => OutputStream::one(Err(e)),
+                    Err(e) => OutputStream::one(Value::error(e)),
                 }
             })
             .flatten()

--- a/crates/nu-command/src/commands/each/group.rs
+++ b/crates/nu-command/src/commands/each/group.rs
@@ -2,9 +2,7 @@ use crate::commands::each::process_row;
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{
-    hir::CapturedBlock, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value,
-};
+use nu_protocol::{hir::CapturedBlock, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 use serde::Deserialize;
 
@@ -44,7 +42,7 @@ impl WholeStreamCommand for EachGroup {
         }]
     }
 
-    fn run(&self, raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
         let context = Arc::new(EvaluationContext::from_args(&raw_args));
         let (each_args, input): (EachGroupArgs, _) = raw_args.process()?;
         let block = Arc::new(Box::new(each_args.block));
@@ -56,7 +54,9 @@ impl WholeStreamCommand for EachGroup {
             input,
         };
 
-        Ok(each_group_iterator.flatten().to_output_stream())
+        Ok(each_group_iterator
+            .flatten()
+            .to_output_stream_with_actions())
     }
 }
 
@@ -122,20 +122,9 @@ pub(crate) fn run_block_on_vec(
 
             // If it returned multiple values, we need to put them into a table and
             // return that.
-            let result = vec.into_iter().collect::<Result<Vec<ReturnSuccess>, _>>();
-            let result_table = match result {
-                Ok(t) => t,
-                Err(e) => return OutputStream::one(Err(e)),
-            };
-
-            let table = result_table
-                .into_iter()
-                .filter_map(|x| x.raw_value())
-                .collect();
-
-            OutputStream::one(Ok(ReturnSuccess::Value(UntaggedValue::Table(table).into())))
+            OutputStream::one(UntaggedValue::Table(vec).into_untagged_value())
         }
-        Err(e) => OutputStream::one(Err(e)),
+        Err(e) => OutputStream::one(Value::error(e)),
     }
 }
 

--- a/crates/nu-command/src/commands/each/group.rs
+++ b/crates/nu-command/src/commands/each/group.rs
@@ -54,9 +54,7 @@ impl WholeStreamCommand for EachGroup {
             input,
         };
 
-        Ok(each_group_iterator
-            .flatten()
-            .to_action_stream())
+        Ok(each_group_iterator.flatten().to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/each/group.rs
+++ b/crates/nu-command/src/commands/each/group.rs
@@ -56,7 +56,7 @@ impl WholeStreamCommand for EachGroup {
 
         Ok(each_group_iterator
             .flatten()
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/each/window.rs
+++ b/crates/nu-command/src/commands/each/window.rs
@@ -49,7 +49,7 @@ impl WholeStreamCommand for EachWindow {
         }]
     }
 
-    fn run(&self, raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
         let context = Arc::new(EvaluationContext::from_args(&raw_args));
         let (each_args, mut input): (EachWindowArgs, _) = raw_args.process()?;
         let block = Arc::new(Box::new(each_args.block));
@@ -83,7 +83,7 @@ impl WholeStreamCommand for EachWindow {
             })
             .filter_map(|x| x)
             .flatten()
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/each/window.rs
+++ b/crates/nu-command/src/commands/each/window.rs
@@ -83,7 +83,7 @@ impl WholeStreamCommand for EachWindow {
             })
             .filter_map(|x| x)
             .flatten()
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/empty.rs
+++ b/crates/nu-command/src/commands/empty.rs
@@ -104,7 +104,7 @@ fn is_empty(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 }
             })
             .flatten()
-            .to_output_stream_with_actions());
+            .to_action_stream());
     }
 
     Ok(input
@@ -120,7 +120,7 @@ fn is_empty(args: CommandArgs) -> Result<ActionStream, ShellError> {
             }
         })
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn process_row(

--- a/crates/nu-command/src/commands/enter.rs
+++ b/crates/nu-command/src/commands/enter.rs
@@ -143,7 +143,7 @@ fn enter(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
                                 ),
                                 x => x,
                             })
-                            .to_output_stream_with_actions())
+                            .to_action_stream())
                     } else {
                         Ok(ActionStream::one(ReturnSuccess::action(
                             CommandAction::EnterValueShell(tagged_contents),

--- a/crates/nu-command/src/commands/enter.rs
+++ b/crates/nu-command/src/commands/enter.rs
@@ -50,7 +50,7 @@ For a more complete list of encodings please refer to the encoding_rs
 documentation link at https://docs.rs/encoding_rs/0.8.28/encoding_rs/#statics"#
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         enter(args)
     }
 
@@ -75,7 +75,7 @@ documentation link at https://docs.rs/encoding_rs/0.8.28/encoding_rs/#statics"#
     }
 }
 
-fn enter(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn enter(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let scope = raw_args.scope.clone();
     let shell_manager = raw_args.shell_manager.clone();
     let head = raw_args.call_info.args.head.clone();
@@ -88,7 +88,7 @@ fn enter(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let location_string = location.display().to_string();
 
     if location.is_dir() {
-        Ok(OutputStream::one(ReturnSuccess::action(
+        Ok(ActionStream::one(ReturnSuccess::action(
             CommandAction::EnterShell(location_string),
         )))
     } else {
@@ -129,8 +129,8 @@ fn enter(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                             scope,
                         };
                         let tag = tagged_contents.tag.clone();
-                        let mut result =
-                            converter.run(new_args.with_input(vec![tagged_contents]))?;
+                        let mut result = converter
+                            .run_with_actions(new_args.with_input(vec![tagged_contents]))?;
                         let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec();
                         Ok(result_vec
                             .into_iter()
@@ -143,19 +143,19 @@ fn enter(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                                 ),
                                 x => x,
                             })
-                            .to_output_stream())
+                            .to_output_stream_with_actions())
                     } else {
-                        Ok(OutputStream::one(ReturnSuccess::action(
+                        Ok(ActionStream::one(ReturnSuccess::action(
                             CommandAction::EnterValueShell(tagged_contents),
                         )))
                     }
                 } else {
-                    Ok(OutputStream::one(ReturnSuccess::action(
+                    Ok(ActionStream::one(ReturnSuccess::action(
                         CommandAction::EnterValueShell(tagged_contents),
                     )))
                 }
             }
-            _ => Ok(OutputStream::one(ReturnSuccess::action(
+            _ => Ok(ActionStream::one(ReturnSuccess::action(
                 CommandAction::EnterValueShell(tagged_contents),
             ))),
         }

--- a/crates/nu-command/src/commands/every.rs
+++ b/crates/nu-command/src/commands/every.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for Every {
         "Show (or skip) every n-th row, starting from the first one."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         every(args)
     }
 
@@ -62,7 +62,7 @@ impl WholeStreamCommand for Every {
     }
 }
 
-fn every(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn every(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (EveryArgs { stride, skip }, input) = args.process()?;
 
     let stride = stride.item;
@@ -80,7 +80,7 @@ fn every(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 None
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/every.rs
+++ b/crates/nu-command/src/commands/every.rs
@@ -80,7 +80,7 @@ fn every(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 None
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/exec.rs
+++ b/crates/nu-command/src/commands/exec.rs
@@ -31,7 +31,7 @@ impl WholeStreamCommand for Exec {
         "Execute command."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         exec(args)
     }
 
@@ -52,7 +52,7 @@ impl WholeStreamCommand for Exec {
 }
 
 #[cfg(unix)]
-fn exec(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn exec(args: CommandArgs) -> Result<ActionStream, ShellError> {
     use std::os::unix::process::CommandExt;
     use std::process::Command;
 

--- a/crates/nu-command/src/commands/exec.rs
+++ b/crates/nu-command/src/commands/exec.rs
@@ -74,7 +74,7 @@ fn exec(args: CommandArgs) -> Result<ActionStream, ShellError> {
 }
 
 #[cfg(not(unix))]
-fn exec(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn exec(args: CommandArgs) -> Result<ActionStream, ShellError> {
     Err(ShellError::labeled_error(
         "Error on exec",
         "exec is not supported on your platform",

--- a/crates/nu-command/src/commands/exit.rs
+++ b/crates/nu-command/src/commands/exit.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for Exit {
         "Exit the current shell (or all shells)."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         exit(args)
     }
 
@@ -43,7 +43,7 @@ impl WholeStreamCommand for Exit {
     }
 }
 
-pub fn exit(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn exit(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
 
     let code = if let Some(value) = args.call_info.args.nth(0) {
@@ -58,7 +58,7 @@ pub fn exit(args: CommandArgs) -> Result<OutputStream, ShellError> {
         CommandAction::LeaveShell(code)
     };
 
-    Ok(OutputStream::one(ReturnSuccess::action(command_action)))
+    Ok(ActionStream::one(ReturnSuccess::action(command_action)))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/first.rs
+++ b/crates/nu-command/src/commands/first.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for First {
         "Show only the first number of rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         first(args)
     }
 
@@ -51,7 +51,7 @@ impl WholeStreamCommand for First {
     }
 }
 
-fn first(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn first(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (FirstArgs { rows }, input) = args.process()?;
     let rows_desired = if let Some(quantity) = rows {
         *quantity
@@ -59,7 +59,7 @@ fn first(args: CommandArgs) -> Result<OutputStream, ShellError> {
         1
     };
 
-    Ok(input.take(rows_desired).to_output_stream())
+    Ok(input.take(rows_desired).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/first.rs
+++ b/crates/nu-command/src/commands/first.rs
@@ -59,7 +59,7 @@ fn first(args: CommandArgs) -> Result<ActionStream, ShellError> {
         1
     };
 
-    Ok(input.take(rows_desired).to_output_stream_with_actions())
+    Ok(input.take(rows_desired).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/flatten.rs
+++ b/crates/nu-command/src/commands/flatten.rs
@@ -26,7 +26,7 @@ impl WholeStreamCommand for Command {
         "Flatten the table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         flatten(args)
     }
 
@@ -51,14 +51,14 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn flatten(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn flatten(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let (Arguments { rest: columns }, input) = args.process()?;
 
     Ok(input
         .map(move |item| flat_value(&columns, &item, &tag).into_iter())
         .flatten()
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 enum TableInside<'a> {

--- a/crates/nu-command/src/commands/flatten.rs
+++ b/crates/nu-command/src/commands/flatten.rs
@@ -58,7 +58,7 @@ fn flatten(args: CommandArgs) -> Result<ActionStream, ShellError> {
     Ok(input
         .map(move |item| flat_value(&columns, &item, &tag).into_iter())
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 enum TableInside<'a> {

--- a/crates/nu-command/src/commands/format/command.rs
+++ b/crates/nu-command/src/commands/format/command.rs
@@ -84,7 +84,7 @@ fn format_command(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
             ReturnSuccess::value(UntaggedValue::string(output).into_untagged_value())
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[derive(Debug)]

--- a/crates/nu-command/src/commands/format/command.rs
+++ b/crates/nu-command/src/commands/format/command.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for Format {
         "Format columns into a string using a simple pattern."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         format_command(args)
     }
 
@@ -43,7 +43,7 @@ impl WholeStreamCommand for Format {
     }
 }
 
-fn format_command(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn format_command(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let ctx = Arc::new(EvaluationContext::from_args(&args));
     let (FormatArgs { pattern }, input) = args.process()?;
 
@@ -84,7 +84,7 @@ fn format_command(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
             ReturnSuccess::value(UntaggedValue::string(output).into_untagged_value())
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[derive(Debug)]

--- a/crates/nu-command/src/commands/format/format_filesize.rs
+++ b/crates/nu-command/src/commands/format/format_filesize.rs
@@ -106,7 +106,7 @@ fn filesize(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
             }
         })
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/from.rs
+++ b/crates/nu-command/src/commands/from.rs
@@ -18,8 +18,8 @@ impl WholeStreamCommand for From {
         "Parse content (string or binary) as a table (input format based on subcommand, like csv, ini, json, toml)."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&From, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/from_csv.rs
+++ b/crates/nu-command/src/commands/from_csv.rs
@@ -36,7 +36,7 @@ impl WholeStreamCommand for FromCsv {
         "Parse text as .csv and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_csv(args)
     }
 
@@ -66,7 +66,7 @@ impl WholeStreamCommand for FromCsv {
     }
 }
 
-fn from_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_csv(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
 
     let (

--- a/crates/nu-command/src/commands/from_delimited_data.rs
+++ b/crates/nu-command/src/commands/from_delimited_data.rs
@@ -51,7 +51,7 @@ pub fn from_delimited_data(
     format_name: &'static str,
     input: InputStream,
     name: Tag,
-) -> Result<OutputStream, ShellError> {
+) -> Result<ActionStream, ShellError> {
     let name_tag = name;
     let concat_string = input.collect_string(name_tag.clone())?;
     let sample_lines = concat_string.item.lines().take(3).collect_vec().join("\n");
@@ -61,8 +61,8 @@ pub fn from_delimited_data(
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_output_stream()),
-            x => Ok(OutputStream::one(x)),
+            } => Ok(list.into_iter().to_output_stream_with_actions()),
+            x => Ok(ActionStream::one(x)),
         },
         Err(err) => {
             let line_one = match pretty_csv_error(err) {

--- a/crates/nu-command/src/commands/from_delimited_data.rs
+++ b/crates/nu-command/src/commands/from_delimited_data.rs
@@ -61,7 +61,7 @@ pub fn from_delimited_data(
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_output_stream_with_actions()),
+            } => Ok(list.into_iter().to_action_stream()),
             x => Ok(ActionStream::one(x)),
         },
         Err(err) => {

--- a/crates/nu-command/src/commands/from_eml.rs
+++ b/crates/nu-command/src/commands/from_eml.rs
@@ -34,7 +34,7 @@ impl WholeStreamCommand for FromEml {
         "Parse text as .eml and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_eml(args)
     }
 }
@@ -72,7 +72,7 @@ fn headerfieldvalue_to_value(tag: &Tag, value: &HeaderFieldValue) -> UntaggedVal
     }
 }
 
-fn from_eml(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_eml(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let (eml_args, input): (FromEmlArgs, _) = args.process()?;
     let value = input.collect_string(tag.clone())?;
@@ -115,7 +115,7 @@ fn from_eml(args: CommandArgs) -> Result<OutputStream, ShellError> {
         dict.insert_untagged("Body", UntaggedValue::string(body));
     }
 
-    Ok(OutputStream::one(ReturnSuccess::value(dict.into_value())))
+    Ok(ActionStream::one(ReturnSuccess::value(dict.into_value())))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/from_ics.rs
+++ b/crates/nu-command/src/commands/from_ics.rs
@@ -22,12 +22,12 @@ impl WholeStreamCommand for FromIcs {
         "Parse text as .ics and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_ics(args)
     }
 }
 
-fn from_ics(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_ics(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -52,7 +52,7 @@ fn from_ics(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     }
 
-    Ok(output.into_iter().to_output_stream())
+    Ok(output.into_iter().to_output_stream_with_actions())
 }
 
 fn calendar_to_value(calendar: IcalCalendar, tag: Tag) -> Value {

--- a/crates/nu-command/src/commands/from_ics.rs
+++ b/crates/nu-command/src/commands/from_ics.rs
@@ -52,7 +52,7 @@ fn from_ics(args: CommandArgs) -> Result<ActionStream, ShellError> {
         }
     }
 
-    Ok(output.into_iter().to_output_stream_with_actions())
+    Ok(output.into_iter().to_action_stream())
 }
 
 fn calendar_to_value(calendar: IcalCalendar, tag: Tag) -> Value {

--- a/crates/nu-command/src/commands/from_ini.rs
+++ b/crates/nu-command/src/commands/from_ini.rs
@@ -70,7 +70,7 @@ fn from_ini(args: CommandArgs) -> Result<ActionStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_output_stream_with_actions()),
+            } => Ok(list.into_iter().to_action_stream()),
             x => Ok(ActionStream::one(x)),
         },
         Err(_) => Err(ShellError::labeled_error_with_secondary(

--- a/crates/nu-command/src/commands/from_ini.rs
+++ b/crates/nu-command/src/commands/from_ini.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for FromIni {
         "Parse text as .ini and create table"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_ini(args)
     }
 }
@@ -59,7 +59,7 @@ pub fn from_ini_string_to_value(
     Ok(convert_ini_top_to_nu_value(&v, tag))
 }
 
-fn from_ini(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_ini(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -70,8 +70,8 @@ fn from_ini(args: CommandArgs) -> Result<OutputStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_output_stream()),
-            x => Ok(OutputStream::one(x)),
+            } => Ok(list.into_iter().to_output_stream_with_actions()),
+            x => Ok(ActionStream::one(x)),
         },
         Err(_) => Err(ShellError::labeled_error_with_secondary(
             "Could not parse as INI",

--- a/crates/nu-command/src/commands/from_json.rs
+++ b/crates/nu-command/src/commands/from_json.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for FromJson {
         "Parse text as .json and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_json(args)
     }
 }
@@ -67,7 +67,7 @@ pub fn from_json_string_to_value(s: String, tag: impl Into<Tag>) -> nu_json::Res
     Ok(convert_json_value_to_nu_value(&v, tag))
 }
 
-fn from_json(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_json(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = args.call_info.name_tag.clone();
 
     let (FromJsonArgs { objects }, input) = args.process()?;
@@ -100,7 +100,7 @@ fn from_json(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     }
                 }
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     } else {
         match from_json_string_to_value(concat_string.item, name_tag.clone()) {
             Ok(x) => match x {
@@ -110,16 +110,16 @@ fn from_json(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 } => Ok(list
                     .into_iter()
                     .map(ReturnSuccess::value)
-                    .to_output_stream()),
+                    .to_output_stream_with_actions()),
 
-                x => Ok(OutputStream::one(ReturnSuccess::value(x))),
+                x => Ok(ActionStream::one(ReturnSuccess::value(x))),
             },
             Err(e) => {
                 let mut message = "Could not parse as JSON (".to_string();
                 message.push_str(&e.to_string());
                 message.push(')');
 
-                Ok(OutputStream::one(Err(
+                Ok(ActionStream::one(Err(
                     ShellError::labeled_error_with_secondary(
                         message,
                         "input cannot be parsed as JSON",

--- a/crates/nu-command/src/commands/from_json.rs
+++ b/crates/nu-command/src/commands/from_json.rs
@@ -100,7 +100,7 @@ fn from_json(args: CommandArgs) -> Result<ActionStream, ShellError> {
                     }
                 }
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     } else {
         match from_json_string_to_value(concat_string.item, name_tag.clone()) {
             Ok(x) => match x {
@@ -110,7 +110,7 @@ fn from_json(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 } => Ok(list
                     .into_iter()
                     .map(ReturnSuccess::value)
-                    .to_output_stream_with_actions()),
+                    .to_action_stream()),
 
                 x => Ok(ActionStream::one(ReturnSuccess::value(x))),
             },

--- a/crates/nu-command/src/commands/from_ods.rs
+++ b/crates/nu-command/src/commands/from_ods.rs
@@ -30,12 +30,12 @@ impl WholeStreamCommand for FromOds {
         "Parse OpenDocument Spreadsheet(.ods) data and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_ods(args)
     }
 }
 
-fn from_ods(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_ods(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let span = tag.span;
 
@@ -87,7 +87,7 @@ fn from_ods(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     }
 
-    Ok(OutputStream::one(ReturnSuccess::value(dict.into_value())))
+    Ok(ActionStream::one(ReturnSuccess::value(dict.into_value())))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/from_ssv.rs
+++ b/crates/nu-command/src/commands/from_ssv.rs
@@ -276,7 +276,7 @@ fn from_ssv(args: CommandArgs) -> Result<ActionStream, ShellError> {
             } => list
                 .into_iter()
                 .map(ReturnSuccess::value)
-                .to_output_stream_with_actions(),
+                .to_action_stream(),
             x => ActionStream::one(ReturnSuccess::value(x)),
         },
     )

--- a/crates/nu-command/src/commands/from_ssv.rs
+++ b/crates/nu-command/src/commands/from_ssv.rs
@@ -45,7 +45,7 @@ impl WholeStreamCommand for FromSsv {
         "Parse text as space-separated values and create a table. The default minimum number of spaces counted as a separator is 2."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_ssv(args)
     }
 }
@@ -246,7 +246,7 @@ fn from_ssv_string_to_value(
     UntaggedValue::Table(rows).into_value(&tag)
 }
 
-fn from_ssv(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_ssv(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (
         FromSsvArgs {
@@ -276,8 +276,8 @@ fn from_ssv(args: CommandArgs) -> Result<OutputStream, ShellError> {
             } => list
                 .into_iter()
                 .map(ReturnSuccess::value)
-                .to_output_stream(),
-            x => OutputStream::one(ReturnSuccess::value(x)),
+                .to_output_stream_with_actions(),
+            x => ActionStream::one(ReturnSuccess::value(x)),
         },
     )
 }

--- a/crates/nu-command/src/commands/from_toml.rs
+++ b/crates/nu-command/src/commands/from_toml.rs
@@ -75,7 +75,7 @@ pub fn from_toml(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 } => list
                     .into_iter()
                     .map(ReturnSuccess::value)
-                    .to_output_stream_with_actions(),
+                    .to_action_stream(),
                 x => ActionStream::one(ReturnSuccess::value(x)),
             },
             Err(_) => {

--- a/crates/nu-command/src/commands/from_toml.rs
+++ b/crates/nu-command/src/commands/from_toml.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for FromToml {
         "Parse text as .toml and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_toml(args)
     }
 }
@@ -60,7 +60,7 @@ pub fn from_toml_string_to_value(s: String, tag: impl Into<Tag>) -> Result<Value
     Ok(convert_toml_value_to_nu_value(&v, tag))
 }
 
-pub fn from_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn from_toml(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -75,8 +75,8 @@ pub fn from_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 } => list
                     .into_iter()
                     .map(ReturnSuccess::value)
-                    .to_output_stream(),
-                x => OutputStream::one(ReturnSuccess::value(x)),
+                    .to_output_stream_with_actions(),
+                x => ActionStream::one(ReturnSuccess::value(x)),
             },
             Err(_) => {
                 return Err(ShellError::labeled_error_with_secondary(

--- a/crates/nu-command/src/commands/from_tsv.rs
+++ b/crates/nu-command/src/commands/from_tsv.rs
@@ -28,12 +28,12 @@ impl WholeStreamCommand for FromTsv {
         "Parse text as .tsv and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_tsv(args)
     }
 }
 
-fn from_tsv(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_tsv(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (FromTsvArgs { noheaders }, input) = args.process()?;
 

--- a/crates/nu-command/src/commands/from_url.rs
+++ b/crates/nu-command/src/commands/from_url.rs
@@ -18,12 +18,12 @@ impl WholeStreamCommand for FromUrl {
         "Parse url-encoded string as a table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_url(args)
     }
 }
 
-fn from_url(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_url(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -40,7 +40,7 @@ fn from_url(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 row.insert_untagged(k, UntaggedValue::string(v));
             }
 
-            Ok(OutputStream::one(ReturnSuccess::value(row.into_value())))
+            Ok(ActionStream::one(ReturnSuccess::value(row.into_value())))
         }
         _ => Err(ShellError::labeled_error_with_secondary(
             "String not compatible with url-encoding",

--- a/crates/nu-command/src/commands/from_vcf.rs
+++ b/crates/nu-command/src/commands/from_vcf.rs
@@ -47,7 +47,7 @@ fn from_vcf(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let collected: Vec<_> = iter.collect();
 
-    Ok(collected.into_iter().to_output_stream_with_actions())
+    Ok(collected.into_iter().to_action_stream())
 }
 
 fn contact_to_value(contact: VcardContact, tag: Tag) -> Value {

--- a/crates/nu-command/src/commands/from_vcf.rs
+++ b/crates/nu-command/src/commands/from_vcf.rs
@@ -21,12 +21,12 @@ impl WholeStreamCommand for FromVcf {
         "Parse text as .vcf and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_vcf(args)
     }
 }
 
-fn from_vcf(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_vcf(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -47,7 +47,7 @@ fn from_vcf(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let collected: Vec<_> = iter.collect();
 
-    Ok(collected.into_iter().to_output_stream())
+    Ok(collected.into_iter().to_output_stream_with_actions())
 }
 
 fn contact_to_value(contact: VcardContact, tag: Tag) -> Value {

--- a/crates/nu-command/src/commands/from_xlsx.rs
+++ b/crates/nu-command/src/commands/from_xlsx.rs
@@ -30,12 +30,12 @@ impl WholeStreamCommand for FromXlsx {
         "Parse binary Excel(.xlsx) data and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_xlsx(args)
     }
 }
 
-fn from_xlsx(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_xlsx(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let span = tag.span;
     let (
@@ -87,7 +87,7 @@ fn from_xlsx(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     }
 
-    Ok(OutputStream::one(ReturnSuccess::value(dict.into_value())))
+    Ok(ActionStream::one(ReturnSuccess::value(dict.into_value())))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/from_xml.rs
+++ b/crates/nu-command/src/commands/from_xml.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for FromXml {
         "Parse text as .xml and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_xml(args)
     }
 }
@@ -94,7 +94,7 @@ pub fn from_xml_string_to_value(s: String, tag: impl Into<Tag>) -> Result<Value,
     Ok(from_document_to_value(&parsed, tag))
 }
 
-fn from_xml(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_xml(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -110,8 +110,8 @@ fn from_xml(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 } => list
                     .into_iter()
                     .map(ReturnSuccess::value)
-                    .to_output_stream(),
-                x => OutputStream::one(ReturnSuccess::value(x)),
+                    .to_output_stream_with_actions(),
+                x => ActionStream::one(ReturnSuccess::value(x)),
             },
             Err(_) => {
                 return Err(ShellError::labeled_error_with_secondary(

--- a/crates/nu-command/src/commands/from_xml.rs
+++ b/crates/nu-command/src/commands/from_xml.rs
@@ -110,7 +110,7 @@ fn from_xml(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 } => list
                     .into_iter()
                     .map(ReturnSuccess::value)
-                    .to_output_stream_with_actions(),
+                    .to_action_stream(),
                 x => ActionStream::one(ReturnSuccess::value(x)),
             },
             Err(_) => {

--- a/crates/nu-command/src/commands/from_yaml.rs
+++ b/crates/nu-command/src/commands/from_yaml.rs
@@ -143,7 +143,7 @@ fn from_yaml(args: CommandArgs) -> Result<ActionStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_output_stream_with_actions()),
+            } => Ok(list.into_iter().to_action_stream()),
             x => Ok(ActionStream::one(x)),
         },
         Err(_) => Err(ShellError::labeled_error_with_secondary(

--- a/crates/nu-command/src/commands/from_yaml.rs
+++ b/crates/nu-command/src/commands/from_yaml.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for FromYaml {
         "Parse text as .yaml/.yml and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_yaml(args)
     }
 }
@@ -38,7 +38,7 @@ impl WholeStreamCommand for FromYml {
         "Parse text as .yaml/.yml and create table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         from_yaml(args)
     }
 }
@@ -131,7 +131,7 @@ pub fn from_yaml_string_to_value(s: String, tag: impl Into<Tag>) -> Result<Value
     convert_yaml_value_to_nu_value(&v, tag)
 }
 
-fn from_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn from_yaml(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -143,8 +143,8 @@ fn from_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_output_stream()),
-            x => Ok(OutputStream::one(x)),
+            } => Ok(list.into_iter().to_output_stream_with_actions()),
+            x => Ok(ActionStream::one(x)),
         },
         Err(_) => Err(ShellError::labeled_error_with_secondary(
             "Could not parse as YAML",

--- a/crates/nu-command/src/commands/get.rs
+++ b/crates/nu-command/src/commands/get.rs
@@ -66,7 +66,7 @@ pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(descs
             .into_iter()
             .map(ReturnSuccess::value)
-            .to_output_stream_with_actions())
+            .to_action_stream())
     } else {
         trace!("get {:?}", column_paths);
         let output_stream = input
@@ -78,7 +78,7 @@ pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
                     .collect::<Vec<_>>()
             })
             .flatten()
-            .to_output_stream_with_actions();
+            .to_action_stream();
         Ok(output_stream)
     }
 }

--- a/crates/nu-command/src/commands/get.rs
+++ b/crates/nu-command/src/commands/get.rs
@@ -34,7 +34,7 @@ impl WholeStreamCommand for Command {
         "Open given cells as text."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         get(args)
     }
 
@@ -54,7 +54,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { mut rest }, mut input) = args.process()?;
     let (column_paths, _) = arguments(&mut rest)?;
 
@@ -66,7 +66,7 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
         Ok(descs
             .into_iter()
             .map(ReturnSuccess::value)
-            .to_output_stream())
+            .to_output_stream_with_actions())
     } else {
         trace!("get {:?}", column_paths);
         let output_stream = input
@@ -78,7 +78,7 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     .collect::<Vec<_>>()
             })
             .flatten()
-            .to_output_stream();
+            .to_output_stream_with_actions();
         Ok(output_stream)
     }
 }

--- a/crates/nu-command/src/commands/group_by_date.rs
+++ b/crates/nu-command/src/commands/group_by_date.rs
@@ -37,7 +37,7 @@ impl WholeStreamCommand for GroupByDate {
         "creates a table grouped by date."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         group_by_date(args)
     }
 
@@ -58,7 +58,7 @@ enum GroupByColumn {
     Name(Option<Tagged<String>>),
 }
 
-pub fn group_by_date(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn group_by_date(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (
         GroupByDateArgs {
@@ -125,7 +125,7 @@ pub fn group_by_date(args: CommandArgs) -> Result<OutputStream, ShellError> {
             }
         };
 
-        Ok(OutputStream::one(ReturnSuccess::value(value_result?)))
+        Ok(ActionStream::one(ReturnSuccess::value(value_result?)))
     }
 }
 

--- a/crates/nu-command/src/commands/hash_/base64_.rs
+++ b/crates/nu-command/src/commands/hash_/base64_.rs
@@ -154,7 +154,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/hash_/base64_.rs
+++ b/crates/nu-command/src/commands/hash_/base64_.rs
@@ -64,7 +64,7 @@ impl WholeStreamCommand for SubCommand {
         "base64 encode or decode a value"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -95,7 +95,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = args.call_info.name_tag.clone();
 
     let (
@@ -109,7 +109,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
     ) = args.process()?;
 
     if encode.item && decode.item {
-        return Ok(OutputStream::one(Err(ShellError::labeled_error(
+        return Ok(ActionStream::one(Err(ShellError::labeled_error(
             "only one of --decode and --encode flags can be used",
             "conflicting flags",
             name_tag,
@@ -154,7 +154,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/hash_/command.rs
+++ b/crates/nu-command/src/commands/hash_/command.rs
@@ -21,8 +21,8 @@ impl WholeStreamCommand for Command {
         "Apply hash function."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&Command, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/hash_/md5_.rs
+++ b/crates/nu-command/src/commands/hash_/md5_.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for SubCommand {
         "md5 encode a value"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -56,7 +56,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { rest }, input) = args.process()?;
 
     let column_paths: Vec<_> = rest;
@@ -78,7 +78,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/hash_/md5_.rs
+++ b/crates/nu-command/src/commands/hash_/md5_.rs
@@ -78,7 +78,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/headers.rs
+++ b/crates/nu-command/src/commands/headers.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for Headers {
         "Use the first row of the table as column names."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         headers(args)
     }
 
@@ -41,7 +41,7 @@ impl WholeStreamCommand for Headers {
     }
 }
 
-pub fn headers(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn headers(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let input = args.input;
     let rows: Vec<Value> = input.collect();
 
@@ -102,7 +102,7 @@ pub fn headers(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 )),
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/headers.rs
+++ b/crates/nu-command/src/commands/headers.rs
@@ -102,7 +102,7 @@ pub fn headers(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 )),
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/help.rs
+++ b/crates/nu-command/src/commands/help.rs
@@ -154,7 +154,7 @@ fn help(args: CommandArgs) -> Result<ActionStream, ShellError> {
                         ReturnSuccess::value(short_desc.into_value())
                     });
 
-            Ok(iterator.to_output_stream_with_actions())
+            Ok(iterator.to_action_stream())
         } else if rest[0].item == "generate_docs" {
             Ok(ActionStream::one(ReturnSuccess::value(generate_docs(
                 &scope,

--- a/crates/nu-command/src/commands/help.rs
+++ b/crates/nu-command/src/commands/help.rs
@@ -31,12 +31,12 @@ impl WholeStreamCommand for Help {
         "Display help information about commands."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         help(args)
     }
 }
 
-fn help(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn help(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let scope = args.scope.clone();
     let (HelpArgs { rest }, ..) = args.process()?;
@@ -154,24 +154,24 @@ fn help(args: CommandArgs) -> Result<OutputStream, ShellError> {
                         ReturnSuccess::value(short_desc.into_value())
                     });
 
-            Ok(iterator.to_output_stream())
+            Ok(iterator.to_output_stream_with_actions())
         } else if rest[0].item == "generate_docs" {
-            Ok(OutputStream::one(ReturnSuccess::value(generate_docs(
+            Ok(ActionStream::one(ReturnSuccess::value(generate_docs(
                 &scope,
             ))))
         } else if rest.len() == 2 {
             // Check for a subcommand
             let command_name = format!("{} {}", rest[0].item, rest[1].item);
             if let Some(command) = scope.get_command(&command_name) {
-                Ok(OutputStream::one(ReturnSuccess::value(
+                Ok(ActionStream::one(ReturnSuccess::value(
                     UntaggedValue::string(get_full_help(command.stream_command(), &scope))
                         .into_value(Tag::unknown()),
                 )))
             } else {
-                Ok(OutputStream::empty())
+                Ok(ActionStream::empty())
             }
         } else if let Some(command) = scope.get_command(&rest[0].item) {
-            Ok(OutputStream::one(ReturnSuccess::value(
+            Ok(ActionStream::one(ReturnSuccess::value(
                 UntaggedValue::string(get_full_help(command.stream_command(), &scope))
                     .into_value(Tag::unknown()),
             )))
@@ -205,7 +205,7 @@ Get the processes on your system actively using CPU:
 
 You can also learn more at https://www.nushell.sh/book/"#;
 
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(msg).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/histogram.rs
+++ b/crates/nu-command/src/commands/histogram.rs
@@ -177,7 +177,7 @@ pub fn histogram(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
             ReturnSuccess::value(fact.into_value())
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn evaluator(by: ColumnPath) -> Box<dyn Fn(usize, &Value) -> Result<Value, ShellError> + Send> {

--- a/crates/nu-command/src/commands/histogram.rs
+++ b/crates/nu-command/src/commands/histogram.rs
@@ -31,7 +31,7 @@ impl WholeStreamCommand for Histogram {
         "Creates a new table with a histogram based on the column name passed in."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         histogram(args)
     }
 
@@ -57,7 +57,7 @@ impl WholeStreamCommand for Histogram {
     }
 }
 
-pub fn histogram(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn histogram(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (input, args) = args.evaluate_once()?.parts();
 
@@ -177,7 +177,7 @@ pub fn histogram(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
             ReturnSuccess::value(fact.into_value())
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn evaluator(by: ColumnPath) -> Box<dyn Fn(usize, &Value) -> Result<Value, ShellError> + Send> {

--- a/crates/nu-command/src/commands/history.rs
+++ b/crates/nu-command/src/commands/history.rs
@@ -57,7 +57,7 @@ fn history(args: CommandArgs) -> Result<ActionStream, ShellError> {
                     Err(_) => None,
                 });
 
-                Ok(output.to_output_stream_with_actions())
+                Ok(output.to_action_stream())
             } else {
                 Err(ShellError::labeled_error(
                     "Could not open history",

--- a/crates/nu-command/src/commands/history.rs
+++ b/crates/nu-command/src/commands/history.rs
@@ -25,12 +25,12 @@ impl WholeStreamCommand for History {
         "Display command history."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         history(args)
     }
 }
 
-fn history(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn history(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
     let (Arguments { clear }, _) = args.process()?;
@@ -44,7 +44,7 @@ fn history(args: CommandArgs) -> Result<OutputStream, ShellError> {
     match clear {
         Some(_) => {
             // This is a NOOP, the logic to clear is handled in cli.rs
-            Ok(OutputStream::empty())
+            Ok(ActionStream::empty())
         }
         None => {
             if let Ok(file) = File::open(path) {
@@ -57,7 +57,7 @@ fn history(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     Err(_) => None,
                 });
 
-                Ok(output.to_output_stream())
+                Ok(output.to_output_stream_with_actions())
             } else {
                 Err(ShellError::labeled_error(
                     "Could not open history",

--- a/crates/nu-command/src/commands/if_.rs
+++ b/crates/nu-command/src/commands/if_.rs
@@ -6,6 +6,7 @@ use nu_errors::ShellError;
 use nu_protocol::{
     hir::CapturedBlock, hir::ClassifiedCommand, Signature, SyntaxShape, UntaggedValue,
 };
+use nu_stream::OutputStream;
 
 pub struct If;
 
@@ -110,11 +111,15 @@ fn if_command(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                 };
                 context.scope.exit_scope();
 
-                result.map(|x| x.to_output_stream())
+                result
             }
-            Err(e) => Ok(vec![Err(e)].into_iter().to_output_stream()),
+            Err(e) => Ok(OutputStream::from_stream(
+                vec![UntaggedValue::Error(e).into_untagged_value()].into_iter(),
+            )),
         },
-        Err(e) => Ok(vec![Err(e)].into_iter().to_output_stream()),
+        Err(e) => Ok(OutputStream::from_stream(
+            vec![UntaggedValue::Error(e).into_untagged_value()].into_iter(),
+        )),
     }
 }
 

--- a/crates/nu-command/src/commands/insert.rs
+++ b/crates/nu-command/src/commands/insert.rs
@@ -168,5 +168,5 @@ fn insert(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
             }
         })
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }

--- a/crates/nu-command/src/commands/insert.rs
+++ b/crates/nu-command/src/commands/insert.rs
@@ -34,7 +34,7 @@ impl WholeStreamCommand for Command {
         "Insert a new column with a given value."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         insert(args)
     }
 
@@ -66,7 +66,7 @@ fn process_row(
     input: Value,
     mut value: Arc<Value>,
     field: Arc<ColumnPath>,
-) -> Result<OutputStream, ShellError> {
+) -> Result<ActionStream, ShellError> {
     let value = Arc::make_mut(&mut value);
 
     Ok(match value {
@@ -116,17 +116,17 @@ fn process_row(
                             value: UntaggedValue::Row(_),
                             ..
                         } => match obj.insert_data_at_column_path(&field, result) {
-                            Ok(v) => OutputStream::one(ReturnSuccess::value(v)),
-                            Err(e) => OutputStream::one(Err(e)),
+                            Ok(v) => ActionStream::one(ReturnSuccess::value(v)),
+                            Err(e) => ActionStream::one(Err(e)),
                         },
-                        _ => OutputStream::one(Err(ShellError::labeled_error(
+                        _ => ActionStream::one(Err(ShellError::labeled_error(
                             "Unrecognized type in stream",
                             "original value",
                             block_tag.clone(),
                         ))),
                     }
                 }
-                Err(e) => OutputStream::one(Err(e)),
+                Err(e) => ActionStream::one(Err(e)),
             }
         }
         value => match input {
@@ -139,18 +139,18 @@ fn process_row(
                 .unwrap_or_else(|| UntaggedValue::nothing().into_untagged_value())
                 .insert_data_at_column_path(&field, value.clone())
             {
-                Ok(v) => OutputStream::one(ReturnSuccess::value(v)),
-                Err(e) => OutputStream::one(Err(e)),
+                Ok(v) => ActionStream::one(ReturnSuccess::value(v)),
+                Err(e) => ActionStream::one(Err(e)),
             },
             _ => match input.insert_data_at_column_path(&field, value.clone()) {
-                Ok(v) => OutputStream::one(ReturnSuccess::value(v)),
-                Err(e) => OutputStream::one(Err(e)),
+                Ok(v) => ActionStream::one(ReturnSuccess::value(v)),
+                Err(e) => ActionStream::one(Err(e)),
             },
         },
     })
 }
 
-fn insert(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn insert(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let context = Arc::new(EvaluationContext::from_args(&raw_args));
     let (Arguments { column, value }, input) = raw_args.process()?;
     let value = Arc::new(value);
@@ -164,9 +164,9 @@ fn insert(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
 
             match process_row(context, input, value, column) {
                 Ok(s) => s,
-                Err(e) => OutputStream::one(Err(e)),
+                Err(e) => ActionStream::one(Err(e)),
             }
         })
         .flatten()
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }

--- a/crates/nu-command/src/commands/into/command.rs
+++ b/crates/nu-command/src/commands/into/command.rs
@@ -18,8 +18,8 @@ impl WholeStreamCommand for Command {
         "Apply into function."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&Command, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/into/int.rs
+++ b/crates/nu-command/src/commands/into/int.rs
@@ -104,7 +104,7 @@ fn into_int(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 pub fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/into/int.rs
+++ b/crates/nu-command/src/commands/into/int.rs
@@ -29,7 +29,7 @@ impl WholeStreamCommand for SubCommand {
         "Convert value to integer"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         into_int(args)
     }
 
@@ -85,7 +85,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn into_int(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn into_int(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { rest: column_paths }, input) = args.process()?;
 
     Ok(input
@@ -104,7 +104,7 @@ fn into_int(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 pub fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/keep/command.rs
+++ b/crates/nu-command/src/commands/keep/command.rs
@@ -61,7 +61,7 @@ fn keep(args: CommandArgs) -> Result<ActionStream, ShellError> {
         1
     };
 
-    Ok(input.take(rows_desired).to_output_stream_with_actions())
+    Ok(input.take(rows_desired).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/keep/command.rs
+++ b/crates/nu-command/src/commands/keep/command.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for Command {
         "Keep the number of rows only."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         keep(args)
     }
 
@@ -53,7 +53,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn keep(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn keep(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { rows }, input) = args.process()?;
     let rows_desired = if let Some(quantity) = rows {
         *quantity
@@ -61,7 +61,7 @@ fn keep(args: CommandArgs) -> Result<OutputStream, ShellError> {
         1
     };
 
-    Ok(input.take(rows_desired).to_output_stream())
+    Ok(input.take(rows_desired).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/keep/until.rs
+++ b/crates/nu-command/src/commands/keep/until.rs
@@ -93,7 +93,7 @@ impl WholeStreamCommand for SubCommand {
 
                 !matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/keep/until.rs
+++ b/crates/nu-command/src/commands/keep/until.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for SubCommand {
         "Keeps rows until the condition matches."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let ctx = Arc::new(EvaluationContext::from_args(&args));
 
         let call_info = args.evaluate_once()?;
@@ -93,7 +93,7 @@ impl WholeStreamCommand for SubCommand {
 
                 !matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/keep/while_.rs
+++ b/crates/nu-command/src/commands/keep/while_.rs
@@ -26,7 +26,7 @@ impl WholeStreamCommand for SubCommand {
         "Keeps rows while the condition matches."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let ctx = Arc::new(EvaluationContext::from_args(&args));
         let call_info = args.evaluate_once()?;
 
@@ -92,7 +92,7 @@ impl WholeStreamCommand for SubCommand {
 
                 matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/keep/while_.rs
+++ b/crates/nu-command/src/commands/keep/while_.rs
@@ -92,7 +92,7 @@ impl WholeStreamCommand for SubCommand {
 
                 matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/kill.rs
+++ b/crates/nu-command/src/commands/kill.rs
@@ -48,7 +48,7 @@ impl WholeStreamCommand for Kill {
         "Kill a process using the process id."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         kill(args)
     }
 
@@ -73,7 +73,7 @@ impl WholeStreamCommand for Kill {
     }
 }
 
-fn kill(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn kill(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (
         KillArgs {
             pid,
@@ -136,7 +136,7 @@ fn kill(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     cmd.status().expect("failed to execute shell command");
 
-    Ok(OutputStream::empty())
+    Ok(ActionStream::empty())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/last.rs
+++ b/crates/nu-command/src/commands/last.rs
@@ -70,7 +70,7 @@ fn last(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let iter = v.into_iter().skip(beginning_rows_to_skip);
 
-    Ok((iter).to_output_stream_with_actions())
+    Ok((iter).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/last.rs
+++ b/crates/nu-command/src/commands/last.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for Last {
         "Show only the last number of rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         last(args)
     }
 
@@ -52,7 +52,7 @@ impl WholeStreamCommand for Last {
     }
 }
 
-fn last(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn last(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (LastArgs { rows }, input) = args.process()?;
     let v: Vec<_> = input.into_vec();
 
@@ -70,7 +70,7 @@ fn last(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let iter = v.into_iter().skip(beginning_rows_to_skip);
 
-    Ok((iter).to_output_stream())
+    Ok((iter).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/length.rs
+++ b/crates/nu-command/src/commands/length.rs
@@ -38,7 +38,7 @@ impl WholeStreamCommand for Length {
             done: false,
             tag,
         }
-        .to_output_stream_with_actions())
+        .to_action_stream())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/commands/length.rs
+++ b/crates/nu-command/src/commands/length.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for Length {
         "Show the total number of rows or items."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (LengthArgs { column }, input) = args.process()?;
 
@@ -38,7 +38,7 @@ impl WholeStreamCommand for Length {
             done: false,
             tag,
         }
-        .to_output_stream())
+        .to_output_stream_with_actions())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/commands/let_.rs
+++ b/crates/nu-command/src/commands/let_.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for Let {
         "Create a variable and give it a value."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         letcmd(args)
     }
 
@@ -36,7 +36,7 @@ impl WholeStreamCommand for Let {
     }
 }
 
-pub fn letcmd(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn letcmd(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
     let args = args.evaluate_once()?;
@@ -94,5 +94,5 @@ pub fn letcmd(args: CommandArgs) -> Result<OutputStream, ShellError> {
     // variable should be set into.
     ctx.scope.add_var(name, value);
 
-    Ok(OutputStream::empty())
+    Ok(ActionStream::empty())
 }

--- a/crates/nu-command/src/commands/let_env.rs
+++ b/crates/nu-command/src/commands/let_env.rs
@@ -38,7 +38,7 @@ impl WholeStreamCommand for LetEnv {
         "Create an environment variable and give it a value."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         set_env(args)
     }
 
@@ -47,7 +47,7 @@ impl WholeStreamCommand for LetEnv {
     }
 }
 
-pub fn set_env(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn set_env(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
 
@@ -99,5 +99,5 @@ pub fn set_env(args: CommandArgs) -> Result<OutputStream, ShellError> {
     // variable should be set into.
     ctx.scope.add_env_var(name, value);
 
-    Ok(OutputStream::empty())
+    Ok(ActionStream::empty())
 }

--- a/crates/nu-command/src/commands/lines.rs
+++ b/crates/nu-command/src/commands/lines.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for Lines {
         "Split single string into rows, one per line."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         lines(args)
     }
 
@@ -42,7 +42,7 @@ fn ends_with_line_ending(st: &str) -> bool {
     }
 }
 
-fn lines(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn lines(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let leftover_string = Arc::new(Mutex::new(String::new()));
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
@@ -113,7 +113,7 @@ fn lines(args: CommandArgs) -> Result<OutputStream, ShellError> {
             }
         })
         .flatten()
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/lines.rs
+++ b/crates/nu-command/src/commands/lines.rs
@@ -113,7 +113,7 @@ fn lines(args: CommandArgs) -> Result<ActionStream, ShellError> {
             }
         })
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/ls.rs
+++ b/crates/nu-command/src/commands/ls.rs
@@ -39,7 +39,7 @@ impl WholeStreamCommand for Ls {
         "View the contents of the current or given path."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let name = args.call_info.name_tag.clone();
         let ctrl_c = args.ctrl_c.clone();
         let shell_manager = args.shell_manager.clone();

--- a/crates/nu-command/src/commands/macros.rs
+++ b/crates/nu-command/src/commands/macros.rs
@@ -33,7 +33,7 @@ macro_rules! command {
                 fn command($args: EvaluatedCommandArgs, ( $($param_name),*, ): ( $($param_type),*, )) -> Result<OutputStream, ShellError> {
                     let output = $body;
 
-                    Ok(output.to_output_stream_with_actions())
+                    Ok(output.to_action_stream())
                 }
 
                 let $args = $args.evaluate_once(registry)?;

--- a/crates/nu-command/src/commands/macros.rs
+++ b/crates/nu-command/src/commands/macros.rs
@@ -33,7 +33,7 @@ macro_rules! command {
                 fn command($args: EvaluatedCommandArgs, ( $($param_name),*, ): ( $($param_type),*, )) -> Result<OutputStream, ShellError> {
                     let output = $body;
 
-                    Ok(output.to_output_stream())
+                    Ok(output.to_output_stream_with_actions())
                 }
 
                 let $args = $args.evaluate_once(registry)?;

--- a/crates/nu-command/src/commands/math/abs.rs
+++ b/crates/nu-command/src/commands/math/abs.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for SubCommand {
         "Returns absolute values of a list of numbers"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let mapped = args.input.map(move |val| match val.value {
             UntaggedValue::Primitive(Primitive::Int(val)) => {
                 UntaggedValue::int(val.magnitude().clone()).into()
@@ -31,7 +31,7 @@ impl WholeStreamCommand for SubCommand {
             }
             other => abs_default(other),
         });
-        Ok(OutputStream::from_input(mapped))
+        Ok(ActionStream::from_input(mapped))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/commands/math/avg.rs
+++ b/crates/nu-command/src/commands/math/avg.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for SubCommand {
         "Finds the average of a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_with_function(args, average)
     }
 

--- a/crates/nu-command/src/commands/math/ceil.rs
+++ b/crates/nu-command/src/commands/math/ceil.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for SubCommand {
         "Applies the ceil function to a list of numbers"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let input = args.input;
 
         run_with_numerical_functions_on_stream(input, ceil_big_int, ceil_big_decimal, ceil_default)

--- a/crates/nu-command/src/commands/math/command.rs
+++ b/crates/nu-command/src/commands/math/command.rs
@@ -18,8 +18,8 @@ impl WholeStreamCommand for Command {
         "Use mathematical functions as aggregate functions on a list of numbers or tables."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(Ok(ReturnSuccess::Value(
             UntaggedValue::string(get_full_help(&Command, &args.scope)).into_value(Tag::unknown()),
         ))))
     }

--- a/crates/nu-command/src/commands/math/eval.rs
+++ b/crates/nu-command/src/commands/math/eval.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for SubCommand {
         )
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         eval(args)
     }
 
@@ -45,13 +45,13 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn eval(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn eval(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.span;
     let (SubCommandArgs { expression }, input) = args.process()?;
 
     if let Some(string) = expression {
         match parse(&string, &string.tag) {
-            Ok(value) => Ok(OutputStream::one(ReturnSuccess::value(value))),
+            Ok(value) => Ok(ActionStream::one(ReturnSuccess::value(value))),
             Err(err) => Err(ShellError::labeled_error(
                 "Math evaluation error",
                 err,
@@ -89,7 +89,7 @@ pub fn eval(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     ))
                 }
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/math/eval.rs
+++ b/crates/nu-command/src/commands/math/eval.rs
@@ -89,7 +89,7 @@ pub fn eval(args: CommandArgs) -> Result<ActionStream, ShellError> {
                     ))
                 }
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/math/floor.rs
+++ b/crates/nu-command/src/commands/math/floor.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for SubCommand {
         "Applies the floor function to a list of numbers"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let input = args.input;
 
         run_with_numerical_functions_on_stream(

--- a/crates/nu-command/src/commands/math/max.rs
+++ b/crates/nu-command/src/commands/math/max.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for SubCommand {
         "Finds the maximum within a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_with_function(args, maximum)
     }
 

--- a/crates/nu-command/src/commands/math/median.rs
+++ b/crates/nu-command/src/commands/math/median.rs
@@ -24,7 +24,7 @@ impl WholeStreamCommand for SubCommand {
         "Gets the median of a list of numbers"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_with_function(args, median)
     }
 

--- a/crates/nu-command/src/commands/math/min.rs
+++ b/crates/nu-command/src/commands/math/min.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for SubCommand {
         "Finds the minimum within a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_with_function(args, minimum)
     }
 

--- a/crates/nu-command/src/commands/math/mode.rs
+++ b/crates/nu-command/src/commands/math/mode.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for SubCommand {
         "Gets the most frequent element(s) from a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_with_function(args, mode)
     }
 

--- a/crates/nu-command/src/commands/math/product.rs
+++ b/crates/nu-command/src/commands/math/product.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for SubCommand {
         "Finds the product of a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_with_function(args, product)
     }
 

--- a/crates/nu-command/src/commands/math/round.rs
+++ b/crates/nu-command/src/commands/math/round.rs
@@ -29,7 +29,7 @@ impl WholeStreamCommand for SubCommand {
         "Applies the round function to a list of numbers"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -57,7 +57,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { precision }, input) = args.process()?;
     let precision = precision.map(|p| p.item).unwrap_or(0);
 
@@ -66,7 +66,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
         UntaggedValue::Primitive(Primitive::Decimal(val)) => round_big_decimal(val, precision),
         other => round_default(other),
     });
-    Ok(OutputStream::from_input(mapped))
+    Ok(ActionStream::from_input(mapped))
 }
 
 fn round_big_int(val: BigInt) -> Value {

--- a/crates/nu-command/src/commands/math/sqrt.rs
+++ b/crates/nu-command/src/commands/math/sqrt.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for SubCommand {
         "Applies the square root function to a list of numbers"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(operate(args))
     }
 
@@ -34,13 +34,13 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> OutputStream {
+fn operate(args: CommandArgs) -> ActionStream {
     let mapped = args.input.map(move |val| match val.value {
         UntaggedValue::Primitive(Primitive::Int(val)) => sqrt_big_decimal(BigDecimal::from(val)),
         UntaggedValue::Primitive(Primitive::Decimal(val)) => sqrt_big_decimal(val),
         other => sqrt_default(other),
     });
-    OutputStream::from_input(mapped)
+    ActionStream::from_input(mapped)
 }
 
 fn sqrt_big_decimal(val: BigDecimal) -> Value {

--- a/crates/nu-command/src/commands/math/stddev.rs
+++ b/crates/nu-command/src/commands/math/stddev.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for SubCommand {
         "Finds the stddev of a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let name = args.call_info.name_tag.clone();
         let (Arguments { sample }, mut input) = args.process()?;
 
@@ -81,13 +81,13 @@ impl WholeStreamCommand for SubCommand {
         }?;
 
         if res.value.is_table() {
-            Ok(OutputStream::from(
+            Ok(ActionStream::from(
                 res.table_entries()
                     .map(|v| ReturnSuccess::value(v.clone()))
                     .collect::<Vec<_>>(),
             ))
         } else {
-            Ok(OutputStream::one(ReturnSuccess::value(res)))
+            Ok(ActionStream::one(ReturnSuccess::value(res)))
         }
     }
 

--- a/crates/nu-command/src/commands/math/sum.rs
+++ b/crates/nu-command/src/commands/math/sum.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for SubCommand {
         "Finds the sum of a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_with_function(args, summation)
     }
 

--- a/crates/nu-command/src/commands/math/utils.rs
+++ b/crates/nu-command/src/commands/math/utils.rs
@@ -9,7 +9,7 @@ pub type MathFunction = fn(values: &[Value], tag: &Tag) -> Result<Value, ShellEr
 pub fn run_with_function(
     args: impl Into<RunnableContext>,
     mf: MathFunction,
-) -> Result<OutputStream, ShellError> {
+) -> Result<ActionStream, ShellError> {
     let RunnableContext {
         mut input,
         call_info,
@@ -23,13 +23,13 @@ pub fn run_with_function(
     match res {
         Ok(v) => {
             if v.value.is_table() {
-                Ok(OutputStream::from(
+                Ok(ActionStream::from(
                     v.table_entries()
                         .map(|v| ReturnSuccess::value(v.clone()))
                         .collect::<Vec<_>>(),
                 ))
             } else {
-                Ok(OutputStream::one(ReturnSuccess::value(v)))
+                Ok(ActionStream::one(ReturnSuccess::value(v)))
             }
         }
         Err(e) => Err(e),
@@ -47,13 +47,13 @@ pub fn run_with_numerical_functions_on_stream(
     int_function: IntFunction,
     decimal_function: DecimalFunction,
     default_function: DefaultFunction,
-) -> Result<OutputStream, ShellError> {
+) -> Result<ActionStream, ShellError> {
     let mapped = input.map(move |val| match val.value {
         UntaggedValue::Primitive(Primitive::Int(val)) => int_function(val),
         UntaggedValue::Primitive(Primitive::Decimal(val)) => decimal_function(val),
         other => default_function(other),
     });
-    Ok(OutputStream::from_input(mapped))
+    Ok(ActionStream::from_input(mapped))
 }
 
 pub fn calculate(values: &[Value], name: &Tag, mf: MathFunction) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/math/variance.rs
+++ b/crates/nu-command/src/commands/math/variance.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for SubCommand {
         "Finds the variance of a list of numbers or tables"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let name = args.call_info.name_tag.clone();
         let (Arguments { sample }, mut input) = args.process()?;
 
@@ -79,13 +79,13 @@ impl WholeStreamCommand for SubCommand {
         }?;
 
         if res.value.is_table() {
-            Ok(OutputStream::from(
+            Ok(ActionStream::from(
                 res.table_entries()
                     .map(|v| ReturnSuccess::value(v.clone()))
                     .collect::<Vec<_>>(),
             ))
         } else {
-            Ok(OutputStream::one(ReturnSuccess::value(res)))
+            Ok(ActionStream::one(ReturnSuccess::value(res)))
         }
     }
 

--- a/crates/nu-command/src/commands/merge.rs
+++ b/crates/nu-command/src/commands/merge.rs
@@ -90,7 +90,7 @@ fn merge(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
                 None => ReturnSuccess::value(value),
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/merge.rs
+++ b/crates/nu-command/src/commands/merge.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for Merge {
         "Merge a table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         merge(args)
     }
 
@@ -45,7 +45,7 @@ impl WholeStreamCommand for Merge {
     }
 }
 
-fn merge(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn merge(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let context = EvaluationContext::from_args(&raw_args);
     let name_tag = raw_args.call_info.name_tag.clone();
     let (merge_args, input): (MergeArgs, _) = raw_args.process()?;
@@ -90,7 +90,7 @@ fn merge(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                 None => ReturnSuccess::value(value),
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/mkdir.rs
+++ b/crates/nu-command/src/commands/mkdir.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for Mkdir {
         "Make directories, creates intermediary directories as required."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         mkdir(args)
     }
 
@@ -35,7 +35,7 @@ impl WholeStreamCommand for Mkdir {
     }
 }
 
-fn mkdir(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn mkdir(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let shell_manager = args.shell_manager.clone();
     let (args, _) = args.process()?;

--- a/crates/nu-command/src/commands/move_/command.rs
+++ b/crates/nu-command/src/commands/move_/command.rs
@@ -169,7 +169,7 @@ fn operate(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
                     ))
                 }
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     } else if let Some(before) = before {
         let member = columns.remove(0);
 
@@ -217,7 +217,7 @@ fn operate(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
                     ))
                 }
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     } else {
         Err(ShellError::labeled_error(
             "no columns given",

--- a/crates/nu-command/src/commands/move_/command.rs
+++ b/crates/nu-command/src/commands/move_/command.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for Command {
         "Move columns."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -82,7 +82,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn operate(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = raw_args.call_info.name_tag.clone();
     let (
         Arguments {
@@ -169,7 +169,7 @@ fn operate(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                     ))
                 }
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     } else if let Some(before) = before {
         let member = columns.remove(0);
 
@@ -217,7 +217,7 @@ fn operate(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                     ))
                 }
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     } else {
         Err(ShellError::labeled_error(
             "no columns given",

--- a/crates/nu-command/src/commands/move_/mv.rs
+++ b/crates/nu-command/src/commands/move_/mv.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for Mv {
         "Move files or directories."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         mv(args)
     }
 
@@ -53,7 +53,7 @@ impl WholeStreamCommand for Mv {
     }
 }
 
-fn mv(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn mv(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let shell_manager = args.shell_manager.clone();
     let (args, _) = args.process()?;

--- a/crates/nu-command/src/commands/next.rs
+++ b/crates/nu-command/src/commands/next.rs
@@ -18,12 +18,12 @@ impl WholeStreamCommand for Next {
         "Go to next shell."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(next(args))
     }
 }
 
-fn next(_args: CommandArgs) -> OutputStream {
+fn next(_args: CommandArgs) -> ActionStream {
     vec![Ok(ReturnSuccess::Action(CommandAction::NextShell))].into()
 }
 

--- a/crates/nu-command/src/commands/nth.rs
+++ b/crates/nu-command/src/commands/nth.rs
@@ -83,7 +83,7 @@ fn nth(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 None
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/nth.rs
+++ b/crates/nu-command/src/commands/nth.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for Nth {
         "Return or skip only the selected rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         nth(args)
     }
 
@@ -58,7 +58,7 @@ impl WholeStreamCommand for Nth {
     }
 }
 
-fn nth(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn nth(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (
         NthArgs {
             row_number,
@@ -83,7 +83,7 @@ fn nth(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 None
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/nu/plugin.rs
+++ b/crates/nu-command/src/commands/nu/plugin.rs
@@ -45,7 +45,7 @@ impl WholeStreamCommand for SubCommand {
         }]
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let scope = args.scope.clone();
         let shell_manager = args.shell_manager.clone();
         let (Arguments { load_path }, _) = args.process()?;
@@ -99,7 +99,7 @@ impl WholeStreamCommand for SubCommand {
             .into());
         }
 
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&SubCommand, &scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/open.rs
+++ b/crates/nu-command/src/commands/open.rs
@@ -57,7 +57,7 @@ For a more complete list of encodings please refer to the encoding_rs
 documentation link at https://docs.rs/encoding_rs/0.8.28/encoding_rs/#statics"#
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         open(args)
     }
 
@@ -99,7 +99,7 @@ pub fn get_encoding(opt: Option<Tagged<String>>) -> Result<&'static Encoding, Sh
     }
 }
 
-fn open(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn open(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let scope = args.scope.clone();
     let cwd = PathBuf::from(args.shell_manager.path());
     let shell_manager = args.shell_manager.clone();
@@ -148,7 +148,7 @@ fn open(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 path.tag.span,
                 encoding,
             )?;
-            return Ok(OutputStream::one(ReturnSuccess::action(
+            return Ok(ActionStream::one(ReturnSuccess::action(
                 CommandAction::AutoConvert(tagged_contents, ext),
             )));
         }
@@ -160,7 +160,7 @@ fn open(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 path.tag.span,
                 encoding,
             )?;
-            return Ok(OutputStream::one(ReturnSuccess::value(tagged_contents)));
+            return Ok(ActionStream::one(ReturnSuccess::value(tagged_contents)));
         }
     }
 
@@ -191,7 +191,7 @@ fn open(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     });
 
-    Ok(OutputStream::new(final_stream))
+    Ok(ActionStream::new(final_stream))
 }
 
 // Note that we do not output a Stream in "fetch" since it is only used by "enter" command

--- a/crates/nu-command/src/commands/parse/command.rs
+++ b/crates/nu-command/src/commands/parse/command.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for Command {
         "Parse columns from string data using a simple pattern."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -49,7 +49,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-pub fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = args.call_info.name_tag.clone();
     let (Arguments { regex, pattern }, input) = args.process()?;
 
@@ -95,7 +95,7 @@ pub fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     }
 
-    Ok(parsed.into_iter().to_output_stream())
+    Ok(parsed.into_iter().to_output_stream_with_actions())
 }
 
 fn build_regex(input: &str, tag: Tag) -> Result<String, ShellError> {

--- a/crates/nu-command/src/commands/parse/command.rs
+++ b/crates/nu-command/src/commands/parse/command.rs
@@ -95,7 +95,7 @@ pub fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         }
     }
 
-    Ok(parsed.into_iter().to_output_stream_with_actions())
+    Ok(parsed.into_iter().to_action_stream())
 }
 
 fn build_regex(input: &str, tag: Tag) -> Result<String, ShellError> {

--- a/crates/nu-command/src/commands/path/basename.rs
+++ b/crates/nu-command/src/commands/path/basename.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for PathBasename {
         "Gets the final component of a path"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathBasenameArguments { replace, rest }, input) = args.process()?;
         let args = Arc::new(PathBasenameArguments { replace, rest });

--- a/crates/nu-command/src/commands/path/command.rs
+++ b/crates/nu-command/src/commands/path/command.rs
@@ -18,8 +18,8 @@ impl WholeStreamCommand for Path {
         "Explore and manipulate paths."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&Path, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/path/dirname.rs
+++ b/crates/nu-command/src/commands/path/dirname.rs
@@ -48,7 +48,7 @@ impl WholeStreamCommand for PathDirname {
         "Gets the parent directory of a path"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (
             PathDirnameArguments {

--- a/crates/nu-command/src/commands/path/exists.rs
+++ b/crates/nu-command/src/commands/path/exists.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for PathExists {
         "Checks whether a path exists"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathExistsArguments { rest }, input) = args.process()?;
         let args = Arc::new(PathExistsArguments { rest });

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for PathExpand {
         "Expands a path to its absolute form"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathExpandArguments { rest }, input) = args.process()?;
         let args = Arc::new(PathExpandArguments { rest });

--- a/crates/nu-command/src/commands/path/extension.rs
+++ b/crates/nu-command/src/commands/path/extension.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for PathExtension {
         "Gets the extension of a path"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathExtensionArguments { replace, rest }, input) = args.process()?;
         let args = Arc::new(PathExtensionArguments { replace, rest });

--- a/crates/nu-command/src/commands/path/filestem.rs
+++ b/crates/nu-command/src/commands/path/filestem.rs
@@ -54,7 +54,7 @@ impl WholeStreamCommand for PathFilestem {
         "Gets the file stem of a path"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (
             PathFilestemArguments {

--- a/crates/nu-command/src/commands/path/join.rs
+++ b/crates/nu-command/src/commands/path/join.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for PathJoin {
         "Joins an input path with another path"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathJoinArguments { path, rest }, input) = args.process()?;
         let args = Arc::new(PathJoinArguments { path, rest });

--- a/crates/nu-command/src/commands/path/mod.rs
+++ b/crates/nu-command/src/commands/path/mod.rs
@@ -83,5 +83,5 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions()
+        .to_action_stream()
 }

--- a/crates/nu-command/src/commands/path/mod.rs
+++ b/crates/nu-command/src/commands/path/mod.rs
@@ -60,7 +60,7 @@ fn operate<F, T>(
     action: &'static F,
     span: Span,
     args: Arc<T>,
-) -> OutputStream
+) -> ActionStream
 where
     T: PathSubcommandArguments + Send + Sync + 'static,
     F: Fn(&Path, &T) -> UntaggedValue + Send + Sync + 'static,
@@ -83,5 +83,5 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream()
+        .to_output_stream_with_actions()
 }

--- a/crates/nu-command/src/commands/path/type.rs
+++ b/crates/nu-command/src/commands/path/type.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for PathType {
         "Gives the type of the object a path refers to (e.g., file, dir, symlink)"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (PathTypeArguments { rest }, input) = args.process()?;
         let args = Arc::new(PathTypeArguments { rest });

--- a/crates/nu-command/src/commands/pivot.rs
+++ b/crates/nu-command/src/commands/pivot.rs
@@ -140,7 +140,7 @@ pub fn pivot(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
         ReturnSuccess::value(dict.into_value())
     }))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/pivot.rs
+++ b/crates/nu-command/src/commands/pivot.rs
@@ -45,12 +45,12 @@ impl WholeStreamCommand for Pivot {
         "Pivots the table contents so rows become columns and columns become rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         pivot(args)
     }
 }
 
-pub fn pivot(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn pivot(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (args, input): (PivotArgs, _) = args.process()?;
     let input = input.into_vec();
@@ -140,7 +140,7 @@ pub fn pivot(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
         ReturnSuccess::value(dict.into_value())
     }))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/prepend.rs
+++ b/crates/nu-command/src/commands/prepend.rs
@@ -50,7 +50,7 @@ fn prepend(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let bos = vec![row].into_iter();
 
-    Ok(bos.chain(input).to_output_stream_with_actions())
+    Ok(bos.chain(input).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/prepend.rs
+++ b/crates/nu-command/src/commands/prepend.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for Prepend {
         "Prepend the given row to the front of the table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         prepend(args)
     }
 
@@ -45,12 +45,12 @@ impl WholeStreamCommand for Prepend {
     }
 }
 
-fn prepend(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn prepend(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (PrependArgs { row }, input) = args.process()?;
 
     let bos = vec![row].into_iter();
 
-    Ok(bos.chain(input).to_output_stream())
+    Ok(bos.chain(input).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/prev.rs
+++ b/crates/nu-command/src/commands/prev.rs
@@ -19,12 +19,12 @@ impl WholeStreamCommand for Previous {
         "Go to previous shell."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(previous(args))
     }
 }
 
-fn previous(_args: CommandArgs) -> OutputStream {
+fn previous(_args: CommandArgs) -> ActionStream {
     vec![Ok(ReturnSuccess::Action(CommandAction::PreviousShell))].into()
 }
 

--- a/crates/nu-command/src/commands/pwd.rs
+++ b/crates/nu-command/src/commands/pwd.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for Pwd {
         "Output the current working directory."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         pwd(args)
     }
 
@@ -31,7 +31,7 @@ impl WholeStreamCommand for Pwd {
     }
 }
 
-pub fn pwd(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn pwd(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let shell_manager = args.shell_manager.clone();
     let args = args.evaluate_once()?;
 

--- a/crates/nu-command/src/commands/random/bool.rs
+++ b/crates/nu-command/src/commands/random/bool.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate a random boolean value"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         bool_command(args)
     }
 
@@ -50,7 +50,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn bool_command(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn bool_command(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (BoolArgs { bias }, _) = args.process()?;
 
     let mut probability = 0.5;
@@ -73,7 +73,7 @@ pub fn bool_command(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let bool_result: bool = rng.gen_bool(probability);
     let bool_untagged_value = UntaggedValue::boolean(bool_result);
 
-    Ok(OutputStream::one(ReturnSuccess::value(bool_untagged_value)))
+    Ok(ActionStream::one(ReturnSuccess::value(bool_untagged_value)))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/random/chars.rs
+++ b/crates/nu-command/src/commands/random/chars.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate random chars"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         chars(args)
     }
 
@@ -53,7 +53,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn chars(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn chars(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (CharsArgs { length }, _) = args.process()?;
 
     let chars_length = length.map_or(DEFAULT_CHARS_LENGTH, |l| l.item);
@@ -64,7 +64,7 @@ pub fn chars(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .collect();
 
     let result = UntaggedValue::string(random_string);
-    Ok(OutputStream::one(ReturnSuccess::value(result)))
+    Ok(ActionStream::one(ReturnSuccess::value(result)))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/random/command.rs
+++ b/crates/nu-command/src/commands/random/command.rs
@@ -18,8 +18,8 @@ impl WholeStreamCommand for Command {
         "Generate random values."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(Ok(ReturnSuccess::Value(
             UntaggedValue::string(get_full_help(&Command, &args.scope)).into_value(Tag::unknown()),
         ))))
     }

--- a/crates/nu-command/src/commands/random/decimal.rs
+++ b/crates/nu-command/src/commands/random/decimal.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate a random decimal within a range [min..max]"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         decimal(args)
     }
 
@@ -57,7 +57,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn decimal(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn decimal(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (DecimalArgs { range }, _) = args.process()?;
 
     let (min, max) = if let Some(range) = &range {
@@ -76,7 +76,7 @@ pub fn decimal(args: CommandArgs) -> Result<OutputStream, ShellError> {
         )),
         Some(Ordering::Equal) => {
             let untagged_result = UntaggedValue::decimal_from_float(min, Span::new(64, 64));
-            Ok(OutputStream::one(ReturnSuccess::value(untagged_result)))
+            Ok(ActionStream::one(ReturnSuccess::value(untagged_result)))
         }
         _ => {
             let mut thread_rng = thread_rng();
@@ -84,7 +84,7 @@ pub fn decimal(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
             let untagged_result = UntaggedValue::decimal_from_float(result, Span::new(64, 64));
 
-            Ok(OutputStream::one(ReturnSuccess::value(untagged_result)))
+            Ok(ActionStream::one(ReturnSuccess::value(untagged_result)))
         }
     }
 }

--- a/crates/nu-command/src/commands/random/dice.rs
+++ b/crates/nu-command/src/commands/random/dice.rs
@@ -38,7 +38,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate a random dice roll"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         dice(args)
     }
 
@@ -58,7 +58,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn dice(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn dice(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
     let (DiceArgs { dice, sides }, _) = args.process()?;
 
@@ -79,7 +79,7 @@ pub fn dice(args: CommandArgs) -> Result<OutputStream, ShellError> {
         UntaggedValue::int(thread_rng.gen_range(1, sides + 1)).into_value(tag.clone())
     });
 
-    Ok((iter).to_output_stream())
+    Ok((iter).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/random/dice.rs
+++ b/crates/nu-command/src/commands/random/dice.rs
@@ -79,7 +79,7 @@ pub fn dice(args: CommandArgs) -> Result<ActionStream, ShellError> {
         UntaggedValue::int(thread_rng.gen_range(1, sides + 1)).into_value(tag.clone())
     });
 
-    Ok((iter).to_output_stream_with_actions())
+    Ok((iter).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/random/integer.rs
+++ b/crates/nu-command/src/commands/random/integer.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate a random integer [min..max]"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         integer(args)
     }
 
@@ -57,7 +57,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn integer(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn integer(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (IntegerArgs { range }, _) = args.process()?;
 
     let (min, max) = if let Some(range) = &range {
@@ -76,7 +76,7 @@ pub fn integer(args: CommandArgs) -> Result<OutputStream, ShellError> {
         )),
         Ordering::Equal => {
             let untagged_result = UntaggedValue::int(min).into_value(Tag::unknown());
-            Ok(OutputStream::one(ReturnSuccess::value(untagged_result)))
+            Ok(ActionStream::one(ReturnSuccess::value(untagged_result)))
         }
         _ => {
             let mut thread_rng = thread_rng();
@@ -86,7 +86,7 @@ pub fn integer(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
             let untagged_result = UntaggedValue::int(result).into_value(Tag::unknown());
 
-            Ok(OutputStream::one(ReturnSuccess::value(untagged_result)))
+            Ok(ActionStream::one(ReturnSuccess::value(untagged_result)))
         }
     }
 }

--- a/crates/nu-command/src/commands/random/uuid.rs
+++ b/crates/nu-command/src/commands/random/uuid.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate a random uuid4 string"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         uuid(args)
     }
 
@@ -32,10 +32,10 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn uuid(_args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn uuid(_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let uuid_4 = Uuid::new_v4().to_hyphenated().to_string();
 
-    Ok(OutputStream::one(ReturnSuccess::value(uuid_4)))
+    Ok(ActionStream::one(ReturnSuccess::value(uuid_4)))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/range.rs
+++ b/crates/nu-command/src/commands/range.rs
@@ -59,7 +59,7 @@ fn range(args: CommandArgs) -> Result<ActionStream, ShellError> {
         .skip(from)
         .take(to - from + 1)
         .map(ReturnSuccess::value)
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/range.rs
+++ b/crates/nu-command/src/commands/range.rs
@@ -29,12 +29,12 @@ impl WholeStreamCommand for Range {
         "Return only the selected rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         range(args)
     }
 }
 
-fn range(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn range(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (RangeArgs { area }, input) = args.process()?;
     let range = area.item;
     let (from, left_inclusive) = range.from;
@@ -59,7 +59,7 @@ fn range(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .skip(from)
         .take(to - from + 1)
         .map(ReturnSuccess::value)
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/reduce.rs
+++ b/crates/nu-command/src/commands/reduce.rs
@@ -150,7 +150,7 @@ fn reduce(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
 
                 result
             })?
-            .to_output_stream_with_actions())
+            .to_action_stream())
     } else {
         let initial = Ok(InputStream::one(start));
         Ok(input
@@ -177,7 +177,7 @@ fn reduce(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
                 context.scope.exit_scope();
                 result
             })?
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/reduce.rs
+++ b/crates/nu-command/src/commands/reduce.rs
@@ -7,7 +7,7 @@ use nu_errors::ShellError;
 use nu_parser::ParserScope;
 use nu_protocol::{hir::CapturedBlock, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
-use nu_stream::OutputStream;
+use nu_stream::ActionStream;
 
 pub struct Reduce;
 
@@ -47,7 +47,7 @@ impl WholeStreamCommand for Reduce {
         "Block must be (A, A) -> A unless --fold is selected, in which case it may be A, B -> A."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         reduce(args)
     }
 
@@ -94,7 +94,7 @@ fn process_row(
     result
 }
 
-fn reduce(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn reduce(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let span = raw_args.call_info.name_tag.span;
     let context = Arc::new(EvaluationContext::from_args(&raw_args));
     let (reduce_args, mut input): (ReduceArgs, _) = raw_args.process()?;
@@ -150,7 +150,7 @@ fn reduce(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
 
                 result
             })?
-            .to_output_stream())
+            .to_output_stream_with_actions())
     } else {
         let initial = Ok(InputStream::one(start));
         Ok(input
@@ -177,7 +177,7 @@ fn reduce(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                 context.scope.exit_scope();
                 result
             })?
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/reject.rs
+++ b/crates/nu-command/src/commands/reject.rs
@@ -53,7 +53,7 @@ fn reject(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     Ok(input
         .map(move |item| ReturnSuccess::value(reject_fields(&item, &fields, &item.tag)))
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/reject.rs
+++ b/crates/nu-command/src/commands/reject.rs
@@ -25,7 +25,7 @@ impl WholeStreamCommand for Reject {
         "Remove the given columns from the table. If you want to remove rows, try 'drop'."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         reject(args)
     }
 
@@ -38,7 +38,7 @@ impl WholeStreamCommand for Reject {
     }
 }
 
-fn reject(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn reject(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (RejectArgs { rest: fields }, input) = args.process()?;
     if fields.is_empty() {
@@ -53,7 +53,7 @@ fn reject(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     Ok(input
         .map(move |item| ReturnSuccess::value(reject_fields(&item, &fields, &item.tag)))
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/rename.rs
+++ b/crates/nu-command/src/commands/rename.rs
@@ -102,7 +102,7 @@ pub fn rename(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 )
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/rename.rs
+++ b/crates/nu-command/src/commands/rename.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for Rename {
         "Creates a new table with columns renamed."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         rename(args)
     }
 
@@ -61,7 +61,7 @@ impl WholeStreamCommand for Rename {
     }
 }
 
-pub fn rename(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn rename(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (Arguments { column_name, rest }, input) = args.process()?;
     let mut new_column_names = vec![vec![column_name]];
@@ -102,7 +102,7 @@ pub fn rename(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 )
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/reverse.rs
+++ b/crates/nu-command/src/commands/reverse.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for Reverse {
         "Reverses the table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         reverse(args)
     }
 
@@ -37,12 +37,12 @@ impl WholeStreamCommand for Reverse {
     }
 }
 
-fn reverse(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn reverse(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let (input, _args) = args.parts();
 
     let input = input.collect::<Vec<_>>();
-    Ok((input.into_iter().rev().map(ReturnSuccess::value)).to_output_stream())
+    Ok((input.into_iter().rev().map(ReturnSuccess::value)).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/reverse.rs
+++ b/crates/nu-command/src/commands/reverse.rs
@@ -42,7 +42,7 @@ fn reverse(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (input, _args) = args.parts();
 
     let input = input.collect::<Vec<_>>();
-    Ok((input.into_iter().rev().map(ReturnSuccess::value)).to_output_stream_with_actions())
+    Ok((input.into_iter().rev().map(ReturnSuccess::value)).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/rm.rs
+++ b/crates/nu-command/src/commands/rm.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for Remove {
         "Remove file(s)."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         rm(args)
     }
 
@@ -62,13 +62,13 @@ impl WholeStreamCommand for Remove {
     }
 }
 
-fn rm(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn rm(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let shell_manager = args.shell_manager.clone();
     let (args, _): (RemoveArgs, _) = args.process()?;
 
     if args.trash.item && args.permanent.item {
-        return Ok(OutputStream::one(Err(ShellError::labeled_error(
+        return Ok(ActionStream::one(Err(ShellError::labeled_error(
             "only one of --permanent and --trash can be used",
             "conflicting flags",
             name,

--- a/crates/nu-command/src/commands/roll/column.rs
+++ b/crates/nu-command/src/commands/roll/column.rs
@@ -65,7 +65,7 @@ pub fn roll(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 .map(ReturnSuccess::value)
         })
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn roll_by(value: Value, options: &Arguments) -> Option<Vec<Value>> {

--- a/crates/nu-command/src/commands/roll/column.rs
+++ b/crates/nu-command/src/commands/roll/column.rs
@@ -47,12 +47,12 @@ impl WholeStreamCommand for SubCommand {
         "Rolls the table columns"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         roll(args)
     }
 }
 
-pub fn roll(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn roll(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (args, input) = args.process()?;
 
     Ok(input
@@ -65,7 +65,7 @@ pub fn roll(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 .map(ReturnSuccess::value)
         })
         .flatten()
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn roll_by(value: Value, options: &Arguments) -> Option<Vec<Value>> {

--- a/crates/nu-command/src/commands/roll/command.rs
+++ b/crates/nu-command/src/commands/roll/command.rs
@@ -26,12 +26,12 @@ impl WholeStreamCommand for Command {
         "Rolls the table rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         roll(args)
     }
 }
 
-pub fn roll(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn roll(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (args, mut input) = args.process()?;
 
@@ -41,7 +41,7 @@ pub fn roll(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .unwrap_or_else(|| vec![UntaggedValue::nothing().into_value(&name)])
         .into_iter()
         .map(ReturnSuccess::value))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }
 
 fn roll_down(values: Vec<Value>, Arguments { by: ref n }: &Arguments) -> Option<Vec<Value>> {

--- a/crates/nu-command/src/commands/roll/command.rs
+++ b/crates/nu-command/src/commands/roll/command.rs
@@ -41,7 +41,7 @@ pub fn roll(args: CommandArgs) -> Result<ActionStream, ShellError> {
         .unwrap_or_else(|| vec![UntaggedValue::nothing().into_value(&name)])
         .into_iter()
         .map(ReturnSuccess::value))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }
 
 fn roll_down(values: Vec<Value>, Arguments { by: ref n }: &Arguments) -> Option<Vec<Value>> {

--- a/crates/nu-command/src/commands/roll/up.rs
+++ b/crates/nu-command/src/commands/roll/up.rs
@@ -41,7 +41,7 @@ pub fn roll(args: CommandArgs) -> Result<ActionStream, ShellError> {
         .unwrap_or_else(|| vec![UntaggedValue::nothing().into_value(&name)])
         .into_iter()
         .map(ReturnSuccess::value))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }
 
 fn roll_up(values: Vec<Value>, Arguments { by: ref n }: &Arguments) -> Option<Vec<Value>> {

--- a/crates/nu-command/src/commands/roll/up.rs
+++ b/crates/nu-command/src/commands/roll/up.rs
@@ -26,12 +26,12 @@ impl WholeStreamCommand for SubCommand {
         "Rolls the table rows"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         roll(args)
     }
 }
 
-pub fn roll(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn roll(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (args, mut input) = args.process()?;
 
@@ -41,7 +41,7 @@ pub fn roll(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .unwrap_or_else(|| vec![UntaggedValue::nothing().into_value(&name)])
         .into_iter()
         .map(ReturnSuccess::value))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }
 
 fn roll_up(values: Vec<Value>, Arguments { by: ref n }: &Arguments) -> Option<Vec<Value>> {

--- a/crates/nu-command/src/commands/rotate/command.rs
+++ b/crates/nu-command/src/commands/rotate/command.rs
@@ -113,5 +113,5 @@ pub fn rotate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         .rev()
         .collect::<Vec<_>>())
     .into_iter()
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }

--- a/crates/nu-command/src/commands/rotate/command.rs
+++ b/crates/nu-command/src/commands/rotate/command.rs
@@ -31,12 +31,12 @@ impl WholeStreamCommand for Command {
         "Rotates the table by 90 degrees clockwise."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         rotate(args)
     }
 }
 
-pub fn rotate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn rotate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (Arguments { rest }, input) = args.process()?;
 
@@ -48,7 +48,7 @@ pub fn rotate(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let descs = descs.into_iter().rev().collect::<Vec<_>>();
 
     if total_rows == 0 {
-        return Ok(OutputStream::empty());
+        return Ok(ActionStream::empty());
     }
 
     let mut headers: Vec<String> = vec![];
@@ -113,5 +113,5 @@ pub fn rotate(args: CommandArgs) -> Result<OutputStream, ShellError> {
         .rev()
         .collect::<Vec<_>>())
     .into_iter()
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }

--- a/crates/nu-command/src/commands/rotate/counter_clockwise.rs
+++ b/crates/nu-command/src/commands/rotate/counter_clockwise.rs
@@ -109,5 +109,5 @@ pub fn rotate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         })
         .collect::<Vec<_>>())
     .into_iter()
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }

--- a/crates/nu-command/src/commands/rotate/counter_clockwise.rs
+++ b/crates/nu-command/src/commands/rotate/counter_clockwise.rs
@@ -31,12 +31,12 @@ impl WholeStreamCommand for SubCommand {
         "Rotates the table by 90 degrees counter clockwise."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         rotate(args)
     }
 }
 
-pub fn rotate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn rotate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (Arguments { rest }, input) = args.process()?;
 
@@ -45,7 +45,7 @@ pub fn rotate(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let total_rows = input.len();
 
     if total_rows == 0 {
-        return Ok(OutputStream::empty());
+        return Ok(ActionStream::empty());
     }
 
     let mut headers: Vec<String> = vec![];
@@ -109,5 +109,5 @@ pub fn rotate(args: CommandArgs) -> Result<OutputStream, ShellError> {
         })
         .collect::<Vec<_>>())
     .into_iter()
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -116,7 +116,7 @@ impl WholeStreamCommand for RunExternalCommand {
                     .shell_manager
                     .cd(cd_args, args.call_info.name_tag.clone());
 
-                return Ok(result?.to_output_stream_with_actions());
+                return Ok(result?.to_action_stream());
             }
         }
 
@@ -128,7 +128,7 @@ impl WholeStreamCommand for RunExternalCommand {
             external_redirection,
         );
 
-        Ok(result?.to_output_stream_with_actions())
+        Ok(result?.to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -62,7 +62,7 @@ impl WholeStreamCommand for RunExternalCommand {
         true
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let positionals = args.call_info.args.positional.clone().ok_or_else(|| {
             ShellError::untagged_runtime_error("positional arguments unexpectedly empty")
         })?;
@@ -116,7 +116,7 @@ impl WholeStreamCommand for RunExternalCommand {
                     .shell_manager
                     .cd(cd_args, args.call_info.name_tag.clone());
 
-                return Ok(result?.to_output_stream());
+                return Ok(result?.to_output_stream_with_actions());
             }
         }
 
@@ -128,7 +128,7 @@ impl WholeStreamCommand for RunExternalCommand {
             external_redirection,
         );
 
-        Ok(result?.to_output_stream())
+        Ok(result?.to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/save.rs
+++ b/crates/nu-command/src/commands/save.rs
@@ -155,12 +155,12 @@ impl WholeStreamCommand for Save {
         "Save the contents of the pipeline to a file."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         save(args)
     }
 }
 
-fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn save(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let mut full_path = PathBuf::from(raw_args.shell_manager.path());
     let name_tag = raw_args.call_info.name_tag.clone();
     let name = raw_args.call_info.name_tag.clone();
@@ -230,7 +230,7 @@ fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                         },
                         scope,
                     };
-                    let mut result = converter.run(new_args.with_input(input))?;
+                    let mut result = converter.run_with_actions(new_args.with_input(input))?;
                     let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec();
                     if converter.is_binary() {
                         process_binary_return_success!('scope, result_vec, name_tag)

--- a/crates/nu-command/src/commands/select.rs
+++ b/crates/nu-command/src/commands/select.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for Command {
         "Down-select table to only these columns."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         select(args)
     }
 
@@ -48,7 +48,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn select(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn select(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (Arguments { mut rest }, input) = args.process()?;
     let (columns, _) = arguments(&mut rest)?;
@@ -155,5 +155,5 @@ fn select(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
         ReturnSuccess::value(out.into_value())
     }))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }

--- a/crates/nu-command/src/commands/select.rs
+++ b/crates/nu-command/src/commands/select.rs
@@ -155,5 +155,5 @@ fn select(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
         ReturnSuccess::value(out.into_value())
     }))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }

--- a/crates/nu-command/src/commands/seq.rs
+++ b/crates/nu-command/src/commands/seq.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::value::StrExt;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 use std::cmp;
 
@@ -317,5 +317,5 @@ fn print_seq(
         .lines()
         .map(|v| v.to_str_value_create_tag())
         .collect();
-    (rows.into_iter().map(ReturnSuccess::value)).to_output_stream()
+    (rows.into_iter()).to_output_stream()
 }

--- a/crates/nu-command/src/commands/seq_dates.rs
+++ b/crates/nu-command/src/commands/seq_dates.rs
@@ -353,7 +353,7 @@ pub fn run_seq_dates(
         .lines()
         .map(|v| v.to_str_value_create_tag())
         .collect();
-    Ok((rows.into_iter().map(ReturnSuccess::value)).to_output_stream_with_actions())
+    Ok((rows.into_iter().map(ReturnSuccess::value)).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/seq_dates.rs
+++ b/crates/nu-command/src/commands/seq_dates.rs
@@ -72,7 +72,7 @@ impl WholeStreamCommand for SeqDates {
         "print sequences of dates"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         seq_dates(args)
     }
 
@@ -131,7 +131,7 @@ impl WholeStreamCommand for SeqDates {
     }
 }
 
-fn seq_dates(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn seq_dates(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let _name = args.call_info.name_tag.clone();
 
     let (
@@ -230,7 +230,7 @@ pub fn run_seq_dates(
     increment: Value,
     day_count: Option<Value>,
     reverse: bool,
-) -> Result<OutputStream, ShellError> {
+) -> Result<ActionStream, ShellError> {
     let today = Local::today().naive_local();
     let mut step_size: i64 = increment
         .as_i64()
@@ -353,7 +353,7 @@ pub fn run_seq_dates(
         .lines()
         .map(|v| v.to_str_value_create_tag())
         .collect();
-    Ok((rows.into_iter().map(ReturnSuccess::value)).to_output_stream())
+    Ok((rows.into_iter().map(ReturnSuccess::value)).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/shells.rs
+++ b/crates/nu-command/src/commands/shells.rs
@@ -19,12 +19,12 @@ impl WholeStreamCommand for Shells {
         "Display the list of current shells."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(shells(args))
     }
 }
 
-fn shells(args: CommandArgs) -> OutputStream {
+fn shells(args: CommandArgs) -> ActionStream {
     let mut shells_out = VecDeque::new();
     let tag = args.call_info.name_tag;
 

--- a/crates/nu-command/src/commands/shuffle.rs
+++ b/crates/nu-command/src/commands/shuffle.rs
@@ -31,7 +31,7 @@ fn shuffle(args: CommandArgs) -> ActionStream {
     values
         .into_iter()
         .map(ReturnSuccess::value)
-        .to_output_stream_with_actions()
+        .to_action_stream()
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/shuffle.rs
+++ b/crates/nu-command/src/commands/shuffle.rs
@@ -17,12 +17,12 @@ impl WholeStreamCommand for Shuffle {
         "Shuffle rows randomly."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(shuffle(args))
     }
 }
 
-fn shuffle(args: CommandArgs) -> OutputStream {
+fn shuffle(args: CommandArgs) -> ActionStream {
     let input = args.input;
     let mut values: Vec<Value> = input.collect();
 
@@ -31,7 +31,7 @@ fn shuffle(args: CommandArgs) -> OutputStream {
     values
         .into_iter()
         .map(ReturnSuccess::value)
-        .to_output_stream()
+        .to_output_stream_with_actions()
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/size.rs
+++ b/crates/nu-command/src/commands/size.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for Size {
         "Gather word count statistics on the text."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(size(args))
     }
 
@@ -54,7 +54,7 @@ impl WholeStreamCommand for Size {
     }
 }
 
-fn size(args: CommandArgs) -> OutputStream {
+fn size(args: CommandArgs) -> ActionStream {
     let input = args.input;
     let tag = args.call_info.name_tag;
     let name_span = tag.span;
@@ -73,7 +73,7 @@ fn size(args: CommandArgs) -> OutputStream {
                 ))
             }
         })
-        .to_output_stream()
+        .to_output_stream_with_actions()
 }
 
 fn count(contents: &str, tag: impl Into<Tag>) -> Value {

--- a/crates/nu-command/src/commands/size.rs
+++ b/crates/nu-command/src/commands/size.rs
@@ -73,7 +73,7 @@ fn size(args: CommandArgs) -> ActionStream {
                 ))
             }
         })
-        .to_output_stream_with_actions()
+        .to_action_stream()
 }
 
 fn count(contents: &str, tag: impl Into<Tag>) -> Value {

--- a/crates/nu-command/src/commands/skip/command.rs
+++ b/crates/nu-command/src/commands/skip/command.rs
@@ -48,7 +48,7 @@ fn skip(args: CommandArgs) -> Result<ActionStream, ShellError> {
         1
     };
 
-    Ok(input.skip(rows_desired).to_output_stream_with_actions())
+    Ok(input.skip(rows_desired).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/skip/command.rs
+++ b/crates/nu-command/src/commands/skip/command.rs
@@ -24,7 +24,7 @@ impl WholeStreamCommand for Command {
         "Skip some number of rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         skip(args)
     }
 
@@ -40,7 +40,7 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn skip(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn skip(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (Arguments { rows }, input) = args.process()?;
     let rows_desired = if let Some(quantity) = rows {
         *quantity
@@ -48,7 +48,7 @@ fn skip(args: CommandArgs) -> Result<OutputStream, ShellError> {
         1
     };
 
-    Ok(input.skip(rows_desired).to_output_stream())
+    Ok(input.skip(rows_desired).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/skip/until.rs
+++ b/crates/nu-command/src/commands/skip/until.rs
@@ -92,7 +92,7 @@ impl WholeStreamCommand for SubCommand {
 
                 !matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/skip/until.rs
+++ b/crates/nu-command/src/commands/skip/until.rs
@@ -26,7 +26,7 @@ impl WholeStreamCommand for SubCommand {
         "Skips rows until the condition matches."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let ctx = Arc::new(EvaluationContext::from_args(&args));
         let call_info = args.evaluate_once()?;
 
@@ -92,7 +92,7 @@ impl WholeStreamCommand for SubCommand {
 
                 !matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/skip/while_.rs
+++ b/crates/nu-command/src/commands/skip/while_.rs
@@ -93,7 +93,7 @@ impl WholeStreamCommand for SubCommand {
 
                 matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/commands/skip/while_.rs
+++ b/crates/nu-command/src/commands/skip/while_.rs
@@ -26,7 +26,7 @@ impl WholeStreamCommand for SubCommand {
         "Skips rows while the condition matches."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let ctx = Arc::new(EvaluationContext::from_args(&args));
         let call_info = args.evaluate_once()?;
 
@@ -93,7 +93,7 @@ impl WholeStreamCommand for SubCommand {
 
                 matches!(result, Ok(ref v) if v.is_true())
             })
-            .to_output_stream())
+            .to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/sleep.rs
+++ b/crates/nu-command/src/commands/sleep.rs
@@ -34,7 +34,7 @@ impl WholeStreamCommand for Sleep {
         "Delay for a specified amount of time."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let ctrl_c = args.ctrl_c().clone();
 
         let (SleepArgs { duration, rest }, _) = args.process()?;
@@ -50,7 +50,7 @@ impl WholeStreamCommand for Sleep {
         // `echo | sleep 1sec` - nothing
         // `sleep 1sec`        - table with 0 elements
 
-        Ok(SleepIterator::new(total_dur, ctrl_c).to_output_stream())
+        Ok(SleepIterator::new(total_dur, ctrl_c).to_output_stream_with_actions())
 
         // if input.is_empty() {
         //     Ok(OutputStream::empty())

--- a/crates/nu-command/src/commands/sleep.rs
+++ b/crates/nu-command/src/commands/sleep.rs
@@ -50,7 +50,7 @@ impl WholeStreamCommand for Sleep {
         // `echo | sleep 1sec` - nothing
         // `sleep 1sec`        - table with 0 elements
 
-        Ok(SleepIterator::new(total_dur, ctrl_c).to_output_stream_with_actions())
+        Ok(SleepIterator::new(total_dur, ctrl_c).to_action_stream())
 
         // if input.is_empty() {
         //     Ok(OutputStream::empty())

--- a/crates/nu-command/src/commands/sort_by.rs
+++ b/crates/nu-command/src/commands/sort_by.rs
@@ -130,7 +130,7 @@ fn sort_by(args: CommandArgs) -> Result<ActionStream, ShellError> {
         vec.reverse()
     }
 
-    Ok((vec.into_iter()).to_output_stream_with_actions())
+    Ok((vec.into_iter()).to_action_stream())
 }
 
 pub fn sort(

--- a/crates/nu-command/src/commands/sort_by.rs
+++ b/crates/nu-command/src/commands/sort_by.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for SortBy {
         "Sort by the given columns, in increasing order."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         sort_by(args)
     }
 
@@ -111,7 +111,7 @@ impl WholeStreamCommand for SortBy {
     }
 }
 
-fn sort_by(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn sort_by(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
 
     let (
@@ -130,7 +130,7 @@ fn sort_by(args: CommandArgs) -> Result<OutputStream, ShellError> {
         vec.reverse()
     }
 
-    Ok((vec.into_iter()).to_output_stream())
+    Ok((vec.into_iter()).to_output_stream_with_actions())
 }
 
 pub fn sort(

--- a/crates/nu-command/src/commands/source.rs
+++ b/crates/nu-command/src/commands/source.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for Source {
         "Runs a script file in the current context."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         source(args)
     }
 
@@ -39,7 +39,7 @@ impl WholeStreamCommand for Source {
     }
 }
 
-pub fn source(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn source(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let ctx = EvaluationContext::from_args(&args);
     let (SourceArgs { filename }, _) = args.process()?;
 
@@ -54,7 +54,7 @@ pub fn source(args: CommandArgs) -> Result<OutputStream, ShellError> {
             if let Err(err) = result {
                 ctx.error(err.into());
             }
-            Ok(OutputStream::empty())
+            Ok(ActionStream::empty())
         }
         Err(_) => {
             ctx.error(ShellError::labeled_error(
@@ -63,7 +63,7 @@ pub fn source(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 filename.span(),
             ));
 
-            Ok(OutputStream::empty())
+            Ok(ActionStream::empty())
         }
     }
 }

--- a/crates/nu-command/src/commands/split/chars.rs
+++ b/crates/nu-command/src/commands/split/chars.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for SubCommand {
         "splits a string's characters into separate rows"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(split_chars(args))
     }
 
@@ -37,7 +37,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn split_chars(args: CommandArgs) -> OutputStream {
+fn split_chars(args: CommandArgs) -> ActionStream {
     let name = args.call_info.name_tag.clone();
     let input = args.input;
     input
@@ -47,9 +47,9 @@ fn split_chars(args: CommandArgs) -> OutputStream {
                     .collect::<Vec<_>>()
                     .into_iter()
                     .map(move |x| ReturnSuccess::value(Value::from(x.to_string())))
-                    .to_output_stream()
+                    .to_output_stream_with_actions()
             } else {
-                OutputStream::one(Err(ShellError::labeled_error_with_secondary(
+                ActionStream::one(Err(ShellError::labeled_error_with_secondary(
                     "Expected a string from pipeline",
                     "requires string input",
                     name.span,
@@ -58,7 +58,7 @@ fn split_chars(args: CommandArgs) -> OutputStream {
                 )))
             }
         })
-        .to_output_stream()
+        .to_output_stream_with_actions()
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/split/chars.rs
+++ b/crates/nu-command/src/commands/split/chars.rs
@@ -47,7 +47,7 @@ fn split_chars(args: CommandArgs) -> ActionStream {
                     .collect::<Vec<_>>()
                     .into_iter()
                     .map(move |x| ReturnSuccess::value(Value::from(x.to_string())))
-                    .to_output_stream_with_actions()
+                    .to_action_stream()
             } else {
                 ActionStream::one(Err(ShellError::labeled_error_with_secondary(
                     "Expected a string from pipeline",
@@ -58,7 +58,7 @@ fn split_chars(args: CommandArgs) -> ActionStream {
                 )))
             }
         })
-        .to_output_stream_with_actions()
+        .to_action_stream()
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/split/column.rs
+++ b/crates/nu-command/src/commands/split/column.rs
@@ -37,12 +37,12 @@ impl WholeStreamCommand for SubCommand {
         "splits contents across multiple columns via the separator."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         split_column(args)
     }
 }
 
-fn split_column(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn split_column(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_span = args.call_info.name_tag.span;
     let (
         SplitColumnArgs {
@@ -102,7 +102,7 @@ fn split_column(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ))
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/split/column.rs
+++ b/crates/nu-command/src/commands/split/column.rs
@@ -102,7 +102,7 @@ fn split_column(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ))
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/split/command.rs
+++ b/crates/nu-command/src/commands/split/command.rs
@@ -19,8 +19,8 @@ impl WholeStreamCommand for Command {
         "Split contents across desired subcommand (like row, column) via the separator."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(Ok(ReturnSuccess::Value(
             UntaggedValue::string(get_full_help(&Command, &args.scope)).into_value(Tag::unknown()),
         ))))
     }

--- a/crates/nu-command/src/commands/split/row.rs
+++ b/crates/nu-command/src/commands/split/row.rs
@@ -29,12 +29,12 @@ impl WholeStreamCommand for SubCommand {
         "splits contents over multiple rows via the separator."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         split_row(args)
     }
 }
 
-fn split_row(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn split_row(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (SplitRowArgs { separator }, input) = args.process()?;
     Ok(input
@@ -60,9 +60,9 @@ fn split_row(args: CommandArgs) -> Result<OutputStream, ShellError> {
                         UntaggedValue::Primitive(Primitive::String(s)).into_value(&v.tag),
                     )
                 }))
-                .to_output_stream()
+                .to_output_stream_with_actions()
             } else {
-                OutputStream::one(Err(ShellError::labeled_error_with_secondary(
+                ActionStream::one(Err(ShellError::labeled_error_with_secondary(
                     "Expected a string from pipeline",
                     "requires string input",
                     name.span,
@@ -71,7 +71,7 @@ fn split_row(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 )))
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/split/row.rs
+++ b/crates/nu-command/src/commands/split/row.rs
@@ -60,7 +60,7 @@ fn split_row(args: CommandArgs) -> Result<ActionStream, ShellError> {
                         UntaggedValue::Primitive(Primitive::String(s)).into_value(&v.tag),
                     )
                 }))
-                .to_output_stream_with_actions()
+                .to_action_stream()
             } else {
                 ActionStream::one(Err(ShellError::labeled_error_with_secondary(
                     "Expected a string from pipeline",
@@ -71,7 +71,7 @@ fn split_row(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 )))
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/split_by.rs
+++ b/crates/nu-command/src/commands/split_by.rs
@@ -30,12 +30,12 @@ impl WholeStreamCommand for SplitBy {
         "Creates a new table with the data from the inner tables split by the column given."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         split_by(args)
     }
 }
 
-pub fn split_by(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn split_by(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (SplitByArgs { column_name }, input) = args.process()?;
     let values: Vec<Value> = input.collect();
@@ -49,7 +49,7 @@ pub fn split_by(args: CommandArgs) -> Result<OutputStream, ShellError> {
     }
 
     let split = split(&column_name, &values[0], &name)?;
-    Ok(OutputStream::one(ReturnSuccess::value(split)))
+    Ok(ActionStream::one(ReturnSuccess::value(split)))
 }
 
 enum Grouper {

--- a/crates/nu-command/src/commands/str_/capitalize.rs
+++ b/crates/nu-command/src/commands/str_/capitalize.rs
@@ -67,7 +67,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/capitalize.rs
+++ b/crates/nu-command/src/commands/str_/capitalize.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for SubCommand {
         "capitalizes text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -43,7 +43,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
             column_paths: params.rest_args()?,
@@ -67,7 +67,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/case/camel_case.rs
+++ b/crates/nu-command/src/commands/str_/case/camel_case.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for SubCommand {
         "converts a string to camelCase"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &to_camel_case)
     }
 

--- a/crates/nu-command/src/commands/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/commands/str_/case/kebab_case.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for SubCommand {
         "converts a string to kebab-case"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &to_kebab_case)
     }
 

--- a/crates/nu-command/src/commands/str_/case/mod.rs
+++ b/crates/nu-command/src/commands/str_/case/mod.rs
@@ -47,7 +47,7 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 pub fn action<F>(

--- a/crates/nu-command/src/commands/str_/case/mod.rs
+++ b/crates/nu-command/src/commands/str_/case/mod.rs
@@ -20,7 +20,7 @@ struct Arguments {
     column_paths: Vec<ColumnPath>,
 }
 
-pub fn operate<F>(args: CommandArgs, case_operation: &'static F) -> Result<OutputStream, ShellError>
+pub fn operate<F>(args: CommandArgs, case_operation: &'static F) -> Result<ActionStream, ShellError>
 where
     F: Fn(&str) -> String + Send + Sync + 'static,
 {
@@ -47,7 +47,7 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 pub fn action<F>(

--- a/crates/nu-command/src/commands/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/commands/str_/case/pascal_case.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for SubCommand {
         "converts a string to PascalCase"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &to_pascal_case)
     }
 

--- a/crates/nu-command/src/commands/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/commands/str_/case/screaming_snake_case.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for SubCommand {
         "converts a string to SCREAMING_SNAKE_CASE"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &to_screaming_snake_case)
     }
 

--- a/crates/nu-command/src/commands/str_/case/snake_case.rs
+++ b/crates/nu-command/src/commands/str_/case/snake_case.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for SubCommand {
         "converts a string to snake_case"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &to_snake_case)
     }
 

--- a/crates/nu-command/src/commands/str_/collect.rs
+++ b/crates/nu-command/src/commands/str_/collect.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for SubCommand {
         "collects a list of strings into a string"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         collect(args)
     }
 
@@ -46,7 +46,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn collect(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn collect(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
 
     let (options, input) = args.extract(|params| {
@@ -68,7 +68,7 @@ pub fn collect(args: CommandArgs) -> Result<OutputStream, ShellError> {
         Ok(strings) => {
             let output = strings.join(&separator);
 
-            Ok(OutputStream::one(ReturnSuccess::value(
+            Ok(ActionStream::one(ReturnSuccess::value(
                 UntaggedValue::string(output).into_value(tag),
             )))
         }

--- a/crates/nu-command/src/commands/str_/command.rs
+++ b/crates/nu-command/src/commands/str_/command.rs
@@ -21,8 +21,8 @@ impl WholeStreamCommand for Command {
         "Apply string function."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&Command, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/str_/contains.rs
+++ b/crates/nu-command/src/commands/str_/contains.rs
@@ -83,7 +83,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/contains.rs
+++ b/crates/nu-command/src/commands/str_/contains.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for SubCommand {
         "Checks if string contains pattern"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -55,7 +55,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             pattern: params.req(0)?,
@@ -83,7 +83,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/downcase.rs
+++ b/crates/nu-command/src/commands/str_/downcase.rs
@@ -67,7 +67,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/downcase.rs
+++ b/crates/nu-command/src/commands/str_/downcase.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for SubCommand {
         "downcases text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -43,7 +43,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
             column_paths: params.rest_args()?,
@@ -67,7 +67,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/ends_with.rs
+++ b/crates/nu-command/src/commands/str_/ends_with.rs
@@ -73,7 +73,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/ends_with.rs
+++ b/crates/nu-command/src/commands/str_/ends_with.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for SubCommand {
         "checks if string ends with pattern"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -46,7 +46,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             pattern: params.req(0)?,
@@ -73,7 +73,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/find_replace.rs
+++ b/crates/nu-command/src/commands/str_/find_replace.rs
@@ -89,7 +89,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/find_replace.rs
+++ b/crates/nu-command/src/commands/str_/find_replace.rs
@@ -38,7 +38,7 @@ impl WholeStreamCommand for SubCommand {
         "finds and replaces text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -60,7 +60,7 @@ impl WholeStreamCommand for SubCommand {
 
 struct FindReplace<'a>(&'a str, &'a str);
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             all: params.has_flag("all"),
@@ -89,7 +89,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/from.rs
+++ b/crates/nu-command/src/commands/str_/from.rs
@@ -100,7 +100,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 // TODO If you're using the with-system-locale feature and you're on Windows, Clang 3.9 or higher is also required.

--- a/crates/nu-command/src/commands/str_/from.rs
+++ b/crates/nu-command/src/commands/str_/from.rs
@@ -43,7 +43,7 @@ impl WholeStreamCommand for SubCommand {
         "Converts numeric types to strings. Trims trailing zeros unless decimals parameter is specified."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -68,7 +68,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
             decimals: if let Some(arg) = params.get_flag("decimals") {
@@ -100,7 +100,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 // TODO If you're using the with-system-locale feature and you're on Windows, Clang 3.9 or higher is also required.

--- a/crates/nu-command/src/commands/str_/index_of.rs
+++ b/crates/nu-command/src/commands/str_/index_of.rs
@@ -122,7 +122,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/index_of.rs
+++ b/crates/nu-command/src/commands/str_/index_of.rs
@@ -49,7 +49,7 @@ impl WholeStreamCommand for SubCommand {
         "Returns starting index of given pattern in string counting from 0. Returns -1 when there are no results."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -89,7 +89,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             pattern: params.req(0)?,
@@ -122,7 +122,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/length.rs
+++ b/crates/nu-command/src/commands/str_/length.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for SubCommand {
         "outputs the lengths of the strings in the pipeline"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -51,7 +51,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
             column_paths: params.rest_args()?,
@@ -75,7 +75,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/length.rs
+++ b/crates/nu-command/src/commands/str_/length.rs
@@ -75,7 +75,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/lpad.rs
+++ b/crates/nu-command/src/commands/str_/lpad.rs
@@ -104,7 +104,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/lpad.rs
+++ b/crates/nu-command/src/commands/str_/lpad.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for SubCommand {
         "pad a string with a character a certain length"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -76,7 +76,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             length: params.req_named("length")?,
@@ -104,7 +104,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/reverse.rs
+++ b/crates/nu-command/src/commands/str_/reverse.rs
@@ -65,7 +65,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/reverse.rs
+++ b/crates/nu-command/src/commands/str_/reverse.rs
@@ -28,7 +28,7 @@ impl WholeStreamCommand for SubCommand {
         "outputs the reversals of the strings in the pipeline"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -41,7 +41,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
             column_paths: params.rest_args()?,
@@ -65,7 +65,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/rpad.rs
+++ b/crates/nu-command/src/commands/str_/rpad.rs
@@ -104,7 +104,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/rpad.rs
+++ b/crates/nu-command/src/commands/str_/rpad.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for SubCommand {
         "pad a string with a character a certain length"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -76,7 +76,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             length: params.req_named("length")?,
@@ -104,7 +104,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/starts_with.rs
+++ b/crates/nu-command/src/commands/str_/starts_with.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for SubCommand {
         "checks if string starts with pattern"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -46,7 +46,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             pattern: params.req(0)?,
@@ -73,7 +73,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/starts_with.rs
+++ b/crates/nu-command/src/commands/str_/starts_with.rs
@@ -73,7 +73,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, pattern: &str, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/substring.rs
+++ b/crates/nu-command/src/commands/str_/substring.rs
@@ -117,7 +117,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, options: &Substring, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/substring.rs
+++ b/crates/nu-command/src/commands/str_/substring.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for SubCommand {
         "substrings text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -86,7 +86,7 @@ impl From<(isize, isize)> for Substring {
 
 struct SubstringText(String, String);
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
 
     let (options, input) = args.extract(|params| {
@@ -117,7 +117,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, options: &Substring, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/to_datetime.rs
+++ b/crates/nu-command/src/commands/str_/to_datetime.rs
@@ -87,7 +87,7 @@ impl WholeStreamCommand for SubCommand {
         "converts text into datetime"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -126,7 +126,7 @@ impl WholeStreamCommand for SubCommand {
 #[derive(Clone)]
 struct DatetimeFormat(String);
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         let (column_paths, _) = arguments(&mut params.rest_args()?)?;
 
@@ -195,7 +195,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/to_datetime.rs
+++ b/crates/nu-command/src/commands/str_/to_datetime.rs
@@ -195,7 +195,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(

--- a/crates/nu-command/src/commands/str_/to_decimal.rs
+++ b/crates/nu-command/src/commands/str_/to_decimal.rs
@@ -70,7 +70,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/to_decimal.rs
+++ b/crates/nu-command/src/commands/str_/to_decimal.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for SubCommand {
         "converts text into decimal"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -46,7 +46,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
             column_paths: params.rest_args()?,
@@ -70,7 +70,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/to_integer.rs
+++ b/crates/nu-command/src/commands/str_/to_integer.rs
@@ -100,7 +100,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>, radix: u32) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/to_integer.rs
+++ b/crates/nu-command/src/commands/str_/to_integer.rs
@@ -37,7 +37,7 @@ impl WholeStreamCommand for SubCommand {
         "converts text into integer"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -67,7 +67,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         let (column_paths, _) = arguments(&mut params.rest_args()?)?;
 
@@ -100,7 +100,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>, radix: u32) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/trim/mod.rs
+++ b/crates/nu-command/src/commands/str_/trim/mod.rs
@@ -19,7 +19,7 @@ struct Arguments {
     column_paths: Vec<ColumnPath>,
 }
 
-pub fn operate<F>(args: CommandArgs, trim_operation: &'static F) -> Result<OutputStream, ShellError>
+pub fn operate<F>(args: CommandArgs, trim_operation: &'static F) -> Result<ActionStream, ShellError>
 where
     F: Fn(&str, Option<char>) -> String + Send + Sync + 'static,
 {
@@ -61,7 +61,7 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/nu-command/src/commands/str_/trim/mod.rs
+++ b/crates/nu-command/src/commands/str_/trim/mod.rs
@@ -61,7 +61,7 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/nu-command/src/commands/str_/trim/trim_both_ends.rs
+++ b/crates/nu-command/src/commands/str_/trim/trim_both_ends.rs
@@ -29,7 +29,7 @@ impl WholeStreamCommand for SubCommand {
         "trims text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &trim)
     }
 

--- a/crates/nu-command/src/commands/str_/trim/trim_left.rs
+++ b/crates/nu-command/src/commands/str_/trim/trim_left.rs
@@ -29,7 +29,7 @@ impl WholeStreamCommand for SubCommand {
         "trims whitespace or character from the beginning of text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &trim_left)
     }
 

--- a/crates/nu-command/src/commands/str_/trim/trim_right.rs
+++ b/crates/nu-command/src/commands/str_/trim/trim_right.rs
@@ -29,7 +29,7 @@ impl WholeStreamCommand for SubCommand {
         "trims whitespace or character from the end of text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args, &trim_right)
     }
 

--- a/crates/nu-command/src/commands/str_/upcase.rs
+++ b/crates/nu-command/src/commands/str_/upcase.rs
@@ -67,7 +67,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/str_/upcase.rs
+++ b/crates/nu-command/src/commands/str_/upcase.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for SubCommand {
         "upcases text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         operate(args)
     }
 
@@ -43,7 +43,7 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
             column_paths: params.rest_args()?,
@@ -67,7 +67,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {

--- a/crates/nu-command/src/commands/tags.rs
+++ b/crates/nu-command/src/commands/tags.rs
@@ -18,12 +18,12 @@ impl WholeStreamCommand for Tags {
         "Read the tags (metadata) for values."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(tags(args))
     }
 }
 
-fn tags(args: CommandArgs) -> OutputStream {
+fn tags(args: CommandArgs) -> ActionStream {
     args.input
         .map(move |v| {
             let mut tags = TaggedDictBuilder::new(v.tag());
@@ -48,7 +48,7 @@ fn tags(args: CommandArgs) -> OutputStream {
 
             tags.into_value()
         })
-        .to_output_stream()
+        .to_output_stream_with_actions()
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/tags.rs
+++ b/crates/nu-command/src/commands/tags.rs
@@ -48,7 +48,7 @@ fn tags(args: CommandArgs) -> ActionStream {
 
             tags.into_value()
         })
-        .to_output_stream_with_actions()
+        .to_action_stream()
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/termsize.rs
+++ b/crates/nu-command/src/commands/termsize.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for TermSize {
         "Returns the terminal size as W H"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let tag = args.call_info.name_tag.clone();
         let (TermSizeArgs { wide, tall }, _) = args.process()?;
 
@@ -35,18 +35,18 @@ impl WholeStreamCommand for TermSize {
         match size {
             Some((w, h)) => {
                 if wide && !tall {
-                    Ok(OutputStream::one(UntaggedValue::int(w).into_value(tag)))
+                    Ok(ActionStream::one(UntaggedValue::int(w).into_value(tag)))
                 } else if !wide && tall {
-                    Ok(OutputStream::one(UntaggedValue::int(h).into_value(tag)))
+                    Ok(ActionStream::one(UntaggedValue::int(h).into_value(tag)))
                 } else {
                     let mut indexmap = IndexMap::with_capacity(2);
                     indexmap.insert("width".to_string(), UntaggedValue::int(w).into_value(&tag));
                     indexmap.insert("height".to_string(), UntaggedValue::int(h).into_value(&tag));
                     let value = UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag);
-                    Ok(OutputStream::one(value))
+                    Ok(ActionStream::one(value))
                 }
             }
-            _ => Ok(OutputStream::one(
+            _ => Ok(ActionStream::one(
                 UntaggedValue::string("0 0".to_string()).into_value(tag),
             )),
         }

--- a/crates/nu-command/src/commands/to.rs
+++ b/crates/nu-command/src/commands/to.rs
@@ -19,8 +19,8 @@ impl WholeStreamCommand for To {
         "Convert table into an output format (based on subcommand, like csv, html, json, yaml)."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&To, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/to_csv.rs
+++ b/crates/nu-command/src/commands/to_csv.rs
@@ -36,12 +36,12 @@ impl WholeStreamCommand for ToCsv {
         "Convert table into .csv text "
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_csv(args)
     }
 }
 
-fn to_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_csv(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (
         ToCsvArgs {

--- a/crates/nu-command/src/commands/to_delimited_data.rs
+++ b/crates/nu-command/src/commands/to_delimited_data.rs
@@ -217,5 +217,5 @@ pub fn to_delimited_data(
             }
         }
     }))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }

--- a/crates/nu-command/src/commands/to_delimited_data.rs
+++ b/crates/nu-command/src/commands/to_delimited_data.rs
@@ -170,7 +170,7 @@ pub fn to_delimited_data(
     format_name: &'static str,
     input: InputStream,
     name: Tag,
-) -> Result<OutputStream, ShellError> {
+) -> Result<ActionStream, ShellError> {
     let name_tag = name;
     let name_span = name_tag.span;
 
@@ -217,5 +217,5 @@ pub fn to_delimited_data(
             }
         }
     }))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }

--- a/crates/nu-command/src/commands/to_html.rs
+++ b/crates/nu-command/src/commands/to_html.rs
@@ -123,7 +123,7 @@ impl WholeStreamCommand for ToHtml {
         "Convert table into simple HTML"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_html(args)
     }
 }
@@ -267,7 +267,7 @@ fn get_list_of_theme_names() -> Vec<String> {
     theme_names
 }
 
-fn to_html(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_html(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = args.call_info.name_tag.clone();
     let (
         ToHtmlArgs {
@@ -300,7 +300,7 @@ fn to_html(args: CommandArgs) -> Result<OutputStream, ShellError> {
         output_string.push_str("https://github.com/mbadolato/iTerm2-Color-Schemes\n");
 
         // Short circuit and return the output_string
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(output_string).into_value(name_tag),
         )))
     } else {
@@ -376,7 +376,7 @@ fn to_html(args: CommandArgs) -> Result<OutputStream, ShellError> {
             output_string = run_regexes(&regex_hm, &output_string);
         }
 
-        Ok(OutputStream::one(ReturnSuccess::value(
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(output_string).into_value(name_tag),
         )))
     }

--- a/crates/nu-command/src/commands/to_json.rs
+++ b/crates/nu-command/src/commands/to_json.rs
@@ -32,7 +32,7 @@ impl WholeStreamCommand for ToJson {
         "Converts table data into JSON text."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_json(args)
     }
 
@@ -157,7 +157,7 @@ fn json_list(input: &[Value]) -> Result<Vec<serde_json::Value>, ShellError> {
     Ok(out)
 }
 
-fn to_json(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_json(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = args.call_info.name_tag.clone();
     let (ToJsonArgs { pretty }, input) = args.process()?;
     let name_span = name_tag.span;
@@ -249,7 +249,7 @@ fn to_json(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 &name_tag,
             )),
         }))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_json.rs
+++ b/crates/nu-command/src/commands/to_json.rs
@@ -249,7 +249,7 @@ fn to_json(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 &name_tag,
             )),
         }))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_md.rs
+++ b/crates/nu-command/src/commands/to_md.rs
@@ -37,7 +37,7 @@ impl WholeStreamCommand for Command {
         "Convert table into simple Markdown"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_md(args)
     }
 
@@ -82,13 +82,13 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn to_md(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_md(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = args.call_info.name_tag.clone();
     let (arguments, input) = args.process()?;
 
     let input: Vec<Value> = input.collect();
 
-    Ok(OutputStream::one(ReturnSuccess::value(
+    Ok(ActionStream::one(ReturnSuccess::value(
         UntaggedValue::string(process(&input, arguments)).into_value(if input.is_empty() {
             name_tag
         } else {

--- a/crates/nu-command/src/commands/to_toml.rs
+++ b/crates/nu-command/src/commands/to_toml.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for ToToml {
         "Convert table into .toml text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_toml(args)
     }
     // TODO: add an example here. What commands to run to get a Row(Dictionary)?
@@ -139,7 +139,7 @@ fn collect_values(input: &[Value]) -> Result<Vec<toml::Value>, ShellError> {
     Ok(out)
 }
 
-fn to_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_toml(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let name_tag = args.name_tag();
     let name_span = name_tag.span;
@@ -179,7 +179,7 @@ fn to_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
             )),
         }
     }))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_toml.rs
+++ b/crates/nu-command/src/commands/to_toml.rs
@@ -179,7 +179,7 @@ fn to_toml(args: CommandArgs) -> Result<ActionStream, ShellError> {
             )),
         }
     }))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_tsv.rs
+++ b/crates/nu-command/src/commands/to_tsv.rs
@@ -28,12 +28,12 @@ impl WholeStreamCommand for ToTsv {
         "Convert table into .tsv text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_tsv(args)
     }
 }
 
-fn to_tsv(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_tsv(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let (ToTsvArgs { noheaders }, input) = args.process()?;
 

--- a/crates/nu-command/src/commands/to_url.rs
+++ b/crates/nu-command/src/commands/to_url.rs
@@ -69,7 +69,7 @@ fn to_url(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 value_tag.span,
             )),
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_url.rs
+++ b/crates/nu-command/src/commands/to_url.rs
@@ -18,12 +18,12 @@ impl WholeStreamCommand for ToUrl {
         "Convert table into url-encoded text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_url(args)
     }
 }
 
-fn to_url(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_url(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -69,7 +69,7 @@ fn to_url(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 value_tag.span,
             )),
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_xml.rs
+++ b/crates/nu-command/src/commands/to_xml.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for ToXml {
         "Convert table into .xml text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_xml(args)
     }
 }
@@ -131,7 +131,7 @@ pub fn write_xml_events<W: Write>(
     Ok(())
 }
 
-fn to_xml(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_xml(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = args.call_info.name_tag.clone();
     let name_span = name_tag.span;
     let (ToXmlArgs { pretty }, input) = args.process()?;
@@ -180,7 +180,7 @@ fn to_xml(args: CommandArgs) -> Result<OutputStream, ShellError> {
             )),
         }
     }))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_xml.rs
+++ b/crates/nu-command/src/commands/to_xml.rs
@@ -180,7 +180,7 @@ fn to_xml(args: CommandArgs) -> Result<ActionStream, ShellError> {
             )),
         }
     }))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_yaml.rs
+++ b/crates/nu-command/src/commands/to_yaml.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for ToYaml {
         "Convert table into .yaml/.yml text"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         to_yaml(args)
     }
 }
@@ -113,7 +113,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
     })
 }
 
-fn to_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn to_yaml(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let name_tag = args.name_tag();
     let name_span = name_tag.span;
@@ -155,7 +155,7 @@ fn to_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
             )),
         }
     }))
-    .to_output_stream())
+    .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/to_yaml.rs
+++ b/crates/nu-command/src/commands/to_yaml.rs
@@ -155,7 +155,7 @@ fn to_yaml(args: CommandArgs) -> Result<ActionStream, ShellError> {
             )),
         }
     }))
-    .to_output_stream_with_actions())
+    .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/touch.rs
+++ b/crates/nu-command/src/commands/touch.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for Touch {
     fn usage(&self) -> &str {
         "Creates one or more files."
     }
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         touch(args)
     }
 
@@ -50,7 +50,7 @@ impl WholeStreamCommand for Touch {
     }
 }
 
-fn touch(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn touch(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (TouchArgs { target, rest }, _) = args.process()?;
 
     for item in vec![target].into_iter().chain(rest.into_iter()) {
@@ -66,7 +66,7 @@ fn touch(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     }
 
-    Ok(OutputStream::empty())
+    Ok(ActionStream::empty())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/uniq.rs
+++ b/crates/nu-command/src/commands/uniq.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for Uniq {
         "Return the unique rows."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         uniq(args)
     }
 
@@ -53,7 +53,7 @@ impl WholeStreamCommand for Uniq {
     }
 }
 
-fn uniq(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let should_show_count = args.has_flag("count");
     let input = args.input;
@@ -115,7 +115,7 @@ fn uniq(args: CommandArgs) -> Result<OutputStream, ShellError> {
         }
     }
 
-    Ok(values_vec_deque.into_iter().to_output_stream())
+    Ok(values_vec_deque.into_iter().to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/uniq.rs
+++ b/crates/nu-command/src/commands/uniq.rs
@@ -115,7 +115,7 @@ fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
         }
     }
 
-    Ok(values_vec_deque.into_iter().to_output_stream_with_actions())
+    Ok(values_vec_deque.into_iter().to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/update.rs
+++ b/crates/nu-command/src/commands/update.rs
@@ -189,5 +189,5 @@ fn update(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
             }
         })
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }

--- a/crates/nu-command/src/commands/update.rs
+++ b/crates/nu-command/src/commands/update.rs
@@ -39,7 +39,7 @@ impl WholeStreamCommand for Command {
         "Update an existing column to have a new value."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         update(args)
     }
 
@@ -70,7 +70,7 @@ fn process_row(
     mut replacement: Arc<Value>,
     field: Arc<ColumnPath>,
     tag: Arc<Tag>,
-) -> Result<OutputStream, ShellError> {
+) -> Result<ActionStream, ShellError> {
     let tag = &*tag;
     let replacement = Arc::make_mut(&mut replacement);
 
@@ -121,21 +121,21 @@ fn process_row(
                             value: UntaggedValue::Row(_),
                             ..
                         } => match obj.replace_data_at_column_path(&field, result) {
-                            Some(v) => OutputStream::one(ReturnSuccess::value(v)),
-                            None => OutputStream::one(Err(ShellError::labeled_error(
+                            Some(v) => ActionStream::one(ReturnSuccess::value(v)),
+                            None => ActionStream::one(Err(ShellError::labeled_error(
                                 "update could not find place to insert column",
                                 "column name",
                                 obj.tag,
                             ))),
                         },
-                        _ => OutputStream::one(Err(ShellError::labeled_error(
+                        _ => ActionStream::one(Err(ShellError::labeled_error(
                             "Unrecognized type in stream",
                             "original value",
                             block_tag.clone(),
                         ))),
                     }
                 }
-                Err(e) => OutputStream::one(Err(e)),
+                Err(e) => ActionStream::one(Err(e)),
             }
         }
         replacement => match input {
@@ -148,8 +148,8 @@ fn process_row(
                 .unwrap_or_else(|| UntaggedValue::nothing().into_untagged_value())
                 .replace_data_at_column_path(&field, replacement.clone())
             {
-                Some(v) => OutputStream::one(ReturnSuccess::value(v)),
-                None => OutputStream::one(Err(ShellError::labeled_error(
+                Some(v) => ActionStream::one(ReturnSuccess::value(v)),
+                None => ActionStream::one(Err(ShellError::labeled_error(
                     "update could not find place to insert column",
                     "column name",
                     field.maybe_span().unwrap_or(tag.span),
@@ -157,8 +157,8 @@ fn process_row(
             },
             Value { value: _, ref tag } => {
                 match input.replace_data_at_column_path(&field, replacement.clone()) {
-                    Some(v) => OutputStream::one(ReturnSuccess::value(v)),
-                    None => OutputStream::one(Err(ShellError::labeled_error(
+                    Some(v) => ActionStream::one(ReturnSuccess::value(v)),
+                    None => ActionStream::one(Err(ShellError::labeled_error(
                         "update could not find place to insert column",
                         "column name",
                         field.maybe_span().unwrap_or(tag.span),
@@ -169,7 +169,7 @@ fn process_row(
     })
 }
 
-fn update(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn update(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let name_tag = Arc::new(raw_args.call_info.name_tag.clone());
     let context = Arc::new(EvaluationContext::from_args(&raw_args));
     let (Arguments { field, replacement }, input) = raw_args.process()?;
@@ -185,9 +185,9 @@ fn update(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
 
             match process_row(context, input, replacement, field, tag) {
                 Ok(s) => s,
-                Err(e) => OutputStream::one(Err(e)),
+                Err(e) => ActionStream::one(Err(e)),
             }
         })
         .flatten()
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }

--- a/crates/nu-command/src/commands/url_/command.rs
+++ b/crates/nu-command/src/commands/url_/command.rs
@@ -18,8 +18,8 @@ impl WholeStreamCommand for Url {
         "Apply url function."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(ReturnSuccess::value(
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(ReturnSuccess::value(
             UntaggedValue::string(get_full_help(&Url, &args.scope)).into_value(Tag::unknown()),
         )))
     }

--- a/crates/nu-command/src/commands/url_/host.rs
+++ b/crates/nu-command/src/commands/url_/host.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for UrlHost {
         "gets the host of a url"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let (DefaultArguments { rest }, input) = args.process()?;
         Ok(operate(input, rest, &host))
     }

--- a/crates/nu-command/src/commands/url_/mod.rs
+++ b/crates/nu-command/src/commands/url_/mod.rs
@@ -63,5 +63,5 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream_with_actions()
+        .to_action_stream()
 }

--- a/crates/nu-command/src/commands/url_/mod.rs
+++ b/crates/nu-command/src/commands/url_/mod.rs
@@ -42,7 +42,7 @@ where
     Ok(v)
 }
 
-fn operate<F>(input: crate::InputStream, paths: Vec<ColumnPath>, action: &'static F) -> OutputStream
+fn operate<F>(input: crate::InputStream, paths: Vec<ColumnPath>, action: &'static F) -> ActionStream
 where
     F: Fn(&Url) -> &str + Send + Sync + 'static,
 {
@@ -63,5 +63,5 @@ where
                 ReturnSuccess::value(ret)
             }
         })
-        .to_output_stream()
+        .to_output_stream_with_actions()
 }

--- a/crates/nu-command/src/commands/url_/path.rs
+++ b/crates/nu-command/src/commands/url_/path.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for UrlPath {
         "gets the path of a url"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let (DefaultArguments { rest }, input) = args.process()?;
         Ok(operate(input, rest, &Url::path))
     }

--- a/crates/nu-command/src/commands/url_/query.rs
+++ b/crates/nu-command/src/commands/url_/query.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for UrlQuery {
         "gets the query of a url"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let (DefaultArguments { rest }, input) = args.process()?;
         Ok(operate(input, rest, &query))
     }

--- a/crates/nu-command/src/commands/url_/scheme.rs
+++ b/crates/nu-command/src/commands/url_/scheme.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for UrlScheme {
         "gets the scheme (eg http, file) of a url"
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let (DefaultArguments { rest }, input) = args.process()?;
         Ok(operate(input, rest, &Url::scheme))
     }

--- a/crates/nu-command/src/commands/version.rs
+++ b/crates/nu-command/src/commands/version.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for Version {
         "Display Nu version."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         version(args)
     }
 
@@ -36,7 +36,7 @@ impl WholeStreamCommand for Version {
     }
 }
 
-pub fn version(args: CommandArgs) -> Result<OutputStream, ShellError> {
+pub fn version(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let tag = args.call_info.args.span;
 
     let mut indexmap = IndexMap::with_capacity(4);
@@ -141,7 +141,7 @@ pub fn version(args: CommandArgs) -> Result<OutputStream, ShellError> {
     );
 
     let value = UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag);
-    Ok(OutputStream::one(value))
+    Ok(ActionStream::one(value))
 }
 
 fn features_enabled() -> Vec<String> {

--- a/crates/nu-command/src/commands/where_.rs
+++ b/crates/nu-command/src/commands/where_.rs
@@ -30,7 +30,7 @@ impl WholeStreamCommand for Command {
         "Filter table to match the condition."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         where_command(args)
     }
 
@@ -59,7 +59,7 @@ impl WholeStreamCommand for Command {
         ]
     }
 }
-fn where_command(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn where_command(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let ctx = Arc::new(EvaluationContext::from_args(&raw_args));
     let tag = raw_args.call_info.name_tag.clone();
     let (Arguments { block }, input) = raw_args.process()?;
@@ -119,7 +119,7 @@ fn where_command(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                 Err(e) => Some(Err(e)),
             }
         })
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/where_.rs
+++ b/crates/nu-command/src/commands/where_.rs
@@ -119,7 +119,7 @@ fn where_command(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
                 Err(e) => Some(Err(e)),
             }
         })
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/which_.rs
+++ b/crates/nu-command/src/commands/which_.rs
@@ -24,7 +24,7 @@ impl WholeStreamCommand for Which {
         "Finds a program file, alias or custom command."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         which(args)
     }
 }
@@ -214,7 +214,7 @@ fn which_single(application: Tagged<String>, all: bool, scope: &Scope) -> Vec<Va
     }
 }
 
-fn which(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn which(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let scope = args.scope.clone();
 
     let (
@@ -233,7 +233,7 @@ fn which(args: CommandArgs) -> Result<OutputStream, ShellError> {
         output.extend(values);
     }
 
-    Ok((output.into_iter().map(ReturnSuccess::value)).to_output_stream())
+    Ok((output.into_iter().map(ReturnSuccess::value)).to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/which_.rs
+++ b/crates/nu-command/src/commands/which_.rs
@@ -233,7 +233,7 @@ fn which(args: CommandArgs) -> Result<ActionStream, ShellError> {
         output.extend(values);
     }
 
-    Ok((output.into_iter().map(ReturnSuccess::value)).to_output_stream_with_actions())
+    Ok((output.into_iter().map(ReturnSuccess::value)).to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/with_env.rs
+++ b/crates/nu-command/src/commands/with_env.rs
@@ -37,7 +37,7 @@ impl WholeStreamCommand for WithEnv {
         "Runs a block with an environment variable set."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         with_env(args)
     }
 
@@ -67,7 +67,7 @@ impl WholeStreamCommand for WithEnv {
     }
 }
 
-fn with_env(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn with_env(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let redirection = raw_args.call_info.args.external_redirection;
     let context = EvaluationContext::from_args(&raw_args);
     let (
@@ -121,7 +121,7 @@ fn with_env(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let result = run_block(&block.block, &context, input);
     context.scope.exit_scope();
 
-    result.map(|x| x.to_output_stream())
+    result.map(|x| x.to_output_stream_with_actions())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/with_env.rs
+++ b/crates/nu-command/src/commands/with_env.rs
@@ -121,7 +121,7 @@ fn with_env(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let result = run_block(&block.block, &context, input);
     context.scope.exit_scope();
 
-    result.map(|x| x.to_output_stream_with_actions())
+    result.map(|x| x.to_action_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/wrap.rs
+++ b/crates/nu-command/src/commands/wrap.rs
@@ -31,7 +31,7 @@ impl WholeStreamCommand for Wrap {
         "Wraps the given data in a table."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         wrap(args)
     }
 
@@ -77,7 +77,7 @@ impl WholeStreamCommand for Wrap {
     }
 }
 
-fn wrap(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn wrap(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (WrapArgs { column }, input) = args.process()?;
     let mut result_table = vec![];
     let mut are_all_rows = true;
@@ -119,9 +119,9 @@ fn wrap(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
         let row = UntaggedValue::row(index_map).into_untagged_value();
 
-        Ok(OutputStream::one(ReturnSuccess::value(row)))
+        Ok(ActionStream::one(ReturnSuccess::value(row)))
     } else {
-        Ok((result_table.into_iter().map(ReturnSuccess::value)).to_output_stream())
+        Ok((result_table.into_iter().map(ReturnSuccess::value)).to_output_stream_with_actions())
     }
 }
 

--- a/crates/nu-command/src/commands/wrap.rs
+++ b/crates/nu-command/src/commands/wrap.rs
@@ -121,7 +121,7 @@ fn wrap(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
         Ok(ActionStream::one(ReturnSuccess::value(row)))
     } else {
-        Ok((result_table.into_iter().map(ReturnSuccess::value)).to_output_stream_with_actions())
+        Ok((result_table.into_iter().map(ReturnSuccess::value)).to_action_stream())
     }
 }
 

--- a/crates/nu-command/src/examples/double_echo.rs
+++ b/crates/nu-command/src/examples/double_echo.rs
@@ -60,8 +60,7 @@ impl WholeStreamCommand for Command {
                             let subtable =
                                 vec![UntaggedValue::Table(values).into_value(base_value.tag())];
 
-                            (subtable.into_iter().map(ReturnSuccess::value))
-                                .to_action_stream()
+                            (subtable.into_iter().map(ReturnSuccess::value)).to_action_stream()
                         } else {
                             (table
                                 .into_iter()

--- a/crates/nu-command/src/examples/double_echo.rs
+++ b/crates/nu-command/src/examples/double_echo.rs
@@ -2,7 +2,7 @@ use nu_errors::ShellError;
 
 use nu_engine::{CommandArgs, WholeStreamCommand};
 use nu_protocol::{Primitive, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
-use nu_stream::{ActionStream, ToOutputStreamWithActions};
+use nu_stream::{ActionStream, ToActionStream};
 
 use serde::Deserialize;
 
@@ -61,7 +61,7 @@ impl WholeStreamCommand for Command {
                                 vec![UntaggedValue::Table(values).into_value(base_value.tag())];
 
                             (subtable.into_iter().map(ReturnSuccess::value))
-                                .to_output_stream_with_actions()
+                                .to_action_stream()
                         } else {
                             (table
                                 .into_iter()
@@ -70,7 +70,7 @@ impl WholeStreamCommand for Command {
                                     v
                                 })
                                 .map(ReturnSuccess::value))
-                            .to_output_stream_with_actions()
+                            .to_action_stream()
                         }
                     }
                     _ => ActionStream::one(Ok(ReturnSuccess::Value(Value {
@@ -81,6 +81,6 @@ impl WholeStreamCommand for Command {
             }
         });
 
-        Ok((stream).flatten().to_output_stream_with_actions())
+        Ok((stream).flatten().to_action_stream())
     }
 }

--- a/crates/nu-command/src/examples/double_ls.rs
+++ b/crates/nu-command/src/examples/double_ls.rs
@@ -3,7 +3,7 @@ use crate::examples::sample::ls::file_listing;
 use nu_engine::{CommandArgs, WholeStreamCommand};
 use nu_errors::ShellError;
 use nu_protocol::{ReturnSuccess, Signature, UntaggedValue, Value};
-use nu_stream::{OutputStream, ToOutputStream};
+use nu_stream::{ActionStream, ToOutputStreamWithActions};
 
 pub struct Command;
 
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Command {
         "Mock ls."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let name_tag = args.call_info.name_tag.clone();
 
         let mut base_value =
@@ -40,6 +40,6 @@ impl WholeStreamCommand for Command {
             .collect::<Vec<_>>()
             .into_iter()
             .map(ReturnSuccess::value))
-        .to_output_stream())
+        .to_output_stream_with_actions())
     }
 }

--- a/crates/nu-command/src/examples/double_ls.rs
+++ b/crates/nu-command/src/examples/double_ls.rs
@@ -3,7 +3,7 @@ use crate::examples::sample::ls::file_listing;
 use nu_engine::{CommandArgs, WholeStreamCommand};
 use nu_errors::ShellError;
 use nu_protocol::{ReturnSuccess, Signature, UntaggedValue, Value};
-use nu_stream::{ActionStream, ToOutputStreamWithActions};
+use nu_stream::{ActionStream, ToActionStream};
 
 pub struct Command;
 
@@ -40,6 +40,6 @@ impl WholeStreamCommand for Command {
             .collect::<Vec<_>>()
             .into_iter()
             .map(ReturnSuccess::value))
-        .to_output_stream_with_actions())
+        .to_action_stream())
     }
 }

--- a/crates/nu-command/src/examples/stub_generate.rs
+++ b/crates/nu-command/src/examples/stub_generate.rs
@@ -2,7 +2,7 @@ use nu_engine::{CommandArgs, WholeStreamCommand};
 use nu_errors::ShellError;
 use nu_protocol::{ReturnSuccess, Signature, UntaggedValue, Value};
 use nu_source::{AnchorLocation, Tag};
-use nu_stream::OutputStream;
+use nu_stream::ActionStream;
 
 use serde::Deserialize;
 
@@ -26,7 +26,7 @@ impl WholeStreamCommand for Command {
         "Generates tables and metadata that mimics behavior of real commands in controlled ways."
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let name_tag = args.call_info.name_tag.clone();
 
         let (Arguments { path: mocked_path }, _input) = args.process()?;
@@ -34,7 +34,7 @@ impl WholeStreamCommand for Command {
         let out = UntaggedValue::string("Yehuda Katz in Ecuador");
 
         if let Some(true) = mocked_path {
-            Ok(OutputStream::one(Ok(ReturnSuccess::Value(Value {
+            Ok(ActionStream::one(Ok(ReturnSuccess::Value(Value {
                 value: out,
                 tag: Tag {
                     anchor: Some(mock_path()),
@@ -42,7 +42,7 @@ impl WholeStreamCommand for Command {
                 },
             }))))
         } else {
-            Ok(OutputStream::one(Ok(ReturnSuccess::Value(
+            Ok(ActionStream::one(Ok(ReturnSuccess::Value(
                 out.into_value(name_tag),
             ))))
         }

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -16,7 +16,7 @@ pub use nu_data::config;
 pub use nu_data::dict::TaggedListBuilder;
 pub use nu_data::primitive;
 pub use nu_data::value;
-pub use nu_stream::{InputStream, InterruptibleStream, OutputStream};
+pub use nu_stream::{ActionStream, InputStream, InterruptibleStream};
 pub use nu_value_ext::ValueExt;
 pub use num_traits::cast::ToPrimitive;
 

--- a/crates/nu-command/src/prelude.rs
+++ b/crates/nu-command/src/prelude.rs
@@ -22,8 +22,8 @@ pub(crate) use nu_engine::{RunnableContext, RunnableContextWithoutInput};
 pub(crate) use nu_parser::ParserScope;
 pub(crate) use nu_protocol::{out, row};
 pub(crate) use nu_source::{AnchorLocation, PrettyDebug, Span, SpannedItem, Tag, TaggedItem};
-pub(crate) use nu_stream::ToInputStream;
-pub(crate) use nu_stream::{InputStream, Interruptible, OutputStream};
+pub(crate) use nu_stream::{ActionStream, InputStream, Interruptible, OutputStream};
+pub(crate) use nu_stream::{ToInputStream, ToOutputStream, ToOutputStreamWithActions};
 pub(crate) use nu_value_ext::ValueExt;
 pub(crate) use num_bigint::BigInt;
 pub(crate) use num_traits::cast::ToPrimitive;
@@ -34,33 +34,48 @@ pub(crate) use std::sync::Arc;
 
 #[allow(clippy::wrong_self_convention)]
 pub trait FromInputStream {
-    fn from_input_stream(self) -> OutputStream;
+    fn from_input_stream(self) -> ActionStream;
 }
 
 impl<T> FromInputStream for T
 where
     T: Iterator<Item = nu_protocol::Value> + Send + Sync + 'static,
 {
-    fn from_input_stream(self) -> OutputStream {
-        OutputStream {
+    fn from_input_stream(self) -> ActionStream {
+        ActionStream {
             values: Box::new(self.map(nu_protocol::ReturnSuccess::value)),
         }
     }
 }
 
-#[allow(clippy::wrong_self_convention)]
-pub trait ToOutputStream {
-    fn to_output_stream(self) -> OutputStream;
-}
+// #[allow(clippy::wrong_self_convention)]
+// pub trait ToOutputStream {
+//     fn to_output_stream(self) -> OutputStream;
+// }
 
-impl<T, U> ToOutputStream for T
-where
-    T: Iterator<Item = U> + Send + Sync + 'static,
-    U: Into<nu_protocol::ReturnValue>,
-{
-    fn to_output_stream(self) -> OutputStream {
-        OutputStream {
-            values: Box::new(self.map(|item| item.into())),
-        }
-    }
-}
+// impl<T, U> ToOutputStream for T
+// where
+//     T: Iterator<Item = U> + Send + Sync + 'static,
+//     U: Into<nu_protocol::ReturnValue>,
+// {
+//     fn to_output_stream(self) -> OutputStream {
+//         OutputStream::from_stream(self)
+//     }
+// }
+
+// #[allow(clippy::wrong_self_convention)]
+// pub trait ToOutputStreamWithAction {
+//     fn to_output_stream_with_actions(self) -> ActionStream;
+// }
+
+// impl<T, U> ToOutputStreamWithAction for T
+// where
+//     T: Iterator<Item = U> + Send + Sync + 'static,
+//     U: Into<nu_protocol::ReturnValue>,
+// {
+//     fn to_output_stream_with_actions(self) -> ActionStream {
+//         ActionStream {
+//             values: Box::new(self.map(|item| item.into())),
+//         }
+//     }
+// }

--- a/crates/nu-command/src/prelude.rs
+++ b/crates/nu-command/src/prelude.rs
@@ -23,7 +23,7 @@ pub(crate) use nu_parser::ParserScope;
 pub(crate) use nu_protocol::{out, row};
 pub(crate) use nu_source::{AnchorLocation, PrettyDebug, Span, SpannedItem, Tag, TaggedItem};
 pub(crate) use nu_stream::{ActionStream, InputStream, Interruptible, OutputStream};
-pub(crate) use nu_stream::{ToInputStream, ToOutputStream, ToActionStream};
+pub(crate) use nu_stream::{ToActionStream, ToInputStream, ToOutputStream};
 pub(crate) use nu_value_ext::ValueExt;
 pub(crate) use num_bigint::BigInt;
 pub(crate) use num_traits::cast::ToPrimitive;

--- a/crates/nu-command/src/prelude.rs
+++ b/crates/nu-command/src/prelude.rs
@@ -23,7 +23,7 @@ pub(crate) use nu_parser::ParserScope;
 pub(crate) use nu_protocol::{out, row};
 pub(crate) use nu_source::{AnchorLocation, PrettyDebug, Span, SpannedItem, Tag, TaggedItem};
 pub(crate) use nu_stream::{ActionStream, InputStream, Interruptible, OutputStream};
-pub(crate) use nu_stream::{ToInputStream, ToOutputStream, ToOutputStreamWithActions};
+pub(crate) use nu_stream::{ToInputStream, ToOutputStream, ToActionStream};
 pub(crate) use nu_value_ext::ValueExt;
 pub(crate) use num_bigint::BigInt;
 pub(crate) use num_traits::cast::ToPrimitive;
@@ -65,7 +65,7 @@ where
 
 // #[allow(clippy::wrong_self_convention)]
 // pub trait ToOutputStreamWithAction {
-//     fn to_output_stream_with_actions(self) -> ActionStream;
+//     fn to_action_stream(self) -> ActionStream;
 // }
 
 // impl<T, U> ToOutputStreamWithAction for T
@@ -73,7 +73,7 @@ where
 //     T: Iterator<Item = U> + Send + Sync + 'static,
 //     U: Into<nu_protocol::ReturnValue>,
 // {
-//     fn to_output_stream_with_actions(self) -> ActionStream {
+//     fn to_action_stream(self) -> ActionStream {
 //         ActionStream {
 //             values: Box::new(self.map(|item| item.into())),
 //         }

--- a/crates/nu-engine/src/evaluate/block.rs
+++ b/crates/nu-engine/src/evaluate/block.rs
@@ -8,16 +8,16 @@ use nu_protocol::hir::{
 };
 use nu_protocol::{ReturnSuccess, UntaggedValue, Value};
 use nu_source::{Span, Tag};
-use nu_stream::InputStream;
-use nu_stream::ToOutputStream;
+use nu_stream::ToOutputStreamWithActions;
+use nu_stream::{InputStream, OutputStream};
 use std::sync::atomic::Ordering;
 
 pub fn run_block(
     block: &Block,
     ctx: &EvaluationContext,
     mut input: InputStream,
-) -> Result<InputStream, ShellError> {
-    let mut output: Result<InputStream, ShellError> = Ok(InputStream::empty());
+) -> Result<OutputStream, ShellError> {
+    let mut output: Result<InputStream, ShellError> = Ok(OutputStream::empty());
     for (_, definition) in block.definitions.iter() {
         ctx.scope.add_definition(definition.clone());
     }
@@ -47,13 +47,13 @@ pub fn run_block(
                         }
                     };
                     match output_stream.next() {
-                        Some(Ok(ReturnSuccess::Value(Value {
+                        Some(Value {
                             value: UntaggedValue::Error(e),
                             ..
-                        }))) => {
+                        }) => {
                             return Err(e);
                         }
-                        Some(Ok(_item)) => {
+                        Some(_item) => {
                             if let Some(err) = ctx.get_errors().get(0) {
                                 ctx.clear_errors();
                                 return Err(err.clone());
@@ -68,9 +68,6 @@ pub fn run_block(
                                 return Err(err.clone());
                             }
                         }
-                        Some(Err(e)) => {
-                            return Err(e);
-                        }
                     }
                 }
             }
@@ -78,12 +75,12 @@ pub fn run_block(
                 return Err(e);
             }
         }
-        output = Ok(InputStream::empty());
+        output = Ok(OutputStream::empty());
         for pipeline in &group.pipelines {
             match output {
                 Ok(inp) if inp.is_empty() => {}
                 Ok(inp) => {
-                    let mut output_stream = inp.to_output_stream();
+                    let mut output_stream = inp.to_output_stream_with_actions();
 
                     match output_stream.next() {
                         Some(Ok(ReturnSuccess::Value(Value {
@@ -123,7 +120,7 @@ pub fn run_block(
             }
             output = run_pipeline(pipeline, ctx, input);
 
-            input = InputStream::empty();
+            input = OutputStream::empty();
         }
     }
 
@@ -134,7 +131,7 @@ fn run_pipeline(
     commands: &Pipeline,
     ctx: &EvaluationContext,
     mut input: InputStream,
-) -> Result<InputStream, ShellError> {
+) -> Result<OutputStream, ShellError> {
     for item in commands.list.clone() {
         input = match item {
             ClassifiedCommand::Dynamic(call) => {

--- a/crates/nu-engine/src/evaluate/block.rs
+++ b/crates/nu-engine/src/evaluate/block.rs
@@ -8,7 +8,7 @@ use nu_protocol::hir::{
 };
 use nu_protocol::{ReturnSuccess, UntaggedValue, Value};
 use nu_source::{Span, Tag};
-use nu_stream::ToOutputStreamWithActions;
+use nu_stream::ToActionStream;
 use nu_stream::{InputStream, OutputStream};
 use std::sync::atomic::Ordering;
 
@@ -80,7 +80,7 @@ pub fn run_block(
             match output {
                 Ok(inp) if inp.is_empty() => {}
                 Ok(inp) => {
-                    let mut output_stream = inp.to_output_stream_with_actions();
+                    let mut output_stream = inp.to_action_stream();
 
                     match output_stream.next() {
                         Some(Ok(ReturnSuccess::Value(Value {

--- a/crates/nu-engine/src/evaluation_context.rs
+++ b/crates/nu-engine/src/evaluation_context.rs
@@ -9,7 +9,7 @@ use nu_data::config::{self, Conf, NuConfig};
 use nu_errors::ShellError;
 use nu_protocol::{hir, ConfigPath};
 use nu_source::{Span, Tag};
-use nu_stream::{InputStream, OutputStream};
+use nu_stream::InputStream;
 use parking_lot::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::{path::Path, sync::Arc};
@@ -113,7 +113,7 @@ impl EvaluationContext {
         name_tag: Tag,
         args: hir::Call,
         input: InputStream,
-    ) -> Result<OutputStream, ShellError> {
+    ) -> Result<InputStream, ShellError> {
         let command_args = self.command_args(args, input, name_tag);
         command.run(command_args)
     }

--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -9,7 +9,7 @@ use encoding_rs::Encoding;
 use nu_data::config::LocalConfigDiff;
 use nu_protocol::{CommandAction, ConfigPath, TaggedDictBuilder, Value};
 use nu_source::{Span, Tag};
-use nu_stream::{ActionStream, Interruptible, ToOutputStreamWithActions};
+use nu_stream::{ActionStream, Interruptible, ToActionStream};
 use std::collections::VecDeque;
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
@@ -222,7 +222,7 @@ impl Shell for FilesystemShell {
                 Some(entry)
             })
             .interruptible(ctrl_c_copy)
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 
     fn cd(&self, args: CdArgs, name: Tag) -> Result<ActionStream, ShellError> {
@@ -758,7 +758,7 @@ impl Shell for FilesystemShell {
                     ))
                 }
             })
-            .to_output_stream_with_actions())
+            .to_action_stream())
     }
 
     fn path(&self) -> String {

--- a/crates/nu-engine/src/plugin/run_plugin.rs
+++ b/crates/nu-engine/src/plugin/run_plugin.rs
@@ -6,7 +6,7 @@ use log::trace;
 use nu_errors::ShellError;
 use nu_plugin::jsonrpc::JsonRpc;
 use nu_protocol::{Primitive, ReturnValue, Signature, UntaggedValue, Value};
-use nu_stream::{OutputStream, ToOutputStream};
+use nu_stream::{ActionStream, ToOutputStreamWithActions};
 use serde::{self, Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::io::prelude::*;
@@ -106,12 +106,12 @@ impl WholeStreamCommand for PluginFilter {
         &self.config.usage
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_filter(self.path.clone(), args)
     }
 }
 
-fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn run_filter(path: String, args: CommandArgs) -> Result<ActionStream, ShellError> {
     trace!("filter_plugin :: {}", path);
 
     let bos = vec![UntaggedValue::Primitive(Primitive::BeginningOfStream).into_untagged_value()]
@@ -175,7 +175,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
 
                     match request_raw {
                         Err(_) => {
-                            return OutputStream::one(Err(ShellError::labeled_error(
+                            return ActionStream::one(Err(ShellError::labeled_error(
                                 "Could not load json from plugin",
                                 "could not load json from plugin",
                                 &call_info.name_tag,
@@ -185,7 +185,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
                             match stdin.write(format!("{}\n", request_raw).as_bytes()) {
                                 Ok(_) => {}
                                 Err(err) => {
-                                    return OutputStream::one(Err(ShellError::unexpected(
+                                    return ActionStream::one(Err(ShellError::unexpected(
                                         format!("{}", err),
                                     )));
                                 }
@@ -201,13 +201,15 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
 
                             match response {
                                 Ok(NuResult::response { params }) => match params {
-                                    Ok(params) => params.into_iter().to_output_stream(),
-                                    Err(e) => {
-                                        vec![ReturnValue::Err(e)].into_iter().to_output_stream()
+                                    Ok(params) => {
+                                        params.into_iter().to_output_stream_with_actions()
                                     }
+                                    Err(e) => vec![ReturnValue::Err(e)]
+                                        .into_iter()
+                                        .to_output_stream_with_actions(),
                                 },
 
-                                Err(e) => OutputStream::one(Err(
+                                Err(e) => ActionStream::one(Err(
                                     ShellError::untagged_runtime_error(format!(
                                         "Error while processing begin_filter response: {:?} {}",
                                         e, input
@@ -215,7 +217,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
                                 )),
                             }
                         }
-                        Err(e) => OutputStream::one(Err(ShellError::untagged_runtime_error(
+                        Err(e) => ActionStream::one(Err(ShellError::untagged_runtime_error(
                             format!("Error while reading begin_filter response: {:?}", e),
                         ))),
                     }
@@ -236,7 +238,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
 
                     match request_raw {
                         Err(_) => {
-                            return OutputStream::one(Err(ShellError::labeled_error(
+                            return ActionStream::one(Err(ShellError::labeled_error(
                                 "Could not load json from plugin",
                                 "could not load json from plugin",
                                 &call_info.name_tag,
@@ -246,7 +248,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
                             match stdin.write(format!("{}\n", request_raw).as_bytes()) {
                                 Ok(_) => {}
                                 Err(err) => {
-                                    return OutputStream::one(Err(ShellError::unexpected(
+                                    return ActionStream::one(Err(ShellError::unexpected(
                                         format!("{}", err),
                                     )));
                                 }
@@ -262,17 +264,19 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
 
                             match response {
                                 Ok(NuResult::response { params }) => match params {
-                                    Ok(params) => params.into_iter().to_output_stream(),
-                                    Err(e) => {
-                                        vec![ReturnValue::Err(e)].into_iter().to_output_stream()
+                                    Ok(params) => {
+                                        params.into_iter().to_output_stream_with_actions()
                                     }
+                                    Err(e) => vec![ReturnValue::Err(e)]
+                                        .into_iter()
+                                        .to_output_stream_with_actions(),
                                 },
                                 Err(e) => vec![Err(ShellError::untagged_runtime_error(format!(
                                     "Error while processing end_filter response: {:?} {}",
                                     e, input
                                 )))]
                                 .into_iter()
-                                .to_output_stream(),
+                                .to_output_stream_with_actions(),
                             }
                         }
                         Err(e) => vec![Err(ShellError::untagged_runtime_error(format!(
@@ -280,7 +284,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
                             e
                         )))]
                         .into_iter()
-                        .to_output_stream(),
+                        .to_output_stream_with_actions(),
                     };
 
                     let stdin = child.stdin.as_mut().expect("Failed to open stdin");
@@ -295,7 +299,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
                             // TODO: Handle error
                         }
                         Err(e) => {
-                            return OutputStream::one(Err(ShellError::untagged_runtime_error(
+                            return ActionStream::one(Err(ShellError::untagged_runtime_error(
                                 format!("Error while processing quit response: {:?}", e),
                             )));
                         }
@@ -322,7 +326,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
                             // TODO: Handle error
                         }
                         Err(e) => {
-                            return OutputStream::one(Err(ShellError::untagged_runtime_error(
+                            return ActionStream::one(Err(ShellError::untagged_runtime_error(
                                 format!("Error while processing filter response: {:?}", e),
                             )));
                         }
@@ -336,12 +340,14 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
 
                             match response {
                                 Ok(NuResult::response { params }) => match params {
-                                    Ok(params) => params.into_iter().to_output_stream(),
-                                    Err(e) => {
-                                        vec![ReturnValue::Err(e)].into_iter().to_output_stream()
+                                    Ok(params) => {
+                                        params.into_iter().to_output_stream_with_actions()
                                     }
+                                    Err(e) => vec![ReturnValue::Err(e)]
+                                        .into_iter()
+                                        .to_output_stream_with_actions(),
                                 },
-                                Err(e) => OutputStream::one(Err(
+                                Err(e) => ActionStream::one(Err(
                                     ShellError::untagged_runtime_error(format!(
                                     "Error while processing filter response: {:?}\n== input ==\n{}",
                                     e, input
@@ -349,7 +355,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
                                 )),
                             }
                         }
-                        Err(e) => OutputStream::one(Err(ShellError::untagged_runtime_error(
+                        Err(e) => ActionStream::one(Err(ShellError::untagged_runtime_error(
                             format!("Error while reading filter response: {:?}", e),
                         ))),
                     }
@@ -357,7 +363,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<OutputStream, ShellErro
             }
         })
         .flatten()
-        .to_output_stream())
+        .to_output_stream_with_actions())
 }
 
 #[derive(new)]
@@ -380,12 +386,12 @@ impl WholeStreamCommand for PluginSink {
         &self.config.usage
     }
 
-    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         run_sink(self.path.clone(), args)
     }
 }
 
-fn run_sink(path: String, args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn run_sink(path: String, args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let call_info = args.call_info.clone();
 
@@ -429,7 +435,7 @@ fn run_sink(path: String, args: CommandArgs) -> Result<OutputStream, ShellError>
             if let Ok(mut child) = child {
                 let _ = child.wait();
 
-                Ok(OutputStream::empty())
+                Ok(ActionStream::empty())
             } else {
                 Err(ShellError::untagged_runtime_error(
                     "Could not create process for sink command",

--- a/crates/nu-engine/src/plugin/run_plugin.rs
+++ b/crates/nu-engine/src/plugin/run_plugin.rs
@@ -6,7 +6,7 @@ use log::trace;
 use nu_errors::ShellError;
 use nu_plugin::jsonrpc::JsonRpc;
 use nu_protocol::{Primitive, ReturnValue, Signature, UntaggedValue, Value};
-use nu_stream::{ActionStream, ToOutputStreamWithActions};
+use nu_stream::{ActionStream, ToActionStream};
 use serde::{self, Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::io::prelude::*;
@@ -201,12 +201,10 @@ fn run_filter(path: String, args: CommandArgs) -> Result<ActionStream, ShellErro
 
                             match response {
                                 Ok(NuResult::response { params }) => match params {
-                                    Ok(params) => {
-                                        params.into_iter().to_output_stream_with_actions()
+                                    Ok(params) => params.into_iter().to_action_stream(),
+                                    Err(e) => {
+                                        vec![ReturnValue::Err(e)].into_iter().to_action_stream()
                                     }
-                                    Err(e) => vec![ReturnValue::Err(e)]
-                                        .into_iter()
-                                        .to_output_stream_with_actions(),
                                 },
 
                                 Err(e) => ActionStream::one(Err(
@@ -264,19 +262,17 @@ fn run_filter(path: String, args: CommandArgs) -> Result<ActionStream, ShellErro
 
                             match response {
                                 Ok(NuResult::response { params }) => match params {
-                                    Ok(params) => {
-                                        params.into_iter().to_output_stream_with_actions()
+                                    Ok(params) => params.into_iter().to_action_stream(),
+                                    Err(e) => {
+                                        vec![ReturnValue::Err(e)].into_iter().to_action_stream()
                                     }
-                                    Err(e) => vec![ReturnValue::Err(e)]
-                                        .into_iter()
-                                        .to_output_stream_with_actions(),
                                 },
                                 Err(e) => vec![Err(ShellError::untagged_runtime_error(format!(
                                     "Error while processing end_filter response: {:?} {}",
                                     e, input
                                 )))]
                                 .into_iter()
-                                .to_output_stream_with_actions(),
+                                .to_action_stream(),
                             }
                         }
                         Err(e) => vec![Err(ShellError::untagged_runtime_error(format!(
@@ -284,7 +280,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<ActionStream, ShellErro
                             e
                         )))]
                         .into_iter()
-                        .to_output_stream_with_actions(),
+                        .to_action_stream(),
                     };
 
                     let stdin = child.stdin.as_mut().expect("Failed to open stdin");
@@ -340,12 +336,10 @@ fn run_filter(path: String, args: CommandArgs) -> Result<ActionStream, ShellErro
 
                             match response {
                                 Ok(NuResult::response { params }) => match params {
-                                    Ok(params) => {
-                                        params.into_iter().to_output_stream_with_actions()
+                                    Ok(params) => params.into_iter().to_action_stream(),
+                                    Err(e) => {
+                                        vec![ReturnValue::Err(e)].into_iter().to_action_stream()
                                     }
-                                    Err(e) => vec![ReturnValue::Err(e)]
-                                        .into_iter()
-                                        .to_output_stream_with_actions(),
                                 },
                                 Err(e) => ActionStream::one(Err(
                                     ShellError::untagged_runtime_error(format!(
@@ -363,7 +357,7 @@ fn run_filter(path: String, args: CommandArgs) -> Result<ActionStream, ShellErro
             }
         })
         .flatten()
-        .to_output_stream_with_actions())
+        .to_action_stream())
 }
 
 #[derive(new)]

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -5,7 +5,7 @@ use nu_protocol::hir::{
     Call, ClassifiedCommand, Expression, InternalCommand, Literal, NamedArguments,
     SpannedExpression,
 };
-use nu_protocol::{Primitive, ReturnSuccess, UntaggedValue, Value};
+use nu_protocol::{Primitive, UntaggedValue, Value};
 use nu_stream::{InputStream, ToInputStream};
 
 use crate::EvaluationContext;
@@ -210,17 +210,16 @@ pub fn process_script(
                 ) {
                     loop {
                         match output_stream.next() {
-                            Some(Ok(ReturnSuccess::Value(Value {
+                            Some(Value {
                                 value: UntaggedValue::Error(e),
                                 ..
-                            }))) => return LineResult::Error(line.to_string(), e),
-                            Some(Ok(_item)) => {
+                            }) => return LineResult::Error(line.to_string(), e),
+                            Some(_item) => {
                                 if ctx.ctrl_c.load(Ordering::SeqCst) {
                                     break;
                                 }
                             }
                             None => break,
-                            Some(Err(e)) => return LineResult::Error(line.to_string(), e),
                         }
                     }
                 }

--- a/crates/nu-engine/src/shell/mod.rs
+++ b/crates/nu-engine/src/shell/mod.rs
@@ -1,4 +1,4 @@
-use nu_stream::OutputStream;
+use nu_stream::ActionStream;
 
 use crate::command_args::EvaluatedWholeStreamCommandArgs;
 use crate::maybe_text_codec::StringOrBinary;
@@ -26,14 +26,14 @@ pub trait Shell: std::fmt::Debug {
         args: LsArgs,
         name: Tag,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<OutputStream, ShellError>;
-    fn cd(&self, args: CdArgs, name: Tag) -> Result<OutputStream, ShellError>;
-    fn cp(&self, args: CopyArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;
-    fn mkdir(&self, args: MkdirArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;
-    fn mv(&self, args: MvArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;
-    fn rm(&self, args: RemoveArgs, name: Tag, path: &str) -> Result<OutputStream, ShellError>;
+    ) -> Result<ActionStream, ShellError>;
+    fn cd(&self, args: CdArgs, name: Tag) -> Result<ActionStream, ShellError>;
+    fn cp(&self, args: CopyArgs, name: Tag, path: &str) -> Result<ActionStream, ShellError>;
+    fn mkdir(&self, args: MkdirArgs, name: Tag, path: &str) -> Result<ActionStream, ShellError>;
+    fn mv(&self, args: MvArgs, name: Tag, path: &str) -> Result<ActionStream, ShellError>;
+    fn rm(&self, args: RemoveArgs, name: Tag, path: &str) -> Result<ActionStream, ShellError>;
     fn path(&self) -> String;
-    fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError>;
+    fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<ActionStream, ShellError>;
     fn set_path(&mut self, path: String);
     fn open(
         &self,
@@ -49,5 +49,5 @@ pub trait Shell: std::fmt::Debug {
         path: &Path,
         contents: &[u8],
         name: Span,
-    ) -> Result<OutputStream, ShellError>;
+    ) -> Result<ActionStream, ShellError>;
 }

--- a/crates/nu-engine/src/shell/shell_manager.rs
+++ b/crates/nu-engine/src/shell/shell_manager.rs
@@ -1,7 +1,7 @@
 use crate::shell::Shell;
 use crate::{command_args::EvaluatedWholeStreamCommandArgs, FilesystemShell};
 use crate::{filesystem::filesystem_shell::FilesystemShellMode, maybe_text_codec::StringOrBinary};
-use nu_stream::OutputStream;
+use nu_stream::ActionStream;
 
 use crate::shell::shell_args::{CdArgs, CopyArgs, LsArgs, MkdirArgs, MvArgs, RemoveArgs};
 use encoding_rs::Encoding;
@@ -69,7 +69,7 @@ impl ShellManager {
         self.shells.lock()[self.current_shell()].path()
     }
 
-    pub fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {
+    pub fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<ActionStream, ShellError> {
         let env = self.shells.lock();
 
         env[self.current_shell()].pwd(args)
@@ -96,7 +96,7 @@ impl ShellManager {
         full_path: &Path,
         save_data: &[u8],
         name: Span,
-    ) -> Result<OutputStream, ShellError> {
+    ) -> Result<ActionStream, ShellError> {
         self.shells.lock()[self.current_shell()].save(full_path, save_data, name)
     }
 
@@ -137,40 +137,40 @@ impl ShellManager {
         args: LsArgs,
         name: Tag,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<OutputStream, ShellError> {
+    ) -> Result<ActionStream, ShellError> {
         let env = self.shells.lock();
 
         env[self.current_shell()].ls(args, name, ctrl_c)
     }
 
-    pub fn cd(&self, args: CdArgs, name: Tag) -> Result<OutputStream, ShellError> {
+    pub fn cd(&self, args: CdArgs, name: Tag) -> Result<ActionStream, ShellError> {
         let env = self.shells.lock();
 
         env[self.current_shell()].cd(args, name)
     }
 
-    pub fn cp(&self, args: CopyArgs, name: Tag) -> Result<OutputStream, ShellError> {
+    pub fn cp(&self, args: CopyArgs, name: Tag) -> Result<ActionStream, ShellError> {
         let shells = self.shells.lock();
 
         let path = shells[self.current_shell()].path();
         shells[self.current_shell()].cp(args, name, &path)
     }
 
-    pub fn rm(&self, args: RemoveArgs, name: Tag) -> Result<OutputStream, ShellError> {
+    pub fn rm(&self, args: RemoveArgs, name: Tag) -> Result<ActionStream, ShellError> {
         let shells = self.shells.lock();
 
         let path = shells[self.current_shell()].path();
         shells[self.current_shell()].rm(args, name, &path)
     }
 
-    pub fn mkdir(&self, args: MkdirArgs, name: Tag) -> Result<OutputStream, ShellError> {
+    pub fn mkdir(&self, args: MkdirArgs, name: Tag) -> Result<ActionStream, ShellError> {
         let shells = self.shells.lock();
 
         let path = shells[self.current_shell()].path();
         shells[self.current_shell()].mkdir(args, name, &path)
     }
 
-    pub fn mv(&self, args: MvArgs, name: Tag) -> Result<OutputStream, ShellError> {
+    pub fn mv(&self, args: MvArgs, name: Tag) -> Result<ActionStream, ShellError> {
         let shells = self.shells.lock();
 
         let path = shells[self.current_shell()].path();

--- a/crates/nu-engine/src/shell/value_shell.rs
+++ b/crates/nu-engine/src/shell/value_shell.rs
@@ -8,7 +8,7 @@ use nu_protocol::ValueStructure;
 use nu_protocol::{ReturnSuccess, ShellTypeName, UntaggedValue, Value};
 use nu_source::SpannedItem;
 use nu_source::{Span, Tag, Tagged};
-use nu_stream::OutputStream;
+use nu_stream::ActionStream;
 use nu_value_ext::ValueExt;
 use std::collections::VecDeque;
 use std::ffi::OsStr;
@@ -99,7 +99,7 @@ impl Shell for ValueShell {
         LsArgs { path, .. }: LsArgs,
         name_tag: Tag,
         _ctrl_c: Arc<AtomicBool>,
-    ) -> Result<OutputStream, ShellError> {
+    ) -> Result<ActionStream, ShellError> {
         let mut full_path = PathBuf::from(self.path());
 
         if let Some(value) = &path {
@@ -133,7 +133,7 @@ impl Shell for ValueShell {
         Ok(output.into())
     }
 
-    fn cd(&self, args: CdArgs, name: Tag) -> Result<OutputStream, ShellError> {
+    fn cd(&self, args: CdArgs, name: Tag) -> Result<ActionStream, ShellError> {
         let destination = args.path;
 
         let path = match destination {
@@ -178,10 +178,10 @@ impl Shell for ValueShell {
             ));
         }
 
-        Ok(OutputStream::one(ReturnSuccess::change_cwd(path)))
+        Ok(ActionStream::one(ReturnSuccess::change_cwd(path)))
     }
 
-    fn cp(&self, _args: CopyArgs, name: Tag, _path: &str) -> Result<OutputStream, ShellError> {
+    fn cp(&self, _args: CopyArgs, name: Tag, _path: &str) -> Result<ActionStream, ShellError> {
         Err(ShellError::labeled_error(
             "cp not currently supported on values",
             "not currently supported",
@@ -189,7 +189,7 @@ impl Shell for ValueShell {
         ))
     }
 
-    fn mv(&self, _args: MvArgs, name: Tag, _path: &str) -> Result<OutputStream, ShellError> {
+    fn mv(&self, _args: MvArgs, name: Tag, _path: &str) -> Result<ActionStream, ShellError> {
         Err(ShellError::labeled_error(
             "mv not currently supported on values",
             "not currently supported",
@@ -197,7 +197,7 @@ impl Shell for ValueShell {
         ))
     }
 
-    fn mkdir(&self, _args: MkdirArgs, name: Tag, _path: &str) -> Result<OutputStream, ShellError> {
+    fn mkdir(&self, _args: MkdirArgs, name: Tag, _path: &str) -> Result<ActionStream, ShellError> {
         Err(ShellError::labeled_error(
             "mkdir not currently supported on values",
             "not currently supported",
@@ -205,7 +205,7 @@ impl Shell for ValueShell {
         ))
     }
 
-    fn rm(&self, _args: RemoveArgs, name: Tag, _path: &str) -> Result<OutputStream, ShellError> {
+    fn rm(&self, _args: RemoveArgs, name: Tag, _path: &str) -> Result<ActionStream, ShellError> {
         Err(ShellError::labeled_error(
             "rm not currently supported on values",
             "not currently supported",
@@ -217,8 +217,8 @@ impl Shell for ValueShell {
         self.path.clone()
     }
 
-    fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<OutputStream, ShellError> {
-        Ok(OutputStream::one(
+    fn pwd(&self, args: EvaluatedWholeStreamCommandArgs) -> Result<ActionStream, ShellError> {
+        Ok(ActionStream::one(
             UntaggedValue::string(self.path()).into_value(&args.call_info.name_tag),
         ))
     }
@@ -247,7 +247,7 @@ impl Shell for ValueShell {
         _path: &Path,
         _contents: &[u8],
         _name: Span,
-    ) -> Result<OutputStream, ShellError> {
+    ) -> Result<ActionStream, ShellError> {
         Err(ShellError::unimplemented(
             "save on help shell is not supported",
         ))

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -309,6 +309,10 @@ impl Value {
         self.tag.clone()
     }
 
+    pub fn error(e: ShellError) -> Value {
+        UntaggedValue::Error(e).into_untagged_value()
+    }
+
     /// View the Value as a string, if possible
     pub fn as_string(&self) -> Result<String, ShellError> {
         match &self.value {

--- a/crates/nu-stream/src/lib.rs
+++ b/crates/nu-stream/src/lib.rs
@@ -7,5 +7,5 @@ mod output;
 pub use input::*;
 pub use interruptible::*;
 pub use output::*;
+pub use prelude::ToActionStream;
 pub use prelude::ToOutputStream;
-pub use prelude::ToOutputStreamWithActions;

--- a/crates/nu-stream/src/lib.rs
+++ b/crates/nu-stream/src/lib.rs
@@ -8,3 +8,4 @@ pub use input::*;
 pub use interruptible::*;
 pub use output::*;
 pub use prelude::ToOutputStream;
+pub use prelude::ToOutputStreamWithActions;

--- a/crates/nu-stream/src/output.rs
+++ b/crates/nu-stream/src/output.rs
@@ -2,11 +2,13 @@ use crate::prelude::*;
 use nu_protocol::{ReturnSuccess, ReturnValue, Value};
 use std::iter::IntoIterator;
 
-pub struct OutputStream {
+pub type OutputStream = InputStream;
+
+pub struct ActionStream {
     pub values: Box<dyn Iterator<Item = ReturnValue> + Send + Sync>,
 }
 
-impl Iterator for OutputStream {
+impl Iterator for ActionStream {
     type Item = ReturnValue;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -14,28 +16,28 @@ impl Iterator for OutputStream {
     }
 }
 
-impl OutputStream {
-    pub fn new(values: impl Iterator<Item = ReturnValue> + Send + Sync + 'static) -> OutputStream {
-        OutputStream {
+impl ActionStream {
+    pub fn new(values: impl Iterator<Item = ReturnValue> + Send + Sync + 'static) -> ActionStream {
+        ActionStream {
             values: Box::new(values),
         }
     }
 
-    pub fn empty() -> OutputStream {
-        OutputStream {
+    pub fn empty() -> ActionStream {
+        ActionStream {
             values: Box::new(std::iter::empty()),
         }
     }
 
-    pub fn one(item: impl Into<ReturnValue>) -> OutputStream {
+    pub fn one(item: impl Into<ReturnValue>) -> ActionStream {
         let item = item.into();
-        OutputStream {
+        ActionStream {
             values: Box::new(std::iter::once(item)),
         }
     }
 
-    pub fn from_input(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> OutputStream {
-        OutputStream {
+    pub fn from_input(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> ActionStream {
+        ActionStream {
             values: Box::new(input.map(ReturnSuccess::value)),
         }
     }
@@ -49,9 +51,9 @@ impl OutputStream {
     }
 }
 
-impl From<InputStream> for OutputStream {
-    fn from(input: InputStream) -> OutputStream {
-        OutputStream {
+impl From<InputStream> for ActionStream {
+    fn from(input: InputStream) -> ActionStream {
+        ActionStream {
             values: Box::new(input.into_iter().map(ReturnSuccess::value)),
         }
     }
@@ -71,35 +73,35 @@ impl From<InputStream> for OutputStream {
 //     }
 // }
 
-impl From<VecDeque<ReturnValue>> for OutputStream {
-    fn from(input: VecDeque<ReturnValue>) -> OutputStream {
-        OutputStream {
+impl From<VecDeque<ReturnValue>> for ActionStream {
+    fn from(input: VecDeque<ReturnValue>) -> ActionStream {
+        ActionStream {
             values: Box::new(input.into_iter()),
         }
     }
 }
 
-impl From<VecDeque<Value>> for OutputStream {
-    fn from(input: VecDeque<Value>) -> OutputStream {
+impl From<VecDeque<Value>> for ActionStream {
+    fn from(input: VecDeque<Value>) -> ActionStream {
         let stream = input.into_iter().map(ReturnSuccess::value);
-        OutputStream {
+        ActionStream {
             values: Box::new(stream),
         }
     }
 }
 
-impl From<Vec<ReturnValue>> for OutputStream {
-    fn from(input: Vec<ReturnValue>) -> OutputStream {
-        OutputStream {
+impl From<Vec<ReturnValue>> for ActionStream {
+    fn from(input: Vec<ReturnValue>) -> ActionStream {
+        ActionStream {
             values: Box::new(input.into_iter()),
         }
     }
 }
 
-impl From<Vec<Value>> for OutputStream {
-    fn from(input: Vec<Value>) -> OutputStream {
+impl From<Vec<Value>> for ActionStream {
+    fn from(input: Vec<Value>) -> ActionStream {
         let stream = input.into_iter().map(ReturnSuccess::value);
-        OutputStream {
+        ActionStream {
             values: Box::new(stream),
         }
     }

--- a/crates/nu-stream/src/prelude.rs
+++ b/crates/nu-stream/src/prelude.rs
@@ -53,16 +53,16 @@ where
 }
 
 #[allow(clippy::wrong_self_convention)]
-pub trait ToOutputStreamWithActions {
-    fn to_output_stream_with_actions(self) -> ActionStream;
+pub trait ToActionStream {
+    fn to_action_stream(self) -> ActionStream;
 }
 
-impl<T, U> ToOutputStreamWithActions for T
+impl<T, U> ToActionStream for T
 where
     T: Iterator<Item = U> + Send + Sync + 'static,
     U: Into<nu_protocol::ReturnValue>,
 {
-    fn to_output_stream_with_actions(self) -> ActionStream {
+    fn to_action_stream(self) -> ActionStream {
         ActionStream {
             values: Box::new(self.map(|item| item.into())),
         }

--- a/crates/nu-stream/src/prelude.rs
+++ b/crates/nu-stream/src/prelude.rs
@@ -34,20 +34,36 @@ macro_rules! trace_out_stream {
 pub(crate) use std::collections::VecDeque;
 pub(crate) use std::sync::Arc;
 
-pub(crate) use crate::{InputStream, OutputStream};
+use nu_protocol::Value;
+
+pub(crate) use crate::{ActionStream, InputStream, OutputStream};
 
 #[allow(clippy::wrong_self_convention)]
 pub trait ToOutputStream {
     fn to_output_stream(self) -> OutputStream;
 }
 
-impl<T, U> ToOutputStream for T
+impl<T> ToOutputStream for T
+where
+    T: Iterator<Item = Value> + Send + Sync + 'static,
+{
+    fn to_output_stream(self) -> OutputStream {
+        OutputStream::from_stream(self)
+    }
+}
+
+#[allow(clippy::wrong_self_convention)]
+pub trait ToOutputStreamWithActions {
+    fn to_output_stream_with_actions(self) -> ActionStream;
+}
+
+impl<T, U> ToOutputStreamWithActions for T
 where
     T: Iterator<Item = U> + Send + Sync + 'static,
     U: Into<nu_protocol::ReturnValue>,
 {
-    fn to_output_stream(self) -> OutputStream {
-        OutputStream {
+    fn to_output_stream_with_actions(self) -> ActionStream {
+        ActionStream {
             values: Box::new(self.map(|item| item.into())),
         }
     }


### PR DESCRIPTION
This splits output streams with actions from those without. If a command doesn't need the option to output actions, they can use OutputStream, which, like InputStream, is a Value-based iterator.  Commands that need actions can implement `run_with_actions` and output an ActionStream.

The reason for this split is two-fold: Value-based iterators are generally easier to work with, leaving you to do less work when you wan to output a value. More importantly, the ability to output Actions was largely going unused. This meant we were pay a large runtime cost for a feature that only a few commands needed. By splitting it, we can get a significant performance boost by just using Value-based iteration where possible.

I've converted a few commands to Value-based iteration and moved the rest to continue using ActionStream and `run_with_actions`, which preserves the existing behaviour.  These can be moved in batches to the new system.