### PR TITLE
update filesize -> filesize math to fix coercion errors

### DIFF
--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -113,11 +113,21 @@ pub fn compute_values(
                 let result = match operator {
                     Operator::Plus => Ok(x + y),
                     Operator::Minus => Ok(x - y),
+                    Operator::Multiply => Ok(x * y),
+                    Operator::Divide => {
+                        if y.is_zero() {
+                            Err((left.type_name(), right.type_name()))
+                        } else {
+                            Ok(x / y)
+                        }
+                    }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
                 Ok(UntaggedValue::Primitive(Primitive::Filesize(result)))
             }
             (Primitive::Filesize(x), Primitive::Int(y)) => match operator {
+                Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Filesize(x + *y as u64))),
+                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Filesize(x - *y as u64))),
                 Operator::Multiply => {
                     Ok(UntaggedValue::Primitive(Primitive::Filesize(x * *y as u64)))
                 }
@@ -127,8 +137,13 @@ pub fn compute_values(
                 _ => Err((left.type_name(), right.type_name())),
             },
             (Primitive::Int(x), Primitive::Filesize(y)) => match operator {
+                Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 + y))),
+                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 - y))),
                 Operator::Multiply => {
                     Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 * y)))
+                }
+                Operator::Divide => {
+                    Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 / y)))
                 }
                 _ => Err((left.type_name(), right.type_name())),
             },

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -126,8 +126,8 @@ pub fn compute_values(
                 Ok(UntaggedValue::Primitive(Primitive::Filesize(result)))
             }
             (Primitive::Filesize(x), Primitive::Int(y)) => match operator {
-                Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Filesize(x + *y as u64))),
-                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Filesize(x - *y as u64))),
+                // Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Filesize(x + *y as u64))),
+                // Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Filesize(x - *y as u64))),
                 Operator::Multiply => {
                     Ok(UntaggedValue::Primitive(Primitive::Filesize(x * *y as u64)))
                 }
@@ -137,14 +137,14 @@ pub fn compute_values(
                 _ => Err((left.type_name(), right.type_name())),
             },
             (Primitive::Int(x), Primitive::Filesize(y)) => match operator {
-                Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 + y))),
-                Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 - y))),
+                // Operator::Plus => Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 + y))),
+                // Operator::Minus => Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 - y))),
                 Operator::Multiply => {
                     Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 * y)))
                 }
-                Operator::Divide => {
-                    Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 / y)))
-                }
+                // Operator::Divide => {
+                //     Ok(UntaggedValue::Primitive(Primitive::Filesize(*x as u64 / y)))
+                // }
                 _ => Err((left.type_name(), right.type_name())),
             },
             (Primitive::Int(x), Primitive::Int(y)) => match operator {


### PR DESCRIPTION
This change allows you to do things like this:
`ls | first | select name size | insert size2 { ls $it.name | get size } | insert ratio { $it.size / $it.size2 }`
or this:
`ls | first | select name size | insert size2 { (ls $it.name | get size) + 300 } | insert ratio { $it.size / $it.size2 }`
Discussion on Discord about how this works
https://discord.com/channels/601130461678272522/601130461678272524/857291675762950165
