### PR TITLE
Added quiet flag rm command #4423

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -244,9 +244,7 @@ fn rm(
                             error: ShellError::SpannedLabeledError(msg, e.to_string(), span),
                         }
                     } else if quiet {
-                        Value::Nothing {
-                            span: Span::new(0, 0),
-                        }
+                        Value::Nothing { span }
                     } else {
                         let val = format!("deleted {:}", f.to_string_lossy());
                         Value::String { val, span }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -215,7 +215,7 @@ fn rm(
                 {
                     let result;
                     #[cfg(feature = "trash-support")]
-                    {
+                    { 
                         use std::io::Error;
                         result = if trash || (rm_always_trash && !permanent) {
                             trash::delete(&f).map_err(|e: trash::Error| {
@@ -242,8 +242,12 @@ fn rm(
                             error: ShellError::SpannedLabeledError(msg, e.to_string(), span),
                         }
                     } else {
-                        let val = format!("deleted {:}", f.to_string_lossy());
-                        Value::String { val, span }
+                        if !force {
+                            let val = format!("deleted {:}", f.to_string_lossy());
+                            Value::String { val, span }
+                        } else {
+                            Value::Nothing { span: Span::new(0, 0) }
+                        }
                     }
                 } else {
                     let msg = format!("Cannot remove {:}. try --recursive", f.to_string_lossy());


### PR DESCRIPTION
#4423 

# Description
Added a "quiet" flag to the rm command. To manage this I return a Value::Nothing struct to return to the map function then filter the "Value::Nothing"s out of the map.

# Tests
All tests are currently passing and other commands used to keep formatting were used
