### PR TITLE
Paren interpolation

### DIFF
--- a/crates/nu-command/src/commands/each/command.rs
+++ b/crates/nu-command/src/commands/each/command.rs
@@ -52,7 +52,7 @@ impl WholeStreamCommand for Each {
             Example {
                 description: "Number each item and echo a message",
                 example:
-                    "echo ['bob' 'fred'] | each --numbered { echo $\"{$it.index} is {$it.item}\" }",
+                    "echo ['bob' 'fred'] | each --numbered { echo $\"($it.index) is ($it.item)\" }",
                 result: Some(vec![Value::from("0 is bob"), Value::from("1 is fred")]),
             },
             Example {

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -8,20 +8,23 @@ fn reduce_table_column() {
         echo "[{month:2,total:30}, {month:3,total:10}, {month:4,total:3}, {month:5,total:60}]"
         | from json
         | get total
-        | reduce -f 20 { $it + (math eval $"{$acc}^1.05")}
+        | reduce -f 20 { $it + (math eval $"($acc)^1.05")}
         | str from -d 1
         "#
         )
     );
 
     assert_eq!(actual.out, "180.6");
+}
 
+#[test]
+fn reduce_table_column_with_path() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
         echo "[{month:2,total:30}, {month:3,total:10}, {month:4,total:3}, {month:5,total:60}]"
         | from json
-        | reduce -f 20 { $it.total + (math eval $"{$acc}^1.05")}
+        | reduce -f 20 { $it.total + (math eval $"($acc)^1.05")}
         | str from -d 1
         "#
         )

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -499,7 +499,7 @@ fn format(input: &str, start: usize) -> (Vec<FormatCommand>, Option<ParseError>)
         loop {
             end += 1;
             if let Some(c) = loop_input.next() {
-                if c == '{' {
+                if c == '(' {
                     break;
                 }
                 before.push(c);
@@ -521,9 +521,9 @@ fn format(input: &str, start: usize) -> (Vec<FormatCommand>, Option<ParseError>)
         let mut open_count = 1;
         while let Some(c) = loop_input.next() {
             end += 1;
-            if c == '{' {
+            if c == '(' {
                 open_count += 1;
-            } else if c == '}' {
+            } else if c == ')' {
                 open_count -= 1;
                 if open_count == 0 {
                     found_end = true;

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -518,14 +518,29 @@ fn format(input: &str, start: usize) -> (Vec<FormatCommand>, Option<ParseError>)
         start = end;
 
         let mut found_end = false;
-        let mut open_count = 1;
+        let mut delimiter_stack = vec![')'];
+
         while let Some(c) = loop_input.next() {
             end += 1;
-            if c == '(' {
-                open_count += 1;
+            if let Some('\'') = delimiter_stack.last() {
+                if c == '\'' {
+                    delimiter_stack.pop();
+                }
+            } else if let Some('"') = delimiter_stack.last() {
+                if c == '"' {
+                    delimiter_stack.pop();
+                }
+            } else if c == '\'' {
+                delimiter_stack.push('\'');
+            } else if c == '"' {
+                delimiter_stack.push('"');
+            } else if c == '(' {
+                delimiter_stack.push(')');
             } else if c == ')' {
-                open_count -= 1;
-                if open_count == 0 {
+                if let Some(')') = delimiter_stack.last() {
+                    delimiter_stack.pop();
+                }
+                if delimiter_stack.is_empty() {
                     found_end = true;
                     break;
                 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -150,6 +150,18 @@ fn string_interpolation_shorthand_overlap() {
 }
 
 #[test]
+fn string_interpolation_and_paren() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+                    $"a paren is ('(')"
+        "#
+    );
+
+    assert_eq!(actual.out, "a paren is (");
+}
+
+#[test]
 fn bignum_large_integer() {
     let actual = nu!(
         cwd: ".",

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -118,7 +118,7 @@ fn string_interpolation_with_it() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo "foo" | each { echo $"{$it}" }
+                    echo "foo" | each { echo $"($it)" }
             "#
     );
 
@@ -130,7 +130,7 @@ fn string_interpolation_with_it_column_path() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo [[name]; [sammie]] | each { echo $"{$it.name}" }
+                    echo [[name]; [sammie]] | each { echo $"($it.name)" }
         "#
     );
 
@@ -142,7 +142,7 @@ fn string_interpolation_shorthand_overlap() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    $"3 + 4 = {3 + 4}"
+                    $"3 + 4 = (3 + 4)"
         "#
     );
 


### PR DESCRIPTION
Switches from brackets to parens for string interpolation.

Before:
```
$"the total is {3 + 4}"
```

After:
```
$"the total is (3 + 4)"
```

This makes it more consistent with other uses of parens. Parens then get to mean "do this first and put the answer here" universally.

If you want to write a paren in place, you can use `('(')` or some variation of dropping into `()` and printing from there