### PR TITLE
from sqlite: Add test case for table selection

### DIFF
--- a/crates/nu-command/tests/format_conversions/sqlite.rs
+++ b/crates/nu-command/tests/format_conversions/sqlite.rs
@@ -18,3 +18,19 @@ fn table_to_sqlite_and_back_into_table() {
 
     assert_eq!(actual.out, "hello");
 }
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn table_to_sqlite_and_back_into_table_select_table() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open sample.db
+            | to sqlite
+            | from sqlite -t [strings]
+            | get table_names
+        "#
+    ));
+
+    assert_eq!(actual.out, "strings");
+}


### PR DESCRIPTION
Add test case for the recently added (PR: #3529 ) table selection feature (`--tables`) in the context of the `from sqlite` command.