### PR TITLE
don't let externals break ansi escapes

### DIFF
--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -114,6 +114,12 @@ impl WholeStreamCommand for RunExternalCommand {
             external_redirection,
         );
 
+        // When externals return, don't let them mess up the ansi escapes
+        #[cfg(windows)]
+        {
+            let _ = nu_ansi_term::enable_ansi_support();
+        }
+
         Ok(result?.to_action_stream())
     }
 }


### PR DESCRIPTION
fixes (hopefully) a problem where externals, especially git for windows, turns off ansi escape commands and horks the output in nushell