### PR TITLE
Use 'table' on scripts and -c commands

### DIFF
--- a/crates/nu-command/tests/commands/append.rs
+++ b/crates/nu-command/tests/commands/append.rs
@@ -7,7 +7,7 @@ fn adds_a_row_to_the_end() {
         r#"
                 echo  [ "Andrés N. Robalino", "Jonathan Turner", "Yehuda Katz" ] 
                 | append "pollo loco"
-                | nth 3
+                | get 3
         "#
     ));
 

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -53,7 +53,7 @@ fn each_no_args_in_block() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [[foo bar]; [a b] [c d] [e f]] | each {|i| $i | to json -r } | nth 1
+        echo [[foo bar]; [a b] [c d] [e f]] | each {|i| $i | to json -r } | get 1
         "#
     ));
 
@@ -65,7 +65,7 @@ fn each_implicit_it_in_block() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [[foo bar]; [a b] [c d] [e f]] | each { nu --testbin cococo $it.foo }
+        echo [[foo bar]; [a b] [c d] [e f]] | each { nu --testbin cococo $it.foo } | str collect
         "#
     ));
 

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -7,7 +7,7 @@ fn find_with_list_search_with_string() {
     let actual = nu!(
     cwd: ".", pipeline(
     r#"
-        [moe larry curly] | find moe
+        [moe larry curly] | find moe | get 0
     "#
     ));
 
@@ -31,7 +31,7 @@ fn find_with_list_search_with_number() {
     let actual = nu!(
     cwd: ".", pipeline(
     r#"
-        [1 2 3 4 5] | find 3
+        [1 2 3 4 5] | find 3 | get 0
     "#
     ));
 

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -43,7 +43,7 @@ fn flatten_nested_tables() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            echo [[Andrés, Nicolás, Robalino]] | flatten | nth 1
+            echo [[Andrés, Nicolás, Robalino]] | flatten | get 1
         "#
     ));
 

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -122,7 +122,7 @@ fn fetches_more_than_one_column_path() {
             r#"
                 open sample.toml
                 | get fortune_tellers.2.name fortune_tellers.0.name fortune_tellers.1.name
-                | nth 2
+                | get 2
             "#
         ));
 
@@ -222,7 +222,7 @@ fn errors_fetching_by_index_out_of_bounds() {
 fn quoted_column_access() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"echo '[{"foo bar": {"baz": 4}}]' | from json | get "foo bar".baz "#
+        r#"echo '[{"foo bar": {"baz": 4}}]' | from json | get "foo bar".baz.0 "#
     );
 
     assert_eq!(actual.out, "4");

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -6,7 +6,7 @@ use nu_test_support::{nu, pipeline};
 fn gets_the_last_row() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | sort-by name | last 1 | get name | str trim"
+        "ls | sort-by name | last 1 | get name.0 | str trim"
     );
 
     assert_eq!(actual.out, "utf16.ini");

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -11,7 +11,7 @@ fn lines() {
             | skip 1
             | first 1
             | split column "="
-            | get Column1
+            | get Column1.0
             | str trim
         "#
     ));

--- a/crates/nu-command/tests/commands/nth.rs
+++ b/crates/nu-command/tests/commands/nth.rs
@@ -13,7 +13,7 @@ fn selects_a_row() {
                 ls
                 | sort-by name
                 | nth 0
-                | get name
+                | get name.0
             "#
         ));
 

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -21,7 +21,7 @@ fn parses_csv() {
             r#"
                 open nu.zion.csv
                 | where author == "Andres N. Robalino"
-                | get source
+                | get source.0
             "#
         ));
 

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -42,7 +42,7 @@ mod simple {
                 r#"
                     echo "{abc}123"
                     | parse "{{abc}{name}"
-                    | get name
+                    | get name.0
                 "#
             ));
 
@@ -58,7 +58,7 @@ mod simple {
                 r#"
                     echo "(abc)123"
                     | parse "(abc){name}"
-                    | get name
+                    | get name.0
                 "#
             ));
 
@@ -75,7 +75,7 @@ mod simple {
                     echo ["1:INFO:component:all is well" "2:ERROR::something bad happened"]
                     | parse "{timestamp}:{level}:{tag}:{entry}"
                     | get entry
-                    | nth 1
+                    | get 1
                 "#
             ));
 
@@ -125,7 +125,7 @@ mod regex {
                 r#"
                     open nushell_git_log_oneline.txt
                     | parse --regex "(?P<Hash>\w+) (?P<Message>.+) \(#(?P<PR>\d+)\)"
-                    | nth 1
+                    | get 1
                     | get PR
                 "#
             ));
@@ -144,7 +144,7 @@ mod regex {
                 r#"
                     open nushell_git_log_oneline.txt
                     | parse --regex "(\w+) (.+) \(#(\d+)\)"
-                    | nth 1
+                    | get 1
                     | get Capture1
                 "#
             ));
