### PR TITLE
move `lang` command to `$nu`

### DIFF
--- a/crates/nu-command/src/commands/platform/mod.rs
+++ b/crates/nu-command/src/commands/platform/mod.rs
@@ -6,7 +6,6 @@ mod clip;
 mod du;
 mod exec;
 mod kill;
-mod lang;
 #[cfg(feature = "clipboard-cli")]
 mod paste;
 mod pwd;
@@ -23,7 +22,6 @@ pub use clip::Clip;
 pub use du::Du;
 pub use exec::Exec;
 pub use kill::Kill;
-pub use lang::Lang;
 #[cfg(feature = "clipboard-cli")]
 pub use paste::Paste;
 pub use pwd::Pwd;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -69,7 +69,6 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(Benchmark),
             // Metadata
             whole_stream_command(Tags),
-            whole_stream_command(Lang),
             // Shells
             whole_stream_command(Next),
             whole_stream_command(Previous),

--- a/crates/nu-engine/src/evaluate/mod.rs
+++ b/crates/nu-engine/src/evaluate/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod evaluate_args;
 pub mod evaluator;
 pub(crate) mod expr;
 pub mod internal;
+pub(crate) mod lang;
 pub(crate) mod operator;
 pub(crate) mod scope;
 pub(crate) mod variables;

--- a/crates/nu-engine/src/evaluate/variables.rs
+++ b/crates/nu-engine/src/evaluate/variables.rs
@@ -1,4 +1,7 @@
-use crate::{evaluate::scope::Scope, EvaluationContext};
+use crate::{
+    evaluate::{lang, scope::Scope},
+    EvaluationContext,
+};
 use indexmap::IndexMap;
 use nu_data::config::path::{default_history_path, history_path};
 use nu_errors::ShellError;
@@ -86,6 +89,12 @@ pub fn nu(scope: &Scope, ctx: &EvaluationContext) -> Result<Value, ShellError> {
             "keybinding-path",
             UntaggedValue::filepath(keybinding_path).into_value(&tag),
         );
+    }
+
+    let cmd_info = lang::Lang::query_commands(scope);
+    match cmd_info {
+        Ok(cmds) => nu_dict.insert_value("lang", UntaggedValue::table(&cmds).into_value(&tag)),
+        Err(_) => nu_dict.insert_value("lang", UntaggedValue::string("no commands found")),
     }
 
     Ok(nu_dict.into_value())


### PR DESCRIPTION
This moves the `lang` command into the `$nu` variable.
![image](https://user-images.githubusercontent.com/343840/124155272-eee81b80-da5b-11eb-9216-d5ef18c63765.png)
