### PR TITLE
fix: filename quoting #  and update and unify surf dependency

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -138,7 +138,7 @@ fn requote(orig_value: String) -> String {
     let mut quotes = vec!['"', '\'', '`'];
     let mut should_quote = false;
     for c in value.chars() {
-        if c.is_whitespace() {
+        if c.is_whitespace() || c == '#' {
             should_quote = true;
         } else if let Some(index) = quotes.iter().position(|q| *q == c) {
             should_quote = true;

--- a/crates/nu_plugin_fetch/Cargo.toml
+++ b/crates/nu_plugin_fetch/Cargo.toml
@@ -16,7 +16,7 @@ nu-errors = { path = "../nu-errors", version = "0.31.1" }
 nu-plugin = { path = "../nu-plugin", version = "0.31.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.31.1" }
 nu-source = { path = "../nu-source", version = "0.31.1" }
-surf = "2.2.0"
+surf = { version = "2.2.0", features = ["hyper-client"] }
 url = "2.2.1"
 mime = "0.3.16"
 

--- a/crates/nu_plugin_fetch/Cargo.toml
+++ b/crates/nu_plugin_fetch/Cargo.toml
@@ -16,7 +16,7 @@ nu-errors = { path = "../nu-errors", version = "0.31.1" }
 nu-plugin = { path = "../nu-plugin", version = "0.31.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.31.1" }
 nu-source = { path = "../nu-source", version = "0.31.1" }
-surf = { version = "2.2.0", features = ["hyper-client"] }
+surf = "2.2.0"
 url = "2.2.1"
 mime = "0.3.16"
 

--- a/crates/nu_plugin_post/Cargo.toml
+++ b/crates/nu_plugin_post/Cargo.toml
@@ -12,13 +12,14 @@ doctest = false
 [dependencies]
 base64 = "0.13.0"
 futures = { version = "0.3.5", features = ["compat", "io-compat"] }
+mime = "0.3.16"
 nu-errors = { path = "../nu-errors", version = "0.31.1" }
 nu-plugin = { path = "../nu-plugin", version = "0.31.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.31.1" }
 nu-source = { path = "../nu-source", version = "0.31.1" }
 num-traits = "0.2.12"
 serde_json = "1.0.57"
-surf = "1.0.3"
+surf = "2.2.0"
 url = "2.1.1"
 
 [features]


### PR DESCRIPTION
The first commit fixes this issue #3496 (autocomplete: filenames with '#' don't get quoted)
The second commit updates the `surf` dependency of 
`nu_plugin_post` from `1.0.3 -> 2.2.0`, matching the `nu_plugin_fetch_crate`.
This reduces the number of crates that `nu` depends on and its compile times.