### PR TITLE
Do less work in `sys`

### DIFF
--- a/crates/nu_plugin_sys/src/sys.rs
+++ b/crates/nu_plugin_sys/src/sys.rs
@@ -197,7 +197,7 @@ pub fn temp(sys: &mut System, tag: Tag) -> Option<UntaggedValue> {
 }
 
 pub async fn sysinfo(tag: Tag) -> Vec<Value> {
-    let mut sys = System::new_all();
+    let mut sys = System::new();
 
     let mut sysinfo = TaggedDictBuilder::with_capacity(&tag, 6);
 


### PR DESCRIPTION
We're currently refreshing systems twice including a refresh of processes which we don't use. Instead, don't do anything up front and refresh just the subsystems we use. (there may be a faster way to do a single configured refresh, but this PR is already an improvement)