### PR TITLE
upgrading dependencies 

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -29,13 +29,13 @@ pretty_env_logger = "0.4.0"
 strip-ansi-escapes = "0.1.0"
 rustyline = { version="9.0.0", optional=true }
 ctrlc = { version="3.1.7", optional=true }
-shadow-rs = { version="0.6", default-features=false, optional=true }
+shadow-rs = { version = "0.8.1", default-features = false, optional = true }
 serde = { version="1.0.123", features=["derive"] }
 serde_yaml = "0.8.16"
 lazy_static = "1.4.0"
 
 [build-dependencies]
-shadow-rs = "0.6"
+shadow-rs = "0.8.1"
 
 [features]
 default = ["shadow-rs"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -81,7 +81,7 @@ term_size = "0.3.2"
 titlecase = "1.1.0"
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 toml = "0.5.8"
-trash = { version="1.3.0", optional=true }
+trash = { version = "2.0.2", optional = true }
 unicode-segmentation = "1.8"
 uuid_crate = { package="uuid", version="0.8.2", features=["v4"], optional=true }
 which = { version="4.1.0", optional=true }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -31,7 +31,7 @@ nu-pretty-hex = { version = "0.40.0", path="../nu-pretty-hex" }
 url = "2.2.1"
 mime = "0.3.16"
 Inflector = "0.11"
-arboard = { version="1.1.0", optional=true }
+arboard = { version = "2.0.1", optional = true }
 base64 = "0.13.0"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 calamine = "0.18.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -74,7 +74,7 @@ serde_urlencoded = "0.7.0"
 serde_yaml = "0.8.16"
 sha2 = "0.9.3"
 strip-ansi-escapes = "0.1.0"
-sysinfo = { version = "0.20.2", optional = true }
+sysinfo = { version = "0.21.1", optional = true }
 thiserror = "1.0.26"
 term = { version="0.7.0", optional=true }
 term_size = "0.3.2"
@@ -105,7 +105,7 @@ users = "0.11.0"
 # num-format = { version = "0.4", features = ["with-system-locale"] }
 
 [build-dependencies]
-shadow-rs = "0.6"
+shadow-rs = "0.8.1"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -33,7 +33,7 @@ mime = "0.3.16"
 Inflector = "0.11"
 arboard = { version="1.1.0", optional=true }
 base64 = "0.13.0"
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { version = "0.3.0", features = ["serde"] }
 calamine = "0.18.0"
 chrono = { version="0.4.19", features=["serde"] }
 chrono-tz = "0.5.3"
@@ -56,7 +56,7 @@ lazy_static = "1.*"
 log = "0.4.14"
 md-5 = "0.9.1"
 meval = "0.2.0"
-num-bigint = { version="0.3.1", features=["serde"] }
+num-bigint = { version="0.4.3", features=["serde"] }
 num-format = { version="0.4.0", features=["with-num-bigint"] }
 num-traits = "0.2.14"
 parking_lot = "0.11.1"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -91,7 +91,8 @@ digest = "0.9.0"
 [dependencies.polars]
 version = "0.17.0"
 optional = true
-features = ["parquet", "json", "random", "pivot", "strings", "is_in", "temporal", "cum_agg", "rolling_window"]
+default-features = false
+features = ["docs", "zip_with", "csv-file", "temporal", "performant", "pretty_fmt", "dtype-slim", "parquet", "json", "random", "pivot", "strings", "is_in", "cum_agg", "rolling_window"]
 
 [target.'cfg(unix)'.dependencies]
 umask = "1.0.0"

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.40.0"
 doctest = false
 
 [dependencies]
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 byte-unit = "4.0.9"
 chrono = "0.4.19"
 common-path = "1.0.0"
@@ -19,7 +19,7 @@ directories-next = "2.0.0"
 getset = "0.1.1"
 indexmap = { version="1.6.1", features=["serde-1"] }
 log = "0.4.14"
-num-bigint = { version="0.3.1", features=["serde"] }
+num-bigint = { version="0.4.3", features=["serde"] }
 num-format = "0.4.0"
 num-traits = "0.2.14"
 serde = { version="1.0.123", features=["derive"] }

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -22,7 +22,7 @@ nu-path = { version = "0.40.0", path="../nu-path" }
 trash = { version="1.3.0", optional=true }
 which = { version="4.0.2", optional=true }
 codespan-reporting = "0.11.0"
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 bytes = "1.1.0"
 chrono = { version="0.4.19", features=["serde"] }
 derive-new = "0.5.8"
@@ -36,7 +36,7 @@ indexmap = { version="1.6.1", features=["serde-1"] }
 itertools = "0.10.0"
 lazy_static = "1.*"
 log = "0.4.14"
-num-bigint = { version="0.3.1", features=["serde"] }
+num-bigint = { version="0.4.3", features=["serde"] }
 parking_lot = "0.11.1"
 rayon = "1.5.0"
 serde = { version="1.0.123", features=["derive"] }

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -19,7 +19,7 @@ nu-ansi-term = { version = "0.40.0", path="../nu-ansi-term" }
 nu-test-support = { version = "0.40.0", path="../nu-test-support" }
 nu-path = { version = "0.40.0", path="../nu-path" }
 
-trash = { version="1.3.0", optional=true }
+trash = { version = "2.0.2", optional = true }
 which = { version="4.0.2", optional=true }
 codespan-reporting = "0.11.0"
 bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }

