### PR TITLE
Fix syntax hightlight when using Circumflex-Operator

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1754,9 +1754,12 @@ fn parse_call(
     if lite_cmd.parts.is_empty() {
         return (None, None);
     } else if lite_cmd.parts[0].item.starts_with('^') {
-        let name = lite_cmd.parts[0]
+        let mut name = lite_cmd.parts[0]
             .clone()
             .map(|v| v.chars().skip(1).collect::<String>());
+
+        name.span = Span::new(name.span.start() + 1, name.span.end());
+
         // TODO this is the same as the `else` branch below, only the name differs. Find a way
         //      to share this functionality.
         let mut args = vec![];


### PR DESCRIPTION
Fixes #3434 

The issue is when  getting name from `lite_cmd.parts[0]`, the `^` is removed but name reused its span so syntax hightlighting is off by one. 

Note that this will create a small different hightlighting compared with current feature. 

Before this PR
```
> ^ls
```
is hightlighted from the whole `^ls`

With this PR

```
> ^ls
```
Only `ls` is hightlighted
