### PR TITLE
change describe so it doesn't output colored strings

### DIFF
--- a/crates/nu-command/src/commands/core_commands/describe.rs
+++ b/crates/nu-command/src/commands/core_commands/describe.rs
@@ -31,7 +31,7 @@ pub fn describe(args: CommandArgs) -> Result<ActionStream, ShellError> {
     Ok(args
         .input
         .map(|row| {
-            let name = value::format_type(&row, 100);
+            let name = value::plain_type(&row, 100);
             ReturnSuccess::value(
                 UntaggedValue::string(name).into_value(Tag::unknown_anchor(row.tag.span)),
             )

--- a/crates/nu-data/src/value.rs
+++ b/crates/nu-data/src/value.rs
@@ -537,6 +537,10 @@ pub fn compare_values(
     Ok(result)
 }
 
+pub fn plain_type<'a>(value: impl Into<&'a UntaggedValue>, width: usize) -> String {
+    Type::from_value(value.into()).plain_string(width)
+}
+
 pub fn format_type<'a>(value: impl Into<&'a UntaggedValue>, width: usize) -> String {
     Type::from_value(value.into()).colored_string(width)
 }


### PR DESCRIPTION
previously `describe` would output formatted/colored text which made doing things like this not very intuitive.
```
> let a = 1
> ($a | describe) == "integer"
false
```
You'd have to do something like this
```
> ($a | describe | into string | ansi strip) == "integer"
true
```
or even worse
```
> ($a | describe | into string) == $"(ansi reset)(ansi cyan)integer(ansi reset)
true
```
even if you put it into a string it would still look like this.
```
> $a | describe | into string | debug --raw
Value {
    value: Primitive(
        String(
            "\u{1b}[0m\u{1b}[36minteger\u{1b}[0m",
        ),
    ),
    tag: Tag {
        anchor: None,
        span: Span {
            start: 8,
            end: 9,
        },
    },
}
```
so i removed the coloring and this works as expected.
```
> ($a | describe) == "integer"
true
```