### PR TITLE
Fix 'enter' to expand path before checking for it

### DIFF
--- a/crates/nu-command/src/shells/enter.rs
+++ b/crates/nu-command/src/shells/enter.rs
@@ -37,6 +37,10 @@ impl Command for Enter {
         let path_span = new_path.span()?;
 
         let new_path = new_path.as_path()?;
+
+        let cwd = current_dir(engine_state, stack)?;
+        let new_path = nu_path::canonicalize_with(new_path, &cwd)?;
+
         if !new_path.exists() {
             return Err(ShellError::DirectoryNotFound(path_span));
         }
@@ -47,9 +51,6 @@ impl Command for Enter {
                 path_span,
             ));
         }
-
-        let cwd = current_dir(engine_state, stack)?;
-        let new_path = nu_path::canonicalize_with(new_path, &cwd)?;
 
         let new_path = Value::String {
             val: new_path.to_string_lossy().to_string(),


### PR DESCRIPTION
# Description

This fixes `enter` to do all its path expansion first, before it checks for the presence of the directory. This fixes a bug with the nu_release script and should generally fix issues where `enter` is being used with variables and in scripts.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
