### PR TITLE
Config commands to engine p

### DIFF
--- a/crates/nu-command/src/commands/config/command.rs
+++ b/crates/nu-command/src/commands/config/command.rs
@@ -2,8 +2,7 @@ use crate::prelude::*;
 use nu_engine::CommandArgs;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
-use nu_stream::ActionStream;
+use nu_protocol::{Signature, UntaggedValue};
 
 pub struct Command;
 
@@ -20,22 +19,19 @@ impl WholeStreamCommand for Command {
         "Configuration management."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let name = args.call_info.name_tag.clone();
 
         if let Some(global_cfg) = &args.configs().lock().global_config {
             let result = global_cfg.vars.clone();
-            Ok(vec![ReturnSuccess::value(
-                UntaggedValue::Row(result.into()).into_value(name),
-            )]
-            .into_iter()
-            .to_action_stream())
+            let value = UntaggedValue::Row(result.into()).into_value(name);
+
+            Ok(OutputStream::one(value))
         } else {
-            Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
-                crate::commands::config::err_no_global_cfg_present(),
-            ))]
-            .into_iter()
-            .to_action_stream())
+            let value = UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present())
+                .into_value(name);
+
+            Ok(OutputStream::one(value))
         }
     }
 }

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -1,14 +1,9 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ColumnPath, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
 
 pub struct SubCommand;
-
-#[derive(Deserialize)]
-pub struct Arguments {
-    column_path: ColumnPath,
-}
 
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
@@ -27,7 +22,7 @@ impl WholeStreamCommand for SubCommand {
         "Gets a value from the config"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         get(args)
     }
 
@@ -40,11 +35,12 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
+pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
+    let args = args.evaluate_once()?;
 
-    let (Arguments { column_path }, _) = args.process()?;
+    let column_path = args.req(0)?;
 
     let result = if let Some(global_cfg) = &ctx.configs.lock().global_config {
         let result = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);
@@ -53,15 +49,16 @@ pub fn get(args: CommandArgs) -> Result<ActionStream, ShellError> {
             Value {
                 value: UntaggedValue::Table(list),
                 ..
-            } => list.into_iter().to_action_stream(),
-            x => ActionStream::one(ReturnSuccess::value(x)),
+            } => OutputStream::from_stream(list.into_iter()),
+            x => OutputStream::one(x),
         })
     } else {
-        Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
-            crate::commands::config::err_no_global_cfg_present(),
-        ))]
-        .into_iter()
-        .to_action_stream())
+        let value = Value {
+            value: UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present()),
+            tag: name,
+        };
+
+        Ok(OutputStream::one(value))
     };
 
     result

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -53,10 +53,8 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
             x => OutputStream::one(x),
         })
     } else {
-        let value = Value {
-            value: UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present()),
-            tag: name,
-        };
+        let value = UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present())
+            .into_value(name);
 
         Ok(OutputStream::one(value))
     };

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -50,10 +50,7 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
             global_cfg.write()?;
             ctx.reload_config(global_cfg)?;
 
-            let value = Value {
-                value: UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present()),
-                tag: remove.tag,
-            };
+            let value: Value = UntaggedValue::row(global_cfg.vars.clone()).into_value(remove.tag);
 
             Ok(OutputStream::one(value))
         } else {
@@ -64,10 +61,8 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
             ))
         }
     } else {
-        let value = Value {
-            value: UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present()),
-            tag: name,
-        };
+        let value = UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present())
+            .into_value(name);
 
         Ok(OutputStream::one(value))
     };

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -1,15 +1,10 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, SyntaxShape, UntaggedValue};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Tagged;
 
 pub struct SubCommand;
-
-#[derive(Deserialize)]
-pub struct Arguments {
-    remove: Tagged<String>,
-}
 
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
@@ -28,7 +23,7 @@ impl WholeStreamCommand for SubCommand {
         "Removes a value from the config"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         remove(args)
     }
 
