### PR TITLE
Add named positionals to all

### DIFF
--- a/crates/nu-command/src/commands/filters/all.rs
+++ b/crates/nu-command/src/commands/filters/all.rs
@@ -96,7 +96,11 @@ fn all(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let result = args.input.fold(init, move |acc, row| {
         let condition = condition.clone();
         let ctx = ctx.clone();
-        ctx.scope.add_var("$it", row);
+        if let Some(positional) = all_args.predicate.block.params.positional.get(0) {
+            ctx.scope.add_var(positional.0.name(), row);
+        } else {
+            ctx.scope.add_var("$it", row);
+        }
 
         let condition = evaluate_baseline_expr(&condition, &ctx);
 

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -20,6 +20,34 @@ fn checks_all_rows_are_true() {
 }
 
 #[test]
+fn checks_all_rows_are_false_with_param() {
+    Playground::setup("all_test_1", |_, nu| {
+        assert_that!(
+            nu.pipeline(&input(
+                r#"
+                [1, 2, 3, 4] | all? { |a| $a >= 5 }
+                "#
+            )),
+            says().stdout("false")
+        );
+    })
+}
+
+#[test]
+fn checks_all_rows_are_true_with_param() {
+    Playground::setup("all_test_1", |_, nu| {
+        assert_that!(
+            nu.pipeline(&input(
+                r#"
+                [1, 2, 3, 4] | all? { |a| $a < 5 }
+                "#
+            )),
+            says().stdout("true")
+        );
+    })
+}
+
+#[test]
 fn checks_all_columns_of_a_table_is_true() {
     Playground::setup("any_test_1", |_, nu| {
         assert_that!(


### PR DESCRIPTION
This adds the ability to name the block param when calling `all?`

```
[1, 2, 3, 4] | all? { |a| $a < 5 }
```