### PR TITLE
updated round to support i64

### DIFF
--- a/crates/nu-command/src/commands/math/round.rs
+++ b/crates/nu-command/src/commands/math/round.rs
@@ -66,6 +66,7 @@ fn operate(args: CommandArgs) -> Result<OutputStream, ShellError> {
         UntaggedValue::Primitive(Primitive::Decimal(val)) => {
             round_big_decimal(val, precision.into())
         }
+        UntaggedValue::Primitive(Primitive::Int(val)) => UntaggedValue::int(val).into(),
         other => round_default(other),
     });
     Ok(mapped.to_output_stream())


### PR DESCRIPTION
if an i64 was passed into `math round` it would produce an error.