### PR TITLE
Clarify `exec` help message; Update to engine-p

### DIFF
--- a/crates/nu-command/src/commands/exec.rs
+++ b/crates/nu-command/src/commands/exec.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 
 pub struct Exec;
 
-#[derive(Deserialize)]
 pub struct ExecArgs {
     pub command: Tagged<PathBuf>,
     pub rest: Vec<Tagged<String>>,
@@ -35,7 +34,7 @@ impl WholeStreamCommand for Exec {
         "Currently supported only on Unix-based systems."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         exec(args)
     }
 
@@ -56,7 +55,7 @@ impl WholeStreamCommand for Exec {
 }
 
 #[cfg(unix)]
-fn exec(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn exec(args: CommandArgs) -> Result<OutputStream, ShellError> {
     use std::os::unix::process::CommandExt;
     use std::process::Command;
 
@@ -83,7 +82,7 @@ fn exec(args: CommandArgs) -> Result<ActionStream, ShellError> {
 }
 
 #[cfg(not(unix))]
-fn exec(args: CommandArgs) -> Result<ActionStream, ShellError> {
+fn exec(args: CommandArgs) -> Result<OutputStream, ShellError> {
     Err(ShellError::labeled_error(
         "Error on exec",
         "exec is not supported on your platform",

--- a/crates/nu-command/src/commands/exec.rs
+++ b/crates/nu-command/src/commands/exec.rs
@@ -23,12 +23,16 @@ impl WholeStreamCommand for Exec {
             .required("command", SyntaxShape::FilePath, "the command to execute")
             .rest(
                 SyntaxShape::GlobPattern,
-                "any additional arguments for command",
+                "any additional arguments for the command",
             )
     }
 
     fn usage(&self) -> &str {
-        "Execute command."
+        "Execute a command, replacing the current process."
+    }
+
+    fn extra_usage(&self) -> &str {
+        "Currently supported only on Unix-based systems."
     }
 
     fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
@@ -38,7 +42,7 @@ impl WholeStreamCommand for Exec {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Execute 'ps aux'",
+                description: "Execute external 'ps aux' tool",
                 example: "exec ps aux",
                 result: None,
             },

--- a/crates/nu-command/src/commands/exec.rs
+++ b/crates/nu-command/src/commands/exec.rs
@@ -2,11 +2,15 @@ use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape};
+
+#[cfg(unix)]
 use nu_source::Tagged;
+#[cfg(unix)]
 use std::path::PathBuf;
 
 pub struct Exec;
 
+#[cfg(unix)]
 pub struct ExecArgs {
     pub command: Tagged<PathBuf>,
     pub rest: Vec<Tagged<String>>,


### PR DESCRIPTION
The main intent was to mention in the help message that `exec` replaces the current process.

I also improved (hopefully) more text and while at it, converted the command to output OutputStream.

List of all commands to be ported: #3390
