### PR TITLE
deprecated commands

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -345,6 +345,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
 
         // Deprecated
         bind_command! {
+            InsertDeprecated,
             PivotDeprecated,
             StrDecimalDeprecated,
             StrIntDeprecated,

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -343,6 +343,17 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             ViewSource,
         };
 
+        // Deprecated
+        bind_command! {
+            PivotDeprecated,
+            StrDecimalDeprecated,
+            StrIntDeprecated,
+            NthDeprecated,
+        };
+
+        #[cfg(feature = "dataframe")]
+        bind_command!(DataframeDeprecated);
+
         #[cfg(feature = "plugin")]
         bind_command!(Register);
 

--- a/crates/nu-command/src/deprecated/dataframe.rs
+++ b/crates/nu-command/src/deprecated/dataframe.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct DataframeDeprecated;
+
+impl Command for DataframeDeprecated {
+    fn name(&self) -> &str {
+        "dataframe"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "dfr".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/insert.rs
+++ b/crates/nu-command/src/deprecated/insert.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct InsertDeprecated;
+
+impl Command for InsertDeprecated {
+    fn name(&self) -> &str {
+        "insert"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "update".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/mod.rs
+++ b/crates/nu-command/src/deprecated/mod.rs
@@ -1,0 +1,15 @@
+mod nth;
+mod pivot;
+mod str_decimal;
+mod str_int;
+
+pub use nth::NthDeprecated;
+pub use pivot::PivotDeprecated;
+pub use str_decimal::StrDecimalDeprecated;
+pub use str_int::StrIntDeprecated;
+
+#[cfg(feature = "dataframe")]
+mod dataframe;
+
+#[cfg(feature = "dataframe")]
+pub use dataframe::DataframeDeprecated;

--- a/crates/nu-command/src/deprecated/mod.rs
+++ b/crates/nu-command/src/deprecated/mod.rs
@@ -1,8 +1,10 @@
+mod insert;
 mod nth;
 mod pivot;
 mod str_decimal;
 mod str_int;
 
+pub use insert::InsertDeprecated;
 pub use nth::NthDeprecated;
 pub use pivot::PivotDeprecated;
 pub use str_decimal::StrDecimalDeprecated;

--- a/crates/nu-command/src/deprecated/nth.rs
+++ b/crates/nu-command/src/deprecated/nth.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct NthDeprecated;
+
+impl Command for NthDeprecated {
+    fn name(&self) -> &str {
+        "nth"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "select".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/pivot.rs
+++ b/crates/nu-command/src/deprecated/pivot.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct PivotDeprecated;
+
+impl Command for PivotDeprecated {
+    fn name(&self) -> &str {
+        "pivot"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "transpose".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/str_decimal.rs
+++ b/crates/nu-command/src/deprecated/str_decimal.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct StrDecimalDeprecated;
+
+impl Command for StrDecimalDeprecated {
+    fn name(&self) -> &str {
+        "str to-decimal"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "into decimal".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/str_int.rs
+++ b/crates/nu-command/src/deprecated/str_int.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct StrIntDeprecated;
+
+impl Command for StrIntDeprecated {
+    fn name(&self) -> &str {
+        "str to-int"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "into int".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -2,6 +2,7 @@ mod conversions;
 mod core_commands;
 mod date;
 mod default_context;
+mod deprecated;
 mod env;
 mod example_test;
 mod experimental;
@@ -24,6 +25,7 @@ pub use conversions::*;
 pub use core_commands::*;
 pub use date::*;
 pub use default_context::*;
+pub use deprecated::*;
 pub use env::*;
 #[cfg(test)]
 pub use example_test::test_examples;

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -267,6 +267,14 @@ pub enum ShellError {
     #[error("{0}")]
     #[diagnostic(help("{1}"))]
     LabeledError(String, String),
+
+    #[error("Deprecated command {0}")]
+    #[diagnostic(code(nu::shell::deprecated_command), url(docsrs))]
+    DeprecatedCommand(
+        String,
+        String,
+        #[label = "{0} is deprecated. Instead use {1}"] Span,
+    ),
 }
 
 impl From<std::io::Error> for ShellError {

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -52,6 +52,7 @@ pub enum Category {
     Hash,
     Generators,
     Custom(String),
+    Deprecated,
 }
 
 impl std::fmt::Display for Category {
@@ -77,6 +78,7 @@ impl std::fmt::Display for Category {
             Category::Hash => "hash",
             Category::Generators => "generators",
             Category::Custom(name) => name,
+            Category::Deprecated => "deprecated",
         };
 
         write!(f, "{}", msg)


### PR DESCRIPTION
# Description

Adds new deprecated category and commands. These commands return an error and prompt the user to the correct alternative

![image](https://user-images.githubusercontent.com/6942205/153379689-0fbe2069-f39e-4c5a-84a6-2a9e6f030efe.png)

  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
