### PR TITLE
remove history file after clearing it

### DIFF
--- a/crates/nu-cli/src/cli.rs
+++ b/crates/nu-cli/src/cli.rs
@@ -372,7 +372,7 @@ pub fn cli(
             LineResult::ClearHistory => {
                 if options.save_history {
                     rl.clear_history();
-                    let _ = rl.append_history(&history_path);
+                    std::fs::remove_file(&history_path)?;
                 }
             }
 


### PR DESCRIPTION
this takes a more radical approach to clearing the history. it first clears the history, which removes the entries from memory. it then removes the history.txt file.
closes #4068