### PR TITLE
fix: panic! during parsing

### DIFF
--- a/crates/nu-parser/src/parse.rs
+++ b/crates/nu-parser/src/parse.rs
@@ -1559,11 +1559,16 @@ fn parse_internal_command(
                                     if error.is_none() {
                                         error = err;
                                     }
-                                } else if error.is_none() {
-                                    error = Some(ParseError::argument_error(
-                                        lite_cmd.parts[0].clone(),
-                                        ArgumentError::MissingValueForName(full_name.to_owned()),
-                                    ));
+                                } else {
+                                    if error.is_none() {
+                                        error = Some(ParseError::argument_error(
+                                            lite_cmd.parts[0].clone(),
+                                            ArgumentError::MissingValueForName(
+                                                full_name.to_owned(),
+                                            ),
+                                        ));
+                                    }
+                                    break;
                                 }
                             }
                         }


### PR DESCRIPTION
Typing `selector -qa` into `nu` would cause a `panic!`
This was the case because the `inner loop` incremented the `idx` that was only checked in the `outer loop` and used it to index into `lite_cmd.parts[idx]`
With the fix we now break the loop.
This wouldn't happen with this `selector -qz` line, because z is not part of the command_line flags of selector. 
`selector -qt` -> panic!
`selector -ma` -> no panic!, because `m` is a flag and doesn't expect an argument 
`selector -mat` -> panic!
