### PR TITLE
Improve quote path completions with drill-down

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -362,21 +362,11 @@ fn file_path_completion(
 ) -> Vec<(nu_protocol::Span, String)> {
     use std::path::{is_separator, Path};
 
-    let partial = if let Some(s) = partial.strip_prefix('"') {
-        s
-    } else {
-        partial
-    };
-
-    let partial = if let Some(s) = partial.strip_suffix('"') {
-        s
-    } else {
-        partial
-    };
+    let partial = partial.replace("\"", "");
 
     let (base_dir_name, partial) = {
         // If partial is only a word we want to search in the current dir
-        let (base, rest) = partial.rsplit_once(is_separator).unwrap_or((".", partial));
+        let (base, rest) = partial.rsplit_once(is_separator).unwrap_or((".", &partial));
         // On windows, this standardizes paths to use \
         let mut base = base.replace(is_separator, &SEP.to_string());
 


### PR DESCRIPTION
# Description

Allow for typing drill-down after the quotes in a filepath completion
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
