### PR TITLE
Small fixes and refactors to paths & source command

### DIFF
--- a/crates/nu-command/src/commands/core_commands/source.rs
+++ b/crates/nu-command/src/commands/core_commands/source.rs
@@ -6,7 +6,7 @@ use nu_path::expand_path;
 use nu_protocol::{Signature, SyntaxShape};
 use nu_source::Tagged;
 
-use std::{borrow::Cow, path::Path, path::PathBuf};
+use std::{path::Path, path::PathBuf};
 
 pub struct Source;
 
@@ -71,9 +71,7 @@ pub fn source(args: CommandArgs) -> Result<OutputStream, ShellError> {
                 Ok(name) => {
                     let path = PathBuf::from(name).join(source_file);
 
-                    if let Ok(contents) =
-                        std::fs::read_to_string(&expand_path(Cow::Borrowed(path.as_path())))
-                    {
+                    if let Ok(contents) = std::fs::read_to_string(&expand_path(path)) {
                         let result = script::run_script_standalone(contents, true, ctx, false);
 
                         if let Err(err) = result {
@@ -91,7 +89,7 @@ pub fn source(args: CommandArgs) -> Result<OutputStream, ShellError> {
 
     let path = Path::new(source_file);
 
-    let contents = std::fs::read_to_string(&expand_path(Cow::Borrowed(path)));
+    let contents = std::fs::read_to_string(&expand_path(path));
 
     match contents {
         Ok(contents) => {

--- a/crates/nu-command/src/commands/path/expand.rs
+++ b/crates/nu-command/src/commands/path/expand.rs
@@ -5,7 +5,7 @@ use nu_errors::ShellError;
 use nu_path::{canonicalize, expand_path};
 use nu_protocol::{ColumnPath, Signature, SyntaxShape, UntaggedValue, Value};
 use nu_source::Span;
-use std::{borrow::Cow, path::Path};
+use std::path::Path;
 
 pub struct PathExpand;
 
@@ -105,7 +105,7 @@ fn action(path: &Path, tag: Tag, args: &PathExpandArguments) -> Value {
             tag.span,
         ))
     } else {
-        UntaggedValue::filepath(expand_path(Cow::Borrowed(path))).into_value(tag)
+        UntaggedValue::filepath(expand_path(path)).into_value(tag)
     }
 }
 

--- a/crates/nu-completion/src/path.rs
+++ b/crates/nu-completion/src/path.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::path::{is_separator, Path, PathBuf};
 
 use super::matchers::Matcher;
@@ -27,7 +26,7 @@ impl PathCompleter {
             (base, rest)
         };
 
-        let base_dir = nu_path::expand_path(Cow::Borrowed(Path::new(&base_dir_name)));
+        let base_dir = nu_path::expand_path(&base_dir_name);
         // This check is here as base_dir.read_dir() with base_dir == "" will open the current dir
         // which we don't want in this case (if we did, base_dir would already be ".")
         if base_dir == Path::new("") {

--- a/crates/nu-engine/src/evaluation_context.rs
+++ b/crates/nu-engine/src/evaluation_context.rs
@@ -10,6 +10,7 @@ use crate::{env::basic_host::BasicHost, Host};
 
 use nu_data::config::{self, Conf, NuConfig};
 use nu_errors::ShellError;
+use nu_path::expand_path;
 use nu_protocol::{hir, ConfigPath, VariableRegistry};
 use nu_source::Spanned;
 use nu_source::{Span, Tag};
@@ -157,7 +158,7 @@ impl EvaluationContext {
 
         for (var, val) in env_vars {
             if var == NATIVE_PATH_ENV_VAR {
-                std::env::set_var(var, val);
+                std::env::set_var(var, expand_path(val));
                 break;
             }
         }

--- a/crates/nu-engine/src/from_value.rs
+++ b/crates/nu-engine/src/from_value.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use bigdecimal::{BigDecimal, ToPrimitive};
 use chrono::{DateTime, FixedOffset};
 use nu_errors::ShellError;
+use nu_path::expand_path;
 use nu_protocol::{
     hir::CapturedBlock, ColumnPath, Dictionary, Primitive, Range, SpannedTypeName, UntaggedValue,
     Value,
@@ -239,11 +240,11 @@ impl FromValue for PathBuf {
             Value {
                 value: UntaggedValue::Primitive(Primitive::String(s)),
                 ..
-            } => Ok(PathBuf::from(s)),
+            } => Ok(expand_path(s)),
             Value {
                 value: UntaggedValue::Primitive(Primitive::FilePath(p)),
                 ..
-            } => Ok(p.clone()),
+            } => Ok(expand_path(p)),
             Value {
                 value: UntaggedValue::Row(_),
                 ..
@@ -265,11 +266,11 @@ impl FromValue for Tagged<PathBuf> {
             Value {
                 value: UntaggedValue::Primitive(Primitive::String(s)),
                 tag,
-            } => Ok(PathBuf::from(s).tagged(tag)),
+            } => Ok(expand_path(s).tagged(tag)),
             Value {
                 value: UntaggedValue::Primitive(Primitive::FilePath(p)),
                 tag,
-            } => Ok(p.clone().tagged(tag)),
+            } => Ok(expand_path(p).tagged(tag)),
             Value {
                 value: UntaggedValue::Row(_),
                 ..

--- a/crates/nu-parser/src/parse/source.rs
+++ b/crates/nu-parser/src/parse/source.rs
@@ -3,7 +3,6 @@ use nu_errors::{ArgumentError, ParseError};
 use nu_path::expand_path;
 use nu_protocol::hir::{Expression, InternalCommand};
 
-use std::borrow::Cow;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -63,9 +62,7 @@ fn find_source_file(
         for lib_path in dir.into_iter().flatten() {
             let path = PathBuf::from(lib_path).join(&file);
 
-            if let Ok(contents) =
-                std::fs::read_to_string(&expand_path(Cow::Borrowed(path.as_path())))
-            {
+            if let Ok(contents) = std::fs::read_to_string(&expand_path(path)) {
                 return parse(&contents, 0, scope);
             }
         }
@@ -73,7 +70,7 @@ fn find_source_file(
 
     let path = Path::new(&file);
 
-    let contents = std::fs::read_to_string(&expand_path(Cow::Borrowed(path)));
+    let contents = std::fs::read_to_string(&expand_path(path));
 
     match contents {
         Ok(contents) => parse(&contents, 0, scope),

--- a/crates/nu-parser/src/parse/source.rs
+++ b/crates/nu-parser/src/parse/source.rs
@@ -1,10 +1,11 @@
 use crate::{lex::tokens::LiteCommand, ParserScope};
 use nu_errors::{ArgumentError, ParseError};
-use nu_path::expand_path;
+use nu_path::{canonicalize, canonicalize_with};
 use nu_protocol::hir::{Expression, InternalCommand};
 
 use std::path::Path;
-use std::path::PathBuf;
+
+use nu_source::SpannedItem;
 
 pub fn parse_source_internal(
     lite_cmd: &LiteCommand,
@@ -36,14 +37,14 @@ fn find_source_file(
     command: &InternalCommand,
     scope: &dyn ParserScope,
 ) -> Result<(), ParseError> {
-    let file = if let Some(ref positional_args) = command.args.positional {
+    let (file, file_span) = if let Some(ref positional_args) = command.args.positional {
         if let Expression::FilePath(ref p) = positional_args[0].expr {
-            p
+            (p.as_path(), &positional_args[0].span)
         } else {
-            Path::new(&lite_cmd.parts[1].item)
+            (Path::new(&lite_cmd.parts[1].item), &lite_cmd.parts[1].span)
         }
     } else {
-        Path::new(&lite_cmd.parts[1].item)
+        (Path::new(&lite_cmd.parts[1].item), &lite_cmd.parts[1].span)
     };
 
     let lib_dirs = nu_data::config::config(nu_source::Tag::unknown())
@@ -60,23 +61,33 @@ fn find_source_file(
 
     if let Some(dir) = lib_dirs {
         for lib_path in dir.into_iter().flatten() {
-            let path = PathBuf::from(lib_path).join(&file);
+            let path = canonicalize_with(&file, lib_path).map_err(|e| {
+                ParseError::general_error(
+                    format!("Can't load source file. Reason: {}", e.to_string()),
+                    "Can't load this file".spanned(file_span),
+                )
+            })?;
 
-            if let Ok(contents) = std::fs::read_to_string(&expand_path(path)) {
+            if let Ok(contents) = std::fs::read_to_string(&path) {
                 return parse(&contents, 0, scope);
             }
         }
     }
 
-    let path = Path::new(&file);
+    let path = canonicalize(&file).map_err(|e| {
+        ParseError::general_error(
+            format!("Can't load source file. Reason: {}", e.to_string()),
+            "Can't load this file".spanned(file_span),
+        )
+    })?;
 
-    let contents = std::fs::read_to_string(&expand_path(path));
+    let contents = std::fs::read_to_string(&path);
 
     match contents {
         Ok(contents) => parse(&contents, 0, scope),
-        Err(_) => Err(ParseError::argument_error(
-            lite_cmd.parts[1].clone(),
-            ArgumentError::BadValue("can't load source file".into()),
+        Err(e) => Err(ParseError::general_error(
+            format!("Can't load source file. Reason: {}", e.to_string()),
+            "Can't load this file".spanned(file_span),
         )),
     }
 }


### PR DESCRIPTION
Notably, fixes #3605 and #1834. Also, improvements to `source` error messages and making sure `source` follows symlinks.

Tracking issue: #3655