### PR TITLE
Fix help flag

### DIFF
--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -56,7 +56,7 @@ fn test_cd_html_color_flag_dark_false() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path: the path to change to<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path: the path to change to<br><br></body></html>"
     );
 }
 
@@ -71,7 +71,7 @@ fn test_no_color_flag() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path: the path to change to<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path: the path to change to<br><br></body></html>"
     );
 }
 
@@ -86,6 +86,6 @@ fn test_html_color_where_flag_dark_false() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Usage:<br>  &gt; where &lt;cond&gt; <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  cond: condition<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Filter values based on a condition.<br><br>Usage:<br>  &gt; where &lt;cond&gt; <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  cond: condition<br><br></body></html>"
     );
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -33,12 +33,11 @@ fn eval_call(
     let decl = engine_state.get_decl(call.decl_id);
 
     if call.named.iter().any(|(flag, _)| flag.item == "help") {
-        let full_help = get_full_help(
-            &decl.signature(),
-            &decl.examples(),
-            engine_state,
-            caller_stack,
-        );
+        let mut signature = decl.signature();
+        signature.usage = decl.usage().to_string();
+        signature.extra_usage = decl.extra_usage().to_string();
+
+        let full_help = get_full_help(&signature, &decl.examples(), engine_state, caller_stack);
         Ok(Value::String {
             val: full_help,
             span: call.head,

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -72,7 +72,7 @@ fn in_variable_6() -> TestResult {
 
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
-    run_test(r#"each --help | lines | length"#, "20")
+    run_test(r#"each --help | lines | length"#, "22")
 }
 
 #[test]


### PR DESCRIPTION
# Description

This change brings `help <command name>` and `<command name> --help` to the same level. The two should now show identical help.

```
> grid --help
Renders the output to a textual terminal grid.

grid was built to give a concise gridded layout for ls. however,
it determines what to put in the grid by looking for a column named
'name'. this works great for tables and records but for lists we
need to do something different. such as with '[one two three] | grid'
it creates a fake column called 'name' for these values so that it
Usage:
  > grid {flags} 

      Display this help message
  -w, --width <Int>
      number of columns wide
  -c, --color
      draw output with color
  -s, --separator <String>
      character to separate grid with
```

cc @fdncred 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
