### PR TITLE
Flexible dropping of rows (by desired row number)

### DIFF
--- a/crates/nu-command/src/commands/filters/drop/mod.rs
+++ b/crates/nu-command/src/commands/filters/drop/mod.rs
@@ -1,5 +1,7 @@
 mod column;
 mod command;
+mod nth;
 
 pub use column::SubCommand as DropColumn;
 pub use command::Command as Drop;
+pub use nth::SubCommand as DropNth;

--- a/crates/nu-command/src/commands/filters/drop/nth.rs
+++ b/crates/nu-command/src/commands/filters/drop/nth.rs
@@ -4,99 +4,76 @@ use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, Value};
 use nu_source::Tagged;
 
-pub struct Nth;
+pub struct SubCommand;
 
-impl WholeStreamCommand for Nth {
+impl WholeStreamCommand for SubCommand {
     fn name(&self) -> &str {
-        "nth"
+        "drop nth"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("nth")
+        Signature::build("drop nth")
             .required(
                 "row number",
                 SyntaxShape::Int,
-                "the number of the row to return",
+                "the number of the row to drop",
             )
-            .rest(SyntaxShape::Any, "Optionally return more rows")
-            .switch("skip", "Skip the rows instead of selecting them", Some('s'))
+            .rest(SyntaxShape::Any, "Optionally drop more rows")
     }
 
     fn usage(&self) -> &str {
-        "Return or skip only the selected rows."
+        "Drops the selected rows."
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        nth(args)
+        drop(args)
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Get the second row",
-                example: "echo [first second third] | nth 1",
-                result: Some(vec![Value::from("second")]),
-            },
-            Example {
-                description: "Get the first and third rows",
-                example: "echo [first second third] | nth 0 2",
+                description: "Drop the second row",
+                example: "echo [first second third] | drop nth 1",
                 result: Some(vec![Value::from("first"), Value::from("third")]),
             },
             Example {
-                description: "Skip the first and third rows",
-                example: "echo [first second third] | nth --skip 0 2",
+                description: "Drop the first and third rows",
+                example: "echo [first second third] | drop nth 0 2",
                 result: Some(vec![Value::from("second")]),
             },
         ]
     }
 }
 
-fn nth(args: CommandArgs) -> Result<OutputStream, ShellError> {
+fn drop(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let row_number: Tagged<u64> = args.req(0)?;
     let and_rows: Vec<Tagged<u64>> = args.rest(1)?;
-    let skip = args.has_flag("skip");
     let input = args.input;
 
     let mut rows: Vec<_> = and_rows.into_iter().map(|x| x.item as usize).collect();
     rows.push(row_number.item as usize);
     rows.sort_unstable();
 
-    Ok(NthIterator {
+    Ok(DropNthIterator {
         input,
         rows,
-        skip,
         current: 0,
     }
     .into_output_stream())
 }
 
-struct NthIterator {
+struct DropNthIterator {
     input: InputStream,
     rows: Vec<usize>,
-    skip: bool,
     current: usize,
 }
 
-impl Iterator for NthIterator {
+impl Iterator for DropNthIterator {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if !self.skip {
-                if let Some(row) = self.rows.get(0) {
-                    if self.current == *row {
-                        self.rows.remove(0);
-                        self.current += 1;
-                        return self.input.next();
-                    } else {
-                        self.current += 1;
-                        let _ = self.input.next();
-                        continue;
-                    }
-                } else {
-                    return None;
-                }
-            } else if let Some(row) = self.rows.get(0) {
+            if let Some(row) = self.rows.get(0) {
                 if self.current == *row {
                     self.rows.remove(0);
                     self.current += 1;

--- a/crates/nu-command/src/commands/mod.rs
+++ b/crates/nu-command/src/commands/mod.rs
@@ -65,12 +65,16 @@ mod tests {
 
     fn full_tests() -> Vec<Command> {
         vec![
+            whole_stream_command(Drop),
+            whole_stream_command(DropNth),
+            whole_stream_command(DropColumn),
             whole_stream_command(Append),
             whole_stream_command(GroupBy),
             whole_stream_command(Insert),
             whole_stream_command(MoveColumn),
             whole_stream_command(Update),
             whole_stream_command(Empty),
+            whole_stream_command(Nth),
             // whole_stream_command(Select),
             // whole_stream_command(Get),
             // Str Command Suite

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -150,6 +150,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(Every),
             whole_stream_command(Nth),
             whole_stream_command(Drop),
+            whole_stream_command(DropNth),
             whole_stream_command(Format),
             whole_stream_command(FileSize),
             whole_stream_command(Where),


### PR DESCRIPTION
We very well support `nth 0 2 3 --skip 1 4` to select particular rows and skip some using a flag. However, in practice we deal with tables (whether they come from parsing or loading files and whatnot) where we don't know the size of the table up front (and everytime we have these, they may have different sizes). There are also other use cases when we use intermediate tables during processing and wish to always drop certain rows and **keep the rest**.

Usage:

```
... | drop nth 0
... | drop nth 3 8
```