### PR TITLE
Only allow unaliasing in current scope, add tests

### DIFF
--- a/crates/nu-engine/src/evaluate/scope.rs
+++ b/crates/nu-engine/src/evaluate/scope.rs
@@ -408,7 +408,7 @@ impl ParserScope for Scope {
     }
 
     fn remove_alias(&self, name: &str) {
-        for frame in self.frames.lock().iter_mut().rev() {
+        if let Some(frame) = self.frames.lock().last_mut() {
             frame.aliases.remove(name);
         }
     }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1150,23 +1150,44 @@ fn unalias_shadowing() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        alias ll = ls -l
-        let xyz = { ll -a }
-        unalias ll
-        do $xyz
+        def test-shadowing [] {
+            alias greet = echo hello;
+            let xyz = { greet };
+            unalias greet;
+            do $xyz
+        };
+        test-shadowing
         "#)
     );
+    assert_eq!(actual.out, "hello");
+}
 
-    assert_eq!(actual.out, "");
+#[test]
+fn unalias_does_not_escape_scope() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-alias [] {
+            alias greet = echo hello;
+            (unalias greet);
+            greet
+        };
+        test-alias
+        "#)
+    );
+    assert_eq!(actual.out, "hello");
 }
 
 #[test]
 fn unalias_hides_alias() {
     let actual = nu!(cwd: ".", pipeline(
-        r#"alias ll = ls -l
-        ll
-        unalias ll
-        ll
+        r#"
+        def test-alias [] {
+            alias ll = ls -l;
+            unalias ll;
+            ll
+        };
+        test-alias
         "#)
     );
 


### PR DESCRIPTION
Just a quick fix for the recently merged `unalias` command.

The previous implementation would loop over the frames and remove aliases from all of them. This is surprising, because other similar commands, such as `unlet-env`, do not do this, but instead only change the current scope. This also had the side effect of removing aliases when a user types (but does not run) `unalias some-alias`.

The test associated with unalias also had some issues, as far as I can tell. The `pipeline` function used with the `nu!` macro joins all lines from the raw string and skips the first one. Essentially, everything passed into `pipeline` is run as a single line. Due to this, the tests were passing, but not for the correct reason. I did not figure out a way to write the tests without defining a command, but that pattern was used in other tests, so I hope it's okay. I also changed the example commands in the tests: instead of `ls -l`, I used `echo`, because it has predictable and testable output. I would be happy to rewrite that or add new tests if something else is preferable.

On a related note, the `skip(1)` filter in the `pipeline` function might have to be removed to avoid similar issues. Removing it does not cause any of the existing tests to fail, as far as I could tell.

And thanks to the Nushell team and everyone who worked on this feature!