### PR TITLE
Add the load-env command

### DIFF
--- a/crates/nu-command/src/commands.rs
+++ b/crates/nu-command/src/commands.rs
@@ -79,6 +79,7 @@ pub(crate) mod length;
 pub(crate) mod let_;
 pub(crate) mod let_env;
 pub(crate) mod lines;
+pub(crate) mod load_env;
 pub(crate) mod ls;
 pub(crate) mod math;
 pub(crate) mod merge;
@@ -226,6 +227,7 @@ pub(crate) use length::Length;
 pub(crate) use let_::Let;
 pub(crate) use let_env::LetEnv;
 pub(crate) use lines::Lines;
+pub(crate) use load_env::LoadEnv;
 pub(crate) use ls::Ls;
 pub(crate) use math::{
     Math, MathAbs, MathAverage, MathCeil, MathEval, MathFloor, MathMaximum, MathMedian,

--- a/crates/nu-command/src/commands/default_context.rs
+++ b/crates/nu-command/src/commands/default_context.rs
@@ -13,6 +13,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(NuPlugin),
             whole_stream_command(Let),
             whole_stream_command(LetEnv),
+            whole_stream_command(LoadEnv),
             whole_stream_command(Def),
             whole_stream_command(Source),
             // System/file operations

--- a/crates/nu-command/src/commands/load_env.rs
+++ b/crates/nu-command/src/commands/load_env.rs
@@ -1,0 +1,84 @@
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+
+use nu_errors::ShellError;
+use nu_protocol::{Signature, Value};
+
+pub struct LoadEnv;
+
+#[derive(Deserialize)]
+struct LoadEnvArgs {}
+
+impl WholeStreamCommand for LoadEnv {
+    fn name(&self) -> &str {
+        "load-env"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("load-env")
+    }
+
+    fn usage(&self) -> &str {
+        "Set environment variables using a table stream"
+    }
+
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        load_env(args)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Load a few variables",
+            example: r#"echo [[name, value]; ["NAME", "JT"] ["AGE", "UNKNOWN"]] | load-env; echo $nu.env.NAME"#,
+            result: Some(vec![Value::from("JT")]),
+        }]
+    }
+}
+
+pub fn load_env(args: CommandArgs) -> Result<ActionStream, ShellError> {
+    let ctx = EvaluationContext::from_args(&args);
+
+    let (LoadEnvArgs {}, stream) = args.process()?;
+
+    for value in stream {
+        let mut var_name = None;
+        let mut var_value = None;
+
+        let tag = value.tag();
+
+        for (key, value) in value.row_entries() {
+            if key == "name" {
+                var_name = Some(value.as_string()?);
+            } else if key == "value" {
+                var_value = Some(value.as_string()?);
+            }
+        }
+
+        match (var_name, var_value) {
+            (Some(name), Some(value)) => ctx.scope.add_env_var(name, value),
+            _ => {
+                return Err(ShellError::labeled_error(
+                    r#"Expected each row in the table to have a "name" and "value" field."#,
+                    r#"expected a "name" and "value" field"#,
+                    tag,
+                ))
+            }
+        }
+    }
+
+    /*
+    ctx.scope.add_vars(&captured.entries);
+
+    let value = evaluate_baseline_expr(&expr, &ctx);
+
+    ctx.scope.exit_scope();
+
+    let value = value?;
+    let value = value.as_string()?;
+
+    let name = name.item;
+
+    */
+
+    Ok(ActionStream::empty())
+}

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -369,6 +369,42 @@ fn proper_shadow_let_env_aliases() {
 }
 
 #[test]
+fn load_env_variable() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo [[name, value]; [TESTENVVAR, "hello world"]] | load-env
+            echo $nu.env.TESTENVVAR
+        "#
+    );
+
+    assert_eq!(actual.out, "hello world");
+}
+
+#[test]
+fn load_env_doesnt_leak() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        do { echo [[name, value]; [xyz, "my message"]] | load-env }; echo $nu.env.xyz
+        "#
+    );
+
+    assert!(actual.err.contains("did you mean"));
+}
+
+#[test]
+fn proper_shadow_load_env_aliases() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let-env DEBUG = true; echo $nu.env.DEBUG | autoview; do { echo [[name, value]; [DEBUG, false]] | load-env; echo $nu.env.DEBUG } | autoview; echo $nu.env.DEBUG
+        "#
+    );
+    assert_eq!(actual.out, "truefalsetrue");
+}
+
+#[test]
 fn proper_shadow_let_aliases() {
     let actual = nu!(
         cwd: ".",

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -382,6 +382,32 @@ fn load_env_variable() {
 }
 
 #[test]
+fn load_env_variable_arg() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            load-env [[name, value]; [TESTENVVAR, "hello world"]]
+            echo $nu.env.TESTENVVAR
+        "#
+    );
+
+    assert_eq!(actual.out, "hello world");
+}
+
+#[test]
+fn load_env_variable_arg_and_stream() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            echo [[name, value]; [TESTVARSTREAM, "true"]] | load-env [[name, value]; [TESTVARARG, "false"]]
+            echo $nu.env | format "{TESTVARSTREAM} {TESTVARARG}"
+        "#
+    );
+
+    assert_eq!(actual.out, "true false");
+}
+
+#[test]
 fn load_env_doesnt_leak() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
load-env can be used to add environment variables dynamically via an
InputStream. This allows developers to create tools that output environment
variables as key-value pairs, then have the user load those variables in using
load-env. This supplants most of the need for an `eval` command, which is
mostly used in POSIX envs for setting env vars.

I did add one deviation to the design in the original spec, and that was to change from accepting a table as an argument to accepting a table as a stream. I believe that this makes the command a bit more flexible and encourages reuse.

Fixes #3481