### PR TITLE
Add a sync from the known path to the env

### DIFF
--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -25,6 +25,7 @@ pub(crate) fn run_external_command(
 ) -> Result<InputStream, ShellError> {
     trace!(target: "nu::run::external", "-> {}", command.name);
 
+    context.sync_path_to_env();
     if !context.host.lock().is_external_cmd(&command.name) {
         return Err(ShellError::labeled_error(
             "Command not found",

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -138,6 +138,7 @@ fn maybe_autocd_dir(cmd: &ExternalCommand, ctx: &mut EvaluationContext) -> Optio
     //   - the command name ends in a path separator, or
     //   - it's not a command on the path and no arguments were given.
     let name = &cmd.name;
+    ctx.sync_path_to_env();
     let path_name = if name.ends_with(std::path::is_separator)
         || (cmd.args.is_empty()
             && PathBuf::from(name).is_dir()

--- a/crates/nu-engine/src/evaluation_context.rs
+++ b/crates/nu-engine/src/evaluation_context.rs
@@ -98,6 +98,17 @@ impl EvaluationContext {
         }
     }
 
+    pub fn sync_path_to_env(&self) {
+        let env_vars = self.scope.get_env_vars();
+
+        for (var, val) in env_vars {
+            if var == "PATH" || var == "Path" || var == "path" {
+                std::env::set_var(var, val);
+                break;
+            }
+        }
+    }
+
     #[allow(unused)]
     pub(crate) fn get_command(&self, name: &str) -> Option<Command> {
         self.scope.get_command(name)

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -101,6 +101,7 @@ pub fn process_script(
                     })
                     .unwrap_or("");
 
+                ctx.sync_path_to_env();
                 if internal_name == "run_external"
                     && args
                         .positional


### PR DESCRIPTION
Sync the path we know in the Scope with the external environment's PATH. This allows commands like `which` and related crates to find binaries in the path (specifically this seems to impact Windows)