### PR TITLE
WIP: experiment with simpler expressions

### DIFF
--- a/crates/nu-engine/src/evaluate/expr.rs
+++ b/crates/nu-engine/src/evaluate/expr.rs
@@ -5,6 +5,7 @@ use log::{log_enabled, trace};
 use crate::evaluation_context::EvaluationContext;
 use nu_errors::ShellError;
 use nu_protocol::hir::SpannedExpression;
+use nu_protocol::{UntaggedValue, Value};
 use nu_stream::{InputStream, ToInputStream};
 
 pub(crate) fn run_expression_block(
@@ -18,5 +19,11 @@ pub(crate) fn run_expression_block(
 
     let output = evaluate_baseline_expr(expr, ctx)?;
 
-    Ok(std::iter::once(Ok(output)).to_input_stream())
+    match output {
+        Value {
+            value: UntaggedValue::Table(x),
+            ..
+        } => Ok(InputStream::from_stream(x.into_iter())),
+        output => Ok(std::iter::once(Ok(output)).to_input_stream()),
+    }
 }


### PR DESCRIPTION
DO NOT MERGE: currently an experiment.

This simplifies the expression syntax so that you can write basic expressions in the command position. This means that command position is only a command if it is a bare word. Other forms of expression will immediately switch to math mode and evaluate the expression for you.

Some examples:

```
> (echo foo)
foo

> (echo 4) + 5
9

> 5 + 4 + 1
10

> "hello world"
hello world

> ^ls
Cargo.lock        docker                 pkg_mgrs           target
Cargo.toml        docs                 README.build.txt  tests
CODE_OF_CONDUCT.md  extra_features_cargo_install.sh  README.md           wix
CONTRIBUTING.md     images                 rustfmt.toml
crates            LICENSE                 samples
debian            Makefile.toml             src

> 5 + 4 | each { echo $it }
9

> "hello world" | str length
11

> let my-block = {echo "hello"}
> do $my-block
hello
```