### PR TITLE
Into binary changes

### DIFF
--- a/crates/nu-command/src/commands/conversions/into/binary.rs
+++ b/crates/nu-command/src/commands/conversions/into/binary.rs
@@ -12,23 +12,10 @@ impl WholeStreamCommand for SubCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("into binary")
-            .rest(
-                SyntaxShape::ColumnPath,
-                "column paths to convert to binary (for table input)",
-            )
-            .named(
-                "skip",
-                SyntaxShape::Int,
-                "skip x number of bytes",
-                Some('s'),
-            )
-            .named(
-                "bytes",
-                SyntaxShape::Int,
-                "show y number of bytes",
-                Some('b'),
-            )
+        Signature::build("into binary").rest(
+            SyntaxShape::ColumnPath,
+            "column paths to convert to binary (for table input)",
+        )
     }
 
     fn usage(&self) -> &str {
@@ -54,42 +41,20 @@ impl WholeStreamCommand for SubCommand {
                 .into()]),
             },
             Example {
-                description: "convert string to a nushell binary primitive",
-                example:
-                    "echo 'This is a string that is exactly 52 characters long.' | into binary --skip 10",
-                result: Some(vec![UntaggedValue::binary(
-                    "string that is exactly 52 characters long."
-                        .to_string()
-                        .as_bytes()
-                        .to_vec(),
-                )
-                .into()]),
-            },
-            Example {
-                description: "convert string to a nushell binary primitive",
-                example:
-                    "echo 'This is a string that is exactly 52 characters long.' | into binary --skip 10 --bytes 10",
-                result: Some(vec![UntaggedValue::binary(
-                    "string tha"
-                        .to_string()
-                        .as_bytes()
-                        .to_vec(),
-                )
-                .into()]),
-            },
-            Example {
                 description: "convert a number to a nushell binary primitive",
                 example: "echo 1 | into binary",
-                result: Some(vec![
-                    UntaggedValue::binary(i64::from(1).to_le_bytes().to_vec()).into()
-                ]),
+                result: Some(vec![UntaggedValue::binary(
+                    i64::from(1).to_le_bytes().to_vec(),
+                )
+                .into()]),
             },
             Example {
                 description: "convert a boolean to a nushell binary primitive",
                 example: "echo $true | into binary",
-                result: Some(vec![
-                    UntaggedValue::binary(i64::from(1).to_le_bytes().to_vec()).into()
-                ]),
+                result: Some(vec![UntaggedValue::binary(
+                    i64::from(1).to_le_bytes().to_vec(),
+                )
+                .into()]),
             },
             Example {
                 description: "convert a filesize to a nushell binary primitive",
@@ -113,38 +78,19 @@ impl WholeStreamCommand for SubCommand {
 }
 
 fn into_binary(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let skip: Option<Value> = args.get_flag("skip")?;
-    let bytes: Option<Value> = args.get_flag("bytes")?;
     let column_paths: Vec<ColumnPath> = args.rest(0)?;
-
-    let stream_chunks = match bytes.clone() {
-        Some(a_byte) => {
-            // if we want to see only a few bytes
-            if a_byte > UntaggedValue::int(0).into_untagged_value() {
-                // return 1 so that we only get one chunk of the stream
-                1
-            } else {
-                // otherwise take all of it
-                usize::MAX
-            }
-        }
-        _ => usize::MAX,
-    };
 
     Ok(args
         .input
-        .take(stream_chunks) // limit the stream
         .map(move |v| {
             if column_paths.is_empty() {
-                action(&v, v.tag(), &skip, &bytes)
+                action(&v, v.tag())
             } else {
                 let mut ret = v;
                 for path in &column_paths {
-                    let skip_clone = skip.clone();
-                    let bytes_clone = bytes.clone();
                     ret = ret.swap_data_by_column_path(
                         path,
-                        Box::new(move |old| action(old, old.tag(), &skip_clone, &bytes_clone)),
+                        Box::new(move |old| action(old, old.tag())),
                     )?;
                 }
 
@@ -156,54 +102,26 @@ fn into_binary(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
 fn int_to_endian(n: i64) -> Vec<u8> {
     if cfg!(target_endian = "little") {
-        // eprintln!("Little Endian");
         n.to_le_bytes().to_vec()
     } else {
-        // eprintln!("Big Endian");
         n.to_be_bytes().to_vec()
     }
 }
 
 fn bigint_to_endian(n: &BigInt) -> Vec<u8> {
     if cfg!(target_endian = "little") {
-        // eprintln!("Little Endian");
         n.to_bytes_le().1
     } else {
-        // eprintln!("Big Endian");
         n.to_bytes_be().1
     }
 }
 
-pub fn action(
-    input: &Value,
-    tag: impl Into<Tag>,
-    skip: &Option<Value>,
-    bytes: &Option<Value>,
-) -> Result<Value, ShellError> {
+pub fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     let tag = tag.into();
-    let skip_bytes = match skip {
-        Some(s) => s.as_usize().unwrap_or(0),
-        None => 0usize,
-    };
-
-    let num_bytes = match bytes {
-        Some(b) => b.as_usize().unwrap_or(0),
-        None => 0usize,
-    };
 
     match &input.value {
         UntaggedValue::Primitive(prim) => Ok(UntaggedValue::binary(match prim {
-            Primitive::Binary(b) => {
-                if num_bytes == 0usize {
-                    b.to_vec().into_iter().skip(skip_bytes).collect()
-                } else {
-                    b.to_vec()
-                        .into_iter()
-                        .skip(skip_bytes)
-                        .take(num_bytes)
-                        .collect()
-                }
-            }
+            Primitive::Binary(b) => b.to_vec(),
             Primitive::Int(n_ref) => int_to_endian(*n_ref),
             Primitive::BigInt(n_ref) => bigint_to_endian(n_ref),
             Primitive::Decimal(dec) => match dec.to_bigint() {
@@ -222,24 +140,7 @@ pub fn action(
                     ));
                 }
             },
-            Primitive::String(a_string) => {
-                if num_bytes == 0usize {
-                    a_string
-                        .as_bytes()
-                        .to_vec()
-                        .into_iter()
-                        .skip(skip_bytes)
-                        .collect()
-                } else {
-                    a_string
-                        .as_bytes()
-                        .to_vec()
-                        .into_iter()
-                        .skip(skip_bytes)
-                        .take(num_bytes)
-                        .collect()
-                }
-            }
+            Primitive::String(a_string) => a_string.as_bytes().to_vec(),
             Primitive::Boolean(a_bool) => match a_bool {
                 false => int_to_endian(0),
                 true => int_to_endian(1),

--- a/crates/nu-command/src/commands/filters/first.rs
+++ b/crates/nu-command/src/commands/filters/first.rs
@@ -125,7 +125,7 @@ fn first(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 "found block",
                 tag,
             )),
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "dataframe"))]
             UntaggedValue::DataFrame(_) => Err(ShellError::labeled_error(
                 "unsure how to handled UntaggedValue::DataFrame",
                 "found dataframe",

--- a/crates/nu-command/src/commands/filters/first.rs
+++ b/crates/nu-command/src/commands/filters/first.rs
@@ -125,6 +125,7 @@ fn first(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 "found block",
                 tag,
             )),
+            #[cfg(not(target_arch = "wasm32"))]
             UntaggedValue::DataFrame(_) => Err(ShellError::labeled_error(
                 "unsure how to handled UntaggedValue::DataFrame",
                 "found dataframe",

--- a/crates/nu-pretty-hex/src/pretty_hex.rs
+++ b/crates/nu-pretty-hex/src/pretty_hex.rs
@@ -172,14 +172,12 @@ where
         .map(|x| *x as u8)
         .collect();
 
-    let source_part = String::from_utf8_lossy(&source_part_vec[..]);
-
     if cfg.title {
         if use_color {
             writeln!(
                 writer,
                 "Length: {0} (0x{0:x}) bytes | {1}printable {2}whitespace {3}ascii_other {4}non_ascii{5}",
-                source_part.as_bytes().as_ref().len(),
+                source_part_vec.len(),
                 Style::default().fg(Color::Cyan).bold().prefix(),
                 Style::default().fg(Color::Green).bold().prefix(),
                 Style::default().fg(Color::Purple).bold().prefix(),
@@ -187,18 +185,14 @@ where
                 Style::default().fg(Color::Yellow).suffix()
             )?;
         } else {
-            writeln!(
-                writer,
-                "Length: {0} (0x{0:x}) bytes",
-                source_part.as_bytes().as_ref().len(),
-            )?;
+            writeln!(writer, "Length: {0} (0x{0:x}) bytes", source_part_vec.len(),)?;
         }
     }
 
-    let lines = source_part.as_bytes().as_ref().chunks(if cfg.width > 0 {
+    let lines = source_part_vec.chunks(if cfg.width > 0 {
         cfg.width
     } else {
-        source_part.as_bytes().as_ref().len()
+        source_part_vec.len()
     });
 
     let lines_len = lines.len();

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -82,6 +82,11 @@ impl UntaggedValue {
         }
     }
 
+    /// Returns true if this value represents a binary
+    pub fn is_binary(&self) -> bool {
+        matches!(self, &UntaggedValue::Primitive(Primitive::Binary(_)))
+    }
+
     /// Returns true if this value represents boolean true
     pub fn is_true(&self) -> bool {
         matches!(self, UntaggedValue::Primitive(Primitive::Boolean(true)))
@@ -418,6 +423,14 @@ impl Value {
         match &self.value {
             UntaggedValue::Primitive(Primitive::Date(dt)) => Ok(dt.format(fmt).to_string()),
             _ => Err(ShellError::type_error("date", self.spanned_type_name())),
+        }
+    }
+
+    /// View a Primitive::Binary as a Vec<u8>, if possible
+    pub fn as_binary_vec(&self) -> Result<Vec<u8>, ShellError> {
+        match &self.value {
+            UntaggedValue::Primitive(Primitive::Binary(bin)) => Ok(bin.to_vec()),
+            _ => Err(ShellError::type_error("binary", self.spanned_type_name())),
         }
     }
 

--- a/crates/nu_plugin_binaryview/src/nu/mod.rs
+++ b/crates/nu_plugin_binaryview/src/nu/mod.rs
@@ -29,9 +29,7 @@ impl Plugin for BinaryView {
             let value_anchor = v.anchor();
             if let UntaggedValue::Primitive(Primitive::Binary(b)) = &v.value {
                 let low_res = call_info.args.has("lores");
-                let skip = call_info.args.get("skip");
-                let length = call_info.args.get("bytes");
-                let _ = view_binary(b, value_anchor.as_ref(), low_res, skip, length);
+                let _ = view_binary(b, value_anchor.as_ref(), low_res);
             }
         }
     }


### PR DESCRIPTION
many updates to make into binary more composable. no skip/bytes filtering is performed any longer by into binary or binaryview or nu-pretty-hex. you have to specify it in the pipeline like `open c:\some\big\file | into binary | first 100`.

* removed --bytes(-b) and --skip(-s) from into binary
* removed --bytes(-b) and --skip(-s) from binaryview
* fixed a bug in nu-prett-hex where String::from_utf8_lossy() was introducing characters that weren't actually there. This manifested by doing `first 25` and nu-pretty-hex returning 30 bytes.
* added is_binary() helper to UntaggedValue, returns true if Value is Primitive::Binary
* added as_binary_vec helper to Value to return a Vec<u8>
* changed `first` from ActionStream to OutputStream
* updated `first` to work with Primitive::Binary
* the `skip` command hasn't been updated yet to support binary

![image](https://user-images.githubusercontent.com/343840/125109635-3ba9a300-e0a9-11eb-97f2-29fc47f80df2.png)

Closes #3414