### PR TITLE
add parameter to set thread count for parallel commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "nu_plugin_query",
  "pretty_assertions",
  "pretty_env_logger",
+ "rayon",
  "reedline",
  "rstest",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ nu-system = { path = "./crates/nu-system", version = "0.59.0" }
 nu-table = { path = "./crates/nu-table", version = "0.59.0"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.59.0"  }
 pretty_env_logger = "0.4.0"
+rayon = "1.5.1"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # mimalloc = { version = "*", default-features = false }
 


### PR DESCRIPTION
# Description

This pr adds a litte control to `par-each`, `par-each group` and other rayon parallel commands that we add. It does this by setting a global threadpool of max threads. Example:  `nu --threads 5` will limit the maximum threads that are spun up in `par-each` commands to 5.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
