### PR TITLE
Implement PartialEq for ReturnSuccess

### DIFF
--- a/crates/nu-protocol/src/config_path.rs
+++ b/crates/nu-protocol/src/config_path.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Specifies a path to a configuration file and its type
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum ConfigPath {
     /// Path to the global configuration file
     Global(PathBuf),

--- a/crates/nu-protocol/src/return_value.rs
+++ b/crates/nu-protocol/src/return_value.rs
@@ -4,7 +4,7 @@ use nu_source::{DbgDocBldr, DebugDocBuilder, PrettyDebug};
 use serde::{Deserialize, Serialize};
 
 /// The inner set of actions for the command processor. Each denotes a way to change state in the processor without changing it directly from the command itself.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum CommandAction {
     /// Change to a new directory or path (in non-filesystem situations)
     ChangePath(String),
@@ -63,7 +63,7 @@ impl PrettyDebug for CommandAction {
 }
 
 /// The fundamental success type in the pipeline. Commands return these values as their main responsibility
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ReturnSuccess {
     /// A value to be used or shown to the user
     Value(Value),
@@ -121,5 +121,16 @@ impl ReturnSuccess {
     /// Helper function for creating actions
     pub fn action(input: CommandAction) -> ReturnValue {
         Ok(ReturnSuccess::Action(input))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ReturnSuccess, ReturnValue, UntaggedValue};
+
+    #[test]
+    fn return_value_can_be_used_in_assert_eq() {
+        let v: ReturnValue = ReturnSuccess::value(UntaggedValue::nothing());
+        assert_eq!(v, v);
     }
 }


### PR DESCRIPTION
This makes `ReturnValue` and `ReturnSuccess` usable in `assert_eq!`.