### PR TITLE
Fix date now rendering issue

### DIFF
--- a/crates/nu-command/src/commands/date/now.rs
+++ b/crates/nu-command/src/commands/date/now.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use chrono::{DateTime, Local};
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Signature, UntaggedValue};
+use nu_protocol::{Dictionary, Signature, UntaggedValue};
 
 pub struct Date;
 
@@ -30,7 +30,12 @@ pub fn now(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let now: DateTime<Local> = Local::now();
 
-    let value = UntaggedValue::date(now.with_timezone(now.offset())).into_value(&tag);
+    let mut indexmap = IndexMap::new();
+    indexmap.insert(
+        "current date".to_string(),
+        UntaggedValue::string(now.with_timezone(now.offset()).to_string()).into_value(&tag),
+    );
+    let value = UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag);
 
     Ok(ActionStream::one(value))
 }

--- a/crates/nu-command/src/commands/date/now.rs
+++ b/crates/nu-command/src/commands/date/now.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use chrono::{DateTime, Local};
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Dictionary, Signature, UntaggedValue};
+use nu_protocol::{Dictionary, Primitive, Signature, UntaggedValue};
 
 pub struct Date;
 
@@ -33,10 +33,10 @@ pub fn now(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let mut indexmap = IndexMap::new();
     indexmap.insert(
         "current date".to_string(),
-        UntaggedValue::string(now.with_timezone(now.offset()).to_string()).into_value(&tag),
+        UntaggedValue::date(now.with_timezone(now.offset())).into_value(&tag),
     );
     let value = UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag);
-
+    
     Ok(ActionStream::one(value))
 }
 


### PR DESCRIPTION
Tried something that closes #3317, but it does not work properly yet. The problem is that I keep the `date` type in the `now.rs` file as before, and put it all in a `row(dictionary)`, but the output is not really as expected:
```
───┬──────────────
 # │ current date
───┼──────────────
 0 │ 0 secs ago
───┴──────────────
```

However, this allows me to have the `date now | date to-table` working nicely
```
───┬──────┬───────┬─────┬──────┬────────┬────────┬──────────
 # │ year │ month │ day │ hour │ minute │ second │ timezone
───┼──────┼───────┼─────┼──────┼────────┼────────┼──────────
 0 │ 2021 │     4 │  14 │   23 │     10 │      1 │ +02:00
───┴──────┴───────┴─────┴──────┴────────┴────────┴──────────
```

If instead in the `now.rs` I make it a string (like in the first commit), then all good there but it breaks `to-table`, which would require to parse the string into datetime again. 

Anyone has any idea why pretty printing the `Primitive(Date)` is not properly handed?