@@ -163,7 +163,7 @@ mod regex {
                 r#"
                     open nushell_git_log_oneline.txt
                     | parse --regex "(?P<Hash>\w+) (.+) \(#(?P<PR>\d+)\)"
-                    | nth 1
+                    | get 1
                     | get Capture2
                 "#
             ));

--- a/crates/nu-command/tests/commands/path/join.rs
+++ b/crates/nu-command/tests/commands/path/join.rs
@@ -9,7 +9,7 @@ fn returns_path_joined_with_column_path() {
         r#"
             echo [ [name]; [eggs] ]
             | path join spam.txt -c [ name ]
-            | get name
+            | get name.0
         "#
     ));
 

--- a/crates/nu-command/tests/commands/path/parse.rs
+++ b/crates/nu-command/tests/commands/path/parse.rs
@@ -107,7 +107,7 @@ fn parses_column_path_extension() {
             echo [[home, barn]; ['home/viking/spam.txt', 'barn/cow/moo.png']]
             | path parse -c [ home barn ]
             | get barn
-            | get extension
+            | get extension.0
         "#
     ));
 

--- a/crates/nu-command/tests/commands/path/split.rs
+++ b/crates/nu-command/tests/commands/path/split.rs
@@ -20,6 +20,7 @@ fn splits_correctly_single_path() {
             'home/viking/spam.txt'
             | path split
             | last
+            | get 0
         "#
     ));
 

--- a/crates/nu-command/tests/commands/prepend.rs
+++ b/crates/nu-command/tests/commands/prepend.rs
@@ -20,7 +20,7 @@ fn adds_a_row_to_the_beginning() {
                 open los_tres_caballeros.txt
                 | lines
                 | prepend "pollo loco"
-                | nth 0
+                | get 0
                 "#
         ));
 

--- a/crates/nu-command/tests/commands/range.rs
+++ b/crates/nu-command/tests/commands/range.rs
@@ -13,7 +13,7 @@ fn selects_a_row() {
                 ls
                 | sort-by name
                 | range 0..0
-                | get name
+                | get name.0
             "#
         ));
 

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -14,7 +14,7 @@ fn regular_columns() {
                 [Yehuda Katz 10/11/2013 A]
             ]
             | select rusty_at last_name
-            | nth 0
+            | get 0
             | get last_name
         "#
     ));

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu;
 fn which_ls() {
     let actual = nu!(
         cwd: ".",
-        "which ls | get path | str trim"
+        "which ls | get path.0 | str trim"
     );
 
     assert_eq!(actual.out, "Nushell built-in command");
@@ -14,7 +14,7 @@ fn which_ls() {
 fn which_alias_ls() {
     let actual = nu!(
         cwd: ".",
-        "alias ls = ls -a; which ls | get path | str trim"
+        "alias ls = ls -a; which ls | get path.0 | str trim"
     );
 
     assert_eq!(actual.out, "Nushell alias: ls -a");
@@ -24,7 +24,7 @@ fn which_alias_ls() {
 fn which_def_ls() {
     let actual = nu!(
         cwd: ".",
-        "def ls [] {echo def}; which ls | get path | str trim"
+        "def ls [] {echo def}; which ls | get path.0 | str trim"
     );
 
     assert_eq!(actual.out, "Nushell custom command");
@@ -34,7 +34,7 @@ fn which_def_ls() {
 fn correct_precedence_alias_def_custom() {
     let actual = nu!(
         cwd: ".",
-        "def ls [] {echo def}; alias ls = echo alias; which ls | get path | str trim"
+        "def ls [] {echo def}; alias ls = echo alias; which ls | get path.0 | str trim"
     );
 
     assert_eq!(actual.out, "Nushell alias: echo alias");

--- a/crates/nu-command/tests/commands/wrap.rs
+++ b/crates/nu-command/tests/commands/wrap.rs
@@ -22,7 +22,7 @@ fn wrap_rows_into_a_row() {
                 | from csv
                 | wrap caballeros
                 | get caballeros
-                | nth 0
+                | get 0
                 | get last_name
             "#
         ));
@@ -51,7 +51,7 @@ fn wrap_rows_into_a_table() {
                 | from csv
                 | get last_name
                 | wrap caballero
-                | nth 2
+                | get 2
                 | get caballero
             "#
         ));

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -62,7 +62,7 @@ fn from_json_text_recognizing_objects_independently_to_table() {
                 open katz.txt
                 | from json -o
                 | where name == "GorbyPuff"
-                | get rusty_luck
+                | get rusty_luck.0
             "#
         ));
 
@@ -90,7 +90,7 @@ fn table_to_json_text() {
                 | select name
                 | to json
                 | from json
-                | nth 0
+                | get 0
                 | get name
             "#
         ));

--- a/crates/nu-command/tests/format_conversions/ods.rs
+++ b/crates/nu-command/tests/format_conversions/ods.rs
@@ -7,7 +7,7 @@ fn from_ods_file_to_table() {
         r#"
             open sample_data.ods
             | get SalesOrders
-            | nth 4
+            | get 4
             | get Column2
         "#
     ));

--- a/crates/nu-command/tests/format_conversions/ssv.rs
+++ b/crates/nu-command/tests/format_conversions/ssv.rs
@@ -20,7 +20,7 @@ fn from_ssv_text_to_table() {
             r#"
                 open oc_get_svc.txt
                 | from ssv
-                | nth 0
+                | get 0
                 | get IP
             "#
         ));
@@ -47,7 +47,7 @@ fn from_ssv_text_to_table_with_separator_specified() {
             r#"
                 open oc_get_svc.txt
                 | from ssv --minimum-spaces 3
-                | nth 0
+                | get 0
                 | get IP
             "#
         ));

