### PR TITLE
speed up windows completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,6 +2606,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "isahc"
 version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3507,7 @@ version = "0.32.1"
 dependencies = [
  "dirs-next",
  "indexmap",
+ "is_executable",
  "nu-data",
  "nu-errors",
  "nu-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ rustyline-support = ["nu-cli/rustyline-support", "nu-command/rustyline-support"]
 term-support = ["nu-cli/term", "nu-command/term"]
 uuid-support = ["nu-cli/uuid_crate", "nu-command/uuid_crate"]
 which-support = ["nu-cli/which", "nu-command/which", "nu-engine/which"]
+executable-support = ["nu-completion/is_executable"]
 
 default = [
     "nu-cli/shadow-rs",
@@ -85,6 +86,7 @@ default = [
     "post",
     "fetch",
     "zip-support",
+    "executable-support",
 ]
 
 stable = ["default"]

--- a/crates/nu-completion/Cargo.toml
+++ b/crates/nu-completion/Cargo.toml
@@ -20,3 +20,4 @@ nu-test-support = { version = "0.32.1", path = "../nu-test-support" }
 
 dirs-next = "2.0.0"
 indexmap = { version = "1.6.1", features = ["serde-1"] }
+is_executable = "1.0.1"

--- a/crates/nu-completion/Cargo.toml
+++ b/crates/nu-completion/Cargo.toml
@@ -20,4 +20,4 @@ nu-test-support = { version = "0.32.1", path = "../nu-test-support" }
 
 dirs-next = "2.0.0"
 indexmap = { version = "1.6.1", features = ["serde-1"] }
-is_executable = "1.0.1"
+is_executable = { version = "1.0.1", optional = true }

--- a/crates/nu-completion/src/command.rs
+++ b/crates/nu-completion/src/command.rs
@@ -1,6 +1,7 @@
 use super::matchers::Matcher;
 use crate::{Completer, CompletionContext, Suggestion};
 use indexmap::set::IndexSet;
+#[cfg(windows)]
 use is_executable::IsExecutable;
 use nu_test_support::NATIVE_PATH_ENV_VAR;
 use std::iter::FromIterator;

--- a/crates/nu-completion/src/command.rs
+++ b/crates/nu-completion/src/command.rs
@@ -1,12 +1,10 @@
-use nu_test_support::NATIVE_PATH_ENV_VAR;
-
-use std::iter::FromIterator;
-use std::path::Path;
-
-use indexmap::set::IndexSet;
-
 use super::matchers::Matcher;
 use crate::{Completer, CompletionContext, Suggestion};
+use indexmap::set::IndexSet;
+use is_executable::IsExecutable;
+use nu_test_support::NATIVE_PATH_ENV_VAR;
+use std::iter::FromIterator;
+use std::path::Path;
 
 pub struct CommandCompleter;
 
@@ -56,45 +54,12 @@ where
     }
 }
 
-// TODO create a struct for "is executable" and store this information in it so we don't recompute
-//      on every dir entry
-
-#[cfg(windows)]
-fn pathext() -> Option<Vec<String>> {
-    std::env::var_os("PATHEXT").map(|v| {
-        v.to_string_lossy()
-            .split(';')
-            // Filter out empty tokens and ';' at the end
-            .filter(|f| f.len() > 1)
-            // Cut off the leading '.' character
-            .map(|ext| ext[1..].to_string())
-            .collect::<Vec<_>>()
-    })
-}
-
 #[cfg(windows)]
 fn is_executable(path: &Path) -> bool {
-    if let Ok(metadata) = path.metadata() {
-        let file_type = metadata.file_type();
-
-        // If the entry isn't a file, it cannot be executable
-        if !(file_type.is_file() || file_type.is_symlink()) {
-            return false;
-        }
-
-        if let Some(extension) = path.extension() {
-            if let Some(exts) = pathext() {
-                exts.iter()
-                    .any(|ext| extension.to_string_lossy().eq_ignore_ascii_case(ext))
-            } else {
-                false
-            }
-        } else {
-            false
-        }
-    } else {
-        false
-    }
+    // This call to a crate essentially checks the PATHEXT on Windows and does some
+    // low level WinAPI calls to determine if the file is executable. It seems quite
+    // a bit faster than calling path.metadata().
+    path.is_executable()
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/nu-completion/src/command.rs
+++ b/crates/nu-completion/src/command.rs
@@ -1,7 +1,7 @@
 use super::matchers::Matcher;
 use crate::{Completer, CompletionContext, Suggestion};
 use indexmap::set::IndexSet;
-#[cfg(windows)]
+#[cfg(feature = "is_executable")]
 use is_executable::IsExecutable;
 use nu_test_support::NATIVE_PATH_ENV_VAR;
 use std::iter::FromIterator;

--- a/crates/nu-completion/src/command.rs
+++ b/crates/nu-completion/src/command.rs
@@ -2,6 +2,7 @@ use super::matchers::Matcher;
 use crate::{Completer, CompletionContext, Suggestion};
 use indexmap::set::IndexSet;
 #[cfg(feature = "is_executable")]
+#[allow(unused)]
 use is_executable::IsExecutable;
 use nu_test_support::NATIVE_PATH_ENV_VAR;
 use std::iter::FromIterator;


### PR DESCRIPTION
This works by avoiding calling `path.metadata()` which is terribly slow.