### PR TITLE
Add built-in var to refer to pipeline values

### DIFF
--- a/crates/nu-command/src/commands/filters/collect.rs
+++ b/crates/nu-command/src/commands/filters/collect.rs
@@ -1,0 +1,90 @@
+use crate::prelude::*;
+use nu_engine::run_block;
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{hir::CapturedBlock, Signature, SyntaxShape, UntaggedValue};
+
+pub struct Command;
+
+impl WholeStreamCommand for Command {
+    fn name(&self) -> &str {
+        "collect"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("collect").required(
+            "block",
+            SyntaxShape::Block,
+            "the block to run once the stream is collected",
+        )
+    }
+
+    fn usage(&self) -> &str {
+        "Collect the stream and pass it to a block."
+    }
+
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        collect(args)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Use the second value in the stream",
+            example: "echo 1 2 3 | collect { |x| echo $x.1 }",
+            result: Some(vec![UntaggedValue::int(2).into()]),
+        }]
+    }
+}
+
+fn collect(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let external_redirection = args.call_info.args.external_redirection;
+    let context = &args.context;
+    let tag = args.call_info.name_tag.clone();
+    let block: CapturedBlock = args.req(0)?;
+    let mut input = args.input;
+    let param = if !block.block.params.positional.is_empty() {
+        block.block.params.positional[0].0.name()
+    } else {
+        "$it"
+    };
+
+    context.scope.enter_scope();
+
+    context.scope.add_vars(&block.captured.entries);
+    let mut input = input.drain_vec();
+    match input.len() {
+        x if x > 1 => {
+            context
+                .scope
+                .add_var(param, UntaggedValue::Table(input).into_value(tag));
+        }
+        1 => {
+            let item = input.swap_remove(0);
+            context.scope.add_var(param, item);
+        }
+        _ => {}
+    }
+
+    let result = run_block(
+        &block.block,
+        &context,
+        InputStream::empty(),
+        external_redirection,
+    );
+    context.scope.exit_scope();
+
+    Ok(result?.into_output_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Command;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        test_examples(Command {})
+    }
+}

--- a/crates/nu-command/src/commands/filters/mod.rs
+++ b/crates/nu-command/src/commands/filters/mod.rs
@@ -1,6 +1,7 @@
 mod all;
 mod any;
 mod append;
+mod collect;
 mod compact;
 mod default;
 mod drop;
@@ -41,6 +42,7 @@ mod wrap;
 pub use all::Command as All;
 pub use any::Command as Any;
 pub use append::Command as Append;
+pub use collect::Command as Collect;
 pub use compact::Compact;
 pub use default::Default;
 pub use drop::*;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -176,6 +176,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(RollUp),
             whole_stream_command(Rotate),
             whole_stream_command(RotateCounterClockwise),
+            whole_stream_command(Collect),
             // Data processing
             whole_stream_command(Histogram),
             whole_stream_command(Autoenv),

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -492,7 +492,7 @@ mod tests {
                 std::matches!(expanded, Cow::Borrowed(_)),
                 "No PathBuf should be needed here (unecessary allocation)"
             );
-            assert!(&expanded == Path::new(s));
+            assert!(expanded == Path::new(s));
         }
 
         #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1004,6 +1004,30 @@ fn date_and_duration_overflow() {
     assert!(actual.err.contains("Duration and date addition overflow"));
 }
 
+#[test]
+fn pipeline_params_simple() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo 1 2 3 | $in.1 * $in.2
+        "#)
+    );
+
+    assert_eq!(actual.out, "6");
+}
+
+#[test]
+fn pipeline_params_inner() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo 1 2 3 | (echo $in.2 6 7 | $in.0 * $in.1 * $in.2)
+        "#)
+    );
+
+    assert_eq!(actual.out, "126");
+}
+
 mod parse {
     use nu_test_support::nu;
 


### PR DESCRIPTION
This adds a `collect` command which can collect the stream and call a block, passing the stream as a parameter.

The PR uses this functionality to infer cases where we want to use the stream as a value. We currently use `$in` to refer to the incoming pipeline.

```
> echo 1 2 3 | $in.1 * $in.2
6
```