### PR TITLE
nu-cli ctrl-c feature support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,6 +3309,7 @@ dependencies = [
 name = "nu-cli"
 version = "0.33.1"
 dependencies = [
+ "ctrlc",
  "indexmap",
  "log 0.4.14",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rstest = "0.10.0"
 [build-dependencies]
 
 [features]
-ctrlc-support = ["nu-command/ctrlc"]
+ctrlc-support = ["nu-cli/ctrlc", "nu-command/ctrlc"]
 ptree-support = ["nu-command/ptree"]
 rustyline-support = ["nu-cli/rustyline-support", "nu-command/rustyline-support"]
 term-support = ["nu-command/term"]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4.14"
 pretty_env_logger = "0.4.0"
 strip-ansi-escapes = "0.1.0"
 rustyline = { version="8.1.0", optional=true }
+ctrlc = { version="3.1.7", optional=true }
 shadow-rs = { version="0.5", default-features=false, optional=true }
 serde = { version="1.0.123", features=["derive"] }
 serde_yaml = "0.8.16"

--- a/crates/nu-command/src/commands/core_commands/version.rs
+++ b/crates/nu-command/src/commands/core_commands/version.rs
@@ -184,6 +184,8 @@ pub fn version(args: CommandArgs) -> Result<OutputStream, ShellError> {
 fn features_enabled() -> Vec<String> {
     let mut names = vec!["default".to_string()];
 
+    // NOTE: There should be another way to know
+    // features on.
     #[cfg(feature = "ctrlc")]
     {
         names.push("ctrlc".to_string());


### PR DESCRIPTION
Seems we do `ctrl` feature checks in `nu-cli` and `nu-command`. We should find a better way to report the enabled features un the `version` command without using the conditionals (or somewhere else)