### PR TITLE
ci: fix macOS agent

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -16,7 +16,7 @@ strategy:
       image: ubuntu-18.04
       style: 'wasm'
     macos-stable:
-      image: macos-10.14
+      image: macOS-10.14
       style: 'unflagged'
     windows-stable:
       image: windows-2019


### PR DESCRIPTION
I noticed the agent documentation uses uppercase: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml
