### PR TITLE
added more escapes to support ansi art

### DIFF
--- a/crates/nu-command/src/commands/strings/char_.rs
+++ b/crates/nu-command/src/commands/strings/char_.rs
@@ -68,6 +68,35 @@ lazy_static! {
         "pound_sign" => '#'.to_string(),                           // #
         "sharp" => '#'.to_string(),                                // #
         "root" => '#'.to_string(),                                 // #
+        "comma" => ','.to_string(), // , comma
+        "semicolon" => ';'.to_string(), // ; semicolon
+        "dollar" => '$'.to_string(), // $ dollar
+        "at" => '@'.to_string(), // @ at
+        "minus" => '-'.to_string(), // - minus
+        "subtract" => '-'.to_string(),
+        "dash" => '-'.to_string(),
+        "plus" => '+'.to_string(), // + plus
+        "add" => '+'.to_string(),
+        "divide" => '/'.to_string(), // / divide, slash
+        "slash" => '/'.to_string(),
+        "backslash" => '\\'.to_string(),// \ backslash
+        "percent" => '%'.to_string(), // % percent
+        "multiply" => '*'.to_string(), // * multiply
+        "greater_than" => '>'.to_string(), // > greater_than
+        "gt" => '>'.to_string(),
+        "less_than" => '<'.to_string(), // < less_than
+        "lt" => '<'.to_string(),
+        "and" => '&'.to_string(), // & and, ampersand
+        "ampersand" => '&'.to_string(),
+        "equal" => '='.to_string(), // = equal
+        "eq" => '='.to_string(), 
+        "double_equal" => '=='.to_string(), // == double_equal
+        "fat_arrow" => '=>'.to_string(), // => fat_arrow
+        "right_arrow" => '->'.to_string(), // -> right_arrow
+        "left_arrow" => '<-'.to_string(), // <- left_arrow
+        "question" => '?'.to_string(), // ? question, q
+        "q" => '?'.to_string(),
+        "colon" => ':'.to_string(), // : colon
 
         // This is the unicode section
         // Unicode names came from https://www.compart.com/en/unicode

--- a/crates/nu-command/src/commands/strings/char_.rs
+++ b/crates/nu-command/src/commands/strings/char_.rs
@@ -89,11 +89,11 @@ lazy_static! {
         "and" => '&'.to_string(), // & and, ampersand
         "ampersand" => '&'.to_string(),
         "equal" => '='.to_string(), // = equal
-        "eq" => '='.to_string(), 
-        "double_equal" => '=='.to_string(), // == double_equal
-        "fat_arrow" => '=>'.to_string(), // => fat_arrow
-        "right_arrow" => '->'.to_string(), // -> right_arrow
-        "left_arrow" => '<-'.to_string(), // <- left_arrow
+        "eq" => '='.to_string(),
+        "double_equal" => "==".to_string(), // == double_equal
+        "fat_arrow" => "=>".to_string(), // => fat_arrow
+        "right_arrow" => "->".to_string(), // -> right_arrow
+        "left_arrow" => "<-".to_string(), // <- left_arrow
         "question" => '?'.to_string(), // ? question, q
         "q" => '?'.to_string(),
         "colon" => ':'.to_string(), // : colon


### PR DESCRIPTION
added a few more to allow some ansi art easily without nushell getting confused
```rust
        "comma" => ','.to_string(), // , comma
        "semicolon" => ';'.to_string(), // ; semicolon
        "dollar" => '$'.to_string(), // $ dollar
        "at" => '@'.to_string(), // @ at
        "minus" => '-'.to_string(), // - minus
        "subtract" => '-'.to_string(),
        "dash" => '-'.to_string(),
        "plus" => '+'.to_string(), // + plus
        "add" => '+'.to_string(),
        "divide" => '/'.to_string(), // / divide, slash
        "slash" => '/'.to_string(),
        "backslash" => '\\'.to_string(),// \ backslash
        "percent" => '%'.to_string(), // % percent
        "multiply" => '*'.to_string(), // * multiply
        "greater_than" => '>'.to_string(), // > greater_than
        "gt" => '>'.to_string(),
        "less_than" => '<'.to_string(), // < less_than
        "lt" => '<'.to_string(),
        "and" => '&'.to_string(), // & and, ampersand
        "ampersand" => '&'.to_string(),
        "equal" => '='.to_string(), // = equal
        "eq" => '='.to_string(), 
        "double_equal" => '=='.to_string(), // == double_equal
        "fat_arrow" => '=>'.to_string(), // => fat_arrow
        "right_arrow" => '->'.to_string(), // -> right_arrow
        "left_arrow" => '<-'.to_string(), // <- left_arrow
        "question" => '?'.to_string(), // ? question, q
        "q" => '?'.to_string(),
        "colon" => ':'.to_string(), // : colon
```