### PR TITLE
Retain tag when accessing a var

### DIFF
--- a/crates/nu-engine/src/evaluate/evaluator.rs
+++ b/crates/nu-engine/src/evaluate/evaluator.rs
@@ -200,7 +200,11 @@ pub fn evaluate_baseline_expr(
                 };
             }
 
-            Ok(item.value.into_value(tag))
+            if path.tail.is_empty() {
+                Ok(item)
+            } else {
+                Ok(item.value.into_value(tag))
+            }
         }
         Expression::Boolean(_boolean) => Ok(UntaggedValue::boolean(*_boolean).into_value(tag)),
         Expression::Garbage => unimplemented!(),
@@ -289,7 +293,10 @@ fn evaluate_invocation(block: &hir::Block, ctx: &EvaluationContext) -> Result<Va
     }
 
     match output.len() {
-        x if x > 1 => Ok(UntaggedValue::Table(output).into_value(Tag::unknown())),
+        x if x > 1 => {
+            let tag = output[0].tag.clone();
+            Ok(UntaggedValue::Table(output).into_value(tag))
+        }
         1 => Ok(output[0].clone()),
         _ => Ok(UntaggedValue::nothing().into_value(Tag::unknown())),
     }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -62,6 +62,60 @@ fn treats_dot_dot_as_path_not_range() {
 }
 
 #[test]
+fn tags_dont_persist_through_column_path() {
+    Playground::setup("dot_dot_dir", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "nu_times.csv",
+            r#"
+                name,rusty_luck,origin
+                Jason,1,Canada
+            "#,
+        )]);
+
+        let actual = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+            mkdir temp;
+            cd temp;
+            let x = (open ../nu_times.csv).name;
+            $x | tags | get anchor | autoview;
+            rmdir temp
+            "#
+        ));
+
+        // chop will remove the last escaped double quote from \"Estados Unidos\"
+        assert!(actual.err.contains("isn't a column"));
+    })
+}
+
+#[test]
+fn tags_persist_through_vars() {
+    Playground::setup("dot_dot_dir", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "nu_times.csv",
+            r#"
+                name,rusty_luck,origin
+                Jason,1,Canada
+            "#,
+        )]);
+
+        let actual = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+            mkdir temp;
+            cd temp;
+            let x = (open ../nu_times.csv);
+            $x | tags | get anchor | autoview;
+            rmdir temp
+            "#
+        ));
+
+        // chop will remove the last escaped double quote from \"Estados Unidos\"
+        assert!(actual.out.contains("nu_times.csv"));
+    })
+}
+
+#[test]
 fn invocation_properly_redirects() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
This will retain tags when accessing values through a var. For example:

```
let a = (open myfile.csv)
$a | tags        # should have anchor
```

But it will not retain them if accessing through a column path:

```
let a = (open myfile.csv)
$a.name | tags    # doesn't have anchor
```

This is because a column path is inner data rather than the whole of the outer data. As such, viewers will try to view inner data as if it's a file, which is confusing and can be really slow depending on platform support. We reserve the anchor then for the top level data item.