### PR TITLE
port network url to engine-p

### DIFF
--- a/crates/nu-command/src/commands/network/url_/command.rs
+++ b/crates/nu-command/src/commands/network/url_/command.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{ReturnSuccess, Signature, UntaggedValue};
+use nu_protocol::{Signature, UntaggedValue};
 
 pub struct Url;
 
@@ -18,10 +18,10 @@ impl WholeStreamCommand for Url {
         "Apply url function."
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
-        Ok(ActionStream::one(ReturnSuccess::value(
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        Ok(OutputStream::one(
             UntaggedValue::string(get_full_help(&Url, args.scope())).into_value(Tag::unknown()),
-        )))
+        ))
     }
 }
 

--- a/crates/nu-command/src/commands/network/url_/host.rs
+++ b/crates/nu-command/src/commands/network/url_/host.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for UrlHost {
         "gets the host of a url"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let rest: Vec<ColumnPath> = args.rest(0)?;
         let input = args.input;
 

--- a/crates/nu-command/src/commands/network/url_/mod.rs
+++ b/crates/nu-command/src/commands/network/url_/mod.rs
@@ -6,7 +6,7 @@ mod scheme;
 
 use crate::prelude::*;
 use nu_errors::ShellError;
-use nu_protocol::{ColumnPath, Primitive, ReturnSuccess, ShellTypeName, UntaggedValue, Value};
+use nu_protocol::{ColumnPath, Primitive, ShellTypeName, UntaggedValue, Value};
 use url::Url;
 
 pub use command::Url as UrlCommand;
@@ -37,14 +37,14 @@ where
     Ok(v)
 }
 
-fn operate<F>(input: crate::InputStream, paths: Vec<ColumnPath>, action: &'static F) -> ActionStream
+fn operate<F>(input: crate::InputStream, paths: Vec<ColumnPath>, action: &'static F) -> OutputStream
 where
     F: Fn(&Url) -> &str + Send + Sync + 'static,
 {
     input
         .map(move |v| {
             if paths.is_empty() {
-                ReturnSuccess::value(handle_value(&action, &v)?)
+                handle_value(&action, &v)
             } else {
                 let mut ret = v;
 
@@ -55,8 +55,8 @@ where
                     )?;
                 }
 
-                ReturnSuccess::value(ret)
+                Ok(ret)
             }
         })
-        .into_action_stream()
+        .into_input_stream()
 }

--- a/crates/nu-command/src/commands/network/url_/path.rs
+++ b/crates/nu-command/src/commands/network/url_/path.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for UrlPath {
         "gets the path of a url"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let rest: Vec<ColumnPath> = args.rest(0)?;
         let input = args.input;
 

--- a/crates/nu-command/src/commands/network/url_/query.rs
+++ b/crates/nu-command/src/commands/network/url_/query.rs
@@ -22,7 +22,7 @@ impl WholeStreamCommand for UrlQuery {
         "gets the query of a url"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let rest: Vec<ColumnPath> = args.rest(0)?;
         let input = args.input;
         Ok(operate(input, rest, &query))

--- a/crates/nu-command/src/commands/network/url_/scheme.rs
+++ b/crates/nu-command/src/commands/network/url_/scheme.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for UrlScheme {
         "gets the scheme (eg http, file) of a url"
     }
 
-    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let rest: Vec<ColumnPath> = args.rest(0)?;
         Ok(operate(args.input, rest, &Url::scheme))
     }


### PR DESCRIPTION
migrate network URL related commands to engine-p.

Part of #3390.