### PR TITLE
plugin_sys: Bump sysinfo dep version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,7 +3864,7 @@ dependencies = [
  "nu-protocol",
  "nu-source",
  "num-bigint 0.3.2",
- "sysinfo",
+ "sysinfo 0.16.5",
 ]
 
 [[package]]
@@ -3928,7 +3928,7 @@ dependencies = [
  "nu-protocol",
  "nu-source",
  "num-bigint 0.3.2",
- "sysinfo",
+ "sysinfo 0.18.2",
 ]
 
 [[package]]
@@ -6162,6 +6162,22 @@ name = "sysinfo"
 version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567e910ef0207be81a4e1bb0491e9a8d9866cf45b20fe1a52c03d347da9ea51b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d404aefa651a24a7f2a1190fec9fb6380ba84ac511a6fefad79eb0e63d39a97d"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/crates/nu_plugin_sys/Cargo.toml
+++ b/crates/nu_plugin_sys/Cargo.toml
@@ -18,6 +18,6 @@ nu-source = { path = "../nu-source", version = "0.32.1" }
 futures = { version = "0.3.5", features = ["compat", "io-compat"] }
 futures-util = "0.3.12"
 num-bigint = "0.3.1"
-sysinfo = "0.16.5"
+sysinfo = "0.18.2"
 
 [build-dependencies]


### PR DESCRIPTION
Closes #3525 

Previous to this commit, the sysinfo crate would show blank `brand` for
Apple M1 architectures whenever you would run `sys | get cpu`.

I have fixed the issue in sysinfo, so bumping the dependency version to 0.18.2
means brand now is retrieved successfully on M1 architectures.