### PR TITLE
Update wasm sample gitignore for node_modules.

### DIFF
--- a/samples/wasm/.gitignore
+++ b/samples/wasm/.gitignore
@@ -2,5 +2,6 @@
 **/*.rs.bk
 Cargo.lock
 bin/
+node_modules
 pkg/
 wasm-pack.log


### PR DESCRIPTION
When building the wasm sample in the way that it is built in CI,
a `node_modules` directory is populated.