### PR TITLE
Fix string interpolation is not working with external command

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -730,7 +730,9 @@ fn parse_external_arg(
     lite_arg: &Spanned<String>,
     scope: &dyn ParserScope,
 ) -> (SpannedExpression, Option<ParseError>) {
-    if lite_arg.item.starts_with('$') || lite_arg.item.starts_with('(') {
+    if lite_arg.item.starts_with('$') {
+        parse_dollar_expr(lite_arg, scope)
+    } else if lite_arg.item.starts_with('(') {
         parse_full_column_path(lite_arg, scope)
     } else {
         (

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -368,4 +368,25 @@ mod external_command_arguments {
             },
         )
     }
+
+    #[test]
+    fn string_interpolation_with_an_external_command() {
+        Playground::setup(
+            "string_interpolation_with_an_external_command",
+            |dirs, sandbox| {
+                sandbox.mkdir("cd");
+
+                sandbox.with_files(vec![EmptyFile("cd/jonathan_likes_cake.txt")]);
+
+                let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                    ^ls $"(pwd)/cd"
+                "#
+                ));
+
+                assert_eq!(actual.out, "jonathan_likes_cake.txt");
+            },
+        )
+    }
 }


### PR DESCRIPTION
Fixes #3668 

After #3642, command likes `^ls $"(pwd)"` stop working. This PR attempts to fix the problem by revert path of #3642 and still keep the behaviour the same (as least it passes the test, but there is potential case i missed).