### PR TITLE
Convert the rest of "random" subcommands to engine-p

### DIFF
--- a/crates/nu-command/src/commands/random/chars.rs
+++ b/crates/nu-command/src/commands/random/chars.rs
@@ -1,14 +1,13 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
 use rand::distributions::Alphanumeric;
 use rand::prelude::{thread_rng, Rng};
 
 pub struct SubCommand;
 
-#[derive(Deserialize)]
 pub struct CharsArgs {
     length: Option<Tagged<u32>>,
 }
@@ -33,7 +32,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate random chars"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         chars(args)
     }
 
@@ -53,18 +52,20 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn chars(args: CommandArgs) -> Result<ActionStream, ShellError> {
-    let (CharsArgs { length }, _) = args.process()?;
+pub fn chars(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let args = args.evaluate_once()?;
+    let cmd_args = CharsArgs {
+        length: args.get_flag("length")?,
+    };
 
-    let chars_length = length.map_or(DEFAULT_CHARS_LENGTH, |l| l.item);
+    let chars_length = cmd_args.length.map_or(DEFAULT_CHARS_LENGTH, |l| l.item);
 
     let random_string: String = thread_rng()
         .sample_iter(&Alphanumeric)
         .take(chars_length as usize)
         .collect();
 
-    let result = UntaggedValue::string(random_string);
-    Ok(ActionStream::one(ReturnSuccess::value(result)))
+    Ok(OutputStream::one(UntaggedValue::string(random_string)))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/random/command.rs
+++ b/crates/nu-command/src/commands/random/command.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
+use nu_protocol::{Signature, UntaggedValue};
 
 pub struct Command;
 
@@ -18,9 +18,10 @@ impl WholeStreamCommand for Command {
         "Generate random values."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
-        Ok(ActionStream::one(Ok(ReturnSuccess::Value(
-            UntaggedValue::string(get_full_help(&Command, args.scope())).into_value(Tag::unknown()),
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        Ok(OutputStream::one(UntaggedValue::string(get_full_help(
+            &Command,
+            args.scope(),
         ))))
     }
 }

--- a/crates/nu-command/src/commands/random/dice.rs
+++ b/crates/nu-command/src/commands/random/dice.rs
@@ -7,7 +7,6 @@ use rand::prelude::{thread_rng, Rng};
 
 pub struct SubCommand;
 
-#[derive(Deserialize)]
 pub struct DiceArgs {
     dice: Option<Tagged<u32>>,
     sides: Option<Tagged<u32>>,
@@ -38,7 +37,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate a random dice roll"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         dice(args)
     }
 
@@ -58,17 +57,22 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn dice(args: CommandArgs) -> Result<ActionStream, ShellError> {
+pub fn dice(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
-    let (DiceArgs { dice, sides }, _) = args.process()?;
 
-    let dice = if let Some(dice_tagged) = dice {
+    let args = args.evaluate_once()?;
+    let cmd_args = DiceArgs {
+        dice: args.get_flag("dice")?,
+        sides: args.get_flag("sides")?,
+    };
+
+    let dice = if let Some(dice_tagged) = cmd_args.dice {
         *dice_tagged
     } else {
         1
     };
 
-    let sides = if let Some(sides_tagged) = sides {
+    let sides = if let Some(sides_tagged) = cmd_args.sides {
         *sides_tagged
     } else {
         6
@@ -79,7 +83,7 @@ pub fn dice(args: CommandArgs) -> Result<ActionStream, ShellError> {
         UntaggedValue::int(thread_rng.gen_range(1, sides + 1)).into_value(tag.clone())
     });
 
-    Ok((iter).to_action_stream())
+    Ok((iter).to_output_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/random/uuid.rs
+++ b/crates/nu-command/src/commands/random/uuid.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature};
+use nu_protocol::Signature;
 use uuid_crate::Uuid;
 
 pub struct SubCommand;
@@ -19,7 +19,7 @@ impl WholeStreamCommand for SubCommand {
         "Generate a random uuid4 string"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         uuid(args)
     }
 
@@ -32,10 +32,10 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn uuid(_args: CommandArgs) -> Result<ActionStream, ShellError> {
+pub fn uuid(_args: CommandArgs) -> Result<OutputStream, ShellError> {
     let uuid_4 = Uuid::new_v4().to_hyphenated().to_string();
 
-    Ok(ActionStream::one(ReturnSuccess::value(uuid_4)))
+    Ok(OutputStream::one(uuid_4))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Just straightforward conversions of all `random` subcommands to engine-p.

Added two more `FromValue` implementations for `Tagged<BigDecimal>` and `Tagged<f64>`.

List of remaining commands to port: https://github.com/nushell/nushell/issues/3390