### PR TITLE
Adding parse fix for power operator error on negative integers and de…

### DIFF
--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -1,6 +1,7 @@
 use crate::base::coerce_compare;
 use crate::base::shape::{Column, InlineShape};
 use crate::primitive::style_primitive;
+use bigdecimal::Signed;
 use chrono::{DateTime, NaiveDate, Utc};
 use nu_errors::ShellError;
 use nu_protocol::hir::Operator;
@@ -172,7 +173,7 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
-                    if prim_u32 >= Some(0) {
+                    if !y.is_negative() {
                         match prim_u32 {
                             Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -223,7 +224,7 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
-                    if prim_u32 >= Some(0) {
+                    if !y.is_negative() {
                         match prim_u32 {
                             Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -274,7 +275,7 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
-                    if prim_u32 >= Some(0) {
+                    if !y.is_negative() {
                         match prim_u32 {
                             Some(num) => {
                                 Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num))))
@@ -319,7 +320,7 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
-                    if prim_u32 >= Some(0) {
+                    if !y.is_negative() {
                         match prim_u32 {
                             Some(num) => {
                                 Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num))))
@@ -388,8 +389,13 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let yp = bigdecimal::ToPrimitive::to_u32(y).unwrap_or(0);
-                        Ok(bigdecimal::BigDecimal::from(x.pow(yp)))
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(p),
+                            None => Err((left.type_name(), right.type_name())),
+                        }
                     }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
@@ -445,8 +451,13 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let yp = bigdecimal::ToPrimitive::to_u32(y).unwrap_or(0);
-                        Ok(bigdecimal::BigDecimal::from(x.pow(yp)))
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(p),
+                            None => Err((left.type_name(), right.type_name())),
+                        }
                     }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -171,9 +171,20 @@ pub fn compute_values(
                 }
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
-                    match prim_u32 {
-                        Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
-                        _ => Err((left.type_name(), right.type_name())),
+
+                    if prim_u32 >= Some(0) {
+                        match prim_u32 {
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
+                    } else {
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
                     }
                 }
                 _ => Err((left.type_name(), right.type_name())),
@@ -211,9 +222,20 @@ pub fn compute_values(
                 }
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
-                    match prim_u32 {
-                        Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
-                        _ => Err((left.type_name(), right.type_name())),
+
+                    if prim_u32 >= Some(0) {
+                        match prim_u32 {
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
+                    } else {
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
                     }
                 }
                 _ => Err((left.type_name(), right.type_name())),
@@ -251,9 +273,20 @@ pub fn compute_values(
                 }
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
-                    match prim_u32 {
-                        Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num)))),
-                        _ => Err((left.type_name(), right.type_name())),
+
+                    if prim_u32 >= Some(0) {
+                        match prim_u32 {
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num)))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
+                    } else {
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
                     }
                 }
                 _ => Err((left.type_name(), right.type_name())),
@@ -283,9 +316,20 @@ pub fn compute_values(
                 }
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
-                    match prim_u32 {
-                        Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num)))),
-                        _ => Err((left.type_name(), right.type_name())),
+
+                    if prim_u32 >= Some(0) {
+                        match prim_u32 {
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num)))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
+                    } else {
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
+                            _ => Err((left.type_name(), right.type_name())),
+                        }
                     }
                 }
                 _ => Err((left.type_name(), right.type_name())),
@@ -308,15 +352,15 @@ pub fn compute_values(
                         Ok(x % bigdecimal::BigDecimal::from(*y))
                     }
                     // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
-                    // Operator::Pow => {
-                    //     let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-                    //     let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                    //     let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
-                    //     match pow {
-                    //         Some(p) => Ok(p),
-                    //         None => Err((left.type_name(), right.type_name())),
-                    //     }
-                    // }
+                    Operator::Pow => {
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(p),
+                            None => Err((left.type_name(), right.type_name())),
+                        }
+                    }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
                 Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))
@@ -339,10 +383,10 @@ pub fn compute_values(
                         Ok(bigdecimal::BigDecimal::from(*x) % y)
                     }
                     // big decimal doesn't support pow yet
-                    // Operator::Pow => {
-                    //     let yp = bigdecimal::ToPrimitive::to_u32(y).unwrap_or(0);
-                    //     Ok(bigdecimal::BigDecimal::from(x.pow(yp)))
-                    // }
+                    Operator::Pow => {
+                        let yp = bigdecimal::ToPrimitive::to_u32(y).unwrap_or(0);
+                        Ok(bigdecimal::BigDecimal::from(x.pow(yp)))
+                    }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
                 Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))
