### PR TITLE
Submit package to winget during release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,8 @@ jobs:
       - linux
       - macos
       - windows
+    outputs:
+      version: ${{ steps.info.outputs.version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -284,3 +286,18 @@ jobs:
           asset_path: ./nushell-windows.msi
           asset_name: ${{ steps.info.outputs.windowsdir }}.msi
           asset_content_type: applictaion/x-msi
+
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    needs: release
+    steps:
+      - name: Submit package to Windows Package Manager Community Repository
+        run: |
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $nushellVersion="${{ needs.release.outputs.version }}"
+          $nushellInstallerName="nu_$($nushellVersion -replace '\.','_')_windows.msi"
+          $installerUrl = "https://github.com/nushell/nushell/releases/download/$nushellVersion/$nushellInstallerName"
+          .\wingetcreate.exe update Nushell.Nushell -v $nushellVersion -u $installerUrl -t ${{ secrets.NUSHELL_PAT }}
+    
+    


### PR DESCRIPTION
Add a new job winget in release.yaml that uses wingetcreate to submit package.

The release uses a PAT that needs to be created by a maintainer of the project and added as a secret to the project in order to be able to submit a PR to the winget packages comunity repository. PAT can be generated from "settings/developer settings/ personal app tokens"  and needs to have the scope public_repo. The value of the generated token must then be copied into a secret "NUSHELL_PAT" of the nushell repository in "Settings/Secrets". We can change this name if needed but we will have to change the name in the github action if we do so.

This PR is linked to #3705 and #1859 