### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cargo install nu
 To install Nu via the [Windows Package Manager](https://aka.ms/winget-cli):
 
 ```shell
-winget install nu
+winget install nushell
 ```
 
 You can also build Nu yourself with all the bells and whistles (be sure to have installed the [dependencies](https://www.nushell.sh/book/installation.html#dependencies) for your platform), once you have checked out this repo with git:


### PR DESCRIPTION
`winget install nu` fails because there's other options for "nu" now.
Using the full `nushell` word solved it for me.

![Screenshot 2021-11-14 000815](https://user-images.githubusercontent.com/444344/141665938-c28c0e7d-f07e-4261-a4f9-db51d3711bec.png)

