### PR TITLE
tweak plugin names in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,23 +98,23 @@ opt-level = "s" # Optimize for size
 
 # Build plugins
 [[bin]]
-name = "nu_plugin_inc"
+name = "nu_plugin_core_inc"
 path = "src/plugins/nu_plugin_core_inc.rs"
 required-features = ["inc"]
 
 [[bin]]
-name = "nu_plugin_example"
+name = "nu_plugin_core_example"
 path = "src/plugins/nu_plugin_core_example.rs"
 required-features = ["example"]
 
 # Extra plugins
 [[bin]]
-name = "nu_plugin_gstat"
+name = "nu_plugin_extra_gstat"
 path = "src/plugins/nu_plugin_extra_gstat.rs"
 required-features = ["gstat"]
 
 [[bin]]
-name = "nu_plugin_query"
+name = "nu_plugin_extra_query"
 path = "src/plugins/nu_plugin_extra_query.rs"
 required-features = ["query"]
 

--- a/Cargo.toml.old
+++ b/Cargo.toml.old
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nu"
 readme = "README.md"
 repository = "https://github.com/nushell/nushell"
-version = "0.59.0"
+version = "0.44.0"
 
 [workspace]
 members = ["crates/*/"]
@@ -18,34 +18,34 @@ members = ["crates/*/"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-cli = { version = "0.59.0", path="./crates/nu-cli", default-features=false }
-nu-command = { version = "0.59.0", path="./crates/nu-command" }
-nu-completion = { version = "0.59.0", path="./crates/nu-completion" }
-nu-data = { version = "0.59.0", path="./crates/nu-data" }
-nu-engine = { version = "0.59.0", path="./crates/nu-engine" }
-nu-errors = { version = "0.59.0", path="./crates/nu-errors" }
-nu-parser = { version = "0.59.0", path="./crates/nu-parser" }
-nu-path = { version = "0.59.0", path="./crates/nu-path" }
-nu-plugin = { version = "0.59.0", path="./crates/nu-plugin" }
-nu-protocol = { version = "0.59.0", path="./crates/nu-protocol" }
-nu-source = { version = "0.59.0", path="./crates/nu-source" }
-nu-value-ext = { version = "0.59.0", path="./crates/nu-value-ext" }
+nu-cli = { version = "0.44.0", path="./crates/nu-cli", default-features=false }
+nu-command = { version = "0.44.0", path="./crates/nu-command" }
+nu-completion = { version = "0.44.0", path="./crates/nu-completion" }
+nu-data = { version = "0.44.0", path="./crates/nu-data" }
+nu-engine = { version = "0.44.0", path="./crates/nu-engine" }
+nu-errors = { version = "0.44.0", path="./crates/nu-errors" }
+nu-parser = { version = "0.44.0", path="./crates/nu-parser" }
+nu-path = { version = "0.44.0", path="./crates/nu-path" }
+nu-plugin = { version = "0.44.0", path="./crates/nu-plugin" }
+nu-protocol = { version = "0.44.0", path="./crates/nu-protocol" }
+nu-source = { version = "0.44.0", path="./crates/nu-source" }
+nu-value-ext = { version = "0.44.0", path="./crates/nu-value-ext" }
 
-# nu_plugin_binaryview = { version = "0.59.0", path="./crates/nu_plugin_binaryview", optional=true }
-# nu_plugin_chart = { version = "0.59.0", path="./crates/nu_plugin_chart", optional=true }
-# nu_plugin_from_bson = { version = "0.59.0", path="./crates/nu_plugin_from_bson", optional=true }
-# nu_plugin_from_sqlite = { version = "0.59.0", path="./crates/nu_plugin_from_sqlite", optional=true }
-# nu_plugin_inc = { version = "0.59.0", path="./crates/nu_plugin_inc", optional=true }
-# nu_plugin_match = { version = "0.59.0", path="./crates/nu_plugin_match", optional=true }
-# nu_plugin_query_json = { version = "0.59.0", path="./crates/nu_plugin_query_json", optional=true }
-# nu_plugin_s3 = { version = "0.59.0", path="./crates/nu_plugin_s3", optional=true }
-# nu_plugin_selector = { version = "0.59.0", path="./crates/nu_plugin_selector", optional=true }
-# nu_plugin_start = { version = "0.59.0", path="./crates/nu_plugin_start", optional=true }
-# nu_plugin_textview = { version = "0.59.0", path="./crates/nu_plugin_textview", optional=true }
-# nu_plugin_to_bson = { version = "0.59.0", path="./crates/nu_plugin_to_bson", optional=true }
-# nu_plugin_to_sqlite = { version = "0.59.0", path="./crates/nu_plugin_to_sqlite", optional=true }
-# nu_plugin_tree = { version = "0.59.0", path="./crates/nu_plugin_tree", optional=true }
-# nu_plugin_xpath = { version = "0.59.0", path="./crates/nu_plugin_xpath", optional=true }
+nu_plugin_binaryview = { version = "0.44.0", path="./crates/nu_plugin_binaryview", optional=true }
+nu_plugin_chart = { version = "0.44.0", path="./crates/nu_plugin_chart", optional=true }
+nu_plugin_from_bson = { version = "0.44.0", path="./crates/nu_plugin_from_bson", optional=true }
+nu_plugin_from_sqlite = { version = "0.44.0", path="./crates/nu_plugin_from_sqlite", optional=true }
+nu_plugin_inc = { version = "0.44.0", path="./crates/nu_plugin_inc", optional=true }
+nu_plugin_match = { version = "0.44.0", path="./crates/nu_plugin_match", optional=true }
+nu_plugin_query_json = { version = "0.44.0", path="./crates/nu_plugin_query_json", optional=true }
+nu_plugin_s3 = { version = "0.44.0", path="./crates/nu_plugin_s3", optional=true }
+nu_plugin_selector = { version = "0.44.0", path="./crates/nu_plugin_selector", optional=true }
+nu_plugin_start = { version = "0.44.0", path="./crates/nu_plugin_start", optional=true }
+nu_plugin_textview = { version = "0.44.0", path="./crates/nu_plugin_textview", optional=true }
+nu_plugin_to_bson = { version = "0.44.0", path="./crates/nu_plugin_to_bson", optional=true }
+nu_plugin_to_sqlite = { version = "0.44.0", path="./crates/nu_plugin_to_sqlite", optional=true }
+nu_plugin_tree = { version = "0.44.0", path="./crates/nu_plugin_tree", optional=true }
+nu_plugin_xpath = { version = "0.44.0", path="./crates/nu_plugin_xpath", optional=true }
 
 # Required to bootstrap the main binary
 ctrlc = { version="3.1.7", optional=true }
@@ -53,7 +53,7 @@ futures = { version="0.3.12", features=["compat", "io-compat"] }
 itertools = "0.10.0"
 
 [dev-dependencies]
-nu-test-support = { version = "0.59.0", path="./crates/nu-test-support" }
+nu-test-support = { version = "0.44.0", path="./crates/nu-test-support" }
 serial_test = "0.5.1"
 hamcrest2 = "0.3.0"
 rstest = "0.10.0"
@@ -76,7 +76,7 @@ default = [
     "which-support",
     "term-support",
     "rustyline-support",
-    # "match",
+    "match",
     "fetch-support",
     "zip-support",
     "dataframe",
@@ -85,44 +85,44 @@ default = [
 stable = ["default"]
 extra = [
     "default",
-    # "binaryview",
-    # "inc",
-    # "tree",
-    # "textview",
+    "binaryview",
+    "inc",
+    "tree",
+    "textview",
     "trash-support",
     "uuid-support",
-    # "start",
-    # "bson",
-    # "sqlite",
-    # "s3",
-    # "chart",
-    # "xpath",
-    # "selector",
-    # "query-json",
+    "start",
+    "bson",
+    "sqlite",
+    "s3",
+    "chart",
+    "xpath",
+    "selector",
+    "query-json",
 ]
 
-# wasi = ["inc", "match", "match", "tree", "rustyline-support"]
+wasi = ["inc", "match", "match", "tree", "rustyline-support"]
 
 # Stable (Default)
-# inc = ["nu_plugin_inc"]
-# match = ["nu_plugin_match"]
-# textview = ["nu_plugin_textview"]
+inc = ["nu_plugin_inc"]
+match = ["nu_plugin_match"]
+textview = ["nu_plugin_textview"]
 
 # Extra
-# binaryview = ["nu_plugin_binaryview"]
-# bson = ["nu_plugin_from_bson", "nu_plugin_to_bson"]
-# chart = ["nu_plugin_chart"]
-# query-json = ["nu_plugin_query_json"]
-# s3 = ["nu_plugin_s3"]
-# selector = ["nu_plugin_selector"]
-# sqlite = ["nu_plugin_from_sqlite", "nu_plugin_to_sqlite"]
-# start = ["nu_plugin_start"]
+binaryview = ["nu_plugin_binaryview"]
+bson = ["nu_plugin_from_bson", "nu_plugin_to_bson"]
+chart = ["nu_plugin_chart"]
+query-json = ["nu_plugin_query_json"]
+s3 = ["nu_plugin_s3"]
+selector = ["nu_plugin_selector"]
+sqlite = ["nu_plugin_from_sqlite", "nu_plugin_to_sqlite"]
+start = ["nu_plugin_start"]
 trash-support = [
     "nu-command/trash-support",
     "nu-engine/trash-support",
 ]
-# tree = ["nu_plugin_tree"]
-# xpath = ["nu_plugin_xpath"]
+tree = ["nu_plugin_tree"]
+xpath = ["nu_plugin_xpath"]
 zip-support = ["nu-command/zip"]
 
 #dataframe feature for nushell
@@ -132,7 +132,7 @@ dataframe = [
     "nu-command/dataframe",
     "nu-value-ext/dataframe",
     "nu-data/dataframe",
-    # "nu_plugin_to_bson/dataframe",
+    "nu_plugin_to_bson/dataframe",
 ]
 
 [profile.release]
@@ -141,88 +141,88 @@ opt-level = "s"  # Optimize for size.
 # Core plugins that ship with `cargo install nu` by default
 # Currently, Cargo limits us to installing only one binary
 # unless we use [[bin]], so we use this as a workaround
-# [[bin]]
-# name = "nu_plugin_core_textview"
-# path = "src/plugins/nu_plugin_core_textview.rs"
-# required-features = ["textview"]
-# 
-# [[bin]]
-# name = "nu_plugin_core_inc"
-# path = "src/plugins/nu_plugin_core_inc.rs"
-# required-features = ["inc"]
-# 
-# [[bin]]
-# name = "nu_plugin_core_match"
-# path = "src/plugins/nu_plugin_core_match.rs"
-# required-features = ["match"]
-# 
-# # Extra plugins
-# 
-# [[bin]]
-# name = "nu_plugin_extra_binaryview"
-# path = "src/plugins/nu_plugin_extra_binaryview.rs"
-# required-features = ["binaryview"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_tree"
-# path = "src/plugins/nu_plugin_extra_tree.rs"
-# required-features = ["tree"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_query_json"
-# path = "src/plugins/nu_plugin_extra_query_json.rs"
-# required-features = ["query-json"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_start"
-# path = "src/plugins/nu_plugin_extra_start.rs"
-# required-features = ["start"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_s3"
-# path = "src/plugins/nu_plugin_extra_s3.rs"
-# required-features = ["s3"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_chart_bar"
-# path = "src/plugins/nu_plugin_extra_chart_bar.rs"
-# required-features = ["chart"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_chart_line"
-# path = "src/plugins/nu_plugin_extra_chart_line.rs"
-# required-features = ["chart"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_xpath"
-# path = "src/plugins/nu_plugin_extra_xpath.rs"
-# required-features = ["xpath"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_selector"
-# path = "src/plugins/nu_plugin_extra_selector.rs"
-# required-features = ["selector"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_from_bson"
-# path = "src/plugins/nu_plugin_extra_from_bson.rs"
-# required-features = ["bson"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_to_bson"
-# path = "src/plugins/nu_plugin_extra_to_bson.rs"
-# required-features = ["bson"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_from_sqlite"
-# path = "src/plugins/nu_plugin_extra_from_sqlite.rs"
-# required-features = ["sqlite"]
-# 
-# [[bin]]
-# name = "nu_plugin_extra_to_sqlite"
-# path = "src/plugins/nu_plugin_extra_to_sqlite.rs"
-# required-features = ["sqlite"]
-# 
+[[bin]]
+name = "nu_plugin_core_textview"
+path = "src/plugins/nu_plugin_core_textview.rs"
+required-features = ["textview"]
+
+[[bin]]
+name = "nu_plugin_core_inc"
+path = "src/plugins/nu_plugin_core_inc.rs"
+required-features = ["inc"]
+
+[[bin]]
+name = "nu_plugin_core_match"
+path = "src/plugins/nu_plugin_core_match.rs"
+required-features = ["match"]
+
+# Extra plugins
+
+[[bin]]
+name = "nu_plugin_extra_binaryview"
+path = "src/plugins/nu_plugin_extra_binaryview.rs"
+required-features = ["binaryview"]
+
+[[bin]]
+name = "nu_plugin_extra_tree"
+path = "src/plugins/nu_plugin_extra_tree.rs"
+required-features = ["tree"]
+
+[[bin]]
+name = "nu_plugin_extra_query_json"
+path = "src/plugins/nu_plugin_extra_query_json.rs"
+required-features = ["query-json"]
+
+[[bin]]
+name = "nu_plugin_extra_start"
+path = "src/plugins/nu_plugin_extra_start.rs"
+required-features = ["start"]
+
+[[bin]]
+name = "nu_plugin_extra_s3"
+path = "src/plugins/nu_plugin_extra_s3.rs"
+required-features = ["s3"]
+
+[[bin]]
+name = "nu_plugin_extra_chart_bar"
+path = "src/plugins/nu_plugin_extra_chart_bar.rs"
+required-features = ["chart"]
+
+[[bin]]
+name = "nu_plugin_extra_chart_line"
+path = "src/plugins/nu_plugin_extra_chart_line.rs"
+required-features = ["chart"]
+
+[[bin]]
+name = "nu_plugin_extra_xpath"
+path = "src/plugins/nu_plugin_extra_xpath.rs"
+required-features = ["xpath"]
+
+[[bin]]
+name = "nu_plugin_extra_selector"
+path = "src/plugins/nu_plugin_extra_selector.rs"
+required-features = ["selector"]
+
+[[bin]]
+name = "nu_plugin_extra_from_bson"
+path = "src/plugins/nu_plugin_extra_from_bson.rs"
+required-features = ["bson"]
+
+[[bin]]
+name = "nu_plugin_extra_to_bson"
+path = "src/plugins/nu_plugin_extra_to_bson.rs"
+required-features = ["bson"]
+
+[[bin]]
+name = "nu_plugin_extra_from_sqlite"
+path = "src/plugins/nu_plugin_extra_from_sqlite.rs"
+required-features = ["sqlite"]
+
+[[bin]]
+name = "nu_plugin_extra_to_sqlite"
+path = "src/plugins/nu_plugin_extra_to_sqlite.rs"
+required-features = ["sqlite"]
+
 # Main nu binary
 [[bin]]
 name = "nu"

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -255,7 +255,7 @@
                                 DiskId='1'
                                 Source='target\$(var.Profile)\nu_plugin_query_json.exe'
                                 KeyPath='yes'/>
-                        </Component> -->
+                        </Component> 
                         <Component Id='binary21' Guid='*' Win64='$(var.Win64)'>
                             <File
                                 Id='exe21'
@@ -263,7 +263,7 @@
                                 DiskId='1'
                                 Source='target\$(var.Profile)\nu_plugin_example.exe'
                                 KeyPath='yes'/>
-                        </Component>
+                        </Component> -->
                         <Component Id='binary22' Guid='*' Win64='$(var.Win64)'>
                             <File
                                 Id='exe22'
@@ -312,8 +312,8 @@
             <ComponentRef Id='binary17'/>
             <ComponentRef Id='binary18'/>
             <ComponentRef Id='binary19'/>
-            <ComponentRef Id='binary20'/> -->
-            <ComponentRef Id='binary21'/>
+            <ComponentRef Id='binary20'/> 
+            <ComponentRef Id='binary21'/> -->
             <ComponentRef Id='binary22'/>
 
             <Feature


### PR DESCRIPTION
# Description

* tweaked wix for the 3rd time
* restored cargo.toml.old so it's easier to read
* removed nu_plugin_example from the release

  
# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
