### PR TITLE
Get rid of header bold option

### DIFF
--- a/crates/nu-command/src/commands/config/set.rs
+++ b/crates/nu-command/src/commands/config/set.rs
@@ -38,7 +38,7 @@ impl WholeStreamCommand for SubCommand {
             },
             Example {
                 description: "Set coloring options",
-                example: "config set color_config [[header_align header_bold]; [left $true]]",
+                example: "config set color_config [[header_align header_color]; [left white_bold]]",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/commands/viewers/table/options.rs
+++ b/crates/nu-command/src/commands/viewers/table/options.rs
@@ -3,7 +3,6 @@ use nu_data::primitive::lookup_ansi_color_style;
 use nu_protocol::Value;
 use nu_table::{Alignment, TextStyle};
 use std::fmt::Debug;
-use log::{trace};
 
 pub trait ConfigExtensions: Debug + Send {
     fn table_mode(&self) -> nu_table::Theme;
@@ -78,9 +77,10 @@ impl ConfigExtensions for NuConfig {
         // FIXME: I agree, this is the long way around, please suggest and alternative.
         let head_color = get_color_from_key_and_subkey(self, "color_config", "header_color");
         let (head_color_style, head_bold_bool) = match head_color {
-            Some(s) => {
-                (lookup_ansi_color_style(s.as_string().unwrap_or_else(|_| "green".to_string())), header_bold_from_value(Some(&s)))
-            }
+            Some(s) => (
+                lookup_ansi_color_style(s.as_string().unwrap_or_else(|_| "green".to_string())),
+                header_bold_from_value(Some(&s)),
+            ),
             None => (nu_ansi_term::Color::Green.normal(), true),
         };
 

--- a/crates/nu-command/src/commands/viewers/table/options.rs
+++ b/crates/nu-command/src/commands/viewers/table/options.rs
@@ -40,12 +40,6 @@ pub fn get_color_from_key_and_subkey(config: &NuConfig, key: &str, subkey: &str)
     None
 }
 
-pub fn header_bold_from_value(bold_value: Option<&Value>) -> bool {
-    bold_value
-        .map(|x| x.as_bool().unwrap_or(true))
-        .unwrap_or(true)
-}
-
 pub fn table_mode(config: &NuConfig) -> nu_table::Theme {
     let vars = &config.vars;
 
@@ -82,11 +76,7 @@ impl ConfigExtensions for NuConfig {
             }
             None => nu_ansi_term::Color::Green.normal(),
         };
-        let head_bold = get_color_from_key_and_subkey(self, "color_config", "header_bold");
-        let head_bold_bool = match head_bold {
-            Some(b) => header_bold_from_value(Some(&b)),
-            None => true,
-        };
+
         let head_align = get_color_from_key_and_subkey(self, "color_config", "header_align");
         let head_alignment = match head_align {
             Some(a) => header_alignment_from_value(Some(&a)),
@@ -95,7 +85,7 @@ impl ConfigExtensions for NuConfig {
 
         TextStyle::new()
             .alignment(head_alignment)
-            .bold(Some(head_bold_bool))
+            .bold(Some(head_color_style.is_bold))
             .fg(head_color_style
                 .foreground
                 .unwrap_or(nu_ansi_term::Color::Green))

--- a/crates/nu-data/src/primitive.rs
+++ b/crates/nu-data/src/primitive.rs
@@ -102,7 +102,6 @@ pub fn string_to_lookup_value(str_prim: &str) -> String {
         "separator_color" => "separator_color".to_string(),
         "header_align" => "header_align".to_string(),
         "header_color" => "header_color".to_string(),
-        "header_bold" => "header_bold".to_string(),
         "header_style" => "header_style".to_string(),
         "index_color" => "index_color".to_string(),
         "leading_trailing_space_bg" => "leading_trailing_space_bg".to_string(),
@@ -144,7 +143,6 @@ pub fn get_color_config(config: &NuConfig) -> HashMap<String, Style> {
     hm.insert("separator_color".to_string(), Color::White.normal());
     hm.insert("header_align".to_string(), Color::Green.bold());
     hm.insert("header_color".to_string(), Color::Green.bold());
-    hm.insert("header_bold".to_string(), Color::Green.bold());
     hm.insert("header_style".to_string(), Style::default());
     hm.insert("index_color".to_string(), Color::Green.bold());
     hm.insert(
@@ -202,9 +200,6 @@ pub fn get_color_config(config: &NuConfig) -> HashMap<String, Style> {
                     update_hashmap(key, value, &mut hm);
                 }
                 "header_color" => {
-                    update_hashmap(key, value, &mut hm);
-                }
-                "header_bold" => {
                     update_hashmap(key, value, &mut hm);
                 }
                 "header_style" => {
@@ -358,14 +353,7 @@ pub fn style_primitive(primitive: &str, color_hm: &HashMap<String, Style>) -> Te
             let style = color_hm.get("header_color");
             match style {
                 Some(s) => TextStyle::with_style(Alignment::Center, *s),
-                None => TextStyle::default_header(),
-            }
-        }
-        "header_bold" => {
-            let style = color_hm.get("header_bold");
-            match style {
-                Some(s) => TextStyle::with_style(Alignment::Center, *s),
-                None => TextStyle::default_header(),
+                None => TextStyle::default_header().bold(Some(true)),
             }
         }
         "header_style" => {

--- a/docs/commands/config-set.md
+++ b/docs/commands/config-set.md
@@ -1,36 +1,44 @@
 # config set
+
 Sets a value in the config
 
 ## Usage
+
 ```shell
-> config set <key> <value> {flags} 
- ```
+> config set <key> <value> {flags}
+```
 
 ## Parameters
-* `<key>` variable name to set
-* `<value>` value to use
+
+-   `<key>` variable name to set
+-   `<value>` value to use
 
 ## Flags
-* -h, --help: Display this help message
+
+-   -h, --help: Display this help message
 
 ## Examples
-  Set auto pivoting
+
+Set auto pivoting
+
 ```shell
 > config set pivot_mode always
- ```
+```
 
-  Set line editor options
+Set line editor options
+
 ```shell
 > config set line_editor [[edit_mode, completion_type]; [emacs circular]]
- ```
+```
 
-  Set coloring options
+Set coloring options
+
 ```shell
-> config set color_config [[header_align header_bold]; [left $true]]
- ```
+> config set color_config [[header_align header_color]; [left white_bold]]
+```
 
-  Set nested options
+Set nested options
+
 ```shell
 > config set color_config.header_color white
- ```
-
+```

--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -53,7 +53,6 @@ primitive_binary = "cyan"
 separator_color = "purple"
 header_align = "l" # left|l, right|r, center|c
 header_color = "c" # green|g, red|r, blue|u, black|b, yellow|y, purple|p, cyan|c, white|w
-header_bold = true
 index_color = "rd"
 leading_trailing_space_bg = "white"
 


### PR DESCRIPTION
# Description
- Get rid of `header_bold` option (use `<color>_bold` instead)
- Update docs removing mentions to `header_bold`

# Context
Fix #4072 

# How has been this tested?
Run nushell: `cargo run --release --features=extra -- --loglevel trace` and run an `ls` as a test