--- a/crates/nu-command/tests/format_conversions/xlsx.rs
+++ b/crates/nu-command/tests/format_conversions/xlsx.rs
@@ -7,7 +7,7 @@ fn from_excel_file_to_table() {
         r#"
             open sample_data.xlsx
             | get SalesOrders
-            | nth 4
+            | get 4
             | get Column2
         "#
     ));

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,10 +1,9 @@
 use miette::Result;
 use nu_engine::{convert_env_values, eval_block};
-use std::{io::Write, path::Path};
+use std::path::Path;
 
 use nu_parser::{lex, lite_parse, parse_block, trim_quotes};
 use nu_protocol::{
-    ast::Call,
     engine::{EngineState, StateDelta, StateWorkingSet},
     Config, PipelineData, Span, Spanned, Value, CONFIG_VARIABLE_ID,
 };
@@ -113,57 +112,7 @@ pub(crate) fn evaluate(
 
     match eval_block(engine_state, &mut stack, &block, input) {
         Ok(pipeline_data) => {
-            match engine_state.find_decl("table".as_bytes()) {
-                Some(decl_id) => {
-                    let table = engine_state.get_decl(decl_id).run(
-                        engine_state,
-                        &mut stack,
-                        &Call::new(Span::new(0, 0)),
-                        pipeline_data,
-                    )?;
-
-                    for item in table {
-                        let stdout = std::io::stdout();
-
-                        if let Value::Error { error } = item {
-                            let working_set = StateWorkingSet::new(engine_state);
-
-                            report_error(&working_set, &error);
-
-                            std::process::exit(1);
-                        }
-
-                        let mut out = item.into_string("\n", &config);
-                        out.push('\n');
-
-                        match stdout.lock().write_all(out.as_bytes()) {
-                            Ok(_) => (),
-                            Err(err) => eprintln!("{}", err),
-                        };
-                    }
-                }
-                None => {
-                    for item in pipeline_data {
-                        let stdout = std::io::stdout();
-
-                        if let Value::Error { error } = item {
-                            let working_set = StateWorkingSet::new(engine_state);
-
-                            report_error(&working_set, &error);
-
-                            std::process::exit(1);
-                        }
-
-                        let mut out = item.into_string("\n", &config);
-                        out.push('\n');
-
-                        match stdout.lock().write_all(out.as_bytes()) {
-                            Ok(_) => (),
-                            Err(err) => eprintln!("{}", err),
-                        };
-                    }
-                }
-            };
+            crate::eval_file::print_table_or_error(engine_state, &mut stack, pipeline_data, &config)
         }
         Err(err) => {
             let working_set = StateWorkingSet::new(engine_state);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,9 +1,10 @@
 use miette::Result;
 use nu_engine::{convert_env_values, eval_block};
-use std::path::Path;
+use std::{io::Write, path::Path};
 
 use nu_parser::{lex, lite_parse, parse_block, trim_quotes};
 use nu_protocol::{
+    ast::Call,
     engine::{EngineState, StateDelta, StateWorkingSet},
     Config, PipelineData, Span, Spanned, Value, CONFIG_VARIABLE_ID,
 };
@@ -112,16 +113,57 @@ pub(crate) fn evaluate(
 
     match eval_block(engine_state, &mut stack, &block, input) {
         Ok(pipeline_data) => {
-            for item in pipeline_data {
-                if let Value::Error { error } = item {
-                    let working_set = StateWorkingSet::new(engine_state);
+            match engine_state.find_decl("table".as_bytes()) {
+                Some(decl_id) => {
+                    let table = engine_state.get_decl(decl_id).run(
+                        engine_state,
+                        &mut stack,
+                        &Call::new(Span::new(0, 0)),
+                        pipeline_data,
+                    )?;
 
-                    report_error(&working_set, &error);
+                    for item in table {
+                        let stdout = std::io::stdout();
 
-                    std::process::exit(1);
+                        if let Value::Error { error } = item {
+                            let working_set = StateWorkingSet::new(engine_state);
+
+                            report_error(&working_set, &error);
+
+                            std::process::exit(1);
+                        }
+
+                        let mut out = item.into_string("\n", &config);
+                        out.push('\n');
+
+                        match stdout.lock().write_all(out.as_bytes()) {
+                            Ok(_) => (),
+                            Err(err) => eprintln!("{}", err),
+                        };
+                    }
                 }
-                println!("{}", item.into_string("\n", &config));
-            }
+                None => {
+                    for item in pipeline_data {
+                        let stdout = std::io::stdout();
+
+                        if let Value::Error { error } = item {
+                            let working_set = StateWorkingSet::new(engine_state);
+
+                            report_error(&working_set, &error);
+
+                            std::process::exit(1);
+                        }
+
+                        let mut out = item.into_string("\n", &config);
+                        out.push('\n');
+
+                        match stdout.lock().write_all(out.as_bytes()) {
+                            Ok(_) => (),
+                            Err(err) => eprintln!("{}", err),
+                        };
+                    }
+                }
+            };
         }
         Err(err) => {
             let working_set = StateWorkingSet::new(engine_state);

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -22,7 +22,10 @@ fn cell_path_var2() -> TestResult {
 
 #[test]
 fn flatten_simple_list() -> TestResult {
-    run_test("[[N, u, s, h, e, l, l]] | flatten", "N\nu\ns\nh\ne\nl\nl")
+    run_test(
+        "[[N, u, s, h, e, l, l]] | flatten | str collect (char nl)",
+        "N\nu\ns\nh\ne\nl\nl",
+    )
 }
 
 #[test]
@@ -33,7 +36,7 @@ fn flatten_get_simple_list() -> TestResult {
 #[test]
 fn flatten_table_get() -> TestResult {
     run_test(
-        "[[origin, people]; [Ecuador, ([[name, meal]; ['Andres', 'arepa']])]] | flatten | get meal",
+        "[[origin, people]; [Ecuador, ([[name, meal]; ['Andres', 'arepa']])]] | flatten | get meal.0",
         "arepa",
     )
 }
@@ -41,7 +44,7 @@ fn flatten_table_get() -> TestResult {
 #[test]
 fn flatten_table_column_get_last() -> TestResult {
     run_test(
-        "[[origin, crate, versions]; [World, ([[name]; ['nu-cli']]), ['0.21', '0.22']]] | flatten versions | last | get versions",
+        "[[origin, crate, versions]; [World, ([[name]; ['nu-cli']]), ['0.21', '0.22']]] | flatten versions | last | get versions.0",
         "0.22",
     )
 }
@@ -56,7 +59,7 @@ fn get_table_columns_1() -> TestResult {
 
 #[test]
 fn get_table_columns_2() -> TestResult {
-    run_test("[[name, age, grade]; [paul,21,a]] | columns | nth 1", "age")
+    run_test("[[name, age, grade]; [paul,21,a]] | columns | get 1", "age")
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -111,7 +111,7 @@ mod it_evaluation {
                 ls
                 | sort-by name
                 | get name
-                | each { nu --testbin cococo $it | lines }
+                | each { nu --testbin cococo $it }
                 | get 1
                 "#
             ));
@@ -136,7 +136,7 @@ mod it_evaluation {
             r#"
                 open nu_candies.txt
                 | lines
-                | each { nu --testbin chop $it | lines}
+                | each { nu --testbin chop $it}
                 | get 1
                 "#
             ));

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -22,7 +22,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
         r#"
             open nu_times.csv
             | get origin
-            | each { ^echo $it | nu --testbin chop | lines }
+            | each { ^echo $it | nu --testbin chop }
             | get 2
             "#
         ));
@@ -102,7 +102,7 @@ fn subexpression_handles_dot() {
         r#"
             echo (open nu_times.csv)
             | get name
-            | each { nu --testbin chop $it | lines }
+            | each { nu --testbin chop $it }
             | get 3
             "#
         ));
@@ -128,7 +128,7 @@ fn string_interpolation_with_it_column_path() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo [[name]; [sammie]] | each { echo $"($it.name)" }
+                    echo [[name]; [sammie]] | each { echo $"($it.name)" } | get 0
         "#
     );
 
@@ -819,7 +819,7 @@ fn table_literals1() {
     let actual = nu!(
         cwd: ".",
         r#"
-            echo [[name age]; [foo 13]] | get age
+            echo [[name age]; [foo 13]] | get age.0
         "#
     );
 


### PR DESCRIPTION
# Description

This adds an automatic view through `table` for scripts and -c commands. This currently follows the same as the configuration setup.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
