### PR TITLE
fix interpolated strings when using unicode

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -650,7 +650,7 @@ fn parse_interpolated_string(
     scope: &dyn ParserScope,
 ) -> (SpannedExpression, Option<ParseError>) {
     trace!("Parse_interpolated_string");
-    let string_len = lite_arg.item.len();
+    let string_len = lite_arg.item.chars().count();
     let inner_string = lite_arg
         .item
         .chars()

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -216,6 +216,19 @@ fn string_interpolation_and_paren() {
 }
 
 #[test]
+fn string_interpolation_with_unicode() {
+    //カ = U+30AB : KATAKANA LETTER KA
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            $"カ"
+        "#
+    );
+
+    assert_eq!(actual.out, "カ");
+}
+
+#[test]
 fn bignum_large_integer() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
This is meant to fix #3849. I think this is the right fix - using `chars().count()` instead of `len()`