### PR TITLE
fix: avoid unnecessary allocation

### DIFF
--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -925,11 +925,8 @@ fn escape_char<W>(wr: &mut W, value: char) -> Result<()>
 where
     W: io::Write,
 {
-    // FIXME: this allocation is required in order to be compatible with stable
-    // rust, which doesn't support encoding a `char` into a stack buffer.
-    let mut s = String::new();
-    s.push(value);
-    escape_bytes(wr, s.as_bytes())
+    let mut scratch = [0_u8; 4];
+    escape_bytes(wr, value.encode_utf8(&mut scratch).as_bytes())
 }
 
 fn fmt_f32_or_null<W>(wr: &mut W, value: f32) -> Result<()>


### PR DESCRIPTION
Turns out stable rust does support encoding a char into a stack buffer as utf8.