### PR TITLE
Fix duration literals in `where` docs

### DIFF
--- a/docs/commands/where.md
+++ b/docs/commands/where.md
@@ -23,15 +23,13 @@ Strings have two additional operators:
 - `=~` (fuzzy match to allow)
 - `!~` (fuzzy match to not allow)
 
-Dates can also be compared using the duration types. For example, `where accessed > 2w` will check the date in accessed to see if it's greater than 2 weeks ago. Durations currently allow these abbreviations:
+Dates can also be compared using the duration types. For example, `where accessed > 2wk` will check the date in accessed to see if it's greater than 2 weeks ago. Durations currently allow these abbreviations:
 
-- `1s` (one second)
-- `1m` (one minute)
-- `1h` (one hour)
-- `1d` (one day)
-- `1w` (one week)
-- `1M` (one month)
-- `1y` (one year)
+- `1sec` (one second)
+- `1min` (one minute)
+- `1hr` (one hour)
+- `1day` (one day)
+- `1wk` (one week)
 
 ## Boolean check
 
@@ -76,7 +74,7 @@ Where with the form `| where readonly` is used to check boolean values. For exam
 ```
 
 ```shell
-> ls -l | where accessed <= 1w
+> ls -l | where accessed <= 1wk
 ───┬────────────────────┬──────┬────────┬──────────┬───────────┬─────────────┬───────┬──────────┬──────────────┬─────────────┬─────────────
  # │ name               │ type │ target │ readonly │ mode      │ uid         │ group │ size     │ created      │ accessed    │ modified
 ───┼────────────────────┼──────┼────────┼──────────┼───────────┼─────────────┼───────┼──────────┼──────────────┼─────────────┼─────────────


### PR DESCRIPTION
Addresses #3569