### PR TITLE
Improve error message when bash-style alias syntax is mistakenly used

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -2025,6 +2025,24 @@ fn parse_alias(call: &LiteCommand, scope: &dyn ParserScope) -> Option<ParseError
         {
             return None;
         }
+
+        if call.parts.get(2).map(|part| part.item.as_str()) != Some("=") {
+            if let Some(equals_span) = [call.parts.get(1), call.parts.get(2)]
+                .iter()
+                .flatten()
+                .filter_map(|part| {
+                    part.find('=')
+                        .map(|offset| Span::for_char(part.span.start() + offset))
+                })
+                .next()
+            {
+                return Some(ParseError::general_error(
+                    "Invalid alias syntax",
+                    "Expected space on both sides of =".spanned(equals_span),
+                ));
+            }
+        }
+
         if call.parts.len() < 4 {
             return Some(ParseError::mismatch("alias", call.parts[0].clone()));
         }


### PR DESCRIPTION
Fixes part of #3250 

This PR modifies `parse_alias` to improve the error message when the space before or after the `=` is omitted in the `alias` command, e.g. `alias foo=ls -l`.

The new error message labels the `=` with the message "Expected space on both sides of =", whereas the old error message is "Expected alias, found alias".