### PR TITLE
expand tilde when reading plugin_dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,6 +2566,7 @@ dependencies = [
  "nu-engine",
  "nu-errors",
  "nu-parser",
+ "nu-path",
  "nu-protocol",
  "nu-source",
  "nu-stream",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -21,6 +21,7 @@ nu-protocol = { version = "0.37.1", path="../nu-protocol" }
 nu-source = { version = "0.37.1", path="../nu-source" }
 nu-stream = { version = "0.37.1", path="../nu-stream" }
 nu-ansi-term = { version = "0.37.1", path="../nu-ansi-term" }
+nu-path = { version = "0.37.1", path="../nu-path" }
 
 indexmap ="1.6.1"
 log = "0.4.14"

--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -24,6 +24,7 @@ use rustyline::{self, error::ReadlineError};
 
 use nu_errors::ShellError;
 use nu_parser::ParserScope;
+use nu_path::expand_tilde;
 use nu_protocol::{hir::ExternalRedirection, ConfigPath, UntaggedValue, Value};
 
 use log::trace;
@@ -54,7 +55,7 @@ pub fn search_paths() -> Vec<std::path::PathBuf> {
         {
             for pipeline in pipelines {
                 if let Ok(plugin_dir) = pipeline.as_string() {
-                    search_paths.push(PathBuf::from(plugin_dir));
+                    search_paths.push(expand_tilde(plugin_dir));
                 }
             }
         }


### PR DESCRIPTION
It would be more convenient if we can use `~` in the `plugin_dirs` config.