### PR TITLE
Allow different names for ...rest

### DIFF
--- a/crates/nu-command/src/commands/charting/histogram.rs
+++ b/crates/nu-command/src/commands/charting/histogram.rs
@@ -22,6 +22,7 @@ impl WholeStreamCommand for Histogram {
                 None,
             )
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "column name to give the histogram's frequency column",
             )

--- a/crates/nu-command/src/commands/conversions/into/binary.rs
+++ b/crates/nu-command/src/commands/conversions/into/binary.rs
@@ -13,6 +13,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("into binary").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "column paths to convert to binary (for table input)",
         )

--- a/crates/nu-command/src/commands/conversions/into/filepath.rs
+++ b/crates/nu-command/src/commands/conversions/into/filepath.rs
@@ -14,6 +14,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("into path").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "column paths to convert to filepath (for table input)",
         )

--- a/crates/nu-command/src/commands/conversions/into/int.rs
+++ b/crates/nu-command/src/commands/conversions/into/int.rs
@@ -13,6 +13,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("into int").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "column paths to convert to int (for table input)",
         )

--- a/crates/nu-command/src/commands/conversions/into/string.rs
+++ b/crates/nu-command/src/commands/conversions/into/string.rs
@@ -20,6 +20,7 @@ impl WholeStreamCommand for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("into string")
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "column paths to convert to string (for table input)",
             )

