### PR TITLE
use heck for string casing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,7 +2358,6 @@ dependencies = [
 name = "nu-command"
 version = "0.41.0"
 dependencies = [
- "Inflector",
  "base64",
  "bigdecimal",
  "calamine",
@@ -2381,6 +2376,7 @@ dependencies = [
  "futures 0.3.18",
  "glob",
  "hamcrest2",
+ "heck 0.4.0",
  "htmlescape",
  "ical",
  "indexmap",
@@ -4474,7 +4470,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -30,7 +30,7 @@ nu-pretty-hex = { version = "0.41.0", path="../nu-pretty-hex" }
 
 url = "2.2.1"
 mime = "0.3.16"
-Inflector = "0.11"
+heck = "0.4.0"
 base64 = "0.13.0"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 calamine = "0.18.0"

--- a/crates/nu-command/src/commands/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/camel_case.rs
@@ -1,6 +1,5 @@
-use super::operate;
+use super::{operate, to_lower_camel_case};
 use crate::prelude::*;
-use inflector::cases::camelcase::to_camel_case;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, Value};
@@ -25,7 +24,7 @@ impl WholeStreamCommand for SubCommand {
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        operate(args, &to_camel_case)
+        operate(args, &to_lower_camel_case)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -40,7 +39,7 @@ impl WholeStreamCommand for SubCommand {
 #[cfg(test)]
 mod tests {
     use super::ShellError;
-    use super::{to_camel_case, SubCommand};
+    use super::{to_lower_camel_case, SubCommand};
     use crate::commands::strings::str_::case::action;
     use nu_source::Tag;
     use nu_test_support::value::string;
@@ -57,7 +56,7 @@ mod tests {
         let word = string("this-is-the-first-case");
         let expected = string("thisIsTheFirstCase");
 
-        let actual = action(&word, Tag::unknown(), &to_camel_case).unwrap();
+        let actual = action(&word, Tag::unknown(), &to_lower_camel_case).unwrap();
         assert_eq!(actual, expected);
     }
     #[test]
@@ -65,7 +64,7 @@ mod tests {
         let word = string("this_is_the_second_case");
         let expected = string("thisIsTheSecondCase");
 
-        let actual = action(&word, Tag::unknown(), &to_camel_case).unwrap();
+        let actual = action(&word, Tag::unknown(), &to_lower_camel_case).unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/commands/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/kebab_case.rs
@@ -1,6 +1,5 @@
-use super::operate;
+use super::{operate, to_kebab_case};
 use crate::prelude::*;
-use inflector::cases::kebabcase::to_kebab_case;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, Value};

--- a/crates/nu-command/src/commands/strings/str_/case/mod.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/mod.rs
@@ -16,6 +16,24 @@ pub use pascal_case::SubCommand as PascalCase;
 pub use screaming_snake_case::SubCommand as ScreamingSnakeCase;
 pub use snake_case::SubCommand as SnakeCase;
 
+use heck::ToKebabCase;
+use heck::ToLowerCamelCase;
+use heck::ToShoutySnakeCase;
+use heck::ToSnakeCase;
+use heck::ToUpperCamelCase;
+macro_rules! create_heck_function {
+    ($func_name:ident) => {
+        pub fn $func_name(a_slice: &str) -> String {
+            a_slice.$func_name()
+        }
+    };
+}
+create_heck_function!(to_upper_camel_case);
+create_heck_function!(to_lower_camel_case);
+create_heck_function!(to_kebab_case);
+create_heck_function!(to_shouty_snake_case);
+create_heck_function!(to_snake_case);
+
 struct Arguments {
     column_paths: Vec<ColumnPath>,
 }

--- a/crates/nu-command/src/commands/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/pascal_case.rs
@@ -1,6 +1,5 @@
-use super::operate;
+use super::{operate, to_upper_camel_case};
 use crate::prelude::*;
-use inflector::cases::pascalcase::to_pascal_case;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, Value};
@@ -25,7 +24,7 @@ impl WholeStreamCommand for SubCommand {
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        operate(args, &to_pascal_case)
+        operate(args, &to_upper_camel_case)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -40,7 +39,7 @@ impl WholeStreamCommand for SubCommand {
 #[cfg(test)]
 mod tests {
     use super::ShellError;
-    use super::{to_pascal_case, SubCommand};
+    use super::{to_upper_camel_case, SubCommand};
     use crate::commands::strings::str_::case::action;
     use nu_source::Tag;
     use nu_test_support::value::string;
@@ -57,7 +56,7 @@ mod tests {
         let word = string("this-is-the-first-case");
         let expected = string("ThisIsTheFirstCase");
 
-        let actual = action(&word, Tag::unknown(), &to_pascal_case).unwrap();
+        let actual = action(&word, Tag::unknown(), &to_upper_camel_case).unwrap();
         assert_eq!(actual, expected);
     }
     #[test]
@@ -65,7 +64,7 @@ mod tests {
         let word = string("this_is_the_second_case");
         let expected = string("ThisIsTheSecondCase");
 
-        let actual = action(&word, Tag::unknown(), &to_pascal_case).unwrap();
+        let actual = action(&word, Tag::unknown(), &to_upper_camel_case).unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/commands/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/screaming_snake_case.rs
@@ -1,6 +1,5 @@
-use super::operate;
+use super::{operate, to_shouty_snake_case};
 use crate::prelude::*;
-use inflector::cases::screamingsnakecase::to_screaming_snake_case;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, Value};
@@ -25,7 +24,7 @@ impl WholeStreamCommand for SubCommand {
     }
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
-        operate(args, &to_screaming_snake_case)
+        operate(args, &to_shouty_snake_case)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -40,7 +39,7 @@ impl WholeStreamCommand for SubCommand {
 #[cfg(test)]
 mod tests {
     use super::ShellError;
-    use super::{to_screaming_snake_case, SubCommand};
+    use super::{to_shouty_snake_case, SubCommand};
     use crate::commands::strings::str_::case::action;
     use nu_source::Tag;
     use nu_test_support::value::string;
@@ -57,7 +56,7 @@ mod tests {
         let word = string("this-is-the-first-case");
         let expected = string("THIS_IS_THE_FIRST_CASE");
 
-        let actual = action(&word, Tag::unknown(), &to_screaming_snake_case).unwrap();
+        let actual = action(&word, Tag::unknown(), &to_shouty_snake_case).unwrap();
         assert_eq!(actual, expected);
     }
     #[test]
@@ -65,7 +64,7 @@ mod tests {
         let word = string("this_is_the_second_case");
         let expected = string("THIS_IS_THE_SECOND_CASE");
 
-        let actual = action(&word, Tag::unknown(), &to_screaming_snake_case).unwrap();
+        let actual = action(&word, Tag::unknown(), &to_shouty_snake_case).unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/commands/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/commands/strings/str_/case/snake_case.rs
@@ -1,6 +1,5 @@
-use super::operate;
+use super::{operate, to_snake_case};
 use crate::prelude::*;
-use inflector::cases::snakecase::to_snake_case;
 use nu_engine::WholeStreamCommand;
 use nu_errors::ShellError;
 use nu_protocol::{Signature, SyntaxShape, Value};


### PR DESCRIPTION
I removed the Inflector dependency in favor of heck for two reasons:
- to close #3674.
- heck seems simpler and actively maintained

We could probably alter the structure of the `str_` module to expose the
individual casing behaviors better.
I did not feel as confident on changing those signatures.

So I took a lazier approach of a macro in the `mod.rs` that creates the public
shimming function to heck's traits.
