### PR TITLE
default to remove to trash to be safer

### DIFF
--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -592,7 +592,7 @@ impl Shell for FilesystemShell {
         let rm_always_trash = nu_data::config::config(Tag::unknown())?
             .get("rm_always_trash")
             .map(|val| val.is_true())
-            .unwrap_or(false);
+            .unwrap_or(true);
 
         #[cfg(not(feature = "trash-support"))]
         {


### PR DESCRIPTION
this change just makes the rm command default to remove to trashcan, assuming the trashcan support is enabled. this was a survey request from a few months ago.