### PR TITLE
Support records in reject command

### DIFF
--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -42,6 +42,7 @@ mod prepend;
 mod random;
 mod range;
 mod reduce;
+mod reject;
 mod rename;
 mod reverse;
 mod rm;

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -1,0 +1,75 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn regular_columns() {
+    let actual = nu!(cwd: ".", pipeline(
+        r#"
+            echo [
+                [first_name, last_name, rusty_at, type];
+
+                [Andrés Robalino 10/11/2013 A]
+                [Jonathan Turner 10/12/2013 B]
+                [Yehuda Katz 10/11/2013 A]
+            ]
+            | reject type first_name
+            | columns
+            | str collect ", "
+        "#
+    ));
+
+    assert_eq!(actual.out, "rusty_at, last_name");
+}
+
+// FIXME: needs more work
+#[ignore]
+#[test]
+fn complex_nested_columns() {
+    let actual = nu!(cwd: ".", pipeline(
+        r#"
+            {
+                "nu": {
+                    "committers": [
+                        {"name": "Andrés N. Robalino"},
+                        {"name": "Jonathan Turner"},
+                        {"name": "Yehuda Katz"}
+                    ],
+                    "releases": [
+                        {"version": "0.2"}
+                        {"version": "0.8"},
+                        {"version": "0.9999999"}
+                    ],
+                    "0xATYKARNU": [
+                        ["Th", "e", " "],
+                        ["BIG", " ", "UnO"],
+                        ["punto", "cero"]
+                    ]
+                }
+            }
+            | reject nu."0xATYKARNU" nu.committers
+            | get nu
+            | columns
+            | str collect ", "
+        "#,
+    ));
+
+    assert_eq!(actual.out, "releases");
+}
+
+#[test]
+fn ignores_duplicate_columns_rejected() {
+    let actual = nu!(cwd: ".", pipeline(
+        r#"
+            echo [
+                ["first name", "last name"];
+
+                [Andrés Robalino]
+                [Andrés Jnth]
+            ]
+            | reject "first name" "first name"
+            | columns
+            | str collect ", "
+        "#
+    ));
+
+    assert_eq!(actual.out, "last name");
+}


### PR DESCRIPTION
# Description

This PR adds support for rejecting record columns, e.g.:

```
〉{foo: 42, bar: 777} | reject foo
╭─────┬─────╮
│ bar │ 777 │
╰─────┴─────╯
```
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
