### PR TITLE
remove ansi colors if this is not a tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,8 +2900,10 @@ dependencies = [
 name = "nu-table"
 version = "0.37.1"
 dependencies = [
+ "atty",
  "nu-ansi-term",
  "regex",
+ "strip-ansi-escapes",
  "unicode-width",
 ]
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -12,7 +12,9 @@ name = "table"
 path = "src/main.rs"
 
 [dependencies]
+atty = "0.2.14"
 nu-ansi-term = { version = "0.37.1", path="../nu-ansi-term" }
 
 regex = "1.4"
+strip-ansi-escapes = "0.1.1"
 unicode-width = "0.1.8"

--- a/crates/nu-table/src/main.rs
+++ b/crates/nu-table/src/main.rs
@@ -27,8 +27,18 @@ fn main() {
     let color_hm: HashMap<String, nu_ansi_term::Style> = HashMap::new();
     // Capture the table as a string
     let output_table = draw_table(&table, width, &color_hm);
-    // Draw the table
-    println!("{}", output_table)
+
+    if atty::is(atty::Stream::Stdout) {
+        // Draw the table with ansi colors
+        println!("{}", output_table)
+    } else {
+        // Draw the table without ansi colors
+        if let Ok(bytes) = strip_ansi_escapes::strip(&output_table) {
+            println!("{}", String::from_utf8_lossy(&bytes))
+        } else {
+            println!("{}", output_table)
+        }
+    }
 }
 
 fn make_table_data() -> (Vec<&'static str>, Vec<&'static str>) {

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -918,7 +918,17 @@ impl WrappedTable {
             output.push_str(&self.print_separator(SeparatorPosition::Bottom, color_hm));
         }
 
-        output
+        if atty::is(atty::Stream::Stdout) {
+            // Draw the table with ansi colors
+            output
+        } else {
+            // Draw the table without ansi colors
+            if let Ok(bytes) = strip_ansi_escapes::strip(&output) {
+                String::from_utf8_lossy(&bytes).to_string()
+            } else {
+                output
+            }
+        }
     }
 }
 


### PR DESCRIPTION
this is an attempt to strip ansi colors from table output if the output is not a tty. we could probably make this a config point or a command line parameter if people want it.

from testing; before:
![image](https://user-images.githubusercontent.com/343840/135627194-ac5b329d-1b1d-4383-9fe8-a1094c7cefb7.png)

after:
![image](https://user-images.githubusercontent.com/343840/135627235-b775b2fa-7a31-4cc1-85a9-800326a5028d.png)

should close #4057