### PR TITLE
Allow aliases to expand and ignore painting outside of lines

### DIFF
--- a/crates/nu-engine/src/from_value.rs
+++ b/crates/nu-engine/src/from_value.rs
@@ -374,6 +374,10 @@ impl FromValue for Vec<Value> {
                 value: UntaggedValue::Table(t),
                 ..
             } => Ok(t.clone()),
+            Value {
+                value: UntaggedValue::Row(_),
+                ..
+            } => Ok(vec![v.clone()]),
             Value { tag, .. } => Err(ShellError::labeled_error(
                 "Can't convert to table",
                 "can't convert to table",

--- a/crates/nu-engine/src/shell/painter.rs
+++ b/crates/nu-engine/src/shell/painter.rs
@@ -46,7 +46,9 @@ impl Painter {
 
     fn paint(&mut self, styled_span: &Spanned<Style>) {
         for pos in styled_span.span.start()..styled_span.span.end() {
-            self.styles[pos] = styled_span.item;
+            if pos < self.styles.len() {
+                self.styles[pos] = styled_span.item;
+            }
         }
     }
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -307,6 +307,18 @@ fn run_custom_command_with_empty_rest() {
 }
 
 #[test]
+fn alias_a_load_env() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            def activate-helper [] { [[name, value]; [BOB, SAM]] }; alias activate = load-env (activate-helper); activate; $nu.env.BOB
+        "#
+    );
+
+    assert_eq!(actual.out, r#"SAM"#);
+}
+
+#[test]
 fn let_variable() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
This does two things:

* Fixes the painter panicking when painting something has been alias-expanded. This isn't the full fix but hopefully should unblock us.
* Allows rows to be converted to tables trivially