### PR TITLE
Add worflow to publish package in winget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,6 @@ jobs:
       - linux
       - macos
       - windows
-    outputs:
-      version: ${{ steps.info.outputs.version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -286,18 +284,3 @@ jobs:
           asset_path: ./nushell-windows.msi
           asset_name: ${{ steps.info.outputs.windowsdir }}.msi
           asset_content_type: applictaion/x-msi
-
-  winget:
-    name: Publish winget package
-    runs-on: windows-latest
-    needs: release
-    steps:
-      - name: Submit package to Windows Package Manager Community Repository
-        run: |
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          $nushellVersion="${{ needs.release.outputs.version }}"
-          $nushellInstallerName="nu_$($nushellVersion -replace '\.','_')_windows.msi"
-          $installerUrl = "https://github.com/nushell/nushell/releases/download/$nushellVersion/$nushellInstallerName"
-          .\wingetcreate.exe update Nushell.Nushell -s -v $nushellVersion -u $installerUrl -t ${{ secrets.NUSHELL_PAT }}
-    
-    

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,0 +1,18 @@
+name: Submit Nushell package to Windows Package Manager Community Repository 
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    steps:
+      - name: Submit package to Windows Package Manager Community Repository
+        run: |
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
+          $installerUrl = $github.release.assets | Where-Object -Property name -match 'windows.msi' | Select -ExpandProperty browser_download_url -First 1
+          .\wingetcreate.exe update Nushell.Nushell -s -v $github.release.tag_name -u $installerUrl -t ${{ secrets.NUSHELL_PAT }}


### PR DESCRIPTION
Remove the job in release workflow to publish to winget.
Trigger winget workflow on published release.

As the release workflow creates a draft release, the job to publish the new version of nushell package in winget cannot work because the url to the installer will only be available once the release is published.

The solution taken here was to trigger a specific workflow once a release is published. This workflow is currently dedicated to winget and only contain a job that publish the new windows package to winget pacakges repository, but it might be a good idea to modify it later to automate the distribution of nushell to other package managers.

The code in the runner does the following:
- download the wingetcreate tool 
- retrieves the url of the windows installer from the webhook event that triggered the workflow and that contain information about the published release
- use the wingetcreate tool to automate the update of the nushell manifest in the Windows Package Manager Community Repository

In order to avoid unexpected problems like during latest release, the workflow has been tested on my fork by pushing a tag 0.34.0 that created a new release that triggered the winget workflow:
- the generated PR to the winget packages repository can be found [here](https://github.com/microsoft/winget-pkgs/pull/22071)
- the workflow run that generated the PR can be found [here](https://github.com/TechWatching/nushell/runs/3133552066)



