### PR TITLE
Migrate last to engine-p

### DIFF
--- a/crates/nu-command/src/commands/last.rs
+++ b/crates/nu-command/src/commands/last.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
-use nu_source::Tagged;
 
 pub struct Last;
 

--- a/crates/nu-command/src/commands/last.rs
+++ b/crates/nu-command/src/commands/last.rs
@@ -52,7 +52,7 @@ fn last(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let v: Vec<_> = args.input.into_vec();
 
     let end_rows_desired = if let Some(quantity) = rows {
-        quantity.as_i64()? as usize
+        quantity.as_usize()?
     } else {
         1
     };

--- a/crates/nu-command/src/commands/last.rs
+++ b/crates/nu-command/src/commands/last.rs
@@ -65,7 +65,7 @@ fn last(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let iter = v.into_iter().skip(beginning_rows_to_skip);
 
-    Ok(OutputStream::from_stream(iter.into_iter()))
+    Ok(OutputStream::from_stream(iter))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As the title says, migrates the `last` command to engine-p.

Let me know if there's a better way I could be unpacking a `Value` into an `i64`, this was really just my best guess.