### PR TITLE
Add paste command

### DIFF
--- a/crates/nu-command/src/commands/platform/mod.rs
+++ b/crates/nu-command/src/commands/platform/mod.rs
@@ -3,11 +3,11 @@ mod benchmark;
 mod clear;
 #[cfg(feature = "clipboard-cli")]
 mod clip;
-#[cfg(feature = "clipboard-cli")]
-mod paste;
 mod du;
 mod exec;
 mod kill;
+#[cfg(feature = "clipboard-cli")]
+mod paste;
 mod pwd;
 mod run_external;
 mod sleep;
@@ -19,11 +19,11 @@ pub use benchmark::Benchmark;
 pub use clear::Clear;
 #[cfg(feature = "clipboard-cli")]
 pub use clip::Clip;
-#[cfg(feature = "clipboard-cli")]
-pub use paste::Paste;
 pub use du::Du;
 pub use exec::Exec;
 pub use kill::Kill;
+#[cfg(feature = "clipboard-cli")]
+pub use paste::Paste;
 pub use pwd::Pwd;
 pub use run_external::RunExternalCommand;
 pub use sleep::Sleep;

--- a/crates/nu-command/src/commands/platform/mod.rs
+++ b/crates/nu-command/src/commands/platform/mod.rs
@@ -3,6 +3,8 @@ mod benchmark;
 mod clear;
 #[cfg(feature = "clipboard-cli")]
 mod clip;
+#[cfg(feature = "clipboard-cli")]
+mod paste;
 mod du;
 mod exec;
 mod kill;
@@ -17,6 +19,8 @@ pub use benchmark::Benchmark;
 pub use clear::Clear;
 #[cfg(feature = "clipboard-cli")]
 pub use clip::Clip;
+#[cfg(feature = "clipboard-cli")]
+pub use paste::Paste;
 pub use du::Du;
 pub use exec::Exec;
 pub use kill::Kill;

--- a/crates/nu-command/src/commands/platform/paste.rs
+++ b/crates/nu-command/src/commands/platform/paste.rs
@@ -24,6 +24,17 @@ impl WholeStreamCommand for Paste {
     fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
         paste(args)
     }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Paste text from your clipboard",
+            example: "echo 'secret value' | clip | paste",
+            result: Some(vec![UntaggedValue::Primitive(Primitive::String(
+                "secret value".to_owned(),
+            ))
+            .into_value(Tag::default())]),
+        }]
+    }
 }
 
 pub fn paste(args: CommandArgs) -> Result<ActionStream, ShellError> {
@@ -46,5 +57,18 @@ pub fn paste(args: CommandArgs) -> Result<ActionStream, ShellError> {
             "could not open clipboard",
             name,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Paste;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        test_examples(Paste {})
     }
 }

--- a/crates/nu-command/src/commands/platform/paste.rs
+++ b/crates/nu-command/src/commands/platform/paste.rs
@@ -1,0 +1,52 @@
+use crate::prelude::*;
+
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{Signature, UntaggedValue, Primitive};
+
+use arboard::Clipboard;
+
+pub struct Paste;
+
+impl WholeStreamCommand for Paste {
+    fn name(&self) -> &str {
+        "paste"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("paste")
+    }
+
+    fn usage(&self) -> &str {
+        "Paste contents from the clipboard"
+    }
+
+    fn run_with_actions(&self, args: CommandArgs) -> Result<ActionStream, ShellError> {
+        paste(args)
+    }
+}
+
+pub fn paste(args: CommandArgs) -> Result<ActionStream, ShellError> {
+    let name = args.call_info.name_tag;
+
+    if let Ok(mut clip_context) = Clipboard::new() {
+        match clip_context.get_text() {
+            Ok(out) => Ok(ActionStream::one(
+                UntaggedValue::Primitive(
+                    Primitive::String(out)
+                )   
+            )),
+            Err(_) => Err(ShellError::labeled_error(
+                "Could not get contents of clipboard",
+                "could not get contents of clipboard",
+                name,
+            ))
+        }
+    } else {
+        Err(ShellError::labeled_error(
+            "Could not open clipboard",
+            "could not open clipboard",
+            name,
+        ))
+    }
+}

--- a/crates/nu-command/src/commands/platform/paste.rs
+++ b/crates/nu-command/src/commands/platform/paste.rs
@@ -59,16 +59,3 @@ pub fn paste(args: CommandArgs) -> Result<ActionStream, ShellError> {
         ))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::Paste;
-    use super::ShellError;
-
-    #[test]
-    fn examples_work_as_expected() -> Result<(), ShellError> {
-        use crate::examples::test as test_examples;
-
-        test_examples(Paste {})
-    }
-}

--- a/crates/nu-command/src/commands/platform/paste.rs
+++ b/crates/nu-command/src/commands/platform/paste.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Signature, UntaggedValue, Primitive};
+use nu_protocol::{Primitive, ReturnSuccess, Signature, UntaggedValue};
 
 use arboard::Clipboard;
 
