### PR TITLE
Remove stringification for binary values in `save` command

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -36,8 +36,6 @@ impl Command for Save {
 
         let span = call.head;
 
-        let config = stack.get_config()?;
-
         let path = call.req::<Spanned<String>>(engine_state, stack, 0)?;
         let arg_span = path.span;
         let path = Path::new(&path.item);
@@ -98,7 +96,7 @@ impl Command for Save {
                 v => Err(ShellError::UnsupportedInput(v.get_type().to_string(), span)),
             }
         } else {
-            match input.into_value() {
+            match input.into_value(span) {
                 Value::String { val, .. } => {
                     if let Err(err) = file.write_all(val.as_bytes()) {
                         return Err(ShellError::IOError(err.to_string()));
@@ -115,8 +113,6 @@ impl Command for Save {
                 }
                 v => Err(ShellError::UnsupportedInput(v.get_type().to_string(), span)),
             }
-
-            Ok(PipelineData::new(span))
         }
     }
 }


### PR DESCRIPTION
# Description

The save command stringifies all input before saving it. This is not intended behaviour for binary values. This PR fixes this behaviour and saves binary data directly.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
