### PR TITLE
Fix external redirect

### DIFF
--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -5,7 +5,10 @@ use nu_engine::run_block;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{
-    hir::{Block, CapturedBlock, ClassifiedCommand, Group, InternalCommand, Pipeline},
+    hir::{
+        Block, CapturedBlock, ClassifiedCommand, ExternalRedirection, Group, InternalCommand,
+        Pipeline,
+    },
     Dictionary, Signature, SyntaxShape, UntaggedValue, Value,
 };
 use rand::{
@@ -84,7 +87,12 @@ fn benchmark(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     // let start = time();
 
     context.scope.enter_scope();
-    let result = run_block(&block.block, &context, input);
+    let result = run_block(
+        &block.block,
+        &context,
+        input,
+        ExternalRedirection::StdoutAndStderr,
+    );
     context.scope.exit_scope();
     let output = result?.into_vec();
 
@@ -154,7 +162,12 @@ where
         let time_block = add_implicit_autoview(time_block.block);
 
         context.scope.enter_scope();
-        let result = run_block(&time_block, context, benchmark_output);
+        let result = run_block(
+            &time_block,
+            context,
+            benchmark_output,
+            ExternalRedirection::StdoutAndStderr,
+        );
         context.scope.exit_scope();
         result?;
         context.clear_errors();

--- a/crates/nu-command/src/commands/do_.rs
+++ b/crates/nu-command/src/commands/do_.rs
@@ -58,7 +58,7 @@ fn do_(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (
         DoArgs {
             ignore_errors,
-            mut block,
+            block,
         },
         input,
     ) = raw_args.process()?;
@@ -81,11 +81,8 @@ fn do_(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
         x => x,
     };
 
-    if let Some(block) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block.block) {
-        block.set_redirect(block_redirection);
-    }
     context.scope.enter_scope();
-    let result = run_block(&block.block, &context, input);
+    let result = run_block(&block.block, &context, input, block_redirection);
     context.scope.exit_scope();
 
     if ignore_errors {

--- a/crates/nu-command/src/commands/each/window.rs
+++ b/crates/nu-command/src/commands/each/window.rs
@@ -51,6 +51,7 @@ impl WholeStreamCommand for EachWindow {
 
     fn run_with_actions(&self, raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
         let context = Arc::new(EvaluationContext::from_args(&raw_args));
+        let external_redirection = raw_args.call_info.args.external_redirection;
         let (each_args, mut input): (EachWindowArgs, _) = raw_args.process()?;
         let block = Arc::new(Box::new(each_args.block));
 
@@ -76,7 +77,12 @@ impl WholeStreamCommand for EachWindow {
                 let local_window = window.clone();
 
                 if i % stride == 0 {
-                    Some(run_block_on_vec(local_window, block, context))
+                    Some(run_block_on_vec(
+                        local_window,
+                        block,
+                        context,
+                        external_redirection,
+                    ))
                 } else {
                     None
                 }

--- a/crates/nu-command/src/commands/empty.rs
+++ b/crates/nu-command/src/commands/empty.rs
@@ -3,8 +3,8 @@ use nu_engine::run_block;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{
-    hir::CapturedBlock, ColumnPath, Primitive, ReturnSuccess, Signature, SyntaxShape,
-    UntaggedValue, Value,
+    hir::CapturedBlock, hir::ExternalRedirection, ColumnPath, Primitive, ReturnSuccess, Signature,
+    SyntaxShape, UntaggedValue, Value,
 };
 
 use crate::utils::arguments::arguments;
@@ -142,7 +142,12 @@ fn process_row(
         context.scope.add_vars(&default_block.captured.entries);
         context.scope.add_var("$it", input.clone());
 
-        let stream = run_block(&default_block.block, &*context, input_stream);
+        let stream = run_block(
+            &default_block.block,
+            &*context,
+            input_stream,
+            ExternalRedirection::Stdout,
+        );
         context.scope.exit_scope();
 
         let mut stream = stream?;

--- a/crates/nu-command/src/commands/group_by.rs
+++ b/crates/nu-command/src/commands/group_by.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use crate::utils::suggestions::suggestions;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
+use nu_protocol::hir::ExternalRedirection;
 use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 use nu_value_ext::as_string;
@@ -148,7 +149,12 @@ pub fn group_by(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 let run = block.clone();
                 let context = context.clone();
 
-                match crate::commands::each::process_row(run, context, value.clone()) {
+                match crate::commands::each::process_row(
+                    run,
+                    context,
+                    value.clone(),
+                    ExternalRedirection::Stdout,
+                ) {
                     Ok(mut s) => {
                         let collection: Vec<Value> = s.drain_vec();
 

--- a/crates/nu-command/src/commands/if_.rs
+++ b/crates/nu-command/src/commands/if_.rs
@@ -59,6 +59,7 @@ impl WholeStreamCommand for If {
 }
 fn if_command(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tag = raw_args.call_info.name_tag.clone();
+    let external_redirection = raw_args.call_info.args.external_redirection;
     let context = Arc::new(EvaluationContext::from_args(&raw_args));
 
     let args = raw_args.evaluate_once()?;
@@ -105,9 +106,9 @@ fn if_command(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
         Ok(condition) => match condition.as_bool() {
             Ok(b) => {
                 let result = if b {
-                    run_block(&then_case.block, &*context, input)
+                    run_block(&then_case.block, &*context, input, external_redirection)
                 } else {
-                    run_block(&else_case.block, &*context, input)
+                    run_block(&else_case.block, &*context, input, external_redirection)
                 };
                 context.scope.exit_scope();
 

--- a/crates/nu-command/src/commands/insert.rs
+++ b/crates/nu-command/src/commands/insert.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use nu_engine::run_block;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
+use nu_protocol::hir::ExternalRedirection;
 use nu_protocol::{
     ColumnPath, Primitive, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value,
 };
@@ -81,7 +82,12 @@ fn process_row(
             context.scope.add_vars(&block.captured.entries);
             context.scope.add_var("$it", input.clone());
 
-            let result = run_block(&block.block, &*context, input_stream);
+            let result = run_block(
+                &block.block,
+                &*context,
+                input_stream,
+                ExternalRedirection::Stdout,
+            );
 
             context.scope.exit_scope();
 

--- a/crates/nu-command/src/commands/merge.rs
+++ b/crates/nu-command/src/commands/merge.rs
@@ -6,7 +6,8 @@ use nu_engine::WholeStreamCommand;
 use indexmap::IndexMap;
 use nu_errors::ShellError;
 use nu_protocol::{
-    hir::CapturedBlock, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value,
+    hir::CapturedBlock, hir::ExternalRedirection, ReturnSuccess, Signature, SyntaxShape,
+    UntaggedValue, Value,
 };
 pub struct Merge;
 
@@ -53,7 +54,12 @@ fn merge(raw_args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     context.scope.enter_scope();
     context.scope.add_vars(&block.captured.entries);
-    let result = run_block(&block.block, &context, InputStream::empty());
+    let result = run_block(
+        &block.block,
+        &context,
+        InputStream::empty(),
+        ExternalRedirection::Stdout,
+    );
     context.scope.exit_scope();
 
     let table: Option<Vec<Value>> = match result {

--- a/crates/nu-command/src/commands/reduce.rs
+++ b/crates/nu-command/src/commands/reduce.rs
@@ -5,7 +5,9 @@ use nu_engine::WholeStreamCommand;
 use nu_engine::{CommandArgs, Example};
 use nu_errors::ShellError;
 use nu_parser::ParserScope;
-use nu_protocol::{hir::CapturedBlock, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{
+    hir::CapturedBlock, hir::ExternalRedirection, Signature, SyntaxShape, UntaggedValue, Value,
+};
 use nu_source::Tagged;
 use nu_stream::ActionStream;
 
@@ -88,7 +90,12 @@ fn process_row(
     context.scope.enter_scope();
     context.scope.add_vars(&block.captured.entries);
     context.scope.add_var("$it", row);
-    let result = run_block(&block.block, context, input_stream);
+    let result = run_block(
+        &block.block,
+        context,
+        input_stream,
+        ExternalRedirection::Stdout,
+    );
     context.scope.exit_scope();
 
     result

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -12,9 +12,6 @@ use nu_protocol::hir::{Expression, ExternalArgs, ExternalCommand, Literal, Spann
 use nu_protocol::{Signature, SyntaxShape};
 use nu_source::Tagged;
 
-#[derive(Deserialize)]
-pub struct RunExternalArgs {}
-
 #[derive(new)]
 pub struct RunExternalCommand {
     /// Whether or not nushell is being used in an interactive context

--- a/crates/nu-command/src/commands/save.rs
+++ b/crates/nu-command/src/commands/save.rs
@@ -1,7 +1,9 @@
 use crate::prelude::*;
 use nu_engine::{UnevaluatedCallInfo, WholeStreamCommand};
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{
+    hir::ExternalRedirection, Primitive, Signature, SyntaxShape, UntaggedValue, Value,
+};
 use nu_source::Tagged;
 use std::path::{Path, PathBuf};
 
@@ -152,7 +154,6 @@ impl WholeStreamCommand for Save {
 }
 
 fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let external_redirection = raw_args.call_info.args.external_redirection;
     let mut full_path = PathBuf::from(raw_args.shell_manager.path());
     let name_tag = raw_args.call_info.name_tag.clone();
     let name = raw_args.call_info.name_tag.clone();
@@ -214,7 +215,7 @@ fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                                 positional: None,
                                 named: None,
                                 span: Span::unknown(),
-                                external_redirection,
+                                external_redirection: ExternalRedirection::Stdout,
                             },
                             name_tag: name_tag.clone(),
                         },

--- a/crates/nu-command/src/commands/save.rs
+++ b/crates/nu-command/src/commands/save.rs
@@ -1,9 +1,7 @@
 use crate::prelude::*;
 use nu_engine::{UnevaluatedCallInfo, WholeStreamCommand};
 use nu_errors::ShellError;
-use nu_protocol::{
-    hir::ExternalRedirection, Primitive, Signature, SyntaxShape, UntaggedValue, Value,
-};
+use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 use std::path::{Path, PathBuf};
 
@@ -154,6 +152,7 @@ impl WholeStreamCommand for Save {
 }
 
 fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let external_redirection = raw_args.call_info.args.external_redirection;
     let mut full_path = PathBuf::from(raw_args.shell_manager.path());
     let name_tag = raw_args.call_info.name_tag.clone();
     let name = raw_args.call_info.name_tag.clone();
@@ -215,7 +214,7 @@ fn save(raw_args: CommandArgs) -> Result<OutputStream, ShellError> {
                                 positional: None,
                                 named: None,
                                 span: Span::unknown(),
-                                external_redirection: ExternalRedirection::Stdout,
+                                external_redirection,
                             },
                             name_tag: name_tag.clone(),
                         },

--- a/crates/nu-command/src/commands/update.rs
+++ b/crates/nu-command/src/commands/update.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use nu_engine::run_block;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
+use nu_protocol::hir::ExternalRedirection;
 use nu_protocol::{
     ColumnPath, Primitive, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value,
 };
@@ -86,7 +87,12 @@ fn process_row(
             context.scope.add_var("$it", input.clone());
             context.scope.add_vars(&captured_block.captured.entries);
 
-            let result = run_block(&captured_block.block, &*context, input_stream);
+            let result = run_block(
+                &captured_block.block,
+                &*context,
+                input_stream,
+                ExternalRedirection::Stdout,
+            );
 
             context.scope.exit_scope();
 

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -11,7 +11,7 @@ use stub_generate::{mock_path, Command as StubOpen};
 use nu_engine::basic_evaluation_context;
 use nu_errors::ShellError;
 use nu_parser::ParserScope;
-use nu_protocol::hir::ClassifiedBlock;
+use nu_protocol::hir::{ClassifiedBlock, ExternalRedirection};
 use nu_protocol::{ShellTypeName, Value};
 use nu_source::AnchorLocation;
 
@@ -231,7 +231,7 @@ fn evaluate_block(
 
     ctx.scope.enter_scope();
 
-    let result = run_block(&block.block, ctx, input_stream);
+    let result = run_block(&block.block, ctx, input_stream, ExternalRedirection::Stdout);
 
     ctx.scope.exit_scope();
 

--- a/crates/nu-engine/src/evaluate/evaluator.rs
+++ b/crates/nu-engine/src/evaluate/evaluator.rs
@@ -278,7 +278,7 @@ fn evaluate_invocation(block: &hir::Block, ctx: &EvaluationContext) -> Result<Va
         None => InputStream::empty(),
     };
 
-    let result = run_block(&block, ctx, input)?;
+    let result = run_block(&block, ctx, input, hir::ExternalRedirection::Stdout)?;
 
     let output = result.into_vec();
 

--- a/crates/nu-engine/src/evaluate/internal.rs
+++ b/crates/nu-engine/src/evaluate/internal.rs
@@ -13,7 +13,7 @@ use nu_source::{PrettyDebug, Span, Tag};
 use nu_stream::{ActionStream, InputStream};
 
 pub(crate) fn run_internal_command(
-    command: InternalCommand,
+    command: &InternalCommand,
     context: &EvaluationContext,
     input: InputStream,
 ) -> Result<InputStream, ShellError> {
@@ -30,7 +30,7 @@ pub(crate) fn run_internal_command(
     let result = context.run_command(
         internal_command,
         Tag::unknown_anchor(command.name_span),
-        command.args,
+        command.args.clone(), // FIXME: this is inefficient
         objects,
     )?;
     Ok(InputStream::from_stream(InternalIteratorSimple {

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -2,8 +2,8 @@ use crate::{maybe_print_errors, path::canonicalize, run_block};
 use crate::{BufCodecReader, MaybeTextCodec, StringOrBinary};
 use nu_errors::ShellError;
 use nu_protocol::hir::{
-    Call, ClassifiedCommand, Expression, InternalCommand, Literal, NamedArguments,
-    SpannedExpression,
+    Call, ClassifiedCommand, Expression, ExternalRedirection, InternalCommand, Literal,
+    NamedArguments, SpannedExpression,
 };
 use nu_protocol::{Primitive, UntaggedValue, Value};
 use nu_stream::{InputStream, ToInputStream};
@@ -185,7 +185,7 @@ pub fn process_script(
 
         trace!("{:#?}", block);
 
-        let result = run_block(&block, ctx, input_stream);
+        let result = run_block(&block, ctx, input_stream, ExternalRedirection::None);
 
         match result {
             Ok(input) => {

--- a/crates/nu-engine/src/whole_stream_command.rs
+++ b/crates/nu-engine/src/whole_stream_command.rs
@@ -77,11 +77,9 @@ impl WholeStreamCommand for Arc<Block> {
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let call_info = args.call_info.clone();
 
-        let mut block = self.clone();
+        let block = self.clone();
 
-        if let Some(block) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block) {
-            block.set_redirect(call_info.args.external_redirection);
-        }
+        let external_redirection = args.call_info.args.external_redirection;
 
         let ctx = EvaluationContext::from_args(&args);
         let evaluated = call_info.evaluate(&ctx)?;
@@ -178,7 +176,7 @@ impl WholeStreamCommand for Arc<Block> {
                 }
             }
         }
-        let result = run_block(&block, &ctx, input);
+        let result = run_block(&block, &ctx, input, external_redirection);
         ctx.scope.exit_scope();
         result
     }

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -434,12 +434,8 @@ fn parse_invocation(
     };
 
     scope.enter_scope();
-    let (mut classified_block, err) = classify_block(&lite_block, scope);
+    let (classified_block, err) = classify_block(&lite_block, scope);
     scope.exit_scope();
-
-    if let Some(x) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut classified_block) {
-        x.set_redirect(ExternalRedirection::Stdout);
-    }
 
     (
         SpannedExpression::new(Expression::Invocation(classified_block), lite_arg.span),

--- a/crates/nu-protocol/src/hir.rs
+++ b/crates/nu-protocol/src/hir.rs
@@ -206,16 +206,6 @@ impl Block {
         self.infer_params();
     }
 
-    pub fn set_redirect(&mut self, external_redirection: ExternalRedirection) {
-        if let Some(group) = self.block.last_mut() {
-            if let Some(pipeline) = group.pipelines.last_mut() {
-                if let Some(ClassifiedCommand::Internal(internal)) = pipeline.list.last_mut() {
-                    internal.args.external_redirection = external_redirection;
-                }
-            }
-        }
-    }
-
     pub fn has_it_usage(&self) -> bool {
         self.block.iter().any(|x| x.has_it_usage())
     }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -68,6 +68,13 @@ fn correctly_escape_external_arguments() {
     assert_eq!(actual.out, "$0");
 }
 
+#[test]
+fn redirects_custom_command_external() {
+    let actual = nu!(cwd: ".", r#"def foo [] { nu --testbin cococo foo bar }; foo | str length "#);
+
+    assert_eq!(actual.out, "8");
+}
+
 mod it_evaluation {
     use super::nu;
     use nu_test_support::fs::Stub::{EmptyFile, FileWithContent, FileWithContentToBeTrimmed};


### PR DESCRIPTION
This removes mutating the external redirection of blocks, which fails if a block is shared (eg, comes from a custom command).

Instead, this passes the required redirection through `run_block`. As a result, this changes the internal API for `run_block` and related.

Fixes #3340 

