### PR TITLE
Rework decoding and filesystem access (fixes #4235)

### DIFF
--- a/crates/nu-command/src/classified/external.rs
+++ b/crates/nu-command/src/classified/external.rs
@@ -358,7 +358,7 @@ fn spawn(
                     let reader = BufReader::new(stdout);
                     let mut reader = BufCodecReader::new(reader, None);
 
-                    while let Some(result) = reader.read_line().transpose() {
+                    while let Some(result) = reader.read_some().transpose() {
                         match result {
                             Ok(line) => match line {
                                 StringOrBinary::String(s) => {
@@ -433,7 +433,7 @@ fn spawn(
                     let reader = BufReader::new(stderr);
                     let mut reader = BufCodecReader::new(reader, None);
 
-                    while let Some(result) = reader.read_line().transpose() {
+                    while let Some(result) = reader.read_some().transpose() {
                         match result {
                             Ok(line) => match line {
                                 StringOrBinary::String(s) => {

--- a/crates/nu-command/src/commands/filesystem/open.rs
+++ b/crates/nu-command/src/commands/filesystem/open.rs
@@ -169,7 +169,7 @@ fn open(args: CommandArgs) -> Result<ActionStream, ShellError> {
         anchor: Some(AnchorLocation::File(path.to_string_lossy().to_string())),
     };
 
-    let value = match reader.read_full()? {
+    let value = match reader.read_to_end()? {
         StringOrBinary::String(s) => {
             ReturnSuccess::value(UntaggedValue::string(s).into_value(file_tag))
         }

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::example::Example;
 pub use crate::filesystem::dir_info::{DirBuilder, DirInfo, FileInfo};
 pub use crate::filesystem::filesystem_shell::FilesystemShell;
 pub use crate::from_value::FromValue;
-pub use crate::maybe_text_codec::{BufCodecReader, MaybeTextCodec, StringOrBinary};
+pub use crate::maybe_text_codec::{BufCodecReader, StringOrBinary};
 pub use crate::print::maybe_print_errors;
 pub use crate::shell::painter::Painter;
 pub use crate::shell::palette::{DefaultPalette, Palette};

--- a/crates/nu-engine/src/maybe_text_codec.rs
+++ b/crates/nu-engine/src/maybe_text_codec.rs
@@ -1,11 +1,6 @@
 use std::io::{BufRead, BufReader, Error, Read};
 
-use encoding_rs::{DecoderResult, Encoding, UTF_8};
-
-#[cfg(not(test))]
-const OUTPUT_BUFFER_SIZE: usize = 8192;
-#[cfg(test)]
-const OUTPUT_BUFFER_SIZE: usize = 4;
+use encoding_rs::{Encoding, UTF_8};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum StringOrBinary {
@@ -27,19 +22,35 @@ impl<R: Read> BufCodecReader<R> {
         }
     }
 
-    /// Read a line of  input and attempt to decode it using the current
-    /// encoding. Returns a `String` if the line can be successfully decoded, or
-    /// a `Binary` otherwise.
-    pub fn read_line(&mut self) -> Result<Option<StringOrBinary>, Error> {
-        let mut buf = Vec::new();
-
-        // Using same delimiter as `BufReader::read_line`, but with our own
-        // encoding.
-        self.input.read_until(b'\n', &mut buf)?;
+    /// Read some input and attempt to decode it using the current encoding.
+    /// Returns a `String` if the line can be successfully decoded, or a
+    /// `Binary` otherwise.
+    pub fn read_some(&mut self) -> Result<Option<StringOrBinary>, Error> {
+        let buf = self.input.fill_buf()?;
 
         if buf.is_empty() {
             return Ok(None);
         }
+
+        let (string, _, replacements) = self.encoding.decode(buf);
+
+        let value = if replacements {
+            StringOrBinary::Binary(buf.to_vec())
+        } else {
+            StringOrBinary::String(string.into_owned())
+        };
+
+        let len = buf.len();
+        self.input.consume(len);
+        Ok(Some(value))
+    }
+
+    /// Read the whole buffer and attempt to decode it using the current
+    /// encoding. Returns a `String` if the line can be successfully decoded, or
+    /// a `Binary` otherwise.
+    pub fn read_to_end(mut self) -> Result<StringOrBinary, Error> {
+        let mut buf = Vec::new();
+        self.input.read_to_end(&mut buf)?;
 
         let (string, _, replacements) = self.encoding.decode(&buf);
 
@@ -49,87 +60,6 @@ impl<R: Read> BufCodecReader<R> {
             StringOrBinary::String(string.into_owned())
         };
 
-        Ok(Some(value))
-    }
-
-    /// Read the whole buffer and attempt to decode it using the current
-    /// encoding. Returns a `String` if the line can be successfully decoded, or
-    /// a `Binary` otherwise.
-    pub fn read_full(mut self) -> Result<StringOrBinary, Error> {
-        let mut decoder = self.encoding.new_decoder();
-
-        let mut init = [0u8; OUTPUT_BUFFER_SIZE];
-
-        let mut fallback = Vec::new();
-        let mut string = String::new();
-        let mut cur = &[][..];
-
-        loop {
-            let (result, read) =
-                decoder.decode_to_string_without_replacement(cur, &mut string, false);
-            cur = &cur[read..];
-
-            match result {
-                DecoderResult::InputEmpty => {
-                    debug_assert!(cur.is_empty());
-
-                    // Satisfy borrow checker.
-                    cur = &[][..];
-
-                    match self.input.read(&mut init[..]) {
-                        Ok(0) => {
-                            break;
-                        }
-                        Ok(n) => {
-                            fallback.extend(&init[..]);
-                            cur = &init[..n];
-                        }
-                        Err(e) => return Err(e),
-                    }
-                }
-                DecoderResult::OutputFull => {
-                    string.reserve(OUTPUT_BUFFER_SIZE);
-                }
-                DecoderResult::Malformed(..) => {
-                    // This is why we maintain `fallback` of all bytes read so
-                    // far. We cannot use `string` because this doesn't
-                    // necessarily represent the underlying bytes read.
-                    if let Err(e) = self.input.read_to_end(&mut fallback) {
-                        return Err(e);
-                    }
-
-                    return Ok(StringOrBinary::Binary(fallback));
-                }
-            }
-        }
-
-        // Perform last decode call, which again needs to be done in a loop.
-        loop {
-            let (result, read) =
-                decoder.decode_to_string_without_replacement(cur, &mut string, true);
-            cur = &cur[read..];
-
-            match result {
-                // NB: InputEmpty when last is set to `true` means that decoding
-                // successfully completed.
-                DecoderResult::InputEmpty => {
-                    debug_assert!(cur.is_empty());
-                    return Ok(StringOrBinary::String(string));
-                }
-                DecoderResult::OutputFull => {
-                    string.reserve(OUTPUT_BUFFER_SIZE);
-                }
-                DecoderResult::Malformed(..) => {
-                    // This is why we maintain `fallback` of all bytes read so
-                    // far. We cannot use `string` because this doesn't
-                    // necessarily represent the underlying bytes read.
-                    if let Err(e) = self.input.read_to_end(&mut fallback) {
-                        return Err(e);
-                    }
-
-                    return Ok(StringOrBinary::Binary(fallback));
-                }
-            }
-        }
+        Ok(value)
     }
 }

--- a/crates/nu-engine/src/maybe_text_codec.rs
+++ b/crates/nu-engine/src/maybe_text_codec.rs
@@ -1,6 +1,4 @@
-use std::io::Read;
-
-use nu_errors::ShellError;
+use std::io::{Error, Read};
 
 use encoding_rs::{Decoder, DecoderResult, Encoding, UTF_8};
 
@@ -31,7 +29,7 @@ impl<R: Read> BufCodecReader<R> {
 
     /// Read the whole buffer into a `String` if it can be successfully decoded,
     /// or a `Binary` if the underlying data cannot be decoded.
-    pub fn read_full(mut self) -> Result<StringOrBinary, ShellError> {
+    pub fn read_full(mut self) -> Result<StringOrBinary, Error> {
         let mut init = [0u8; OUTPUT_BUFFER_SIZE];
 
         let mut fallback = Vec::new();
@@ -59,7 +57,7 @@ impl<R: Read> BufCodecReader<R> {
                             fallback.extend(&init[..]);
                             cur = &init[..n];
                         }
-                        Err(e) => return Err(ShellError::untagged_runtime_error(e.to_string())),
+                        Err(e) => return Err(e),
                     }
                 }
                 DecoderResult::OutputFull => {
@@ -70,7 +68,7 @@ impl<R: Read> BufCodecReader<R> {
                     // far. We cannot use `string` because this doesn't
                     // necessarily represent the underlying bytes read.
                     if let Err(e) = self.input.read_to_end(&mut fallback) {
-                        return Err(ShellError::untagged_runtime_error(e.to_string()));
+                        return Err(e);
                     }
 
                     return Ok(StringOrBinary::Binary(fallback));
@@ -100,7 +98,7 @@ impl<R: Read> BufCodecReader<R> {
                     // far. We cannot use `string` because this doesn't
                     // necessarily represent the underlying bytes read.
                     if let Err(e) = self.input.read_to_end(&mut fallback) {
-                        return Err(ShellError::untagged_runtime_error(e.to_string()));
+                        return Err(e);
                     }
 
                     return Ok(StringOrBinary::Binary(fallback));

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -193,7 +193,7 @@ pub fn process_script(
 
             let iter = std::iter::from_fn(move || {
                 let line = reader
-                    .read_line()
+                    .read_some()
                     .transpose()?
                     .expect("Internal error: could not read lines of text from stdin");
 

--- a/crates/nu-engine/src/script.rs
+++ b/crates/nu-engine/src/script.rs
@@ -192,7 +192,7 @@ pub fn process_script(
 
             let primitive = match BufCodecReader::new(buf_reader, None).read_full() {
                 Ok(primitive) => primitive,
-                Err(e) => return LineResult::Error(Default::default(), e),
+                Err(e) => return LineResult::Error(Default::default(), e.into()),
             };
 
             let primitive = match primitive {

--- a/crates/nu-engine/src/shell/mod.rs
+++ b/crates/nu-engine/src/shell/mod.rs
@@ -1,11 +1,10 @@
 use nu_stream::{ActionStream, OutputStream};
 
-use crate::maybe_text_codec::StringOrBinary;
 pub use crate::shell::shell_args::{CdArgs, CopyArgs, LsArgs, MkdirArgs, MvArgs, RemoveArgs};
 use crate::CommandArgs;
-use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use nu_source::{Span, Tag};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -35,15 +34,7 @@ pub trait Shell: std::fmt::Debug {
     fn path(&self) -> String;
     fn pwd(&self, args: CommandArgs) -> Result<ActionStream, ShellError>;
     fn set_path(&mut self, path: String);
-    fn open(
-        &self,
-        path: &Path,
-        name: Span,
-        with_encoding: Option<&'static Encoding>,
-    ) -> Result<
-        Box<dyn Iterator<Item = Result<StringOrBinary, ShellError>> + Send + Sync>,
-        ShellError,
-    >;
+    fn open(&self, path: &Path, name: Span) -> Result<Box<dyn Read + Send + Sync>, ShellError>;
     fn save(
         &mut self,
         path: &Path,

--- a/crates/nu-engine/src/shell/shell_manager.rs
+++ b/crates/nu-engine/src/shell/shell_manager.rs
@@ -1,13 +1,13 @@
+use crate::filesystem::filesystem_shell::FilesystemShellMode;
 use crate::shell::Shell;
-use crate::{filesystem::filesystem_shell::FilesystemShellMode, maybe_text_codec::StringOrBinary};
 use crate::{CommandArgs, FilesystemShell};
 use nu_stream::{ActionStream, OutputStream};
 
 use crate::shell::shell_args::{CdArgs, CopyArgs, LsArgs, MkdirArgs, MvArgs, RemoveArgs};
-use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use nu_source::{Span, Tag};
 use parking_lot::Mutex;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -92,12 +92,8 @@ impl ShellManager {
         &self,
         full_path: &Path,
         name: Span,
-        with_encoding: Option<&'static Encoding>,
-    ) -> Result<
-        Box<dyn Iterator<Item = Result<StringOrBinary, ShellError>> + Send + Sync>,
-        ShellError,
-    > {
-        self.shells.lock()[self.current_shell()].open(full_path, name, with_encoding)
+    ) -> Result<Box<dyn Read + Send + Sync>, ShellError> {
+        self.shells.lock()[self.current_shell()].open(full_path, name)
     }
 
     pub fn save(

--- a/crates/nu-engine/src/shell/value_shell.rs
+++ b/crates/nu-engine/src/shell/value_shell.rs
@@ -1,8 +1,6 @@
-use crate::maybe_text_codec::StringOrBinary;
 use crate::shell::shell_args::{CdArgs, CopyArgs, LsArgs, MkdirArgs, MvArgs, RemoveArgs};
 use crate::shell::Shell;
 use crate::CommandArgs;
-use encoding_rs::Encoding;
 use nu_errors::ShellError;
 use nu_protocol::ValueStructure;
 use nu_protocol::{ReturnSuccess, ShellTypeName, UntaggedValue, Value};
@@ -12,6 +10,7 @@ use nu_stream::{ActionStream, OutputStream};
 use nu_value_ext::ValueExt;
 use std::collections::VecDeque;
 use std::ffi::OsStr;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -229,15 +228,7 @@ impl Shell for ValueShell {
         self.path = path;
     }
 
-    fn open(
-        &self,
-        _path: &Path,
-        _name: Span,
-        _with_encoding: Option<&'static Encoding>,
-    ) -> Result<
-        Box<dyn Iterator<Item = Result<StringOrBinary, ShellError>> + Send + Sync>,
-        ShellError,
-    > {
+    fn open(&self, _path: &Path, _name: Span) -> Result<Box<dyn Read + Send + Sync>, ShellError> {
         Err(ShellError::unimplemented(
             "open on help shell is not supported",
         ))


### PR DESCRIPTION
This changes `BufCodecReader` to correctly use the `encoding_rs` API with respect to the `last` parameter (even with `decode_to_string`) which currently is always set to `false` ([see docs](https://docs.rs/encoding_rs/latest/encoding_rs/struct.Decoder.html)). While in practice this probably works regardless, there could be edge cases where it doesn't.

> During the processing of a single stream, the caller must call decode_* zero or more times with last set to false and then call decode_* at least once with last set to true. If decode_* returns InputEmpty, the processing of the stream has ended. Otherwise, the caller must call decode_* again with last set to true (or treat a Malformed result as a fatal error).

This also fixes #4235 by treating every input regardless of size the same way - decoding until we read `0` bytes. This ensures that files which are larger than 32mb are still treated as a single (large) value rather than one per filled read.

Finally the `Shell::open` method has been changed to return a `Read`. And when we hit the `32mb` limit this is implemented through a `Cursor` which ensures that the whole read file has been buffered into memory. I would question doing this at all - because most filesystems come with their own cache already which is better. I.e. it's shared across applications and doesn't require an allocation for every file being opened.