### PR TITLE
Bump rand version used by nu-command to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
  "quick-xml 0.21.0",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.7.3",
+ "rand 0.8.4",
  "rayon",
  "regex 1.5.4",
  "roxmltree",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -69,7 +69,7 @@ pin-utils = "0.1.0"
 ptree = { version="0.3.1", optional=true }
 query_interface = "0.3.5"
 quick-xml = "0.21.0"
-rand = "0.7.3"
+rand = "0.8"
 rayon = "1.5.0"
 regex = "1.4.3"
 roxmltree = "0.14.0"

--- a/crates/nu-command/src/commands/platform/benchmark.rs
+++ b/crates/nu-command/src/commands/platform/benchmark.rs
@@ -12,8 +12,8 @@ use nu_protocol::{
     Dictionary, Signature, SyntaxShape, UntaggedValue, Value,
 };
 use rand::{
-    distributions::Alphanumeric,
-    prelude::{thread_rng, Rng},
+    distributions::{Alphanumeric, Distribution},
+    thread_rng, Rng,
 };
 use std::time::Instant;
 
@@ -206,8 +206,12 @@ fn add_implicit_autoview(mut block: Arc<Block>) -> Arc<Block> {
 
 fn generate_random_env_value() -> String {
     let mut thread_rng = thread_rng();
-    let len = thread_rng.gen_range(1, 16 * 1024);
-    thread_rng.sample_iter(&Alphanumeric).take(len).collect()
+    let len = thread_rng.gen_range(1..16 * 1024);
+    Alphanumeric
+        .sample_iter(&mut thread_rng)
+        .take(len)
+        .map(char::from)
+        .collect()
 }
 
 fn generate_free_name(env: &indexmap::IndexMap<String, String>) -> String {

--- a/crates/nu-command/src/commands/random/chars.rs
+++ b/crates/nu-command/src/commands/random/chars.rs
@@ -3,8 +3,8 @@ use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
-use rand::distributions::Alphanumeric;
-use rand::prelude::{thread_rng, Rng};
+use rand::distributions::{Alphanumeric, Distribution};
+use rand::thread_rng;
 
 pub struct SubCommand;
 
@@ -58,10 +58,12 @@ pub fn chars(args: CommandArgs) -> Result<OutputStream, ShellError> {
     };
 
     let chars_length = cmd_args.length.map_or(DEFAULT_CHARS_LENGTH, |l| l.item);
+    let mut rng = thread_rng();
 
-    let random_string: String = thread_rng()
-        .sample_iter(&Alphanumeric)
+    let random_string: String = Alphanumeric
+        .sample_iter(&mut rng)
         .take(chars_length as usize)
+        .map(char::from)
         .collect();
 
     Ok(OutputStream::one(UntaggedValue::string(random_string)))

--- a/crates/nu-command/src/commands/random/decimal.rs
+++ b/crates/nu-command/src/commands/random/decimal.rs
@@ -81,7 +81,7 @@ pub fn decimal(args: CommandArgs) -> Result<OutputStream, ShellError> {
         ))),
         _ => {
             let mut thread_rng = thread_rng();
-            let result: f64 = thread_rng.gen_range(min, max);
+            let result: f64 = thread_rng.gen_range(min..max);
 
             Ok(OutputStream::one(UntaggedValue::decimal_from_float(
                 result,

--- a/crates/nu-command/src/commands/random/dice.rs
+++ b/crates/nu-command/src/commands/random/dice.rs
@@ -79,7 +79,7 @@ pub fn dice(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let iter = (0..dice).map(move |_| {
         let mut thread_rng = thread_rng();
-        UntaggedValue::int(thread_rng.gen_range(1, sides + 1)).into_value(tag.clone())
+        UntaggedValue::int(thread_rng.gen_range(1..sides + 1)).into_value(tag.clone())
     });
 
     Ok((iter).into_output_stream())

--- a/crates/nu-command/src/commands/random/integer.rs
+++ b/crates/nu-command/src/commands/random/integer.rs
@@ -82,7 +82,7 @@ pub fn integer(args: CommandArgs) -> Result<OutputStream, ShellError> {
             let mut thread_rng = thread_rng();
             // add 1 to max, because gen_range is right-exclusive
             let max = max.saturating_add(1);
-            let result: i64 = thread_rng.gen_range(min, max);
+            let result: i64 = thread_rng.gen_range(min..max);
 
             Ok(OutputStream::one(
                 UntaggedValue::int(result).into_value(Tag::unknown()),


### PR DESCRIPTION
I noticed a lot of different `rand` version dependencies, keeping the project itself
at the latest might help to cut down that number when dependencies also upgrade.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>