### PR TITLE
Add `--all` switch to `str trim`

### DIFF
--- a/crates/nu-command/src/commands/str_/trim/trim_both_ends.rs
+++ b/crates/nu-command/src/commands/str_/trim/trim_both_ends.rs
@@ -23,6 +23,11 @@ impl WholeStreamCommand for SubCommand {
                 "character to trim (default: whitespace)",
                 Some('c'),
             )
+            .switch(
+                "all",
+                "also trim multiple occurrences of 'char' to a single one",
+                Some('a'),
+            )
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION
resolves #3482 

## Overview
This PR will implement an `--all` switch to `str trim` that collapses multiple occurrences of a char (say whitespace for simplicity) inside a string to a single one. For instance, `echo 'abc    def' | str trim --all` should return `'abc def'`.

## Status
- [ ] add `--all` switch to the command's arguments
- [x] mention `--all` switch in the command's help text
- [ ] implement the extended trim function
- [ ] add an example to the command
- [ ] test extensively
- [ ] update all documentation on the command