### PR TITLE
fix broken `-w` param for `grid`

### DIFF
--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -31,7 +31,7 @@ impl Command for Griddle {
             .named(
                 "width",
                 SyntaxShape::Int,
-                "number of columns wide",
+                "number of terminal columns wide (not output columns)",
                 Some('w'),
             )
             .switch("color", "draw output with color", Some('c'))
@@ -60,7 +60,7 @@ prints out the list properly."#
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let width_param: Option<String> = call.get_flag(engine_state, stack, "width")?;
+        let width_param: Option<i64> = call.get_flag(engine_state, stack, "width")?;
         let color_param: bool = call.has_flag("color");
         let separator_param: Option<String> = call.get_flag(engine_state, stack, "separator")?;
         let config = stack.get_config().unwrap_or_default();
@@ -156,7 +156,7 @@ fn strip_ansi(string: &str) -> Cow<str> {
 fn create_grid_output(
     items: Vec<(usize, String, String)>,
     call: &Call,
-    width_param: Option<String>,
+    width_param: Option<i64>,
     color_param: bool,
     separator_param: Option<String>,
     env_str: Option<String>,
@@ -168,7 +168,7 @@ fn create_grid_output(
     };
 
     let cols = if let Some(col) = width_param {
-        col.parse::<u16>().unwrap_or(80)
+        col as u16
     } else if let Some((Width(w), Height(_h))) = terminal_size::terminal_size() {
         w
     } else {


### PR DESCRIPTION
# Description

for some reason the `--width/-w` parameter stopped working. I also clarified that `--width` doesn't mean how man output columns but how many terminal columns. So, if you have a terminal width of 100 and you specify `--width 50` then the grid should take up roughly half of your screen.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
