### PR TITLE
added CustomCompleter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
  "bugreport",
  "clap",
  "clircle",
- "console",
+ "console 0.14.1",
  "content_inspector",
  "dirs-next",
  "encoding",
@@ -653,6 +653,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +947,18 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.9.0"
+source = "git+https://github.com/rsteube/dialoguer?branch=fuzzy-paging#92b59e2ca8aed50ed8ebc7e094aa8c7e7f2b6d99"
+dependencies = [
+ "console 0.15.0",
+ "fuzzy-matcher",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -1442,6 +1469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,7 +1947,7 @@ version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58019516c1403ac45b106c9fc4e8fcbd77a78e98b014c619d1506338902ccfa4"
 dependencies = [
- "console",
+ "console 0.14.1",
  "lazy_static",
  "serde",
  "serde_json",
@@ -2538,6 +2574,7 @@ name = "nu-cli"
 version = "0.38.0"
 dependencies = [
  "ctrlc",
+ "dialoguer",
  "indexmap",
  "lazy_static",
  "log",
@@ -2662,6 +2699,8 @@ dependencies = [
  "nu-source",
  "nu-test-support",
  "parking_lot",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5017,6 +5056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5622,6 +5670,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 
 [[package]]
 name = "zip"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 doctest = false
 
 [dependencies]
+dialoguer = { git = "https://github.com/rsteube/dialoguer", branch = "fuzzy-paging", features = ["fuzzy-select"] }
 nu-completion = { version = "0.38.0", path="../nu-completion" }
 nu-command = { version = "0.38.0", path="../nu-command" }
 nu-data = { version = "0.38.0", path="../nu-data" }

--- a/crates/nu-completion/Cargo.toml
+++ b/crates/nu-completion/Cargo.toml
@@ -19,6 +19,9 @@ nu-source = { version = "0.38.0", path="../nu-source" }
 nu-test-support = { version = "0.38.0", path="../nu-test-support" }
 indexmap = { version="1.6.1", features=["serde-1"] }
 
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.61"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 is_executable = "1.0.1"
 

--- a/crates/nu-completion/src/completer.rs
+++ b/crates/nu-completion/src/completer.rs
@@ -4,6 +4,7 @@ use nu_parser::NewlineMode;
 use nu_source::{Span, Tag};
 
 use crate::command::CommandCompleter;
+use crate::custom::CustomCompleter;
 use crate::engine;
 use crate::flag::FlagCompleter;
 use crate::matchers;
@@ -55,6 +56,17 @@ impl NuCompleter {
         if locations.is_empty() {
             (pos, Vec::new())
         } else {
+            let custom_completer = CustomCompleter {
+                line: line,
+                pos: pos,
+                locations: locations.clone(),
+                context: context,
+            };
+            match custom_completer.complete() {
+                Some(x) => return x,
+                _ => {}
+            };
+
             let mut pos = locations[0].span.start();
 
             for location in &locations {

--- a/crates/nu-completion/src/custom.rs
+++ b/crates/nu-completion/src/custom.rs
@@ -1,0 +1,127 @@
+use crate::engine;
+use crate::CompletionContext;
+use crate::Suggestion;
+use engine::LocationType;
+use nu_parser::NewlineMode;
+use std::process::Command;
+use std::str::from_utf8;
+
+pub struct CustomCompleter<'a> {
+    pub(crate) line: &'a str,
+    pub(crate) pos: usize,
+    pub(crate) locations: Vec<engine::CompletionLocation>,
+    pub(crate) context: &'a dyn CompletionContext,
+}
+
+impl CustomCompleter<'_> {
+    fn completer(&self, cmd: &str) -> Option<Command> {
+        if let Some(global_cfg) = &self
+            .context
+            .source()
+            .engine_state
+            .configs
+            .lock()
+            .global_config
+        {
+            if let Some(completion_vars) = global_cfg.var("completion") {
+                for (idx, value) in completion_vars.row_entries() {
+                    if idx == cmd {
+                        let mut args = Vec::new();
+                        for v in value.table_entries() {
+                            match v.as_string() {
+                                Ok(s) => {
+                                    args.push(s);
+                                }
+                                _ => return None,
+                            }
+                        }
+                        if args.len() > 0 {
+                            let mut command = Command::new(&args[0]);
+                            if args.len() > 1 {
+                                command.args(&args[1..]);
+                            }
+                            return Some(command);
+                        }
+                    }
+                }
+            }
+        };
+        None
+    }
+
+    fn words(&self) -> (usize, Vec<&str>) {
+        if self.locations.is_empty() {
+            return (self.pos, Vec::new());
+        } else {
+            let cursor_pos = self.pos;
+            let mut pos = self.locations[0].span.start();
+            let mut command_start = 0;
+            for location in &self.locations {
+                if location.span.start() <= cursor_pos && location.span.end() >= cursor_pos {
+                    pos = location.span.start();
+                }
+                if location.span.start() <= cursor_pos {
+                    match location.item {
+                        LocationType::Command => command_start = location.span.start(),
+                        _ => {}
+                    }
+                }
+            }
+
+            let mut words = Vec::new();
+            for token in nu_parser::lex(self.line, 0, NewlineMode::Normal).0 {
+                if token.span.start() < command_start {
+                    // ensure part of current command
+                    continue;
+                }
+
+                if token.span.start() <= cursor_pos && token.span.end() >= cursor_pos {
+                    words.push(&self.line[token.span.start()..cursor_pos]);
+                    break;
+                } else if token.span.end() < cursor_pos {
+                    words.push(token.span.slice(self.line));
+                }
+            }
+
+            for location in &self.locations {
+                if location.span.start() <= cursor_pos && location.span.end() >= cursor_pos {
+                    let partial = location.span.slice(self.line).to_string();
+                    if partial.len() == 0 {
+                        words.push("") // current word being completed is empty
+                    }
+                }
+            }
+
+            (pos, words)
+        }
+    }
+
+    pub fn complete(&self) -> Option<(usize, Vec<Suggestion>)> {
+        let (pos, words) = self.words();
+
+        if words.len() < 2 {
+            None
+        } else {
+            if let Some(mut completer) = self.completer(words[0]) {
+                // quick fix quoted words by simply removing `'` and `"` (won't work with those actually containing quotes)
+                let patched: Vec<String> = words
+                    .into_iter()
+                    .map(|w| w.replace("'", "").replace('"', ""))
+                    .collect();
+
+                let output = completer.args(patched).output();
+
+                let output_str = match output {
+                    Ok(o) => from_utf8(&o.stdout).unwrap_or("").to_owned(),
+                    _ => "".to_owned(),
+                };
+
+                let suggestions: Vec<Suggestion> =
+                    serde_json::from_str(&output_str).unwrap_or(Vec::new());
+                Some((pos, suggestions))
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/crates/nu-completion/src/lib.rs
+++ b/crates/nu-completion/src/lib.rs
@@ -1,5 +1,6 @@
 pub(crate) mod command;
 pub(crate) mod completer;
+pub(crate) mod custom;
 pub(crate) mod engine;
 pub(crate) mod flag;
 pub(crate) mod matchers;
@@ -10,10 +11,11 @@ use nu_engine::EvaluationContext;
 use nu_protocol::{SignatureRegistry, VariableRegistry};
 
 use matchers::Matcher;
+use serde::Deserialize;
 
 pub use completer::NuCompleter;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct Suggestion {
     pub display: String,
     pub replacement: String,


### PR DESCRIPTION
basic idea is to somehow enable registration of custom completers which are invoked and passed the current command line up to cursor position to then return completions as json (or similar)

- uses nushell config to register the completers (permanent and bloats it up though)
- uses dialoguer with added paging to `fuzzy_select` (still some issues with line removal)

this currently works with [carapace-bin](https://github.com/rsteube/carapace-bin) after adding the config entries:
```sh
carapace _carapace nushell | save carapace.nu ; nu -c 'source carapace.nu'
```

related: https://github.com/nushell/nushell/issues/290
related: https://github.com/nushell/engine-q/pull/239
related: https://github.com/mitsuhiko/dialoguer/compare/master...rsteube:fuzzy-paging