### PR TITLE
Read from standard input in `rm`

### DIFF
--- a/crates/nu-command/src/commands/filesystem/rm.rs
+++ b/crates/nu-command/src/commands/filesystem/rm.rs
@@ -83,23 +83,14 @@ fn rm(args: CommandArgs) -> Result<ActionStream, ShellError> {
         ))));
     }
 
-    if rm_args.rest.len() == 0 {
+    if rm_args.rest.is_empty() {
         let mut input_peek = args.input.peekable();
-        loop {
-            match &mut input_peek.next() {
-                Some(v) => match &v.value {
-                    UntaggedValue::Primitive(v) => match &v {
-                        Primitive::FilePath(path) => {
-                            rm_args.rest.push(Tagged {
-                                item: path.to_path_buf(),
-                                tag: args.call_info.name_tag.clone(),
-                            });
-                        }
-                        _ => {}
-                    },
-                    _ => {}
-                },
-                None => break,
+        while let Some(v) = &input_peek.next() {
+            if let UntaggedValue::Primitive(Primitive::FilePath(path)) = &v.value {
+                rm_args.rest.push(Tagged {
+                    item: path.to_path_buf(),
+                    tag: args.call_info.name_tag.clone(),
+                })
             };
         }
     }

--- a/crates/nu-command/src/commands/filesystem/rm.rs
+++ b/crates/nu-command/src/commands/filesystem/rm.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use nu_engine::shell::RemoveArgs;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
-use nu_protocol::{Primitive, Signature, SyntaxShape, TaggedDictBuilder, UntaggedValue};
+use nu_protocol::{Primitive, Signature, SyntaxShape, UntaggedValue};
 use nu_source::Tagged;
 
 pub struct Remove;
@@ -26,7 +26,7 @@ impl WholeStreamCommand for Remove {
             )
             .switch("recursive", "delete subdirectories recursively", Some('r'))
             .switch("force", "suppress error when no file", Some('f'))
-            .optional("files", SyntaxShape::GlobPattern, "the file path(s) to remove")
+            .rest(SyntaxShape::GlobPattern, "the file path(s) to remove")
     }
 
     fn usage(&self) -> &str {
@@ -94,12 +94,12 @@ fn rm(args: CommandArgs) -> Result<ActionStream, ShellError> {
                                 item: path.to_path_buf(),
                                 tag: args.call_info.name_tag.clone(),
                             });
-                        },
+                        }
                         _ => {}
                     },
                     _ => {}
                 },
-                None => break
+                None => break,
             };
         }
     }


### PR DESCRIPTION
With this change, rm falls back to reading from the standard input if no
arguments are supplied. This leads to more intuitive pipes as seen in
https://github.com/nushell/nushell/issues/2824

 ls | get name | sort-by | first 20 | each {rm $it} becomes
 ls | get name | sort-by | first 20 | rm

This is just a proof of concept and I'd like to know the devs' thoughts before continuing work on this. Preferably (and as discussed in #2824) I'd like more commands that take args to fall back and use the standard input instead, and I'm not sure where the devs and other users stand on this.

This is how it looks like in action: 
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/82497827/125207083-ebe4fa80-e2a7-11eb-91a9-0dfd8dbc3041.png">
