### PR TITLE
upgrade dependencies

### DIFF
--- a/crates/nu-ansi-term/src/style.rs
+++ b/crates/nu-ansi-term/src/style.rs
@@ -613,7 +613,7 @@ mod serde_json_tests {
             let serialized = serde_json::to_string(&color).unwrap();
             let deserialized: Color = serde_json::from_str(&serialized).unwrap();
 
-            assert_eq!(color, &deserialized);
+            assert_eq!(color, deserialized);
         }
     }
 

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -36,8 +36,5 @@ nu-test-support = { version = "0.39.0", path="../nu-test-support" }
 nu-value-ext = { version = "0.39.0", path="../nu-value-ext" }
 nu-ansi-term = { version = "0.39.0", path="../nu-ansi-term" }
 
-[target.'cfg(unix)'.dependencies]
-users = "0.11.0"
-
 [features]
 dataframe = ["nu-protocol/dataframe"]

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -23,7 +23,7 @@ trash = { version="1.3.0", optional=true }
 which = { version="4.0.2", optional=true }
 codespan-reporting = "0.11.0"
 bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
-bytes = "0.5.6"
+bytes = "1.1.0"
 chrono = { version="0.4.19", features=["serde"] }
 derive-new = "0.5.8"
 dirs-next = "2.0.0"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -22,7 +22,6 @@ nu-path = { version = "0.39.0", path="../nu-path" }
 trash = { version="1.3.0", optional=true }
 which = { version="4.0.2", optional=true }
 codespan-reporting = "0.11.0"
-ansi_term = "0.12.1"
 bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
 bytes = "0.5.6"
 chrono = { version="0.4.19", features=["serde"] }

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -20,7 +20,7 @@ nu-ansi-term = { path="../nu-ansi-term", version = "0.39.0" }
 rand = "0.8.3"
 
 [dev-dependencies]
-heapless = "0.6.1"
+heapless = { version = "0.7.8", default-features = false }
 
 # [features]
 # default = ["alloc"]

--- a/crates/nu-pretty-hex/tests/tests.rs
+++ b/crates/nu-pretty-hex/tests/tests.rs
@@ -166,7 +166,7 @@ fn test_hex_write_with_simple_config() {
         core::str::from_utf8(b"00 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f").unwrap();
     // let expected =
     //     "\u{1b}[38;5;242m00\u{1b}[0m \u{1b}[1;35m01\u{1b}[0m \u{1b}[1;35m02\u{1b}[0m \u{1b}[1;";
-    let mut buffer = heapless::Vec::<u8, heapless::consts::U50>::new();
+    let mut buffer = heapless::Vec::<u8, 50>::new();
 
     hex_write(&mut buffer, &bytes, config, None).unwrap();
 

--- a/crates/nu_plugin_binaryview/Cargo.toml
+++ b/crates/nu_plugin_binaryview/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 crossterm = "0.19"
-image = { version="0.22.4", default_features=false, features=["png_codec", "jpeg"] }
+image = { version = "0.23.14", default_features = false, features = ["png", "jpeg"] }
 neso = "0.5.0"
 nu-errors = { path="../nu-errors", version = "0.39.0" }
 nu-plugin = { path="../nu-plugin", version = "0.39.0" }

--- a/crates/nu_plugin_from_bson/Cargo.toml
+++ b/crates/nu_plugin_from_bson/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
-bson = { version="0.14.1", features=["decimal128"] }
+bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
 nu-errors = { path="../nu-errors", version = "0.39.0" }
 nu-plugin = { path="../nu-plugin", version = "0.39.0" }
 nu-protocol = { path="../nu-protocol", version = "0.39.0" }

--- a/crates/nu_plugin_from_mp4/Cargo.toml
+++ b/crates/nu_plugin_from_mp4/Cargo.toml
@@ -15,6 +15,6 @@ nu-plugin = { path="../nu-plugin", version = "0.39.0" }
 nu-protocol = { path="../nu-protocol", version = "0.39.0" }
 nu-source = { path="../nu-source", version = "0.39.0" }
 tempfile = "3.2.0"
-mp4 = "0.8.2"
+mp4 = "0.9.0"
 
 [build-dependencies]

--- a/crates/nu_plugin_from_mp4/src/from_mp4.rs
+++ b/crates/nu_plugin_from_mp4/src/from_mp4.rs
@@ -27,7 +27,7 @@ pub fn convert_mp4_file_to_nu_value(path: &Path, tag: Tag) -> Result<Value, mp4:
 
     // Build tracks table
     let mut tracks = Vec::new();
-    for track in mp4.tracks() {
+    for track in mp4.tracks().values() {
         let mut curr_track_dict = TaggedDictBuilder::new(tag.clone());
 
         curr_track_dict.insert_untagged("track id", UntaggedValue::int(track.track_id()));

--- a/crates/nu_plugin_start/Cargo.toml
+++ b/crates/nu_plugin_start/Cargo.toml
@@ -15,9 +15,11 @@ nu-errors = { path="../nu-errors", version = "0.39.0" }
 nu-plugin = { path="../nu-plugin", version = "0.39.0" }
 nu-protocol = { path="../nu-protocol", version = "0.39.0" }
 nu-source = { path="../nu-source", version = "0.39.0" }
-open = "1.4.0"
 url = "2.2.0"
 webbrowser = "0.5.5"
+
+[target.'cfg(windows)'.dependencies]
+open = "1.4.0"
 
 [build-dependencies]
 nu-errors = { version = "0.39.0", path="../nu-errors" }

--- a/crates/nu_plugin_to_bson/Cargo.toml
+++ b/crates/nu_plugin_to_bson/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.39.0"
 doctest = false
 
 [dependencies]
-bson = "0.14.1"
+bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
 nu-errors = { path="../nu-errors", version = "0.39.0" }
 nu-plugin = { path="../nu-plugin", version = "0.39.0" }
 nu-protocol = { path="../nu-protocol", version = "0.39.0" }


### PR DESCRIPTION
The first commit `remove unused dependencies` also fixes one test.
The different upgrade-commits each upgrade one dependency.
This results in less duplicate dependencies being compiled because of outdated dependencies in the older versions. 
It also results in getting patch-updates for the now current versions, if any become available.