### PR TITLE
fix docs/sample_config/config.toml: use env.PROMPT_COMMAND

### DIFF
--- a/docs/sample_config/config.toml
+++ b/docs/sample_config/config.toml
@@ -14,7 +14,11 @@ pivot_mode = "auto" # auto, always, never
 ctrlc_exit = false
 complete_from_path = true
 rm_always_trash = true
-prompt = "build-string (ansi gb) (pwd) (ansi reset) '(' (ansi cb) (do -i { git rev-parse --abbrev-ref HEAD } | str trim ) (ansi reset) ')' (char newline) (ansi yb) (date format '%m/%d/%Y %I:%M:%S%.3f %p') (ansi reset) '> ' "
+
+[env]
+# nu now reads PROMPT_COMMAND env var instead of "prompt" config parameter
+# and if fails to parse it, it silently ignores it and uses default prompt
+PROMPT_COMMAND = "build-string (ansi gb) (pwd) (ansi reset) '(' (ansi cb) (do -i { git rev-parse --abbrev-ref HEAD } | str trim ) (ansi reset) ')' (char newline) (ansi yb) (date format '%m/%d/%Y %I:%M:%S%.3f %p') (ansi reset) '> ' "
 
 # for each of the options in the color_config section, you are able to set
 # the color alone or with one of the following attributes.


### PR DESCRIPTION
`docs/sample_config/config.toml` seems to be outdated.
Is there any other place where configs are documented?
