### PR TITLE
add locale for ls size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr_core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2807c5e92588b6bf1c8c0354af2a4f079d0586c683df322aea719d5dc9b8d5bb"
+dependencies = [
+ "cty",
+ "memchr",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1266,12 @@ dependencies = [
  "nix",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7313c0d620d0cb4dbd9d019e461a4beb501071ff46ec0ab933efb4daa76d73e3"
 
 [[package]]
 name = "curl"
@@ -3586,6 +3602,7 @@ dependencies = [
  "query_interface",
  "serde 1.0.125",
  "sha2 0.9.3",
+ "sys-locale",
  "toml",
  "users",
 ]
@@ -6233,6 +6250,19 @@ dependencies = [
  "serde_json",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f89ebb59fa30d4f65fafc2d68e94f6975256fd87e812dd99cb6e020c8563df"
+dependencies = [
+ "cc",
+ "cstr_core",
+ "libc",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -12,8 +12,8 @@ doctest = false
 [dependencies]
 bigdecimal = "0.2.0"
 byte-unit = "4.0.9"
-
 chrono = "0.4.19"
+common-path = "1.0.0"
 derive-new = "0.5.8"
 directories-next = { version = "2.0.0", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
@@ -25,9 +25,9 @@ num-format = "0.4.0"
 num-traits = "0.2.14"
 query_interface = "0.3.5"
 serde = { version = "1.0.123", features = ["derive"] }
-toml = "0.5.8"
 sha2 = "0.9.3"
-common-path = "1.0.0"
+sys-locale = "0.1.0"
+toml = "0.5.8"
 
 nu-errors = { version = "0.31.1", path = "../nu-errors" }
 nu-protocol = { version = "0.31.1", path = "../nu-protocol" }

--- a/crates/nu-data/src/base/shape.rs
+++ b/crates/nu-data/src/base/shape.rs
@@ -11,6 +11,7 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
+use sys_locale::get_locale;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct InlineRange {
@@ -195,8 +196,10 @@ impl InlineShape {
 
             match adj_byte.get_unit() {
                 byte_unit::ByteUnit::B => {
+                    let locale_string = get_locale().unwrap_or_else(|| String::from("en-US"));
+                    let locale = num_format::Locale::from_name(locale_string).unwrap_or(Locale::en);
                     let locale_byte = adj_byte.get_value() as u64;
-                    let locale_byte_string = locale_byte.to_formatted_string(&Locale::en);
+                    let locale_byte_string = locale_byte.to_formatted_string(&locale);
                     if filesize_format.1 == "auto" {
                         let doc = (DbgDocBldr::primitive(locale_byte_string)
                             + DbgDocBldr::space()


### PR DESCRIPTION
when you have `filesize_format = "B"` set in your config.toml file you should be able to see the thousands separators based on your locale. i.e. some locales use `,` other locales use `.` and i'm not sure if there are others.


This is with the `de_DE` locale on linux: (note the number separators)
![image](https://user-images.githubusercontent.com/343840/119736601-93ff4b00-be43-11eb-9f17-0d9303e89cd6.png)
This is with `en-US` on windows:
![image](https://user-images.githubusercontent.com/343840/119736671-b2fddd00-be43-11eb-91c0-512cad551d5d.png)
