### PR TITLE
Fix "Index out of bounds" when input to the group-by filter is empty. #4369

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -95,7 +95,6 @@ pub fn group_by(
     let mut keys: Vec<Result<String, ShellError>> = vec![];
     let mut group_strategy = Grouper::ByColumn(None);
 
-
     if values.is_empty() {
         return Err(ShellError::SpannedLabeledError(
             "expected table from pipeline".into(),

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -95,7 +95,6 @@ pub fn group_by(
     let mut keys: Vec<Result<String, ShellError>> = vec![];
     let mut group_strategy = Grouper::ByColumn(None);
 
-    let first = values[0].clone();
 
     if values.is_empty() {
         return Err(ShellError::SpannedLabeledError(
@@ -104,6 +103,8 @@ pub fn group_by(
             name,
         ));
     }
+
+    let first = values[0].clone();
 
     let value_list = Value::List {
         vals: values.clone(),

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -97,3 +97,17 @@ fn errors_if_block_given_evaluates_more_than_one_row() {
         assert!(actual.err.contains("Unknown column"));
     })
 }
+
+#[test]
+fn errors_if_input_empty() {
+    Playground::setup("group_by_empty_test", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+            group-by date
+        "#
+        ));
+
+        assert!(actual.err.contains("expected table from pipeline"));
+    });
+}


### PR DESCRIPTION
# Description

Fix issue #4369: "Index out of bounds" when input to the group-by filter is empty. 

After:
```
C:\Users\henry\contrib\nushell〉group-by date                                                                            
Error:
  x expected table from pipeline
   ,-[entry #1:1:1]
 1 | group-by date
   : ^^^^|^^^
   :     `-- requires a table input
   `----
```
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
   NOTE: two tests in external.rs failed before these commits
