### PR TITLE
Don't panic if the other end of std{out,err} is closed

### DIFF
--- a/crates/nu-protocol/src/macros.rs
+++ b/crates/nu-protocol/src/macros.rs
@@ -47,4 +47,3 @@ macro_rules! row {
          ::nu_protocol::UntaggedValue::row(map).into_untagged_value()
     }}
 }
-

--- a/crates/nu-protocol/src/macros.rs
+++ b/crates/nu-protocol/src/macros.rs
@@ -6,7 +6,7 @@
 macro_rules! out {
     ($($tokens:tt)*) => {
         use std::io::Write;
-        print!($($tokens)*);
+        write!(std::io::stdout(), $($tokens)*).unwrap_or(());
         let _ = std::io::stdout().flush();
     }
 }
@@ -17,7 +17,12 @@ macro_rules! out {
 /// and stray printlns left by accident
 #[macro_export]
 macro_rules! outln {
-    ($($tokens:tt)*) => { println!($($tokens)*) }
+    ($($tokens:tt)*) => {
+        {
+            use std::io::Write;
+            writeln!(std::io::stdout(), $($tokens)*).unwrap_or(())
+        }
+    }
 }
 
 /// Outputs to standard error
@@ -26,7 +31,12 @@ macro_rules! outln {
 /// and stray printlns left by accident
 #[macro_export]
 macro_rules! errln {
-    ($($tokens:tt)*) => { eprintln!($($tokens)*) }
+    ($($tokens:tt)*) => {
+        {
+            use std::io::Write;
+            writeln!(std::io::stderr(), $($tokens)*).unwrap_or(())
+        }
+    }
 }
 
 #[macro_export]
@@ -37,3 +47,4 @@ macro_rules! row {
          ::nu_protocol::UntaggedValue::row(map).into_untagged_value()
     }}
 }
+

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -55,6 +55,7 @@ fn plugins_are_declared_with_wix() {
 }
 
 #[test]
+#[cfg(not(windows))]
 fn do_not_panic_if_broken_pipe() {
     // `nu -h | false`
     // used to panic with a BrokenPipe error

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -53,3 +53,16 @@ fn plugins_are_declared_with_wix() {
 
     assert_eq!(actual.out, "0");
 }
+
+#[test]
+fn do_not_panic_if_broken_pipe() {
+    // `nu -h | false`
+    // used to panic with a BrokenPipe error
+    let child_output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!("{:?} -h | false", nu_test_support::fs::executable_path()))
+        .output()
+        .expect("failed to execute process");
+
+    assert!(child_output.stderr.is_empty());
+}

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -60,7 +60,10 @@ fn do_not_panic_if_broken_pipe() {
     // used to panic with a BrokenPipe error
     let child_output = std::process::Command::new("sh")
         .arg("-c")
-        .arg(format!("{:?} -h | false", nu_test_support::fs::executable_path()))
+        .arg(format!(
+            "{:?} -h | false",
+            nu_test_support::fs::executable_path()
+        ))
         .output()
         .expect("failed to execute process");
 


### PR DESCRIPTION
Fixes #4161

The bug was triggered by https://github.com/rust-lang/rust/issues/24821

Now, we will simply ignore BrokenPipe errors when trying to write to stdout.

Testing: I have tested the fix manually and it works (`cargo run -- -h | false` doesn't panic anymore). I have also added an automated test, but I'm not sure we'll want to keep it. If you have sugestions about a better automated test please let me know.

 