### PR TITLE
in/not-in for strings

### DIFF
--- a/crates/nu-protocol/src/return_value.rs
+++ b/crates/nu-protocol/src/return_value.rs
@@ -130,7 +130,8 @@ mod tests {
 
     #[test]
     fn return_value_can_be_used_in_assert_eq() {
-        let v: ReturnValue = ReturnSuccess::value(UntaggedValue::nothing());
-        assert_eq!(v, v);
+        let v1: ReturnValue = ReturnSuccess::value(UntaggedValue::nothing());
+        let v2: ReturnValue = ReturnSuccess::value(UntaggedValue::nothing());
+        assert_eq!(v1, v2);
     }
 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -679,6 +679,31 @@ fn negative_decimal_start() {
 
     assert_eq!(actual.out, "2.7");
 }
+
+#[test]
+fn string_inside_of() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            "bob" in "bobby"
+        "#
+    );
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn string_not_inside_of() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            "bob" not-in "bobby"
+        "#
+    );
+
+    assert_eq!(actual.out, "false");
+}
+
 #[test]
 fn index_row() {
     let actual = nu!(


### PR DESCRIPTION
`"bob" in "bobby"` will now work as `in` and `not-in` will also be able to handle string/substrings