### PR TITLE
Fix build on NetBSD

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -73,7 +73,7 @@ serde_urlencoded = "0.7.0"
 serde_yaml = "0.8.16"
 sha2 = "0.9.3"
 strip-ansi-escapes = "0.1.0"
-sysinfo = { version = "0.21.1", optional = true }
+sysinfo = { version = "0.21.2", optional = true }
 thiserror = "1.0.26"
 term = { version="0.7.0", optional=true }
 term_size = "0.3.2"


### PR DESCRIPTION
See, https://github.com/GuillaumeGomez/sysinfo/issues/625 for further details.
Updating sysinfo to 0.21.2 fixes the build

/home/pin()
2021-12-09 12:35 > version | pivot key value | to md
|key|value|
|-|-|
|version|0.41.0|
|branch|master|
|short_commit|2d330f5c|
|commit_hash|2d330f5c77275014b24b1624045a77a52ec6bf57|
|commit_date|2021-12-06 21:36:34 +00:00|
|build_os|netbsd-x86_64|
|rust_version|rustc 1.57.0|
|cargo_version|cargo 1.57.0|
|pkg_version|0.41.0|
|build_time|2021-12-09 11:11:33 +01:00|
|build_rust_channel|release|
|features|ctrlc, dataframe, default, rustyline, term, which, zip|
|installed_plugins|fetch, inc, match, post, ps, sys, textview|
