### PR TITLE
Remove ptree dep from nu-command, remove associated feature.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ Run `version | pivot` and paste the output to show OS, features, etc.
 │ 4 │ pkg_version        │ 0.24.1                                                                │
 │ 5 │ build_time         │ 2020-12-18 09:54:09                                                   │
 │ 6 │ build_rust_channel │ release                                                               │
-│ 7 │ features           │ ctrlc, default, directories, dirs, git, ichwh, ptree, rich-benchmark, │
+│ 7 │ features           │ ctrlc, default, directories, dirs, git, ichwh, rich-benchmark,        │
 │   │                    │ rustyline, term, uuid, which, zip                                     │
 ╰───┴────────────────────┴───────────────────────────────────────────────────────────────────────╯
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,6 @@ dependencies = [
  "parking_lot 0.11.1",
  "pin-utils",
  "polars",
- "ptree",
  "query_interface",
  "quick-xml 0.22.0",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ rstest = "0.10.0"
 
 [features]
 ctrlc-support = ["nu-cli/ctrlc", "nu-command/ctrlc"]
-ptree-support = ["nu-command/ptree"]
 rustyline-support = ["nu-cli/rustyline-support", "nu-command/rustyline-support"]
 term-support = ["nu-command/term"]
 uuid-support = ["nu-command/uuid_crate"]
@@ -96,7 +95,6 @@ extra = [
     "binaryview",
     "inc",
     "tree",
-    "ptree-support",
     "textview",
     "clipboard-cli",
     "trash-support",
@@ -111,7 +109,7 @@ extra = [
     "query-json",
 ]
 
-wasi = ["inc", "match", "ptree-support", "match", "tree", "rustyline-support"]
+wasi = ["inc", "match", "match", "tree", "rustyline-support"]
 
 # Stable (Default)
 fetch = ["nu_plugin_fetch"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -66,7 +66,6 @@ num-format = { version="0.4.0", features=["with-num-bigint"] }
 num-traits = "0.2.14"
 parking_lot = "0.11.1"
 pin-utils = "0.1.0"
-ptree = { version="0.3.1", optional=true }
 query_interface = "0.3.5"
 quick-xml = "0.22"
 rand = "0.8"

--- a/crates/nu-command/src/commands/core_commands/version.rs
+++ b/crates/nu-command/src/commands/core_commands/version.rs
@@ -191,11 +191,6 @@ fn features_enabled() -> Vec<String> {
         names.push("ctrlc".to_string());
     }
 
-    #[cfg(feature = "ptree")]
-    {
-        names.push("ptree".to_string());
-    }
-
     // #[cfg(feature = "rich-benchmark")]
     // {
     //     names.push("rich-benchmark".to_string());


### PR DESCRIPTION
Nothing used the `ptree` feature or optional dependency within
`nu-command` except to include it within the `version` output. This
may be related to when `nu-cli` also had a `ptree` feature, but
I'm not sure.

That leaves the code within `nu_plugin_tree` as the sole remaining
user of `ptree`, which is already covered by the feature `tree`
and included in the `version` output.