--- a/crates/nu-command/src/commands/core_commands/alias.rs
+++ b/crates/nu-command/src/commands/core_commands/alias.rs
@@ -15,7 +15,7 @@ impl WholeStreamCommand for Alias {
         Signature::build("alias")
             .required("name", SyntaxShape::String, "the name of the alias")
             .required("equals", SyntaxShape::String, "the equals sign")
-            .rest(SyntaxShape::Any, "the expansion for the alias")
+            .rest("rest", SyntaxShape::Any, "the expansion for the alias")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/core_commands/do_.rs
+++ b/crates/nu-command/src/commands/core_commands/do_.rs
@@ -27,7 +27,7 @@ impl WholeStreamCommand for Do {
                 "ignore errors as the block runs",
                 Some('i'),
             )
-            .rest(SyntaxShape::Any, "the parameter(s) for the block")
+            .rest("rest", SyntaxShape::Any, "the parameter(s) for the block")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/core_commands/echo.rs
+++ b/crates/nu-command/src/commands/core_commands/echo.rs
@@ -12,7 +12,7 @@ impl WholeStreamCommand for Echo {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("echo").rest(SyntaxShape::Any, "the values to echo")
+        Signature::build("echo").rest("rest", SyntaxShape::Any, "the values to echo")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/core_commands/help.rs
+++ b/crates/nu-command/src/commands/core_commands/help.rs
@@ -18,7 +18,11 @@ impl WholeStreamCommand for Help {
 
     fn signature(&self) -> Signature {
         Signature::build("help")
-            .rest(SyntaxShape::String, "the name of command to get help on")
+            .rest(
+                "rest",
+                SyntaxShape::String,
+                "the name of command to get help on",
+            )
             .named(
                 "find",
                 SyntaxShape::String,

--- a/crates/nu-command/src/commands/core_commands/nu_signature.rs
+++ b/crates/nu-command/src/commands/core_commands/nu_signature.rs
@@ -41,7 +41,7 @@ impl WholeStreamCommand for Command {
                 "custom configuration source file",
                 None,
             )
-            .rest(SyntaxShape::String, "source file(s) to run")
+            .rest("rest", SyntaxShape::String, "source file(s) to run")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/dataframe/drop.rs
+++ b/crates/nu-command/src/commands/dataframe/drop.rs
@@ -20,7 +20,11 @@ impl WholeStreamCommand for DataFrame {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("dataframe drop").rest(SyntaxShape::Any, "column names to be dropped")
+        Signature::build("dataframe drop").rest(
+            "rest",
+            SyntaxShape::Any,
+            "column names to be dropped",
+        )
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/crates/nu-command/src/commands/dataframe/get.rs
+++ b/crates/nu-command/src/commands/dataframe/get.rs
@@ -19,7 +19,11 @@ impl WholeStreamCommand for DataFrame {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("dataframe get").rest(SyntaxShape::Any, "column names to sort dataframe")
+        Signature::build("dataframe get").rest(
+            "rest",
+            SyntaxShape::Any,
+            "column names to sort dataframe",
+        )
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/crates/nu-command/src/commands/dataframe/groupby.rs
+++ b/crates/nu-command/src/commands/dataframe/groupby.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for DataFrame {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("dataframe group-by").rest(SyntaxShape::Any, "groupby columns")
+        Signature::build("dataframe group-by").rest("rest", SyntaxShape::Any, "groupby columns")
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/crates/nu-command/src/commands/dataframe/select.rs
+++ b/crates/nu-command/src/commands/dataframe/select.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for DataFrame {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("dataframe select").rest(SyntaxShape::Any, "selected column names")
+        Signature::build("dataframe select").rest("rest", SyntaxShape::Any, "selected column names")
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/crates/nu-command/src/commands/dataframe/sort.rs
+++ b/crates/nu-command/src/commands/dataframe/sort.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for DataFrame {
     fn signature(&self) -> Signature {
         Signature::build("dataframe sort")
             .switch("reverse", "invert sort", Some('r'))
-            .rest(SyntaxShape::Any, "column names to sort dataframe")
+            .rest("rest", SyntaxShape::Any, "column names to sort dataframe")
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {

--- a/crates/nu-command/src/commands/filesystem/mkdir.rs
+++ b/crates/nu-command/src/commands/filesystem/mkdir.rs
@@ -12,6 +12,7 @@ impl WholeStreamCommand for Mkdir {
     fn signature(&self) -> Signature {
         Signature::build("mkdir")
             .rest(
+                "rest",
                 SyntaxShape::FilePath,
                 "the name(s) of the path(s) to create",
             )

--- a/crates/nu-command/src/commands/filesystem/rm.rs
+++ b/crates/nu-command/src/commands/filesystem/rm.rs
@@ -26,7 +26,11 @@ impl WholeStreamCommand for Remove {
             )
             .switch("recursive", "delete subdirectories recursively", Some('r'))
             .switch("force", "suppress error when no file", Some('f'))
-            .rest(SyntaxShape::GlobPattern, "the file path(s) to remove")
+            .rest(
+                "rest",
+                SyntaxShape::GlobPattern,
+                "the file path(s) to remove",
+            )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/filesystem/touch.rs
+++ b/crates/nu-command/src/commands/filesystem/touch.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for Touch {
                 SyntaxShape::FilePath,
                 "the path of the file you want to create",
             )
-            .rest(SyntaxShape::FilePath, "additional files to create")
+            .rest("rest", SyntaxShape::FilePath, "additional files to create")
     }
     fn usage(&self) -> &str {
         "Creates one or more files."

--- a/crates/nu-command/src/commands/filters/compact.rs
+++ b/crates/nu-command/src/commands/filters/compact.rs
@@ -17,7 +17,11 @@ impl WholeStreamCommand for Compact {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("compact").rest(SyntaxShape::Any, "the columns to compact from the table")
+        Signature::build("compact").rest(
+            "rest",
+            SyntaxShape::Any,
+            "the columns to compact from the table",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/filters/drop/nth.rs
+++ b/crates/nu-command/src/commands/filters/drop/nth.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for SubCommand {
                 SyntaxShape::Int,
                 "the number of the row to drop",
             )
-            .rest(SyntaxShape::Any, "Optionally drop more rows")
+            .rest("rest", SyntaxShape::Any, "Optionally drop more rows")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/filters/empty.rs
+++ b/crates/nu-command/src/commands/filters/empty.rs
@@ -19,6 +19,7 @@ impl WholeStreamCommand for Command {
     fn signature(&self) -> Signature {
         Signature::build("empty?")
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "the names of the columns to check emptiness",
             )

--- a/crates/nu-command/src/commands/filters/flatten.rs
+++ b/crates/nu-command/src/commands/filters/flatten.rs
@@ -14,7 +14,11 @@ impl WholeStreamCommand for Command {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("flatten").rest(SyntaxShape::String, "optionally flatten data by column")
+        Signature::build("flatten").rest(
+            "rest",
+            SyntaxShape::String,
+            "optionally flatten data by column",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/filters/get.rs
+++ b/crates/nu-command/src/commands/filters/get.rs
@@ -19,6 +19,7 @@ impl WholeStreamCommand for Command {
 
     fn signature(&self) -> Signature {
         Signature::build("get").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally return additional data by path",
         )

--- a/crates/nu-command/src/commands/filters/move_.rs
+++ b/crates/nu-command/src/commands/filters/move_.rs
@@ -14,7 +14,7 @@ impl WholeStreamCommand for Command {
 
     fn signature(&self) -> Signature {
         Signature::build("move")
-            .rest(SyntaxShape::ColumnPath, "the columns to move")
+            .rest("rest", SyntaxShape::ColumnPath, "the columns to move")
             .named(
                 "after",
                 SyntaxShape::ColumnPath,

--- a/crates/nu-command/src/commands/filters/nth.rs
+++ b/crates/nu-command/src/commands/filters/nth.rs
@@ -18,7 +18,7 @@ impl WholeStreamCommand for Nth {
                 SyntaxShape::Int,
                 "the number of the row to return",
             )
-            .rest(SyntaxShape::Any, "Optionally return more rows")
+            .rest("rest", SyntaxShape::Any, "Optionally return more rows")
             .switch("skip", "Skip the rows instead of selecting them", Some('s'))
     }
 

--- a/crates/nu-command/src/commands/filters/pivot.rs
+++ b/crates/nu-command/src/commands/filters/pivot.rs
@@ -36,6 +36,7 @@ impl WholeStreamCommand for Pivot {
                 Some('i'),
             )
             .rest(
+                "rest",
                 SyntaxShape::String,
                 "the names to give columns once pivoted",
             )

--- a/crates/nu-command/src/commands/filters/reject.rs
+++ b/crates/nu-command/src/commands/filters/reject.rs
@@ -13,7 +13,11 @@ impl WholeStreamCommand for Reject {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("reject").rest(SyntaxShape::String, "the names of columns to remove")
+        Signature::build("reject").rest(
+            "rest",
+            SyntaxShape::String,
+            "the names of columns to remove",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/filters/rename.rs
+++ b/crates/nu-command/src/commands/filters/rename.rs
@@ -19,7 +19,11 @@ impl WholeStreamCommand for Rename {
                 SyntaxShape::String,
                 "the new name for the first column",
             )
-            .rest(SyntaxShape::String, "the new name for additional columns")
+            .rest(
+                "rest",
+                SyntaxShape::String,
+                "the new name for additional columns",
+            )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/filters/rotate/command.rs
+++ b/crates/nu-command/src/commands/filters/rotate/command.rs
@@ -17,6 +17,7 @@ impl WholeStreamCommand for Command {
 
     fn signature(&self) -> Signature {
         Signature::build("rotate").rest(
+            "rest",
             SyntaxShape::String,
             "the names to give columns once rotated",
         )

--- a/crates/nu-command/src/commands/filters/rotate/counter_clockwise.rs
+++ b/crates/nu-command/src/commands/filters/rotate/counter_clockwise.rs
@@ -17,6 +17,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("rotate counter-clockwise").rest(
+            "rest",
             SyntaxShape::String,
             "the names to give columns once rotated",
         )

--- a/crates/nu-command/src/commands/filters/select.rs
+++ b/crates/nu-command/src/commands/filters/select.rs
@@ -16,6 +16,7 @@ impl WholeStreamCommand for Command {
 
     fn signature(&self) -> Signature {
         Signature::build("select").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "the columns to select from the table",
         )

--- a/crates/nu-command/src/commands/filters/sort_by.rs
+++ b/crates/nu-command/src/commands/filters/sort_by.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for SortBy {
                 Some('i'),
             )
             .switch("reverse", "Sort in reverse order", Some('r'))
-            .rest(SyntaxShape::String, "the column(s) to sort by")
+            .rest("rest", SyntaxShape::String, "the column(s) to sort by")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/generators/hash_/base64_.rs
+++ b/crates/nu-command/src/commands/generators/hash_/base64_.rs
@@ -45,6 +45,7 @@ impl WholeStreamCommand for SubCommand {
                 "decode the input from base64",
                 Some('d'))
             .rest(
+"rest",
                 SyntaxShape::ColumnPath,
                 "optionally base64 encode / decode data by column paths",
             )

--- a/crates/nu-command/src/commands/generators/hash_/command.rs
+++ b/crates/nu-command/src/commands/generators/hash_/command.rs
@@ -12,6 +12,7 @@ impl WholeStreamCommand for Command {
 
     fn signature(&self) -> Signature {
         Signature::build("hash").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert by column paths",
         )

--- a/crates/nu-command/src/commands/generators/hash_/generic_digest.rs
+++ b/crates/nu-command/src/commands/generators/hash_/generic_digest.rs
@@ -38,6 +38,7 @@ where
 
     fn signature(&self) -> Signature {
         Signature::build(self.name()).rest(
+            "rest",
             SyntaxShape::ColumnPath,
             format!("optionally {} encode data by column paths", D::name()),
         )

--- a/crates/nu-command/src/commands/generators/seq.rs
+++ b/crates/nu-command/src/commands/generators/seq.rs
@@ -15,7 +15,7 @@ impl WholeStreamCommand for Seq {
 
     fn signature(&self) -> Signature {
         Signature::build("seq")
-            .rest(SyntaxShape::Number, "sequence values")
+            .rest("rest", SyntaxShape::Number, "sequence values")
             .named(
                 "separator",
                 SyntaxShape::String,

--- a/crates/nu-command/src/commands/network/url_/host.rs
+++ b/crates/nu-command/src/commands/network/url_/host.rs
@@ -14,8 +14,11 @@ impl WholeStreamCommand for UrlHost {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("url host")
-            .rest(SyntaxShape::ColumnPath, "optionally operate by column path")
+        Signature::build("url host").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "optionally operate by column path",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/network/url_/path.rs
+++ b/crates/nu-command/src/commands/network/url_/path.rs
@@ -14,8 +14,11 @@ impl WholeStreamCommand for UrlPath {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("url path")
-            .rest(SyntaxShape::ColumnPath, "optionally operate by column path")
+        Signature::build("url path").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "optionally operate by column path",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/network/url_/query.rs
+++ b/crates/nu-command/src/commands/network/url_/query.rs
@@ -14,8 +14,11 @@ impl WholeStreamCommand for UrlQuery {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("url query")
-            .rest(SyntaxShape::ColumnPath, "optionally operate by column path")
+        Signature::build("url query").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "optionally operate by column path",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/network/url_/scheme.rs
+++ b/crates/nu-command/src/commands/network/url_/scheme.rs
@@ -14,7 +14,11 @@ impl WholeStreamCommand for UrlScheme {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("url scheme").rest(SyntaxShape::ColumnPath, "optionally operate by path")
+        Signature::build("url scheme").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "optionally operate by path",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/path/basename.rs
+++ b/crates/nu-command/src/commands/path/basename.rs
@@ -26,7 +26,11 @@ impl WholeStreamCommand for PathBasename {
 
     fn signature(&self) -> Signature {
         Signature::build("path basename")
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+            .rest(
+                "rest",
+                SyntaxShape::ColumnPath,
+                "Optionally operate by column path",
+            )
             .named(
                 "replace",
                 SyntaxShape::String,

--- a/crates/nu-command/src/commands/path/dirname.rs
+++ b/crates/nu-command/src/commands/path/dirname.rs
@@ -27,7 +27,11 @@ impl WholeStreamCommand for PathDirname {
 
     fn signature(&self) -> Signature {
         Signature::build("path dirname")
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+            .rest(
+                "rest",
+                SyntaxShape::ColumnPath,
+                "Optionally operate by column path",
+            )
             .named(
                 "replace",
                 SyntaxShape::String,

--- a/crates/nu-command/src/commands/path/exists.rs
+++ b/crates/nu-command/src/commands/path/exists.rs
@@ -23,8 +23,11 @@ impl WholeStreamCommand for PathExists {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("path exists")
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+        Signature::build("path exists").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "Optionally operate by column path",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -32,7 +32,11 @@ impl WholeStreamCommand for PathExpand {
                 "Throw an error if the path could not be expanded",
                 Some('s'),
             )
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+            .rest(
+                "rest",
+                SyntaxShape::ColumnPath,
+                "Optionally operate by column path",
+            )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/path/join.rs
+++ b/crates/nu-command/src/commands/path/join.rs
@@ -26,7 +26,11 @@ impl WholeStreamCommand for PathJoin {
 
     fn signature(&self) -> Signature {
         Signature::build("path join")
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+            .rest(
+                "rest",
+                SyntaxShape::ColumnPath,
+                "Optionally operate by column path",
+            )
             .named(
                 "append",
                 SyntaxShape::FilePath,

--- a/crates/nu-command/src/commands/path/parse.rs
+++ b/crates/nu-command/src/commands/path/parse.rs
@@ -28,7 +28,11 @@ impl WholeStreamCommand for PathParse {
 
     fn signature(&self) -> Signature {
         Signature::build("path parse")
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+            .rest(
+                "rest",
+                SyntaxShape::ColumnPath,
+                "Optionally operate by column path",
+            )
             .named(
                 "extension",
                 SyntaxShape::String,

--- a/crates/nu-command/src/commands/path/relative_to.rs
+++ b/crates/nu-command/src/commands/path/relative_to.rs
@@ -31,7 +31,11 @@ impl WholeStreamCommand for PathRelativeTo {
                 SyntaxShape::FilePath,
                 "Parent shared with the input path",
             )
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+            .rest(
+                "rest",
+                SyntaxShape::ColumnPath,
+                "Optionally operate by column path",
+            )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/path/split.rs
+++ b/crates/nu-command/src/commands/path/split.rs
@@ -23,8 +23,11 @@ impl WholeStreamCommand for PathSplit {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("path split")
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+        Signature::build("path split").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "Optionally operate by column path",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/path/type.rs
+++ b/crates/nu-command/src/commands/path/type.rs
@@ -24,8 +24,11 @@ impl WholeStreamCommand for PathType {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("path type")
-            .rest(SyntaxShape::ColumnPath, "Optionally operate by column path")
+        Signature::build("path type").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "Optionally operate by column path",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/commands/platform/ansi/gradient.rs
@@ -40,6 +40,7 @@ impl WholeStreamCommand for SubCommand {
                 Some('d'),
             )
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally, draw gradients using text from column paths",
             )

--- a/crates/nu-command/src/commands/platform/ansi/strip.rs
+++ b/crates/nu-command/src/commands/platform/ansi/strip.rs
@@ -15,6 +15,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("ansi strip").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally, remove ansi sequences by column paths",
         )

--- a/crates/nu-command/src/commands/platform/exec.rs
+++ b/crates/nu-command/src/commands/platform/exec.rs
@@ -25,6 +25,7 @@ impl WholeStreamCommand for Exec {
         Signature::build("exec")
             .required("command", SyntaxShape::FilePath, "the command to execute")
             .rest(
+                "rest",
                 SyntaxShape::GlobPattern,
                 "any additional arguments for the command",
             )

--- a/crates/nu-command/src/commands/platform/kill.rs
+++ b/crates/nu-command/src/commands/platform/kill.rs
@@ -19,7 +19,7 @@ impl WholeStreamCommand for Kill {
                 SyntaxShape::Int,
                 "process id of process that is to be killed",
             )
-            .rest(SyntaxShape::Int, "rest of processes to kill")
+            .rest("rest", SyntaxShape::Int, "rest of processes to kill")
             .switch("force", "forcefully kill the process", Some('f'))
             .switch("quiet", "won't print anything to the console", Some('q'));
 

--- a/crates/nu-command/src/commands/platform/run_external.rs
+++ b/crates/nu-command/src/commands/platform/run_external.rs
@@ -43,7 +43,7 @@ impl WholeStreamCommand for RunExternalCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).rest(SyntaxShape::Any, "external command arguments")
+        Signature::build(self.name()).rest("rest", SyntaxShape::Any, "external command arguments")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/platform/sleep.rs
+++ b/crates/nu-command/src/commands/platform/sleep.rs
@@ -21,7 +21,7 @@ impl WholeStreamCommand for Sleep {
     fn signature(&self) -> Signature {
         Signature::build("sleep")
             .required("duration", SyntaxShape::Duration, "time to sleep")
-            .rest(SyntaxShape::Duration, "additional time")
+            .rest("rest", SyntaxShape::Duration, "additional time")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/platform/which_.rs
+++ b/crates/nu-command/src/commands/platform/which_.rs
@@ -16,7 +16,7 @@ impl WholeStreamCommand for Which {
     fn signature(&self) -> Signature {
         Signature::build("which")
             .required("application", SyntaxShape::String, "application")
-            .rest(SyntaxShape::String, "additional applications")
+            .rest("rest", SyntaxShape::String, "additional applications")
             .switch("all", "list all executables", Some('a'))
     }
 

--- a/crates/nu-command/src/commands/strings/build_string.rs
+++ b/crates/nu-command/src/commands/strings/build_string.rs
@@ -13,8 +13,11 @@ impl WholeStreamCommand for BuildString {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("build-string")
-            .rest(SyntaxShape::Any, "all values to form into the string")
+        Signature::build("build-string").rest(
+            "rest",
+            SyntaxShape::Any,
+            "all values to form into the string",
+        )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/strings/char_.rs
+++ b/crates/nu-command/src/commands/strings/char_.rs
@@ -135,7 +135,7 @@ impl WholeStreamCommand for Char {
                 SyntaxShape::Any,
                 "the name of the character to output",
             )
-            .rest(SyntaxShape::String, "multiple Unicode bytes")
+            .rest("rest", SyntaxShape::String, "multiple Unicode bytes")
             .switch("list", "List all supported character names", Some('l'))
             .switch("unicode", "Unicode string i.e. 1f378", Some('u'))
     }

--- a/crates/nu-command/src/commands/strings/split/column.rs
+++ b/crates/nu-command/src/commands/strings/split/column.rs
@@ -22,7 +22,11 @@ impl WholeStreamCommand for SubCommand {
                 "the character that denotes what separates columns",
             )
             .switch("collapse-empty", "remove empty columns", Some('c'))
-            .rest(SyntaxShape::String, "column names to give the new columns")
+            .rest(
+                "rest",
+                SyntaxShape::String,
+                "column names to give the new columns",
+            )
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/strings/str_/capitalize.rs
+++ b/crates/nu-command/src/commands/strings/str_/capitalize.rs
@@ -19,6 +19,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str capitalize").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally capitalize text by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/camel_case.rs
@@ -14,6 +14,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str camel-case").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert text to camelCase by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/kebab_case.rs
@@ -14,6 +14,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str kebab-case").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert text to kebab-case by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/pascal_case.rs
@@ -14,6 +14,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str pascal-case").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert text to PascalCase by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/screaming_snake_case.rs
@@ -14,6 +14,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str screaming-snake-case").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert text to SCREAMING_SNAKE_CASE by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/snake_case.rs
@@ -14,6 +14,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str snake-case").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert text to snake_case by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/command.rs
+++ b/crates/nu-command/src/commands/strings/str_/command.rs
@@ -12,6 +12,7 @@ impl WholeStreamCommand for Command {
 
     fn signature(&self) -> Signature {
         Signature::build("str").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/contains.rs
+++ b/crates/nu-command/src/commands/strings/str_/contains.rs
@@ -25,6 +25,7 @@ impl WholeStreamCommand for SubCommand {
         Signature::build("str contains")
             .required("pattern", SyntaxShape::String, "the pattern to find")
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally check if string contains pattern by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/downcase.rs
+++ b/crates/nu-command/src/commands/strings/str_/downcase.rs
@@ -21,6 +21,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str downcase").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally downcase text by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/commands/strings/str_/ends_with.rs
@@ -24,6 +24,7 @@ impl WholeStreamCommand for SubCommand {
         Signature::build("str ends-with")
             .required("pattern", SyntaxShape::String, "the pattern to match")
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally matches suffix of text by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/find_replace.rs
+++ b/crates/nu-command/src/commands/strings/str_/find_replace.rs
@@ -28,6 +28,7 @@ impl WholeStreamCommand for SubCommand {
             .required("find", SyntaxShape::String, "the pattern to find")
             .required("replace", SyntaxShape::String, "the replacement pattern")
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally find and replace text by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/index_of.rs
+++ b/crates/nu-command/src/commands/strings/str_/index_of.rs
@@ -33,6 +33,7 @@ impl WholeStreamCommand for SubCommand {
                 "the pattern to find index of",
             )
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally returns index of pattern in string by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/length.rs
+++ b/crates/nu-command/src/commands/strings/str_/length.rs
@@ -19,6 +19,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str length").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally find length of text by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/lpad.rs
+++ b/crates/nu-command/src/commands/strings/str_/lpad.rs
@@ -31,6 +31,7 @@ impl WholeStreamCommand for SubCommand {
                 Some('c'),
             )
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally check if string contains pattern by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/reverse.rs
+++ b/crates/nu-command/src/commands/strings/str_/reverse.rs
@@ -19,6 +19,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str reverse").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally reverse text by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/rpad.rs
+++ b/crates/nu-command/src/commands/strings/str_/rpad.rs
@@ -31,6 +31,7 @@ impl WholeStreamCommand for SubCommand {
                 Some('c'),
             )
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally check if string contains pattern by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/commands/strings/str_/starts_with.rs
@@ -24,6 +24,7 @@ impl WholeStreamCommand for SubCommand {
         Signature::build("str starts-with")
             .required("pattern", SyntaxShape::String, "the pattern to match")
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally matches prefix of text by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/substring.rs
+++ b/crates/nu-command/src/commands/strings/str_/substring.rs
@@ -31,6 +31,7 @@ impl WholeStreamCommand for SubCommand {
                 "the indexes to substring [start end]",
             )
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally substring text by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/to_datetime.rs
+++ b/crates/nu-command/src/commands/strings/str_/to_datetime.rs
@@ -77,6 +77,7 @@ impl WholeStreamCommand for SubCommand {
                 Some('f'),
             )
             .rest(
+"rest",
                 SyntaxShape::Any,
                 "optionally convert text into datetime by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/to_decimal.rs
+++ b/crates/nu-command/src/commands/strings/str_/to_decimal.rs
@@ -24,6 +24,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str to-decimal").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally convert text into decimal by column paths",
         )

--- a/crates/nu-command/src/commands/strings/str_/to_integer.rs
+++ b/crates/nu-command/src/commands/strings/str_/to_integer.rs
@@ -24,6 +24,7 @@ impl WholeStreamCommand for SubCommand {
         Signature::build("str to-int")
             .named("radix", SyntaxShape::Number, "radix of integer", Some('r'))
             .rest(
+                "rest",
                 SyntaxShape::ColumnPath,
                 "optionally convert text into integer by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/trim/command.rs
+++ b/crates/nu-command/src/commands/strings/str_/trim/command.rs
@@ -14,6 +14,7 @@ impl WholeStreamCommand for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("str trim")
             .rest(
+"rest",
                 SyntaxShape::ColumnPath,
                 "optionally trim text by column paths",
             )

--- a/crates/nu-command/src/commands/strings/str_/upcase.rs
+++ b/crates/nu-command/src/commands/strings/str_/upcase.rs
@@ -21,6 +21,7 @@ impl WholeStreamCommand for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str upcase").rest(
+            "rest",
             SyntaxShape::ColumnPath,
             "optionally upcase text by column paths",
         )

--- a/crates/nu-command/src/examples/double_echo.rs
+++ b/crates/nu-command/src/examples/double_echo.rs
@@ -20,7 +20,7 @@ impl WholeStreamCommand for Command {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("echo").rest(SyntaxShape::Any, "the values to echo")
+        Signature::build("echo").rest("rest", SyntaxShape::Any, "the values to echo")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-completion/src/engine.rs
+++ b/crates/nu-completion/src/engine.rs
@@ -356,7 +356,8 @@ mod tests {
         #[test]
         fn completes_internal_command_names() {
             let registry: VecRegistry =
-                vec![Signature::build("echo").rest(SyntaxShape::Any, "the values to echo")].into();
+                vec![Signature::build("echo").rest("rest", SyntaxShape::Any, "the values to echo")]
+                    .into();
             let line = "echo 1 | echo 2";
 
             assert_eq!(
@@ -402,7 +403,7 @@ mod tests {
         fn completes_flags() {
             let registry: VecRegistry = vec![Signature::build("du")
                 .switch("recursive", "the values to echo", None)
-                .rest(SyntaxShape::Any, "blah")]
+                .rest("rest", SyntaxShape::Any, "blah")]
             .into();
 
             let line = "du --recurs";
@@ -442,7 +443,7 @@ mod tests {
         fn completes_flags_with_just_a_single_hyphen() {
             let registry: VecRegistry = vec![Signature::build("du")
                 .switch("recursive", "the values to echo", None)
-                .rest(SyntaxShape::Any, "blah")]
+                .rest("rest", SyntaxShape::Any, "blah")]
             .into();
 
             let line = "du -";
@@ -459,7 +460,8 @@ mod tests {
         #[test]
         fn completes_arguments() {
             let registry: VecRegistry =
-                vec![Signature::build("echo").rest(SyntaxShape::Any, "the values to echo")].into();
+                vec![Signature::build("echo").rest("rest", SyntaxShape::Any, "the values to echo")]
+                    .into();
             let line = "echo 1 | echo 2";
 
             assert_eq!(

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -205,7 +205,7 @@ pub fn get_documentation(
         }
 
         if let Some(rest_positional) = &signature.rest_positional {
-            long_desc.push_str(&format!("  ...args: {}\n", rest_positional.1));
+            long_desc.push_str(&format!("  ...args: {}\n", rest_positional.2));
         }
     }
     if !signature.named.is_empty() {

--- a/crates/nu-engine/src/evaluate/lang.rs
+++ b/crates/nu-engine/src/evaluate/lang.rs
@@ -125,7 +125,7 @@ fn get_signature(sig: &mut Signature, tag: Tag) -> Vec<Value> {
     }
 
     match r {
-        Some((shape, desc)) => {
+        Some((rest_name, shape, desc)) => {
             let mut indexmap = IndexMap::new();
             // let output = format!("Rest|{}|{}|{}\n", name, shape.syntax_shape_name(), desc);
             // eprintln!("{}", output);
@@ -136,7 +136,7 @@ fn get_signature(sig: &mut Signature, tag: Tag) -> Vec<Value> {
             );
             indexmap.insert(
                 "parameter_name".to_string(),
-                UntaggedValue::string("".to_string()).into_value(&tag),
+                UntaggedValue::string(rest_name.to_string()).into_value(&tag),
             );
             indexmap.insert(
                 "parameter_type".to_string(),

--- a/crates/nu-engine/src/types/deduction.rs
+++ b/crates/nu-engine/src/types/deduction.rs
@@ -468,7 +468,10 @@ impl VarSyntaxShapeDeductor {
             if let Expression::Variable(var_name, _) = &positional.expr {
                 let deduced_shape = {
                     if pos_idx >= signature.positional.len() {
-                        signature.rest_positional.as_ref().map(|(shape, _)| shape)
+                        signature
+                            .rest_positional
+                            .as_ref()
+                            .map(|(_, shape, _)| shape)
                     } else {
                         match &signature.positional[pos_idx].0 {
                             PositionalType::Mandatory(_, shape)

--- a/crates/nu-engine/src/whole_stream_command.rs
+++ b/crates/nu-engine/src/whole_stream_command.rs
@@ -139,7 +139,7 @@ impl WholeStreamCommand for Arc<Block> {
                     _ => break,
                 }
             }
-            if block.params.rest_positional.is_some() {
+            if let Some(rest_pos) = &block.params.rest_positional {
                 let elements: Vec<_> = args_iter.collect();
                 let start = if let Some(first) = elements.first() {
                     first.tag.span.start()
@@ -153,15 +153,15 @@ impl WholeStreamCommand for Arc<Block> {
                 };
 
                 ctx.scope.add_var(
-                    "$rest",
+                    format!("${}", rest_pos.0),
                     UntaggedValue::Table(elements).into_value(Span::new(start, end)),
                 );
             }
-        } else if block.params.rest_positional.is_some() {
+        } else if let Some(rest_pos) = &block.params.rest_positional {
             //If there is a rest arg, but no args were provided,
             //we have to set $rest to an empty table
             ctx.scope.add_var(
-                "$rest",
+                format!("${}", rest_pos.0),
                 UntaggedValue::Table(Vec::new()).into_value(Span::new(0, 0)),
             );
         }

--- a/crates/nu-parser/src/flag.rs
+++ b/crates/nu-parser/src/flag.rs
@@ -88,7 +88,7 @@ mod tests {
         Signature::build("bundle add")
             .switch("skip-install", "Adds the gem to the Gemfile but does not install it.", None)
             .named("group", SyntaxShape::String, "Specify the group(s) for the added gem. Multiple groups should be separated by commas.", Some('g'))
-            .rest(SyntaxShape::Any, "options")
+            .rest("rest", SyntaxShape::Any, "options")
     }
 
     #[test]

--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1602,7 +1602,7 @@ fn parse_internal_command(
 
             positional.push(arg);
             current_positional += 1;
-        } else if let Some((rest_type, _)) = &signature.rest_positional {
+        } else if let Some((_, rest_type, _)) = &signature.rest_positional {
             let (arg, err) = parse_arg(*rest_type, scope, &lite_cmd.parts[idx]);
             if error.is_none() {
                 error = err;

--- a/crates/nu-parser/src/parse/def/primitives.rs
+++ b/crates/nu-parser/src/parse/def/primitives.rs
@@ -185,20 +185,20 @@ pub fn parse_type_token(type_: &Token) -> (SyntaxShape, Option<ParseError>) {
     }
 }
 
-pub(crate) fn parse_rest_name(name_token: &Token) -> Option<ParseError> {
+pub(crate) fn parse_rest_name(name_token: &Token) -> (Spanned<String>, Option<ParseError>) {
     return if let TokenContents::Baseline(name) = &name_token.contents {
-        if !name.starts_with("...") {
-            Some(parse_rest_name_err(name_token))
-        } else if !name.starts_with("...rest") {
-            Some(ParseError::mismatch(
-                "rest argument name to be 'rest'",
-                token_to_spanned_string(name_token),
-            ))
-        } else {
-            None
+        match name.strip_prefix("...") {
+            Some(var_name) => (var_name.to_string().spanned(name_token.span), None),
+            None => (
+                "InternalError".to_string().spanned(name_token.span),
+                Some(parse_rest_name_err(name_token)),
+            ),
         }
     } else {
-        Some(parse_rest_name_err(name_token))
+        (
+            "InternalError".to_string().spanned(name_token.span),
+            Some(parse_rest_name_err(name_token)),
+        )
     };
 
     fn parse_rest_name_err(token: &Token) -> ParseError {

--- a/crates/nu-parser/src/parse/def/signature.rs
+++ b/crates/nu-parser/src/parse/def/signature.rs
@@ -231,7 +231,7 @@ fn parse_rest(
     tokens: &[Token],
     tokens_as_str: &Spanned<String>,
 ) -> (
-    Option<(SyntaxShape, Description)>,
+    Option<(String, SyntaxShape, Description)>,
     usize,
     Option<ParseError>,
 ) {
@@ -251,7 +251,7 @@ fn parse_rest(
     let mut type_ = SyntaxShape::Any;
     let mut comment = "".to_string();
 
-    let error = parse_rest_name(&tokens[i]);
+    let (name, error) = parse_rest_name(&tokens[i]);
     err = err.or(error);
     i += 1;
 
@@ -268,7 +268,7 @@ fn parse_rest(
         comment = parsed_comment.unwrap_or_else(|| "".to_string());
     }
 
-    (Some((type_, comment)), i, err)
+    (Some((name.item.to_string(), type_, comment)), i, err)
 }
 
 fn parse_optional_type(tokens: &[Token]) -> (Option<SyntaxShape>, usize, Option<ParseError>) {
@@ -352,7 +352,7 @@ fn to_signature(
     name: &str,
     params: Vec<Parameter>,
     flags: Vec<Flag>,
-    rest: Option<(SyntaxShape, Description)>,
+    rest: Option<(String, SyntaxShape, Description)>,
 ) -> Signature {
     let mut sign = Signature::new(name);
 

--- a/crates/nu-parser/src/parse/def/tests.rs
+++ b/crates/nu-parser/src/parse/def/tests.rs
@@ -332,7 +332,7 @@ fn simple_def_with_rest_arg() {
     assert!(err.is_none());
     assert_eq!(
         sign.rest_positional,
-        Some((SyntaxShape::Any, "".to_string()))
+        Some(("rest".to_string(), SyntaxShape::Any, "".to_string()))
     );
 }
 
@@ -344,7 +344,11 @@ fn simple_def_with_rest_arg_with_type_and_comment() {
     assert!(err.is_none());
     assert_eq!(
         sign.rest_positional,
-        Some((SyntaxShape::FilePath, "My super cool rest arg".to_string()))
+        Some((
+            "rest".to_string(),
+            SyntaxShape::FilePath,
+            "My super cool rest arg".to_string()
+        ))
     );
 }
 
@@ -380,6 +384,10 @@ fn simple_def_with_param_flag_and_rest() {
     );
     assert_eq!(
         sign.rest_positional,
-        Some((SyntaxShape::Table, "Another rest".to_string()))
+        Some((
+            "rest".to_string(),
+            SyntaxShape::Table,
+            "Another rest".to_string()
+        ))
     );
 }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -147,7 +147,7 @@ pub struct Signature {
     /// The list of positional arguments, both required and optional, and their corresponding types and help text
     pub positional: Vec<(PositionalType, Description)>,
     /// After the positional arguments, a catch-all for the rest of the arguments that might follow, their type, and help text
-    pub rest_positional: Option<(SyntaxShape, Description)>,
+    pub rest_positional: Option<(String, SyntaxShape, Description)>,
     /// The named flags with corresponding type and help text
     pub named: IndexMap<String, (NamedType, Description)>,
     /// The type of values being sent out from the command into the pipeline, if any
@@ -194,7 +194,7 @@ impl Signature {
             allowed.insert(shape.display());
         }
 
-        if let Some((shape, _)) = &self.rest_positional {
+        if let Some((_, shape, _)) = &self.rest_positional {
             allowed.insert(shape.display());
         }
 
@@ -348,8 +348,13 @@ impl Signature {
     /// Set the type for the "rest" of the positional arguments
     /// Note: Not naming the field in your struct holding the rest values "rest", can
     /// cause errors when deserializing
-    pub fn rest(mut self, ty: SyntaxShape, desc: impl Into<String>) -> Signature {
-        self.rest_positional = Some((ty, desc.into()));
+    pub fn rest(
+        mut self,
+        name: impl Into<String>,
+        ty: SyntaxShape,
+        desc: impl Into<String>,
+    ) -> Signature {
+        self.rest_positional = Some((name.into(), ty, desc.into()));
         self
     }
 

--- a/crates/nu_plugin_inc/src/nu/mod.rs
+++ b/crates/nu_plugin_inc/src/nu/mod.rs
@@ -31,7 +31,7 @@ impl Plugin for Inc {
                 "increment the patch version (eg 1.2.1 -> 1.2.2)",
                 Some('p'),
             )
-            .rest(SyntaxShape::ColumnPath, "the column(s) to update")
+            .rest("rest", SyntaxShape::ColumnPath, "the column(s) to update")
             .filter())
     }
 

--- a/crates/nu_plugin_start/src/nu/mod.rs
+++ b/crates/nu_plugin_start/src/nu/mod.rs
@@ -8,7 +8,11 @@ impl Plugin for Start {
     fn config(&mut self) -> Result<Signature, ShellError> {
         Ok(Signature::build("start")
             .desc("Opens each file/directory/URL using the default application")
-            .rest(SyntaxShape::String, "files/urls/directories to open")
+            .rest(
+                "rest",
+                SyntaxShape::String,
+                "files/urls/directories to open",
+            )
             .named(
                 "application",
                 SyntaxShape::String,


### PR DESCRIPTION
Resolves #3945

This change requires an explicit name for the rest argument in `WholeStreamCommand`, which is why there are so many changed files. I've set the names of the rest arguments of all commands to `rest`, to keep everything the same.

I've marked this PR as a draft, because I still have to write tests, but if anyone has feedback in the meantime, I'm happy to receive it.