### PR TITLE
add `date humanize` command

### DIFF
--- a/crates/nu-command/src/commands/generators/date/humanize.rs
+++ b/crates/nu-command/src/commands/generators/date/humanize.rs
@@ -1,0 +1,81 @@
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{Dictionary, Primitive, Signature, UntaggedValue, Value};
+
+pub struct Date;
+
+impl WholeStreamCommand for Date {
+    fn name(&self) -> &str {
+        "date humanize"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("date humanize").switch("table", "print date in a table", Some('t'))
+    }
+
+    fn usage(&self) -> &str {
+        "Print a 'humanized' format for the date, relative to now."
+    }
+
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        humanize(args)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Humanize the current date",
+            example: "date now | date humanize",
+            result: None,
+        }]
+    }
+}
+
+pub fn humanize(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let tag = args.call_info.name_tag.clone();
+
+    let table: Option<bool> = args.get_flag("table")?;
+    let input = args.input;
+
+    Ok(input
+        .map(move |value| match value {
+            Value {
+                value: UntaggedValue::Primitive(dt @ Primitive::Date(_)),
+                ..
+            } => {
+                let output = nu_protocol::format_primitive(&dt, None);
+                let value = if table.is_some() {
+                    let mut indexmap = IndexMap::new();
+                    indexmap.insert(
+                        "formatted".to_string(),
+                        UntaggedValue::string(&output).into_value(&tag),
+                    );
+
+                    UntaggedValue::Row(Dictionary::from(indexmap)).into_value(&tag)
+                } else {
+                    UntaggedValue::string(&output).into_value(&tag)
+                };
+
+                Ok(value)
+            }
+            _ => Err(ShellError::labeled_error(
+                "Expected a date from pipeline",
+                "requires date input",
+                &tag,
+            )),
+        })
+        .into_input_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Date;
+    use super::ShellError;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        test_examples(Date {})
+    }
+}

--- a/crates/nu-command/src/commands/generators/date/mod.rs
+++ b/crates/nu-command/src/commands/generators/date/mod.rs
@@ -1,5 +1,6 @@
 pub mod command;
 pub mod format;
+pub mod humanize;
 pub mod list_timezone;
 pub mod now;
 pub mod to_table;
@@ -9,6 +10,7 @@ mod parser;
 
 pub use command::Command as Date;
 pub use format::Date as DateFormat;
+pub use humanize::Date as DateHumanize;
 pub use list_timezone::Date as DateListTimeZone;
 pub use now::Date as DateNow;
 pub use to_table::Date as DateToTable;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -51,6 +51,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(DateToTable),
             whole_stream_command(DateToTimeZone),
             whole_stream_command(DateFormat),
+            whole_stream_command(DateHumanize),
             whole_stream_command(Cal),
             whole_stream_command(Mkdir),
             whole_stream_command(Mv),

--- a/docs/commands/date-humanize.md
+++ b/docs/commands/date-humanize.md
@@ -1,0 +1,24 @@
+# date humanize
+Print a 'humanized' format for the date, relative to now.
+
+## Usage
+```shell
+> date humanize
+ ```
+
+## Flags
+* -h, --help: Display this help message
+* -t, --table: print date in a table
+
+## Examples
+  Format the current date
+```shell
+> date now | date humanize
+ ```
+
+  Format the current date and print in a table
+```shell
+> date now | date humanize -t
+ ```
+
+


### PR DESCRIPTION
```
❯ date humanize -h
Print a 'humanized' format for the date, relative to now.

Usage:
  > date humanize {flags}

Flags:
  -h, --help: Display this help message
  -t, --table: print date in a table

Examples:
  Humanize the current date
  > date now | date humanize
```

p.s. I'm wondering if you'd rather I change `date format` such that the format string is optional, and by default, we just use the format_primitive function (so it would "humanize" the date by default)