### PR TITLE
Fix `trash-support` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ default = ["plugin", "inc", "example", "which"]
 stable = ["default"]
 extra = [ "default", "dataframe", "gstat", "zip-support", "query", ]
 wasi = ["inc"]
+trash-support = ["nu-command/trash-support"]
 
 # Stable (Default)
 inc = ["nu_plugin_inc"]

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+#[cfg(feature = "trash-support")]
 use std::io::ErrorKind;
 #[cfg(unix)]
 use std::os::unix::prelude::FileTypeExt;
@@ -73,6 +74,7 @@ fn rm(
     call: &Call,
 ) -> Result<PipelineData, ShellError> {
     let trash = call.has_flag("trash");
+    #[cfg(feature = "trash-support")]
     let permanent = call.has_flag("permanent");
     let recursive = call.has_flag("recursive");
     let force = call.has_flag("force");


### PR DESCRIPTION
# Description

Pass it through to be inclued with `--all-features`

Make clippy without `--all-features` happy


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