@@ -365,15 +409,15 @@ pub fn compute_values(
                         Ok(x % bigdecimal::BigDecimal::from(y.clone()))
                     }
                     // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
-                    // Operator::Pow => {
-                    //     let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-                    //     let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                    //     let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
-                    //     match pow {
-                    //         Some(p) => Ok(p),
-                    //         None => Err((left.type_name(), right.type_name())),
-                    //     }
-                    // }
+                    Operator::Pow => {
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(p),
+                            None => Err((left.type_name(), right.type_name())),
+                        }
+                    }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
                 Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))
@@ -396,10 +440,10 @@ pub fn compute_values(
                         Ok(bigdecimal::BigDecimal::from(x.clone()) % y)
                     }
                     // big decimal doesn't support pow yet
-                    // Operator::Pow => {
-                    //     let yp = bigdecimal::ToPrimitive::to_u32(y).unwrap_or(0);
-                    //     Ok(bigdecimal::BigDecimal::from(x.pow(yp)))
-                    // }
+                    Operator::Pow => {
+                        let yp = bigdecimal::ToPrimitive::to_u32(y).unwrap_or(0);
+                        Ok(bigdecimal::BigDecimal::from(x.pow(yp)))
+                    }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
                 Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))
@@ -422,15 +466,15 @@ pub fn compute_values(
                         Ok(x % y)
                     }
                     // big decimal doesn't support pow yet
-                    // Operator::Pow => {
-                    //     let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-                    //     let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                    //     let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
-                    //     match pow {
-                    //         Some(p) => Ok(p),
-                    //         None => Err((left.type_name(), right.type_name())),
-                    //     }
-                    // }
+                    Operator::Pow => {
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        match pow {
+                            Some(p) => Ok(p),
+                            None => Err((left.type_name(), right.type_name())),
+                        }
+                    }
                     _ => Err((left.type_name(), right.type_name())),
                 }?;
                 Ok(UntaggedValue::Primitive(Primitive::Decimal(result)))

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -10,6 +10,7 @@ use nu_protocol::{Primitive, Type, UntaggedValue};
 use nu_source::{DebugDocBuilder, PrettyDebug, Span, Tagged};
 use nu_table::TextStyle;
 use num_bigint::BigInt;
+use num_bigint::ToBigInt;
 use num_traits::{ToPrimitive, Zero};
 use std::collections::HashMap;
 
