### PR TITLE
Remove unnecessary work from ps

### DIFF
--- a/crates/nu_plugin_ps/src/ps.rs
+++ b/crates/nu_plugin_ps/src/ps.rs
@@ -15,15 +15,12 @@ impl Ps {
 pub async fn ps(tag: Tag, long: bool) -> Result<Vec<Value>, ShellError> {
     let mut sys = System::new_all();
     sys.refresh_all();
-    let duration = std::time::Duration::from_millis(500);
-    std::thread::sleep(duration);
 
     let mut output = vec![];
 
     let result: Vec<_> = sys.get_processes().iter().map(|x| *x.0).collect();
 
     for pid in result.into_iter() {
-        sys.refresh_process(pid);
         if let Some(result) = sys.get_process(pid) {
             let mut dict = TaggedDictBuilder::new(&tag);
             dict.insert_untagged("pid", UntaggedValue::int(pid));


### PR DESCRIPTION
The ps plugin has an unnecessary call to `std::thread::sleep(500ms)` that
delays runtime by 500ms. Additionally, there is a call to
`sysinfo::SystemExt::refresh_process`, which is not required as the previous
call to sysinfo::SystemExt::refresh_all handles the "refresh" of all processes
without a need to do this individually. Combining both of these improvements
means that running ps runs nearly instantaneously.

I've tested this on an M1 macbook air, and results appear identical with the exception of differences in CPU usage/memory info for some processes. I have to assume that this is due to different invocations of the command observing slightly different states of my real system.

Fixes #3402