### PR TITLE
Juicy features cargo installer wrapper

### DIFF
--- a/extra_features_cargo_install.sh
+++ b/extra_features_cargo_install.sh
@@ -1,1 +1,1 @@
-cargo install --path . --force --features=extra
+cargo install --path . --features=extra

--- a/extra_features_cargo_install.sh
+++ b/extra_features_cargo_install.sh
@@ -1,0 +1,1 @@
+cargo install --path . --force --features=extra


### PR DESCRIPTION
Since I have the preference to checkout and install nushell directly from this repository, it has been kind of an annoyance to always check the nushell's book for the case there has been any change on the command to install all juicy stuff.

So I would like to propose having this script here, where it would always be updated accordingly.