### PR TITLE
Fix in-shell docs for kill command in engine-q

### DIFF
--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -137,7 +137,7 @@ impl Command for Kill {
         vec![
             Example {
                 description: "Kill the pid using the most memory",
-                example: "ps | sort-by mem | last | kill $it.pid",
+                example: "ps | sort-by mem | last | kill $in.pid",
                 result: None,
             },
             Example {


### PR DESCRIPTION
# Description

`$it` isn't used anymore and causes a syntax error. Replaces it with `$in` in the first example.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
