### PR TITLE
[fix] [gitpod] force rebuild of dev container to use latest rust

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full
 
 # Gitpod will not rebuild Nushell's dev image unless *some* change is made to this Dockerfile.
 # To force a rebuild, simply increase this counter:
-ENV TRIGGER_REBUILD 1
+ENV TRIGGER_REBUILD 2
 
 USER gitpod
 


### PR DESCRIPTION
the cached container used rustc 1.48,
Upon going over the documentation for the `gitpod/workspace-full` container template, it automatically updates itself to use the latest rust within a reasonable time frame. 

turns out this container was cached and wasnt rebuilding/updating