### PR TITLE
Make `let-env` work like `let`

### DIFF
--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -20,7 +20,7 @@ impl Command for LetEnv {
             .required("var_name", SyntaxShape::String, "variable name")
             .required(
                 "initial_value",
-                SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::Any)),
+                SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::Expression)),
                 "equals sign followed by value",
             )
             .category(Category::Env)

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -194,7 +194,7 @@ fn let_sees_in_variable2() -> TestResult {
 #[test]
 fn def_env() -> TestResult {
     run_test(
-        r#"def-env bob [] { let-env BAR = BAZ }; bob; $env.BAR"#,
+        r#"def-env bob [] { let-env BAR = "BAZ" }; bob; $env.BAR"#,
         "BAZ",
     )
 }
@@ -202,7 +202,7 @@ fn def_env() -> TestResult {
 #[test]
 fn not_def_env() -> TestResult {
     fail_test(
-        r#"def bob [] { let-env BAR = BAZ }; bob; $env.BAR"#,
+        r#"def bob [] { let-env BAR = "BAZ" }; bob; $env.BAR"#,
         "did you mean",
     )
 }
@@ -226,7 +226,7 @@ fn def_env_then_hide() -> TestResult {
 #[test]
 fn export_def_env() -> TestResult {
     run_test(
-        r#"module foo { export def-env bob [] { let-env BAR = BAZ } }; use foo bob; bob; $env.BAR"#,
+        r#"module foo { export def-env bob [] { let-env BAR = "BAZ" } }; use foo bob; bob; $env.BAR"#,
         "BAZ",
     )
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -189,3 +189,11 @@ fn commands_have_usage() -> TestResult {
 fn equals_separates_long_flag() -> TestResult {
     run_test(r#"seq 1 4 --separator='+'"#, "1+2+3+4")
 }
+
+#[test]
+fn let_env_expressions() -> TestResult {
+    run_test(
+        r#"let-env PATH = if (env | any? name == VENV_OLD_PATH) { $env.VENV_OLD_PATH } else { $env.PATH }; echo done"#,
+        "done",
+    )
+}

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -464,7 +464,7 @@ fn proper_shadow_let_env_aliases() {
     let actual = nu!(
         cwd: ".",
         r#"
-        let-env DEBUG = true; echo $env.DEBUG | table; do { let-env DEBUG = false; echo $env.DEBUG } | table; echo $env.DEBUG
+        let-env DEBUG = "true"; echo $env.DEBUG | table; do { let-env DEBUG = "false"; echo $env.DEBUG } | table; echo $env.DEBUG
         "#
     );
     assert_eq!(actual.out, "truefalsetrue");
@@ -513,7 +513,7 @@ fn proper_shadow_load_env_aliases() {
     let actual = nu!(
         cwd: ".",
         r#"
-        let-env DEBUG = true; echo $env.DEBUG | table; do { echo {DEBUG: "false"} | load-env; echo $env.DEBUG } | table; echo $env.DEBUG
+        let-env DEBUG = "true"; echo $env.DEBUG | table; do { echo {DEBUG: "false"} | load-env; echo $env.DEBUG } | table; echo $env.DEBUG
         "#
     );
     assert_eq!(actual.out, "truefalsetrue");


### PR DESCRIPTION
# Description

Let `let-env` work like `let` by using an expression form as the right-hand value that we're assigning from. 

Fixes #4379 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
