### PR TITLE
Remove dirs, directories and directories-support features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,16 +66,6 @@ hamcrest2 = "0.3.0"
 
 [features]
 ctrlc-support = ["nu-cli/ctrlc", "nu-command/ctrlc"]
-directories-support = [
-    "nu-cli/directories",
-    "nu-cli/dirs",
-    "nu-completion/dirs",
-    "nu-command/directories",
-    "nu-command/dirs",
-    "nu-data/directories",
-    "nu-data/dirs",
-    "nu-engine/dirs",
-]
 ptree-support = ["nu-cli/ptree", "nu-command/ptree"]
 rustyline-support = ["nu-cli/rustyline-support", "nu-command/rustyline-support"]
 term-support = ["nu-cli/term", "nu-command/term"]
@@ -86,7 +76,6 @@ default = [
     "nu-cli/shadow-rs",
     "sys",
     "ps",
-    "directories-support",
     "ctrlc-support",
     "which-support",
     "term-support",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -43,8 +43,8 @@ codespan-reporting = "0.11.0"
 csv = "1.1.5"
 ctrlc = { version = "3.1.7", optional = true }
 derive-new = "0.5.8"
-directories-next = { version = "2.0.0", optional = true }
-dirs-next = { version = "2.0.0", optional = true }
+directories-next = "2.0.0"
+dirs-next = "2.0.0"
 dtparse = "1.2.0"
 dunce = "1.0.1"
 eml-parser = "0.1.0"
@@ -131,5 +131,3 @@ clipboard-cli = ["arboard"]
 rustyline-support = ["rustyline", "nu-engine/rustyline-support"]
 stable = []
 trash-support = ["trash"]
-dirs = ["dirs-next"]
-directories = ["directories-next"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -40,8 +40,8 @@ crossterm = { version = "0.19.0", optional = true }
 csv = "1.1.3"
 ctrlc = { version = "3.1.7", optional = true }
 derive-new = "0.5.8"
-directories-next = { version = "2.0.0", optional = true }
-dirs-next = { version = "2.0.0", optional = true }
+directories-next = "2.0.0"
+dirs-next = "2.0.0"
 dtparse = "1.2.0"
 dunce = "1.0.1"
 eml-parser = "0.1.0"
@@ -133,7 +133,5 @@ clipboard-cli = ["arboard"]
 rustyline-support = ["rustyline"]
 stable = []
 trash-support = ["trash"]
-directories = ["directories-next"]
-dirs = ["dirs-next"]
 table-pager = ["minus", "crossterm"]
 dataframe = ["nu-protocol/dataframe", "polars"]

--- a/crates/nu-command/src/commands/classified/external.rs
+++ b/crates/nu-command/src/commands/classified/external.rs
@@ -105,18 +105,7 @@ fn run_with_stdin(
     let process_args = command_args
         .iter()
         .map(|(arg, _is_literal)| {
-            let home_dir;
-
-            #[cfg(feature = "dirs")]
-            {
-                home_dir = dirs_next::home_dir;
-            }
-            #[cfg(not(feature = "dirs"))]
-            {
-                home_dir = || Some(std::path::PathBuf::from("/"));
-            }
-
-            let arg = expand_tilde(arg.deref(), home_dir);
+            let arg = expand_tilde(arg.deref(), dirs_next::home_dir);
 
             #[cfg(not(windows))]
             {

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -1,6 +1,5 @@
 use super::{operate, PathSubcommandArguments};
 use crate::prelude::*;
-#[cfg(feature = "dirs")]
 use nu_engine::filesystem::path::expand_tilde;
 use nu_engine::filesystem::path::resolve_dots;
 use nu_engine::WholeStreamCommand;
@@ -104,7 +103,6 @@ fn action(path: &Path, tag: Tag, args: &PathExpandArguments) -> Value {
         ))
     } else {
         // "best effort" mode, just expand tilde and resolve single/double dots
-        #[cfg(feature = "dirs")]
         let path = match expand_tilde(path) {
             Some(expanded) => expanded,
             None => path.into(),

--- a/crates/nu-command/src/commands/version.rs
+++ b/crates/nu-command/src/commands/version.rs
@@ -189,16 +189,6 @@ fn features_enabled() -> Vec<String> {
         names.push("ctrlc".to_string());
     }
 
-    #[cfg(feature = "dirs")]
-    {
-        names.push("dirs".to_string());
-    }
-
-    #[cfg(feature = "directories")]
-    {
-        names.push("directories".to_string());
-    }
-
     #[cfg(feature = "ptree")]
     {
         names.push("ptree".to_string());

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -127,7 +127,6 @@ fn filesystem_change_current_directory_to_parent_directory_after_delete_cwd() {
     })
 }
 
-#[cfg(feature = "dirs")]
 #[test]
 fn filesystem_change_to_home_directory() {
     Playground::setup("cd_test_8", |dirs, _| {

--- a/crates/nu-completion/Cargo.toml
+++ b/crates/nu-completion/Cargo.toml
@@ -17,8 +17,5 @@ nu-protocol = { version = "0.32.1", path = "../nu-protocol" }
 nu-source = { version = "0.32.1", path = "../nu-source" }
 nu-test-support = { version = "0.32.1", path = "../nu-test-support" }
 
-dirs-next = { version = "2.0.0", optional = true }
+dirs-next = "2.0.0"
 indexmap = { version = "1.6.1", features = ["serde-1"] }
-
-[features]
-dirs = ["dirs-next"]

--- a/crates/nu-completion/src/path.rs
+++ b/crates/nu-completion/src/path.rs
@@ -26,19 +26,12 @@ impl PathCompleter {
         let base_dir = if base_dir_name.is_empty() {
             PathBuf::from(".")
         } else {
-            #[cfg(feature = "dirs")]
-            {
-                let home_prefix = format!("~{}", SEP);
-                if base_dir_name.starts_with(&home_prefix) {
-                    let mut home_dir = dirs_next::home_dir().unwrap_or_else(|| PathBuf::from("~"));
-                    home_dir.push(&base_dir_name[2..]);
-                    home_dir
-                } else {
-                    PathBuf::from(base_dir_name)
-                }
-            }
-            #[cfg(not(feature = "dirs"))]
-            {
+            let home_prefix = format!("~{}", SEP);
+            if base_dir_name.starts_with(&home_prefix) {
+                let mut home_dir = dirs_next::home_dir().unwrap_or_else(|| PathBuf::from("~"));
+                home_dir.push(&base_dir_name[2..]);
+                home_dir
+            } else {
                 PathBuf::from(base_dir_name)
             }
         };

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -15,8 +15,8 @@ byte-unit = "4.0.9"
 chrono = "0.4.19"
 common-path = "1.0.0"
 derive-new = "0.5.8"
-directories-next = { version = "2.0.0", optional = true }
-dirs-next = { version = "2.0.0", optional = true }
+directories-next = "2.0.0"
+dirs-next = "2.0.0"
 getset = "0.1.1"
 indexmap = { version = "1.6.1", features = ["serde-1"] }
 log = "0.4.14"
@@ -48,6 +48,4 @@ features = ["strings", "checked_arithmetic"]
 users = "0.11.0"
 
 [features]
-directories = ["directories-next"]
-dirs = ["dirs-next"]
 dataframe = ["nu-protocol/dataframe", "polars"]

--- a/crates/nu-data/src/config.rs
+++ b/crates/nu-data/src/config.rs
@@ -161,7 +161,6 @@ pub fn value_to_toml_value(v: &Value) -> Result<toml::Value, ShellError> {
     }
 }
 
-#[cfg(feature = "directories")]
 pub fn config_path() -> Result<PathBuf, ShellError> {
     use directories_next::ProjectDirs;
 
@@ -173,13 +172,6 @@ pub fn config_path() -> Result<PathBuf, ShellError> {
     })?;
 
     Ok(path)
-}
-
-#[cfg(not(feature = "directories"))]
-pub fn config_path() -> Result<PathBuf, ShellError> {
-    // FIXME: unsure if this should be error or a simple default
-
-    Ok(std::path::PathBuf::from("/"))
 }
 
 pub fn default_path() -> Result<PathBuf, ShellError> {
@@ -197,7 +189,6 @@ pub fn default_path_for(file: &Option<PathBuf>) -> Result<PathBuf, ShellError> {
     Ok(filename)
 }
 
-#[cfg(feature = "directories")]
 pub fn user_data() -> Result<PathBuf, ShellError> {
     use directories_next::ProjectDirs;
 
@@ -212,13 +203,6 @@ pub fn user_data() -> Result<PathBuf, ShellError> {
     })?;
 
     Ok(path)
-}
-
-#[cfg(not(feature = "directories"))]
-pub fn user_data() -> Result<PathBuf, ShellError> {
-    // FIXME: unsure if this should be error or a simple default
-
-    Ok(std::path::PathBuf::from("/"))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -29,7 +29,7 @@ bigdecimal = "0.2.0"
 bytes = "0.5.6"
 chrono = { version = "0.4.19", features = ["serde"] }
 derive-new = "0.5.8"
-dirs-next = { version = "2.0.0", optional = true }
+dirs-next = "2.0.0"
 dunce = "1.0.1"
 encoding_rs = "0.8.28"
 filesize = "0.2.0"
@@ -63,6 +63,5 @@ hamcrest2 = "0.3.0"
 
 [features]
 rustyline-support = []
-dirs = ["dirs-next"]
 trash-support = ["trash"]
 dataframe = ["nu-protocol/dataframe"]

--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -90,15 +90,7 @@ impl FilesystemShell {
 }
 
 pub fn homedir_if_possible() -> Option<PathBuf> {
-    #[cfg(feature = "dirs")]
-    {
-        dirs_next::home_dir()
-    }
-
-    #[cfg(not(feature = "dirs"))]
-    {
-        None
-    }
+    dirs_next::home_dir()
 }
 
 impl Shell for FilesystemShell {

--- a/crates/nu-engine/src/filesystem/path.rs
+++ b/crates/nu-engine/src/filesystem/path.rs
@@ -31,16 +31,11 @@ where
         // path on all supported systems.
         relative_to.as_ref().to_owned()
     } else if path.as_ref().starts_with("~") {
-        #[cfg(feature = "dirs")]
-        {
-            let expanded_path = expand_tilde(path.as_ref());
-            match expanded_path {
-                Some(p) => p,
-                _ => path.as_ref().to_owned(),
-            }
+        let expanded_path = expand_tilde(path.as_ref());
+        match expanded_path {
+            Some(p) => p,
+            _ => path.as_ref().to_owned(),
         }
-        #[cfg(not(feature = "dirs"))]
-        relative_to.as_ref().join(path)
     } else {
         relative_to.as_ref().join(path)
     };
@@ -85,7 +80,6 @@ where
 }
 
 // borrowed from here https://stackoverflow.com/questions/54267608/expand-tilde-in-rust-path-idiomatically
-#[cfg(feature = "dirs")]
 pub fn expand_tilde<P: AsRef<Path>>(path_user_input: P) -> Option<PathBuf> {
     let p = path_user_input.as_ref();
     if !p.starts_with("~") {


### PR DESCRIPTION
First step towards cleaning up the path-related code.

The removed features were essentially used only for supporting home and project directories. I believe there is no reason for them to exist since both `dirs-next` and `directories-next` crates return `None` when asked about home/project dirs. Furthermore, the workarounds around missing these features were also problematic -- yet another reason to remove them.

