### PR TITLE
save --append: create file if it doesn't exist

### DIFF
--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -47,3 +47,21 @@ fn writes_out_csv() {
         assert!(actual.contains("nu,0.14,A new type of shell,MIT,2018"));
     })
 }
+
+#[test]
+fn save_append_will_create_file_if_not_exists() {
+    Playground::setup("save_test_3", |dirs, sandbox| {
+        sandbox.with_files(vec![]);
+
+        let expected_file = dirs.test().join("new-file.txt");
+
+        nu!(
+            cwd: dirs.root(),
+            r#"echo hello | save --raw --append save_test_3/new-file.txt"#,
+        );
+
+        let actual = file_contents(expected_file);
+        println!("{}", actual);
+        assert!(actual == "hello");
+    })
+}

--- a/crates/nu-engine/src/filesystem/filesystem_shell.rs
+++ b/crates/nu-engine/src/filesystem/filesystem_shell.rs
@@ -884,7 +884,7 @@ impl Shell for FilesystemShell {
     ) -> Result<OutputStream, ShellError> {
         let mut options = OpenOptions::new();
         if append {
-            options.append(true)
+            options.append(true).create(true)
         } else {
             options.write(true).create(true).truncate(true)
         };


### PR DESCRIPTION
Hello team,

Fixes #4113

It wasn't clear from the issue if you wanted to get this fixed. If you did, then maybe this will do it. Otherwise, it was still a good exercise. 

Let me know what you think.