### PR TITLE
Add explicit block params

### DIFF
--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -37,7 +37,7 @@ impl<'s> Flatten<'s> {
                 )
                 .collect(),
             Expression::Command => vec![LocationType::Command.spanned(e.span)],
-            Expression::Path(path) => self.expression(&path.head),
+            Expression::FullColumnPath(path) => self.expression(&path.head),
             Expression::Variable(_, _) => vec![LocationType::Variable.spanned(e.span)],
 
             Expression::Boolean(_)

--- a/crates/nu-cli/src/types/deduction.rs
+++ b/crates/nu-cli/src/types/deduction.rs
@@ -296,7 +296,7 @@ fn get_shape_of_expr(expr: &SpannedExpression) -> Option<SyntaxShape> {
         Expression::List(_) => Some(SyntaxShape::Table),
         Expression::Boolean(_) => Some(SyntaxShape::String),
 
-        Expression::Path(_) => Some(SyntaxShape::ColumnPath),
+        Expression::FullColumnPath(_) => Some(SyntaxShape::ColumnPath),
         Expression::FilePath(_) => Some(SyntaxShape::FilePath),
         Expression::Block(_) => Some(SyntaxShape::Block),
         Expression::ExternalCommand(_) => Some(SyntaxShape::String),
@@ -539,7 +539,7 @@ impl VarSyntaxShapeDeductor {
                 trace!("Inferring vars in block");
                 self.infer_shape(&b, scope)?;
             }
-            Expression::Path(path) => {
+            Expression::FullColumnPath(path) => {
                 trace!("Inferring vars in path");
                 match &path.head.expr {
                     //PathMember can't be var yet (?)
@@ -790,7 +790,7 @@ impl VarSyntaxShapeDeductor {
                         | Expression::Binary(_)
                         | Expression::Range(_)
                         | Expression::Block(_)
-                        | Expression::Path(_)
+                        | Expression::FullColumnPath(_)
                         | Expression::FilePath(_)
                         | Expression::ExternalCommand(_)
                         | Expression::Command

--- a/crates/nu-command/src/commands/each/command.rs
+++ b/crates/nu-command/src/commands/each/command.rs
@@ -57,10 +57,13 @@ impl WholeStreamCommand for Each {
             },
             Example {
                 description: "Name the block variable that each uses",
-                example:
-                    "[1, 2, 3] | each {|x| $x + 100}",
-                result: Some(vec![UntaggedValue::int(101).into(), UntaggedValue::int(102).into(), UntaggedValue::int(103).into()]),
-            }
+                example: "[1, 2, 3] | each {|x| $x + 100}",
+                result: Some(vec![
+                    UntaggedValue::int(101).into(),
+                    UntaggedValue::int(102).into(),
+                    UntaggedValue::int(103).into(),
+                ]),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/commands/each/command.rs
+++ b/crates/nu-command/src/commands/each/command.rs
@@ -55,6 +55,12 @@ impl WholeStreamCommand for Each {
                     "echo ['bob' 'fred'] | each --numbered { echo $\"{$it.index} is {$it.item}\" }",
                 result: Some(vec![Value::from("0 is bob"), Value::from("1 is fred")]),
             },
+            Example {
+                description: "Name the block variable that each uses",
+                example:
+                    "[1, 2, 3] | each {|x| $x + 100}",
+                result: Some(vec![UntaggedValue::int(101).into(), UntaggedValue::int(102).into(), UntaggedValue::int(103).into()]),
+            }
         ]
     }
 }

--- a/crates/nu-engine/src/evaluate/evaluator.rs
+++ b/crates/nu-engine/src/evaluate/evaluator.rs
@@ -159,7 +159,7 @@ pub fn evaluate_baseline_expr(
                     .into_value(&tag),
             )
         }
-        Expression::Path(path) => {
+        Expression::FullColumnPath(path) => {
             let value = evaluate_baseline_expr(&path.head, ctx)?;
             let mut item = value;
 

--- a/crates/nu-parser/src/parse/def.rs
+++ b/crates/nu-parser/src/parse/def.rs
@@ -16,6 +16,7 @@ use crate::lex::lexer::{lex, parse_block};
 use crate::ParserScope;
 
 use self::signature::parse_signature;
+pub use self::signature::{lex_split_baseline_tokens_on, parse_parameter};
 
 mod data_structs;
 mod primitives;

--- a/crates/nu-parser/src/parse/def/tests.rs
+++ b/crates/nu-parser/src/parse/def/tests.rs
@@ -19,11 +19,11 @@ fn simple_def_with_params() {
         sign.positional,
         vec![
             (
-                PositionalType::Optional("param1".into(), SyntaxShape::Int),
+                PositionalType::Optional("$param1".into(), SyntaxShape::Int),
                 "".into()
             ),
             (
-                PositionalType::Mandatory("param2".into(), SyntaxShape::String),
+                PositionalType::Mandatory("$param2".into(), SyntaxShape::String),
                 "".into()
             ),
         ]
@@ -40,11 +40,11 @@ fn simple_def_with_optional_param_without_type() {
         sign.positional,
         vec![
             (
-                PositionalType::Optional("param1".into(), SyntaxShape::Any),
+                PositionalType::Optional("$param1".into(), SyntaxShape::Any),
                 "".into()
             ),
             (
-                PositionalType::Optional("param2".into(), SyntaxShape::Any),
+                PositionalType::Optional("$param2".into(), SyntaxShape::Any),
                 "".into()
             ),
         ]
@@ -64,11 +64,11 @@ fn simple_def_with_params_with_comment() {
         sign.positional,
         vec![
             (
-                PositionalType::Mandatory("param1".into(), SyntaxShape::FilePath),
+                PositionalType::Mandatory("$param1".into(), SyntaxShape::FilePath),
                 "My first param".into()
             ),
             (
-                PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
+                PositionalType::Mandatory("$param2".into(), SyntaxShape::Number),
                 "My second param".into()
             ),
         ]
@@ -88,11 +88,11 @@ fn simple_def_with_params_without_type() {
         sign.positional,
         vec![
             (
-                PositionalType::Mandatory("param1".into(), SyntaxShape::Any),
+                PositionalType::Mandatory("$param1".into(), SyntaxShape::Any),
                 "My first param".into()
             ),
             (
-                PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
+                PositionalType::Mandatory("$param2".into(), SyntaxShape::Number),
                 "My second param".into()
             ),
         ]
@@ -116,23 +116,23 @@ fn oddly_but_correct_written_params() {
         sign.positional,
         vec![
             (
-                PositionalType::Mandatory("param1".into(), SyntaxShape::Int),
+                PositionalType::Mandatory("$param1".into(), SyntaxShape::Int),
                 "param1".into()
             ),
             (
-                PositionalType::Mandatory("param2".into(), SyntaxShape::Number),
+                PositionalType::Mandatory("$param2".into(), SyntaxShape::Number),
                 "My second param".into()
             ),
             (
-                PositionalType::Mandatory("param4".into(), SyntaxShape::Any),
+                PositionalType::Mandatory("$param4".into(), SyntaxShape::Any),
                 "".into()
             ),
             (
-                PositionalType::Mandatory("param5".into(), SyntaxShape::FilePath),
+                PositionalType::Mandatory("$param5".into(), SyntaxShape::FilePath),
                 "".into()
             ),
             (
-                PositionalType::Mandatory("param6".into(), SyntaxShape::Any),
+                PositionalType::Mandatory("$param6".into(), SyntaxShape::Any),
                 "param6".into()
             ),
         ]
@@ -225,19 +225,19 @@ fn simple_def_with_params_and_flags() {
         sign.positional,
         vec![
             (
-                PositionalType::Mandatory("param1".into(), SyntaxShape::Any),
+                PositionalType::Mandatory("$param1".into(), SyntaxShape::Any),
                 "".into()
             ),
             (
-                PositionalType::Mandatory("param2".into(), SyntaxShape::Table),
+                PositionalType::Mandatory("$param2".into(), SyntaxShape::Table),
                 "Param2 Doc".into()
             ),
             (
-                PositionalType::Mandatory("param3".into(), SyntaxShape::Number),
+                PositionalType::Mandatory("$param3".into(), SyntaxShape::Number),
                 "".into()
             ),
             (
-                PositionalType::Optional("param4".into(), SyntaxShape::Table),
+                PositionalType::Optional("$param4".into(), SyntaxShape::Table),
                 "Optional Param".into()
             ),
         ]
@@ -262,15 +262,15 @@ fn simple_def_with_parameters_and_flags_no_delimiter() {
         // --flag3 # Third flag
         vec![
             (
-                PositionalType::Mandatory("param1".into(), SyntaxShape::Int),
+                PositionalType::Mandatory("$param1".into(), SyntaxShape::Int),
                 "".into()
             ),
             (
-                PositionalType::Mandatory("param2".into(), SyntaxShape::Any),
+                PositionalType::Mandatory("$param2".into(), SyntaxShape::Any),
                 "".into()
             ),
             (
-                PositionalType::Mandatory("param3".into(), SyntaxShape::Any),
+                PositionalType::Mandatory("$param3".into(), SyntaxShape::Any),
                 "Param3".into()
             ),
         ]
@@ -302,7 +302,7 @@ fn simple_example_signature() {
     assert_eq!(
         sign.positional,
         vec![(
-            PositionalType::Mandatory("d".into(), SyntaxShape::Int),
+            PositionalType::Mandatory("$d".into(), SyntaxShape::Int),
             "The required d parameter".into()
         )]
     );
@@ -374,7 +374,7 @@ fn simple_def_with_param_flag_and_rest() {
     assert_eq!(
         sign.positional,
         vec![(
-            PositionalType::Mandatory("d".into(), SyntaxShape::String),
+            PositionalType::Mandatory("$d".into(), SyntaxShape::String),
             "The required d parameter".into()
         )]
     );


### PR DESCRIPTION
This adds explicit block params. These params follow similarly to positional params for definitions.

```
[1, 2, 3] | each { |x| $x + 100 }
```

The indicator is starting with the `|`. We use the pipe because it's familiar to folks coming from other languages and it's currently an invalid starting token.

You can optionally add the `$` to the front:

```
[1, 2, 3] | each { |$x| $x + 100 }
```

I've gone ahead and fixed dynamic block invocations. This allows blocks to be called in command positions (note that variables in command positions is still an expression rather than a call)

```
{|x| echo $x} 100
```