### PR TITLE
Add support for subcommand completions

### DIFF
--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -461,7 +461,10 @@ mod tests {
 
             assert_eq!(
                 completion_location(line, &registry, 6),
-                vec![LocationType::Argument(Some("echo".to_string()), None)],
+                vec![
+                    LocationType::Command,
+                    LocationType::Argument(Some("echo".to_string()), None)
+                ],
             );
         }
     }

--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -418,7 +418,10 @@ mod tests {
 
             assert_eq!(
                 completion_location(line, &registry, 3),
-                vec![LocationType::Argument(Some("cd".to_string()), None)],
+                vec![
+                    LocationType::Command,
+                    LocationType::Argument(Some("cd".to_string()), None)
+                ],
             );
         }
 

--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -203,6 +203,7 @@ pub fn completion_location(line: &str, block: &Block, pos: usize) -> Vec<Complet
     } else {
         let mut command = None;
         let mut prev = None;
+
         for loc in &locations {
             // We don't use span.contains because we want to include the end. This handles the case
             // where the cursor is just after the text (i.e., no space between cursor and text)
@@ -220,12 +221,21 @@ pub fn completion_location(line: &str, block: &Block, pos: usize) -> Vec<Complet
                             ]
                         } else {
                             let mut output = vec![];
-                            if locations.len() == 2 {
-                                output.push(LocationType::Command.spanned(Span::new(
-                                    locations[0].span.start(),
-                                    locations[1].span.end(),
-                                )));
+
+                            for rloc in locations.iter().rev() {
+                                if let Spanned {
+                                    span,
+                                    item: LocationType::Command,
+                                } = &rloc
+                                {
+                                    output.push(LocationType::Command.spanned(Span::new(
+                                        span.start(),
+                                        locations[locations.len() - 1].span.end(),
+                                    )));
+                                    break;
+                                }
                             }
+
                             output.push(loc.clone());
                             output
                         }

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -6,7 +6,7 @@ use crate::completion::path::{PathCompleter, PathSuggestion};
 use crate::completion::{self, Completer, Suggestion};
 use nu_engine::EvaluationContext;
 use nu_parser::ParserScope;
-use nu_source::Tag;
+use nu_source::{Span, Tag};
 
 use std::borrow::Cow;
 
@@ -72,6 +72,7 @@ impl NuCompleter {
 
                         LocationType::Argument(cmd, _arg_name) => {
                             let path_completer = PathCompleter;
+                            let prepend = Span::new(pos, location.span.start()).slice(line);
 
                             const QUOTE_CHARS: &[char] = &['\'', '"', '`'];
 
@@ -103,7 +104,11 @@ impl NuCompleter {
                             }
                             .into_iter()
                             .map(|s| Suggestion {
-                                replacement: requote(s.suggestion.replacement),
+                                replacement: format!(
+                                    "{}{}",
+                                    prepend,
+                                    requote(s.suggestion.replacement)
+                                ),
                                 display: s.suggestion.display,
                             })
                             .collect()


### PR DESCRIPTION
This prepends the command span to our possible completions if it looks like we might possibly be completing a subcommand. This allows you to complete subcommands in the following new locations:

```
str 
    ^
```

```
str lp
     ^
```