### PR TITLE
Groupby operations on dataframes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,8 +211,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrow"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-rs?rev=d008f31b107c1030a1f5144c164e8ca8bf543576#d008f31b107c1030a1f5144c164e8ca8bf543576"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cdf087304d5cdd743abd621b4b1b388848d29491932dae6f676ec89ebda0ae"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -223,7 +224,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "lexical-core",
  "multiversion",
- "num 0.3.1",
+ "num 0.4.0",
  "rand 0.7.3",
  "regex 1.5.3",
  "serde 1.0.125",
@@ -441,12 +442,6 @@ dependencies = [
  "byteorder",
  "safemem 0.3.3",
 ]
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -4093,20 +4088,6 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint 0.3.2",
- "num-complex 0.3.1",
- "num-integer",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
@@ -4160,15 +4141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
  "num-traits 0.2.14",
 ]
 
@@ -4232,7 +4204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
- "num-bigint 0.3.2",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -4457,17 +4428,18 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-rs?rev=d008f31b107c1030a1f5144c164e8ca8bf543576#d008f31b107c1030a1f5144c164e8ca8bf543576"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193b8db290021fa28a6447df8f433e39b3caab20ee08b874d0a5c1c34aef68de"
 dependencies = [
  "arrow",
- "base64 0.12.3",
+ "base64 0.13.0",
  "brotli",
  "byteorder",
  "chrono",
  "flate2",
  "lz4",
- "num-bigint 0.3.2",
+ "num-bigint 0.4.0",
  "parquet-format",
  "snap",
  "thrift",
@@ -4696,8 +4668,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.13.1"
-source = "git+https://github.com/ritchie46/polars?rev=3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0#3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4e2e025126632e8e19d53cd9b655da344bd4942ba603ad246c7776b6401844"
 dependencies = [
  "polars-core",
  "polars-io",
@@ -4706,8 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.13.0"
-source = "git+https://github.com/ritchie46/polars?rev=3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0#3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3534c76a7bafaca9c783506a1f331ad746621d3808ab2407c02ffadd9e99326"
 dependencies = [
  "arrow",
  "num 0.4.0",
@@ -4716,8 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.13.2"
-source = "git+https://github.com/ritchie46/polars?rev=3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0#3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad76c4d55017da2d0f8930b0caa327d12286c1e4407469f361e84fad176f9601"
 dependencies = [
  "ahash 0.7.2",
  "anyhow",
@@ -4739,8 +4714,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.13.0"
-source = "git+https://github.com/ritchie46/polars?rev=3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0#3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f20f27363d85f847a2b7e9d1bfd426bff18680691dd42ff17ca91893f12f89"
 dependencies = [
  "ahash 0.7.2",
  "anyhow",
@@ -4762,8 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.13.0"
-source = "git+https://github.com/ritchie46/polars?rev=3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0#3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595906f951bacf223625ed6b0e4e73153eb9e251850bb2f9c36d78828334f32b"
 dependencies = [
  "ahash 0.7.2",
  "itertools",
@@ -7427,18 +7404,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.7.0+zstd.1.4.9"
+version = "0.8.1+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
+checksum = "357d6bb1bd9c6f6a55a5a15c74d01260b272f724dc60cc829b86ebd2172ac5ef"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.1.0+zstd.1.4.9"
+version = "4.1.0+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
+checksum = "d30375f78e185ca4c91930f42ea2c0162f9aa29737032501f93b79266d985ae7"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -7446,9 +7423,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.5.0+zstd.1.4.9"
+version = "1.6.0+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
+checksum = "2141bed8922b427761470e6bbfeff255da94fa20b0bbeab0d9297fcaf71e3aa7"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,8 +160,8 @@ dataframe = [
     "nu-command/dataframe",
     "nu-value-ext/dataframe",
     "nu-data/dataframe",
-    "nu_plugin_post/dataframe",
-    "nu_plugin_to_bson/dataframe",
+    #"nu_plugin_post/dataframe",
+    #"nu_plugin_to_bson/dataframe",
 ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,8 +160,8 @@ dataframe = [
     "nu-command/dataframe",
     "nu-value-ext/dataframe",
     "nu-data/dataframe",
-    #"nu_plugin_post/dataframe",
-    #"nu_plugin_to_bson/dataframe",
+    "nu_plugin_post/dataframe",
+    "nu_plugin_to_bson/dataframe",
 ]
 
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -99,12 +99,7 @@ uuid_crate = { package = "uuid", version = "0.8.2", features = ["v4"], optional 
 which = { version = "4.1.0", optional = true }
 zip = { version = "0.5.9", optional = true }
 
-[dependencies.polars]
-version = "0.13.1"
-git = "https://github.com/ritchie46/polars"
-rev = "3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0"
-optional = true
-features = ["parquet", "json"]
+polars = { version = "0.13.3",optional = true, features = ["parquet", "json"] }
 
 [target.'cfg(unix)'.dependencies]
 umask = "1.0.0"

--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -187,7 +187,7 @@ pub(crate) mod touch;
 pub(crate) use all::Command as All;
 pub(crate) use any::Command as Any;
 #[cfg(feature = "dataframe")]
-pub(crate) use dataframe::{DataFrame, DataFrameList, DataFrameLoad};
+pub(crate) use dataframe::{DataFrame, DataFrameGroupBy, DataFrameList, DataFrameLoad};
 pub(crate) use enter::Enter;
 pub(crate) use every::Every;
 pub(crate) use exec::Exec;

--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -187,7 +187,7 @@ pub(crate) mod touch;
 pub(crate) use all::Command as All;
 pub(crate) use any::Command as Any;
 #[cfg(feature = "dataframe")]
-pub(crate) use dataframe::{Dataframe, DataframeList, DataframeLoad};
+pub(crate) use dataframe::{DataFrame, DataFrameList, DataFrameLoad};
 pub(crate) use enter::Enter;
 pub(crate) use every::Every;
 pub(crate) use exec::Exec;

--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -4,7 +4,10 @@ use crate::primitive::get_color_config;
 use nu_data::value::format_leaf;
 use nu_engine::{UnevaluatedCallInfo, WholeStreamCommand};
 use nu_errors::ShellError;
-use nu_protocol::hir::{self, Expression, ExternalRedirection, Literal, SpannedExpression};
+use nu_protocol::{
+    dataframe::PolarsStruct,
+    hir::{self, Expression, ExternalRedirection, Literal, SpannedExpression},
+};
 use nu_protocol::{Primitive, Signature, UntaggedValue, Value};
 use nu_table::TextStyle;
 
@@ -236,7 +239,7 @@ pub fn autoview(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     }
                     #[cfg(feature = "dataframe")]
                     Value {
-                        value: UntaggedValue::Dataframe(df),
+                        value: UntaggedValue::Data(PolarsStruct::DataFrame(df)),
                         ..
                     } => {
                         if let Some(table) = table {

--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -4,10 +4,7 @@ use crate::primitive::get_color_config;
 use nu_data::value::format_leaf;
 use nu_engine::{UnevaluatedCallInfo, WholeStreamCommand};
 use nu_errors::ShellError;
-use nu_protocol::{
-    dataframe::PolarsStruct,
-    hir::{self, Expression, ExternalRedirection, Literal, SpannedExpression},
-};
+use nu_protocol::hir::{self, Expression, ExternalRedirection, Literal, SpannedExpression};
 use nu_protocol::{Primitive, Signature, UntaggedValue, Value};
 use nu_table::TextStyle;
 
@@ -239,7 +236,7 @@ pub fn autoview(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     }
                     #[cfg(feature = "dataframe")]
                     Value {
-                        value: UntaggedValue::Data(PolarsStruct::DataFrame(df)),
+                        value: UntaggedValue::DataFrame(df),
                         ..
                     } => {
                         if let Some(table) = table {

--- a/crates/nu-command/src/commands/dataframe/command.rs
+++ b/crates/nu-command/src/commands/dataframe/command.rs
@@ -1,10 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{
-    dataframe::{NuDataFrame, PolarsStruct},
-    Signature, UntaggedValue,
-};
+use nu_protocol::{dataframe::NuDataFrame, Signature, UntaggedValue};
 
 pub struct Command;
 
@@ -26,8 +23,7 @@ impl WholeStreamCommand for Command {
         let args = args.evaluate_once()?;
 
         let df = NuDataFrame::try_from_iter(args.input, &tag)?;
-        let init =
-            InputStream::one(UntaggedValue::Data(PolarsStruct::DataFrame(df)).into_value(&tag));
+        let init = InputStream::one(UntaggedValue::DataFrame(df).into_value(&tag));
 
         Ok(init.to_output_stream())
     }

--- a/crates/nu-command/src/commands/dataframe/command.rs
+++ b/crates/nu-command/src/commands/dataframe/command.rs
@@ -1,7 +1,10 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{dataframe::NuDataFrame, Signature, UntaggedValue};
+use nu_protocol::{
+    dataframe::{NuDataFrame, PolarsStruct},
+    Signature, UntaggedValue,
+};
 
 pub struct Command;
 
@@ -23,7 +26,8 @@ impl WholeStreamCommand for Command {
         let args = args.evaluate_once()?;
 
         let df = NuDataFrame::try_from_iter(args.input, &tag)?;
-        let init = InputStream::one(UntaggedValue::Dataframe(df).into_value(&tag));
+        let init =
+            InputStream::one(UntaggedValue::Data(PolarsStruct::DataFrame(df)).into_value(&tag));
 
         Ok(init.to_output_stream())
     }

--- a/crates/nu-command/src/commands/dataframe/groupby.rs
+++ b/crates/nu-command/src/commands/dataframe/groupby.rs
@@ -1,0 +1,37 @@
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{
+    dataframe::{NuDataFrame, PolarsStruct},
+    Signature, UntaggedValue,
+};
+
+pub struct DataFrame;
+
+impl WholeStreamCommand for DataFrame {
+    fn name(&self) -> &str {
+        "dataframe groupby"
+    }
+
+    fn usage(&self) -> &str {
+        "Creates a groupby operation on a dataframe"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("dataframe groupby")
+    }
+
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        groupby(args)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Takes an input stream and converts it to a dataframe",
+            example: "echo [[a b];[1 2] [3 4]] | dataframe",
+            result: None,
+        }]
+    }
+}
+
+fn groupby(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {}

--- a/crates/nu-command/src/commands/dataframe/groupby.rs
+++ b/crates/nu-command/src/commands/dataframe/groupby.rs
@@ -2,9 +2,73 @@ use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{
-    dataframe::{NuDataFrame, PolarsStruct},
-    Signature, UntaggedValue,
+    dataframe::NuDataFrame, Primitive, Signature, SyntaxShape, UntaggedValue, Value,
 };
+use nu_source::Tagged;
+use polars::frame::groupby::GroupBy;
+
+enum Operation {
+    Mean,
+    Sum,
+    Min,
+    Max,
+    First,
+    Last,
+    Nunique,
+    Quantile(f64),
+    Median,
+    //Var,
+    //Std,
+    Count,
+}
+
+impl Operation {
+    fn from_tagged(
+        name: &Tagged<String>,
+        quantile: Option<Tagged<f64>>,
+    ) -> Result<Operation, ShellError> {
+        match name.item.as_ref() {
+            "mean" => Ok(Operation::Mean),
+            "sum" => Ok(Operation::Sum),
+            "min" => Ok(Operation::Min),
+            "max" => Ok(Operation::Max),
+            "first" => Ok(Operation::First),
+            "last" => Ok(Operation::Last),
+            "nunique" => Ok(Operation::Nunique),
+            "quantile" => {
+                match quantile {
+                    None => Err(ShellError::labeled_error(
+                        "Quantile value not fount",
+                        "Quantile operation requires quantile value",
+                        &name.tag,
+                    )),
+                Some(value ) => {
+                    if (value.item < 0.0) | (value.item > 1.0) {
+                        Err(ShellError::labeled_error(
+                            "Inappropriate quantile",
+                            "Quantile value should be between 0.0 and 1.0",
+                            &value.tag,
+                        ))
+                    } else {
+                        Ok(Operation::Quantile(value.item))
+                    }
+                }
+                }
+            }
+            "median" => Ok(Operation::Median),
+            //"var" => Ok(Operation::Var),
+            //"std" => Ok(Operation::Std),
+            "count" => Ok(Operation::Count),
+            _ => Err(ShellError::labeled_error_with_secondary(
+                "Operation not fount",
+                "Operation does not exist",
+                &name.tag,
+                "Perhaps you want: mean, sum, min, max, first, last, nunique, quantile, median, count",
+                &name.tag,
+            )),
+        }
+    }
+}
 
 pub struct DataFrame;
 
@@ -19,6 +83,19 @@ impl WholeStreamCommand for DataFrame {
 
     fn signature(&self) -> Signature {
         Signature::build("dataframe groupby")
+            .required("columns", SyntaxShape::Table, "groupby columns")
+            .required(
+                "aggregation columns",
+                SyntaxShape::Table,
+                "columns to perform aggregation",
+            )
+            .required("operation", SyntaxShape::String, "aggregate operation")
+            .named(
+                "quantile",
+                SyntaxShape::Number,
+                "auantile value for quantile operation",
+                Some('q'),
+            )
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
@@ -27,11 +104,159 @@ impl WholeStreamCommand for DataFrame {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Takes an input stream and converts it to a dataframe",
-            example: "echo [[a b];[1 2] [3 4]] | dataframe",
+            description: "",
+            example: "",
             result: None,
         }]
     }
 }
 
-fn groupby(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {}
+fn groupby(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let tag = args.call_info.name_tag.clone();
+    let mut args = args.evaluate_once()?;
+
+    let quantile: Option<Tagged<f64>> = args.get_flag("quantile")?;
+    let operation: Tagged<String> = args.req(2)?;
+    let op = Operation::from_tagged(&operation, quantile)?;
+
+    // Extracting the names of the columns to perform the groupby
+    let columns: Vec<Value> = args.req(0)?;
+
+    // Extracting the first tag from the groupby column names
+    let mut col_span = match columns
+        .iter()
+        .nth(0)
+        .map(|v| Span::new(v.tag.span.start(), v.tag.span.end()))
+    {
+        Some(span) => span,
+        None => {
+            return Err(ShellError::labeled_error(
+                "Empty groupby names list",
+                "Empty list for groupby column names",
+                &tag,
+            ))
+        }
+    };
+
+    let columns_string = columns
+        .into_iter()
+        .map(|value| match value.value {
+            UntaggedValue::Primitive(Primitive::String(s)) => {
+                col_span = col_span.until(value.tag.span);
+                Ok(s)
+            }
+            _ => Err(ShellError::labeled_error(
+                "Incorrect column format",
+                "Only string as column name",
+                &value.tag,
+            )),
+        })
+        .collect::<Result<Vec<String>, _>>()?;
+
+    // Extracting the names of the columns to perform the aggregation
+    let agg_cols: Vec<Value> = args.req(1)?;
+
+    // Extracting the first tag from the aggregation column names
+    let mut agg_span = match agg_cols
+        .iter()
+        .nth(0)
+        .map(|v| Span::new(v.tag.span.start(), v.tag.span.end()))
+    {
+        Some(span) => span,
+        None => {
+            return Err(ShellError::labeled_error(
+                "Empty aggregation names list",
+                "Empty list for aggregation column names",
+                &tag,
+            ))
+        }
+    };
+
+    let aggregation_string = agg_cols
+        .into_iter()
+        .map(|value| match value.value {
+            UntaggedValue::Primitive(Primitive::String(s)) => {
+                agg_span = agg_span.until(value.tag.span);
+                Ok(s)
+            }
+            _ => Err(ShellError::labeled_error(
+                "Incorrect column format",
+                "Only string as column name",
+                value.tag,
+            )),
+        })
+        .collect::<Result<Vec<String>, _>>()?;
+
+    // The operation is only done in one dataframe. Only one input is
+    // expected from the InputStream
+    match args.input.next() {
+        None => Err(ShellError::labeled_error(
+            "No input received",
+            "missing dataframe input from stream",
+            &tag,
+        )),
+        Some(value) => {
+            if let UntaggedValue::DataFrame(NuDataFrame {
+                dataframe: Some(df),
+                ..
+            }) = value.value
+            {
+                let groupby = df
+                    .groupby(&columns_string)
+                    .map_err(|e| {
+                        ShellError::labeled_error("Groupby error", format!("{}", e), col_span)
+                    })?
+                    .select(&aggregation_string);
+
+                let res = perform_aggregation(groupby, op, &operation.tag, &agg_span)?;
+
+                let final_df = Value {
+                    tag,
+                    value: UntaggedValue::DataFrame(NuDataFrame {
+                        dataframe: Some(res),
+                        name: "agg result".to_string(),
+                    }),
+                };
+
+                Ok(OutputStream::one(final_df))
+            } else {
+                Err(ShellError::labeled_error(
+                    "No dataframe in stream",
+                    "no dataframe found in input stream",
+                    &tag,
+                ))
+            }
+        }
+    }
+}
+
+fn perform_aggregation(
+    groupby: GroupBy,
+    operation: Operation,
+    operation_tag: &Tag,
+    agg_span: &Span,
+) -> Result<polars::prelude::DataFrame, ShellError> {
+    match operation {
+        Operation::Mean => groupby.mean(),
+        Operation::Sum => groupby.sum(),
+        Operation::Min => groupby.min(),
+        Operation::Max => groupby.max(),
+        Operation::First => groupby.first(),
+        Operation::Last => groupby.last(),
+        Operation::Nunique => groupby.n_unique(),
+        Operation::Quantile(quantile) => groupby.quantile(quantile),
+        Operation::Median => groupby.median(),
+        //Operation::Var => groupby.var(),
+        //Operation::Std => groupby.std(),
+        Operation::Count => groupby.count(),
+    }
+    .map_err(|e| {
+        let span = if e.to_string().contains("Not found") {
+            agg_span
+        } else {
+            &operation_tag.span
+        };
+
+        ShellError::labeled_error("Aggregation error", format!("{}", e), span)
+    })
+}

--- a/crates/nu-command/src/commands/dataframe/list.rs
+++ b/crates/nu-command/src/commands/dataframe/list.rs
@@ -3,9 +3,9 @@ use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{dataframe::PolarsStruct, Signature, TaggedDictBuilder, UntaggedValue, Value};
 
-pub struct Dataframe;
+pub struct DataFrame;
 
-impl WholeStreamCommand for Dataframe {
+impl WholeStreamCommand for DataFrame {
     fn name(&self) -> &str {
         "dataframe list"
     }

--- a/crates/nu-command/src/commands/dataframe/list.rs
+++ b/crates/nu-command/src/commands/dataframe/list.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{dataframe::PolarsStruct, Signature, TaggedDictBuilder, UntaggedValue, Value};
+use nu_protocol::{Signature, TaggedDictBuilder, UntaggedValue, Value};
 
 pub struct DataFrame;
 
@@ -23,7 +23,7 @@ impl WholeStreamCommand for DataFrame {
 
         let mut dataframes: Vec<Value> = Vec::new();
         for (name, value) in args.context.scope.get_vars() {
-            if let UntaggedValue::Data(PolarsStruct::DataFrame(df)) = value.value {
+            if let UntaggedValue::DataFrame(df) = value.value {
                 let mut data = TaggedDictBuilder::new(value.tag);
 
                 let polars_df = df.dataframe.unwrap();

--- a/crates/nu-command/src/commands/dataframe/list.rs
+++ b/crates/nu-command/src/commands/dataframe/list.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Signature, TaggedDictBuilder, UntaggedValue, Value};
+use nu_protocol::{dataframe::PolarsStruct, Signature, TaggedDictBuilder, UntaggedValue, Value};
 
 pub struct Dataframe;
 
@@ -23,7 +23,7 @@ impl WholeStreamCommand for Dataframe {
 
         let mut dataframes: Vec<Value> = Vec::new();
         for (name, value) in args.context.scope.get_vars() {
-            if let UntaggedValue::Dataframe(df) = value.value {
+            if let UntaggedValue::Data(PolarsStruct::DataFrame(df)) = value.value {
                 let mut data = TaggedDictBuilder::new(value.tag);
 
                 let polars_df = df.dataframe.unwrap();

--- a/crates/nu-command/src/commands/dataframe/load.rs
+++ b/crates/nu-command/src/commands/dataframe/load.rs
@@ -4,8 +4,7 @@ use crate::prelude::*;
 use nu_engine::{EvaluatedCommandArgs, WholeStreamCommand};
 use nu_errors::ShellError;
 use nu_protocol::{
-    dataframe::{NuDataFrame, PolarsStruct},
-    Primitive, Signature, SyntaxShape, UntaggedValue, Value,
+    dataframe::NuDataFrame, Primitive, Signature, SyntaxShape, UntaggedValue, Value,
 };
 
 use nu_source::Tagged;
@@ -113,9 +112,7 @@ fn create_from_file(args: CommandArgs) -> Result<OutputStream, ShellError> {
         name: file_name,
     };
 
-    let init = InputStream::one(
-        UntaggedValue::Data(PolarsStruct::DataFrame(nu_dataframe)).into_value(&tag),
-    );
+    let init = InputStream::one(UntaggedValue::DataFrame(nu_dataframe).into_value(&tag));
 
     Ok(init.to_output_stream())
 }

--- a/crates/nu-command/src/commands/dataframe/load.rs
+++ b/crates/nu-command/src/commands/dataframe/load.rs
@@ -12,9 +12,9 @@ use nu_source::Tagged;
 use polars::prelude::{CsvReader, JsonReader, ParquetReader, SerReader};
 use std::fs::File;
 
-pub struct Dataframe;
+pub struct DataFrame;
 
-impl WholeStreamCommand for Dataframe {
+impl WholeStreamCommand for DataFrame {
     fn name(&self) -> &str {
         "dataframe load"
     }

--- a/crates/nu-command/src/commands/dataframe/load.rs
+++ b/crates/nu-command/src/commands/dataframe/load.rs
@@ -4,7 +4,8 @@ use crate::prelude::*;
 use nu_engine::{EvaluatedCommandArgs, WholeStreamCommand};
 use nu_errors::ShellError;
 use nu_protocol::{
-    dataframe::NuDataFrame, Primitive, Signature, SyntaxShape, UntaggedValue, Value,
+    dataframe::{NuDataFrame, PolarsStruct},
+    Primitive, Signature, SyntaxShape, UntaggedValue, Value,
 };
 
 use nu_source::Tagged;
@@ -112,7 +113,9 @@ fn create_from_file(args: CommandArgs) -> Result<OutputStream, ShellError> {
         name: file_name,
     };
 
-    let init = InputStream::one(UntaggedValue::Dataframe(nu_dataframe).into_value(&tag));
+    let init = InputStream::one(
+        UntaggedValue::Data(PolarsStruct::DataFrame(nu_dataframe)).into_value(&tag),
+    );
 
     Ok(init.to_output_stream())
 }

--- a/crates/nu-command/src/commands/dataframe/mod.rs
+++ b/crates/nu-command/src/commands/dataframe/mod.rs
@@ -1,7 +1,9 @@
 pub mod command;
+pub mod groupby;
 pub mod list;
 pub mod load;
 
-pub use command::Command as Dataframe;
-pub use list::Dataframe as DataframeList;
-pub use load::Dataframe as DataframeLoad;
+pub use command::Command as DataFrame;
+pub use groupby::DataFrame as DataFrameGroupBy;
+pub use list::DataFrame as DataFrameList;
+pub use load::DataFrame as DataFrameLoad;

--- a/crates/nu-command/src/commands/default_context.rs
+++ b/crates/nu-command/src/commands/default_context.rs
@@ -257,6 +257,8 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(DataFrameLoad),
             #[cfg(feature = "dataframe")]
             whole_stream_command(DataFrameList),
+            #[cfg(feature = "dataframe")]
+            whole_stream_command(DataFrameGroupBy),
         ]);
 
         #[cfg(feature = "clipboard-cli")]

--- a/crates/nu-command/src/commands/default_context.rs
+++ b/crates/nu-command/src/commands/default_context.rs
@@ -252,11 +252,11 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(SeqDates),
             whole_stream_command(TermSize),
             #[cfg(feature = "dataframe")]
-            whole_stream_command(Dataframe),
+            whole_stream_command(DataFrame),
             #[cfg(feature = "dataframe")]
-            whole_stream_command(DataframeLoad),
+            whole_stream_command(DataFrameLoad),
             #[cfg(feature = "dataframe")]
-            whole_stream_command(DataframeList),
+            whole_stream_command(DataFrameList),
         ]);
 
         #[cfg(feature = "clipboard-cli")]

--- a/crates/nu-command/src/commands/to_json.rs
+++ b/crates/nu-command/src/commands/to_json.rs
@@ -115,7 +115,7 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
             serde_json::Value::Null
         }
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Dataframe(_) => serde_json::Value::Null,
+        UntaggedValue::Data(_) => serde_json::Value::Null,
         UntaggedValue::Primitive(Primitive::Binary(b)) => serde_json::Value::Array(
             b.iter()
                 .map(|x| {

--- a/crates/nu-command/src/commands/to_json.rs
+++ b/crates/nu-command/src/commands/to_json.rs
@@ -115,7 +115,7 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
             serde_json::Value::Null
         }
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Data(_) => serde_json::Value::Null,
+        UntaggedValue::DataFrame(_) => serde_json::Value::Null,
         UntaggedValue::Primitive(Primitive::Binary(b)) => serde_json::Value::Array(
             b.iter()
                 .map(|x| {

--- a/crates/nu-command/src/commands/to_toml.rs
+++ b/crates/nu-command/src/commands/to_toml.rs
@@ -74,7 +74,7 @@ fn helper(v: &Value) -> Result<toml::Value, ShellError> {
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Block(_) => toml::Value::String("<Block>".to_string()),
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Dataframe(_) => toml::Value::String("<Dataframe>".to_string()),
+        UntaggedValue::Data(_) => toml::Value::String("<Data>".to_string()),
         UntaggedValue::Primitive(Primitive::Range(_)) => toml::Value::String("<Range>".to_string()),
         UntaggedValue::Primitive(Primitive::Binary(b)) => {
             toml::Value::Array(b.iter().map(|x| toml::Value::Integer(*x as i64)).collect())

--- a/crates/nu-command/src/commands/to_toml.rs
+++ b/crates/nu-command/src/commands/to_toml.rs
@@ -74,7 +74,7 @@ fn helper(v: &Value) -> Result<toml::Value, ShellError> {
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Block(_) => toml::Value::String("<Block>".to_string()),
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Data(_) => toml::Value::String("<Data>".to_string()),
+        UntaggedValue::DataFrame(_) => toml::Value::String("<Data>".to_string()),
         UntaggedValue::Primitive(Primitive::Range(_)) => toml::Value::String("<Range>".to_string()),
         UntaggedValue::Primitive(Primitive::Binary(b)) => {
             toml::Value::Array(b.iter().map(|x| toml::Value::Integer(*x as i64)).collect())

--- a/crates/nu-command/src/commands/to_yaml.rs
+++ b/crates/nu-command/src/commands/to_yaml.rs
@@ -96,7 +96,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
             serde_yaml::Value::Null
         }
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Dataframe(_) => serde_yaml::Value::Null,
+        UntaggedValue::Data(_) => serde_yaml::Value::Null,
         UntaggedValue::Primitive(Primitive::Binary(b)) => serde_yaml::Value::Sequence(
             b.iter()
                 .map(|x| serde_yaml::Value::Number(serde_yaml::Number::from(*x)))

--- a/crates/nu-command/src/commands/to_yaml.rs
+++ b/crates/nu-command/src/commands/to_yaml.rs
@@ -96,7 +96,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
             serde_yaml::Value::Null
         }
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Data(_) => serde_yaml::Value::Null,
+        UntaggedValue::DataFrame(_) => serde_yaml::Value::Null,
         UntaggedValue::Primitive(Primitive::Binary(b)) => serde_yaml::Value::Sequence(
             b.iter()
                 .map(|x| serde_yaml::Value::Number(serde_yaml::Number::from(*x)))

--- a/crates/nu-command/src/commands/uniq.rs
+++ b/crates/nu-command/src/commands/uniq.rs
@@ -156,9 +156,9 @@ fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
                         ))
                     }
                     #[cfg(feature = "dataframe")]
-                    UntaggedValue::Dataframe(_) => {
+                    UntaggedValue::Data(_) => {
                         return Err(ShellError::labeled_error(
-                            "uniq -c cannot operate on dataframes.",
+                            "uniq -c cannot operate on data structs",
                             "source",
                             item.0.tag.span,
                         ))

--- a/crates/nu-command/src/commands/uniq.rs
+++ b/crates/nu-command/src/commands/uniq.rs
@@ -156,7 +156,7 @@ fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
                         ))
                     }
                     #[cfg(feature = "dataframe")]
-                    UntaggedValue::Data(_) => {
+                    UntaggedValue::DataFrame(_) => {
                         return Err(ShellError::labeled_error(
                             "uniq -c cannot operate on data structs",
                             "source",

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -46,7 +46,7 @@ pub enum InlineShape {
 
     // TODO: Dataframe type
     #[cfg(feature = "dataframe")]
-    Data,
+    DataFrame,
 
     // Stream markers (used as bookend markers rather than actual values)
     BeginningOfStream,
@@ -130,7 +130,7 @@ impl InlineShape {
             UntaggedValue::Error(_) => InlineShape::Error,
             UntaggedValue::Block(_) => InlineShape::Block,
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Data(_) => InlineShape::Data,
+            UntaggedValue::DataFrame(_) => InlineShape::DataFrame,
         }
     }
 
@@ -322,7 +322,7 @@ impl PrettyDebug for FormatInlineShape {
             InlineShape::Block => DbgDocBldr::opaque("block"),
             InlineShape::Error => DbgDocBldr::error("error"),
             #[cfg(feature = "dataframe")]
-            InlineShape::Data => DbgDocBldr::error("data_pretty_formatter"),
+            InlineShape::DataFrame => DbgDocBldr::error("dataframe_pretty_formatter"),
             InlineShape::BeginningOfStream => DbgDocBldr::blank(),
             InlineShape::EndOfStream => DbgDocBldr::blank(),
         }

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -46,7 +46,7 @@ pub enum InlineShape {
 
     // TODO: Dataframe type
     #[cfg(feature = "dataframe")]
-    Dataframe,
+    Data,
 
     // Stream markers (used as bookend markers rather than actual values)
     BeginningOfStream,
@@ -130,7 +130,7 @@ impl InlineShape {
             UntaggedValue::Error(_) => InlineShape::Error,
             UntaggedValue::Block(_) => InlineShape::Block,
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Dataframe(_) => InlineShape::Dataframe,
+            UntaggedValue::Data(_) => InlineShape::Data,
         }
     }
 
@@ -322,7 +322,7 @@ impl PrettyDebug for FormatInlineShape {
             InlineShape::Block => DbgDocBldr::opaque("block"),
             InlineShape::Error => DbgDocBldr::error("error"),
             #[cfg(feature = "dataframe")]
-            InlineShape::Dataframe => DbgDocBldr::error("dataframe_pretty_FormatInlineShape"),
+            InlineShape::Data => DbgDocBldr::error("data_pretty_formatter"),
             InlineShape::BeginningOfStream => DbgDocBldr::blank(),
             InlineShape::EndOfStream => DbgDocBldr::blank(),
         }

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -117,7 +117,7 @@ fn helper(v: &Value) -> Result<toml::Value, ShellError> {
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Block(_) => toml::Value::String("<Block>".to_string()),
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Data(_) => toml::Value::String("<Data>".to_string()),
+        UntaggedValue::DataFrame(_) => toml::Value::String("<Data>".to_string()),
         UntaggedValue::Primitive(Primitive::Range(_)) => toml::Value::String("<Range>".to_string()),
         UntaggedValue::Primitive(Primitive::Binary(b)) => {
             toml::Value::Array(b.iter().map(|x| toml::Value::Integer(*x as i64)).collect())

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -117,7 +117,7 @@ fn helper(v: &Value) -> Result<toml::Value, ShellError> {
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Block(_) => toml::Value::String("<Block>".to_string()),
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Dataframe(_) => toml::Value::String("<Dataframe>".to_string()),
+        UntaggedValue::Data(_) => toml::Value::String("<Data>".to_string()),
         UntaggedValue::Primitive(Primitive::Range(_)) => toml::Value::String("<Range>".to_string()),
         UntaggedValue::Primitive(Primitive::Binary(b)) => {
             toml::Value::Array(b.iter().map(|x| toml::Value::Integer(*x as i64)).collect())

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
 
-polars = {version="0.13.1", git = "https://github.com/ritchie46/polars", rev = "3efad9a5c380c64a5eb78b4b7ad257e1e606b9f0", optional = true}
+polars = {version="0.13.3", optional = true}
 
 # implement conversions
 serde_json = "1.0"

--- a/crates/nu-protocol/src/dataframe/mod.rs
+++ b/crates/nu-protocol/src/dataframe/mod.rs
@@ -6,9 +6,5 @@ pub use nu_dataframe::NuDataFrame;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
 pub enum PolarsStruct {
     DataFrame(NuDataFrame),
-    Series,
-    GroupBy,
-    LazyFrame,
-    GroupTuples,
     None,
 }

--- a/crates/nu-protocol/src/dataframe/mod.rs
+++ b/crates/nu-protocol/src/dataframe/mod.rs
@@ -1,10 +1,3 @@
-use serde::{Deserialize, Serialize};
 pub mod nu_dataframe;
 
 pub use nu_dataframe::NuDataFrame;
-
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
-pub enum PolarsStruct {
-    DataFrame(NuDataFrame),
-    None,
-}

--- a/crates/nu-protocol/src/dataframe/mod.rs
+++ b/crates/nu-protocol/src/dataframe/mod.rs
@@ -1,3 +1,14 @@
+use serde::{Deserialize, Serialize};
 pub mod nu_dataframe;
 
 pub use nu_dataframe::NuDataFrame;
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
+pub enum PolarsStruct {
+    DataFrame(NuDataFrame),
+    Series,
+    GroupBy,
+    LazyFrame,
+    GroupTuples,
+    None,
+}

--- a/crates/nu-protocol/src/type_shape.rs
+++ b/crates/nu-protocol/src/type_shape.rs
@@ -74,7 +74,7 @@ pub enum Type {
 
     /// Dataframe
     #[cfg(feature = "dataframe")]
-    Dataframe,
+    Data,
 }
 
 /// A shape representation of the type of a row
@@ -191,7 +191,7 @@ impl Type {
             UntaggedValue::Error(_) => Type::Error,
             UntaggedValue::Block(_) => Type::Block,
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Dataframe(_) => Type::Dataframe,
+            UntaggedValue::Data(_) => Type::Data,
         }
     }
 }
@@ -298,7 +298,7 @@ impl PrettyDebug for Type {
             }
             Type::Block => ty("block"),
             #[cfg(feature = "dataframe")]
-            Type::Dataframe => ty("dataframe_pretty_debug_for_Type"),
+            Type::Data => ty("data_type_formatter"),
         }
     }
 }

--- a/crates/nu-protocol/src/type_shape.rs
+++ b/crates/nu-protocol/src/type_shape.rs
@@ -74,7 +74,7 @@ pub enum Type {
 
     /// Dataframe
     #[cfg(feature = "dataframe")]
-    Data,
+    DataFrame,
 }
 
 /// A shape representation of the type of a row
@@ -191,7 +191,7 @@ impl Type {
             UntaggedValue::Error(_) => Type::Error,
             UntaggedValue::Block(_) => Type::Block,
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Data(_) => Type::Data,
+            UntaggedValue::DataFrame(_) => Type::DataFrame,
         }
     }
 }
@@ -298,7 +298,7 @@ impl PrettyDebug for Type {
             }
             Type::Block => ty("block"),
             #[cfg(feature = "dataframe")]
-            Type::Data => ty("data_type_formatter"),
+            Type::DataFrame => ty("data_type_formatter"),
         }
     }
 }

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 #[cfg(feature = "dataframe")]
-use crate::dataframe::NuDataFrame;
+use crate::dataframe::PolarsStruct;
 
 /// The core structured values that flow through a pipeline
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
@@ -51,9 +51,10 @@ pub enum UntaggedValue {
     /// A block of Nu code, eg `{ ls | get name ; echo "done" }` with its captured values
     Block(Box<hir::CapturedBlock>),
 
-    /// NuDataframe
+    /// Data option that holds the polars structs required to to data
+    /// manipulation and operations using polars dataframes
     #[cfg(feature = "dataframe")]
-    Dataframe(NuDataFrame),
+    Data(PolarsStruct),
 }
 
 impl UntaggedValue {
@@ -671,7 +672,7 @@ impl ShellTypeName for UntaggedValue {
             UntaggedValue::Error(_) => "error",
             UntaggedValue::Block(_) => "block",
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Dataframe(_) => "dataframe",
+            UntaggedValue::Data(_) => "data",
         }
     }
 }

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 #[cfg(feature = "dataframe")]
-use crate::dataframe::PolarsStruct;
+use crate::dataframe::NuDataFrame;
 
 /// The core structured values that flow through a pipeline
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize, Deserialize)]
@@ -54,7 +54,7 @@ pub enum UntaggedValue {
     /// Data option that holds the polars structs required to to data
     /// manipulation and operations using polars dataframes
     #[cfg(feature = "dataframe")]
-    Data(PolarsStruct),
+    DataFrame(NuDataFrame),
 }
 
 impl UntaggedValue {
@@ -672,7 +672,7 @@ impl ShellTypeName for UntaggedValue {
             UntaggedValue::Error(_) => "error",
             UntaggedValue::Block(_) => "block",
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Data(_) => "data",
+            UntaggedValue::DataFrame(_) => "dataframe",
         }
     }
 }

--- a/crates/nu-protocol/src/value/debug.rs
+++ b/crates/nu-protocol/src/value/debug.rs
@@ -25,7 +25,7 @@ impl PrettyDebug for Value {
             UntaggedValue::Error(_) => DbgDocBldr::error("error"),
             UntaggedValue::Block(_) => DbgDocBldr::opaque("block"),
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Data(_) => DbgDocBldr::opaque("data_prettydebug_for_data"),
+            UntaggedValue::DataFrame(_) => DbgDocBldr::opaque("dataframe_prettydebug_for_data"),
         }
     }
 }

--- a/crates/nu-protocol/src/value/debug.rs
+++ b/crates/nu-protocol/src/value/debug.rs
@@ -25,7 +25,7 @@ impl PrettyDebug for Value {
             UntaggedValue::Error(_) => DbgDocBldr::error("error"),
             UntaggedValue::Block(_) => DbgDocBldr::opaque("block"),
             #[cfg(feature = "dataframe")]
-            UntaggedValue::Dataframe(_) => DbgDocBldr::opaque("dataframe_prettydebug_for_Value"),
+            UntaggedValue::Data(_) => DbgDocBldr::opaque("data_prettydebug_for_data"),
         }
     }
 }

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -725,7 +725,9 @@ pub fn get_data<'value>(value: &'value Value, desc: &str) -> MaybeOwned<'value, 
             MaybeOwned::Owned(UntaggedValue::nothing().into_untagged_value())
         }
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Data(_) => MaybeOwned::Owned(UntaggedValue::nothing().into_untagged_value()),
+        UntaggedValue::DataFrame(_) => {
+            MaybeOwned::Owned(UntaggedValue::nothing().into_untagged_value())
+        }
     }
 }
 

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -725,9 +725,7 @@ pub fn get_data<'value>(value: &'value Value, desc: &str) -> MaybeOwned<'value, 
             MaybeOwned::Owned(UntaggedValue::nothing().into_untagged_value())
         }
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Dataframe(_) => {
-            MaybeOwned::Owned(UntaggedValue::nothing().into_untagged_value())
-        }
+        UntaggedValue::Data(_) => MaybeOwned::Owned(UntaggedValue::nothing().into_untagged_value()),
     }
 }
 

--- a/crates/nu_plugin_post/src/post.rs
+++ b/crates/nu_plugin_post/src/post.rs
@@ -401,10 +401,10 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
 
         UntaggedValue::Table(l) => serde_json::Value::Array(json_list(l)?),
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Dataframe(_) => {
+        UntaggedValue::Data(_) => {
             return Err(ShellError::labeled_error(
-                "Cannot convert dataframe",
-                "Cannot convert dataframe",
+                "Cannot convert data struct",
+                "Cannot convert data struct",
                 &v.tag,
             ))
         }

--- a/crates/nu_plugin_post/src/post.rs
+++ b/crates/nu_plugin_post/src/post.rs
@@ -401,7 +401,7 @@ pub fn value_to_json_value(v: &Value) -> Result<serde_json::Value, ShellError> {
 
         UntaggedValue::Table(l) => serde_json::Value::Array(json_list(l)?),
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Data(_) => {
+        UntaggedValue::DataFrame(_) => {
             return Err(ShellError::labeled_error(
                 "Cannot convert data struct",
                 "Cannot convert data struct",

--- a/crates/nu_plugin_to_bson/src/to_bson.rs
+++ b/crates/nu_plugin_to_bson/src/to_bson.rs
@@ -64,7 +64,7 @@ pub fn value_to_bson_value(v: &Value) -> Result<Bson, ShellError> {
         ),
         UntaggedValue::Block(_) | UntaggedValue::Primitive(Primitive::Range(_)) => Bson::Null,
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Dataframe(_) => Bson::Null,
+        UntaggedValue::Data(_) => Bson::Null,
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Primitive(Primitive::Binary(b)) => {
             Bson::Binary(BinarySubtype::Generic, b.clone())

--- a/crates/nu_plugin_to_bson/src/to_bson.rs
+++ b/crates/nu_plugin_to_bson/src/to_bson.rs
@@ -64,7 +64,7 @@ pub fn value_to_bson_value(v: &Value) -> Result<Bson, ShellError> {
         ),
         UntaggedValue::Block(_) | UntaggedValue::Primitive(Primitive::Range(_)) => Bson::Null,
         #[cfg(feature = "dataframe")]
-        UntaggedValue::Data(_) => Bson::Null,
+        UntaggedValue::DataFrame(_) => Bson::Null,
         UntaggedValue::Error(e) => return Err(e.clone()),
         UntaggedValue::Primitive(Primitive::Binary(b)) => {
             Bson::Binary(BinarySubtype::Generic, b.clone())


### PR DESCRIPTION
With this PR the new command `dataframe groupby` is introduced. 

This command allows to perform groupby aggregate operations on dataframes resulting in new aggregated dataframes.

![image](https://user-images.githubusercontent.com/6942205/119239459-27353980-bb41-11eb-8a8e-3fd6d6d73daa.png)

Allowed operations:

- Mean
- Sum
- Min
- Max
- First
- Last
- Nunique
- Quantile(f64)
- Median
- Count
