### PR TITLE
add query json plugin for experimentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gjson"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864178e25a00c41404f1728997c9a21a7b746be1faefe6ce4dc41eb48bb4234f"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3110,6 +3116,7 @@ dependencies = [
  "nu_plugin_match",
  "nu_plugin_post",
  "nu_plugin_ps",
+ "nu_plugin_query_json",
  "nu_plugin_s3",
  "nu_plugin_selector",
  "nu_plugin_start",
@@ -3702,6 +3709,18 @@ dependencies = [
  "nu-source",
  "num-bigint 0.3.2",
  "sysinfo",
+]
+
+[[package]]
+name = "nu_plugin_query_json"
+version = "0.29.2"
+dependencies = [
+ "gjson",
+ "nu-errors",
+ "nu-plugin",
+ "nu-protocol",
+ "nu-source",
+ "nu-test-support",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ nu_plugin_inc = { version = "0.29.2", path = "./crates/nu_plugin_inc", optional 
 nu_plugin_match = { version = "0.29.2", path = "./crates/nu_plugin_match", optional = true }
 nu_plugin_post = { version = "0.29.2", path = "./crates/nu_plugin_post", optional = true }
 nu_plugin_ps = { version = "0.29.2", path = "./crates/nu_plugin_ps", optional = true }
+nu_plugin_query_json = { version = "0.29.2", path = "./crates/nu_plugin_query_json", optional = true }
 nu_plugin_s3 = { version = "0.29.2", path = "./crates/nu_plugin_s3", optional = true }
 nu_plugin_selector = { version = "0.29.2", path = "./crates/nu_plugin_selector", optional = true }
 nu_plugin_start = { version = "0.29.2", path = "./crates/nu_plugin_start", optional = true }
@@ -121,6 +122,7 @@ extra = [
     "chart",
     "xpath",
     "selector",
+    "query-json",
 ]
 
 wasi = ["inc", "match", "ptree-support", "match", "tree", "rustyline-support"]
@@ -141,6 +143,7 @@ binaryview = ["nu_plugin_binaryview"]
 bson = ["nu_plugin_from_bson", "nu_plugin_to_bson"]
 chart = ["nu_plugin_chart"]
 clipboard-cli = ["nu-cli/clipboard-cli", "nu-command/clipboard-cli"]
+query-json = ["nu_plugin_query_json"]
 s3 = ["nu_plugin_s3"]
 selector = ["nu_plugin_selector"]
 sqlite = ["nu_plugin_from_sqlite", "nu_plugin_to_sqlite"]
@@ -213,6 +216,11 @@ required-features = ["binaryview"]
 name = "nu_plugin_extra_tree"
 path = "src/plugins/nu_plugin_extra_tree.rs"
 required-features = ["tree"]
+
+[[bin]]
+name = "nu_plugin_extra_query_json"
+path = "src/plugins/nu_plugin_extra_query_json.rs"
+required-features = ["query-json"]
 
 [[bin]]
 name = "nu_plugin_extra_start"

--- a/crates/nu_plugin_query_json/Cargo.toml
+++ b/crates/nu_plugin_query_json/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+authors = ["The Nu Project Contributors"]
+description = "query json files with gjson"
+edition = "2018"
+license = "MIT"
+name = "nu_plugin_query_json"
+version = "0.29.2"
+
+[lib]
+doctest = false
+
+[dependencies]
+gjson = "0.7.1"
+nu-errors = { version = "0.29.2", path = "../nu-errors" }
+nu-plugin = { version = "0.29.2", path = "../nu-plugin" }
+nu-protocol = { version = "0.29.2", path = "../nu-protocol" }
+nu-source = { version = "0.29.2", path = "../nu-source" }
+
+[dev-dependencies]
+nu-test-support = { path = "../nu-test-support", version = "0.29.2" }

--- a/crates/nu_plugin_query_json/src/lib.rs
+++ b/crates/nu_plugin_query_json/src/lib.rs
@@ -1,0 +1,4 @@
+mod nu;
+mod query_json;
+
+pub use query_json::QueryJson;

--- a/crates/nu_plugin_query_json/src/main.rs
+++ b/crates/nu_plugin_query_json/src/main.rs
@@ -1,0 +1,6 @@
+use nu_plugin::serve_plugin;
+use nu_plugin_query_json::QueryJson;
+
+fn main() {
+    serve_plugin(&mut QueryJson::new());
+}

--- a/crates/nu_plugin_query_json/src/nu/mod.rs
+++ b/crates/nu_plugin_query_json/src/nu/mod.rs
@@ -1,0 +1,48 @@
+use nu_errors::ShellError;
+use nu_plugin::Plugin;
+use nu_protocol::{
+    CallInfo, Primitive, ReturnSuccess, ReturnValue, Signature, SyntaxShape, UntaggedValue, Value,
+};
+use nu_source::TaggedItem;
+
+use crate::{query_json::begin_json_query, QueryJson};
+
+impl Plugin for QueryJson {
+    fn config(&mut self) -> Result<Signature, ShellError> {
+        Ok(Signature::build("query json")
+            .desc("execute json query on json file (open --raw <file> | query json 'query string')\nsee https://gjson.dev/ for more info.")
+            .required("query", SyntaxShape::String, "json query")
+            .filter())
+    }
+
+    fn begin_filter(&mut self, call_info: CallInfo) -> Result<Vec<ReturnValue>, ShellError> {
+        let tag = call_info.name_tag;
+        let query = call_info.args.nth(0).ok_or_else(|| {
+            ShellError::labeled_error("json query not passed", "json query not passed", &tag)
+        })?;
+
+        self.query = query.as_string()?;
+        self.tag = tag;
+
+        Ok(vec![])
+    }
+
+    fn filter(&mut self, input: Value) -> Result<Vec<ReturnValue>, ShellError> {
+        match input {
+            Value {
+                value: UntaggedValue::Primitive(Primitive::String(s)),
+                ..
+            } => Ok(begin_json_query(s, (*self.query).tagged(&self.tag))
+                .into_iter()
+                .map(ReturnSuccess::value)
+                .collect()),
+            Value { tag, .. } => Err(ShellError::labeled_error_with_secondary(
+                "Expected text from pipeline",
+                "requires text input",
+                &self.tag,
+                "value originates from here",
+                tag,
+            )),
+        }
+    }
+}

--- a/crates/nu_plugin_query_json/src/nu/mod.rs
+++ b/crates/nu_plugin_query_json/src/nu/mod.rs
@@ -32,10 +32,10 @@ impl Plugin for QueryJson {
             Value {
                 value: UntaggedValue::Primitive(Primitive::String(s)),
                 ..
-            } => Ok(begin_json_query(s, (*self.query).tagged(&self.tag))
-                .into_iter()
-                .map(ReturnSuccess::value)
-                .collect()),
+            } => match begin_json_query(s, (*self.query).tagged(&self.tag)) {
+                Ok(result) => Ok(result.into_iter().map(ReturnSuccess::value).collect()),
+                Err(err) => Err(err),
+            },
             Value { tag, .. } => Err(ShellError::labeled_error_with_secondary(
                 "Expected text from pipeline",
                 "requires text input",

--- a/crates/nu_plugin_query_json/src/query_json.rs
+++ b/crates/nu_plugin_query_json/src/query_json.rs
@@ -55,7 +55,7 @@ fn execute_json_query(
                 ret.push(c)
             }
         }
-        _ => (()),
+        _ => (),
     }
 
     Ok(ret)

--- a/crates/nu_plugin_query_json/src/query_json.rs
+++ b/crates/nu_plugin_query_json/src/query_json.rs
@@ -1,0 +1,83 @@
+use gjson::Value as gjValue;
+use nu_protocol::Value;
+use nu_source::{Tag, Tagged};
+
+pub struct QueryJson {
+    pub query: String,
+    pub tag: Tag,
+}
+
+impl QueryJson {
+    pub fn new() -> QueryJson {
+        QueryJson {
+            query: String::new(),
+            tag: Tag::unknown(),
+        }
+    }
+}
+
+impl Default for QueryJson {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn begin_json_query(input: String, query: Tagged<&str>) -> Vec<Value> {
+    execute_json_query(input, query.item.to_string(), query.tag())
+}
+
+fn execute_json_query(
+    input_string: String,
+    query_string: String,
+    tag: impl Into<Tag>,
+) -> Vec<Value> {
+    let _tag = tag.into();
+    let mut ret: Vec<Value> = vec![];
+    let val: gjValue = gjson::get(input_string.as_str(), &query_string);
+
+    let json_str = val.json();
+    let json_val = Value::from(json_str);
+    ret.push(json_val);
+
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use gjson::{valid, Value as gjValue};
+
+    #[test]
+    fn validate_string() {
+        let json = r#"{ "name": { "first": "Tom", "last": "Anderson" }, "age": 37, "children": ["Sara", "Alex", "Jack"], "friends": [ { "first": "James", "last": "Murphy" }, { "first": "Roger", "last": "Craig" } ] }"#;
+        let val = valid(json);
+        assert_eq!(val, true);
+    }
+
+    #[test]
+    fn answer_from_get_age() {
+        let json = r#"{ "name": { "first": "Tom", "last": "Anderson" }, "age": 37, "children": ["Sara", "Alex", "Jack"], "friends": [ { "first": "James", "last": "Murphy" }, { "first": "Roger", "last": "Craig" } ] }"#;
+        let val: gjValue = gjson::get(json, "age");
+        assert_eq!(val.str(), "37");
+    }
+
+    #[test]
+    fn answer_from_get_children() {
+        let json = r#"{ "name": { "first": "Tom", "last": "Anderson" }, "age": 37, "children": ["Sara", "Alex", "Jack"], "friends": [ { "first": "James", "last": "Murphy" }, { "first": "Roger", "last": "Craig" } ] }"#;
+        let val: gjValue = gjson::get(json, "children");
+        assert_eq!(val.str(), r#"["Sara", "Alex", "Jack"]"#);
+    }
+
+    #[test]
+    fn answer_from_get_children_count() {
+        let json = r#"{ "name": { "first": "Tom", "last": "Anderson" }, "age": 37, "children": ["Sara", "Alex", "Jack"], "friends": [ { "first": "James", "last": "Murphy" }, { "first": "Roger", "last": "Craig" } ] }"#;
+        let val: gjValue = gjson::get(json, "children.#");
+        assert_eq!(val.str(), "3");
+    }
+
+    #[test]
+    fn answer_from_get_friends_first_name() {
+        let json = r#"{ "name": { "first": "Tom", "last": "Anderson" }, "age": 37, "children": ["Sara", "Alex", "Jack"], "friends": [ { "first": "James", "last": "Murphy" }, { "first": "Roger", "last": "Craig" } ] }"#;
+        let val: gjValue = gjson::get(json, "friends.#.first");
+        assert_eq!(val.str(), r#"["James","Roger"]"#);
+    }
+}

--- a/src/plugins/nu_plugin_extra_query_json.rs
+++ b/src/plugins/nu_plugin_extra_query_json.rs
@@ -1,0 +1,6 @@
+use nu_plugin::serve_plugin;
+use nu_plugin_query_json::QueryJson;
+
+fn main() {
+    serve_plugin(&mut QueryJson::new());
+}

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -280,6 +280,14 @@
                                 Source='target\$(var.Profile)\nu_plugin_selector.exe'
                                 KeyPath='yes'/>
                         </Component>
+                        <Component Id='binary24' Guid='*' Win64='$(var.Win64)'>
+                            <File
+                                Id='exe24'
+                                Name='nu_plugin_query_json.exe'
+                                DiskId='1'
+                                Source='target\$(var.Profile)\nu_plugin_query_json.exe'
+                                KeyPath='yes'/>
+                        </Component>
                     </Directory>
                 </Directory>
             </Directory>
@@ -324,6 +332,7 @@
             <ComponentRef Id='binary21'/>
             <ComponentRef Id='binary22'/>
             <ComponentRef Id='binary23'/>
+            <ComponentRef Id='binary24'/>
 
             <Feature
                 Id='Environment'


### PR DESCRIPTION
This plugin uses the cool `gjson` crate to query json files.

![image](https://user-images.githubusercontent.com/343840/115044869-8dbc9d00-9e9b-11eb-9c57-d4bb3bd567ce.png)
given this json file. here are some results
```json
{
  "name": { "first": "Tom", "last": "Anderson" },
  "age": 37,
  "children": ["Sara", "Alex", "Jack"],
  "friends": [
    { "first": "James", "last": "Murphy" },
    { "first": "Roger", "last": "Craig" }
  ]
}
```
![image](https://user-images.githubusercontent.com/343840/115246637-afac5e80-a0eb-11eb-96a8-37ad50029fd5.png)

Depending on modifiers, output the json string.
![image](https://user-images.githubusercontent.com/343840/115257950-2d756780-a0f6-11eb-9ddd-ba49e7153ff9.png)
These are the modifiers
```
@reverse: Reverse an array or the members of an object.
@ugly: Remove all whitespace from JSON.
@pretty: Make the JSON more human readable.
@this: Returns the current element. It can be used to retrieve the root element.
@valid: Ensure the json document is valid.
@flatten: Flattens an array.
@join: Joins multiple objects into a single object.
```
See https://gjson.dev/ for a playground using this crate.

One thing I don't like about my implementation is that you have to use `open --raw`. If someone wants to fix that, I'd be happy. :)