### PR TITLE
Dataframe feature for plugins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,9 @@ dataframe = [
     "nu-protocol/dataframe",
     "nu-command/dataframe",
     "nu-value-ext/dataframe",
-    "nu-data/dataframe"
+    "nu-data/dataframe",
+    "nu_plugin_post/dataframe",
+    "nu_plugin_to_bson/dataframe",
 ]
 
 

--- a/crates/nu_plugin_post/Cargo.toml
+++ b/crates/nu_plugin_post/Cargo.toml
@@ -21,4 +21,8 @@ serde_json = "1.0.57"
 surf = "1.0.3"
 url = "2.1.1"
 
+[features]
+dataframe = ["nu-protocol/dataframe"]
+
+
 [build-dependencies]

--- a/crates/nu_plugin_post/src/post.rs
+++ b/crates/nu_plugin_post/src/post.rs
@@ -400,6 +400,14 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
         }
 
         UntaggedValue::Table(l) => serde_json::Value::Array(json_list(l)?),
+        #[cfg(feature = "dataframe")]
+        UntaggedValue::Dataframe(_) => {
+            return Err(ShellError::labeled_error(
+                "Cannot convert dataframe",
+                "Cannot convert dataframe",
+                &v.tag,
+            ))
+        }
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Block(_) | UntaggedValue::Primitive(Primitive::Range(_)) => {
             serde_json::Value::Null

--- a/crates/nu_plugin_to_bson/Cargo.toml
+++ b/crates/nu_plugin_to_bson/Cargo.toml
@@ -18,4 +18,7 @@ nu-source = { path = "../nu-source", version = "0.31.1" }
 nu-value-ext = { path = "../nu-value-ext", version = "0.31.1" }
 num-traits = "0.2.14"
 
+[features]
+dataframe = ["nu-protocol/dataframe"]
+
 [build-dependencies]

--- a/crates/nu_plugin_to_bson/src/to_bson.rs
+++ b/crates/nu_plugin_to_bson/src/to_bson.rs
@@ -64,6 +64,8 @@ pub fn value_to_bson_value(v: &Value) -> Result<Bson, ShellError> {
                 .collect::<Result<_, _>>()?,
         ),
         UntaggedValue::Block(_) | UntaggedValue::Primitive(Primitive::Range(_)) => Bson::Null,
+        #[cfg(feature = "dataframe")]
+        UntaggedValue::Dataframe(_) => Bson::Null,
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Primitive(Primitive::Binary(b)) => {
             Bson::Binary(BinarySubtype::Generic, b.clone())


### PR DESCRIPTION
The `UntaggedValue::Dataframe` wasn't considered in the `nu_plugin_post` and `nu_plugin_to_bson` plugins. This was causing compilation errors when the `dataframe` feature is used with those plugins enabled. This PR adds the `dataframe` feature to those plugins to allow compilation.