### PR TITLE
Update minus, tui to remove crossterm 0.18 dep.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,22 +1115,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e86d73f2a0b407b5768d10a8c720cf5d2df49a9efc10ca09176d201ead4b7fb"
-dependencies = [
- "bitflags",
- "crossterm_winapi 0.6.2",
- "lazy_static 1.4.0",
- "libc",
- "mio 0.7.13",
- "parking_lot 0.11.1",
- "signal-hook 0.1.17",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c"
@@ -1158,15 +1142,6 @@ dependencies = [
  "parking_lot 0.11.1",
  "signal-hook 0.3.9",
  "signal-hook-mio",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db"
-dependencies = [
  "winapi 0.3.9",
 ]
 
@@ -6861,13 +6836,13 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tui"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ced152a8e9295a5b168adc254074525c17ac4a83c90b2716274cc38118bddc9"
+checksum = "861d8f3ad314ede6219bcb2ab844054b1de279ee37a9bc38e3d606f9d3fb2a71"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.18.2",
+ "crossterm 0.19.0",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -60,7 +60,7 @@ lazy_static = "1.*"
 log = "0.4.14"
 md5 = "0.7.0"
 meval = "0.2.0"
-minus = { version="3.3.0", optional=true, features=["async_std_lib", "search"] }
+minus = { version="3.4.0", optional=true, features=["async_std_lib", "search"] }
 num-bigint = { version="0.3.1", features=["serde"] }
 num-format = { version="0.4.0", features=["with-num-bigint"] }
 num-traits = "0.2.14"

--- a/crates/nu_plugin_chart/Cargo.toml
+++ b/crates/nu_plugin_chart/Cargo.toml
@@ -18,4 +18,4 @@ nu-source = { path="../nu-source", version="0.33.1" }
 nu-value-ext = { path="../nu-value-ext", version="0.33.1" }
 
 crossterm = "0.19.0"
-tui = { version="0.14.0", default-features=false, features=["crossterm"] }
+tui = { version="0.15.0", default-features=false, features=["crossterm"] }

--- a/crates/nu_plugin_chart/src/bar.rs
+++ b/crates/nu_plugin_chart/src/bar.rs
@@ -108,7 +108,8 @@ impl<'a> Bar<'a> {
                 );
 
             f.render_widget(barchart, chunks[0]);
-        })
+        })?;
+        Ok(())
     }
 
     pub fn on_right(&mut self) {

--- a/crates/nu_plugin_chart/src/line.rs
+++ b/crates/nu_plugin_chart/src/line.rs
@@ -140,6 +140,7 @@ impl<'a> Line<'a> {
                         .bounds(self.y_range),
                 );
             f.render_widget(chart, chunks[0]);
-        })
+        })?;
+        Ok(())
     }
 }


### PR DESCRIPTION
We already depend on crossterm 0.19 (and 0.20), so we can at least
remove the usage of 0.18 by updating minus and tui.