### PR TITLE
Make sure that scripts can also have custom commands.

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -1,6 +1,5 @@
 use crate::line_editor::configure_ctrl_c;
 use nu_ansi_term::Color;
-use nu_command::commands::default_context::create_default_context;
 use nu_engine::{maybe_print_errors, run_block, script::run_script_standalone, EvaluationContext};
 
 #[allow(unused_imports)]
@@ -124,9 +123,7 @@ pub fn search_paths() -> Vec<std::path::PathBuf> {
     search_paths
 }
 
-pub fn run_script_file(options: Options) -> Result<(), Box<dyn Error>> {
-    let context = create_default_context(false)?;
-
+pub fn run_script_file(context: EvaluationContext, options: Options) -> Result<(), Box<dyn Error>> {
     if let Some(cfg) = options.config {
         load_cfg_as_global_cfg(&context, PathBuf::from(cfg));
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         Some(values) => {
             options.scripts = vec![NuScript::code(values)?];
 
-            nu_cli::run_script_file(options)?;
+            let context = create_default_context(false)?;
+            nu_cli::run_script_file(context, options)?;
             return Ok(());
         }
     }
@@ -161,7 +162,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             options.scripts = vec![NuScript::source_file(filepath.as_os_str())?];
 
-            nu_cli::run_script_file(options)?;
+            let context = create_default_context(false)?;
+            nu_cli::run_script_file(context, options)?;
             return Ok(());
         }
 


### PR DESCRIPTION
With the current code it is possible to attach custom commands from
a custom binary, but only for interactive mode. This change makes
it possible to also customize the evaluation context for commands
and scripts.