### PR TITLE
Fix type error when Value is viewed as file path

### DIFF
--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -324,7 +324,7 @@ impl Value {
     pub fn as_filepath(&self) -> Result<PathBuf, ShellError> {
         match &self.value {
             UntaggedValue::Primitive(Primitive::FilePath(path)) => Ok(path.clone()),
-            _ => Err(ShellError::type_error("string", self.spanned_type_name())),
+            _ => Err(ShellError::type_error("path", self.spanned_type_name())),
         }
     }
 


### PR DESCRIPTION
I believe this should be "path", not "string".