### PR TITLE
Fix "Running echo .. starts printing integers forever"

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -227,6 +227,15 @@ fn parse_range(
         );
     };
 
+    if lite_arg.item[0..dotdot_pos].is_empty()
+        && lite_arg.item[(dotdot_pos + operator_str.len())..].is_empty()
+    {
+        return (
+            garbage(lite_arg.span),
+            Some(ParseError::mismatch("range", lite_arg.clone())),
+        );
+    }
+
     let numbers: Vec<_> = lite_arg.item.split(operator_str).collect();
 
     if numbers.len() != 2 {

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -434,6 +434,30 @@ fn index_cell_alt() {
 }
 
 #[test]
+fn not_echoing_ranges_without_numbers() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo ..
+        "#
+    );
+
+    assert_eq!(actual.out, "..");
+}
+
+#[test]
+fn not_echoing_exclusive_ranges_without_numbers() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo ..<
+        "#
+    );
+
+    assert_eq!(actual.out, "..<");
+}
+
+#[test]
 fn echoing_ranges() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
Fixes  #3313 

New behaviour
```
echo ..
.. 
```
```
echo ..<
..< 
```

`echo 1..` or `echo ..<10` for example will keep working as usual 
