### PR TITLE
Fix regression in the plugin selector

### DIFF
--- a/crates/nu_plugin_selector/src/selector.rs
+++ b/crates/nu_plugin_selector/src/selector.rs
@@ -35,7 +35,7 @@ impl Default for Selector {
 }
 
 pub fn begin_selector_query(input_html: String, selector: &Selector) -> Vec<Value> {
-    if selector.as_table.is_some() {
+    if !selector.as_table.value.is_string() {
         retrieve_tables(input_html.as_str(), &selector.as_table, selector.inspect)
     } else {
         match selector.attribute.is_empty() {


### PR DESCRIPTION
Fixed #4085 

Explanation: 

After #4004 we added the -t flag, the problem was that for checking if that flag was set we used.
```

if selector.as_table.is_some() {
        retrieve_tables(input_html.as_str(), &selector.as_table, selector.inspect)
    } else { 
```
The problem is that is turns out, that even if you don't set the flag, it will still be there. Like this, the value will be an empty string 
![image](https://user-images.githubusercontent.com/11317382/137966075-effc935b-b57b-4ca7-a29d-0f981b1c27ca.png)
In a correct table operation tha value looks more like this
![image](https://user-images.githubusercontent.com/11317382/137966135-f3ad7aca-a72e-4be8-bc32-a550310751e3.png)
So all i did was get the value and check if it was a string, because in the correct cases it will be a Vec