### PR TITLE
temporarily turn off s3 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,6 @@ dependencies = [
  "nu_plugin_post",
  "nu_plugin_ps",
  "nu_plugin_query_json",
- "nu_plugin_s3",
  "nu_plugin_selector",
  "nu_plugin_start",
  "nu_plugin_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ nu_plugin_match = { version = "0.34.1", path="./crates/nu_plugin_match", optiona
 nu_plugin_post = { version = "0.34.1", path="./crates/nu_plugin_post", optional=true }
 nu_plugin_ps = { version = "0.34.1", path="./crates/nu_plugin_ps", optional=true }
 nu_plugin_query_json = { version = "0.34.1", path="./crates/nu_plugin_query_json", optional=true }
-nu_plugin_s3 = { version = "0.34.1", path="./crates/nu_plugin_s3", optional=true }
+# nu_plugin_s3 = { version = "0.34.1", path="./crates/nu_plugin_s3", optional=true }
 nu_plugin_selector = { version = "0.34.1", path="./crates/nu_plugin_selector", optional=true }
 nu_plugin_start = { version = "0.34.1", path="./crates/nu_plugin_start", optional=true }
 nu_plugin_sys = { version = "0.34.1", path="./crates/nu_plugin_sys", optional=true }
@@ -100,7 +100,7 @@ extra = [
     "start",
     "bson",
     "sqlite",
-    "s3",
+    # "s3",
     "chart",
     "xpath",
     "selector",
@@ -124,7 +124,7 @@ bson = ["nu_plugin_from_bson", "nu_plugin_to_bson"]
 chart = ["nu_plugin_chart"]
 clipboard-cli = ["nu-command/clipboard-cli"]
 query-json = ["nu_plugin_query_json"]
-s3 = ["nu_plugin_s3"]
+# s3 = ["nu_plugin_s3"]
 selector = ["nu_plugin_selector"]
 sqlite = ["nu_plugin_from_sqlite", "nu_plugin_to_sqlite"]
 start = ["nu_plugin_start"]
@@ -210,10 +210,10 @@ name = "nu_plugin_extra_start"
 path = "src/plugins/nu_plugin_extra_start.rs"
 required-features = ["start"]
 
-[[bin]]
-name = "nu_plugin_extra_s3"
-path = "src/plugins/nu_plugin_extra_s3.rs"
-required-features = ["s3"]
+# [[bin]]
+# name = "nu_plugin_extra_s3"
+# path = "src/plugins/nu_plugin_extra_s3.rs"
+# required-features = ["s3"]
 
 [[bin]]
 name = "nu_plugin_extra_chart_bar"

--- a/crates/nu_plugin_s3/Cargo.toml
+++ b/crates/nu_plugin_s3/Cargo.toml
@@ -15,6 +15,6 @@ nu-errors = { path="../nu-errors", version = "0.34.1" }
 nu-plugin = { path="../nu-plugin", version = "0.34.1" }
 nu-protocol = { path="../nu-protocol", version = "0.34.1" }
 nu-source = { path="../nu-source", version = "0.34.1" }
-s3handler = "0.7"
+s3handler = "0.7.3"
 
 [build-dependencies]


### PR DESCRIPTION
Currently getting this error when I try to build:

```
  Installing nu v0.34.1 (/home/jt/Source/nushell)
    Updating crates.io index
error: failed to compile `nu v0.34.1 (/home/jt/Source/nushell)`, intermediate artifacts can be found at `/home/jt/Source/nushell/target`

Caused by:
  failed to select a version for the requirement `hmac = "^0.4"`
  candidate versions found which didn't match: 0.11.0, 0.10.1, 0.10.0, ...
  location searched: crates.io index
  required by package `s3handler v0.7.3`
      ... which is depended on by `nu_plugin_s3 v0.34.1 (/home/jt/Source/nushell/crates/nu_plugin_s3)`
      ... which is depended on by `nu v0.34.1 (/home/jt/Source/nushell)`
```

This PR temporarily removes s3 support so we can continue building. Once the dependent packages update their dependencies we should be able to re-enable