### PR TITLE
Add ColumnPath support to default/compact

### DIFF
--- a/crates/nu-command/src/examples.rs
+++ b/crates/nu-command/src/examples.rs
@@ -21,8 +21,8 @@ use crate::commands::{
 };
 
 use crate::commands::{
-    Append, BuildString, Collect, Each, Echo, First, Get, If, IntoInt, Keep, Last, Let, Math,
-    MathMode, Nth, Select, StrCollect, Wrap,
+    Append, BuildString, Collect, Each, Echo, First, FromJson, Get, If, IntoInt, Keep, Last, Let,
+    Math, MathMode, Nth, Select, StrCollect, Wrap,
 };
 use nu_engine::{run_block, whole_stream_command, Command, EvaluationContext, WholeStreamCommand};
 use nu_stream::InputStream;
@@ -109,6 +109,7 @@ pub fn test(cmd: impl WholeStreamCommand + 'static) -> Result<(), ShellError> {
         whole_stream_command(Each {}),
         whole_stream_command(Let {}),
         whole_stream_command(cmd),
+        whole_stream_command(FromJson),
         whole_stream_command(Select),
         whole_stream_command(StrCollect),
         whole_stream_command(Collect),


### PR DESCRIPTION
Fixes #4274. `default` and `compact` are now implemented using `ColumnPath`s
instead of strings, this means that the commands are now capable of supporting
column path syntax for things like special characters in the paths.