### PR TITLE
^ls doesn't exist on windows

### DIFF
--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -380,6 +380,7 @@ mod external_command_arguments {
         )
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn string_interpolation_with_an_external_command() {
         Playground::setup(


### PR DESCRIPTION
`ls` doesn't exist on windows so this test fails.