### PR TITLE
Further improve block/subexpr parse

### DIFF
--- a/crates/nu-parser/src/lex/lexer.rs
+++ b/crates/nu-parser/src/lex/lexer.rs
@@ -105,18 +105,7 @@ pub fn baseline(src: &mut Input, span_offset: usize) -> (Spanned<String>, Option
                 break;
             }
             in_comment = true;
-        } else if c == '\n' {
-            in_comment = false;
-            if is_termination(&block_level, c) {
-                break;
-            } else {
-                // Note: this allows us to parse expressions that span
-                // multiple lines inside of a block
-                let _ = src.next();
-                token_contents.push(' ');
-                continue;
-            }
-        } else if c == '\r' {
+        } else if c == '\n' || c == '\r' {
             in_comment = false;
             if is_termination(&block_level, c) {
                 break;

--- a/crates/nu-parser/src/lex/lexer.rs
+++ b/crates/nu-parser/src/lex/lexer.rs
@@ -116,6 +116,17 @@ pub fn baseline(src: &mut Input, span_offset: usize) -> (Spanned<String>, Option
                 token_contents.push(' ');
                 continue;
             }
+        } else if c == '\r' {
+            in_comment = false;
+            if is_termination(&block_level, c) {
+                break;
+            } else {
+                // Note: this allows us to parse expressions that span
+                // multiple lines inside of a block
+                let _ = src.next();
+                token_contents.push(' ');
+                continue;
+            }
         } else if in_comment {
             if is_termination(&block_level, c) {
                 break;

--- a/crates/nu-parser/src/lex/lexer.rs
+++ b/crates/nu-parser/src/lex/lexer.rs
@@ -109,6 +109,12 @@ pub fn baseline(src: &mut Input, span_offset: usize) -> (Spanned<String>, Option
             in_comment = false;
             if is_termination(&block_level, c) {
                 break;
+            } else {
+                // Note: this allows us to parse expressions that span
+                // multiple lines inside of a block
+                let _ = src.next();
+                token_contents.push(' ');
+                continue;
             }
         } else if in_comment {
             if is_termination(&block_level, c) {

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -897,10 +897,7 @@ fn parse_arg(
 
     // before anything else, try to see if this is a number in paranthesis
     if lite_arg.item.starts_with('(') {
-        let (expr, err) = parse_full_column_path(&lite_arg, scope);
-        if err.is_none() {
-            return (expr, None);
-        }
+        return parse_full_column_path(&lite_arg, scope);
     }
 
     match expected_type {

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -216,6 +216,50 @@ fn string_interpolation_and_paren() {
 }
 
 #[test]
+fn paren_multiline() {
+    Playground::setup("invocation_handles_dot", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "multiline.nu",
+            r#"
+                   (2 +
+                    3)
+            "#,
+        )]);
+
+        let actual = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+            nu multiline.nu
+            "#
+        ));
+
+        assert_eq!(actual.out, "5");
+    })
+}
+
+#[test]
+fn bracket_multiline() {
+    Playground::setup("invocation_handles_dot", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "multiline.nu",
+            r#"
+                   {2 +
+                    7}
+            "#,
+        )]);
+
+        let actual = nu!(
+        cwd: dirs.test(), pipeline(
+        r#"
+            nu multiline.nu
+            "#
+        ));
+
+        assert_eq!(actual.out, "9");
+    })
+}
+
+#[test]
 fn bignum_large_integer() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
This allows blocks and subexpressions to span lines in a better way. It's now possible to span subexpressions across lines, like so:

```
(2 + 
3)
```

The same can be done with blocks. I also cleaned up the parser so that a partial subexpression now errors in the correct spot, allowing for coloring to work more evenly.