### PR TITLE
Remove rest_args() from evaluated CommandArgs

### DIFF
--- a/crates/nu-command/src/commands/ansi/strip.rs
+++ b/crates/nu-command/src/commands/ansi/strip.rs
@@ -40,7 +40,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
 
-    let column_paths: Vec<_> = args.rest_args()?;
+    let column_paths: Vec<_> = args.rest(0)?;
 
     let result: Vec<Value> = args
         .input

--- a/crates/nu-command/src/commands/path/basename.rs
+++ b/crates/nu-command/src/commands/path/basename.rs
@@ -43,7 +43,7 @@ impl WholeStreamCommand for PathBasename {
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathBasenameArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
             replace: args.get_flag("replace")?,
         });
 

--- a/crates/nu-command/src/commands/path/dirname.rs
+++ b/crates/nu-command/src/commands/path/dirname.rs
@@ -50,7 +50,7 @@ impl WholeStreamCommand for PathDirname {
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathDirnameArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
             replace: args.get_flag("replace")?,
             num_levels: args.get_flag("num-levels")?,
         });

--- a/crates/nu-command/src/commands/path/exists.rs
+++ b/crates/nu-command/src/commands/path/exists.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for PathExists {
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathExistsArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
         });
 
         Ok(operate(args.input, &action, tag.span, cmd_args))

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for PathExpand {
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathExpandArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
         });
 
         Ok(operate(args.input, &action, tag.span, cmd_args))

--- a/crates/nu-command/src/commands/path/join.rs
+++ b/crates/nu-command/src/commands/path/join.rs
@@ -48,7 +48,7 @@ the output of 'path parse' and 'path split' subcommands."#
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathJoinArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
             append: args.get_flag("append")?,
         });
 

--- a/crates/nu-command/src/commands/path/parse.rs
+++ b/crates/nu-command/src/commands/path/parse.rs
@@ -50,7 +50,7 @@ On Windows, an extra 'prefix' column is added."#
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathParseArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
             extension: args.get_flag("extension")?,
         });
 

--- a/crates/nu-command/src/commands/path/split.rs
+++ b/crates/nu-command/src/commands/path/split.rs
@@ -35,7 +35,7 @@ impl WholeStreamCommand for PathSplit {
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathSplitArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
         });
 
         Ok(operate_split(args.input, &action, tag.span, cmd_args))

--- a/crates/nu-command/src/commands/path/type.rs
+++ b/crates/nu-command/src/commands/path/type.rs
@@ -36,7 +36,7 @@ impl WholeStreamCommand for PathType {
         let tag = args.call_info.name_tag.clone();
         let args = args.evaluate_once()?;
         let cmd_args = Arc::new(PathTypeArguments {
-            rest: args.rest_args()?,
+            rest: args.rest(0)?,
         });
 
         Ok(operate(args.input, &action, tag.span, cmd_args))

--- a/crates/nu-command/src/commands/str_/capitalize.rs
+++ b/crates/nu-command/src/commands/str_/capitalize.rs
@@ -46,7 +46,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/case/mod.rs
+++ b/crates/nu-command/src/commands/str_/case/mod.rs
@@ -26,7 +26,7 @@ where
 {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/downcase.rs
+++ b/crates/nu-command/src/commands/str_/downcase.rs
@@ -46,7 +46,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/from.rs
+++ b/crates/nu-command/src/commands/str_/from.rs
@@ -73,7 +73,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(Arguments {
             decimals: params.get_flag("decimals")?,
             group_digits: false,
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/length.rs
+++ b/crates/nu-command/src/commands/str_/length.rs
@@ -54,7 +54,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/lpad.rs
+++ b/crates/nu-command/src/commands/str_/lpad.rs
@@ -81,7 +81,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(Arc::new(Arguments {
             length: params.req_named("length")?,
             character: params.req_named("character")?,
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         }))
     })?;
 

--- a/crates/nu-command/src/commands/str_/reverse.rs
+++ b/crates/nu-command/src/commands/str_/reverse.rs
@@ -44,7 +44,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/rpad.rs
+++ b/crates/nu-command/src/commands/str_/rpad.rs
@@ -81,7 +81,7 @@ fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
         Ok(Arc::new(Arguments {
             length: params.req_named("length")?,
             character: params.req_named("character")?,
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         }))
     })?;
 

--- a/crates/nu-command/src/commands/str_/to_datetime.rs
+++ b/crates/nu-command/src/commands/str_/to_datetime.rs
@@ -128,7 +128,7 @@ struct DatetimeFormat(String);
 
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
-        let (column_paths, _) = arguments(&mut params.rest_args()?)?;
+        let (column_paths, _) = arguments(&mut params.rest(0)?)?;
 
         Ok(Arguments {
             timezone: params.get_flag("timezone")?,

--- a/crates/nu-command/src/commands/str_/to_decimal.rs
+++ b/crates/nu-command/src/commands/str_/to_decimal.rs
@@ -49,7 +49,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-command/src/commands/str_/to_integer.rs
+++ b/crates/nu-command/src/commands/str_/to_integer.rs
@@ -66,7 +66,7 @@ impl WholeStreamCommand for SubCommand {
 
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
-        let (column_paths, _) = arguments(&mut params.rest_args()?)?;
+        let (column_paths, _) = arguments(&mut params.rest(0)?)?;
 
         Ok(Arguments {
             radix: params.get_flag("radix")?,

--- a/crates/nu-command/src/commands/str_/trim/mod.rs
+++ b/crates/nu-command/src/commands/str_/trim/mod.rs
@@ -26,7 +26,7 @@ where
     let (options, input) = args.extract(|params| {
         Ok(Arc::new(Arguments {
             character: params.get_flag("char")?,
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         }))
     })?;
 

--- a/crates/nu-command/src/commands/str_/upcase.rs
+++ b/crates/nu-command/src/commands/str_/upcase.rs
@@ -46,7 +46,7 @@ impl WholeStreamCommand for SubCommand {
 fn operate(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let (options, input) = args.extract(|params| {
         Ok(Arguments {
-            column_paths: params.rest_args()?,
+            column_paths: params.rest(0)?,
         })
     })?;
 

--- a/crates/nu-engine/src/command_args.rs
+++ b/crates/nu-engine/src/command_args.rs
@@ -201,10 +201,6 @@ impl EvaluatedCommandArgsWithoutInput {
         }
     }
 
-    pub fn rest_args<T: FromValue>(&self) -> Result<Vec<T>, ShellError> {
-        self.rest(0)
-    }
-
     pub fn rest<T: FromValue>(&self, starting_pos: usize) -> Result<Vec<T>, ShellError> {
         let mut output = vec![];
 


### PR DESCRIPTION
`rest_args()` was too error prone when positional arguments were used with the rest arguments. Now, you need to explicitly state from which position you want to count the rest args (e.g., `rest(0)`).

Closes #3443