### PR TITLE
Fix completion crash

### DIFF
--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -54,7 +54,14 @@ impl NuCompleter {
         if locations.is_empty() {
             (pos, Vec::new())
         } else {
-            let pos = locations[0].span.start();
+            let mut pos = locations[0].span.start();
+
+            for location in &locations {
+                if location.span.start() < pos {
+                    pos = location.span.start();
+                }
+            }
+
             let suggestions = locations
                 .into_iter()
                 .flat_map(|location| {


### PR DESCRIPTION
Make sure we're actually at the furthest starting span. Prevents a crash from completing in the middle of the line