### PR TITLE
Path expand fixes

### DIFF
--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -90,10 +90,6 @@ impl WholeStreamCommand for PathExpand {
 }
 
 fn action(path: &Path, tag: Tag, args: &PathExpandArguments) -> Value {
-    let ps = path.to_string_lossy();
-    let expanded = shellexpand::tilde(&ps);
-    let path: &Path = expanded.as_ref().as_ref();
-
     if let Ok(p) = dunce::canonicalize(path) {
         UntaggedValue::filepath(p).into_value(tag)
     } else if args.strict {

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -63,7 +63,9 @@ impl WholeStreamCommand for PathExpand {
             Example {
                 description: "Expand a relative path",
                 example: r"'foo\..\bar' | path expand",
-                result: None, // don't know where cwd is
+                result: Some(vec![
+                    UntaggedValue::filepath("bar").into_value(Span::new(0, 12))
+                ]),
             },
         ]
     }

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -1,6 +1,8 @@
 use super::{operate, PathSubcommandArguments};
 use crate::prelude::*;
-use nu_engine::filesystem::path::{expand_tilde, resolve_dots};
+#[cfg(feature = "dirs")]
+use nu_engine::filesystem::path::expand_tilde;
+use nu_engine::filesystem::path::resolve_dots;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{ColumnPath, Signature, SyntaxShape, UntaggedValue, Value};

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -36,7 +36,7 @@ impl WholeStreamCommand for PathExpand {
     }
 
     fn usage(&self) -> &str {
-        "Expand a path to its absolute form"
+        "Try to expand a path to its absolute form"
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/crates/nu-engine/src/filesystem/path.rs
+++ b/crates/nu-engine/src/filesystem/path.rs
@@ -1,6 +1,25 @@
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
+pub fn resolve_dots<P>(path: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    let mut result = PathBuf::new();
+
+    path.as_ref()
+        .components()
+        .for_each(|component| match component {
+            Component::ParentDir => {
+                result.pop();
+            }
+            Component::CurDir => {}
+            _ => result.push(component),
+        });
+
+    dunce::simplified(&result).to_path_buf()
+}
+
 pub fn absolutize<P, Q>(relative_to: P, path: Q) -> PathBuf
 where
     P: AsRef<Path>,
@@ -67,7 +86,7 @@ where
 
 // borrowed from here https://stackoverflow.com/questions/54267608/expand-tilde-in-rust-path-idiomatically
 #[cfg(feature = "dirs")]
-fn expand_tilde<P: AsRef<Path>>(path_user_input: P) -> Option<PathBuf> {
+pub fn expand_tilde<P: AsRef<Path>>(path_user_input: P) -> Option<PathBuf> {
     let p = path_user_input.as_ref();
     if !p.starts_with("~") {
         return Some(p.to_path_buf());


### PR DESCRIPTION
Adding extra functionality to make `path expand` more intuitive & flexible to use.

Needs better examples & tests. Also, see the spans bug below.