### PR TITLE
Remove 'help' Nu bin positional support.

### DIFF
--- a/crates/nu-cli/src/app.rs
+++ b/crates/nu-cli/src/app.rs
@@ -153,27 +153,10 @@ impl App {
     }
 
     pub fn help(&self) -> bool {
-        let help_asked = self
-            .options
-            .get("args")
-            .map(|v| {
-                v.table_entries().next().map(|v| {
-                    if let Ok(value) = v.as_string() {
-                        value == "help"
-                    } else {
-                        false
-                    }
-                })
-            })
-            .flatten()
-            .unwrap_or(false);
-
-        if help_asked {
-            self.options.shift();
-            return true;
-        }
-
-        false
+        self.options
+            .get("help")
+            .map(|v| matches!(v.as_bool(), Ok(true)))
+            .unwrap_or(false)
     }
 
     pub fn scripts(&self) -> Option<Vec<Result<String, ShellError>>> {
@@ -408,7 +391,7 @@ mod tests {
     fn has_help() -> Result<(), ShellError> {
         let ui = cli_app();
 
-        ui.parse("nu help")?;
+        ui.parse("nu --help")?;
         assert_eq!(ui.help(), true);
         Ok(())
     }

--- a/crates/nu-command/src/commands/nu/command.rs
+++ b/crates/nu-command/src/commands/nu/command.rs
@@ -13,11 +13,11 @@ impl WholeStreamCommand for Command {
             .switch("stdin", "stdin", None)
             .switch("skip-plugins", "do not load plugins", None)
             .switch("no-history", "don't save history", None)
-            .named("commands", SyntaxShape::String, "Nu commands", Some('c'))
+            .named("commands", SyntaxShape::String, "commands", Some('c'))
             .named(
                 "testbin",
                 SyntaxShape::String,
-                "BIN: echo_env, cococo, iecho, fail, nonu, chop, repeater, meow",
+                "test bin: echo_env, cococo, iecho, fail, nonu, chop, repeater, meow",
                 None,
             )
             .named("develop", SyntaxShape::String, "trace mode", None)
@@ -34,12 +34,12 @@ impl WholeStreamCommand for Command {
                 "custom configuration source file",
                 None,
             )
-            .optional("script", SyntaxShape::FilePath, "The Nu script to run")
-            .rest(SyntaxShape::String, "Left overs...")
+            .optional("script", SyntaxShape::FilePath, "script to run")
+            .rest(SyntaxShape::String, "...")
     }
 
     fn usage(&self) -> &str {
-        "Nu"
+        "Nu - A new type of shell."
     }
 }
 


### PR DESCRIPTION
Mostly to keep parity with the rest of Nu internal commands (`-h` and `--help`) instead.