### PR TITLE
WIP: Add `date` to custom command types

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -968,6 +968,7 @@ fn parse_arg(
         ),
         SyntaxShape::Filesize => parse_filesize(lite_arg),
         SyntaxShape::Duration => parse_duration(lite_arg),
+        SyntaxShape::Date => unimplemented!(),
         SyntaxShape::FilePath => {
             let trimmed = trim_quotes(&lite_arg.item);
             let path = PathBuf::from(trimmed);

--- a/crates/nu-parser/src/parse/def/primitives.rs
+++ b/crates/nu-parser/src/parse/def/primitives.rs
@@ -167,6 +167,7 @@ pub fn parse_type_token(type_: &Token) -> (SyntaxShape, Option<ParseError>) {
             "path" => (SyntaxShape::FilePath, None),
             "table" => (SyntaxShape::Table, None),
             "duration" => (SyntaxShape::Duration, None),
+            "date" => (SyntaxShape::Date, None),
             "filesize" => (SyntaxShape::Filesize, None),
             "number" => (SyntaxShape::Number, None),
             "pattern" => (SyntaxShape::GlobPattern, None),

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -30,6 +30,8 @@ pub enum SyntaxShape {
     Filesize,
     /// A duration value is allowed, eg `19day`
     Duration,
+    /// A date value is allowed, eg `2021-10-23`
+    Date,
     /// An operator
     Operator,
     /// A math expression which expands shorthand forms on the lefthand side, eg `foo > 1`
@@ -54,6 +56,7 @@ impl SyntaxShape {
             SyntaxShape::Block => "block",
             SyntaxShape::Table => "table",
             SyntaxShape::Duration => "duration",
+            SyntaxShape::Date => "date",
             SyntaxShape::Filesize => "filesize",
             SyntaxShape::Operator => "operator",
             SyntaxShape::RowCondition => "condition",


### PR DESCRIPTION
This pull requests aims at adding `date` to custom command types

# Todo

- [ ] parsing ? where is it parsed
    - [ ] which date format can be parsed ?
- [ ] what have I missed ?
- [ ] tests