### PR TITLE
allow fetch to follow redirects

### DIFF
--- a/crates/nu_plugin_fetch/src/fetch.rs
+++ b/crates/nu_plugin_fetch/src/fetch.rs
@@ -113,7 +113,8 @@ async fn helper(
         _ => None,
     };
 
-    let mut response = surf::RequestBuilder::new(surf::http::Method::Get, url);
+    let mut response = surf::RequestBuilder::new(surf::http::Method::Get, url)
+        .middleware(surf::middleware::Redirect::default());
 
     if let Some(login) = login {
         response = surf::get(location).header("Authorization", format!("Basic {}", login));


### PR DESCRIPTION
This change should allow `fetch` to follow redirects like `fetch https://dot.net/v1/dotnet-install.ps1`