### PR TITLE
Count the size of the directories when calculating the size in DirInfo

### DIFF
--- a/crates/nu-engine/src/filesystem/dir_info.rs
+++ b/crates/nu-engine/src/filesystem/dir_info.rs
@@ -97,9 +97,9 @@ impl DirInfo {
 
         match std::fs::metadata(&s.path) {
             Ok(d) => {
-                s.size = d.len();   // dir entry size
+                s.size = d.len(); // dir entry size
                 s.blocks = file_real_size_fast(&s.path, &d).ok().unwrap_or(0);
-            },
+            }
             Err(e) => s = s.add_error(e.into()),
         };
 

--- a/crates/nu-engine/src/filesystem/dir_info.rs
+++ b/crates/nu-engine/src/filesystem/dir_info.rs
@@ -95,6 +95,14 @@ impl DirInfo {
             path,
         };
 
+        match std::fs::metadata(&s.path) {
+            Ok(d) => {
+                s.size = d.len();   // dir entry size
+                s.blocks = file_real_size_fast(&s.path, &d).ok().unwrap_or(0);
+            },
+            Err(e) => s = s.add_error(e.into()),
+        };
+
         match std::fs::read_dir(&s.path) {
             Ok(d) => {
                 for f in d {


### PR DESCRIPTION
I noticed that the `size` and `blocks` in `DirInfo` struct only take account of the sizes and blocks of files in that directory(recursively), which resulting in the inaccuracy output of `du` command. Since the directories do take actual disk space, I guess it will make more sense if we take the size of sub-directories into consideration when calculating the size in `DirInfo`.