### PR TITLE
Allow load-env to remove vars if value is $nothing

### DIFF
--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -535,6 +535,54 @@ fn proper_shadow_load_env_aliases() {
 }
 
 #[test]
+fn load_env_removes_with_nothing() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        load-env [[name, value]; [DEBUG true]]
+        echo $nu.env.DEBUG
+        load-env [[name, value]; [DEBUG $nothing]]
+        echo $nu.env.DEBUG
+        "#
+    );
+    assert_eq!(actual.out, "true");
+    assert!(actual.err.contains("error"));
+    assert!(actual.err.contains("Unknown column"));
+}
+
+#[test]
+fn load_env_removes_and_adds_with_nothing() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        load-env [[name, value]; [DEBUG1 "1"] [DEBUG2 "2"]]
+        echo $nu.env.DEBUG1
+        echo $nu.env.DEBUG2
+        load-env [[name, value]; [DEBUG1 "3"] [DEBUG2 $nothing]]
+        echo $nu.env.DEBUG1
+        echo $nu.env.DEBUG2
+        "#
+    );
+    assert_eq!(actual.out, "124");
+    assert!(actual.err.contains("error"));
+    assert!(actual.err.contains("Unknown column"));
+}
+
+#[test]
+fn load_env_error_when_removing_non_existent() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let-env DEBUG = true
+        load-env [[name, value]; [DEBUG $nothing]]
+        load-env [[name, value]; [DEBUG $nothing]]
+        "#
+    );
+    assert!(actual.err.contains("error"));
+    assert!(actual.err.contains("Not an environment variable"));
+}
+
+#[test]
 fn proper_shadow_let_aliases() {
     let actual = nu!(
         cwd: ".",

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -563,7 +563,7 @@ fn load_env_removes_and_adds_with_nothing() {
         echo $nu.env.DEBUG2
         "#
     );
-    assert_eq!(actual.out, "124");
+    assert_eq!(actual.out, "123");
     assert!(actual.err.contains("error"));
     assert!(actual.err.contains("Unknown column"));
 }


### PR DESCRIPTION
This allows the user to pass a table of environment variables, which can either have a string value or $nothing. If the value is $nothing, the value is removed the same way as using unlet-env.

For example:

```
load-env [[name, value]; [DEBUG1 123] [DEBUG2 345]]
echo $nu.env.DEBUG1  # == 123
echo $nu.env.DEBUG2  # == 345
load-env [[name, value]; [DEBUG1 678] [DEBUG2 $nothing]]
echo $nu.env.DEBUG1  # == 678
echo $nu.env.DEBUG2  # not found!
```

A possible use case for this is managing virtual environments. Activating them usually requires a single `load-env (create-table)`. Deactivating them currently requires several `unlet-env` calls, as well as `load-env` to overwrite env vars (such as PATH). This change allows users to remove, add and change variables in a single call, which makes activation and deactivation of virtual environments work the same way.