### PR TITLE
Resolve issues with `rm *` globbing

### DIFF
--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -276,3 +276,33 @@ fn no_errors_if_attempting_to_delete_non_existent_file_with_f_flag() {
         assert!(!actual.err.contains("no valid path"));
     })
 }
+
+#[test]
+fn rm_wildcard_keeps_dotfiles() {
+    Playground::setup("rm_test_15", |dirs, sandbox| {
+        sandbox.with_files(vec![EmptyFile("foo"), EmptyFile(".bar")]);
+
+        nu!(
+            cwd: dirs.test(),
+            r#"rm *"#
+        );
+
+        assert!(!files_exist_at(vec!["foo"], dirs.test()));
+        assert!(files_exist_at(vec![".bar"], dirs.test()));
+    })
+}
+
+#[test]
+fn rm_wildcard_leading_dot_deletes_dotfiles() {
+    Playground::setup("rm_test_16", |dirs, sandbox| {
+        sandbox.with_files(vec![EmptyFile("foo"), EmptyFile(".bar")]);
+
+        nu!(
+            cwd: dirs.test(),
+            r#"rm .*"#
+        );
+
+        assert!(files_exist_at(vec!["foo"], dirs.test()));
+        assert!(!files_exist_at(vec![".bar"], dirs.test()));
+    })
+}


### PR DESCRIPTION
Using the `*` wildcard should not attempt to delete files with a leading dot
unless the more explicit `.*` is used. `rm *` should also not attempt to delete
the current directory or its parent directory (`.` and `..`). I have resolved
this bug as well in a less satisfactory way. I think it may be the case that we
can only disambiguate the `.` and `..` path segments by using `Path::display`.
Here is a short list of alternatives that I tried:

- `Path::ends_with()` can detect `/..` but not `/.`.
- `Path::iter()` and `Path::components()` leave out `/.`.
- `Path::file_name()` normalizes `/.` to the parent component's file name.

Fixes #3508