### PR TITLE
Dont unwrap rustyline helper in cli

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -301,7 +301,9 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
             }
         };
 
-        rl.helper_mut().expect("No helper").colored_prompt = colored_prompt;
+        if let Some(helper) = rl.helper_mut() {
+            helper.colored_prompt = colored_prompt;
+        }
         let mut initial_command = Some(String::new());
         let mut readline = Err(ReadlineError::Eof);
         while let Some(ref cmd) = initial_command {


### PR DESCRIPTION
This is a temporary fix for  #3380. More info on this error path is in the issue.

If nu fails to load a user config on startup, no helper is set and the
later call to `rl.helper_mut()` will panic. There may be better ways to
handle this long-term, but printing an error about the failure to parse
the config and then starting with default values seems reasonable.