### PR TITLE
 Replacing InputStream with Value.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,18 +72,18 @@ uuid-support = ["nu-command/uuid_crate"]
 which-support = ["nu-command/which", "nu-engine/which"]
 
 default = [
-    "nu-cli/shadow-rs",
-    "sys",
-    "ps",
-    "ctrlc-support",
-    "which-support",
-    "term-support",
-    "rustyline-support",
-    "match",
-    "post",
-    "fetch",
-    "zip-support",
-    "dataframe",
+    # "nu-cli/shadow-rs",
+    # "sys",
+    # "ps",
+    # "ctrlc-support",
+    # "which-support",
+    # "term-support",
+    # "rustyline-support",
+    # "match",
+    # "post",
+    # "fetch",
+    # "zip-support",
+    # "dataframe",
 ]
 
 stable = ["default"]

--- a/crates/nu-command/src/commands/filters/empty.rs
+++ b/crates/nu-command/src/commands/filters/empty.rs
@@ -108,6 +108,7 @@ fn is_empty(args: CommandArgs) -> Result<ActionStream, ShellError> {
 
     Ok(input
         .map(move |input| {
+            println!("VALUE: {:?}\n", input.value);
             let columns = columns.clone();
 
             match process_row(&context, input, &block, columns) {

--- a/crates/nu-command/tests/commands/empty.rs
+++ b/crates/nu-command/tests/commands/empty.rs
@@ -1,6 +1,43 @@
 use nu_test_support::{nu, pipeline};
 
 #[test]
+fn emptiness_for_nothing() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            $nothing | empty?
+        "#
+    ));
+
+    assert_eq!(actual.out, "false");
+}
+
+
+#[test]
+fn emptiness_for_non_table() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            echo true | empty?
+        "#
+    ));
+
+    assert_eq!(actual.out, "false");
+}
+
+#[test]
+fn emptiness_for_list() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            [] | empty?
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
 fn reports_emptiness() {
     let actual = nu!(
         cwd: ".", pipeline(

--- a/crates/nu-engine/src/evaluate/evaluator.rs
+++ b/crates/nu-engine/src/evaluate/evaluator.rs
@@ -305,24 +305,24 @@ fn evaluate_subexpression(
 ) -> Result<Value, ShellError> {
     // FIXME: we should use a real context here
     let input = match ctx.scope.get_var("$it") {
-        Some(it) => InputStream::one(it),
+        Some(it) => it,
         None => InputStream::empty(),
     };
 
     let result = run_block(block, ctx, input, hir::ExternalRedirection::Stdout)?;
 
-    let output = result.into_vec();
+    let output = result;
 
     if let Some(e) = ctx.get_errors().get(0) {
         return Err(e.clone());
     }
-
-    match output.len() {
-        x if x > 1 => {
-            let tag = output[0].tag.clone();
-            Ok(UntaggedValue::Table(output).into_value(tag))
-        }
-        1 => Ok(output[0].clone()),
-        _ => Ok(UntaggedValue::nothing().into_value(Tag::unknown())),
-    }
+    Ok(output)
+    // match output.len() {
+    //     x if x > 1 => {
+    //         let tag = output[0].tag.clone();
+    //         Ok(UntaggedValue::Table(output).into_value(tag))
+    //     }
+    //     1 => Ok(output.clone()),
+    //     _ => Ok(UntaggedValue::nothing().into_value(Tag::unknown())),
+    // }
 }

--- a/crates/nu-engine/src/evaluate/expr.rs
+++ b/crates/nu-engine/src/evaluate/expr.rs
@@ -6,7 +6,7 @@ use crate::evaluation_context::EvaluationContext;
 use nu_errors::ShellError;
 use nu_protocol::hir::SpannedExpression;
 use nu_protocol::{UntaggedValue, Value};
-use nu_stream::{InputStream, IntoInputStream};
+use nu_stream::{InputStream};
 
 pub(crate) fn run_expression_block(
     expr: &SpannedExpression,
@@ -17,13 +17,13 @@ pub(crate) fn run_expression_block(
         trace!(target: "nu::run::expr", "{:?}", expr);
     }
 
-    let output = evaluate_baseline_expr(expr, ctx)?;
+    Ok(evaluate_baseline_expr(expr, ctx)?)
 
-    match output {
-        Value {
-            value: UntaggedValue::Table(x),
-            ..
-        } => Ok(InputStream::from_stream(x.into_iter())),
-        output => Ok(std::iter::once(Ok(output)).into_input_stream()),
-    }
+    // match output {
+    //     Value {
+    //         value: UntaggedValue::Table(x),
+    //         ..
+    //     } => Ok(InputStream::from_stream(x.into_iter())),
+    //     output => Ok(std::iter::once(Ok(output)).into_input_stream()),
+    // }
 }

--- a/crates/nu-engine/src/evaluate/internal.rs
+++ b/crates/nu-engine/src/evaluate/internal.rs
@@ -33,33 +33,42 @@ pub(crate) fn run_internal_command(
         command.args.clone(), // FIXME: this is inefficient
         objects,
     )?;
-    Ok(InputStream::from_stream(InternalIteratorSimple {
-        context: context.clone(),
-        input: result,
-    }))
+    Ok(result)
+    // match result {
+    //     Value {
+    //         value: UntaggedValue::Error(err),
+    //         ..
+    //     } => {
+
+    //     }
+    // }
+    // Ok(InputStream::from_stream(InternalIteratorSimple {
+    //     context: context.clone(),
+    //     input: result,
+    // }))
 }
 
-struct InternalIteratorSimple {
+struct InternalInputSimple {
     context: EvaluationContext,
     input: InputStream,
 }
 
-impl Iterator for InternalIteratorSimple {
-    type Item = Value;
+// impl Iterator for InternalIteratorSimple {
+//     type Item = Value;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.input.next() {
-            Some(Value {
-                value: UntaggedValue::Error(err),
-                ..
-            }) => {
-                self.context.error(err);
-                None
-            }
-            x => x,
-        }
-    }
-}
+//     fn next(&mut self) -> Option<Self::Item> {
+//         match self.input.next() {
+//             Some(Value {
+//                 value: UntaggedValue::Error(err),
+//                 ..
+//             }) => {
+//                 self.context.error(err);
+//                 None
+//             }
+//             x => x,
+//         }
+//     }
+// }
 
 pub struct InternalIterator {
     pub context: EvaluationContext,

--- a/crates/nu-protocol/src/type_shape.rs
+++ b/crates/nu-protocol/src/type_shape.rs
@@ -23,7 +23,7 @@ pub struct RangeType {
     to: (Type, RangeInclusion),
 }
 
-/// Representation of for the type of a value in Nu
+/// Representation for the type of a value in Nu
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Type {
     /// A value which has no value
@@ -189,8 +189,8 @@ impl Type {
     /// Convert a value into its corresponding Type
     pub fn from_value<'a>(value: impl Into<&'a UntaggedValue>) -> Type {
         match value.into() {
-            UntaggedValue::Primitive(p) => Type::from_primitive(p),
-            UntaggedValue::Row(row) => Type::from_dictionary(row),
+            UntaggedValue::Primitive(p) => Type::from_primitive(&p),
+            UntaggedValue::Row(row) => Type::from_dictionary(&row),
             UntaggedValue::Table(table) => Type::from_table(table.iter()),
             UntaggedValue::Error(_) => Type::Error,
             UntaggedValue::Block(_) => Type::Block,

--- a/crates/nu-protocol/src/value.rs
+++ b/crates/nu-protocol/src/value.rs
@@ -309,6 +309,15 @@ impl std::ops::Deref for Value {
 }
 
 impl Value {
+    /// Helper to create an empty Value
+    pub fn empty() -> Self {
+        Value {
+            value: UntaggedValue::Primitive(Primitive::Nothing),
+            tag: Tag::unknown(),
+        }
+    }
+
+
     /// Helper to create a Value
     pub fn new(untagged_value: UntaggedValue, the_tag: Tag) -> Self {
         Value {

--- a/crates/nu-stream/src/input.rs
+++ b/crates/nu-stream/src/input.rs
@@ -3,186 +3,167 @@ use nu_errors::ShellError;
 use nu_protocol::{Primitive, Type, UntaggedValue, Value};
 use nu_source::{HasFallibleSpan, PrettyDebug, Tag, Tagged, TaggedItem};
 
-pub struct InputStream {
-    values: Box<dyn Iterator<Item = Value> + Send + Sync>,
+pub type InputStream = Value;
 
-    // Whether or not an empty stream was explicitly requested via InputStream::empty
-    empty: bool,
-}
+// impl InputStream {
+//     pub fn empty() -> InputStream {
+//         return Value::nothing();
+//     }
 
-impl Iterator for InputStream {
-    type Item = Value;
+//     pub fn one(item: impl Into<Value>) -> InputStream {
+//         return item.into();
+//     }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.values.next()
-    }
-}
+//     pub fn into_vec(self) -> Vec<Value> {
+//         self.values.collect()
+//     }
 
-impl InputStream {
-    pub fn empty() -> InputStream {
-        InputStream {
-            values: Box::new(std::iter::empty()),
-            empty: true,
-        }
-    }
+//     pub fn is_empty(&self) -> bool {
+//         self.empty
+//     }
 
-    pub fn one(item: impl Into<Value>) -> InputStream {
-        InputStream {
-            values: Box::new(std::iter::once(item.into())),
-            empty: false,
-        }
-    }
+//     pub fn drain_vec(&mut self) -> Vec<Value> {
+//         let mut output = vec![];
+//         for x in &mut self.values {
+//             output.push(x);
+//         }
+//         output
+//     }
 
-    pub fn into_vec(self) -> Vec<Value> {
-        self.values.collect()
-    }
+//     pub fn from_stream(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> InputStream {
+//         InputStream {
+//             values: Box::new(input),
+//             empty: false,
+//         }
+//     }
 
-    pub fn is_empty(&self) -> bool {
-        self.empty
-    }
+//     pub fn collect_string(mut self, tag: Tag) -> Result<Tagged<String>, ShellError> {
+//         let mut bytes = vec![];
+//         let mut value_tag = tag.clone();
 
-    pub fn drain_vec(&mut self) -> Vec<Value> {
-        let mut output = vec![];
-        for x in &mut self.values {
-            output.push(x);
-        }
-        output
-    }
+//         loop {
+//             match self.values.next() {
+//                 Some(Value {
+//                     value: UntaggedValue::Primitive(Primitive::String(s)),
+//                     tag: value_t,
+//                 }) => {
+//                     value_tag = value_t;
+//                     bytes.extend_from_slice(&s.into_bytes());
+//                 }
+//                 Some(Value {
+//                     value: UntaggedValue::Primitive(Primitive::Binary(b)),
+//                     tag: value_t,
+//                 }) => {
+//                     value_tag = value_t;
+//                     bytes.extend_from_slice(&b);
+//                 }
+//                 Some(Value {
+//                     value: UntaggedValue::Primitive(Primitive::Nothing),
+//                     tag: value_t,
+//                 }) => {
+//                     value_tag = value_t;
+//                 }
+//                 Some(Value {
+//                     tag: value_tag,
+//                     value,
+//                 }) => {
+//                     return Err(ShellError::labeled_error_with_secondary(
+//                         "Expected a string from pipeline",
+//                         "requires string input",
+//                         tag,
+//                         format!(
+//                             "{} originates from here",
+//                             Type::from_value(&value).plain_string(100000)
+//                         ),
+//                         value_tag,
+//                     ))
+//                 }
+//                 None => break,
+//             }
+//         }
 
-    pub fn from_stream(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> InputStream {
-        InputStream {
-            values: Box::new(input),
-            empty: false,
-        }
-    }
+//         match String::from_utf8(bytes) {
+//             Ok(s) => Ok(s.tagged(value_tag)),
+//             Err(_) => Err(ShellError::labeled_error_with_secondary(
+//                 "Expected a string from pipeline",
+//                 "requires string input",
+//                 tag,
+//                 "value originates from here",
+//                 value_tag,
+//             )),
+//         }
+//     }
 
-    pub fn collect_string(mut self, tag: Tag) -> Result<Tagged<String>, ShellError> {
-        let mut bytes = vec![];
-        let mut value_tag = tag.clone();
+//     pub fn collect_binary(mut self, tag: Tag) -> Result<Tagged<Vec<u8>>, ShellError> {
+//         let mut bytes = vec![];
+//         let mut value_tag = tag.clone();
 
-        loop {
-            match self.values.next() {
-                Some(Value {
-                    value: UntaggedValue::Primitive(Primitive::String(s)),
-                    tag: value_t,
-                }) => {
-                    value_tag = value_t;
-                    bytes.extend_from_slice(&s.into_bytes());
-                }
-                Some(Value {
-                    value: UntaggedValue::Primitive(Primitive::Binary(b)),
-                    tag: value_t,
-                }) => {
-                    value_tag = value_t;
-                    bytes.extend_from_slice(&b);
-                }
-                Some(Value {
-                    value: UntaggedValue::Primitive(Primitive::Nothing),
-                    tag: value_t,
-                }) => {
-                    value_tag = value_t;
-                }
-                Some(Value {
-                    tag: value_tag,
-                    value,
-                }) => {
-                    return Err(ShellError::labeled_error_with_secondary(
-                        "Expected a string from pipeline",
-                        "requires string input",
-                        tag,
-                        format!(
-                            "{} originates from here",
-                            Type::from_value(&value).plain_string(100000)
-                        ),
-                        value_tag,
-                    ))
-                }
-                None => break,
-            }
-        }
+//         loop {
+//             match self.values.next() {
+//                 Some(Value {
+//                     value: UntaggedValue::Primitive(Primitive::Binary(b)),
+//                     tag: value_t,
+//                 }) => {
+//                     value_tag = value_t;
+//                     bytes.extend_from_slice(&b);
+//                 }
+//                 Some(Value {
+//                     tag: value_tag,
+//                     value: _,
+//                 }) => {
+//                     return Err(ShellError::labeled_error_with_secondary(
+//                         "Expected binary from pipeline",
+//                         "requires binary input",
+//                         tag,
+//                         "value originates from here",
+//                         value_tag,
+//                     ));
+//                 }
+//                 None => break,
+//             }
+//         }
 
-        match String::from_utf8(bytes) {
-            Ok(s) => Ok(s.tagged(value_tag)),
-            Err(_) => Err(ShellError::labeled_error_with_secondary(
-                "Expected a string from pipeline",
-                "requires string input",
-                tag,
-                "value originates from here",
-                value_tag,
-            )),
-        }
-    }
+//         Ok(bytes.tagged(value_tag))
+//     }
+// }
 
-    pub fn collect_binary(mut self, tag: Tag) -> Result<Tagged<Vec<u8>>, ShellError> {
-        let mut bytes = vec![];
-        let mut value_tag = tag.clone();
+// impl From<VecDeque<Value>> for InputStream {
+//     fn from(input: VecDeque<Value>) -> InputStream {
+//         InputStream {
+//             values: Box::new(input.into_iter()),
+//             empty: false,
+//         }
+//     }
+// }
 
-        loop {
-            match self.values.next() {
-                Some(Value {
-                    value: UntaggedValue::Primitive(Primitive::Binary(b)),
-                    tag: value_t,
-                }) => {
-                    value_tag = value_t;
-                    bytes.extend_from_slice(&b);
-                }
-                Some(Value {
-                    tag: value_tag,
-                    value: _,
-                }) => {
-                    return Err(ShellError::labeled_error_with_secondary(
-                        "Expected binary from pipeline",
-                        "requires binary input",
-                        tag,
-                        "value originates from here",
-                        value_tag,
-                    ));
-                }
-                None => break,
-            }
-        }
+// impl From<Vec<Value>> for InputStream {
+//     fn from(input: Vec<Value>) -> InputStream {
+//         InputStream {
+//             values: Box::new(input.into_iter()),
+//             empty: false,
+//         }
+//     }
+// }
 
-        Ok(bytes.tagged(value_tag))
-    }
-}
+// pub trait IntoInputStream {
+//     fn into_input_stream(self) -> InputStream;
+// }
 
-impl From<VecDeque<Value>> for InputStream {
-    fn from(input: VecDeque<Value>) -> InputStream {
-        InputStream {
-            values: Box::new(input.into_iter()),
-            empty: false,
-        }
-    }
-}
-
-impl From<Vec<Value>> for InputStream {
-    fn from(input: Vec<Value>) -> InputStream {
-        InputStream {
-            values: Box::new(input.into_iter()),
-            empty: false,
-        }
-    }
-}
-
-pub trait IntoInputStream {
-    fn into_input_stream(self) -> InputStream;
-}
-
-impl<T, U> IntoInputStream for T
-where
-    T: Iterator<Item = U> + Send + Sync + 'static,
-    U: Into<Result<nu_protocol::Value, nu_errors::ShellError>>,
-{
-    fn into_input_stream(self) -> InputStream {
-        InputStream {
-            empty: false,
-            values: Box::new(self.map(|item| match item.into() {
-                Ok(result) => result,
-                Err(err) => match HasFallibleSpan::maybe_span(&err) {
-                    Some(span) => nu_protocol::UntaggedValue::Error(err).into_value(span),
-                    None => nu_protocol::UntaggedValue::Error(err).into_untagged_value(),
-                },
-            })),
-        }
-    }
-}
+// impl<T, U> IntoInputStream for T
+// where
+//     T: Iterator<Item = U> + Send + Sync + 'static,
+//     U: Into<Result<nu_protocol::Value, nu_errors::ShellError>>,
+// {
+//     fn into_input_stream(self) -> InputStream {
+//         InputStream {
+//             empty: false,
+//             values: Box::new(self.map(|item| match item.into() {
+//                 Ok(result) => result,
+//                 Err(err) => match HasFallibleSpan::maybe_span(&err) {
+//                     Some(span) => nu_protocol::UntaggedValue::Error(err).into_value(span),
+//                     None => nu_protocol::UntaggedValue::Error(err).into_untagged_value(),
+//                 },
+//             })),
+//         }
+//     }
+// }

--- a/crates/nu-stream/src/interruptible.rs
+++ b/crates/nu-stream/src/interruptible.rs
@@ -1,15 +1,17 @@
+use nu_protocol::Value;
+
 use crate::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-pub struct InterruptibleStream<V> {
-    inner: Box<dyn Iterator<Item = V> + Send + Sync>,
+pub struct InterruptibleStream {
+    inner: Box<Value>,
     interrupt_signal: Arc<AtomicBool>,
 }
 
-impl<V> InterruptibleStream<V> {
-    pub fn new<S>(inner: S, interrupt_signal: Arc<AtomicBool>) -> InterruptibleStream<V>
-    where
-        S: Iterator<Item = V> + Send + Sync + 'static,
+impl InterruptibleStream {
+    pub fn new(inner: Value, interrupt_signal: Arc<AtomicBool>) -> InterruptibleStream
+    // where
+    //     S: Iterator<Item = V> + Send + Sync + 'static,
     {
         InterruptibleStream {
             inner: Box::new(inner),
@@ -18,27 +20,27 @@ impl<V> InterruptibleStream<V> {
     }
 }
 
-impl<V> Iterator for InterruptibleStream<V> {
-    type Item = V;
+// impl<V> Iterator for InterruptibleStream<V> {
+//     type Item = V;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.interrupt_signal.load(Ordering::SeqCst) {
-            None
-        } else {
-            self.inner.next()
-        }
-    }
-}
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if self.interrupt_signal.load(Ordering::SeqCst) {
+//             None
+//         } else {
+//             self.inner.next()
+//         }
+//     }
+// }
 
-pub trait Interruptible<V> {
-    fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V>;
-}
+// pub trait Interruptible {
+//     fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream;
+// }
 
-impl<S, V> Interruptible<V> for S
-where
-    S: Iterator<Item = V> + Send + Sync + 'static,
-{
-    fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V> {
-        InterruptibleStream::new(self, ctrl_c)
-    }
-}
+// impl<S, V> Interruptible<V> for S
+// where
+//     S: Iterator<Item = V> + Send + Sync + 'static,
+// {
+//     fn interruptible(self, ctrl_c: Arc<AtomicBool>) -> InterruptibleStream<V> {
+//         InterruptibleStream::new(self, ctrl_c)
+//     }
+// }

--- a/crates/nu-stream/src/lib.rs
+++ b/crates/nu-stream/src/lib.rs
@@ -7,5 +7,5 @@ mod output;
 pub use input::*;
 pub use interruptible::*;
 pub use output::*;
-pub use prelude::IntoActionStream;
-pub use prelude::IntoOutputStream;
+// pub use prelude::IntoActionStream;
+// pub use prelude::IntoOutputStream;

--- a/crates/nu-stream/src/output.rs
+++ b/crates/nu-stream/src/output.rs
@@ -4,107 +4,109 @@ use std::iter::IntoIterator;
 
 pub type OutputStream = InputStream;
 
-pub struct ActionStream {
-    pub values: Box<dyn Iterator<Item = ReturnValue> + Send + Sync>,
-}
+pub type ActionStream = Value;
 
-impl Iterator for ActionStream {
-    type Item = ReturnValue;
+// pub struct ActionStream {
+//     pub values: Box<dyn Iterator<Item = ReturnValue> + Send + Sync>,
+// }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.values.next()
-    }
-}
+// impl Iterator for ActionStream {
+//     type Item = ReturnValue;
 
-impl ActionStream {
-    pub fn new(values: impl Iterator<Item = ReturnValue> + Send + Sync + 'static) -> ActionStream {
-        ActionStream {
-            values: Box::new(values),
-        }
-    }
+//     fn next(&mut self) -> Option<Self::Item> {
+//         self.values.next()
+//     }
+// }
 
-    pub fn empty() -> ActionStream {
-        ActionStream {
-            values: Box::new(std::iter::empty()),
-        }
-    }
+// impl ActionStream {
+//     pub fn new(values: impl Iterator<Item = ReturnValue> + Send + Sync + 'static) -> ActionStream {
+//         ActionStream {
+//             values: Box::new(values),
+//         }
+//     }
 
-    pub fn one(item: impl Into<ReturnValue>) -> ActionStream {
-        let item = item.into();
-        ActionStream {
-            values: Box::new(std::iter::once(item)),
-        }
-    }
+//     pub fn empty() -> ActionStream {
+//         ActionStream {
+//             values: Box::new(std::iter::empty()),
+//         }
+//     }
 
-    pub fn from_input(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> ActionStream {
-        ActionStream {
-            values: Box::new(input.map(ReturnSuccess::value)),
-        }
-    }
+//     pub fn one(item: impl Into<ReturnValue>) -> ActionStream {
+//         let item = item.into();
+//         ActionStream {
+//             values: Box::new(std::iter::once(item)),
+//         }
+//     }
 
-    pub fn drain_vec(&mut self) -> Vec<ReturnValue> {
-        let mut output = vec![];
-
-        for x in &mut self.values {
-            output.push(x);
-        }
-
-        output
-    }
-}
-
-impl From<InputStream> for ActionStream {
-    fn from(input: InputStream) -> ActionStream {
-        ActionStream {
-            values: Box::new(input.into_iter().map(ReturnSuccess::value)),
-        }
-    }
-}
-
-// impl From<impl Iterator<Item = Value> + Send + Sync + 'static> for OutputStream {
-//     fn from(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> OutputStream {
-//         OutputStream {
+//     pub fn from_input(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> ActionStream {
+//         ActionStream {
 //             values: Box::new(input.map(ReturnSuccess::value)),
+//         }
+//     }
+
+//     pub fn drain_vec(&mut self) -> Vec<ReturnValue> {
+//         let mut output = vec![];
+
+//         for x in &mut self.values {
+//             output.push(x);
+//         }
+
+//         output
+//     }
+// }
+
+// impl From<InputStream> for ActionStream {
+//     fn from(input: InputStream) -> ActionStream {
+//         ActionStream {
+//             values: Box::new(input.into_iter().map(ReturnSuccess::value)),
 //         }
 //     }
 // }
 
-// impl From<BoxStream<'static, ReturnValue>> for OutputStream {
-//     fn from(input: BoxStream<'static, ReturnValue>) -> OutputStream {
-//         OutputStream { values: input }
+// // impl From<impl Iterator<Item = Value> + Send + Sync + 'static> for OutputStream {
+// //     fn from(input: impl Iterator<Item = Value> + Send + Sync + 'static) -> OutputStream {
+// //         OutputStream {
+// //             values: Box::new(input.map(ReturnSuccess::value)),
+// //         }
+// //     }
+// // }
+
+// // impl From<BoxStream<'static, ReturnValue>> for OutputStream {
+// //     fn from(input: BoxStream<'static, ReturnValue>) -> OutputStream {
+// //         OutputStream { values: input }
+// //     }
+// // }
+
+// impl From<VecDeque<ReturnValue>> for ActionStream {
+//     fn from(input: VecDeque<ReturnValue>) -> ActionStream {
+//         ActionStream {
+//             values: Box::new(input.into_iter()),
+//         }
 //     }
 // }
 
-impl From<VecDeque<ReturnValue>> for ActionStream {
-    fn from(input: VecDeque<ReturnValue>) -> ActionStream {
-        ActionStream {
-            values: Box::new(input.into_iter()),
-        }
-    }
-}
+// impl From<VecDeque<Value>> for ActionStream {
+//     fn from(input: VecDeque<Value>) -> ActionStream {
+//         let stream = input.into_iter().map(ReturnSuccess::value);
+//         ActionStream {
+//             values: Box::new(stream),
+//         }
+//     }
+// }
 
-impl From<VecDeque<Value>> for ActionStream {
-    fn from(input: VecDeque<Value>) -> ActionStream {
-        let stream = input.into_iter().map(ReturnSuccess::value);
-        ActionStream {
-            values: Box::new(stream),
-        }
-    }
-}
+// impl From<Vec<ReturnValue>> for ActionStream {
+//     fn from(input: Vec<ReturnValue>) -> ActionStream {
+//         ActionStream {
+//             values: Box::new(input.into_iter()),
+//         }
+//     }
+// }
 
-impl From<Vec<ReturnValue>> for ActionStream {
-    fn from(input: Vec<ReturnValue>) -> ActionStream {
-        ActionStream {
-            values: Box::new(input.into_iter()),
-        }
-    }
-}
-
-impl From<Vec<Value>> for ActionStream {
-    fn from(input: Vec<Value>) -> ActionStream {
-        let stream = input.into_iter().map(ReturnSuccess::value);
-        ActionStream {
-            values: Box::new(stream),
-        }
-    }
-}
+// impl From<Vec<Value>> for ActionStream {
+//     fn from(input: Vec<Value>) -> ActionStream {
+//         let stream = input.into_iter().map(ReturnSuccess::value);
+//         ActionStream {
+//             values: Box::new(stream),
+//         }
+//     }
+// }

--- a/crates/nu-stream/src/prelude.rs
+++ b/crates/nu-stream/src/prelude.rs
@@ -42,27 +42,27 @@ pub trait IntoOutputStream {
     fn into_output_stream(self) -> OutputStream;
 }
 
-impl<T> IntoOutputStream for T
-where
-    T: Iterator<Item = Value> + Send + Sync + 'static,
-{
-    fn into_output_stream(self) -> OutputStream {
-        OutputStream::from_stream(self)
-    }
-}
+// impl<T> IntoOutputStream for T
+// where
+//     T: Iterator<Item = Value> + Send + Sync + 'static,
+// {
+//     fn into_output_stream(self) -> OutputStream {
+//         OutputStream::from_stream(self)
+//     }
+// }
 
-pub trait IntoActionStream {
-    fn into_action_stream(self) -> ActionStream;
-}
+// pub trait IntoActionStream {
+//     fn into_action_stream(self) -> ActionStream;
+// }
 
-impl<T, U> IntoActionStream for T
-where
-    T: Iterator<Item = U> + Send + Sync + 'static,
-    U: Into<nu_protocol::ReturnValue>,
-{
-    fn into_action_stream(self) -> ActionStream {
-        ActionStream {
-            values: Box::new(self.map(|item| item.into())),
-        }
-    }
-}
+// impl<T, U> IntoActionStream for T
+// where
+//     T: Iterator<Item = U> + Send + Sync + 'static,
+//     U: Into<nu_protocol::ReturnValue>,
+// {
+//     fn into_action_stream(self) -> ActionStream {
+//         ActionStream {
+//             values: Box::new(self.map(|item| item.into())),
+//         }
+//     }
+// }

--- a/samples/wasm/Cargo.toml
+++ b/samples/wasm/Cargo.toml
@@ -5,6 +5,7 @@ name = "wasm"
 version = "0.1.0"
 
 [lib]
+path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [features]


### PR DESCRIPTION
Right now, `ActionStream`, `InputStream` and `OutputStream` look like this:
```rust
pub struct ActionStream {
    pub values: Box<dyn Iterator<Item = ReturnValue> + Send + Sync>,
}
```
Therefore in a pipeline, an iterable is passed from one command to the next. This leads to problems since the meaning of "iteration" gets conflated in the codebase: when a single table is being passed, the iterator consists of rows, but when it consists of primitive values, its an iterable of one element with the primitive (number, datetime, boolean, etc.). This has led to at least 3 bugs with the empty list `[]` value, and there are probably more that are related.

This PR is to simplify the codebase considerably by removing ActionStream and its counterparts and using `Value` as the structured value being passed in the pipeline. Currently, `Value` looks like this:
```rust
pub enum UntaggedValue {
    /// A primitive (or fundamental) type of values
    Primitive(Primitive),

    /// A table row
    Row(Dictionary),

    /// A full inner (or embedded) table
    Table(Vec<Value>),

    /// An error value that represents an error that occurred as the values in the pipeline were built
    Error(ShellError),

    /// A block of Nu code, eg `{ ls | get name ; echo "done" }` with its captured values
    Block(Box<hir::CapturedBlock>),

    /// A stream of values to be consumed one after another
    Stream(Box<dyn Iterator<Item = UntaggedValue>> + Send + Sync),

    /// Main nushell dataframe
    #[cfg(feature = "dataframe")]
    DataFrame(NuDataFrame),

    /// Data option that holds intermediate struct required to do data
    /// manipulation and operations for dataframes such as groupby, lazy frames
    /// and lazy groupby
    #[cfg(feature = "dataframe")]
    FrameStruct(FrameStruct),
}
```

However, the Value is subject to change.