### PR TITLE
Fix multi-command variable captures

### DIFF
--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -13,7 +13,7 @@ pub use flatten::{
 pub use lex::{lex, Token, TokenContents};
 pub use lite_parse::{lite_parse, LiteBlock};
 
-pub use parser::{find_captures_in_expr, parse, parse_block, trim_quotes, Import};
+pub use parser::{parse, parse_block, trim_quotes, Import};
 
 #[cfg(feature = "plugin")]
 pub use parse_keywords::parse_register;

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -13,9 +13,9 @@ use crate::{
     lex, lite_parse,
     lite_parse::LiteCommand,
     parser::{
-        check_call, check_name, find_captures_in_block, garbage, garbage_statement, parse,
-        parse_block_expression, parse_internal_call, parse_multispan_value, parse_signature,
-        parse_string, parse_var_with_opt_type, trim_quotes,
+        check_call, check_name, garbage, garbage_statement, parse, parse_block_expression,
+        parse_internal_call, parse_multispan_value, parse_signature, parse_string,
+        parse_var_with_opt_type, trim_quotes,
     },
     ParseError,
 };
@@ -149,18 +149,6 @@ pub fn parse_for(
                 var_id: Some(*var_id),
             },
         );
-
-        let block = working_set.get_block(block_id);
-
-        // Now that we have a signature for the block, we know more about what variables
-        // will come into scope as params. Because of this, we need to recalculated what
-        // variables this block will capture from the outside.
-        let mut seen = vec![];
-        let mut seen_decls = vec![];
-        let captures = find_captures_in_block(working_set, block, &mut seen, &mut seen_decls);
-
-        let mut block = working_set.get_block_mut(block_id);
-        block.captures = captures;
     }
 
     (
@@ -324,19 +312,7 @@ pub fn parse_def(
 
             let mut block = working_set.get_block_mut(block_id);
             block.signature = signature;
-
-            let block = working_set.get_block(block_id);
-
-            // Now that we have a signature for the block, we know more about what variables
-            // will come into scope as params. Because of this, we need to recalculated what
-            // variables this block will capture from the outside.
-            let mut seen = vec![];
-            let mut seen_decls = vec![];
-            let captures = find_captures_in_block(working_set, block, &mut seen, &mut seen_decls);
-
-            let mut block = working_set.get_block_mut(block_id);
             block.redirect_env = def_call == b"def-env";
-            block.captures = captures;
         } else {
             error = error.or_else(|| {
                 Some(ParseError::InternalError(

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -212,3 +212,87 @@ fn string_interpolation_paren_test2() -> TestResult {
 fn string_interpolation_paren_test3() -> TestResult {
     run_test(r#"$"('(')("test")test(')')""#, "(testtest)")
 }
+
+#[test]
+fn capture_multiple_commands() -> TestResult {
+    run_test(
+        r#"
+let CONST_A = 'Hello'
+
+def 'say-hi' [] {
+    echo (call-me)
+}
+
+def 'call-me' [] {
+    echo $CONST_A
+}
+
+[(say-hi) (call-me)] | str collect    
+    
+    "#,
+        "HelloHello",
+    )
+}
+
+#[test]
+fn capture_multiple_commands2() -> TestResult {
+    run_test(
+        r#"
+let CONST_A = 'Hello'
+
+def 'call-me' [] {
+    echo $CONST_A
+}
+
+def 'say-hi' [] {
+    echo (call-me)
+}
+
+[(say-hi) (call-me)] | str collect    
+    
+    "#,
+        "HelloHello",
+    )
+}
+
+#[test]
+fn capture_multiple_commands3() -> TestResult {
+    run_test(
+        r#"
+let CONST_A = 'Hello'
+
+def 'say-hi' [] {
+    echo (call-me)
+}
+
+def 'call-me' [] {
+    echo $CONST_A
+}
+
+[(call-me) (say-hi)] | str collect    
+    
+    "#,
+        "HelloHello",
+    )
+}
+
+#[test]
+fn capture_multiple_commands4() -> TestResult {
+    run_test(
+        r#"
+let CONST_A = 'Hello'
+
+def 'call-me' [] {
+    echo $CONST_A
+}
+
+def 'say-hi' [] {
+    echo (call-me)
+}
+
+[(call-me) (say-hi)] | str collect    
+    
+    "#,
+        "HelloHello",
+    )
+}


### PR DESCRIPTION
# Description

This delays variable capture calculation until after the parser has run. This allows us to start checking after all the bodies of custom commands have been filled out. After this point, we can go back over the complete definitions and find where they capture variables outside of themselves.

fixes #4402 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
