### PR TITLE
feat: add unalias to deprecated command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -357,6 +357,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             StrDecimalDeprecated,
             StrIntDeprecated,
             NthDeprecated,
+            UnaliasDeprecated,
         };
 
         #[cfg(feature = "dataframe")]

--- a/crates/nu-command/src/deprecated/mod.rs
+++ b/crates/nu-command/src/deprecated/mod.rs
@@ -3,12 +3,14 @@ mod nth;
 mod pivot;
 mod str_decimal;
 mod str_int;
+mod unalias;
 
 pub use insert::InsertDeprecated;
 pub use nth::NthDeprecated;
 pub use pivot::PivotDeprecated;
 pub use str_decimal::StrDecimalDeprecated;
 pub use str_int::StrIntDeprecated;
+pub use unalias::UnaliasDeprecated;
 
 #[cfg(feature = "dataframe")]
 mod dataframe;

--- a/crates/nu-command/src/deprecated/unalias.rs
+++ b/crates/nu-command/src/deprecated/unalias.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct UnaliasDeprecated;
+
+impl Command for UnaliasDeprecated {
+    fn name(&self) -> &str {
+        "unalias"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "hide".to_string(),
+            call.head,
+        ))
+    }
+}


### PR DESCRIPTION
# Description

mark `unalias` as deprecated command 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
