### PR TITLE
Port range to engine-p

### DIFF
--- a/crates/nu-command/src/commands/range.rs
+++ b/crates/nu-command/src/commands/range.rs
@@ -1,13 +1,10 @@
 use crate::prelude::*;
-use nu_engine::deserializer::NumericRange;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{RangeInclusion, ReturnSuccess, Signature, SyntaxShape};
-use nu_source::Tagged;
+use nu_protocol::{RangeInclusion, Signature, SyntaxShape, Value};
 
-#[derive(Deserialize)]
 struct RangeArgs {
-    area: Tagged<NumericRange>,
+    range: nu_protocol::Range,
 }
 
 pub struct Range;
@@ -19,7 +16,7 @@ impl WholeStreamCommand for Range {
 
     fn signature(&self) -> Signature {
         Signature::build("range").required(
-            "rows ",
+            "rows",
             SyntaxShape::Range,
             "range of rows to return: Eg) 4..7 (=> from 4 to 7)",
         )
@@ -29,25 +26,35 @@ impl WholeStreamCommand for Range {
         "Return only the selected rows."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         range(args)
     }
 }
 
-fn range(args: CommandArgs) -> Result<ActionStream, ShellError> {
-    let (RangeArgs { area }, input) = args.process()?;
-    let range = area.item;
-    let (from, left_inclusive) = range.from;
-    let (to, right_inclusive) = range.to;
-    let from = from.map(|from| *from as usize).unwrap_or(0).saturating_add(
-        if left_inclusive == RangeInclusion::Inclusive {
+fn range(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let args = args.evaluate_once()?;
+    let cmd_args = RangeArgs {
+        range: args.req(0)?,
+    };
+
+    let (from, left_inclusive) = cmd_args.range.from;
+    let (to, right_inclusive) = cmd_args.range.to;
+    let from_span = from.span;
+    let to_span = to.span;
+
+    let from = from
+        .map(|from| from.as_usize(from_span))
+        .item
+        .unwrap_or(0)
+        .saturating_add(if left_inclusive == RangeInclusion::Inclusive {
             0
         } else {
             1
-        },
-    );
+        });
+
     let to = to
-        .map(|to| *to as usize)
+        .map(|to| to.as_usize(to_span))
+        .item
         .unwrap_or(usize::MAX)
         .saturating_sub(if right_inclusive == RangeInclusion::Inclusive {
             0
@@ -55,11 +62,11 @@ fn range(args: CommandArgs) -> Result<ActionStream, ShellError> {
             1
         });
 
-    Ok(input
-        .skip(from)
-        .take(to - from + 1)
-        .map(ReturnSuccess::value)
-        .to_action_stream())
+    if from > to {
+        Ok(OutputStream::one(Value::nothing()))
+    } else {
+        Ok(args.input.skip(from).take(to - from + 1).to_output_stream())
+    }
 }
 
 #[cfg(test)]

--- a/crates/nu-engine/src/from_value.rs
+++ b/crates/nu-engine/src/from_value.rs
@@ -40,6 +40,7 @@ impl FromValue for num_bigint::BigInt {
         }
     }
 }
+
 impl FromValue for Tagged<u64> {
     fn from_value(v: &Value) -> Result<Self, ShellError> {
         let tag = v.tag.clone();


### PR DESCRIPTION
### Changes:
* Removes arg serialization
* action stream -> output stream
* uses nu_protocol::Range instead of NumericRange
* random missing newline I found in the code

I'm not sure what is the purpose behind having both deserializer::NumericRange and nu_protocol::Range. I moved it to the latter. NumericRange is used in just a handful places in the code, so I believe with the move of all commands to engine-p, it could be phased out.