### PR TITLE
Support equals sign in shorthand environment variable values

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1997,7 +1997,7 @@ fn expand_shorthand_forms(
         if lite_pipeline.commands[0].parts[0].contains('=')
             && !lite_pipeline.commands[0].parts[0].starts_with('$')
         {
-            let assignment: Vec<_> = lite_pipeline.commands[0].parts[0].split('=').collect();
+            let assignment: Vec<_> = lite_pipeline.commands[0].parts[0].splitn(2, '=').collect();
             if assignment.len() != 2 {
                 (
                     lite_pipeline.clone(),

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -15,6 +15,52 @@ fn env_shorthand() {
 }
 
 #[test]
+fn env_shorthand_with_equals() {
+    let actual = nu!(cwd: ".", r#"
+        RUST_LOG=my_module=info $nu.env.RUST_LOG
+    "#);
+    assert_eq!(actual.out, "my_module=info");
+}
+
+#[test]
+fn env_shorthand_with_comma_equals() {
+    let actual = nu!(cwd: ".", r#"
+        RUST_LOG=info,my_module=info $nu.env.RUST_LOG
+    "#);
+    assert_eq!(actual.out, "info,my_module=info");
+}
+
+#[test]
+fn env_shorthand_with_comma_colons_equals() {
+    let actual = nu!(cwd: ".", r#"
+        RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace $nu.env.RUST_LOG
+    "#);
+    assert_eq!(actual.out, "info,my_module=info,lib_crate::lib_mod=trace");
+}
+
+#[test]
+fn env_shorthand_multi_second_with_comma_colons_equals() {
+    let actual = nu!(cwd: ".", r#"
+        FOO=bar RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace $nu.env.FOO + $nu.env.RUST_LOG
+    "#);
+    assert_eq!(
+        actual.out,
+        "barinfo,my_module=info,lib_crate::lib_mod=trace"
+    );
+}
+
+#[test]
+fn env_shorthand_multi_first_with_comma_colons_equals() {
+    let actual = nu!(cwd: ".", r#"
+        RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace FOO=bar $nu.env.FOO + $nu.env.RUST_LOG
+    "#);
+    assert_eq!(
+        actual.out,
+        "barinfo,my_module=info,lib_crate::lib_mod=trace"
+    );
+}
+
+#[test]
 fn env_shorthand_multi() {
     let actual = nu!(cwd: ".", r#"
         FOO=bar BAR=baz $nu.env.FOO + $nu.env.BAR


### PR DESCRIPTION
Some environment variables, such as `RUST_LOG` include equals signs. Nushell
should support this in the shorthand environment variable syntax so that
developers using these variables can control them easily. We accomplish this by
swapping `std::str::split` for `std::str::splitn`, which ensures that we only
consider the first equals sign in the string instead of all of them, which we
did previously.

Closes #3867