### PR TITLE
document no openssl building

### DIFF
--- a/docs/howto_build_without_openssl.md
+++ b/docs/howto_build_without_openssl.md
@@ -1,0 +1,9 @@
+# how to compile without OpenSSL
+
+You may find it desirable to compile nu shell without requiring an OpenSSL installation on your system.
+
+You can do this by runnning:
+```sh
+cargo build --no-default-features --features=rustyline-support
+```
+


### PR DESCRIPTION
- Fix wrong path separator (#3829)
-  Support other variables than PATH in pathvar (2nd attempt) (#3828)
- change describe so it doesn't output colored strings (#3832)
- Read from standard input in `rm` (#3763)
- add `date humanize` command (#3833)
- use chrono_humanize for datetime formatting (#3834)
- All is a DataFrame (#3812)
- Bump to 0.34.1 (#3835)
- Add sha256 to the hash command (#3836)
- append dataframes (#3839)
- added the ability to compare time units like 1hr < 2hr (#3845)
- Update implementing_a_command.md (#3848)
- Remove dependencies (#3853)
- Fix select to insert nulls in sparse tables instead of ignoring absent values (#3857)
- Unify use of the `surf` crate (#3855)
- document compiling without openssl
