### PR TITLE
Refactor rarely changing engine state into its own struct

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -167,7 +167,7 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
 
     //Configure rustyline
     let mut rl = default_rustyline_editor_configuration();
-    let history_path = if let Some(cfg) = &context.configs.lock().global_config {
+    let history_path = if let Some(cfg) = &context.engine_state.configs.lock().global_config {
         let _ = configure_rustyline_editor(&mut rl, cfg);
         let helper = Some(nu_line_editor_helper(&context, cfg));
         rl.set_helper(helper);
@@ -182,16 +182,17 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
     }
 
     //set vars from cfg if present
-    let (skip_welcome_message, prompt) = if let Some(cfg) = &context.configs.lock().global_config {
-        (
-            cfg.var("skip_welcome_message")
-                .map(|x| x.is_true())
-                .unwrap_or(false),
-            cfg.var("prompt"),
-        )
-    } else {
-        (false, None)
-    };
+    let (skip_welcome_message, prompt) =
+        if let Some(cfg) = &context.engine_state.configs.lock().global_config {
+            (
+                cfg.var("skip_welcome_message")
+                    .map(|x| x.is_true())
+                    .unwrap_or(false),
+                cfg.var("prompt"),
+            )
+        } else {
+            (false, None)
+        };
 
     //Check whether dir we start in contains local cfg file and if so load it.
     load_local_cfg_if_present(&context);
@@ -217,12 +218,12 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
     let mut ctrlcbreak = false;
 
     loop {
-        if context.ctrl_c.load(Ordering::SeqCst) {
-            context.ctrl_c.store(false, Ordering::SeqCst);
+        if context.engine_state.ctrl_c.load(Ordering::SeqCst) {
+            context.engine_state.ctrl_c.store(false, Ordering::SeqCst);
             continue;
         }
 
-        let cwd = context.shell_manager.path();
+        let cwd = context.engine_state.shell_manager.path();
 
         let colored_prompt = {
             if let Some(prompt) = &prompt {
@@ -266,14 +267,22 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
                                 }
                             }
                             Err(e) => {
-                                context.host.lock().print_err(e, &Text::from(prompt_line));
+                                context
+                                    .engine_state
+                                    .host
+                                    .lock()
+                                    .print_err(e, &Text::from(prompt_line));
                                 context.clear_errors();
 
                                 "> ".to_string()
                             }
                         },
                         Err(e) => {
-                            context.host.lock().print_err(e, &Text::from(prompt_line));
+                            context
+                                .engine_state
+                                .host
+                                .lock()
+                                .print_err(e, &Text::from(prompt_line));
                             context.clear_errors();
 
                             "> ".to_string()
@@ -360,6 +369,7 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
                 }
 
                 context
+                    .engine_state
                     .host
                     .lock()
                     .print_err(err, &Text::from(session_text.clone()));
@@ -374,6 +384,7 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
 
             LineResult::CtrlC => {
                 let config_ctrlc_exit = context
+                    .engine_state
                     .configs
                     .lock()
                     .global_config
@@ -400,8 +411,8 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
             }
 
             LineResult::CtrlD => {
-                context.shell_manager.remove_at_current();
-                if context.shell_manager.is_empty() {
+                context.engine_state.shell_manager.remove_at_current();
+                if context.engine_state.shell_manager.is_empty() {
                     break;
                 }
             }
@@ -423,15 +434,25 @@ pub fn cli(context: EvaluationContext, options: Options) -> Result<(), Box<dyn E
 
 pub fn load_local_cfg_if_present(context: &EvaluationContext) {
     trace!("Loading local cfg if present");
-    match config::loadable_cfg_exists_in_dir(PathBuf::from(context.shell_manager.path())) {
+    match config::loadable_cfg_exists_in_dir(PathBuf::from(
+        context.engine_state.shell_manager.path(),
+    )) {
         Ok(Some(cfg_path)) => {
             if let Err(err) = context.load_config(&ConfigPath::Local(cfg_path)) {
-                context.host.lock().print_err(err, &Text::from(""))
+                context
+                    .engine_state
+                    .host
+                    .lock()
+                    .print_err(err, &Text::from(""))
             }
         }
         Err(e) => {
             //Report error while checking for local cfg file
-            context.host.lock().print_err(e, &Text::from(""))
+            context
+                .engine_state
+                .host
+                .lock()
+                .print_err(e, &Text::from(""))
         }
         Ok(None) => {
             //No local cfg file present in start dir
@@ -441,7 +462,11 @@ pub fn load_local_cfg_if_present(context: &EvaluationContext) {
 
 fn load_cfg_as_global_cfg(context: &EvaluationContext, path: PathBuf) {
     if let Err(err) = context.load_config(&ConfigPath::Global(path)) {
-        context.host.lock().print_err(err, &Text::from(""));
+        context
+            .engine_state
+            .host
+            .lock()
+            .print_err(err, &Text::from(""));
     }
 }
 
@@ -451,7 +476,11 @@ pub fn load_global_cfg(context: &EvaluationContext) {
             load_cfg_as_global_cfg(context, path);
         }
         Err(e) => {
-            context.host.lock().print_err(e, &Text::from(""));
+            context
+                .engine_state
+                .host
+                .lock()
+                .print_err(e, &Text::from(""));
         }
     }
 }

--- a/crates/nu-cli/src/line_editor.rs
+++ b/crates/nu-cli/src/line_editor.rs
@@ -258,14 +258,14 @@ pub fn rustyline_hinter(
 pub fn configure_ctrl_c(_context: &EvaluationContext) -> Result<(), Box<dyn Error>> {
     #[cfg(feature = "ctrlc")]
     {
-        let cc = _context.ctrl_c.clone();
+        let cc = _context.engine_state.ctrl_c.clone();
 
         ctrlc::set_handler(move || {
             cc.store(true, Ordering::SeqCst);
         })?;
 
-        if _context.ctrl_c.load(Ordering::SeqCst) {
-            _context.ctrl_c.store(false, Ordering::SeqCst);
+        if _context.engine_state.ctrl_c.load(Ordering::SeqCst) {
+            _context.engine_state.ctrl_c.store(false, Ordering::SeqCst);
         }
     }
 

--- a/crates/nu-cli/src/line_editor.rs
+++ b/crates/nu-cli/src/line_editor.rs
@@ -258,14 +258,14 @@ pub fn rustyline_hinter(
 pub fn configure_ctrl_c(_context: &EvaluationContext) -> Result<(), Box<dyn Error>> {
     #[cfg(feature = "ctrlc")]
     {
-        let cc = _context.engine_state.ctrl_c.clone();
+        let cc = _context.ctrl_c().clone();
 
         ctrlc::set_handler(move || {
             cc.store(true, Ordering::SeqCst);
         })?;
 
-        if _context.engine_state.ctrl_c.load(Ordering::SeqCst) {
-            _context.engine_state.ctrl_c.store(false, Ordering::SeqCst);
+        if _context.ctrl_c().load(Ordering::SeqCst) {
+            _context.ctrl_c().store(false, Ordering::SeqCst);
         }
     }
 

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -84,7 +84,7 @@ impl rustyline::highlight::Highlighter for Helper {
     }
 
     fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
-        let cfg = &self.context.configs.lock();
+        let cfg = &self.context.engine_state.configs.lock();
         if let Some(palette) = &cfg.syntax_config {
             Painter::paint_string(line, &self.context.scope, palette)
         } else {

--- a/crates/nu-cli/src/shell/helper.rs
+++ b/crates/nu-cli/src/shell/helper.rs
@@ -84,7 +84,7 @@ impl rustyline::highlight::Highlighter for Helper {
     }
 
     fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
-        let cfg = &self.context.engine_state.configs.lock();
+        let cfg = &self.context.configs().lock();
         if let Some(palette) = &cfg.syntax_config {
             Painter::paint_string(line, &self.context.scope, palette)
         } else {

--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -59,7 +59,7 @@ pub fn autoview(args: CommandArgs) -> Result<OutputStream, ShellError> {
     if let Some(x) = input_stream.next() {
         match input_stream.next() {
             Some(y) => {
-                let ctrl_c = context.engine_state.ctrl_c.clone();
+                let ctrl_c = context.ctrl_c().clone();
                 let xy = vec![x, y];
                 let xy_stream = xy.into_iter().chain(input_stream).interruptible(ctrl_c);
 
@@ -192,7 +192,7 @@ pub fn autoview(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     } => {
                         let pivot_mode = configuration.pivot_mode();
 
-                        let term_width = context.engine_state.host.lock().width();
+                        let term_width = context.host().lock().width();
                         if pivot_mode.is_always()
                             || (pivot_mode.is_auto()
                                 && (row

--- a/crates/nu-command/src/commands/autoview/command.rs
+++ b/crates/nu-command/src/commands/autoview/command.rs
@@ -59,7 +59,7 @@ pub fn autoview(args: CommandArgs) -> Result<OutputStream, ShellError> {
     if let Some(x) = input_stream.next() {
         match input_stream.next() {
             Some(y) => {
-                let ctrl_c = context.ctrl_c.clone();
+                let ctrl_c = context.engine_state.ctrl_c.clone();
                 let xy = vec![x, y];
                 let xy_stream = xy.into_iter().chain(input_stream).interruptible(ctrl_c);
 
@@ -192,7 +192,7 @@ pub fn autoview(args: CommandArgs) -> Result<OutputStream, ShellError> {
                     } => {
                         let pivot_mode = configuration.pivot_mode();
 
-                        let term_width = context.host.lock().width();
+                        let term_width = context.engine_state.host.lock().width();
                         if pivot_mode.is_always()
                             || (pivot_mode.is_auto()
                                 && (row

--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -27,12 +27,7 @@ pub(crate) fn run_external_command(
     trace!(target: "nu::run::external", "-> {}", command.name);
 
     context.sync_path_to_env();
-    if !context
-        .engine_state
-        .host
-        .lock()
-        .is_external_cmd(&command.name)
-    {
+    if !context.host().lock().is_external_cmd(&command.name) {
         return Err(ShellError::labeled_error(
             "Command not found",
             format!("command {} not found", &command.name),
@@ -64,7 +59,7 @@ fn run_with_stdin(
     input: InputStream,
     external_redirection: ExternalRedirection,
 ) -> Result<InputStream, ShellError> {
-    let path = context.engine_state.shell_manager.path();
+    let path = context.shell_manager().path();
 
     let mut command_args = vec![];
     for arg in command.args.iter() {

--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -27,7 +27,12 @@ pub(crate) fn run_external_command(
     trace!(target: "nu::run::external", "-> {}", command.name);
 
     context.sync_path_to_env();
-    if !context.host.lock().is_external_cmd(&command.name) {
+    if !context
+        .engine_state
+        .host
+        .lock()
+        .is_external_cmd(&command.name)
+    {
         return Err(ShellError::labeled_error(
             "Command not found",
             format!("command {} not found", &command.name),
@@ -59,7 +64,7 @@ fn run_with_stdin(
     input: InputStream,
     external_redirection: ExternalRedirection,
 ) -> Result<InputStream, ShellError> {
-    let path = context.shell_manager.path();
+    let path = context.engine_state.shell_manager.path();
 
     let mut command_args = vec![];
     for arg in command.args.iter() {

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -41,7 +41,7 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let column_path = args.req(0)?;
 
-    let result = if let Some(global_cfg) = &ctx.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &ctx.engine_state.configs.lock().global_config {
         let result = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);
         let value = crate::commands::get::get_column_path(&column_path, &result)?;
         Ok(match value {

--- a/crates/nu-command/src/commands/config/get.rs
+++ b/crates/nu-command/src/commands/config/get.rs
@@ -41,7 +41,7 @@ pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let column_path = args.req(0)?;
 
-    let result = if let Some(global_cfg) = &ctx.engine_state.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &ctx.configs().lock().global_config {
         let result = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);
         let value = crate::commands::get::get_column_path(&column_path, &result)?;
         Ok(match value {

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -43,7 +43,7 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let key = remove.to_string();
 
-    let result = if let Some(global_cfg) = &mut ctx.engine_state.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &mut ctx.configs().lock().global_config {
         if global_cfg.vars.contains_key(&key) {
             global_cfg.vars.swap_remove(&key);
             global_cfg.write()?;

--- a/crates/nu-command/src/commands/config/remove.rs
+++ b/crates/nu-command/src/commands/config/remove.rs
@@ -43,7 +43,7 @@ pub fn remove(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let key = remove.to_string();
 
-    let result = if let Some(global_cfg) = &mut ctx.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &mut ctx.engine_state.configs.lock().global_config {
         if global_cfg.vars.contains_key(&key) {
             global_cfg.vars.swap_remove(&key);
             global_cfg.write()?;

--- a/crates/nu-command/src/commands/config/set.rs
+++ b/crates/nu-command/src/commands/config/set.rs
@@ -57,7 +57,7 @@ pub fn set(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let column_path = args.req(0)?;
     let mut value: Value = args.req(1)?;
 
-    let result = if let Some(global_cfg) = &mut ctx.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &mut ctx.engine_state.configs.lock().global_config {
         let configuration = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);
 
         if let UntaggedValue::Table(rows) = &value.value {

--- a/crates/nu-command/src/commands/config/set.rs
+++ b/crates/nu-command/src/commands/config/set.rs
@@ -57,7 +57,7 @@ pub fn set(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let column_path = args.req(0)?;
     let mut value: Value = args.req(1)?;
 
-    let result = if let Some(global_cfg) = &mut ctx.engine_state.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &mut ctx.configs().lock().global_config {
         let configuration = UntaggedValue::row(global_cfg.vars.clone()).into_value(&name);
 
         if let UntaggedValue::Table(rows) = &value.value {

--- a/crates/nu-command/src/commands/config/set_into.rs
+++ b/crates/nu-command/src/commands/config/set_into.rs
@@ -45,7 +45,7 @@ pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let rows: Vec<Value> = args.input.collect();
     let key = set_into.to_string();
 
-    let result = if let Some(global_cfg) = &mut ctx.engine_state.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &mut ctx.configs().lock().global_config {
         if rows.is_empty() {
             return Err(ShellError::labeled_error(
                 "No values given for set_into",

--- a/crates/nu-command/src/commands/config/set_into.rs
+++ b/crates/nu-command/src/commands/config/set_into.rs
@@ -45,7 +45,7 @@ pub fn set_into(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let rows: Vec<Value> = args.input.collect();
     let key = set_into.to_string();
 
-    let result = if let Some(global_cfg) = &mut ctx.configs.lock().global_config {
+    let result = if let Some(global_cfg) = &mut ctx.engine_state.configs.lock().global_config {
         if rows.is_empty() {
             return Err(ShellError::labeled_error(
                 "No values given for set_into",

--- a/crates/nu-command/src/commands/dataframe/dtypes.rs
+++ b/crates/nu-command/src/commands/dataframe/dtypes.rs
@@ -31,6 +31,7 @@ impl WholeStreamCommand for DataFrame {
     }
 }
 
+#[allow(clippy::needless_collect)]
 fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tag = args.call_info.name_tag.clone();
 

--- a/crates/nu-command/src/commands/enter.rs
+++ b/crates/nu-command/src/commands/enter.rs
@@ -73,7 +73,7 @@ fn enter(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let head = args.call_info.args.head.clone();
     let context = args.context.clone();
     let scope = args.scope().clone();
-    let path = args.context.shell_manager.path();
+    let path = args.context.engine_state.shell_manager.path();
 
     let location: Tagged<PathBuf> = args.req(0)?;
     let encoding: Option<Tagged<String>> = args.get_flag("encoding")?;

--- a/crates/nu-command/src/commands/enter.rs
+++ b/crates/nu-command/src/commands/enter.rs
@@ -73,7 +73,7 @@ fn enter(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let head = args.call_info.args.head.clone();
     let context = args.context.clone();
     let scope = args.scope().clone();
-    let path = args.context.engine_state.shell_manager.path();
+    let path = args.context.shell_manager().path();
 
     let location: Tagged<PathBuf> = args.req(0)?;
     let encoding: Option<Tagged<String>> = args.get_flag("encoding")?;

--- a/crates/nu-command/src/commands/history.rs
+++ b/crates/nu-command/src/commands/history.rs
@@ -31,7 +31,7 @@ fn history(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let clear = args.has_flag("clear");
 
-    let path = if let Some(global_cfg) = &ctx.configs.lock().global_config {
+    let path = if let Some(global_cfg) = &ctx.engine_state.configs.lock().global_config {
         nu_data::config::path::history_path_or_default(global_cfg)
     } else {
         nu_data::config::path::default_history_path()

--- a/crates/nu-command/src/commands/history.rs
+++ b/crates/nu-command/src/commands/history.rs
@@ -31,7 +31,7 @@ fn history(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     let clear = args.has_flag("clear");
 
-    let path = if let Some(global_cfg) = &ctx.engine_state.configs.lock().global_config {
+    let path = if let Some(global_cfg) = &ctx.configs().lock().global_config {
         nu_data::config::path::history_path_or_default(global_cfg)
     } else {
         nu_data::config::path::default_history_path()

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -152,7 +152,7 @@ fn maybe_autocd_dir(cmd: &ExternalCommand, ctx: &mut EvaluationContext) -> Optio
 
                 let split_path: Vec<_> = current_path.split(':').collect();
                 if split_path.len() > 1 {
-                    ctx.windows_drives_previous_cwd
+                    ctx.windows_drives_previous_cwd()
                         .lock()
                         .insert(split_path[0].to_string(), current_path);
                 }
@@ -160,7 +160,7 @@ fn maybe_autocd_dir(cmd: &ExternalCommand, ctx: &mut EvaluationContext) -> Optio
                 let name = name.to_uppercase();
                 let new_drive: Vec<_> = name.split(':').collect();
 
-                if let Some(val) = ctx.windows_drives_previous_cwd.lock().get(new_drive[0]) {
+                if let Some(val) = ctx.windows_drives_previous_cwd().lock().get(new_drive[0]) {
                     val.to_string()
                 } else {
                     name

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -148,7 +148,7 @@ fn maybe_autocd_dir(cmd: &ExternalCommand, ctx: &mut EvaluationContext) -> Optio
             if name.ends_with(':') {
                 // This looks like a drive shortcut. We need to a) switch drives and b) go back to the previous directory we were viewing on that drive
                 // But first, we need to save where we are now
-                let current_path = ctx.shell_manager.path();
+                let current_path = ctx.shell_manager().path();
 
                 let split_path: Vec<_> = current_path.split(':').collect();
                 if split_path.len() > 1 {

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -99,6 +99,7 @@ impl WholeStreamCommand for RunExternalCommand {
                 };
 
                 let result = external_context
+                    .engine_state
                     .shell_manager
                     .cd(cd_args, args.call_info.name_tag);
 
@@ -135,7 +136,7 @@ fn maybe_autocd_dir(cmd: &ExternalCommand, ctx: &mut EvaluationContext) -> Optio
         || (cmd.args.is_empty()
             && PathBuf::from(name).is_dir()
             && dunce::canonicalize(name).is_ok()
-            && !ctx.host.lock().is_external_cmd(name))
+            && !ctx.engine_state.host.lock().is_external_cmd(name))
     {
         Some(name)
     } else {

--- a/crates/nu-command/src/commands/run_external.rs
+++ b/crates/nu-command/src/commands/run_external.rs
@@ -99,8 +99,7 @@ impl WholeStreamCommand for RunExternalCommand {
                 };
 
                 let result = external_context
-                    .engine_state
-                    .shell_manager
+                    .shell_manager()
                     .cd(cd_args, args.call_info.name_tag);
 
                 return Ok(result?.to_action_stream());
@@ -136,7 +135,7 @@ fn maybe_autocd_dir(cmd: &ExternalCommand, ctx: &mut EvaluationContext) -> Optio
         || (cmd.args.is_empty()
             && PathBuf::from(name).is_dir()
             && dunce::canonicalize(name).is_ok()
-            && !ctx.engine_state.host.lock().is_external_cmd(name))
+            && !ctx.host().lock().is_external_cmd(name))
     {
         Some(name)
     } else {

--- a/crates/nu-engine/src/command_args.rs
+++ b/crates/nu-engine/src/command_args.rs
@@ -27,23 +27,23 @@ impl CommandArgs {
     }
 
     pub fn host(&self) -> Arc<parking_lot::Mutex<Box<dyn Host>>> {
-        self.context.engine_state.host.clone()
+        self.context.host().clone()
     }
 
     pub fn current_errors(&self) -> Arc<Mutex<Vec<ShellError>>> {
-        self.context.engine_state.current_errors.clone()
+        self.context.current_errors().clone()
     }
 
     pub fn ctrl_c(&self) -> Arc<AtomicBool> {
-        self.context.engine_state.ctrl_c.clone()
+        self.context.ctrl_c().clone()
     }
 
     pub fn configs(&self) -> Arc<Mutex<ConfigHolder>> {
-        self.context.engine_state.configs.clone()
+        self.context.configs().clone()
     }
 
     pub fn shell_manager(&self) -> ShellManager {
-        self.context.engine_state.shell_manager.clone()
+        self.context.shell_manager().clone()
     }
 
     pub fn nth(&self, pos: usize) -> Option<&SpannedExpression> {

--- a/crates/nu-engine/src/command_args.rs
+++ b/crates/nu-engine/src/command_args.rs
@@ -27,23 +27,23 @@ impl CommandArgs {
     }
 
     pub fn host(&self) -> Arc<parking_lot::Mutex<Box<dyn Host>>> {
-        self.context.host.clone()
+        self.context.engine_state.host.clone()
     }
 
     pub fn current_errors(&self) -> Arc<Mutex<Vec<ShellError>>> {
-        self.context.current_errors.clone()
+        self.context.engine_state.current_errors.clone()
     }
 
     pub fn ctrl_c(&self) -> Arc<AtomicBool> {
-        self.context.ctrl_c.clone()
+        self.context.engine_state.ctrl_c.clone()
     }
 
     pub fn configs(&self) -> Arc<Mutex<ConfigHolder>> {
-        self.context.configs.clone()
+        self.context.engine_state.configs.clone()
     }
 
     pub fn shell_manager(&self) -> ShellManager {
-        self.context.shell_manager.clone()
+        self.context.engine_state.shell_manager.clone()
     }
 
     pub fn nth(&self, pos: usize) -> Option<&SpannedExpression> {

--- a/crates/nu-engine/src/evaluate/block.rs
+++ b/crates/nu-engine/src/evaluate/block.rs
@@ -60,7 +60,7 @@ pub fn run_block(
                                 ctx.clear_errors();
                                 return Err(err.clone());
                             }
-                            if ctx.engine_state.ctrl_c.load(Ordering::SeqCst) {
+                            if ctx.ctrl_c().load(Ordering::SeqCst) {
                                 return Ok(InputStream::empty());
                             }
                         }
@@ -96,7 +96,7 @@ pub fn run_block(
                                 ctx.clear_errors();
                                 return Err(err.clone());
                             }
-                            if ctx.engine_state.ctrl_c.load(Ordering::SeqCst) {
+                            if ctx.ctrl_c().load(Ordering::SeqCst) {
                                 // This early return doesn't return the result
                                 // we have so far, but breaking out of this loop
                                 // causes lifetime issues. A future contribution

--- a/crates/nu-engine/src/evaluate/block.rs
+++ b/crates/nu-engine/src/evaluate/block.rs
@@ -60,7 +60,7 @@ pub fn run_block(
                                 ctx.clear_errors();
                                 return Err(err.clone());
                             }
-                            if ctx.ctrl_c.load(Ordering::SeqCst) {
+                            if ctx.engine_state.ctrl_c.load(Ordering::SeqCst) {
                                 return Ok(InputStream::empty());
                             }
                         }
@@ -96,7 +96,7 @@ pub fn run_block(
                                 ctx.clear_errors();
                                 return Err(err.clone());
                             }
-                            if ctx.ctrl_c.load(Ordering::SeqCst) {
+                            if ctx.engine_state.ctrl_c.load(Ordering::SeqCst) {
                                 // This early return doesn't return the result
                                 // we have so far, but breaking out of this loop
                                 // causes lifetime issues. A future contribution

--- a/crates/nu-engine/src/evaluate/internal.rs
+++ b/crates/nu-engine/src/evaluate/internal.rs
@@ -79,7 +79,7 @@ impl Iterator for InternalIterator {
             match item {
                 Ok(ReturnSuccess::Action(action)) => match action {
                     CommandAction::ChangePath(path) => {
-                        self.context.shell_manager.set_path(path);
+                        self.context.engine_state.shell_manager.set_path(path);
                     }
                     CommandAction::Exit(code) => std::process::exit(code), // TODO: save history.txt
                     CommandAction::Error(err) => {
@@ -135,24 +135,28 @@ impl Iterator for InternalIterator {
                     }
                     CommandAction::EnterValueShell(value) => {
                         self.context
+                            .engine_state
                             .shell_manager
                             .insert_at_current(Box::new(ValueShell::new(value)));
                     }
                     CommandAction::EnterShell(location) => {
-                        let mode = if self.context.shell_manager.is_interactive() {
+                        let mode = if self.context.engine_state.shell_manager.is_interactive() {
                             FilesystemShellMode::Cli
                         } else {
                             FilesystemShellMode::Script
                         };
-                        self.context.shell_manager.insert_at_current(Box::new(
-                            match FilesystemShell::with_location(location, mode) {
-                                Ok(v) => v,
-                                Err(err) => {
-                                    self.context.error(err.into());
-                                    break;
-                                }
-                            },
-                        ));
+                        self.context
+                            .engine_state
+                            .shell_manager
+                            .insert_at_current(Box::new(
+                                match FilesystemShell::with_location(location, mode) {
+                                    Ok(v) => v,
+                                    Err(err) => {
+                                        self.context.error(err.into());
+                                        break;
+                                    }
+                                },
+                            ));
                     }
                     CommandAction::AddPlugins(path) => {
                         match crate::plugin::build_plugin::scan(vec![std::path::PathBuf::from(
@@ -172,14 +176,14 @@ impl Iterator for InternalIterator {
                         }
                     }
                     CommandAction::PreviousShell => {
-                        self.context.shell_manager.prev();
+                        self.context.engine_state.shell_manager.prev();
                     }
                     CommandAction::NextShell => {
-                        self.context.shell_manager.next();
+                        self.context.engine_state.shell_manager.next();
                     }
                     CommandAction::LeaveShell(code) => {
-                        self.context.shell_manager.remove_at_current();
-                        if self.context.shell_manager.is_empty() {
+                        self.context.engine_state.shell_manager.remove_at_current();
+                        if self.context.engine_state.shell_manager.is_empty() {
                             std::process::exit(code); // TODO: save history.txt
                         }
                     }

--- a/crates/nu-engine/src/evaluate/variables.rs
+++ b/crates/nu-engine/src/evaluate/variables.rs
@@ -30,7 +30,7 @@ pub fn nu(
         UntaggedValue::filepath(default_history_path()).into_value(&tag),
     );
 
-    if let Some(global_cfg) = &ctx.configs.lock().global_config {
+    if let Some(global_cfg) = &ctx.engine_state.configs.lock().global_config {
         nu_dict.insert_value(
             "config",
             UntaggedValue::row(global_cfg.vars.clone()).into_value(&tag),

--- a/crates/nu-engine/src/evaluate/variables.rs
+++ b/crates/nu-engine/src/evaluate/variables.rs
@@ -30,7 +30,7 @@ pub fn nu(
         UntaggedValue::filepath(default_history_path()).into_value(&tag),
     );
 
-    if let Some(global_cfg) = &ctx.engine_state.configs.lock().global_config {
+    if let Some(global_cfg) = &ctx.configs().lock().global_config {
         nu_dict.insert_value(
             "config",
             UntaggedValue::row(global_cfg.vars.clone()).into_value(&tag),

--- a/crates/nu-engine/src/evaluation_context.rs
+++ b/crates/nu-engine/src/evaluation_context.rs
@@ -33,7 +33,7 @@ pub struct EngineState {
 #[derive(Clone, Default)]
 pub struct EvaluationContext {
     pub scope: Scope,
-    pub engine_state: Arc<EngineState>,
+    engine_state: Arc<EngineState>,
 }
 
 impl EvaluationContext {
@@ -80,6 +80,32 @@ impl EvaluationContext {
 
     pub fn error(&self, error: ShellError) {
         self.with_errors(|errors| errors.push(error))
+    }
+
+    pub fn host(&self) -> &Arc<parking_lot::Mutex<Box<dyn Host>>> {
+        &self.engine_state.host
+    }
+
+    pub fn current_errors(&self) -> &Arc<Mutex<Vec<ShellError>>> {
+        &self.engine_state.current_errors
+    }
+
+    pub fn ctrl_c(&self) -> &Arc<AtomicBool> {
+        &self.engine_state.ctrl_c
+    }
+
+    pub fn configs(&self) -> &Arc<Mutex<ConfigHolder>> {
+        &self.engine_state.configs
+    }
+
+    pub fn shell_manager(&self) -> &ShellManager {
+        &self.engine_state.shell_manager
+    }
+
+    pub fn windows_drives_previous_cwd(
+        &self,
+    ) -> &Arc<Mutex<std::collections::HashMap<String, String>>> {
+        &self.engine_state.windows_drives_previous_cwd
     }
 
     pub fn clear_errors(&self) {

--- a/crates/nu-engine/src/print.rs
+++ b/crates/nu-engine/src/print.rs
@@ -3,14 +3,14 @@ use nu_source::Text;
 use crate::EvaluationContext;
 
 pub fn maybe_print_errors(context: &EvaluationContext, source: Text) -> bool {
-    let errors = context.engine_state.current_errors.clone();
+    let errors = context.current_errors().clone();
     let mut errors = errors.lock();
 
     if errors.len() > 0 {
         let error = errors[0].clone();
         *errors = vec![];
 
-        context.engine_state.host.lock().print_err(error, &source);
+        context.host().lock().print_err(error, &source);
         true
     } else {
         false

--- a/crates/nu-engine/src/print.rs
+++ b/crates/nu-engine/src/print.rs
@@ -3,14 +3,14 @@ use nu_source::Text;
 use crate::EvaluationContext;
 
 pub fn maybe_print_errors(context: &EvaluationContext, source: Text) -> bool {
-    let errors = context.current_errors.clone();
+    let errors = context.engine_state.current_errors.clone();
     let mut errors = errors.lock();
 
     if errors.len() > 0 {
         let error = errors[0].clone();
         *errors = vec![];
 
-        context.host.lock().print_err(error, &source);
+        context.engine_state.host.lock().print_err(error, &source);
         true
     } else {
         false

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -133,7 +133,7 @@ pub fn process_script(
                             if name.ends_with(':') {
                                 // This looks like a drive shortcut. We need to a) switch drives and b) go back to the previous directory we were viewing on that drive
                                 // But first, we need to save where we are now
-                                let current_path = ctx.shell_manager.path();
+                                let current_path = ctx.shell_manager().path();
 
                                 let split_path: Vec<_> = current_path.split(':').collect();
                                 if split_path.len() > 1 {

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -42,13 +42,12 @@ pub fn run_script_in_dir(
     ctx: &EvaluationContext,
 ) -> Result<(), Box<dyn Error>> {
     //Save path before to switch back to it after executing script
-    let path_before = ctx.engine_state.shell_manager.path();
+    let path_before = ctx.shell_manager().path();
 
-    ctx.engine_state
-        .shell_manager
+    ctx.shell_manager()
         .set_path(dir.to_string_lossy().to_string());
     run_script_standalone(script, false, ctx, false)?;
-    ctx.engine_state.shell_manager.set_path(path_before);
+    ctx.shell_manager().set_path(path_before);
 
     Ok(())
 }
@@ -119,9 +118,9 @@ pub fn process_script(
                         .as_ref()
                         .map(NamedArguments::is_empty)
                         .unwrap_or(true)
-                    && canonicalize(ctx.engine_state.shell_manager.path(), name).is_ok()
+                    && canonicalize(ctx.shell_manager().path(), name).is_ok()
                     && Path::new(&name).is_dir()
-                    && !ctx.engine_state.host.lock().is_external_cmd(name)
+                    && !ctx.host().lock().is_external_cmd(name)
                 {
                     let tag = Tag {
                         anchor: Some(AnchorLocation::Source(line.into())),
@@ -170,7 +169,7 @@ pub fn process_script(
                         }),
                     };
 
-                    return match ctx.engine_state.shell_manager.cd(cd_args, tag) {
+                    return match ctx.shell_manager().cd(cd_args, tag) {
                         Err(e) => LineResult::Error(line.to_string(), e),
                         Ok(stream) => {
                             let iter = InternalIterator {
@@ -245,7 +244,7 @@ pub fn process_script(
                                 ..
                             }) => return LineResult::Error(line.to_string(), e),
                             Some(_item) => {
-                                if ctx.engine_state.ctrl_c.load(Ordering::SeqCst) {
+                                if ctx.ctrl_c().load(Ordering::SeqCst) {
                                     break;
                                 }
                             }
@@ -268,8 +267,7 @@ pub fn run_script_standalone(
     exit_on_error: bool,
 ) -> Result<(), Box<dyn Error>> {
     context
-        .engine_state
-        .shell_manager
+        .shell_manager()
         .enter_script_mode()
         .map_err(Box::new)?;
     let line = process_script(&script_text, context, redirect_stdin, 0, false);
@@ -277,7 +275,7 @@ pub fn run_script_standalone(
     match line {
         LineResult::Success(line) => {
             let error_code = {
-                let errors = context.engine_state.current_errors.clone();
+                let errors = context.current_errors().clone();
                 let errors = errors.lock();
 
                 if errors.len() > 0 {
@@ -295,8 +293,7 @@ pub fn run_script_standalone(
 
         LineResult::Error(line, err) => {
             context
-                .engine_state
-                .host
+                .host()
                 .lock()
                 .print_err(err, &Text::from(line.clone()));
 
@@ -310,7 +307,7 @@ pub fn run_script_standalone(
     }
 
     //exit script mode shell
-    context.engine_state.shell_manager.remove_at_current();
+    context.shell_manager().remove_at_current();
 
     Ok(())
 }

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -137,7 +137,7 @@ pub fn process_script(
 
                                 let split_path: Vec<_> = current_path.split(':').collect();
                                 if split_path.len() > 1 {
-                                    ctx.windows_drives_previous_cwd
+                                    ctx.windows_drives_previous_cwd()
                                         .lock()
                                         .insert(split_path[0].to_string(), current_path);
                                 }
@@ -146,7 +146,7 @@ pub fn process_script(
                                 let new_drive: Vec<_> = name.split(':').collect();
 
                                 if let Some(val) =
-                                    ctx.windows_drives_previous_cwd.lock().get(new_drive[0])
+                                    ctx.windows_drives_previous_cwd().lock().get(new_drive[0])
                                 {
                                     val.to_string()
                                 } else {

--- a/crates/nu-protocol/src/dataframe/nu_dataframe.rs
+++ b/crates/nu-protocol/src/dataframe/nu_dataframe.rs
@@ -134,6 +134,7 @@ impl NuDataFrame {
         from_parsed_columns(column_values, tag)
     }
 
+    #[allow(clippy::clippy::wrong_self_convention)]
     pub fn to_value(self, tag: Tag) -> Value {
         Value {
             value: UntaggedValue::DataFrame(PolarsData::EagerDataFrame(self)),

--- a/crates/nu-protocol/src/dataframe/nu_series.rs
+++ b/crates/nu-protocol/src/dataframe/nu_series.rs
@@ -97,6 +97,7 @@ impl NuSeries {
         from_parsed_vector(vec_values, name)
     }
 
+    #[allow(clippy::clippy::wrong_self_convention)]
     pub fn to_value(self, tag: Tag) -> Value {
         Value {
             value: UntaggedValue::DataFrame(PolarsData::Series(self)),


### PR DESCRIPTION
This moves the rarely changing engine state into its own struct, which allows us to pay less for each clone. I've added some convenience methods to access the various parts.

This has the nice side effect of making some of our benchmarks faster. Here is the difference with gradient.nu:

## Before
```
───┬───────────────────
 # │     real time     
───┼───────────────────
 0 │ 169ms 709us 822ns 
───┴───────────────────
```

## After
```
───┬───────────────────
 # │     real time     
───┼───────────────────
 0 │ 137ms 473us 687ns 
───┴───────────────────
```