@@ -41,9 +36,11 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn remove(args: CommandArgs) -> Result<ActionStream, ShellError> {
+pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
-    let (Arguments { remove }, _) = args.process()?;
+    let args = args.evaluate_once()?;
+    let remove: Tagged<String> = args.req(0)?;
 
     let key = remove.to_string();
 
@@ -52,11 +49,13 @@ pub fn remove(args: CommandArgs) -> Result<ActionStream, ShellError> {
             global_cfg.vars.swap_remove(&key);
             global_cfg.write()?;
             ctx.reload_config(global_cfg)?;
-            Ok(vec![ReturnSuccess::value(
-                UntaggedValue::row(global_cfg.vars.clone()).into_value(remove.tag()),
-            )]
-            .into_iter()
-            .to_action_stream())
+
+            let value = Value {
+                value: UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present()),
+                tag: remove.tag,
+            };
+
+            Ok(OutputStream::one(value))
         } else {
             Err(ShellError::labeled_error(
                 "Key does not exist in config",
@@ -65,11 +64,12 @@ pub fn remove(args: CommandArgs) -> Result<ActionStream, ShellError> {
             ))
         }
     } else {
-        Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
-            crate::commands::config::err_no_global_cfg_present(),
-        ))]
-        .into_iter()
-        .to_action_stream())
+        let value = Value {
+            value: UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present()),
+            tag: name,
+        };
+
+        Ok(OutputStream::one(value))
     };
 
     result

--- a/crates/nu-command/src/commands/config/set.rs
+++ b/crates/nu-command/src/commands/config/set.rs
@@ -1,15 +1,9 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ColumnPath, ReturnSuccess, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_protocol::{Signature, SyntaxShape, UntaggedValue, Value};
 
 pub struct SubCommand;
-
-#[derive(Deserialize)]
-pub struct Arguments {
-    column_path: ColumnPath,
-    value: Value,
-}
 
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
@@ -26,7 +20,7 @@ impl WholeStreamCommand for SubCommand {
         "Sets a value in the config"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         set(args)
     }
 
@@ -56,16 +50,13 @@ impl WholeStreamCommand for SubCommand {
     }
 }
 
-pub fn set(args: CommandArgs) -> Result<ActionStream, ShellError> {
+pub fn set(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let name = args.call_info.name_tag.clone();
     let ctx = EvaluationContext::from_args(&args);
-    let (
-        Arguments {
-            column_path,
-            mut value,
-        },
-        _,
-    ) = args.process()?;
+    let args = args.evaluate_once()?;
+
+    let column_path = args.req(0)?;
+    let mut value: Value = args.req(1)?;
 
     let result = if let Some(global_cfg) = &mut ctx.configs.lock().global_config {
         let configuration = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);
@@ -85,19 +76,17 @@ pub fn set(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 global_cfg.write()?;
                 ctx.reload_config(global_cfg)?;
 
-                Ok(ActionStream::one(ReturnSuccess::value(
-                    UntaggedValue::row(global_cfg.vars.clone()).into_value(name),
-                )))
+                let value = UntaggedValue::row(global_cfg.vars.clone()).into_value(name);
+                Ok(OutputStream::one(value))
             }
-            Ok(_) => Ok(ActionStream::empty()),
+            Ok(_) => Ok(OutputStream::empty()),
             Err(reason) => Err(reason),
         }
     } else {
-        Ok(vec![ReturnSuccess::value(UntaggedValue::Error(
-            crate::commands::config::err_no_global_cfg_present(),
-        ))]
-        .into_iter()
-        .to_action_stream())
+        let value = UntaggedValue::Error(crate::commands::config::err_no_global_cfg_present())
+            .into_value(name);
+
+        Ok(OutputStream::one(value))
     };
 
     result


### PR DESCRIPTION
Changed config commands to engine p:

- config/get.rs
- config/remove.rs
- config/set.rs
- config/set_into.rs
- config/path.rs
- config/clear.rs

List of remaining commands to port: #3390