### PR TITLE
recognize negative numbers as numbers rather than flags

### DIFF
--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -1,3 +1,4 @@
+use nu_parser::str_is_flag;
 use nu_protocol::hir::*;
 use nu_source::{Span, Spanned, SpannedItem};
 
@@ -103,7 +104,7 @@ impl<'s> Flatten<'s> {
             result.extend(positionals.flat_map(|positional| match positional.expr {
                 Expression::Garbage => {
                     let garbage = positional.span.slice(self.line);
-                    let location = if garbage.starts_with('-') {
+                    let location = if str_is_flag(garbage) {
                         LocationType::Flag(internal.name.clone())
                     } else {
                         // TODO we may be able to map this to the name of a positional,

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -13,7 +13,9 @@ mod signature;
 
 pub use lex::lexer::{lex, parse_block};
 pub use lex::tokens::{LiteBlock, LiteCommand, LiteGroup, LitePipeline};
-pub use parse::{classify_block, garbage, parse, parse_full_column_path, parse_math_expression};
+pub use parse::{
+    classify_block, garbage, parse, parse_full_column_path, parse_math_expression, str_is_flag,
+};
 pub use path::expand_ndots;
 pub use path::expand_path;
 pub use scope::ParserScope;

--- a/crates/nu-parser/src/parse/def/signature.rs
+++ b/crates/nu-parser/src/parse/def/signature.rs
@@ -336,7 +336,21 @@ fn is_rest(token: &Token) -> bool {
 ///True for short or longform flags. False otherwise
 fn is_flag(token: &Token) -> bool {
     match &token.contents {
-        TokenContents::Baseline(item) => item.starts_with('-'),
+        TokenContents::Baseline(item) => {
+            if item.starts_with('-') {
+                if let Some(first) = item.chars().skip(1).next() {
+                    if first >= '0' && first <= '9' {
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        }
         _ => false,
     }
 }


### PR DESCRIPTION
You said in #3042 that short flags should not be numbers (like `-0` or `-1`).
And I recently realized that negative numbers are not supported in cases like:

- `echo -10`
- `let x = -10`
- `echo -10..-5` or `echo -5..-10`
- `seq -10 -5` or `seq -5 -1 -10`

This PR adds this support to these kind of commands.
(`0..-10` or `5..-5` already works)

I could not find any existing short flags that use numbers.
My quick search:
```
$ grep -r "Some('[0-9]" crates/
crates/nu-pretty-hex/src/pretty_hex.rs:    let null_char = Some('0');
```

The one in `pretty_hex.rs` doesn't seem related.
So I hope this doesn't break anything.