@@ -31,16 +31,14 @@ pub fn paste(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     if let Ok(mut clip_context) = Clipboard::new() {
         match clip_context.get_text() {
-            Ok(out) => Ok(ActionStream::one(
-                UntaggedValue::Primitive(
-                    Primitive::String(out)
-                )   
-            )),
+            Ok(out) => Ok(ActionStream::one(ReturnSuccess::value(
+                UntaggedValue::Primitive(Primitive::String(out)),
+            ))),
             Err(_) => Err(ShellError::labeled_error(
                 "Could not get contents of clipboard",
                 "could not get contents of clipboard",
                 name,
-            ))
+            )),
         }
     } else {
         Err(ShellError::labeled_error(

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -320,7 +320,10 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
 
         #[cfg(feature = "clipboard-cli")]
         {
-            context.add_commands(vec![whole_stream_command(crate::commands::Clip)]);
+            context.add_commands(vec![
+                whole_stream_command(crate::commands::Clip),
+                whole_stream_command(crate::commands::Paste)
+            ]);
         }
     }
 

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -322,7 +322,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
         {
             context.add_commands(vec![
                 whole_stream_command(crate::commands::Clip),
-                whole_stream_command(crate::commands::Paste)
+                whole_stream_command(crate::commands::Paste),
             ]);
         }
     }

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -17,8 +17,8 @@ use nu_source::AnchorLocation;
 #[cfg(feature = "clipboard-cli")]
 use crate::commands::Clip;
 use crate::commands::{
-    Append, BuildString, Clip, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth,
-    Select, StrCollect, Wrap,
+    Append, BuildString, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth, Select,
+    StrCollect, Wrap,
 };
 use nu_engine::{run_block, whole_stream_command, Command, EvaluationContext, WholeStreamCommand};
 use nu_stream::InputStream;

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -18,6 +18,8 @@ use crate::commands::{
     Append, BuildString, Clip, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth,
     Select, StrCollect, Wrap,
 };
+#[cfg(feature = "clipboard-cli")]
+use crate::commands::Clip;
 use nu_engine::{run_block, whole_stream_command, Command, EvaluationContext, WholeStreamCommand};
 use nu_stream::InputStream;
 

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -14,8 +14,6 @@ use nu_protocol::hir::{ClassifiedBlock, ExternalRedirection};
 use nu_protocol::{ShellTypeName, Value};
 use nu_source::AnchorLocation;
 
-#[cfg(feature = "clipboard-cli")]
-use crate::commands::Clip;
 use crate::commands::{
     Append, BuildString, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth, Select,
     StrCollect, Wrap,
@@ -105,8 +103,6 @@ pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
         whole_stream_command(Select),
         whole_stream_command(StrCollect),
         whole_stream_command(Wrap),
-        #[cfg(feature = "clipboard-cli")]
-        whole_stream_command(Clip),
     ]);
 
     for sample_pipeline in examples {

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -17,6 +17,7 @@ use nu_source::AnchorLocation;
 use crate::commands::{
     Append, BuildString, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth, Select,
     StrCollect, Wrap,
+    Clip,
 };
 use nu_engine::{run_block, whole_stream_command, Command, EvaluationContext, WholeStreamCommand};
 use nu_stream::InputStream;
@@ -103,6 +104,8 @@ pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
         whole_stream_command(Select),
         whole_stream_command(StrCollect),
         whole_stream_command(Wrap),
+        #[cfg(feature = "clipboard-cli")]
+        whole_stream_command(Clip),
     ]);
 
     for sample_pipeline in examples {

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -14,12 +14,12 @@ use nu_protocol::hir::{ClassifiedBlock, ExternalRedirection};
 use nu_protocol::{ShellTypeName, Value};
 use nu_source::AnchorLocation;
 
+#[cfg(feature = "clipboard-cli")]
+use crate::commands::Clip;
 use crate::commands::{
     Append, BuildString, Clip, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth,
     Select, StrCollect, Wrap,
 };
-#[cfg(feature = "clipboard-cli")]
-use crate::commands::Clip;
 use nu_engine::{run_block, whole_stream_command, Command, EvaluationContext, WholeStreamCommand};
 use nu_stream::InputStream;
 

--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -15,9 +15,8 @@ use nu_protocol::{ShellTypeName, Value};
 use nu_source::AnchorLocation;
 
 use crate::commands::{
-    Append, BuildString, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth, Select,
-    StrCollect, Wrap,
-    Clip,
+    Append, BuildString, Clip, Each, Echo, First, Get, Keep, Last, Let, Math, MathMode, Nth,
+    Select, StrCollect, Wrap,
 };
 use nu_engine::{run_block, whole_stream_command, Command, EvaluationContext, WholeStreamCommand};
 use nu_stream::InputStream;


### PR DESCRIPTION
This PR adds a `paste` command that lets you paste the contents of the clipboard.

Fixes #1690 

Test Plan:
Run this inside of nushell
```
$ echo "secret value" | clip | paste
```
Output:
```
$ secret value
```