### PR TITLE
stale.yml: mention time to close in stale message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,8 +19,8 @@ jobs:
           operations-per-run: 520
           enable-statistics: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is being marked stale because it has been open for 90 days without activity. If you feel that this is in error, please comment below and we will keep it marked as active.'
-          stale-pr-message: 'This PR is being marked stale because it has been open for 45 days without activity. If this PR is still active, please comment below and we will keep it marked as active.'
+          stale-issue-message: 'This issue is being marked stale because it has been open for 90 days without activity. If you feel that this is in error, please comment below and we will keep it marked as active. Otherwise, it will be closed in 10 days.'
+          stale-pr-message: 'This PR is being marked stale because it has been open for 45 days without activity. If this PR is still active, please comment below and we will keep it marked as active. Otherwise, it will be closed in 10 days.'
           close-issue-message: 'This issue has been marked stale for more than 10 days without activity. Closing this issue, but if you find that the issue is still valid, please reopen.'
           close-pr-message: 'This PR has been marked stale for more than 10 days without activity. Closing this PR, but if you are still working on it, please reopen.'
           days-before-issue-stale: 90


### PR DESCRIPTION
The number of days before stale-bot closes an issue is configurable (in fact, closing issues/PRs can even be disabled, as shown e.g. [here](https://github.com/NixOS/nixpkgs/blob/c24a48c092fe5064c62188814639e375f797a40c/.github/stale.yml)).

This PR makes the stale message explicit about what's going to happen when an issue or PR is marked as stale.