### PR TITLE
upgrade polars to 0.17

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -89,7 +89,7 @@ zip = { version="0.5.9", optional=true }
 digest = "0.9.0"
 
 [dependencies.polars]
-version = "0.16.0"
+version = "0.17.0"
 optional = true
 features = ["parquet", "json", "random", "pivot", "strings", "is_in", "temporal", "cum_agg", "rolling_window"]
 

--- a/crates/nu-command/src/commands/dataframe/describe.rs
+++ b/crates/nu-command/src/commands/dataframe/describe.rs
@@ -121,7 +121,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let tail = df.as_ref().get_columns().iter().map(|col| {
         let count = col.len() as f64;
 
-        let sum = match col.sum_as_series().cast_with_dtype(&DataType::Float64) {
+        let sum = match col.sum_as_series().cast(&DataType::Float64) {
             Ok(ca) => match ca.get(0) {
                 AnyValue::Float64(v) => Some(v),
                 _ => None,
@@ -144,7 +144,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
             _ => None,
         };
 
-        let min = match col.min_as_series().cast_with_dtype(&DataType::Float64) {
+        let min = match col.min_as_series().cast(&DataType::Float64) {
             Ok(ca) => match ca.get(0) {
                 AnyValue::Float64(v) => Some(v),
                 _ => None,
@@ -153,7 +153,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
         };
 
         let q_25 = match col.quantile_as_series(0.25) {
-            Ok(ca) => match ca.cast_with_dtype(&DataType::Float64) {
+            Ok(ca) => match ca.cast(&DataType::Float64) {
                 Ok(ca) => match ca.get(0) {
                     AnyValue::Float64(v) => Some(v),
                     _ => None,
@@ -164,7 +164,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
         };
 
         let q_50 = match col.quantile_as_series(0.50) {
-            Ok(ca) => match ca.cast_with_dtype(&DataType::Float64) {
+            Ok(ca) => match ca.cast(&DataType::Float64) {
                 Ok(ca) => match ca.get(0) {
                     AnyValue::Float64(v) => Some(v),
                     _ => None,
@@ -175,7 +175,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
         };
 
         let q_75 = match col.quantile_as_series(0.75) {
-            Ok(ca) => match ca.cast_with_dtype(&DataType::Float64) {
+            Ok(ca) => match ca.cast(&DataType::Float64) {
                 Ok(ca) => match ca.get(0) {
                     AnyValue::Float64(v) => Some(v),
                     _ => None,
@@ -185,7 +185,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
             Err(_) => None,
         };
 
-        let max = match col.max_as_series().cast_with_dtype(&DataType::Float64) {
+        let max = match col.max_as_series().cast(&DataType::Float64) {
             Ok(ca) => match ca.get(0) {
                 AnyValue::Float64(v) => Some(v),
                 _ => None,

--- a/crates/nu-command/src/commands/dataframe/series/get_day.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_day.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.day().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_hour.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_hour.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.hour().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_minute.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_minute.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.minute().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_month.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_month.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.month().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_nanosecond.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_nanosecond.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.nanosecond().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_ordinal.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_ordinal.rs
@@ -56,7 +56,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.ordinal().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_second.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_second.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.second().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_week.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_week.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.week().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_weekday.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_weekday.rs
@@ -53,7 +53,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.weekday().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/get_year.rs
+++ b/crates/nu-command/src/commands/dataframe/series/get_year.rs
@@ -56,7 +56,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.year().into_series();

--- a/crates/nu-command/src/commands/dataframe/series/set_with_idx.rs
+++ b/crates/nu-command/src/commands/dataframe/series/set_with_idx.rs
@@ -78,7 +78,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let casted = match indices.dtype() {
         DataType::UInt32 | DataType::UInt64 | DataType::Int32 | DataType::Int64 => indices
             .as_ref()
-            .cast_with_dtype(&DataType::UInt32)
+            .cast(&DataType::UInt32)
             .map_err(|e| parse_polars_error::<&str>(&e, &value.tag.span, None)),
         _ => Err(ShellError::labeled_error_with_secondary(
             "Incorrect type",

--- a/crates/nu-command/src/commands/dataframe/series/strftime.rs
+++ b/crates/nu-command/src/commands/dataframe/series/strftime.rs
@@ -58,7 +58,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let series = df.as_series(&df_tag.span)?;
 
     let casted = series
-        .date64()
+        .datetime()
         .map_err(|e| parse_polars_error::<&str>(&e, &df_tag.span, None))?;
 
     let res = casted.strftime(&fmt.item).into_series();

--- a/crates/nu-command/src/commands/dataframe/take.rs
+++ b/crates/nu-command/src/commands/dataframe/take.rs
@@ -92,7 +92,7 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let casted = match series.dtype() {
         DataType::UInt32 | DataType::UInt64 | DataType::Int32 | DataType::Int64 => series
             .as_ref()
-            .cast_with_dtype(&DataType::UInt32)
+            .cast(&DataType::UInt32)
             .map_err(|e| parse_polars_error::<&str>(&e, &value.tag.span, None)),
         _ => Err(ShellError::labeled_error_with_secondary(
             "Incorrect type",

--- a/crates/nu-command/src/commands/dataframe/to_csv.rs
+++ b/crates/nu-command/src/commands/dataframe/to_csv.rs
@@ -73,9 +73,9 @@ fn command(mut args: CommandArgs) -> Result<OutputStream, ShellError> {
     let writer = CsvWriter::new(&mut file);
 
     let writer = if no_header {
-        writer.has_headers(false)
+        writer.has_header(false)
     } else {
-        writer.has_headers(true)
+        writer.has_header(true)
     };
 
     let writer = match delimiter {

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -27,9 +27,9 @@ serde = { version="1.0", features=["derive"] }
 serde_bytes = "0.11.5"
 
 [dependencies.polars]
-version = "0.16.0"
+version = "0.17.0"
 optional = true
-features = ["default", "serde", "rows", "strings", "checked_arithmetic", "object", "dtype-duration-ns"]
+features = ["default", "serde", "rows", "strings", "checked_arithmetic", "object", "dtype-date", "dtype-datetime", "dtype-time"]
 
 [features]
 dataframe = ["polars"]

--- a/crates/nu-protocol/src/dataframe/compute_between.rs
+++ b/crates/nu-protocol/src/dataframe/compute_between.rs
@@ -603,7 +603,7 @@ where
 {
     match series.dtype() {
         DataType::UInt32 | DataType::Int32 | DataType::UInt64 => {
-            let to_i64 = series.cast_with_dtype(&DataType::Int64);
+            let to_i64 = series.cast(&DataType::Int64);
 
             match to_i64 {
                 Ok(series) => {
@@ -661,7 +661,7 @@ where
 {
     match series.dtype() {
         DataType::Float32 => {
-            let to_f64 = series.cast_with_dtype(&DataType::Float64);
+            let to_f64 = series.cast(&DataType::Float64);
 
             match to_f64 {
                 Ok(series) => {
@@ -731,7 +731,7 @@ where
 {
     match series.dtype() {
         DataType::UInt32 | DataType::Int32 | DataType::UInt64 => {
-            let to_i64 = series.cast_with_dtype(&DataType::Int64);
+            let to_i64 = series.cast(&DataType::Int64);
 
             match to_i64 {
                 Ok(series) => {
@@ -789,7 +789,7 @@ where
 {
     match series.dtype() {
         DataType::Float32 => {
-            let to_f64 = series.cast_with_dtype(&DataType::Float64);
+            let to_f64 = series.cast(&DataType::Float64);
 
             match to_f64 {
                 Ok(series) => {

--- a/crates/nu-protocol/src/dataframe/nu_dataframe.rs
+++ b/crates/nu-protocol/src/dataframe/nu_dataframe.rs
@@ -87,7 +87,7 @@ impl PartialEq for NuDataFrame {
                 // Casting needed to compare other numeric types with nushell numeric type.
                 // In nushell we only have i64 integer numeric types and any array created
                 // with nushell untagged primitives will be of type i64
-                DataType::UInt32 => match self_series.cast_with_dtype(&DataType::Int64) {
+                DataType::UInt32 => match self_series.cast(&DataType::Int64) {
                     Ok(series) => series,
                     Err(_) => return false,
                 },


### PR DESCRIPTION
Fixes #4121 

I had to remove the `ignore_nulls` switch from the rolling window commands, as this option has been removed from the polars function signatures.

The `suffix` flag has been added to the `join` command.

Please give this PR a good review to make sure I did not miss anything ;)