--- a/crates/nu-errors/Cargo.toml
+++ b/crates/nu-errors/Cargo.toml
@@ -13,11 +13,11 @@ doctest = false
 nu-source = { path="../nu-source", version = "0.40.0" }
 nu-ansi-term = { version = "0.40.0", path="../nu-ansi-term" }
 
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 codespan-reporting = { version="0.11.0", features=["serialization"] }
 derive-new = "0.5.8"
 getset = "0.1.1"
-num-bigint = { version="0.3.1", features=["serde"] }
+num-bigint = { version="0.4.3", features=["serde"] }
 num-traits = "0.2.14"
 serde = { version="1.0.123", features=["derive"] }
 

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -7,11 +7,11 @@ name = "nu-parser"
 version = "0.40.0"
 
 [dependencies]
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 derive-new = "0.5.8"
 indexmap = { version="1.6.1", features=["serde-1"] }
 log = "0.4"
-num-bigint = { version="0.3.1", features=["serde"] }
+num-bigint = { version="0.4.3", features=["serde"] }
 itertools = "0.10.0"
 smart-default = "0.6.0"
 

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -29,7 +29,8 @@ serde_bytes = "0.11.5"
 [dependencies.polars]
 version = "0.17.0"
 optional = true
-features = ["default", "serde", "rows", "strings", "checked_arithmetic", "object", "dtype-date", "dtype-datetime", "dtype-time"]
+default-features = false
+features = ["docs", "zip_with", "csv-file", "temporal", "performant", "pretty_fmt", "dtype-slim", "serde", "rows", "strings", "checked_arithmetic", "object", "dtype-date", "dtype-datetime", "dtype-time"]
 
 [features]
 dataframe = ["polars"]

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.40.0"
 doctest = false
 
 [dependencies]
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 byte-unit = "4.0.9"
 chrono = { version="0.4.19", features=["serde"] }
 chrono-humanize = "0.2.1"
@@ -20,7 +20,7 @@ indexmap = { version="1.6.1", features=["serde-1"] }
 log = "0.4.14"
 nu-errors = { path="../nu-errors", version = "0.40.0" }
 nu-source = { path="../nu-source", version = "0.40.0" }
-num-bigint = { version="0.3.1", features=["serde"] }
+num-bigint = { version = "0.4.3", features = ["serde"] }
 num-integer = "0.1.44"
 num-traits = "0.2.14"
 serde = { version="1.0", features=["derive"] }

--- a/crates/nu-serde/Cargo.toml
+++ b/crates/nu-serde/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/nushell/nushell"
 documentation = "https://docs.rs/nu-serde"
 
 [dependencies]
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 nu-protocol = { version = "0.40.0", path = "../nu-protocol" }
 nu-source = { version = "0.40.0", path = "../nu-source" }
 serde = "1"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -15,11 +15,11 @@ nu-path = { version = "0.40.0", path="../nu-path" }
 nu-protocol = { path="../nu-protocol", version = "0.40.0" }
 nu-source = { path="../nu-source", version = "0.40.0" }
 
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 chrono = "0.4.19"
 getset = "0.1.1"
 glob = "0.3.0"
 indexmap = { version="1.6.1", features=["serde-1"] }
-num-bigint = { version="0.3.1", features=["serde"] }
+num-bigint = { version="0.4.3", features=["serde"] }
 tempfile = "3.2.0"
 hamcrest2 = "0.3.0"

--- a/crates/nu_plugin_from_bson/Cargo.toml
+++ b/crates/nu_plugin_from_bson/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.40.0"
 doctest = false
 
 [dependencies]
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
 nu-errors = { path="../nu-errors", version = "0.40.0" }
 nu-plugin = { path="../nu-plugin", version = "0.40.0" }

--- a/crates/nu_plugin_from_sqlite/Cargo.toml
+++ b/crates/nu_plugin_from_sqlite/Cargo.toml
@@ -19,6 +19,6 @@ tempfile = "3.2.0"
 
 [dependencies.rusqlite]
 features = ["bundled", "blob"]
-version = "0.25.3"
+version = "0.26.1"
 
 [build-dependencies]

