### PR TITLE
feat: spawn the executables directly if possible

### DIFF
--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -18,7 +18,7 @@ use nu_protocol::hir::{ExternalCommand, ExternalRedirection};
 use nu_protocol::{Primitive, ShellTypeName, UntaggedValue, Value};
 use nu_source::Tag;
 
-#[cfg(feature = "which-support")]
+#[cfg(feature = "which")]
 use which::which;
 
 pub(crate) fn run_external_command(
@@ -181,7 +181,7 @@ fn spawn_sh_command(command: &ExternalCommand, args: &[String]) -> Command {
 /// a function to spawn any external command
 fn spawn_any(command: &ExternalCommand, args: &[String]) -> Command {
     // resolve the executable name if it is spawnable directly
-    #[cfg(feature = "which-support")]
+    #[cfg(feature = "which")]
     if let Result::Ok(full_path) = which(&command.name) {
         if let Some(extension) = full_path.extension() {
             #[cfg(windows)]

--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -189,7 +189,7 @@ fn spawn_any(command: &ExternalCommand, args: &[String], cwd: &str) -> Command {
     if let Result::Ok(full_path) = which_in(&command.name, env::var_os("PATH"), cwd) {
         if let Some(extension) = full_path.extension() {
             #[cfg(windows)]
-            if extension == "EXE" {
+            if extension.eq_ignore_ascii_case("exe") {
                 // if exe spawn it directly
                 return spawn_exe(full_path, args);
             } else {
@@ -199,7 +199,10 @@ fn spawn_any(command: &ExternalCommand, args: &[String], cwd: &str) -> Command {
                 return spawn_cmd_command(command, args);
             }
             #[cfg(not(windows))]
-            if extension != "SH" && extension != "BASH" {
+            if !["sh", "bash"]
+                .iter()
+                .any(|ext| extension.eq_ignore_ascii_case(ext))
+            {
                 // if exe spawn it directly
                 return spawn_exe(full_path, args);
             } else {
@@ -212,6 +215,7 @@ fn spawn_any(command: &ExternalCommand, args: &[String], cwd: &str) -> Command {
     if cfg!(windows) {
         spawn_cmd_command(command, args)
     } else {
+        // TODO what happens if that os doesn't support spawning sh?
         spawn_sh_command(command, args)
     }
 }


### PR DESCRIPTION
This pull request changes nu-command so that it spawns the process directly if:
- They are a `.exe` on Windows
- They are not a `.sh` or `.bash` on not windows.

Benefits:
- As I explained in [this comment](https://github.com/nushell/nushell/issues/3898#issuecomment-894000812), this is another step towards making Nushell a standalone shell that doesn't need to shell out unless it is running a script for a particular shell (cmd, sh, ps1, etc.).
- Fixes the bug with multiline strings. Fixes #3898 
- Better performance due to direct spawning.

For example, this script shows ~30 ms less latency.
After:
```nu
C:\> benchmark { node -e 'console.log("sssss")' }
───┬──────────────────
 # │    real time
───┼──────────────────
 0 │ 54ms 875us 700ns
───┴──────────────────
```
Before
```nu
C:\> benchmark { node -e 'console.log("sssss")' }
───┬──────────────────
 # │    real time
───┼──────────────────
 0 │ 79ms 136us 800ns  
───┴──────────────────
```

