### PR TITLE
Fix string interpolation paren cases

### DIFF
--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -197,3 +197,18 @@ fn let_env_expressions() -> TestResult {
         "done",
     )
 }
+
+#[test]
+fn string_interpolation_paren_test() -> TestResult {
+    run_test(r#"$"('(')(')')""#, "()")
+}
+
+#[test]
+fn string_interpolation_paren_test2() -> TestResult {
+    run_test(r#"$"('(')test(')')""#, "(test)")
+}
+
+#[test]
+fn string_interpolation_paren_test3() -> TestResult {
+    run_test(r#"$"('(')("test")test(')')""#, "(testtest)")
+}


### PR DESCRIPTION
# Description

Fixes some cases with parens inside of string interpolations. New test cases that now work:

```
$"Test ('(')(')')" # doesn't work
$"Test ('(')test(')')" # doesn't
$"Test ('(')("test")test(')')" #doesn't work
```

(h/t to Genna on discord for pointing this one out)
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
