### PR TITLE
Drop with iter range

### DIFF
--- a/crates/nu-command/src/commands/filters/drop/nth.rs
+++ b/crates/nu-command/src/commands/filters/drop/nth.rs
@@ -18,9 +18,9 @@ impl WholeStreamCommand for SubCommand {
                 "row number or row range",
                 // FIXME: we can make this accept either Int or Range when we can compose SyntaxShapes
                 SyntaxShape::Any,
-                "the number of the row to drop",
+                "the number of the row to drop or a range to drop consecutive rows",
             )
-            .rest("rest", SyntaxShape::Any, "Optionally drop more rows (Only if first argument is number)")
+            .rest("rest", SyntaxShape::Any, "Optionally drop more rows (Ignored if first argument is a range)")
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/commands/filters/drop/nth.rs
+++ b/crates/nu-command/src/commands/filters/drop/nth.rs
@@ -15,12 +15,12 @@ impl WholeStreamCommand for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("drop nth")
             .required(
-                "row number",
+                "row number or row range",
                 // FIXME: we can make this accept either Int or Range when we can compose SyntaxShapes
                 SyntaxShape::Any,
                 "the number of the row to drop",
             )
-            .rest("rest", SyntaxShape::Any, "Optionally drop more rows")
+            .rest("rest", SyntaxShape::Any, "Optionally drop more rows (Only if first argument is number)")
     }
 
     fn usage(&self) -> &str {
@@ -43,6 +43,11 @@ impl WholeStreamCommand for SubCommand {
                 example: "echo [first second third] | drop nth 0 2",
                 result: Some(vec![Value::from("second")]),
             },
+            Example {
+                description: "Drop range rows from second to fourth",
+                example: "echo [first second third fourth fifth] | drop nth (1..3)",
+                result: Some(vec![Value::from("first fifth")]),
+            }
         ]
     }
 }

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -66,3 +66,25 @@ fn more_rows_than_table_has() {
 
     assert_eq!(actual.out, "0");
 }
+
+#[test]
+fn nth_range_inclusive() {
+    let actual = nu!(cwd: ".", "echo 10..15 | drop nth (2..3) | to json");
+
+    assert_eq!(actual.out, "[10,11,14,15]");
+}
+
+#[test]
+fn nth_range_exclusive() {
+    let actual = nu!(cwd: ".", "echo 10..15 | drop nth (1..<3) | to json");
+
+    assert_eq!(actual.out, "[10,13,14,15]");
+}
+
+#[test]
+fn nth_missing_first_argument() {
+    let actual = nu!(cwd: ".", "echo 10..15 | drop nth \"\"");
+
+    assert!(actual.err.contains("Expected int or range"));
+    assert!(actual.err.contains("found string"));
+}


### PR DESCRIPTION
Adds feature #4210 

## Changes
* First argument of `drop nth` can also be a range now

## Questions
* I am not sure how to add stride to the range drop because it seems like current `Range` implementation doesn't support it.
* It seems like we can't compose `SyntaxShape` so I changed first argument from `Int` to `Any` to accept both int and ranges.