### PR TITLE
case-insensitive completion matching by default on Windows

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -44,6 +44,10 @@ impl NuCompleter {
         let matcher = matcher.as_str();
         let matcher: &dyn Matcher = match matcher {
             "case-insensitive" => &matchers::case_insensitive::Matcher,
+            "case-sensitive" => &matchers::case_sensitive::Matcher,
+            #[cfg(target_os = "windows")]
+            _ => &matchers::case_insensitive::Matcher,
+            #[cfg(not(target_os = "windows"))]
             _ => &matchers::case_sensitive::Matcher,
         };
 


### PR DESCRIPTION
Since Windows filenames are case-insensitive, I think it is better to have case-insensitive completion matching by default.
This PR does just that. All other platforms still use case-sesnsitive matching by default.