### PR TITLE
Implement `path relative-to` subcommand

### DIFF
--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -240,8 +240,8 @@ pub(crate) use nth::Nth;
 pub(crate) use open::Open;
 pub(crate) use parse::Parse;
 pub(crate) use path::{
-    PathBasename, PathCommand, PathDirname, PathExists, PathExpand, PathJoin, PathParse, PathSplit,
-    PathType,
+    PathBasename, PathCommand, PathDirname, PathExists, PathExpand, PathJoin, PathParse,
+    PathRelativeTo, PathSplit, PathType,
 };
 pub(crate) use pivot::Pivot;
 pub(crate) use prepend::Prepend;

--- a/crates/nu-command/src/commands/default_context.rs
+++ b/crates/nu-command/src/commands/default_context.rs
@@ -240,6 +240,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(PathExpand),
             whole_stream_command(PathJoin),
             whole_stream_command(PathParse),
+            whole_stream_command(PathRelativeTo),
             whole_stream_command(PathSplit),
             whole_stream_command(PathType),
             // Url

--- a/crates/nu-command/src/commands/path/mod.rs
+++ b/crates/nu-command/src/commands/path/mod.rs
@@ -5,6 +5,7 @@ mod exists;
 mod expand;
 mod join;
 mod parse;
+mod relative_to;
 mod split;
 mod r#type;
 
@@ -25,6 +26,7 @@ pub use expand::PathExpand;
 pub use join::PathJoin;
 pub use parse::PathParse;
 pub use r#type::PathType;
+pub use relative_to::PathRelativeTo;
 pub use split::PathSplit;
 
 #[cfg(windows)]

--- a/crates/nu-command/src/commands/path/relative_to.rs
+++ b/crates/nu-command/src/commands/path/relative_to.rs
@@ -1,0 +1,119 @@
+use super::{operate, PathSubcommandArguments};
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{ColumnPath, Signature, SyntaxShape, UntaggedValue, Value};
+use nu_source::Tagged;
+use std::path::{Path, PathBuf};
+
+pub struct PathRelativeTo;
+
+struct PathRelativeToArguments {
+    path: Tagged<PathBuf>,
+    rest: Vec<ColumnPath>,
+}
+
+impl PathSubcommandArguments for PathRelativeToArguments {
+    fn get_column_paths(&self) -> &Vec<ColumnPath> {
+        &self.rest
+    }
+}
+
+impl WholeStreamCommand for PathRelativeTo {
+    fn name(&self) -> &str {
+        "path relative-to"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("path relative-to")
+            .required(
+                "path",
+                SyntaxShape::FilePath,
+                "Parent shared with the input path",
+            )
+            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+    }
+
+    fn usage(&self) -> &str {
+        "Get a path as relative to another path."
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"Can be used only when the input and the argument paths are either both
+absolute or both relative. The argument path needs to be a parent of the input
+path."#
+    }
+
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        let tag = args.call_info.name_tag.clone();
+        let args = args.evaluate_once()?;
+        let cmd_args = Arc::new(PathRelativeToArguments {
+            path: args.req(0)?,
+            rest: args.rest(1)?,
+        });
+
+        Ok(operate(args.input, &action, tag.span, cmd_args))
+    }
+
+    #[cfg(windows)]
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Find a relative path from two absolute paths",
+                example: r"'C:\Users\viking' | path relative-to 'C:\Users'",
+                result: Some(vec![Value::from(UntaggedValue::filepath(r"viking"))]),
+            },
+            Example {
+                description: "Find a relative path from two relative paths",
+                example: r"'eggs\bacon\sausage\spam' | path relative-to 'eggs\bacon\sausage'",
+                result: Some(vec![Value::from(UntaggedValue::filepath(r"spam"))]),
+            },
+        ]
+    }
+
+    #[cfg(not(windows))]
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Find a relative path from two absolute paths",
+                example: r"'/home/viking' | path relative-to '/home'",
+                result: Some(vec![Value::from(UntaggedValue::filepath(r"viking"))]),
+            },
+            Example {
+                description: "Find a relative path from two relative paths",
+                example: r"'eggs/bacon/sausage/spam' | path relative-to 'eggs/bacon/sausage'",
+                result: Some(vec![Value::from(UntaggedValue::filepath(r"spam"))]),
+            },
+        ]
+    }
+}
+
+fn action(path: &Path, tag: Tag, args: &PathRelativeToArguments) -> Value {
+    match path.strip_prefix(&args.path.item) {
+        Ok(p) => UntaggedValue::filepath(p).into_value(tag),
+        Err(_) => Value::error(ShellError::labeled_error_with_secondary(
+            format!(
+                "'{}' is not a subpath of '{}'",
+                path.to_string_lossy(),
+                &args.path.item.to_string_lossy()
+            ),
+            "should be a parent of the input path",
+            args.path.tag.span,
+            "originates from here",
+            tag.span,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathRelativeTo;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        test_examples(PathRelativeTo {})
+    }
+}


### PR DESCRIPTION
Implements `path relative-to` subcommand. It converts the input path as a relative to the argument path, like this:
```
> 'eggs/bacon/sausage/spam' | path relative-to 'eggs/bacon/sausage'
spam
```

Inspired by [Python's pathlib](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.relative_to). 
