### PR TITLE
correctly escape pipe in windows/cmd.exe

### DIFF
--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -149,8 +149,9 @@ fn spawn(
             process.arg("/c");
             process.arg(&command.name);
             for arg in args {
+                eprintln!("args {}", &arg);
                 // Clean the args before we use them:
-                let arg = arg.replace("|", "\\|");
+                let arg = arg.replace("|", "^|");
                 process.arg(&arg);
             }
             process
@@ -165,8 +166,8 @@ fn spawn(
         }
     };
 
-    process.current_dir(path);
     trace!(target: "nu::run::external", "cwd = {:?}", &path);
+    process.current_dir(path);
 
     process.env_clear();
     process.envs(scope.get_env_vars());

--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -149,8 +149,9 @@ fn spawn(
             process.arg("/c");
             process.arg(&command.name);
             for arg in args {
-                eprintln!("args {}", &arg);
                 // Clean the args before we use them:
+                // https://stackoverflow.com/questions/1200235/how-to-pass-a-quoted-pipe-character-to-cmd-exe
+                // cmd.exe needs to have a caret to escape a pipe
                 let arg = arg.replace("|", "^|");
                 process.arg(&arg);
             }
@@ -166,8 +167,8 @@ fn spawn(
         }
     };
 
-    trace!(target: "nu::run::external", "cwd = {:?}", &path);
     process.current_dir(path);
+    trace!(target: "nu::run::external", "cwd = {:?}", &path);
 
     process.env_clear();
     process.envs(scope.get_env_vars());


### PR DESCRIPTION
changed escape from `\\|` to `^|` based on #3454 and [SO article](https://stackoverflow.com/questions/1200235/how-to-pass-a-quoted-pipe-character-to-cmd-exe)