### PR TITLE
Sanitize arguments to external commands a bit better

### DIFF
--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -121,7 +121,7 @@ fn run_with_stdin(
             #[cfg(windows)]
             {
                 if let Some(unquoted) = remove_quotes(&arg) {
-                    unquoted
+                    unquoted.to_string()
                 } else {
                     arg
                 }

--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -51,6 +51,7 @@ fn trim_double_quotes(input: &str) -> String {
 
     match (chars.next(), chars.next_back()) {
         (Some('"'), Some('"')) => chars.collect(),
+        (Some('\''), Some('\'')) => chars.collect(),
         _ => input.to_string(),
     }
 }
@@ -112,8 +113,7 @@ fn run_with_stdin(
             #[cfg(not(windows))]
             {
                 if !_is_literal {
-                    let escaped = escape_double_quotes(&arg);
-                    add_double_quotes(&escaped)
+                    arg.to_string()
                 } else {
                     trim_double_quotes(&arg)
                 }
@@ -177,7 +177,7 @@ fn shell_arg_escape(arg: &str) -> String {
         "" => String::from("''"),
         s if !has_unsafe_shell_characters(s) => String::from(s),
         _ => {
-            let single_quotes_escaped = arg.split('\'').join("\\'");
+            let single_quotes_escaped = arg.split('\'').join("'\"'\"'");
             format!("'{}'", single_quotes_escaped)
         }
     }

--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -46,7 +46,7 @@ pub(crate) fn run_external_command(
 }
 
 #[allow(unused)]
-fn trim_double_quotes(input: &str) -> String {
+fn trim_enclosing_quotes(input: &str) -> String {
     let mut chars = input.chars();
 
     match (chars.next(), chars.next_back()) {
@@ -113,17 +113,17 @@ fn run_with_stdin(
             #[cfg(not(windows))]
             {
                 if !_is_literal {
-                    arg.to_string()
+                    arg
                 } else {
-                    trim_double_quotes(&arg)
+                    trim_enclosing_quotes(&arg)
                 }
             }
             #[cfg(windows)]
             {
                 if let Some(unquoted) = remove_quotes(&arg) {
-                    unquoted.to_string()
+                    unquoted
                 } else {
-                    arg.to_string()
+                    arg
                 }
             }
         })
@@ -166,7 +166,7 @@ fn spawn_cmd_command(command: &ExternalCommand, args: &[String]) -> Command {
 
 fn has_unsafe_shell_characters(arg: &str) -> bool {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"[^\w@%+=:,./-]").unwrap();
+        static ref RE: Regex = Regex::new(r"[^\w@%+=:,./-]").expect("regex to be valid");
     }
 
     RE.is_match(arg)

--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -55,7 +55,11 @@ fn trim_double_quotes(input: &str) -> String {
 
 #[allow(unused)]
 fn escape_where_needed(input: &str) -> String {
-    input.split(' ').join("\\ ").split('\'').join("\\'")
+    input
+        .split(' ').join("\\ ")
+        .split('\'').join("\\'")
+        .split(';').join("\\;")
+        .split('&').join("\\&")
 }
 
 fn run_with_stdin(
@@ -588,7 +592,7 @@ fn shell_os_paths() -> Vec<std::path::PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{add_double_quotes, argument_is_quoted, escape_double_quotes, remove_quotes};
+    use super::{add_double_quotes, argument_is_quoted, escape_double_quotes, remove_quotes, escape_where_needed};
     #[cfg(feature = "which")]
     use super::{run_external_command, InputStream};
 
@@ -709,5 +713,13 @@ mod tests {
         assert_eq!(remove_quotes(r#"andrés""#), None);
         assert_eq!(remove_quotes("'andrés'"), Some("andrés"));
         assert_eq!(remove_quotes(r#""andrés""#), Some("andrés"));
+    }
+
+    #[test]
+    fn escape_where_needed_handles_for_arguments() {
+        assert_eq!(escape_where_needed("a b"), "a\\ b");
+        assert_eq!(escape_where_needed("aaa;bbb"), "aaa\\;bbb");
+        assert_eq!(escape_where_needed("a b& ;'c"),
+                   r#"a\ b\&\ \;\'c"#);
     }
 }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -401,4 +401,48 @@ mod external_command_arguments {
             },
         )
     }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn semicolons_are_sanitized_before_passing_to_subshell() {
+        let actual = nu!(
+            cwd: ".",
+            "^echo \"a;b\""
+        );
+
+        assert_eq!(actual.out, "a;b");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn ampersands_are_sanitized_before_passing_to_subshell() {
+        let actual = nu!(
+            cwd: ".",
+            "^echo \"a&b\""
+        );
+
+        assert_eq!(actual.out, "a&b");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn subcommands_are_sanitized_before_passing_to_subshell() {
+        let actual = nu!(
+            cwd: ",",
+            "^echo \"$(ls)\""
+        );
+
+        assert_eq!(actual.out, "$(ls)");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn shell_arguments_are_sanitized_even_if_coming_from_other_commands() {
+        let actual = nu!(
+            cwd: ",",
+            "^echo (echo \"a;&$(hello)\")"
+        );
+
+        assert_eq!(actual.out, "a;&$(hello)");
+    }
 }


### PR DESCRIPTION
Fixes #4140 

We are passing commands into a shell underneath but we were not
escaping arguments correctly. This new version of the code also takes
into consideration the ";" and "&" characters, which have special
meaning in shells.

We would probably benefit from a more robust way to join arguments to
shell programs. Python's stdlib has shlex.join, and perhaps we can
take that implementation as a reference.

Testing: I have added a few unit tests to the `escape_where_needed` function. Ideally I would add tests that
run an external command and verify that that works, like `^echo aa;bbb`, but I couldn't find any test like that
that I could take as reference. Also I have no idea if this test would also apply to windows because I'm
not familiar with Windows shells. Testing manually on my build of nushell did work.