### PR TITLE
Fix parsing dot dot path

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -486,13 +486,11 @@ fn parse_dollar_expr(
         //Return invocation
         trace!("Parsing invocation expression");
         parse_invocation(lite_arg, scope)
-    } else if lite_arg.item.contains("..") {
-        parse_range(lite_arg, scope)
-    } else if lite_arg.item.contains('.') {
-        trace!("Parsing path expression");
-        parse_full_column_path(lite_arg, scope)
+    } else if let (expr, None) = parse_range(lite_arg, scope) {
+        (expr, None)
+    } else if let (expr, None) = parse_full_column_path(lite_arg, scope) {
+        (expr, None)
     } else {
-        trace!("Parsing variable expression");
         parse_variable(lite_arg, scope)
     }
 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -35,6 +35,33 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
 }
 
 #[test]
+fn treats_dot_dot_as_path_not_range() {
+    Playground::setup("dot_dot_dir", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "nu_times.csv",
+            r#"
+                name,rusty_luck,origin
+                Jason,1,Canada
+            "#,
+        )]);
+
+        let actual = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+            mkdir temp;
+            cd temp;
+            echo $(open ../nu_times.csv).name | autoview;
+            cd ..;
+            rmdir temp
+            "#
+        ));
+
+        // chop will remove the last escaped double quote from \"Estados Unidos\"
+        assert_eq!(actual.out, "Jason");
+    })
+}
+
+#[test]
 fn invocation_properly_redirects() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
Fixes one of the cases where we mistake `..` in a path to mean a range instead of a path.