### PR TITLE
Add sha256 to the hash command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,6 +2831,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "md5"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,6 +3237,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "derive-new",
+ "digest 0.9.0",
  "directories-next",
  "dirs-next",
  "dtparse",
@@ -3244,7 +3256,7 @@ dependencies = [
  "itertools",
  "lazy_static 1.4.0",
  "log",
- "md5 0.7.0",
+ "md-5",
  "meval",
  "minus",
  "nu-ansi-term",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -58,7 +58,7 @@ indexmap = { version="1.7", features=["serde-1"] }
 itertools = "0.10.0"
 lazy_static = "1.*"
 log = "0.4.14"
-md5 = "0.7.0"
+md-5 = "0.9.1"
 meval = "0.2.0"
 minus = { version="3.4.0", optional=true, features=["async_std_lib", "search"] }
 num-bigint = { version="0.3.1", features=["serde"] }
@@ -96,6 +96,7 @@ url = "2.2.0"
 uuid_crate = { package="uuid", version="0.8.2", features=["v4"], optional=true }
 which = { version="4.1.0", optional=true }
 zip = { version="0.5.9", optional=true }
+digest = "0.9.0"
 
 [dependencies.polars]
 version = "0.14.7"

--- a/crates/nu-command/src/commands/generators/hash_/generic_digest.rs
+++ b/crates/nu-command/src/commands/generators/hash_/generic_digest.rs
@@ -1,0 +1,58 @@
+use crate::prelude::*;
+use nu_errors::ShellError;
+use nu_protocol::ShellTypeName;
+use nu_protocol::{ColumnPath, Primitive, UntaggedValue, Value};
+use nu_source::Tag;
+
+pub fn run<D>(args: CommandArgs) -> Result<OutputStream, ShellError>
+where
+    D: digest::Digest,
+    digest::Output<D>: core::fmt::LowerHex,
+{
+    let column_paths: Vec<ColumnPath> = args.rest(0)?;
+
+    Ok(args
+        .input
+        .map(move |v| {
+            if column_paths.is_empty() {
+                action::<D>(&v, v.tag())
+            } else {
+                let mut ret = v;
+
+                for path in &column_paths {
+                    ret = ret.swap_data_by_column_path(
+                        path,
+                        Box::new(move |old| action::<D>(old, old.tag())),
+                    )?;
+                }
+
+                Ok(ret)
+            }
+        })
+        .into_input_stream())
+}
+
+pub fn action<D>(input: &Value, tag: Tag) -> Result<Value, ShellError>
+where
+    D: digest::Digest,
+    digest::Output<D>: core::fmt::LowerHex,
+{
+    match &input.value {
+        UntaggedValue::Primitive(Primitive::String(s)) => {
+            let digest_result = D::digest(s.as_bytes());
+            Ok(UntaggedValue::string(&format!("{:x}", digest_result)).into_value(tag))
+        }
+        UntaggedValue::Primitive(Primitive::Binary(bytes)) => {
+            let digest_result = D::digest(bytes);
+            Ok(UntaggedValue::string(&format!("{:x}", digest_result)).into_value(tag))
+        }
+        other => {
+            let got = format!("got {}", other.type_name());
+            Err(ShellError::labeled_error(
+                "value is not supported for hashing",
+                got,
+                tag.span,
+            ))
+        }
+    }
+}

--- a/crates/nu-command/src/commands/generators/hash_/mod.rs
+++ b/crates/nu-command/src/commands/generators/hash_/mod.rs
@@ -1,7 +1,10 @@
 mod base64_;
 mod command;
+mod generic_digest;
 mod md5_;
+mod sha256_;
 
 pub use base64_::SubCommand as HashBase64;
 pub use command::Command as Hash;
 pub use md5_::SubCommand as HashMd5;
+pub use sha256_::SubCommand as HashSha256;

--- a/crates/nu-command/src/commands/generators/hash_/sha256_.rs
+++ b/crates/nu-command/src/commands/generators/hash_/sha256_.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
-use md5::Md5;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, UntaggedValue};
+use sha2::Sha256;
 
 use super::generic_digest;
 
