### PR TITLE
Hide alias

### DIFF
--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -17,11 +17,11 @@ impl Command for Hide {
     }
 
     fn usage(&self) -> &str {
-        "Hide definitions in the current scope"
+        "Hide symbols in the current scope"
     }
 
     fn extra_usage(&self) -> &str {
-        "If there is a definition and an environment variable with the same name in the current scope, first the definition will be hidden, then the environment variable."
+        "Symbols are hidden by priority: First aliases, then custom commands, then environment variables."
     }
 
     fn run(
@@ -67,7 +67,7 @@ impl Command for Hide {
                             overlay.env_var_with_head(name, &import_pattern.head.name)
                         {
                             output.push((name, id));
-                        } else if !overlay.has_decl(name) {
+                        } else if !(overlay.has_alias(name) || overlay.has_decl(name)) {
                             return Err(ShellError::EnvVarNotFoundAtRuntime(
                                 String::from_utf8_lossy(name).into(),
                                 *span,
@@ -84,7 +84,7 @@ impl Command for Hide {
                                 overlay.env_var_with_head(name, &import_pattern.head.name)
                             {
                                 output.push((name, id));
-                            } else if !overlay.has_decl(name) {
+                            } else if !(overlay.has_alias(name) || overlay.has_decl(name)) {
                                 return Err(ShellError::EnvVarNotFoundAtRuntime(
                                     String::from_utf8_lossy(name).into(),
                                     *span,

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -82,9 +82,9 @@ fn get_entries_in_aliases(engine_state: &EngineState, name: &str, span: Span) ->
         .into_iter()
         .map(|spans| {
             spans
-                .into_iter()
+                .iter()
                 .map(|span| {
-                    String::from_utf8_lossy(engine_state.get_span_contents(&span)).to_string()
+                    String::from_utf8_lossy(engine_state.get_span_contents(span)).to_string()
                 })
                 .join(" ")
         })

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -945,9 +945,10 @@ pub fn eval_variable(
                     commands.push(Value::Record { cols, vals, span })
                 }
 
-                for alias in &frame.aliases {
+                for (alias_name, alias_id) in &frame.aliases {
+                    let alias = engine_state.get_alias(*alias_id);
                     let mut alias_text = String::new();
-                    for span in alias.1 {
+                    for span in alias {
                         let contents = engine_state.get_span_contents(span);
                         if !alias_text.is_empty() {
                             alias_text.push(' ');
@@ -956,7 +957,7 @@ pub fn eval_variable(
                     }
                     aliases.push((
                         Value::String {
-                            val: String::from_utf8_lossy(alias.0).to_string(),
+                            val: String::from_utf8_lossy(alias_name).to_string(),
                             span,
                         },
                         Value::string(alias_text, span),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1361,7 +1361,9 @@ pub fn parse_hide(
                     let mut aliases = vec![];
                     let mut decls = vec![];
 
-                    if let Some(item) = overlay.alias_name_with_head(name, &import_pattern.head.name) {
+                    if let Some(item) =
+                        overlay.alias_name_with_head(name, &import_pattern.head.name)
+                    {
                         aliases.push(item);
                     } else if let Some(item) =
                         overlay.decl_name_with_head(name, &import_pattern.head.name)
@@ -1378,7 +1380,8 @@ pub fn parse_hide(
                     let mut decls = vec![];
 
                     for (name, span) in names {
-                        if let Some(item) = overlay.alias_name_with_head(name, &import_pattern.head.name)
+                        if let Some(item) =
+                            overlay.alias_name_with_head(name, &import_pattern.head.name)
                         {
                             aliases.push(item);
                         } else if let Some(item) =

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -828,8 +828,10 @@ pub fn parse_call(
 
         if expand_aliases {
             // If the word is an alias, expand it and re-parse the expression
-            if let Some(expansion) = working_set.find_alias(&name) {
+            if let Some(alias_id) = working_set.find_alias(&name) {
                 trace!("expanding alias");
+
+                let expansion = working_set.get_alias(alias_id);
 
                 let orig_span = spans[pos];
                 let mut new_spans: Vec<Span> = vec![];

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -50,6 +50,7 @@ impl Visibility {
     fn merge_with(&mut self, other: Visibility) {
         // overwrite own values with the other
         self.decl_ids.extend(other.decl_ids);
+        self.alias_ids.extend(other.alias_ids);
         // self.env_var_ids.extend(other.env_var_ids);
     }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -205,6 +205,7 @@ impl EngineState {
         self.files.extend(delta.files);
         self.file_contents.extend(delta.file_contents);
         self.decls.extend(delta.decls);
+        self.aliases.extend(delta.aliases);
         self.vars.extend(delta.vars);
         self.blocks.extend(delta.blocks);
         self.overlays.extend(delta.overlays);

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -468,7 +468,7 @@ impl EngineState {
     pub fn get_alias(&self, alias_id: AliasId) -> &[Span] {
         self.aliases
             .get(alias_id)
-            .expect("internal error: missing declaration")
+            .expect("internal error: missing alias")
             .as_ref()
     }
 
@@ -1147,7 +1147,7 @@ impl<'a> StateWorkingSet<'a> {
             self.delta
                 .aliases
                 .get(alias_id - num_permanent_aliases)
-                .expect("internal error: missing declaration")
+                .expect("internal error: missing alias")
                 .as_ref()
         }
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1,7 +1,7 @@
 use super::{Command, Stack};
 use crate::{
-    ast::Block, AliasId, BlockId, DeclId, Example, Overlay, OverlayId, ShellError, Signature, Span, Type,
-    VarId,
+    ast::Block, AliasId, BlockId, DeclId, Example, Overlay, OverlayId, ShellError, Signature, Span,
+    Type, VarId,
 };
 use core::panic;
 use std::{
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone)]
 struct Visibility {
     decl_ids: HashMap<DeclId, bool>,
-    alias_ids: HashMap<AliasId, bool>
+    alias_ids: HashMap<AliasId, bool>,
 }
 
 impl Visibility {
@@ -802,7 +802,7 @@ impl<'a> StateWorkingSet<'a> {
         let mut visibility: Visibility = Visibility::new();
 
         // Since we can mutate scope frames in delta, remove the id directly
-for scope in self.delta.scope.iter_mut().rev() {
+        for scope in self.delta.scope.iter_mut().rev() {
             visibility.append(&scope.visibility);
 
             if let Some(decl_id) = scope.decls.remove(name) {
@@ -868,13 +868,13 @@ for scope in self.delta.scope.iter_mut().rev() {
 
     pub fn hide_decls(&mut self, decls: &[Vec<u8>]) {
         for decl in decls.iter() {
-            self.hide_decl(&decl); // let's assume no errors
+            self.hide_decl(decl); // let's assume no errors
         }
     }
 
     pub fn hide_aliases(&mut self, aliases: &[Vec<u8>]) {
         for alias in aliases.iter() {
-            self.hide_alias(&alias); // let's assume no errors
+            self.hide_alias(alias); // let's assume no errors
         }
     }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -43,8 +43,8 @@ impl Visibility {
         self.decl_ids.insert(*decl_id, true);
     }
 
-    fn use_alias_id(&mut self, alias_id: &DeclId) {
-        self.decl_ids.insert(*alias_id, true);
+    fn use_alias_id(&mut self, alias_id: &AliasId) {
+        self.alias_ids.insert(*alias_id, true);
     }
 
     fn merge_with(&mut self, other: Visibility) {

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -1,4 +1,5 @@
 pub type VarId = usize;
 pub type DeclId = usize;
+pub type AliasId = usize;
 pub type BlockId = usize;
 pub type OverlayId = usize;

--- a/crates/nu-protocol/src/overlay.rs
+++ b/crates/nu-protocol/src/overlay.rs
@@ -1,4 +1,4 @@
-use crate::{BlockId, DeclId, Span};
+use crate::{AliasId, BlockId, DeclId, Span};
 
 use indexmap::IndexMap;
 
@@ -9,6 +9,7 @@ use indexmap::IndexMap;
 #[derive(Debug, Clone)]
 pub struct Overlay {
     pub decls: IndexMap<Vec<u8>, DeclId>,
+    pub aliases: IndexMap<Vec<u8>, AliasId>,
     pub env_vars: IndexMap<Vec<u8>, BlockId>,
     pub span: Option<Span>,
 }
@@ -17,6 +18,7 @@ impl Overlay {
     pub fn new() -> Self {
         Overlay {
             decls: IndexMap::new(),
+            aliases: IndexMap::new(),
             env_vars: IndexMap::new(),
             span: None,
         }
@@ -25,6 +27,7 @@ impl Overlay {
     pub fn from_span(span: Span) -> Self {
         Overlay {
             decls: IndexMap::new(),
+            aliases: IndexMap::new(),
             env_vars: IndexMap::new(),
             span: Some(span),
         }
@@ -32,6 +35,10 @@ impl Overlay {
 
     pub fn add_decl(&mut self, name: &[u8], decl_id: DeclId) -> Option<DeclId> {
         self.decls.insert(name.to_vec(), decl_id)
+    }
+
+    pub fn add_alias(&mut self, name: &[u8], alias_id: AliasId) -> Option<AliasId> {
+        self.aliases.insert(name.to_vec(), alias_id)
     }
 
     pub fn add_env_var(&mut self, name: &[u8], block_id: BlockId) -> Option<BlockId> {
@@ -51,16 +58,35 @@ impl Overlay {
         self.decls.get(name).copied()
     }
 
+    pub fn get_alias_id(&self, name: &[u8]) -> Option<AliasId> {
+        self.aliases.get(name).copied()
+    }
+
     pub fn has_decl(&self, name: &[u8]) -> bool {
         self.decls.contains_key(name)
     }
 
-    pub fn decl_with_head(&self, name: &[u8], head: &[u8]) -> Option<(Vec<u8>, DeclId)> {
-        if let Some(id) = self.get_decl_id(name) {
+    pub fn has_alias(&self, name: &[u8]) -> bool {
+        self.aliases.contains_key(name)
+    }
+
+    pub fn decl_name_with_head(&self, name: &[u8], head: &[u8]) -> Option<Vec<u8>> {
+        if self.has_decl(name) {
             let mut new_name = head.to_vec();
             new_name.push(b' ');
             new_name.extend(name);
-            Some((new_name, id))
+            Some(new_name)
+        } else {
+            None
+        }
+    }
+
+    pub fn alias_name_with_head(&self, name: &[u8], head: &[u8]) -> Option<Vec<u8>> {
+        if self.has_alias(name) {
+            let mut new_name = head.to_vec();
+            new_name.push(b' ');
+            new_name.extend(name);
+            Some(new_name)
         } else {
             None
         }
@@ -78,8 +104,47 @@ impl Overlay {
             .collect()
     }
 
+    pub fn decl_names_with_head(&self, head: &[u8]) -> Vec<Vec<u8>> {
+        self.decls
+            .keys()
+            .map(|name| {
+                let mut new_name = head.to_vec();
+                new_name.push(b' ');
+                new_name.extend(name);
+                new_name
+            })
+            .collect()
+    }
+
+    pub fn alias_names_with_head(&self, head: &[u8]) -> Vec<Vec<u8>> {
+        self.aliases
+            .keys()
+            .map(|name| {
+                let mut new_name = head.to_vec();
+                new_name.push(b' ');
+                new_name.extend(name);
+                new_name
+            })
+            .collect()
+    }
+
     pub fn decls(&self) -> Vec<(Vec<u8>, DeclId)> {
         self.decls
+            .iter()
+            .map(|(name, id)| (name.clone(), *id))
+            .collect()
+    }
+
+    pub fn decl_names(&self) -> Vec<Vec<u8>> {
+        self.decls.keys().cloned().collect()
+    }
+
+    pub fn alias_names(&self) -> Vec<Vec<u8>> {
+        self.aliases.keys().cloned().collect()
+    }
+
+    pub fn aliases(&self) -> Vec<(Vec<u8>, AliasId)> {
+        self.aliases
             .iter()
             .map(|(name, id)| (name.clone(), *id))
             .collect()

--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -10,6 +10,14 @@ fn hides_def() -> TestResult {
 }
 
 #[test]
+fn hides_alias() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; hide foo; foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
 fn hides_env() -> TestResult {
     fail_test(r#"let-env foo = "foo"; hide foo; $env.foo"#, "did you mean")
 }
@@ -21,6 +29,14 @@ fn hides_def_then_redefines() -> TestResult {
     fail_test(
         r#"def foo [] { "foo" }; hide foo; def foo [] { "bar" }; foo"#,
         "defined more than once",
+    )
+}
+
+#[test]
+fn hides_alias_then_redefines() -> TestResult {
+    run_test(
+        r#"alias foo = echo "foo"; hide foo; alias foo = echo "foo"; foo"#,
+        "foo",
     )
 }
 
@@ -60,6 +76,38 @@ fn hides_def_in_scope_3() -> TestResult {
 fn hides_def_in_scope_4() -> TestResult {
     fail_test(
         r#"def foo [] { "foo" }; do { def foo [] { "bar" }; hide foo; hide foo; foo }"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_in_scope_1() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; do { hide foo; foo }"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_in_scope_2() -> TestResult {
+    run_test(
+        r#"alias foo = echo "foo"; do { alias foo = echo "bar"; hide foo; foo }"#,
+        "foo",
+    )
+}
+
+#[test]
+fn hides_alias_in_scope_3() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; do { hide foo; alias foo = echo "bar"; hide foo; foo }"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_in_scope_4() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; do { alias foo = echo "bar"; hide foo; hide foo; foo }"#,
         "", // we just care if it errors
     )
 }
@@ -105,6 +153,14 @@ fn hide_def_twice_not_allowed() -> TestResult {
 }
 
 #[test]
+fn hide_alias_twice_not_allowed() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; hide foo; hide foo"#,
+        "did not find",
+    )
+}
+
+#[test]
 fn hide_env_twice_not_allowed() -> TestResult {
     fail_test(r#"let-env foo = "foo"; hide foo; hide foo"#, "did not find")
 }
@@ -126,10 +182,66 @@ fn hides_def_runs_env_2() -> TestResult {
 }
 
 #[test]
+fn hides_alias_runs_def_1() -> TestResult {
+    run_test(
+        r#"def foo [] { "bar" }; alias foo = echo "foo"; hide foo; foo"#,
+        "bar",
+    )
+}
+
+#[test]
+fn hides_alias_runs_def_2() -> TestResult {
+    run_test(
+        r#"alias foo = echo "foo"; def foo [] { "bar" }; hide foo; foo"#,
+        "bar",
+    )
+}
+
+#[test]
+fn hides_alias_runs_env_1() -> TestResult {
+    run_test(
+        r#"let-env foo = "bar"; alias foo = echo "foo"; hide foo; $env.foo"#,
+        "bar",
+    )
+}
+
+#[test]
+fn hides_alias_runs_env_2() -> TestResult {
+    run_test(
+        r#"alias foo = echo "foo"; let-env foo = "bar"; hide foo; $env.foo"#,
+        "bar",
+    )
+}
+
+#[test]
 fn hides_def_and_env() -> TestResult {
     fail_test(
         r#"let-env foo = "bar"; def foo [] { "foo" }; hide foo; hide foo; $env.foo"#,
         "did you mean",
+    )
+}
+
+#[test]
+fn hides_alias_and_def() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; def foo [] { "bar" }; hide foo; hide foo; foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_def_and_env_1() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; def foo [] { "foo" }; let-env foo = "bar"; hide foo; hide foo; hide foo; $env.foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_def_and_env_2() -> TestResult {
+    fail_test(
+        r#"alias foo = echo "foo"; def foo [] { "foo" }; let-env foo = "bar"; hide foo; hide foo; hide foo; foo"#,
+        "", // we just care if it errors
     )
 }
 


### PR DESCRIPTION
# Description

Adds ability to `hide alias` as a replacement for `unalias`.

It follows identical code paths as hiding decls and paves a way towards exporting aliases from modules.

Also some minor cleanups.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
