### PR TITLE
Improve expr parse

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1577,7 +1577,7 @@ fn parse_internal_command(
             let arg = {
                 let (new_idx, expr, err) = parse_positional_argument(
                     idx,
-                    &lite_cmd,
+                    lite_cmd,
                     &signature.positional[current_positional].0,
                     signature.positional.len() - current_positional - 1,
                     scope,
@@ -1802,7 +1802,7 @@ fn parse_call(
     } else if lite_cmd.parts[0].item.starts_with('$')
         || lite_cmd.parts[0].item.starts_with('\"')
         || lite_cmd.parts[0].item.starts_with('\'')
-        || lite_cmd.parts[0].item.starts_with('-')
+        || (lite_cmd.parts[0].item.starts_with('-') && parse_int(&lite_cmd.parts[0]).1.is_none())
         || lite_cmd.parts[0].item.starts_with('0')
         || lite_cmd.parts[0].item.starts_with('1')
         || lite_cmd.parts[0].item.starts_with('2')

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1802,7 +1802,14 @@ fn parse_call(
     } else if lite_cmd.parts[0].item.starts_with('$')
         || lite_cmd.parts[0].item.starts_with('\"')
         || lite_cmd.parts[0].item.starts_with('\'')
-        || (lite_cmd.parts[0].item.starts_with('-') && parse_int(&lite_cmd.parts[0]).1.is_none())
+        || (lite_cmd.parts[0].item.starts_with('-')
+            && parse_arg(SyntaxShape::Number, scope, &lite_cmd.parts[0])
+                .1
+                .is_none())
+        || (lite_cmd.parts[0].item.starts_with('-')
+            && parse_arg(SyntaxShape::Range, scope, &lite_cmd.parts[0])
+                .1
+                .is_none())
         || lite_cmd.parts[0].item.starts_with('0')
         || lite_cmd.parts[0].item.starts_with('1')
         || lite_cmd.parts[0].item.starts_with('2')

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -631,6 +631,17 @@ fn dash_def() {
 }
 
 #[test]
+fn negative_decimal_start() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            -1.3 + 4
+        "#
+    );
+
+    assert_eq!(actual.out, "2.7");
+}
+#[test]
 fn index_row() {
     let actual = nu!(
         cwd: ".",

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -619,6 +619,18 @@ fn index_out_of_bounds() {
 }
 
 #[test]
+fn dash_def() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            def - [x, y] { $x - $y }; - 4 1
+        "#
+    );
+
+    assert_eq!(actual.out, "3");
+}
+
+#[test]
 fn index_row() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
Improves the math expression parser so that the first position no longer allows a plain `-`