### PR TITLE
Improve def parse errors

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1853,13 +1853,8 @@ fn parse_call(
     // Check if it's an internal command
     if let Some(signature) = scope.get_signature(&lite_cmd.parts[0].item) {
         if lite_cmd.parts[0].item == "def" {
-            let error = parse_definition(&lite_cmd, scope);
-            if error.is_some() {
-                return (
-                    Some(ClassifiedCommand::Expr(Box::new(garbage(lite_cmd.span())))),
-                    error,
-                );
-            }
+            let err = parse_definition(&lite_cmd, scope);
+            error = error.or(err);
         }
         let (mut internal_command, err) = parse_internal_command(&lite_cmd, scope, &signature, 0);
 

--- a/crates/nu-parser/src/parse/def.rs
+++ b/crates/nu-parser/src/parse/def.rs
@@ -8,7 +8,7 @@ use crate::{
 use indexmap::IndexMap;
 use nu_errors::ParseError;
 use nu_protocol::hir::Block;
-use nu_source::{HasSpan, SpannedItem};
+use nu_source::{HasSpan, Span, SpannedItem};
 
 //use crate::errors::{ParseError, ParseResult};
 use crate::lex::lexer::{lex, parse_block};
@@ -28,59 +28,100 @@ pub(crate) fn parse_definition(call: &LiteCommand, scope: &dyn ParserScope) -> O
     // So our main goal here is to parse the block now that the names and
     // prototypes of adjacent commands are also available
 
-    if call.parts.len() == 4 {
-        if call.parts[0].item != "def" {
-            return Some(ParseError::mismatch("definition", call.parts[0].clone()));
-        }
-
-        let name = trim_quotes(&call.parts[1].item);
-        let (mut signature, err) = parse_signature(&name, &call.parts[2]);
-
-        //Add commands comments to signature usage
-        signature.usage = call.comments_joined();
-
-        if err.is_some() {
-            return err;
-        };
-
-        let mut chars = call.parts[3].chars();
-        match (chars.next(), chars.next_back()) {
-            (Some('{'), Some('}')) => {
-                // We have a literal block
-                let string: String = chars.collect();
-
-                scope.enter_scope();
-
-                let (tokens, err) = lex(&string, call.parts[3].span.start() + 1);
-                if err.is_some() {
-                    return err;
-                };
-                let (lite_block, err) = parse_block(tokens);
-                if err.is_some() {
-                    return err;
-                };
-
-                let (mut block, err) = classify_block(&lite_block, scope);
-                scope.exit_scope();
-
-                if let Some(block) = std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block)
-                {
-                    block.params = signature;
-                    block.params.name = name;
-                }
-
-                scope.add_definition(block);
-
-                err
+    match call.parts.len() {
+        4 => {
+            if call.parts[0].item != "def" {
+                return Some(ParseError::mismatch("definition", call.parts[0].clone()));
             }
-            _ => Some(ParseError::mismatch("body", call.parts[3].clone())),
+
+            let name = trim_quotes(&call.parts[1].item);
+            let (mut signature, err) = parse_signature(&name, &call.parts[2]);
+
+            //Add commands comments to signature usage
+            signature.usage = call.comments_joined();
+
+            if err.is_some() {
+                return err;
+            };
+
+            let mut chars = call.parts[3].chars();
+            match (chars.next(), chars.next_back()) {
+                (Some('{'), Some('}')) => {
+                    // We have a literal block
+                    let string: String = chars.collect();
+
+                    scope.enter_scope();
+
+                    let (tokens, err) = lex(&string, call.parts[3].span.start() + 1);
+                    if err.is_some() {
+                        return err;
+                    };
+                    let (lite_block, err) = parse_block(tokens);
+                    if err.is_some() {
+                        return err;
+                    };
+
+                    let (mut block, err) = classify_block(&lite_block, scope);
+                    scope.exit_scope();
+
+                    if let Some(block) =
+                        std::sync::Arc::<nu_protocol::hir::Block>::get_mut(&mut block)
+                    {
+                        block.params = signature;
+                        block.params.name = name;
+                    }
+
+                    scope.add_definition(block);
+
+                    err
+                }
+                _ => Some(ParseError::mismatch("body", call.parts[3].clone())),
+            }
         }
-    } else {
-        Some(ParseError::internal_error(
-            "Wrong shape. Expected def name [signature] {body}."
+
+        3 => Some(ParseError::general_error(
+            "wrong shape. Expected: def name [signature] {body}",
+            "expected definition body".to_string().spanned(Span::new(
+                call.parts[2].span.end(),
+                call.parts[2].span.end(),
+            )),
+        )),
+        2 => Some(ParseError::general_error(
+            "wrong shape. Expected: def name [signature] {body}",
+            "expected definition parameters"
                 .to_string()
-                .spanned(call.span()),
-        ))
+                .spanned(Span::new(
+                    call.parts[1].span.end(),
+                    call.parts[1].span.end(),
+                )),
+        )),
+        1 => Some(ParseError::general_error(
+            "wrong shape. Expected: def name [signature] {body}",
+            "expected definition name".to_string().spanned(Span::new(
+                call.parts[0].span.end(),
+                call.parts[0].span.end(),
+            )),
+        )),
+        0 => Some(ParseError::general_error(
+            "wrong shape. Expected: def name [signature] {body}",
+            "expected 'def' keyword'".to_string().spanned(call.span()),
+        )),
+
+        x if x < 4 => Some(ParseError::general_error(
+            "wrong shape. Expected: def name [signature] {body}",
+            "expected: def name [signature] {body}"
+                .to_string()
+                .spanned(Span::new(
+                    call.parts[x - 1].span.end(),
+                    call.parts[x - 1].span.end(),
+                )),
+        )),
+        _ => Some(ParseError::general_error(
+            "extra arguments given. Expected: def name [signature] {body}.",
+            "extra argument given"
+                .to_string()
+                .spanned(call.parts[4].span()),
+        )),
     }
 }
 


### PR DESCRIPTION

![Screenshot from 2021-06-25 16-37-32](https://user-images.githubusercontent.com/547158/123370518-fd55b380-d5d3-11eb-9859-d41400ffe6de.png)


```
> def foo [] {bod} {}
error: extra arguments given. Expected: def name [signature] {body}.
  ┌─ shell:1:18
  │
1 │ def foo [] {bod} {}
  │                  ^^ extra argument given

> def foo [] {bod}
> def foo []
error: wrong shape. Expected: def name [signature] {body}
  ┌─ shell:3:11
  │
3 │ def foo []
  │           ^ expected definition body

> def foo
error: wrong shape. Expected: def name [signature] {body}
  ┌─ shell:4:8
  │
4 │ def foo
  │        ^ expected definition parameters

> def
error: wrong shape. Expected: def name [signature] {body}
  ┌─ shell:5:4
  │
5 │ def
  │    ^ expected definition name
```