### PR TITLE
Move to* and from* to engine-p

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,8 @@ table-pager = ["nu-command/table-pager"]
 #strip = "symbols" #Couldn't get working +nightly
 codegen-units = 1 #Reduce parallel codegen units
 lto = true #Link Time Optimization
-opt-level = 'z' #Optimize for size
+# opt-level = 'z' #Optimize for size
+# debug = true
 
 # Core plugins that ship with `cargo install nu` by default
 # Currently, Cargo limits us to installing only one binary

--- a/crates/nu-command/src/commands/ansi/command.rs
+++ b/crates/nu-command/src/commands/ansi/command.rs
@@ -115,12 +115,11 @@ Format: #
     fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         let args = args.evaluate_once()?;
 
-        let code: Option<Result<Tagged<String>, ShellError>> = args.opt(0);
-        let escape: Option<Result<Tagged<String>, ShellError>> = args.get_flag("escape");
-        let osc: Option<Result<Tagged<String>, ShellError>> = args.get_flag("osc");
+        let code: Option<Tagged<String>> = args.opt(0)?;
+        let escape: Option<Tagged<String>> = args.get_flag("escape")?;
+        let osc: Option<Tagged<String>> = args.get_flag("osc")?;
 
         if let Some(e) = escape {
-            let e = e?;
             let esc_vec: Vec<char> = e.item.chars().collect();
             if esc_vec[0] == '\\' {
                 return Err(ShellError::labeled_error(
@@ -136,7 +135,6 @@ Format: #
         }
 
         if let Some(o) = osc {
-            let o = o?;
             let osc_vec: Vec<char> = o.item.chars().collect();
             if osc_vec[0] == '\\' {
                 return Err(ShellError::labeled_error(
@@ -155,7 +153,6 @@ Format: #
         }
 
         if let Some(code) = code {
-            let code = code?;
             let ansi_code = str_to_ansi(&code.item);
 
             if let Some(output) = ansi_code {

--- a/crates/nu-command/src/commands/enter.rs
+++ b/crates/nu-command/src/commands/enter.rs
@@ -129,19 +129,19 @@ fn enter(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
                             scope,
                         };
                         let tag = tagged_contents.tag.clone();
-                        let mut result = converter
-                            .run_with_actions(new_args.with_input(vec![tagged_contents]))?;
-                        let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec();
+                        let mut result =
+                            converter.run(new_args.with_input(vec![tagged_contents]))?;
+                        let result_vec: Vec<Value> = result.drain_vec();
                         Ok(result_vec
                             .into_iter()
-                            .map(move |res| match res {
-                                Ok(ReturnSuccess::Value(Value { value, .. })) => Ok(
-                                    ReturnSuccess::Action(CommandAction::EnterValueShell(Value {
+                            .map(move |res| {
+                                let Value { value, .. } = res;
+                                Ok(ReturnSuccess::Action(CommandAction::EnterValueShell(
+                                    Value {
                                         value,
                                         tag: tag.clone(),
-                                    })),
-                                ),
-                                x => x,
+                                    },
+                                )))
                             })
                             .to_action_stream())
                     } else {

--- a/crates/nu-command/src/commands/from.rs
+++ b/crates/nu-command/src/commands/from.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
+use nu_protocol::{Signature, UntaggedValue};
 
 pub struct From;
 
@@ -18,10 +18,10 @@ impl WholeStreamCommand for From {
         "Parse content (string or binary) as a table (input format based on subcommand, like csv, ini, json, toml)."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
-        Ok(ActionStream::one(ReturnSuccess::value(
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        Ok(OutputStream::one(
             UntaggedValue::string(get_full_help(&From, &args.scope)).into_value(Tag::unknown()),
-        )))
+        ))
     }
 }
 

--- a/crates/nu-command/src/commands/from_csv.rs
+++ b/crates/nu-command/src/commands/from_csv.rs
@@ -6,12 +6,6 @@ use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue, Value};
 
 pub struct FromCsv;
 
-#[derive(Deserialize)]
-pub struct FromCsvArgs {
-    noheaders: bool,
-    separator: Option<Value>,
-}
-
 impl WholeStreamCommand for FromCsv {
     fn name(&self) -> &str {
         "from csv"
@@ -36,7 +30,7 @@ impl WholeStreamCommand for FromCsv {
         "Parse text as .csv and create table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_csv(args)
     }
 
@@ -66,16 +60,14 @@ impl WholeStreamCommand for FromCsv {
     }
 }
 
-fn from_csv(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn from_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
+    let args = args.evaluate_once()?;
 
-    let (
-        FromCsvArgs {
-            noheaders,
-            separator,
-        },
-        input,
-    ) = args.process()?;
+    let noheaders = args.has_flag("noheaders");
+    let separator: Option<Value> = args.get_flag("separator")?;
+    let input = args.input;
+
     let sep = match separator {
         Some(Value {
             value: UntaggedValue::Primitive(Primitive::String(s)),

--- a/crates/nu-command/src/commands/from_delimited_data.rs
+++ b/crates/nu-command/src/commands/from_delimited_data.rs
@@ -51,7 +51,7 @@ pub fn from_delimited_data(
     format_name: &'static str,
     input: InputStream,
     name: Tag,
-) -> Result<ActionStream, ShellError> {
+) -> Result<OutputStream, ShellError> {
     let name_tag = name;
     let concat_string = input.collect_string(name_tag.clone())?;
     let sample_lines = concat_string.item.lines().take(3).collect_vec().join("\n");
@@ -61,8 +61,8 @@ pub fn from_delimited_data(
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_action_stream()),
-            x => Ok(ActionStream::one(x)),
+            } => Ok(list.into_iter().to_output_stream()),
+            x => Ok(OutputStream::one(x)),
         },
         Err(err) => {
             let line_one = match pretty_csv_error(err) {

--- a/crates/nu-command/src/commands/from_ics.rs
+++ b/crates/nu-command/src/commands/from_ics.rs
@@ -4,7 +4,7 @@ use ical::parser::ical::component::*;
 use ical::property::Property;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, ReturnSuccess, Signature, TaggedDictBuilder, UntaggedValue, Value};
+use nu_protocol::{Primitive, Signature, TaggedDictBuilder, UntaggedValue, Value};
 use std::io::BufReader;
 
 pub struct FromIcs;
@@ -22,12 +22,12 @@ impl WholeStreamCommand for FromIcs {
         "Parse text as .ics and create table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_ics(args)
     }
 }
 
-fn from_ics(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn from_ics(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -43,8 +43,8 @@ fn from_ics(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     for calendar in parser {
         match calendar {
-            Ok(c) => output.push(ReturnSuccess::value(calendar_to_value(c, tag.clone()))),
-            Err(_) => output.push(Err(ShellError::labeled_error(
+            Ok(c) => output.push(calendar_to_value(c, tag.clone())),
+            Err(_) => output.push(Value::error(ShellError::labeled_error(
                 "Could not parse as .ics",
                 "input cannot be parsed as .ics",
                 tag.clone(),
@@ -52,7 +52,7 @@ fn from_ics(args: CommandArgs) -> Result<ActionStream, ShellError> {
         }
     }
 
-    Ok(output.into_iter().to_action_stream())
+    Ok(output.into_iter().to_output_stream())
 }
 
 fn calendar_to_value(calendar: IcalCalendar, tag: Tag) -> Value {

--- a/crates/nu-command/src/commands/from_ini.rs
+++ b/crates/nu-command/src/commands/from_ini.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for FromIni {
         "Parse text as .ini and create table"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_ini(args)
     }
 }
@@ -59,7 +59,7 @@ pub fn from_ini_string_to_value(
     Ok(convert_ini_top_to_nu_value(&v, tag))
 }
 
-fn from_ini(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn from_ini(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -70,8 +70,8 @@ fn from_ini(args: CommandArgs) -> Result<ActionStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_action_stream()),
-            x => Ok(ActionStream::one(x)),
+            } => Ok(list.into_iter().to_output_stream()),
+            x => Ok(OutputStream::one(x)),
         },
         Err(_) => Err(ShellError::labeled_error_with_secondary(
             "Could not parse as INI",

--- a/crates/nu-command/src/commands/from_toml.rs
+++ b/crates/nu-command/src/commands/from_toml.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, ReturnSuccess, Signature, TaggedDictBuilder, UntaggedValue, Value};
+use nu_protocol::{Primitive, Signature, TaggedDictBuilder, UntaggedValue, Value};
 
 pub struct FromToml;
 
@@ -18,7 +18,7 @@ impl WholeStreamCommand for FromToml {
         "Parse text as .toml and create table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_toml(args)
     }
 }
@@ -60,7 +60,7 @@ pub fn from_toml_string_to_value(s: String, tag: impl Into<Tag>) -> Result<Value
     Ok(convert_toml_value_to_nu_value(&v, tag))
 }
 
-pub fn from_toml(args: CommandArgs) -> Result<ActionStream, ShellError> {
+pub fn from_toml(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -72,11 +72,8 @@ pub fn from_toml(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 Value {
                     value: UntaggedValue::Table(list),
                     ..
-                } => list
-                    .into_iter()
-                    .map(ReturnSuccess::value)
-                    .to_action_stream(),
-                x => ActionStream::one(ReturnSuccess::value(x)),
+                } => list.into_iter().to_output_stream(),
+                x => OutputStream::one(x),
             },
             Err(_) => {
                 return Err(ShellError::labeled_error_with_secondary(

--- a/crates/nu-command/src/commands/from_tsv.rs
+++ b/crates/nu-command/src/commands/from_tsv.rs
@@ -6,11 +6,6 @@ use nu_protocol::Signature;
 
 pub struct FromTsv;
 
-#[derive(Deserialize)]
-pub struct FromTsvArgs {
-    noheaders: bool,
-}
-
 impl WholeStreamCommand for FromTsv {
     fn name(&self) -> &str {
         "from tsv"
@@ -28,14 +23,16 @@ impl WholeStreamCommand for FromTsv {
         "Parse text as .tsv and create table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_tsv(args)
     }
 }
 
-fn from_tsv(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn from_tsv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
-    let (FromTsvArgs { noheaders }, input) = args.process()?;
+    let args = args.evaluate_once()?;
+    let noheaders = args.has_flag("noheaders");
+    let input = args.input;
 
     from_delimited_data(noheaders, '\t', "TSV", input, name)
 }

--- a/crates/nu-command/src/commands/from_url.rs
+++ b/crates/nu-command/src/commands/from_url.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, TaggedDictBuilder, UntaggedValue};
+use nu_protocol::{Signature, TaggedDictBuilder, UntaggedValue};
 
 pub struct FromUrl;
 
@@ -18,12 +18,12 @@ impl WholeStreamCommand for FromUrl {
         "Parse url-encoded string as a table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_url(args)
     }
 }
 
-fn from_url(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn from_url(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -40,7 +40,7 @@ fn from_url(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 row.insert_untagged(k, UntaggedValue::string(v));
             }
 
-            Ok(ActionStream::one(ReturnSuccess::value(row.into_value())))
+            Ok(OutputStream::one(row.into_value()))
         }
         _ => Err(ShellError::labeled_error_with_secondary(
             "String not compatible with url-encoding",

--- a/crates/nu-command/src/commands/from_xml.rs
+++ b/crates/nu-command/src/commands/from_xml.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, ReturnSuccess, Signature, TaggedDictBuilder, UntaggedValue, Value};
+use nu_protocol::{Primitive, Signature, TaggedDictBuilder, UntaggedValue, Value};
 
 pub struct FromXml;
 
@@ -18,7 +18,7 @@ impl WholeStreamCommand for FromXml {
         "Parse text as .xml and create table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_xml(args)
     }
 }
@@ -94,7 +94,7 @@ pub fn from_xml_string_to_value(s: String, tag: impl Into<Tag>) -> Result<Value,
     Ok(from_document_to_value(&parsed, tag))
 }
 
-fn from_xml(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn from_xml(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -107,11 +107,8 @@ fn from_xml(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 Value {
                     value: UntaggedValue::Table(list),
                     ..
-                } => list
-                    .into_iter()
-                    .map(ReturnSuccess::value)
-                    .to_action_stream(),
-                x => ActionStream::one(ReturnSuccess::value(x)),
+                } => list.into_iter().to_output_stream(),
+                x => OutputStream::one(x),
             },
             Err(_) => {
                 return Err(ShellError::labeled_error_with_secondary(

--- a/crates/nu-command/src/commands/from_yaml.rs
+++ b/crates/nu-command/src/commands/from_yaml.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for FromYaml {
         "Parse text as .yaml/.yml and create table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_yaml(args)
     }
 }
@@ -38,7 +38,7 @@ impl WholeStreamCommand for FromYml {
         "Parse text as .yaml/.yml and create table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         from_yaml(args)
     }
 }
@@ -131,7 +131,7 @@ pub fn from_yaml_string_to_value(s: String, tag: impl Into<Tag>) -> Result<Value
     convert_yaml_value_to_nu_value(&v, tag)
 }
 
-fn from_yaml(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn from_yaml(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.name_tag();
     let input = args.input;
@@ -143,8 +143,8 @@ fn from_yaml(args: CommandArgs) -> Result<ActionStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => Ok(list.into_iter().to_action_stream()),
-            x => Ok(ActionStream::one(x)),
+            } => Ok(list.into_iter().to_output_stream()),
+            x => Ok(OutputStream::one(x)),
         },
         Err(_) => Err(ShellError::labeled_error_with_secondary(
             "Could not parse as YAML",

--- a/crates/nu-command/src/commands/math/eval.rs
+++ b/crates/nu-command/src/commands/math/eval.rs
@@ -42,11 +42,11 @@ impl WholeStreamCommand for SubCommand {
 
 pub fn eval(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
-    let expression: Option<Result<Tagged<String>, ShellError>> = args.opt(0);
+    let expression: Option<Tagged<String>> = args.opt(0)?;
     let name = args.call_info.name_tag.clone();
     let input = args.input;
 
-    if let Some(Ok(string)) = expression {
+    if let Some(string) = expression {
         match parse(&string, &string.tag) {
             Ok(value) => Ok(OutputStream::one(value)),
             Err(err) => Err(ShellError::labeled_error(
@@ -58,10 +58,10 @@ pub fn eval(args: CommandArgs) -> Result<OutputStream, ShellError> {
     } else {
         let mapped: Result<Vec<_>, _> = input
             .map(move |x| {
-                if let Some(Ok(Tagged {
+                if let Some(Tagged {
                     tag,
                     item: expression,
-                })) = &expression
+                }) = &expression
                 {
                     UntaggedValue::string(expression).into_value(tag)
                 } else {

--- a/crates/nu-command/src/commands/math/round.rs
+++ b/crates/nu-command/src/commands/math/round.rs
@@ -54,10 +54,10 @@ impl WholeStreamCommand for SubCommand {
 
 fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
-    let precision: Option<Result<Tagged<i16>, ShellError>> = args.get_flag("precision");
+    let precision: Option<Tagged<i16>> = args.get_flag("precision")?;
     let input = args.input;
     let precision = if let Some(precision) = precision {
-        precision?.item
+        precision.item
     } else {
         0
     };

--- a/crates/nu-command/src/commands/save.rs
+++ b/crates/nu-command/src/commands/save.rs
@@ -2,8 +2,7 @@ use crate::prelude::*;
 use nu_engine::{UnevaluatedCallInfo, WholeStreamCommand};
 use nu_errors::ShellError;
 use nu_protocol::{
-    hir::ExternalRedirection, Primitive, ReturnSuccess, Signature, SyntaxShape, UntaggedValue,
-    Value,
+    hir::ExternalRedirection, Primitive, Signature, SyntaxShape, UntaggedValue, Value,
 };
 use nu_source::Tagged;
 use std::path::{Path, PathBuf};
@@ -81,10 +80,10 @@ macro_rules! process_string_return_success {
         let mut result_string = String::new();
         for res in $result_vec {
             match res {
-                Ok(ReturnSuccess::Value(Value {
+                Value {
                     value: UntaggedValue::Primitive(Primitive::String(s)),
                     ..
-                })) => {
+                } => {
                     result_string.push_str(&s);
                 }
                 _ => {
@@ -105,10 +104,10 @@ macro_rules! process_binary_return_success {
         let mut result_binary: Vec<u8> = Vec::new();
         for res in $result_vec {
             match res {
-                Ok(ReturnSuccess::Value(Value {
+                Value {
                     value: UntaggedValue::Primitive(Primitive::Binary(b)),
                     ..
-                })) => {
+                } => {
                     for u in b.into_iter() {
                         result_binary.push(u);
                     }
@@ -222,8 +221,8 @@ fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                         },
                         scope,
                     };
-                    let mut result = converter.run_with_actions(new_args.with_input(input))?;
-                    let result_vec: Vec<Result<ReturnSuccess, ShellError>> = result.drain_vec();
+                    let mut result = converter.run(new_args.with_input(input))?;
+                    let result_vec: Vec<Value> = result.drain_vec();
                     if converter.is_binary() {
                         process_binary_return_success!('scope, result_vec, name_tag)
                     } else {

--- a/crates/nu-command/src/commands/select.rs
+++ b/crates/nu-command/src/commands/select.rs
@@ -3,15 +3,10 @@ use crate::utils::arguments::arguments;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{
-    PathMember, Primitive, ReturnSuccess, Signature, SyntaxShape, TaggedDictBuilder,
-    UnspannedPathMember, UntaggedValue, Value,
+    PathMember, Primitive, Signature, SyntaxShape, TaggedDictBuilder, UnspannedPathMember,
+    UntaggedValue, Value,
 };
 use nu_value_ext::{as_string, get_data_by_column_path};
-
-#[derive(Deserialize)]
-struct Arguments {
-    rest: Vec<Value>,
-}
 
 pub struct Command;
 
@@ -28,7 +23,7 @@ impl WholeStreamCommand for Command {
         "Down-select table to only these columns."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         select(args)
     }
 
@@ -48,9 +43,11 @@ impl WholeStreamCommand for Command {
     }
 }
 
-fn select(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn select(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
-    let (Arguments { mut rest }, input) = args.process()?;
+    let args = args.evaluate_once()?;
+    let mut rest = args.rest(0)?;
+    let input = args.input;
     let (columns, _) = arguments(&mut rest)?;
 
     if columns.is_empty() {
@@ -153,7 +150,7 @@ fn select(args: CommandArgs) -> Result<ActionStream, ShellError> {
             }
         }
 
-        ReturnSuccess::value(out.into_value())
+        out.into_value()
     }))
-    .to_action_stream())
+    .to_output_stream())
 }

--- a/crates/nu-command/src/commands/str_/collect.rs
+++ b/crates/nu-command/src/commands/str_/collect.rs
@@ -51,11 +51,7 @@ pub fn collect(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            separator: if let Some(arg) = params.opt(0) {
-                Some(arg?)
-            } else {
-                None
-            },
+            separator: params.opt(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/from.rs
+++ b/crates/nu-command/src/commands/str_/from.rs
@@ -71,11 +71,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            decimals: if let Some(arg) = params.get_flag("decimals") {
-                Some(arg?)
-            } else {
-                None
-            },
+            decimals: params.get_flag("decimals")?,
             group_digits: false,
             column_paths: params.rest_args()?,
         })

--- a/crates/nu-command/src/commands/str_/index_of.rs
+++ b/crates/nu-command/src/commands/str_/index_of.rs
@@ -93,11 +93,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             pattern: params.req(0)?,
-            range: if let Some(arg) = params.get_flag("range") {
-                Some(arg?)
-            } else {
-                None
-            },
+            range: params.get_flag("range")?,
             end: params.has_flag("end"),
             column_paths: params.rest(1)?,
         }))

--- a/crates/nu-command/src/commands/str_/to_datetime.rs
+++ b/crates/nu-command/src/commands/str_/to_datetime.rs
@@ -131,21 +131,9 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         let (column_paths, _) = arguments(&mut params.rest_args()?)?;
 
         Ok(Arguments {
-            timezone: if let Some(arg) = params.get_flag("timezone") {
-                Some(arg?)
-            } else {
-                None
-            },
-            offset: if let Some(arg) = params.get_flag("offset") {
-                Some(arg?)
-            } else {
-                None
-            },
-            format: if let Some(arg) = params.get_flag("format") {
-                Some(arg?)
-            } else {
-                None
-            },
+            timezone: params.get_flag("timezone")?,
+            offset: params.get_flag("offset")?,
+            format: params.get_flag("format")?,
             column_paths,
         })
     })?;

--- a/crates/nu-command/src/commands/str_/to_integer.rs
+++ b/crates/nu-command/src/commands/str_/to_integer.rs
@@ -72,11 +72,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         let (column_paths, _) = arguments(&mut params.rest_args()?)?;
 
         Ok(Arguments {
-            radix: if let Some(arg) = params.get_flag("radix") {
-                Some(arg?)
-            } else {
-                None
-            },
+            radix: params.get_flag("radix")?,
             column_paths,
         })
     })?;

--- a/crates/nu-command/src/commands/str_/trim/mod.rs
+++ b/crates/nu-command/src/commands/str_/trim/mod.rs
@@ -25,11 +25,7 @@ where
 {
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
-            character: if let Some(arg) = params.get_flag("char") {
-                Some(arg?)
-            } else {
-                None
-            },
+            character: params.get_flag("char")?,
             column_paths: params.rest_args()?,
         }))
     })?;

--- a/crates/nu-command/src/commands/table/command.rs
+++ b/crates/nu-command/src/commands/table/command.rs
@@ -176,8 +176,8 @@ fn table(args: CommandArgs) -> Result<OutputStream, ShellError> {
     // config.toml.... yet.
     let color_hm = get_color_config(&configuration);
 
-    let mut start_number = if let Some(f) = args.get_flag("start_number") {
-        f?
+    let mut start_number = if let Some(f) = args.get_flag("start_number")? {
+        f
     } else {
         0
     };

--- a/crates/nu-command/src/commands/to.rs
+++ b/crates/nu-command/src/commands/to.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
+use nu_protocol::{Signature, UntaggedValue};
 
 #[derive(Clone)]
 pub struct To;
@@ -19,10 +19,10 @@ impl WholeStreamCommand for To {
         "Convert table into an output format (based on subcommand, like csv, html, json, yaml)."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
-        Ok(ActionStream::one(ReturnSuccess::value(
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        Ok(OutputStream::one(
             UntaggedValue::string(get_full_help(&To, &args.scope)).into_value(Tag::unknown()),
-        )))
+        ))
     }
 }
 

--- a/crates/nu-command/src/commands/to_csv.rs
+++ b/crates/nu-command/src/commands/to_csv.rs
@@ -6,12 +6,6 @@ use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue, Value};
 
 pub struct ToCsv;
 
-#[derive(Deserialize)]
-pub struct ToCsvArgs {
-    noheaders: bool,
-    separator: Option<Value>,
-}
-
 impl WholeStreamCommand for ToCsv {
     fn name(&self) -> &str {
         "to csv"
@@ -36,20 +30,17 @@ impl WholeStreamCommand for ToCsv {
         "Convert table into .csv text "
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         to_csv(args)
     }
 }
 
-fn to_csv(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn to_csv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
-    let (
-        ToCsvArgs {
-            separator,
-            noheaders,
-        },
-        input,
-    ) = args.process()?;
+    let args = args.evaluate_once()?;
+    let separator: Option<Value> = args.get_flag("separator")?;
+    let noheaders = args.has_flag("noheaders");
+    let input = args.input;
     let sep = match separator {
         Some(Value {
             value: UntaggedValue::Primitive(Primitive::String(s)),

--- a/crates/nu-command/src/commands/to_delimited_data.rs
+++ b/crates/nu-command/src/commands/to_delimited_data.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use csv::WriterBuilder;
 use indexmap::{indexset, IndexSet};
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, ReturnSuccess, UntaggedValue, Value};
+use nu_protocol::{Primitive, UntaggedValue, Value};
 use nu_source::Spanned;
 use nu_value_ext::{as_string, ValueExt};
 
@@ -170,7 +170,7 @@ pub fn to_delimited_data(
     format_name: &'static str,
     input: InputStream,
     name: Tag,
-) -> Result<ActionStream, ShellError> {
+) -> Result<OutputStream, ShellError> {
     let name_tag = name;
     let name_span = name_tag.span;
 
@@ -197,9 +197,7 @@ pub fn to_delimited_data(
                         x.replace_range(0..start, "");
                     }
                 }
-                ReturnSuccess::value(
-                    UntaggedValue::Primitive(Primitive::String(x)).into_value(&name_tag),
-                )
+                UntaggedValue::Primitive(Primitive::String(x)).into_value(&name_tag)
             }
             Err(_) => {
                 let expected = format!(
@@ -207,7 +205,7 @@ pub fn to_delimited_data(
                     format_name
                 );
                 let requires = format!("requires {}-compatible input", format_name);
-                Err(ShellError::labeled_error_with_secondary(
+                Value::error(ShellError::labeled_error_with_secondary(
                     expected,
                     requires,
                     name_span,
@@ -217,5 +215,5 @@ pub fn to_delimited_data(
             }
         }
     }))
-    .to_action_stream())
+    .to_output_stream())
 }

--- a/crates/nu-command/src/commands/to_tsv.rs
+++ b/crates/nu-command/src/commands/to_tsv.rs
@@ -6,11 +6,6 @@ use nu_protocol::Signature;
 
 pub struct ToTsv;
 
-#[derive(Deserialize)]
-pub struct ToTsvArgs {
-    noheaders: bool,
-}
-
 impl WholeStreamCommand for ToTsv {
     fn name(&self) -> &str {
         "to tsv"
@@ -28,16 +23,17 @@ impl WholeStreamCommand for ToTsv {
         "Convert table into .tsv text"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         to_tsv(args)
     }
 }
 
-fn to_tsv(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn to_tsv(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
-    let (ToTsvArgs { noheaders }, input) = args.process()?;
+    let args = args.evaluate_once()?;
+    let noheaders = args.has_flag("noheaders");
 
-    to_delimited_data(noheaders, '\t', "TSV", input, name)
+    to_delimited_data(noheaders, '\t', "TSV", args.input, name)
 }
 
 #[cfg(test)]

--- a/crates/nu-engine/src/command_args.rs
+++ b/crates/nu-engine/src/command_args.rs
@@ -229,11 +229,12 @@ impl EvaluatedCommandArgs {
             .ok_or_else(|| ShellError::unimplemented("Better error: expect_nth"))
     }
 
-    pub fn get_flag<T: FromValue>(&self, name: &str) -> Option<Result<T, ShellError>> {
-        self.call_info
-            .args
-            .get(name)
-            .map(|x| FromValue::from_value(x))
+    pub fn get_flag<T: FromValue>(&self, name: &str) -> Result<Option<T>, ShellError> {
+        if let Some(arg) = self.call_info.args.get(name) {
+            FromValue::from_value(arg).map(Some)
+        } else {
+            Ok(None)
+        }
     }
 
     pub fn req_named<T: FromValue>(&self, name: &str) -> Result<T, ShellError> {
@@ -259,11 +260,11 @@ impl EvaluatedCommandArgs {
         }
     }
 
-    pub fn opt<T: FromValue>(&self, pos: usize) -> Option<Result<T, ShellError>> {
+    pub fn opt<T: FromValue>(&self, pos: usize) -> Result<Option<T>, ShellError> {
         if let Some(v) = self.nth(pos) {
-            Some(FromValue::from_value(v))
+            FromValue::from_value(v).map(Some)
         } else {
-            None
+            Ok(None)
         }
     }
 

--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -9,7 +9,7 @@ use encoding_rs::Encoding;
 use nu_data::config::LocalConfigDiff;
 use nu_protocol::{CommandAction, ConfigPath, TaggedDictBuilder, Value};
 use nu_source::{Span, Tag};
-use nu_stream::{ActionStream, Interruptible, ToActionStream};
+use nu_stream::{ActionStream, Interruptible, OutputStream, ToActionStream};
 use std::collections::VecDeque;
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
@@ -860,9 +860,9 @@ impl Shell for FilesystemShell {
         full_path: &Path,
         save_data: &[u8],
         name: Span,
-    ) -> Result<ActionStream, ShellError> {
+    ) -> Result<OutputStream, ShellError> {
         match std::fs::write(full_path, save_data) {
-            Ok(_) => Ok(ActionStream::empty()),
+            Ok(_) => Ok(OutputStream::empty()),
             Err(e) => Err(ShellError::labeled_error(
                 e.to_string(),
                 "IO error while saving",

--- a/crates/nu-engine/src/from_value.rs
+++ b/crates/nu-engine/src/from_value.rs
@@ -166,6 +166,26 @@ impl FromValue for PathBuf {
     }
 }
 
+impl FromValue for Tagged<PathBuf> {
+    fn from_value(v: &Value) -> Result<Self, ShellError> {
+        match v {
+            Value {
+                value: UntaggedValue::Primitive(Primitive::String(s)),
+                tag,
+            } => Ok(PathBuf::from(s).tagged(tag)),
+            Value {
+                value: UntaggedValue::Primitive(Primitive::FilePath(p)),
+                tag,
+            } => Ok(p.clone().tagged(tag)),
+            Value { tag, .. } => Err(ShellError::labeled_error(
+                "Can't convert to filepath",
+                "can't convert to filepath",
+                tag.span,
+            )),
+        }
+    }
+}
+
 impl FromValue for ColumnPath {
     fn from_value(v: &Value) -> Result<Self, ShellError> {
         match v {

--- a/crates/nu-engine/src/shell/mod.rs
+++ b/crates/nu-engine/src/shell/mod.rs
@@ -1,4 +1,4 @@
-use nu_stream::ActionStream;
+use nu_stream::{ActionStream, OutputStream};
 
 use crate::command_args::EvaluatedWholeStreamCommandArgs;
 use crate::maybe_text_codec::StringOrBinary;
@@ -49,5 +49,5 @@ pub trait Shell: std::fmt::Debug {
         path: &Path,
         contents: &[u8],
         name: Span,
-    ) -> Result<ActionStream, ShellError>;
+    ) -> Result<OutputStream, ShellError>;
 }

--- a/crates/nu-engine/src/shell/shell_manager.rs
+++ b/crates/nu-engine/src/shell/shell_manager.rs
@@ -1,7 +1,7 @@
 use crate::shell::Shell;
 use crate::{command_args::EvaluatedWholeStreamCommandArgs, FilesystemShell};
 use crate::{filesystem::filesystem_shell::FilesystemShellMode, maybe_text_codec::StringOrBinary};
-use nu_stream::ActionStream;
+use nu_stream::{ActionStream, OutputStream};
 
 use crate::shell::shell_args::{CdArgs, CopyArgs, LsArgs, MkdirArgs, MvArgs, RemoveArgs};
 use encoding_rs::Encoding;
@@ -96,7 +96,7 @@ impl ShellManager {
         full_path: &Path,
         save_data: &[u8],
         name: Span,
-    ) -> Result<ActionStream, ShellError> {
+    ) -> Result<OutputStream, ShellError> {
         self.shells.lock()[self.current_shell()].save(full_path, save_data, name)
     }
 

--- a/crates/nu-engine/src/shell/value_shell.rs
+++ b/crates/nu-engine/src/shell/value_shell.rs
@@ -8,7 +8,7 @@ use nu_protocol::ValueStructure;
 use nu_protocol::{ReturnSuccess, ShellTypeName, UntaggedValue, Value};
 use nu_source::SpannedItem;
 use nu_source::{Span, Tag, Tagged};
-use nu_stream::ActionStream;
+use nu_stream::{ActionStream, OutputStream};
 use nu_value_ext::ValueExt;
 use std::collections::VecDeque;
 use std::ffi::OsStr;
@@ -247,7 +247,7 @@ impl Shell for ValueShell {
         _path: &Path,
         _contents: &[u8],
         _name: Span,
-    ) -> Result<ActionStream, ShellError> {
+    ) -> Result<OutputStream, ShellError> {
         Err(ShellError::unimplemented(
             "save on help shell is not supported",
         ))

--- a/crates/nu-errors/src/lib.rs
+++ b/crates/nu-errors/src/lib.rs
@@ -641,7 +641,7 @@ impl ShellError {
     }
 
     pub fn unimplemented(title: impl Into<String>) -> ShellError {
-        ShellError::unimplemented(&format!("Unimplemented: {}", title.into()))
+        ShellError::untagged_runtime_error(&format!("Unimplemented: {}", title.into()))
     }
 
     pub fn unexpected(title: impl Into<String>) -> ShellError {


### PR DESCRIPTION
This PR does a few things and one unrelated thing:

* Moves `to*` and `from*` commands to engine-p
* Fixes an infinite recursion during erroring on unimplemented (oops)
* Remove using size optimisation by default. In my tests, I found opt-level=3 (the default) was noticeably faster for the benchmarks I tried
