### PR TITLE
WIP on #3085 - silencing "command failed" diagnostic

### DIFF
--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -432,10 +432,8 @@ fn spawn(
                     if let Ok(cfg) = cfg {
                         if cfg.contains_key("nonzero_exit_errors") {
                             let _ = stdout_read_tx.send(Ok(Value {
-                                value: UntaggedValue::Error(ShellError::labeled_error(
-                                    "External command failed",
-                                    "command failed",
-                                    &stdout_name_tag,
+                                value: UntaggedValue::Error(ShellError::command_failed(
+                                    &stdout_name_tag.span,
                                 )),
                                 tag: stdout_name_tag.clone(),
                             }));


### PR DESCRIPTION
This is my work-in-progress attempt to fix #3085. I'm making a PR early to claim the issue, and get early feedback on my approach.

I think the approach should be:

- [x] Add error enum that's specific to the command-failed case
- [ ] add a config flag to enable this behaviour (or maybe replace/supplement the `nonzero_exit_errors` boolean with an enum-like thing - "verbose"|"quiet"|"ignored"?)
- [ ] catch that error and treat it specially if it bubbles up to the top level (not sure where this lives yet)
- [ ] clean up my TODOs.
- [ ] some kind of tests? (I have been running `/usr/bin/false` as a manual test)
- [ ] (stretch goal): find a way to report this to starship
- [ ] (stretch goal): Maybe save the exit code into a variable somewhere?

Does this sound about right?


(Heading to bed now. I might not get back to this until next weekend)
