### PR TITLE
fixed `show_hints` option to allow hints to be turned off

### DIFF
--- a/crates/nu-cli/src/line_editor.rs
+++ b/crates/nu-cli/src/line_editor.rs
@@ -247,7 +247,7 @@ pub fn rustyline_hinter(
 ) -> Option<rustyline::hint::HistoryHinter> {
     if let Some(line_editor_vars) = config.var("line_editor") {
         for (idx, value) in line_editor_vars.row_entries() {
-            if idx == "show_hints" && value.expect_string() == "false" {
+            if idx == "show_hints" && value.as_bool() == Ok(false) {
                 return None;
             }
         }

--- a/crates/nu-cli/src/shell.rs
+++ b/crates/nu-cli/src/shell.rs
@@ -90,7 +90,10 @@ impl rustyline::completion::Completer for Helper {
 impl rustyline::hint::Hinter for Helper {
     type Hint = String;
     fn hint(&self, line: &str, pos: usize, ctx: &rustyline::Context<'_>) -> Option<String> {
-        self.hinter.as_ref().and_then(|h| h.hint(line, pos, ctx))
+        match &self.hinter {
+            Some(the_hinter) => the_hinter.hint(line, pos, ctx),
+            None => Some("".to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
this fix enables the `show_hints` configuration point in the `[line_editor]` section of the `config.toml` to turn off rustylines hinting system.

closed #3768