### PR TITLE
 #3385: Add ignore-case and duplicated options to uniq command 

### DIFF
--- a/crates/nu-command/src/commands/uniq.rs
+++ b/crates/nu-command/src/commands/uniq.rs
@@ -13,8 +13,16 @@ impl WholeStreamCommand for Uniq {
     fn signature(&self) -> Signature {
         Signature::build("uniq")
             .switch("count", "Count the unique rows", Some('c'))
-            .switch("repeated", "Count the rows that has more than one value", Some('d'))
-            .switch("ignore-case", "Ignore differences in case when comparing", Some('i'))
+            .switch(
+                "repeated",
+                "Count the rows that has more than one value",
+                Some('d'),
+            )
+            .switch(
+                "ignore-case",
+                "Ignore differences in case when comparing",
+                Some('i'),
+            )
     }
 
     fn usage(&self) -> &str {
@@ -39,9 +47,7 @@ impl WholeStreamCommand for Uniq {
             Example {
                 description: "Only print duplicate lines, one for each group",
                 example: "echo [1 2 2] | uniq -d",
-                result: Some(vec![
-                    UntaggedValue::int(2).into()
-                ]),
+                result: Some(vec![UntaggedValue::int(2).into()]),
             },
             Example {
                 description: "Ignore differences in case when comparing",
@@ -75,7 +81,11 @@ fn to_lowercase(value: nu_protocol::Value) -> nu_protocol::Value {
     use nu_protocol::value::StringExt;
 
     if value.is_string() {
-        value.value.expect_string().to_lowercase().to_string_value(value.tag)
+        value
+            .value
+            .expect_string()
+            .to_lowercase()
+            .to_string_value(value.tag)
     } else {
         value
     }
@@ -103,10 +113,7 @@ fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let mut values_vec_deque = VecDeque::new();
 
     let values = if show_repeated {
-        uniq_values
-            .into_iter()
-            .filter(|i| i.1 > 1)
-            .collect::<_>()
+        uniq_values.into_iter().filter(|i| i.1 > 1).collect::<_>()
     } else {
         uniq_values
     };

--- a/crates/nu-command/src/commands/uniq.rs
+++ b/crates/nu-command/src/commands/uniq.rs
@@ -11,7 +11,10 @@ impl WholeStreamCommand for Uniq {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("uniq").switch("count", "Count the unique rows", Some('c'))
+        Signature::build("uniq")
+            .switch("count", "Count the unique rows", Some('c'))
+            .switch("repeated", "Count the rows that has more than one value", Some('d'))
+            .switch("ignore-case", "Ignore differences in case when comparing", Some('i'))
     }
 
     fn usage(&self) -> &str {
@@ -34,6 +37,21 @@ impl WholeStreamCommand for Uniq {
                 ]),
             },
             Example {
+                description: "Only print duplicate lines, one for each group",
+                example: "echo [1 2 2] | uniq -d",
+                result: Some(vec![
+                    UntaggedValue::int(2).into()
+                ]),
+            },
+            Example {
+                description: "Ignore differences in case when comparing",
+                example: "echo ['hello' 'goodbye' 'Hello'] | uniq -i",
+                result: Some(vec![
+                    UntaggedValue::string("hello").into(),
+                    UntaggedValue::string("goodbye").into(),
+                ]),
+            },
+            Example {
                 description: "Remove duplicate rows and show counts of a list/table",
                 example: "echo [1 2 2] | uniq -c",
                 result: Some(vec![
@@ -53,22 +71,48 @@ impl WholeStreamCommand for Uniq {
     }
 }
 
+fn to_lowercase(value: nu_protocol::Value) -> nu_protocol::Value {
+    use nu_protocol::value::StringExt;
+
+    if value.is_string() {
+        value.value.expect_string().to_lowercase().to_string_value(value.tag)
+    } else {
+        value
+    }
+}
+
 fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let args = args.evaluate_once()?;
     let should_show_count = args.has_flag("count");
+    let show_repeated = args.has_flag("repeated");
+    let ignore_case = args.has_flag("ignore-case");
     let input = args.input;
     let uniq_values = {
         let mut counter = IndexMap::<nu_protocol::Value, usize>::new();
         for line in input.into_vec() {
-            *counter.entry(line).or_insert(0) += 1;
+            let item = if ignore_case {
+                to_lowercase(line)
+            } else {
+                line
+            };
+            *counter.entry(item).or_insert(0) += 1;
         }
         counter
     };
 
     let mut values_vec_deque = VecDeque::new();
 
+    let values = if show_repeated {
+        uniq_values
+            .into_iter()
+            .filter(|i| i.1 > 1)
+            .collect::<_>()
+    } else {
+        uniq_values
+    };
+
     if should_show_count {
-        for item in uniq_values {
+        for item in values {
             use nu_protocol::Value;
             let value = {
                 match item.0.value {
@@ -110,7 +154,7 @@ fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
             values_vec_deque.push_back(value);
         }
     } else {
-        for item in uniq_values {
+        for item in values {
             values_vec_deque.push_back(item.0);
         }
     }


### PR DESCRIPTION
Add the following options to uniq command :

* "ignore-case" (-i) Ignore differences in case when comparing.
* "repeated" (-d) Count the rows that has more than one value.

Trying to mimic GNU's uniq command https://man7.org/linux/man-pages/man1/uniq.1.html as reported in #3385 .