### PR TITLE
Remove empty `trace` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,6 @@ extra = [
 
 wasi = ["inc", "match", "ptree-support", "match", "tree", "rustyline-support"]
 
-trace = ["nu-parser/trace"]
-
 # Stable (Default)
 fetch = ["nu_plugin_fetch"]
 inc = ["nu_plugin_inc"]

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -28,4 +28,3 @@ nu-test-support = { version="0.33.1", path="../nu-test-support" }
 
 [features]
 stable = []
-trace = []

--- a/crates/nu-stream/Cargo.toml
+++ b/crates/nu-stream/Cargo.toml
@@ -15,4 +15,3 @@ futures = { version="0.3.12", features=["compat", "io-compat"] }
 
 [features]
 stable = []
-trace = []


### PR DESCRIPTION
In `nu-parser`, this was a relic of when nom was used by the parser
and it would enable using `nom-tracable`.