### PR TITLE
#3385: Add unique option for uniq command

### DIFF
--- a/crates/nu-command/src/commands/filters/uniq.rs
+++ b/crates/nu-command/src/commands/filters/uniq.rs
@@ -23,6 +23,7 @@ impl WholeStreamCommand for Uniq {
                 "Ignore differences in case when comparing",
                 Some('i'),
             )
+            .switch("unique", "Only print unique lines", Some('u'))
     }
 
     fn usage(&self) -> &str {
@@ -48,6 +49,11 @@ impl WholeStreamCommand for Uniq {
                 description: "Only print duplicate lines, one for each group",
                 example: "echo [1 2 2] | uniq -d",
                 result: Some(vec![UntaggedValue::int(2).into()]),
+            },
+            Example {
+                description: "Only print unique lines lines",
+                example: "echo [1 2 2] | uniq -u",
+                result: Some(vec![UntaggedValue::int(1).into()]),
             },
             Example {
                 description: "Ignore differences in case when comparing",
@@ -95,6 +101,7 @@ fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
     let should_show_count = args.has_flag("count");
     let show_repeated = args.has_flag("repeated");
     let ignore_case = args.has_flag("ignore-case");
+    let only_uniques = args.has_flag("unique");
     let input = args.input;
     let uniq_values = {
         let mut counter = IndexMap::<nu_protocol::Value, usize>::new();
@@ -109,13 +116,17 @@ fn uniq(args: CommandArgs) -> Result<ActionStream, ShellError> {
         counter
     };
 
-    let mut values_vec_deque = VecDeque::new();
-
-    let values = if show_repeated {
+    let mut values = if show_repeated {
         uniq_values.into_iter().filter(|i| i.1 > 1).collect::<_>()
     } else {
         uniq_values
     };
+
+    if only_uniques {
+        values = values.into_iter().filter(|i| i.1 == 1).collect::<_>();
+    }
+
+    let mut values_vec_deque = VecDeque::new();
 
     if should_show_count {
         for item in values {

--- a/crates/nu-command/src/commands/filters/uniq.rs
+++ b/crates/nu-command/src/commands/filters/uniq.rs
@@ -23,7 +23,7 @@ impl WholeStreamCommand for Uniq {
                 "Ignore differences in case when comparing",
                 Some('i'),
             )
-            .switch("unique", "Only print unique lines", Some('u'))
+            .switch("unique", "Only return unique values", Some('u'))
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -171,6 +171,26 @@ fn uniq_counting() {
 }
 
 #[test]
+fn uniq_unique() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            echo [1 2 3 4 1 5]
+            | uniq --unique
+        "#
+    ));
+    let expected = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        echo [2 3 4 5]
+        "#
+    ));
+    print!("{}", actual.out);
+    print!("{}", expected.out);
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
 fn uniq_simple_vals_ints() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(


### PR DESCRIPTION
Added option --unique (-u) to the command uniq

I tried to mimic the GNU's `uniq -u` behavior
Fixes #3385