@@ -173,15 +174,23 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
+                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                    let convert_x = match x.is_negative() {
+                        true => -1.0 * x_float,
+                        false => 1.0 * x_float,
+                    };
+
                     if !y.is_negative() {
                         match prim_u32 {
-                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(
+                                (convert_x as i64).pow(num),
+                            ))),
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -224,15 +233,23 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
+                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                    let convert_x = match x.is_negative() {
+                        true => -1.0 * x_float,
+                        false => 1.0 * x_float,
+                    };
+
                     if !y.is_negative() {
                         match prim_u32 {
-                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(x.pow(num)))),
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(
+                                (convert_x as i64).pow(num),
+                            ))),
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -275,17 +292,24 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
+                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                    let convert_x = match x.is_negative() {
+                        true => -1.0 * x_float,
+                        false => 1.0 * x_float,
+                    };
+
                     if !y.is_negative() {
+                        let cast_x = convert_x.to_bigint().unwrap();
                         match prim_u32 {
                             Some(num) => {
-                                Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num))))
+                                Ok(UntaggedValue::Primitive(Primitive::BigInt(cast_x.pow(num))))
                             }
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -319,18 +343,29 @@ pub fn compute_values(
                 }
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
+                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                    let convert_x = match x.is_negative() {
+                        true => -1.0 * x_float,
+                        false => 1.0 * x_float,
+                    };
 
                     if !y.is_negative() {
+                        let cast_x = convert_x.to_bigint().unwrap();
                         match prim_u32 {
                             Some(num) => {
-                                Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num))))
+                                Ok(UntaggedValue::Primitive(Primitive::BigInt(cast_x.pow(num))))
                             }
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+
+                        let pow = match x.is_negative() {
+                            true => bigdecimal::FromPrimitive::from_f64((convert_x).powf(yp)),
+                            false => bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp)),
+                        };
+
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -358,9 +393,15 @@ pub fn compute_values(
                     }
                     // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
                     Operator::Pow => {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                        let convert_x = match x.is_negative() {
+                            true => -1.0 * x_float,
+                            false => 1.0 * x_float,
+                        };
+
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -389,9 +430,14 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                        let convert_x = match x.is_negative() {
+                            true => -1.0 * x_float,
+                            false => 1.0 * x_float,
+                        };
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -420,9 +466,15 @@ pub fn compute_values(
                     }
                     // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
                     Operator::Pow => {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                        let convert_x = match x.is_negative() {
+                            true => -1.0 * x_float,
+                            false => 1.0 * x_float,
+                        };
+
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -451,9 +503,15 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                        let convert_x = match x.is_negative() {
+                            true => -1.0 * x_float,
+                            false => 1.0 * x_float,
+                        };
+
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -482,9 +540,14 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                        let convert_x = match x.is_negative() {
+                            true => -1.0 * x_float,
+                            false => 1.0 * x_float,
+                        };
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(xp.powf(yp));
+                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -633,9 +696,11 @@ pub fn format_for_column<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::merge_values;
     use super::Date as d;
     use super::UntaggedValue as v;
+    use super::{compute_values, merge_values};
+    use nu_protocol::hir::Operator;
+    use nu_protocol::{Primitive, UntaggedValue};
     use nu_source::TaggedItem;
 
     use indexmap::indexmap;
@@ -663,5 +728,84 @@ mod tests {
             other_table_author_row,
             merge_values(&table_author_row, &other_table_author_row).unwrap()
         );
+    }
+
+    #[test]
+    fn pow_operator_negatives_and_decimals() {
+        // test 2 ** 2
+        let result_one = compute_values(
+            Operator::Pow,
+            &UntaggedValue::Primitive(Primitive::Int(2)),
+            &UntaggedValue::Primitive(Primitive::Int(2)),
+        );
+
+        assert_eq!(
+            result_one.unwrap(),
+            UntaggedValue::Primitive(Primitive::Int(4))
+        );
+
+        // test 2 ** 2.0
+        let rhs_decimal = bigdecimal::FromPrimitive::from_f64(2.0).unwrap();
+
+        let result_two = compute_values(
+            Operator::Pow,
+            &UntaggedValue::Primitive(Primitive::Int(2)),
+            &UntaggedValue::Primitive(Primitive::Decimal(rhs_decimal)),
+        );
+
+        let should_equal_four_decimal = bigdecimal::FromPrimitive::from_f64(4.0).unwrap();
+
+        assert_eq!(
+            result_two.unwrap(),
+            UntaggedValue::Primitive(Primitive::Decimal(should_equal_four_decimal))
+        );
+
+        // test 2.0 ** 2.0
+        let rhs_decimal = bigdecimal::FromPrimitive::from_f64(2.0).unwrap();
+        let lhs_decimal = bigdecimal::FromPrimitive::from_f64(2.0).unwrap();
+        let should_equal_four_decimal = bigdecimal::FromPrimitive::from_f64(4.0).unwrap();
+
+        let result_three = compute_values(
+            Operator::Pow,
+            &UntaggedValue::Primitive(Primitive::Decimal(lhs_decimal)),
+            &UntaggedValue::Primitive(Primitive::Decimal(rhs_decimal)),
+        );
+
+        assert_eq!(
+            result_three.unwrap(),
+            UntaggedValue::Primitive(Primitive::Decimal(should_equal_four_decimal))
+        );
+
+        // test 2 ** -2
+        let result_four = compute_values(
+            Operator::Pow,
+            &UntaggedValue::Primitive(Primitive::Int(2)),
+            &UntaggedValue::Primitive(Primitive::Int(-2)),
+        );
+
+        let should_equal_zero_decimal = bigdecimal::FromPrimitive::from_f64(0.25).unwrap();
+
+        assert_eq!(
+            result_four.unwrap(),
+            UntaggedValue::Primitive(Primitive::Decimal(should_equal_zero_decimal))
+        );
+
+        // test -2 ** -2
+        let result_five = compute_values(
+            Operator::Pow,
+            &UntaggedValue::Primitive(Primitive::Int(-2)),
+            &UntaggedValue::Primitive(Primitive::Int(-2)),
+        );
+
+        let should_equal_neg_zero_decimal = bigdecimal::FromPrimitive::from_f64(-0.25).unwrap();
+
+        // Need to validate
+
+        /*
+        assert_eq!(
+            result_five.unwrap(),
+            UntaggedValue::Primitive(Primitive::Decimal(should_equal_neg_zero_decimal))
+        );
+        */
     }
 }

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -276,7 +276,9 @@ pub fn compute_values(
 
                     if prim_u32 >= Some(0) {
                         match prim_u32 {
-                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num)))),
+                            Some(num) => {
+                                Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num))))
+                            }
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
@@ -319,7 +321,9 @@ pub fn compute_values(
 
                     if prim_u32 >= Some(0) {
                         match prim_u32 {
-                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num)))),
+                            Some(num) => {
+                                Ok(UntaggedValue::Primitive(Primitive::BigInt(x.pow(num))))
+                            }
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -174,23 +174,25 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
-                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                    let convert_x = match x.is_negative() {
-                        true => -1.0 * x_float,
-                        false => 1.0 * x_float,
+                    let sign = match x.is_negative() {
+                        true => -1,
+                        false => 1,
                     };
 
                     if !y.is_negative() {
                         match prim_u32 {
                             Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(
-                                (convert_x as i64).pow(num),
+                                sign * (x.pow(num)),
                             ))),
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
+
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -233,23 +235,23 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
-                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                    let convert_x = match x.is_negative() {
-                        true => -1.0 * x_float,
-                        false => 1.0 * x_float,
+                    let sign = match x.is_negative() {
+                        true => -1,
+                        false => 1,
                     };
 
                     if !y.is_negative() {
                         match prim_u32 {
                             Some(num) => Ok(UntaggedValue::Primitive(Primitive::Int(
-                                (convert_x as i64).pow(num),
+                                sign * (x.pow(num)),
                             ))),
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -292,24 +294,22 @@ pub fn compute_values(
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
 
-                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                    let convert_x = match x.is_negative() {
-                        true => -1.0 * x_float,
-                        false => 1.0 * x_float,
+                    let sign = match x.is_negative() {
+                        true => -1,
+                        false => 1,
                     };
 
                     if !y.is_negative() {
-                        let cast_x = convert_x.to_bigint().unwrap();
                         match prim_u32 {
-                            Some(num) => {
-                                Ok(UntaggedValue::Primitive(Primitive::BigInt(cast_x.pow(num))))
-                            }
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(
+                                (sign.to_bigint().unwrap_or_default()) * x.pow(num),
+                            ))),
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let pow = bigdecimal::FromPrimitive::from_f64((sign as f64) * xp.powf(yp));
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
                             _ => Err((left.type_name(), right.type_name())),
@@ -343,28 +343,25 @@ pub fn compute_values(
                 }
                 Operator::Pow => {
                     let prim_u32 = ToPrimitive::to_u32(y);
-                    let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
 
-                    let convert_x = match x.is_negative() {
-                        true => -1.0 * x_float,
-                        false => 1.0 * x_float,
+                    let sign = match x.is_negative() {
+                        true => -1,
+                        false => 1,
                     };
 
                     if !y.is_negative() {
-                        let cast_x = convert_x.to_bigint().unwrap();
                         match prim_u32 {
-                            Some(num) => {
-                                Ok(UntaggedValue::Primitive(Primitive::BigInt(cast_x.pow(num))))
-                            }
+                            Some(num) => Ok(UntaggedValue::Primitive(Primitive::BigInt(
+                                (sign.to_bigint().unwrap_or_default()).pow(num),
+                            ))),
                             _ => Err((left.type_name(), right.type_name())),
                         }
                     } else {
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
 
-                        let pow = match x.is_negative() {
-                            true => bigdecimal::FromPrimitive::from_f64((convert_x).powf(yp)),
-                            false => bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp)),
-                        };
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
 
                         match pow {
                             Some(p) => Ok(UntaggedValue::Primitive(Primitive::Decimal(p))),
@@ -393,15 +390,15 @@ pub fn compute_values(
                     }
                     // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
                     Operator::Pow => {
-                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                        let convert_x = match x.is_negative() {
-                            true => -1.0 * x_float,
-                            false => 1.0 * x_float,
+                        let sign = match x.is_negative() {
+                            true => -1,
+                            false => 1,
                         };
 
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -430,14 +427,15 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                        let convert_x = match x.is_negative() {
-                            true => -1.0 * x_float,
-                            false => 1.0 * x_float,
+                        let sign = match x.is_negative() {
+                            true => -1,
+                            false => 1,
                         };
+
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -466,15 +464,15 @@ pub fn compute_values(
                     }
                     // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
                     Operator::Pow => {
-                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                        let convert_x = match x.is_negative() {
-                            true => -1.0 * x_float,
-                            false => 1.0 * x_float,
+                        let sign = match x.is_negative() {
+                            true => -1,
+                            false => 1,
                         };
 
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -503,15 +501,15 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                        let convert_x = match x.is_negative() {
-                            true => -1.0 * x_float,
-                            false => 1.0 * x_float,
+                        let sign = match x.is_negative() {
+                            true => -1,
+                            false => 1,
                         };
 
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -540,14 +538,15 @@ pub fn compute_values(
                     }
                     // big decimal doesn't support pow yet
                     Operator::Pow => {
-                        let x_float = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
-
-                        let convert_x = match x.is_negative() {
-                            true => -1.0 * x_float,
-                            false => 1.0 * x_float,
+                        let sign = match x.is_negative() {
+                            true => -1,
+                            false => 1,
                         };
+
                         let yp = bigdecimal::ToPrimitive::to_f64(y).unwrap_or(0.0);
-                        let pow = bigdecimal::FromPrimitive::from_f64(convert_x.powf(yp));
+                        let xp = bigdecimal::ToPrimitive::to_f64(x).unwrap_or(0.0);
+                        let pow =
+                            bigdecimal::FromPrimitive::from_f64((sign as f64) * (xp.powf(yp)));
                         match pow {
                             Some(p) => Ok(p),
                             None => Err((left.type_name(), right.type_name())),
@@ -799,13 +798,37 @@ mod tests {
 
         let should_equal_neg_zero_decimal = bigdecimal::FromPrimitive::from_f64(-0.25).unwrap();
 
-        // Need to validate
-
-        /*
         assert_eq!(
             result_five.unwrap(),
             UntaggedValue::Primitive(Primitive::Decimal(should_equal_neg_zero_decimal))
         );
-        */
+
+        // test -2 ** 2
+        let result_six = compute_values(
+            Operator::Pow,
+            &UntaggedValue::Primitive(Primitive::Int(-2)),
+            &UntaggedValue::Primitive(Primitive::Int(2)),
+        );
+
+        assert_eq!(
+            result_six.unwrap(),
+            UntaggedValue::Primitive(Primitive::Int(-4))
+        );
+
+        // test -2.0 ** 2
+        let lhs_decimal = bigdecimal::FromPrimitive::from_f64(-2.0).unwrap();
+        let should_equal_neg_four_decimal = bigdecimal::FromPrimitive::from_f64(-4.0).unwrap();
+
+        let result_seven = compute_values(
+            Operator::Pow,
+            &UntaggedValue::Primitive(Primitive::Decimal(lhs_decimal)),
+            &UntaggedValue::Primitive(Primitive::Int(2)),
+        );
+
+        // Need to validate
+        assert_eq!(
+            result_seven.unwrap(),
+            UntaggedValue::Primitive(Primitive::Decimal(should_equal_neg_four_decimal))
+        );
     }
 }

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -388,7 +388,7 @@ pub fn compute_values(
                         }
                         Ok(x % bigdecimal::BigDecimal::from(*y))
                     }
-                    // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
+
                     Operator::Pow => {
                         let sign = match x.is_negative() {
                             true => -1,
@@ -425,7 +425,7 @@ pub fn compute_values(
                         }
                         Ok(bigdecimal::BigDecimal::from(*x) % y)
                     }
-                    // big decimal doesn't support pow yet
+
                     Operator::Pow => {
                         let sign = match x.is_negative() {
                             true => -1,
@@ -462,7 +462,7 @@ pub fn compute_values(
                         }
                         Ok(x % bigdecimal::BigDecimal::from(y.clone()))
                     }
-                    // leaving this here for the hope that bigdecimal will one day support pow/powf/fpow
+
                     Operator::Pow => {
                         let sign = match x.is_negative() {
                             true => -1,
@@ -499,7 +499,7 @@ pub fn compute_values(
                         }
                         Ok(bigdecimal::BigDecimal::from(x.clone()) % y)
                     }
-                    // big decimal doesn't support pow yet
+
                     Operator::Pow => {
                         let sign = match x.is_negative() {
                             true => -1,
@@ -536,7 +536,7 @@ pub fn compute_values(
                         }
                         Ok(x % y)
                     }
-                    // big decimal doesn't support pow yet
+
                     Operator::Pow => {
                         let sign = match x.is_negative() {
                             true => -1,


### PR DESCRIPTION
This PR is to fix a bug that was highlighted in this issue: https://github.com/nushell/nushell/issues/3284#issue-853711534. It appears that the `BigDecimal` type can now use `pow()` so I removed the comments for those pattern matches. In addition to this, I added additional checks and a fix for when an integer is negative. On the right hand side of the parser, if we see an integer when using the `**` operator we would expect to get a `Decimal` type. Before we would get an int so I changed that. I'm still a beginner at Rust so the code may not be written the best. I would love to get some feedback on this! 