### PR TITLE
Update descriptions for crates split out from nu-cli

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Nu Project Contributors"]
 build = "build.rs"
-description = "CLI for nushell"
+description = "Commands for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-command"

--- a/crates/nu-data/Cargo.toml
+++ b/crates/nu-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nu Project Contributors"]
-description = "CLI for nushell"
+description = "Data for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu-data"


### PR DESCRIPTION
`nu-command` and `nu-data` were split out, but the descriptions still
say 'CLI'.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>