### PR TITLE
Properly evaluate dynamic blocks

### DIFF
--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -391,6 +391,17 @@ fn proper_shadow_set_aliases() {
     assert_eq!(actual.out, "falsetruefalse");
 }
 
+#[test]
+fn run_dynamic_blocks() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let block = { echo "holaaaa" }; $block
+        "#
+    );
+    assert_eq!(actual.out, "holaaaa");
+}
+
 #[cfg(feature = "which")]
 #[test]
 fn argument_invocation_reports_errors() {


### PR DESCRIPTION
This evaluates the head of a dynamic call rather than pattern matching it. Fixes the issue where you couldn't invoke a variable because it's now seen as a column-path (which is more technically correct).