### PR TITLE
Only discard command comment if prev token was comment

### DIFF
--- a/crates/nu-parser/src/lex/lexer.rs
+++ b/crates/nu-parser/src/lex/lexer.rs
@@ -364,11 +364,21 @@ pub fn parse_block(tokens: Vec<Token>) -> (LiteBlock, Option<ParseError>) {
                 // If we encounter two newline characters in a row, use a special eoleol event,
                 // which allows the parser to discard comments that shouldn't be treated as
                 // documentation for the following item.
-                if let Some(Token {
-                    contents: TokenContents::Eol,
-                    ..
-                }) = tokens.peek()
-                {
+                let last_was_comment = std::matches!(
+                    parser.prev_token,
+                    Some(Token {
+                        contents: TokenContents::Comment(..),
+                        ..
+                    })
+                );
+                let next_is_eol = std::matches!(
+                    tokens.peek(),
+                    Some(Token {
+                        contents: TokenContents::Eol,
+                        ..
+                    })
+                );
+                if last_was_comment && next_is_eol {
                     tokens.next();
                     parser.eoleol();
                 } else {

--- a/crates/nu-parser/tests/main.rs
+++ b/crates/nu-parser/tests/main.rs
@@ -23,3 +23,44 @@ fn defs_contain_comment_in_help() {
         assert!(actual.out.contains("I comment and test. I am a good boy."));
     });
 }
+
+#[test]
+fn defs_contain_multiple_comments_in_help() {
+    Playground::setup("comment_test_2", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent(
+            "my_def.nu",
+            r#"
+                # I comment and test. I am a good boy.
+                def comment_philosphy [] {
+                    echo It’s not a bug – it’s an undocumented feature. (Anonymous)
+                }
+
+                # I comment and test all my functions. I am a very good boy.
+                def comment_philosphy_2 [] {
+                    echo It’s not a bug – it’s an undocumented feature. (Anonymous)
+                }
+
+
+                # I comment and test all my functions. I am the best boy.
+                def comment_philosphy_3 [] {
+                    echo It’s not a bug – it’s an undocumented feature. (Anonymous)
+                }
+                "#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), r#"
+            source my_def.nu
+            help comment_philosphy
+            help comment_philosphy_2
+            help comment_philosphy_3
+            "#);
+
+        assert!(actual.out.contains("I comment and test. I am a good boy."));
+        assert!(actual
+            .out
+            .contains("I comment and test all my functions. I am a very good boy."));
+        assert!(actual
+            .out
+            .contains("I comment and test all my functions. I am the best boy."));
+    });
+}


### PR DESCRIPTION
This fixes issues where, in a file with multiple def commands with their own doc comments, some of the comments would be discarded.