### PR TITLE
let date commands pull default date

### DIFF
--- a/crates/nu-command/src/commands/date/format.rs
+++ b/crates/nu-command/src/commands/date/format.rs
@@ -49,8 +49,13 @@ pub fn format(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let format: Tagged<String> = args.req(0)?;
     let table: Option<bool> = args.get_flag("table")?;
 
-    Ok(args
-        .input
+    let input = if args.input.is_empty() {
+        InputStream::one(crate::commands::date::now::date_now(&tag))
+    } else {
+        args.input
+    };
+
+    Ok(input
         .map(move |value| match value {
             Value {
                 value: UntaggedValue::Primitive(Primitive::Date(dt)),

--- a/crates/nu-command/src/commands/date/now.rs
+++ b/crates/nu-command/src/commands/date/now.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use chrono::{DateTime, Local};
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Signature, UntaggedValue};
+use nu_protocol::{Signature, UntaggedValue, Value};
 
 pub struct Date;
 
@@ -24,13 +24,16 @@ impl WholeStreamCommand for Date {
     }
 }
 
-pub fn now(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let args = args.evaluate_once()?;
-    let tag = args.call_info.name_tag.clone();
-
+pub fn date_now(tag: &Tag) -> Value {
     let now: DateTime<Local> = Local::now();
 
-    let value = UntaggedValue::date(now.with_timezone(now.offset())).into_value(&tag);
+    UntaggedValue::date(now.with_timezone(now.offset())).into_value(tag)
+}
+
+pub fn now(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let args = args.evaluate_once()?;
+
+    let value = date_now(&args.call_info.name_tag);
 
     Ok(OutputStream::one(value))
 }

--- a/crates/nu-command/src/commands/date/to_table.rs
+++ b/crates/nu-command/src/commands/date/to_table.rs
@@ -36,7 +36,11 @@ impl WholeStreamCommand for Date {
 fn to_table(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let args = args.evaluate_once()?;
     let tag = args.call_info.name_tag.clone();
-    let input = args.input;
+    let input = if args.input.is_empty() {
+        InputStream::one(crate::commands::date::now::date_now(&tag))
+    } else {
+        args.input
+    };
 
     Ok(input
         .map(move |value| match value {


### PR DESCRIPTION
This lets date commands `date format` and `date to-table` check the input, and if it's empty, pull the current date and use that.