### PR TITLE
 `$nothing` should be convertible to empty string #3711 

### DIFF
--- a/crates/nu-command/src/commands/conversions/into/string.rs
+++ b/crates/nu-command/src/commands/conversions/into/string.rs
@@ -138,7 +138,7 @@ pub fn action(
                 let byte_string = InlineShape::format_bytes(*a_filesize, None);
                 byte_string.1
             }
-            Primitive::Nothing => "nothing".to_string(),
+            Primitive::Nothing => "".to_string(),
             _ => {
                 return Err(ShellError::unimplemented(&format!(
                     "into string for primitive: {:?}",

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -1,4 +1,5 @@
-use nu_test_support::playground::{Dirs, Playground};
+use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
@@ -155,4 +156,16 @@ fn from_table() {
 
     assert!(actual.out.contains("32.38"));
     assert!(actual.out.contains("15.20"));
+}
+
+#[test]
+fn from_nothing() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        $nothing | into string
+        "#
+    ));
+
+    assert!(actual.out == "");
 }

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -1,4 +1,5 @@
 mod collect;
+mod into_string;
 
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;


### PR DESCRIPTION
Resolves #3711

This PR modifies `into string` so that it converts `$nothing` into the empty string, rather than `"nothing"`.

I noticed the tests in `into_string.rs` were not included in `nu-command`'s tests. I think we want to run these tests, so I added a `mod into_string;` at the top of `nu-command/tests/commands/str_/mod.rs`. Let me know if these were intentionally excluded.

I added a single test to cover the new behavior. I think should be good for review.

Thanks!