### PR TITLE
Added BigInt handling to the delimited file format for the 'to' command

### DIFF
--- a/crates/nu-command/src/commands/formats/to/delimited.rs
+++ b/crates/nu-command/src/commands/formats/to/delimited.rs
@@ -136,7 +136,8 @@ fn to_string_tagged_value(v: &Value) -> Result<String, ShellError> {
             | Primitive::Boolean(_)
             | Primitive::Decimal(_)
             | Primitive::FilePath(_)
-            | Primitive::Int(_),
+            | Primitive::Int(_)
+            | Primitive::BigInt(_),
         ) => as_string(v),
         UntaggedValue::Primitive(Primitive::Date(d)) => Ok(d.to_string()),
         UntaggedValue::Primitive(Primitive::Nothing) => Ok(String::new()),

--- a/crates/nu-value-ext/src/lib.rs
+++ b/crates/nu-value-ext/src/lib.rs
@@ -698,6 +698,7 @@ pub fn as_string(value: &Value) -> Result<String, ShellError> {
         UntaggedValue::Primitive(Primitive::Int(x)) => Ok(x.to_string()),
         UntaggedValue::Primitive(Primitive::Filesize(x)) => Ok(x.to_string()),
         UntaggedValue::Primitive(Primitive::FilePath(x)) => Ok(x.display().to_string()),
+        UntaggedValue::Primitive(Primitive::BigInt(x)) => Ok(x.to_string()),
         UntaggedValue::Primitive(Primitive::ColumnPath(path)) => Ok(path
             .iter()
             .map(|member| match &member.unspanned {


### PR DESCRIPTION
Closes #3982 by adding a path for Primitive::BigInt to to_string_tagged_value.