### PR TITLE
Add support to run external command with string evaluation

### DIFF
--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -69,6 +69,18 @@ fn correctly_escape_external_arguments() {
 }
 
 #[test]
+fn execute_binary_in_string() {
+    let actual = nu!(
+    cwd: ".",
+    r#"
+        let cmd = echo
+        ^$"($cmd)" '$0'
+    "#);
+
+    assert_eq!(actual.out, "$0");
+}
+
+#[test]
 fn redirects_custom_command_external() {
     let actual = nu!(cwd: ".", r#"def foo [] { nu --testbin cococo foo bar }; foo | str length "#);
 


### PR DESCRIPTION
fixes #3433

This PR adds support to run external command in string as following example:

```
> let folder = /bin
> ^$"($folder)/ps"
    PID TTY          TIME CMD
  9187 pts/6      00:00:00 nu
  57190 pts/6    00:00:00 ps
```