### PR TITLE
Fix 90 degrees tables problem

### DIFF
--- a/crates/nu_plugin_selector/src/selector.rs
+++ b/crates/nu_plugin_selector/src/selector.rs
@@ -139,7 +139,9 @@ fn retrieve_table(mut table: Table, columns: &Value) -> Vec<Value> {
                     .get(col)
                     .unwrap_or(&format!("Missing column: '{}'", &col))
                     .to_string();
-                if at_least_one_row_filled == false && val != String::from(format!("Missing column: '{}'", &col)) {
+                if at_least_one_row_filled == false
+                    && val != String::from(format!("Missing column: '{}'", &col))
+                {
                     at_least_one_row_filled = true;
                 }
                 dict.insert_value(

--- a/crates/nu_plugin_selector/src/selector.rs
+++ b/crates/nu_plugin_selector/src/selector.rs
@@ -139,9 +139,7 @@ fn retrieve_table(mut table: Table, columns: &Value) -> Vec<Value> {
                     .get(col)
                     .unwrap_or(&format!("Missing column: '{}'", &col))
                     .to_string();
-                if !at_least_one_row_filled
-                    && val != format!("Missing column: '{}'", &col)
-                {
+                if !at_least_one_row_filled && val != format!("Missing column: '{}'", &col) {
                     at_least_one_row_filled = true;
                 }
                 dict.insert_value(

--- a/crates/nu_plugin_selector/src/selector.rs
+++ b/crates/nu_plugin_selector/src/selector.rs
@@ -139,8 +139,8 @@ fn retrieve_table(mut table: Table, columns: &Value) -> Vec<Value> {
                     .get(col)
                     .unwrap_or(&format!("Missing column: '{}'", &col))
                     .to_string();
-                if at_least_one_row_filled == false
-                    && val != String::from(format!("Missing column: '{}'", &col))
+                if !at_least_one_row_filled
+                    && val != format!("Missing column: '{}'", &col)
                 {
                     at_least_one_row_filled = true;
                 }

--- a/crates/nu_plugin_selector/src/selector.rs
+++ b/crates/nu_plugin_selector/src/selector.rs
@@ -99,26 +99,21 @@ fn retrieve_table(mut table: Table, columns: &Value) -> Vec<Value> {
             cols.push(x.convert_to_string());
         }
     }
-    // since cols was empty and headers is not, it means that headers were manually populated
-    // so let's fake the data in order to build a proper table. this situation happens when
-    // there are tables where the first column is actually the headers. kind of like a table
-    // that has been rotated ccw 90 degrees
+
     if cols.is_empty() && !table.headers().is_empty() {
         for col in table.headers().keys() {
             cols.push(col.to_string());
         }
-
-        let mut data2 = Vec::new();
-        for x in &table.data {
-            data2.push(x.join(", "));
-        }
-        // eprintln!("data2={:?}", data2);
-        table.data = vec![data2];
     }
 
     let mut table_out = Vec::new();
+    // sometimes there are tables where the first column is the headers, kind of like
+    // a table has ben rotated ccw 90 degrees, in these cases all columns will be missing
+    // we keep track of this with this variable so we can deal with it later
+    let mut at_least_one_row_filled = false;
     // if columns are still empty, let's just make a single column table with the data
     if cols.is_empty() {
+        at_least_one_row_filled = true;
         let table_with_no_empties: Vec<_> = table.iter().filter(|item| !item.is_empty()).collect();
 
         for row in &table_with_no_empties {
@@ -138,12 +133,15 @@ fn retrieve_table(mut table: Table, columns: &Value) -> Vec<Value> {
             let mut dict = TaggedDictBuilder::new(Tag::unknown());
             // eprintln!("row={:?}", &row);
             for col in &cols {
-                // eprintln!("col={:?}", &col);
+                //eprintln!("col={:?}", &col);
                 let key = col.to_string();
                 let val = row
                     .get(col)
                     .unwrap_or(&format!("Missing column: '{}'", &col))
                     .to_string();
+                if at_least_one_row_filled == false && val != String::from(format!("Missing column: '{}'", &col)) {
+                    at_least_one_row_filled = true;
+                }
                 dict.insert_value(
                     key,
                     UntaggedValue::Primitive(Primitive::String(val)).into_value(Tag::unknown()),
@@ -151,6 +149,14 @@ fn retrieve_table(mut table: Table, columns: &Value) -> Vec<Value> {
             }
             table_out.push(dict.into_value());
         }
+    }
+    if !at_least_one_row_filled {
+        let mut data2 = Vec::new();
+        for x in &table.data {
+            data2.push(x.join(", "));
+        }
+        table.data = vec![data2];
+        return retrieve_table(table, columns);
     }
     table_out
 }


### PR DESCRIPTION
As @fdncred pointed out in the #4036 PR. We have a problem when it comes to scraping multiple tables without specifying the header, the reason for that is that sometimes we have what he called a 90 degrees table, which is basically a table where the first column is the headers. A good example for that are these cards that wikipedia shows in some pages. 
![image](https://user-images.githubusercontent.com/11317382/134777978-a78ffd9c-40c2-4c15-ae5d-92e6cc45b2d8.png)

```
fetch https://en.wikipedia.org/wiki/Microsoft_Excel | selector -t [] | nth 5 | flatten
╭───┬─────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────╮
│ # │ Extension                                               │ Description                                               │ Format                                                     │
├───┼─────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
│ 0 │ Excel Macro-enabled Workbook, .xlsm, As Excel Workbook, │ Excel Binary Workbook, .xlsb, As Excel Macro-enabled      │ Excel Workbook, .xlsx, The default Excel 2007 and later    │
│   │ but with macro support.                                 │ Workbook, but storing information in binary form rather   │ workbook format. In reality, a Zip compressed archive with │
│   │                                                         │ than XML documents for opening and saving documents more  │ a directory structure of XML text documents. Functions as  │
│   │                                                         │ quickly and efficiently. Intended especially for very     │ the primary replacement for the former binary .xls format, │
│   │                                                         │ large documents with tens of thousands of rows, and/or    │ although it does not support Excel macros for security     │
│   │                                                         │ several hundreds of columns. This format is very useful   │ reasons. Saving as .xlsx offers file size reduction over   │
│   │                                                         │ for shrinking large Excel files as is often the case when │ .xls[38]                                                   │
│   │                                                         │ doing data analysis.                                      │                                                            │
╰───┴─────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────╯

```
```
fetch https://en.wikipedia.org/wiki/Microsoft_Excel | selector -t [Format Extension Description] | nth 0 | flatten
╭───┬──────────────────────────────┬───────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ # │ Format                       │ Extension │ Description                                                                                                                               │
├───┼──────────────────────────────┼───────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ 0 │ Excel Workbook               │ .xlsx     │ The default Excel 2007 and later workbook format. In reality, a Zip compressed archive with a directory structure of XML text documents.  │
│   │                              │           │ Functions as the primary replacement for the former binary .xls format, although it does not support Excel macros for security reasons.   │
│   │                              │           │ Saving as .xlsx offers file size reduction over .xls[38]                                                                                  │
│ 1 │ Excel Macro-enabled Workbook │ .xlsm     │ As Excel Workbook, but with macro support.                                                                                                │
│ 2 │ Excel Binary Workbook        │ .xlsb     │ As Excel Macro-enabled Workbook, but storing information in binary form rather than XML documents for opening and saving documents more   │
│   │                              │           │ quickly and efficiently. Intended especially for very large documents with tens of thousands of rows, and/or several hundreds of columns. │
│   │                              │           │ This format is very useful for shrinking large Excel files as is often the case when doing data analysis.                                 │
│ 3 │ Excel Macro-enabled Template │ .xltm     │ A template document that forms a basis for actual workbooks, with macro support. The replacement for the old .xlt format.                 │
│ 4 │ Excel Add-in                 │ .xlam     │ Excel add-in to add extra functionality and tools. Inherent macro support because of the file purpose.                                    │
╰───┴──────────────────────────────┴───────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
As you can see the first table is broken. This fix solves this problem by once a table is detected as being 90 degrees rebuildings, to check the drop in performance by having to rebuild some tables i decided to do a benchmark. Using hyperfine i ran this script in the old code and in the new. Below are the results
```
   # benchmark.nu
   fetch http://localhost:8000/Documentos/Microsoft%20Excel%20-%20Wikipedia.html | selector -t []
   fetch http://localhost:8000/Documentos/List%20of%20Advanced%20Dungeons%20%26%20Dragons%202nd%20edition%20monsters%20-%20Wikipedia.html | selector -t []
   fetch http://localhost:8000/Documentos/List%20of%20Falcon%209%20and%20Falcon%20Heavy%20launches%20-%20Wikipedia.html | selector -t []
   fetch http://localhost:8000/Documentos/List%20of%20ISU%20World%20Standings%20and%20Season%27s%20World%20Ranking%20statistics%20-%20Wikipedia.html | selector -t []
   fetch http://localhost:8000/Documentos/List%20of%20The%20Amazing%20Spider-Man%20issues%20-%20Wikipedia.html | selector -t []
```

Old
```
❯ hyperfine "nu benchmark.nu"
Benchmark #1: nu benchmark.nu
  Time (mean ± σ):     709.8 ms ±  12.0 ms    [User: 648.2 ms, System: 79.1 ms]
  Range (min … max):   703.2 ms … 740.7 ms    10 runs
```
New
```

❯ hyperfine "nu benchmark.nu"
Benchmark #1: nu benchmark.nu
  Time (mean ± σ):     868.5 ms ±   9.2 ms    [User: 790.3 ms, System: 99.9 ms]
  Range (min … max):   856.0 ms … 885.9 ms    10 runs
```
As we can see we have some miliseconds more, note that this was done using 4 of the biggest pages in all wikipedia, the drop will depend on how many of the tables are bad formated. If you guys think that this drop in performance is not acceptable. We could possibly give to the user the option of trying to do this kind of thing(something that would indicate that we are trying to adequate html to tables, i don't know the best name), my only issue with this is that i can't think of a context where you wouldn't want a proper displayed table, but adding a flag should be quite easy.  
