### PR TITLE
Improve completions inside of a pipeline

### DIFF
--- a/crates/nu-cli/src/completion/engine.rs
+++ b/crates/nu-cli/src/completion/engine.rs
@@ -228,11 +228,13 @@ pub fn completion_location(line: &str, block: &Block, pos: usize) -> Vec<Complet
                                     item: LocationType::Command,
                                 } = &rloc
                                 {
-                                    output.push(LocationType::Command.spanned(Span::new(
-                                        span.start(),
-                                        locations[locations.len() - 1].span.end(),
-                                    )));
-                                    break;
+                                    if span.start() <= pos {
+                                        output.push(
+                                            LocationType::Command
+                                                .spanned(Span::new(span.start(), pos)),
+                                        );
+                                        break;
+                                    }
                                 }
                             }
 

--- a/crates/nu-cli/src/shell/completer.rs
+++ b/crates/nu-cli/src/shell/completer.rs
@@ -54,7 +54,14 @@ impl NuCompleter {
         if locations.is_empty() {
             (pos, Vec::new())
         } else {
-            let pos = locations[0].span.start();
+            let mut pos = locations[0].span.start();
+
+            for location in &locations {
+                if location.span.start() < pos {
+                    pos = location.span.start();
+                }
+            }
+
             let suggestions = locations
                 .into_iter()
                 .flat_map(|location| {


### PR DESCRIPTION
This allows subcommand completion inside of a pipe, as in this example:

```
ls | into s<TAB> | foo
```