### PR TITLE
Support completion when cursor inside an argument

### DIFF
--- a/crates/nu-completion/src/engine.rs
+++ b/crates/nu-completion/src/engine.rs
@@ -238,11 +238,19 @@ pub fn completion_location(line: &str, block: &Block, pos: usize) -> Vec<Complet
                                 }
                             }
 
-                            output.push(loc.clone());
+                            output.push({
+                                let mut partial_loc = loc.clone();
+                                partial_loc.span = Span::new(loc.span.start(), pos);
+                                partial_loc
+                            });
                             output
                         }
                     }
-                    _ => vec![loc.clone()],
+                    _ => vec![{
+                        let mut partial_loc = loc.clone();
+                        partial_loc.span = Span::new(loc.span.start(), pos);
+                        partial_loc
+                    }],
                 };
             } else if pos < loc.span.start() {
                 break;


### PR DESCRIPTION
Bash supports completion even when the cursor is in an argument, this is very useful for some fixup after the initial completion. e.g:

```
> ls /path<coursor here>/to/file
```

Let add this feature as well.

Signed-off-by: Tw <wei.tan@intel.com>