@@ -10,39 +10,39 @@ pub struct SubCommand;
 
 impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
-        "hash md5"
+        "hash sha256"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("hash md5").rest(
+        Signature::build("hash sha256").rest(
             SyntaxShape::ColumnPath,
-            "optionally md5 encode data by column paths",
+            "optionally sha256 encode data by column paths",
         )
     }
 
     fn usage(&self) -> &str {
-        "md5 encode a value"
+        "sha256 encode a value"
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        generic_digest::run::<Md5>(args)
+        generic_digest::run::<Sha256>(args)
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "md5 encode a string",
-                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash md5",
+                description: "sha256 encode a string",
+                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash sha256",
                 result: Some(vec![UntaggedValue::string(
-                    "c3fcd3d76192e4007dfb496cca67e13b",
+                    "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73",
                 )
                 .into_untagged_value()]),
             },
             Example {
-                description: "md5 encode a file",
-                example: "open ./nu_0_24_1_windows.zip | hash md5",
+                description: "sha256 encode a file",
+                example: "open ./nu_0_24_1_windows.zip | hash sha256",
                 result: Some(vec![UntaggedValue::string(
-                    "dcf30f2836a1a99fc55cf72e28272606",
+                    "c47a10dc272b1221f0380a2ae0f7d7fa830b3e378f2f5309bbf13f61ad211913",
                 )
                 .into_untagged_value()]),
             },
@@ -52,20 +52,22 @@ impl WholeStreamCommand for SubCommand {
 
 #[cfg(test)]
 mod tests {
-    use md5::Md5;
     use nu_protocol::{Primitive, UntaggedValue};
     use nu_source::Tag;
     use nu_test_support::value::string;
+    use sha2::Sha256;
 
     use crate::commands::generators::hash_::generic_digest::action;
 
     #[test]
     fn md5_encode_string() {
         let word = string("abcdefghijklmnopqrstuvwxyz");
-        let expected =
-            UntaggedValue::string("c3fcd3d76192e4007dfb496cca67e13b").into_untagged_value();
+        let expected = UntaggedValue::string(
+            "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73",
+        )
+        .into_untagged_value();
 
-        let actual = action::<Md5>(&word, Tag::unknown()).unwrap();
+        let actual = action::<Sha256>(&word, Tag::unknown()).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -73,10 +75,12 @@ mod tests {
     fn md5_encode_bytes() {
         let bytes = vec![0xC0, 0xFF, 0xEE];
         let binary = UntaggedValue::Primitive(Primitive::Binary(bytes)).into_untagged_value();
-        let expected =
-            UntaggedValue::string("5f80e231382769b0102b1164cf722d83").into_untagged_value();
+        let expected = UntaggedValue::string(
+            "c47a10dc272b1221f0380a2ae0f7d7fa830b3e378f2f5309bbf13f61ad211913",
+        )
+        .into_untagged_value();
 
-        let actual = action::<Md5>(&binary, Tag::unknown()).unwrap();
+        let actual = action::<Sha256>(&binary, Tag::unknown()).unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -85,6 +85,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(Hash),
             whole_stream_command(HashBase64),
             whole_stream_command(HashMd5),
+            whole_stream_command(HashSha256),
             whole_stream_command(Split),
             whole_stream_command(SplitColumn),
             whole_stream_command(SplitRow),


### PR DESCRIPTION
I needed to calculate sha 256 from nu and didn't want to parse `sha256sum` results since it doesn't seem to be cross-platform.  I remembered a Discord  chat from a couple of weeks ago about adding hashers to the `hash` command so I went and implemented it. Let me know if it's useful and what can be improved.

I've moved `operate()` and `action()` from the original `md5` code to a separate helper file which makes those function work over a generic [`Digest`](https://docs.rs/digest/0.9.0/digest/trait.Digest.html) trait.

This should make it trivial to add extra hashers from this list: https://github.com/RustCrypto/hashes#supported-algorithms

Md5 and Sha256 use this helper now. I had to change the dependency from `md5` to `md-5` since the former doesn't implement `Digest` (the link above contains more details.)