### PR TITLE
Improve external quoting logic

### DIFF
--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -38,6 +38,7 @@ pub(crate) fn run_external_command(
     run_with_stdin(command, context, input, external_redirection)
 }
 
+#[allow(unused)]
 fn trim_double_quotes(input: &str) -> String {
     let mut chars = input.chars();
 
@@ -47,6 +48,7 @@ fn trim_double_quotes(input: &str) -> String {
     }
 }
 
+#[allow(unused)]
 fn escape_where_needed(input: &str) -> String {
     input.split(' ').join("\\ ").split('\'').join("\\'")
 }

--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -38,6 +38,19 @@ pub(crate) fn run_external_command(
     run_with_stdin(command, context, input, external_redirection)
 }
 
+fn trim_double_quotes(input: &str) -> String {
+    let mut chars = input.chars();
+
+    match (chars.next(), chars.next_back()) {
+        (Some('"'), Some('"')) => chars.collect(),
+        _ => input.to_string(),
+    }
+}
+
+fn escape_where_needed(input: &str) -> String {
+    input.split(' ').join("\\ ").split('\'').join("\\'")
+}
+
 fn run_with_stdin(
     command: ExternalCommand,
     context: &mut EvaluationContext,
@@ -81,6 +94,7 @@ fn run_with_stdin(
             }
             _ => {
                 let trimmed_value_string = value.as_string()?.trim_end_matches('\n').to_string();
+                //let trimmed_value_string = trim_quotes(&trimmed_value_string);
                 command_args.push((trimmed_value_string, is_literal));
             }
         }
@@ -108,7 +122,12 @@ fn run_with_stdin(
                     let escaped = escape_double_quotes(&arg);
                     add_double_quotes(&escaped)
                 } else {
-                    arg.as_ref().to_string()
+                    let trimmed = trim_double_quotes(&arg);
+                    if trimmed != arg {
+                        escape_where_needed(&trimmed)
+                    } else {
+                        trimmed
+                    }
                 }
             }
             #[cfg(windows)]

--- a/crates/nu-command/src/utils/test_bins.rs
+++ b/crates/nu-command/src/utils/test_bins.rs
@@ -29,7 +29,7 @@ pub fn meow() {
     let args: Vec<String> = args();
 
     for arg in args.iter().skip(1) {
-        let contents = std::fs::read_to_string(arg).unwrap();
+        let contents = std::fs::read_to_string(arg).expect("Expected a filepath");
         println!("{}", contents);
     }
 }

--- a/crates/nu-command/src/utils/test_bins.rs
+++ b/crates/nu-command/src/utils/test_bins.rs
@@ -25,6 +25,15 @@ pub fn cococo() {
     }
 }
 
+pub fn meow() {
+    let args: Vec<String> = args();
+
+    for arg in args.iter().skip(1) {
+        let contents = std::fs::read_to_string(arg).unwrap();
+        println!("{}", contents);
+    }
+}
+
 pub fn nonu() {
     args().iter().skip(1).for_each(|arg| print!("{}", arg));
 }

--- a/crates/nu-protocol/src/value/column_path.rs
+++ b/crates/nu-protocol/src/value/column_path.rs
@@ -199,7 +199,6 @@ fn trim_quotes(input: &str) -> String {
     match (chars.next(), chars.next_back()) {
         (Some('\''), Some('\'')) => chars.collect(),
         (Some('"'), Some('"')) => chars.collect(),
-        (Some('`'), Some('`')) => chars.collect(),
         _ => input.to_string(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .long("testbin")
                 .value_name("TESTBIN")
                 .possible_values(&[
-                    "echo_env", "cococo", "iecho", "fail", "nonu", "chop", "repeater", "meow"
+                    "echo_env", "cococo", "iecho", "fail", "nonu", "chop", "repeater", "meow",
                 ])
                 .takes_value(true),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .long("testbin")
                 .value_name("TESTBIN")
                 .possible_values(&[
-                    "echo_env", "cococo", "iecho", "fail", "nonu", "chop", "repeater",
+                    "echo_env", "cococo", "iecho", "fail", "nonu", "chop", "repeater", "meow"
                 ])
                 .takes_value(true),
         )
@@ -90,6 +90,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         match bin {
             "echo_env" => binaries::echo_env(),
             "cococo" => binaries::cococo(),
+            "meow" => binaries::meow(),
             "iecho" => binaries::iecho(),
             "fail" => binaries::fail(),
             "nonu" => binaries::nonu(),

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -199,8 +199,8 @@ mod stdin_evaluation {
 
 mod external_words {
     use super::nu;
+    use nu_test_support::fs::Stub::FileWithContent;
     use nu_test_support::{pipeline, playground::Playground};
-    use nu_test_support::fs::Stub::{FileWithContent};
     #[test]
     fn relaxed_external_words() {
         let actual = nu!(cwd: ".", r#"

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -199,7 +199,8 @@ mod stdin_evaluation {
 
 mod external_words {
     use super::nu;
-
+    use nu_test_support::{pipeline, playground::Playground};
+    use nu_test_support::fs::Stub::{FileWithContent};
     #[test]
     fn relaxed_external_words() {
         let actual = nu!(cwd: ".", r#"
@@ -216,6 +217,27 @@ mod external_words {
         "#);
 
         assert_eq!(actual.out, "test \"things\"");
+    }
+
+    #[test]
+    fn external_arg_with_quotes() {
+        Playground::setup("external_arg_with_quotes", |dirs, sandbox| {
+            sandbox.with_files(vec![FileWithContent(
+                "sample.toml",
+                r#"
+                    nu_party_venue = "zion"
+                "#,
+            )]);
+
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                    nu --testbin meow "sample.toml" | from toml | get nu_party_venue
+                "#
+            ));
+
+            assert_eq!(actual.out, "zion");
+        })
     }
 }
 


### PR DESCRIPTION
This PR:
* Improves the quoting logic for external arguments
* Adds a new testbin called "meow" which does a `cat`
* Adds a bit of additional escaping logic

fixes #3329 