### PR TITLE
Commands to engine p

### DIFF
--- a/crates/nu-command/src/commands/ansi/command.rs
+++ b/crates/nu-command/src/commands/ansi/command.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use nu_ansi_term::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 
 pub struct Command;
@@ -112,7 +112,7 @@ Format: #
         ]
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let args = args.evaluate_once()?;
 
         let code: Option<Tagged<String>> = args.opt(0)?;
@@ -129,9 +129,9 @@ Format: #
                 ));
             }
             let output = format!("\x1b[{}", e.item);
-            return Ok(ActionStream::one(ReturnSuccess::value(
+            return Ok(OutputStream::one(
                 UntaggedValue::string(output).into_value(e.tag()),
-            )));
+            ));
         }
 
         if let Some(o) = osc {
@@ -147,18 +147,18 @@ Format: #
             //Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
             // OCS's need to end with a bell '\x07' char
             let output = format!("\x1b]{};", o.item);
-            return Ok(ActionStream::one(ReturnSuccess::value(
+            return Ok(OutputStream::one(
                 UntaggedValue::string(output).into_value(o.tag()),
-            )));
+            ));
         }
 
         if let Some(code) = code {
             let ansi_code = str_to_ansi(&code.item);
 
             if let Some(output) = ansi_code {
-                Ok(ActionStream::one(ReturnSuccess::value(
+                Ok(OutputStream::one(
                     UntaggedValue::string(output).into_value(code.tag()),
-                )))
+                ))
             } else {
                 Err(ShellError::labeled_error(
                     "Unknown ansi code",

--- a/crates/nu-command/src/commands/ansi/strip.rs
+++ b/crates/nu-command/src/commands/ansi/strip.rs
@@ -2,16 +2,11 @@ use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::ShellTypeName;
-use nu_protocol::{ColumnPath, Primitive, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tag;
 use strip_ansi_escapes::strip;
 
 pub struct SubCommand;
-
-#[derive(Deserialize)]
-struct Arguments {
-    rest: Vec<ColumnPath>,
-}
 
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
@@ -43,10 +38,12 @@ impl WholeStreamCommand for SubCommand {
 }
 
 fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let (Arguments { rest }, input) = args.process()?;
-    let column_paths: Vec<_> = rest;
+    let args = args.evaluate_once()?;
 
-    let result: Vec<Value> = input
+    let column_paths: Vec<_> = args.rest_args()?;
+
+    let result: Vec<Value> = args
+        .input
         .map(move |v| {
             if column_paths.is_empty() {
                 action(&v, v.tag())

--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -50,7 +50,7 @@ impl WholeStreamCommand for Benchmark {
         "Runs a block and returns the time it took to execute it."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         benchmark(args)
     }
 
@@ -70,7 +70,7 @@ impl WholeStreamCommand for Benchmark {
     }
 }
 
-fn benchmark(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn benchmark(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tag = args.call_info.args.span;
     let mut context = EvaluationContext::from_args(&args);
     let scope = args.scope().clone();
@@ -142,10 +142,10 @@ fn benchmark_output<T, Output>(
     passthrough: Option<CapturedBlock>,
     tag: T,
     context: &mut EvaluationContext,
-) -> Result<ActionStream, ShellError>
+) -> Result<OutputStream, ShellError>
 where
     T: Into<Tag> + Copy,
-    Output: Into<ActionStream>,
+    Output: Into<OutputStream>,
 {
     let value = UntaggedValue::Row(Dictionary::from(
         indexmap
@@ -174,7 +174,7 @@ where
 
         Ok(block_output.into())
     } else {
-        let benchmark_output = ActionStream::one(value);
+        let benchmark_output = OutputStream::one(value);
         Ok(benchmark_output)
     }
 }

--- a/crates/nu-command/src/commands/benchmark.rs
+++ b/crates/nu-command/src/commands/benchmark.rs
@@ -74,7 +74,12 @@ fn benchmark(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tag = args.call_info.args.span;
     let mut context = EvaluationContext::from_args(&args);
     let scope = args.scope().clone();
-    let (BenchmarkArgs { block, passthrough }, input) = args.process()?;
+
+    let args = args.evaluate_once()?;
+    let cmd_args = BenchmarkArgs {
+        block: args.req(0)?,
+        passthrough: args.get_flag("passthrough")?,
+    };
 
     let env = scope.get_env_vars();
     let name = generate_free_name(&env);
@@ -88,11 +93,12 @@ fn benchmark(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     context.scope.enter_scope();
     let result = run_block(
-        &block.block,
+        &cmd_args.block.block,
         &context,
-        input,
+        args.input,
         ExternalRedirection::StdoutAndStderr,
     );
+
     context.scope.exit_scope();
     let output = result?.into_vec();
 
@@ -109,7 +115,7 @@ fn benchmark(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
         let real_time = into_big_int(end_time - start_time);
         indexmap.insert("real time".to_string(), real_time);
-        benchmark_output(indexmap, output, passthrough, &tag, &mut context)
+        benchmark_output(indexmap, output, cmd_args.passthrough, &tag, &mut context)
     }
     // return advanced stats
     // #[cfg(feature = "rich-benchmark")]


### PR DESCRIPTION
Changed commands to engine p:
- ansi/strip.rs
- benchmark.rs

Removed Action stream and `args.process`

List of remaining commands to port: #3390

