### PR TITLE
date commands ported

### DIFF
--- a/crates/nu-command/src/commands/date/command.rs
+++ b/crates/nu-command/src/commands/date/command.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
+use nu_protocol::{Signature, UntaggedValue};
 
 pub struct Command;
 
@@ -18,10 +18,10 @@ impl WholeStreamCommand for Command {
         "Apply date function."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
-        Ok(ActionStream::one(ReturnSuccess::value(
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        Ok(OutputStream::one(
             UntaggedValue::string(get_full_help(&Command, args.scope())).into_value(Tag::unknown()),
-        )))
+        ))
     }
 }
 

--- a/crates/nu-command/src/commands/date/list_timezone.rs
+++ b/crates/nu-command/src/commands/date/list_timezone.rs
@@ -3,7 +3,7 @@ use chrono_tz::TZ_VARIANTS;
 use indexmap::IndexMap;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Dictionary, ReturnSuccess, Signature, UntaggedValue};
+use nu_protocol::{Dictionary, Signature, UntaggedValue};
 
 pub struct Date;
 
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Date {
         "List supported time zones."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         list_timezone(args)
     }
 
@@ -40,7 +40,7 @@ impl WholeStreamCommand for Date {
     }
 }
 
-fn list_timezone(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn list_timezone(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.call_info.name_tag.clone();
 
@@ -52,12 +52,10 @@ fn list_timezone(args: CommandArgs) -> Result<ActionStream, ShellError> {
             UntaggedValue::string(tz.name()).into_value(&tag),
         );
 
-        Ok(ReturnSuccess::Value(
-            UntaggedValue::Row(Dictionary { entries }).into_value(&tag),
-        ))
+        Ok(UntaggedValue::Row(Dictionary { entries }).into_value(&tag))
     });
 
-    Ok(list.into_iter().to_action_stream())
+    Ok(list.into_iter().to_input_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/now.rs
+++ b/crates/nu-command/src/commands/date/now.rs
@@ -19,12 +19,12 @@ impl WholeStreamCommand for Date {
         "Get the current date."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         now(args)
     }
 }
 
-pub fn now(args: CommandArgs) -> Result<ActionStream, ShellError> {
+pub fn now(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.call_info.name_tag.clone();
 
@@ -32,7 +32,7 @@ pub fn now(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let value = UntaggedValue::date(now.with_timezone(now.offset())).into_value(&tag);
 
-    Ok(ActionStream::one(value))
+    Ok(OutputStream::one(value))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/to_table.rs
+++ b/crates/nu-command/src/commands/date/to_table.rs
@@ -3,7 +3,7 @@ use chrono::{Datelike, Timelike};
 use indexmap::IndexMap;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Dictionary, Primitive, ReturnSuccess, Signature, UntaggedValue, Value};
+use nu_protocol::{Dictionary, Primitive, Signature, UntaggedValue, Value};
 
 pub struct Date;
 
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Date {
         "Print the date in a structured table."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         to_table(args)
     }
 
@@ -33,7 +33,7 @@ impl WholeStreamCommand for Date {
     }
 }
 
-fn to_table(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn to_table(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.call_info.name_tag.clone();
     let input = args.input;
@@ -79,7 +79,7 @@ fn to_table(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
                 let value = UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag);
 
-                ReturnSuccess::value(value)
+                Ok(value)
             }
             _ => Err(ShellError::labeled_error(
                 "Expected a date from pipeline",
@@ -87,7 +87,7 @@ fn to_table(args: CommandArgs) -> Result<ActionStream, ShellError> {
                 &tag,
             )),
         })
-        .to_action_stream())
+        .to_input_stream())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/commands/date/utc.rs
+++ b/crates/nu-command/src/commands/date/utc.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for Date {
         "return the current date in utc."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         utc(args)
     }
 }


### PR DESCRIPTION
Changed date commands to engine p:

- date
- date/format
- date/list-timezone
- date/now
- date/to-table
- date/to-timezone

List of remaining commands to port: #3390