--- a/crates/nu_plugin_from_sqlite/Cargo.toml
+++ b/crates/nu_plugin_from_sqlite/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.40.0"
 doctest = false
 
 [dependencies]
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 nu-errors = { path="../nu-errors", version = "0.40.0" }
 nu-plugin = { path="../nu-plugin", version = "0.40.0" }
 nu-protocol = { path="../nu-protocol", version = "0.40.0" }

--- a/crates/nu_plugin_from_sqlite/src/from_sqlite.rs
+++ b/crates/nu_plugin_from_sqlite/src/from_sqlite.rs
@@ -61,7 +61,7 @@ pub fn convert_sqlite_file_to_nu_value(
 
 fn convert_sqlite_row_to_nu_value(row: &Row, tag: impl Into<Tag> + Clone) -> Value {
     let mut collected = TaggedDictBuilder::new(tag.clone());
-    for (i, c) in row.column_names().iter().enumerate() {
+    for (i, c) in row.as_ref().column_names().iter().enumerate() {
         collected.insert_value(
             c.to_string(),
             convert_sqlite_value_to_nu_value(row.get_ref_unwrap(i), tag.clone()),

--- a/crates/nu_plugin_query_json/Cargo.toml
+++ b/crates/nu_plugin_query_json/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.40.0"
 doctest = false
 
 [dependencies]
-gjson = "0.7.1"
+gjson = "0.8.0"
 nu-errors = { version = "0.40.0", path="../nu-errors" }
 nu-plugin = { version = "0.40.0", path="../nu-plugin" }
 nu-protocol = { version = "0.40.0", path="../nu-protocol" }

--- a/crates/nu_plugin_s3/Cargo.toml
+++ b/crates/nu_plugin_s3/Cargo.toml
@@ -15,6 +15,6 @@ nu-errors = { path="../nu-errors", version = "0.40.0" }
 nu-plugin = { path="../nu-plugin", version = "0.40.0" }
 nu-protocol = { path="../nu-protocol", version = "0.40.0" }
 nu-source = { path="../nu-source", version = "0.40.0" }
-s3handler = "0.7"
+s3handler = "0.7.5"
 
 [build-dependencies]

--- a/crates/nu_plugin_textview/Cargo.toml
+++ b/crates/nu_plugin_textview/Cargo.toml
@@ -16,7 +16,7 @@ nu-plugin = { path="../nu-plugin", version = "0.40.0" }
 nu-protocol = { path="../nu-protocol", version = "0.40.0" }
 nu-source = { path="../nu-source", version = "0.40.0" }
 
-bat = { version="0.18", features=["regex-fancy", "paging", "git"] }
+bat = { version="0.18", default-features = false,  features=["regex-fancy", "paging", "git"] }
 term_size = "0.3.2"
 url = "2.2.0"
 

--- a/crates/nu_plugin_to_sqlite/Cargo.toml
+++ b/crates/nu_plugin_to_sqlite/Cargo.toml
@@ -19,6 +19,6 @@ tempfile = "3.2.0"
 
 [dependencies.rusqlite]
 features = ["bundled", "blob"]
-version = "0.25.3"
+version = "0.26.1"
 
 [build-dependencies]

--- a/crates/nu_plugin_tree/Cargo.toml
+++ b/crates/nu_plugin_tree/Cargo.toml
@@ -14,7 +14,7 @@ derive-new = "0.5.8"
 nu-errors = { path="../nu-errors", version = "0.40.0" }
 nu-plugin = { path="../nu-plugin", version = "0.40.0" }
 nu-protocol = { path="../nu-protocol", version = "0.40.0" }
-ptree = { version = "0.3.1", default-features = false }
+ptree = { version = "0.4.0", default-features = false }
 
 
 [build-dependencies]

--- a/crates/nu_plugin_xpath/Cargo.toml
+++ b/crates/nu_plugin_xpath/Cargo.toml
@@ -15,7 +15,7 @@ nu-plugin = { path="../nu-plugin", version = "0.40.0" }
 nu-protocol = { version = "0.40.0", path="../nu-protocol" }
 nu-source = { version = "0.40.0", path="../nu-source" }
 
-bigdecimal = { package = "bigdecimal-rs", version = "0.2.1", features = ["serde"] }
+bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 indexmap = { version="1.6.1", features=["serde-1"] }
 sxd-document = "0.3.2"
 sxd-xpath = "0.4.2"


### PR DESCRIPTION
The `bat` dependency had its `default-features` enabled, which are only required for the CLI application and not when used as a library.
For `polars`, I disabled the `default-features` and manually enabled all of them again, except for `plain_fmt`. The default `plain_fmt` depends on `prettytable-rs` which saw its last release on `0.8.0 Sep 27, 2018` and pulls in `term 0.5`. 
`Pretty_fmt` depends on `comfy-table`. This results in fewer duplicate dependencies because of old and semver-incompatible versions.
After the upgrades, fewer duplicate, semver-incompatible crates get included in nu.

