### PR TITLE
Add subcommand `into filesize`

### DIFF
--- a/crates/nu-command/src/commands/conversions/into/filesize.rs
+++ b/crates/nu-command/src/commands/conversions/into/filesize.rs
@@ -104,7 +104,7 @@ pub fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
     let tag = tag.into();
     match &input.value {
         UntaggedValue::Primitive(prim) => Ok(UntaggedValue::filesize(match prim {
-            Primitive::String(a_string) => match int_from_string(a_string, &tag) {
+            Primitive::String(a_string) => match int_from_string(a_string.trim(), &tag) {
                 Ok(n) => n,
                 Err(e) => {
                     return Err(e);

--- a/crates/nu-command/src/commands/conversions/into/filesize.rs
+++ b/crates/nu-command/src/commands/conversions/into/filesize.rs
@@ -1,0 +1,182 @@
+use std::convert::TryInto;
+
+use crate::prelude::*;
+use nu_engine::WholeStreamCommand;
+use nu_errors::ShellError;
+use nu_protocol::{ColumnPath, Primitive, Signature, SyntaxShape, UntaggedValue, Value};
+use num_bigint::ToBigInt;
+
+pub struct SubCommand;
+
+impl WholeStreamCommand for SubCommand {
+    fn name(&self) -> &str {
+        "into filesize"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("into filesize").rest(
+            "rest",
+            SyntaxShape::ColumnPath,
+            "column paths to convert to filesize (for table input)",
+        )
+    }
+
+    fn usage(&self) -> &str {
+        "Convert value to filesize"
+    }
+
+    fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
+        into_filesize(args)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Convert string to filesize in table",
+                example: "echo [[bytes]; ['5'] [3.2] [4] [2kb]] | into filesize num",
+                result: Some(vec![
+                    UntaggedValue::row(indexmap! {
+                        "bytes".to_string() => UntaggedValue::filesize(5).into(),
+                    })
+                    .into(),
+                    UntaggedValue::row(indexmap! {
+                        "bytes".to_string() => UntaggedValue::filesize(3).into(),
+                    })
+                    .into(),
+                    UntaggedValue::row(indexmap! {
+                        "bytes".to_string() => UntaggedValue::filesize(4).into(),
+                    })
+                    .into(),
+                    UntaggedValue::row(indexmap! {
+                        "bytes".to_string() => UntaggedValue::filesize(2000).into(),
+                    })
+                    .into(),
+                ]),
+            },
+            Example {
+                description: "Convert string to filesize",
+                example: "echo '2' | into filesize",
+                result: Some(vec![UntaggedValue::filesize(2).into()]),
+            },
+            Example {
+                description: "Convert decimal to filesize",
+                example: "echo 8.3 | into filesize",
+                result: Some(vec![UntaggedValue::filesize(8).into()]),
+            },
+            Example {
+                description: "Convert int to filesize",
+                example: "echo 5 | into filesize",
+                result: Some(vec![UntaggedValue::filesize(5).into()]),
+            },
+            Example {
+                description: "Convert file size to filesize",
+                example: "echo 4KB | into filesize",
+                result: Some(vec![UntaggedValue::filesize(4000).into()]),
+            },
+        ]
+    }
+}
+
+fn into_filesize(args: CommandArgs) -> Result<OutputStream, ShellError> {
+    let column_paths: Vec<ColumnPath> = args.rest(0)?;
+
+    Ok(args
+        .input
+        .map(move |v| {
+            if column_paths.is_empty() {
+                action(&v, v.tag())
+            } else {
+                let mut ret = v;
+                for path in &column_paths {
+                    ret = ret.swap_data_by_column_path(
+                        path,
+                        Box::new(move |old| action(old, old.tag())),
+                    )?;
+                }
+
+                Ok(ret)
+            }
+        })
+        .into_input_stream())
+}
+
+pub fn action(input: &Value, tag: impl Into<Tag>) -> Result<Value, ShellError> {
+    let tag = tag.into();
+    match &input.value {
+        UntaggedValue::Primitive(prim) => Ok(UntaggedValue::filesize(match prim {
+            Primitive::String(a_string) => match int_from_string(a_string, &tag) {
+                Ok(n) => n,
+                Err(e) => {
+                    return Err(e);
+                }
+            },
+            Primitive::Decimal(dec) => match dec.to_bigint() {
+                Some(n) => match n.to_u64() {
+                    Some(i) => i,
+                    None => {
+                        return Err(ShellError::unimplemented(
+                            "failed to convert decimal to filesize",
+                        ));
+                    }
+                },
+                None => {
+                    return Err(ShellError::unimplemented(
+                        "failed to convert decimal to filesize",
+                    ));
+                }
+            },
+            Primitive::Int(n_ref) => (*n_ref).try_into().map_err(|_| {
+                ShellError::unimplemented("cannot convert negative integer to filesize")
+            })?,
+            Primitive::Filesize(a_filesize) => *a_filesize,
+            _ => {
+                return Err(ShellError::unimplemented(
+                    "'into filesize' for non-numeric primitives",
+                ))
+            }
+        })
+        .into_value(&tag)),
+        UntaggedValue::Row(_) => Err(ShellError::labeled_error(
+            "specify column name to use, with 'into filesize COLUMN'",
+            "found table",
+            tag,
+        )),
+        _ => Err(ShellError::unimplemented(
+            "'into filesize' for unsupported type",
+        )),
+    }
+}
+
+fn int_from_string(a_string: &str, tag: &Tag) -> Result<u64, ShellError> {
+    match a_string.parse::<u64>() {
+        Ok(n) => Ok(n),
+        Err(_) => match a_string.parse::<f64>() {
+            Ok(f) => match f.to_u64() {
+                Some(i) => Ok(i),
+                None => Err(ShellError::labeled_error(
+                    "Could not convert string value to filesize",
+                    "original value",
+                    tag.clone(),
+                )),
+            },
+            Err(_) => Err(ShellError::labeled_error(
+                "Could not convert string value to filesize",
+                "original value",
+                tag.clone(),
+            )),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShellError;
+    use super::SubCommand;
+
+    #[test]
+    fn examples_work_as_expected() -> Result<(), ShellError> {
+        use crate::examples::test as test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/commands/conversions/into/filesize.rs
+++ b/crates/nu-command/src/commands/conversions/into/filesize.rs
@@ -33,7 +33,7 @@ impl WholeStreamCommand for SubCommand {
         vec![
             Example {
                 description: "Convert string to filesize in table",
-                example: "echo [[bytes]; ['5'] [3.2] [4] [2kb]] | into filesize num",
+                example: "echo [[bytes]; ['5'] [3.2] [4] [2kb]] | into filesize bytes",
                 result: Some(vec![
                     UntaggedValue::row(indexmap! {
                         "bytes".to_string() => UntaggedValue::filesize(5).into(),

--- a/crates/nu-command/src/commands/conversions/into/mod.rs
+++ b/crates/nu-command/src/commands/conversions/into/mod.rs
@@ -1,9 +1,11 @@
 mod binary;
 mod command;
 mod filepath;
+mod filesize;
 mod int;
 pub mod string;
 
+pub use self::filesize::SubCommand as IntoFilesize;
 pub use binary::SubCommand as IntoBinary;
 pub use command::Command as Into;
 pub use filepath::SubCommand as IntoFilepath;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -137,6 +137,7 @@ pub fn create_default_context(interactive: bool) -> Result<EvaluationContext, Bo
             whole_stream_command(IntoBinary),
             whole_stream_command(IntoInt),
             whole_stream_command(IntoFilepath),
+            whole_stream_command(IntoFilesize),
             whole_stream_command(IntoString),
             whole_stream_command(SplitBy),
             // Row manipulation

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -37,6 +37,33 @@ fn into_filesize_str() {
 }
 
 #[test]
+fn into_filesize_str_newline() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        '2000
+' | into filesize
+        "#
+    ));
+
+    assert!(actual.out.contains("2.0 KB"));
+}
+
+#[test]
+fn into_filesize_str_many_newlines() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        '2000
+
+' | into filesize
+        "#
+    ));
+
+    assert!(actual.out.contains("2.0 KB"));
+}
+
+#[test]
 fn into_filesize_filesize() {
     let actual = nu!(
         cwd: ".", pipeline(

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -1,0 +1,49 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn into_filesize_int() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        1 | into filesize
+        "#
+    ));
+
+    assert!(actual.out.contains("1 B"));
+}
+
+#[test]
+fn into_filesize_decimal() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        1.2 | into filesize
+        "#
+    ));
+
+    assert!(actual.out.contains("1 B"));
+}
+
+#[test]
+fn into_filesize_str() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        '2000' | into filesize
+        "#
+    ));
+
+    assert!(actual.out.contains("2.0 KB"));
+}
+
+#[test]
+fn into_filesize_filesize() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        3kb | into filesize
+        "#
+    ));
+
+    assert!(actual.out.contains("3.0 KB"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -25,6 +25,7 @@ mod headers;
 mod help;
 mod histogram;
 mod insert;
+mod into_filesize;
 mod into_int;
 mod keep;
 mod last;


### PR DESCRIPTION
It's currently not possible to convert a number or a string containing a number
into a filesize. The only way to create an instance of filesize type today is
with a literal in nushell syntax. This commit adds the `into filesize`
subcommand so that file sizes can be created from the outputs of programs
producing numbers or strings, like standard unix tools.

There is a limitation with this - it doesn't currently parse values like `10 MB`
or `10 MiB`, it can only look at the number itself. If the desire is there, more
flexible parsing can be added.

Created after comments from @fdncred on #3985.