### PR TITLE
make nu-cli mod app public

### DIFF
--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -4,7 +4,7 @@ extern crate quickcheck;
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
 
-mod app;
+pub mod app;
 mod cli;
 #[cfg(feature = "rustyline-support")]
 mod keybinding;


### PR DESCRIPTION
This enables a nice simple cli use case:
```rust
use nu_cli::{app::CliOptions, create_default_context};
use std::error::Error;

fn main() -> Result<(), Box<dyn Error>> {
    let options = CliOptions::new();
    let context = create_default_context(true)?;
    nu_cli::cli(context, options)?;
    Ok(())
}

```
