### PR TITLE
ci: update macOS agent

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -16,7 +16,7 @@ strategy:
       image: ubuntu-18.04
       style: 'wasm'
     macos-stable:
-      image: macOS-10.14
+      image: macOS-10.15
       style: 'unflagged'
     windows-stable:
       image: windows-2019


### PR DESCRIPTION
10.14 has been deprecated: https://github.com/Azure/azure-sdk-for-cpp/issues/3168

This hopefully fixes recent CI failures!
