### PR TITLE
Update minimum required rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Try it in Gitpod.
 
 Up-to-date installation instructions can be found in the [installation chapter of the book](https://www.nushell.sh/book/installation.html). **Windows users**: please note that Nu works on Windows 10 and does not currently have Windows 7/8.1 support.
 
-To build Nu, you will need to use the **latest stable (1.47 or later)** version of the compiler.
+To build Nu, you will need to use the **latest stable (1.51 or later)** version of the compiler.
 
 Required dependencies:
 


### PR DESCRIPTION
Hello!

The readme specifies that nushell requires rust 1.47, but that is no longer correct.

this commit:

https://github.com/nushell/nushell/commit/c80a9585b0569e9489ac93c47048cb39e295aa17#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87eL5682-R5978

updates the indirect dependency `str-buf` from `1.0.5` to `2.0.0` which requires const generics and thus rust 1.51. :)

https://github.com/DoumanAsh/str-buf/commit/1a99d1bc0f91742edc4dd4ee3aaf03d3c9c0f8a9