### PR TITLE
Bump rusqlite from 0.24.2 to 0.25.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,12 +87,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
-name = "ahash"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
@@ -2288,9 +2282,6 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.7",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2298,17 +2289,17 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.2",
+ "ahash",
  "rayon",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2861,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.20.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4715,7 +4706,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88561e850748c507f0fc7835b35e795e770597ceecb14e0a8f7d8abf8346645d"
 dependencies = [
- "ahash 0.7.2",
+ "ahash",
  "anyhow",
  "arrow",
  "chrono",
@@ -4741,7 +4732,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27388810ec5f3346838725aa0aa49343802c1344b96fe82229ae781c62c98bc7"
 dependencies = [
- "ahash 0.7.2",
+ "ahash",
  "anyhow",
  "arrow",
  "csv",
@@ -4765,7 +4756,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7f83284970a9db7d0b6a56d6f944c3988587429c124c1d087188e9d2c7ad7c"
 dependencies = [
- "ahash 0.7.2",
+ "ahash",
  "itertools",
  "polars-arrow",
  "polars-core",
@@ -5338,9 +5329,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38ee71cbab2c827ec0ac24e76f82eca723cee92c509a65f67dee393c25112"
+checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -115,7 +115,7 @@ users = "0.11.0"
 [dependencies.rusqlite]
 features = ["bundled", "blob"]
 optional = true
-version = "0.24.2"
+version = "0.25.3"
 
 [build-dependencies]
 shadow-rs = "0.5"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -117,7 +117,7 @@ users = "0.11.0"
 [dependencies.rusqlite]
 features = ["bundled", "blob"]
 optional = true
-version = "0.24.2"
+version = "0.25.3"
 
 [build-dependencies]
 shadow-rs = "0.5"

--- a/crates/nu_plugin_from_sqlite/Cargo.toml
+++ b/crates/nu_plugin_from_sqlite/Cargo.toml
@@ -21,6 +21,6 @@ tempfile = "3.2.0"
 
 [dependencies.rusqlite]
 features = ["bundled", "blob"]
-version = "0.24.2"
+version = "0.25.3"
 
 [build-dependencies]

--- a/crates/nu_plugin_to_sqlite/Cargo.toml
+++ b/crates/nu_plugin_to_sqlite/Cargo.toml
@@ -21,6 +21,6 @@ tempfile = "3.2.0"
 
 [dependencies.rusqlite]
 features = ["bundled", "blob"]
-version = "0.24.2"
+version = "0.25.3"
 
 [build-dependencies]

--- a/crates/nu_plugin_to_sqlite/src/to_sqlite.rs
+++ b/crates/nu_plugin_to_sqlite/src/to_sqlite.rs
@@ -2,7 +2,7 @@ use hex::encode;
 use nu_errors::ShellError;
 use nu_protocol::{Dictionary, Primitive, ReturnSuccess, ReturnValue, UntaggedValue, Value};
 use nu_source::Tag;
-use rusqlite::{Connection, NO_PARAMS};
+use rusqlite::Connection;
 use std::io::Read;
 
 #[derive(Default)]
@@ -138,8 +138,8 @@ fn sqlite_input_stream_to_bytes(values: Vec<Value>) -> Result<Value, std::io::Er
                     continue;
                 }
                 match conn
-                    .execute(&create, NO_PARAMS)
-                    .and_then(|_| conn.execute(&insert, NO_PARAMS))
+                    .execute(&create, [])
+                    .and_then(|_| conn.execute(&insert, []))
                 {
                     Ok(_) => (),
                     Err(e) => {


### PR DESCRIPTION
Bump `rusqlite` to the most recent version: [https://github.com/rusqlite/rusqlite/releases/tag/v0.25.3](https://github.com/rusqlite/rusqlite/releases/tag/v0.25.3)