### PR TITLE
to sqlite: Fix panic caused by empty input tables

### DIFF
--- a/crates/nu_plugin_to_sqlite/src/to_sqlite.rs
+++ b/crates/nu_plugin_to_sqlite/src/to_sqlite.rs
@@ -80,7 +80,7 @@ fn get_insert_values(rows: Vec<Value>) -> Result<String, std::io::Error> {
         })
         .collect();
     let values = values?;
-    Ok(values.into_iter().fold("".to_string(), comma_concat))
+    Ok(values.join(", "))
 }
 
 fn generate_statements(table: Dictionary) -> Result<(String, String), std::io::Error> {
@@ -100,7 +100,12 @@ fn generate_statements(table: Dictionary) -> Result<(String, String), std::io::E
         Some(Value {
             value: UntaggedValue::Table(l),
             ..
-        }) => (get_columns(l), get_insert_values(l.to_vec())),
+        }) => {
+            if l.is_empty() {
+                return Ok((String::new(), String::new()));
+            }
+            (get_columns(l), get_insert_values(l.to_vec()))
+        }
         _ => {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
@@ -108,6 +113,7 @@ fn generate_statements(table: Dictionary) -> Result<(String, String), std::io::E
             ))
         }
     };
+
     let create = format!("create table {}({})", table_name, columns?);
     let insert = format!("insert into {} values {}", table_name, insert_values?);
     Ok((create, insert))
@@ -128,6 +134,9 @@ fn sqlite_input_stream_to_bytes(values: Vec<Value>) -> Result<Value, std::io::Er
         match &value.value {
             UntaggedValue::Row(d) => {
                 let (create, insert) = generate_statements(d.to_owned())?;
+                if create.is_empty() {
+                    continue;
+                }
                 match conn
                     .execute(&create, NO_PARAMS)
                     .and_then(|_| conn.execute(&insert, NO_PARAMS))

--- a/docs/commands/to-sqlite.md
+++ b/docs/commands/to-sqlite.md
@@ -1,5 +1,5 @@
 # to sqlite
-Convert table into sqlite binary
+Convert table into sqlite binary. Empty tables are skipped.
 
 ## Usage
 ```shell


### PR DESCRIPTION
This PR fixes a panic caused by `to sqlite` when one or more input tables were empty. Now, empty input tables are skipped (a note describing this behavior was added in the documentation).