### PR TITLE
Fixed printing of builtin kill command #4392

### DIFF
--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{ast::Call, span};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
     Value,
 };
 use std::process::{Command as CommandSys, Stdio};
@@ -128,9 +128,15 @@ impl Command for Kill {
                 .stderr(Stdio::null());
         }
 
-        cmd.status().expect("failed to execute shell command");
-
-        Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+        let output = cmd.output().expect("failed to execute shell command");
+        let val = String::from(String::from_utf8(output.stdout).unwrap().trim_end());
+        
+        if val.is_empty() {
+            Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+        } else {
+            Ok(vec![Value::String { val, span: call.head, }].into_iter().into_pipeline_data(engine_state.ctrlc.clone()))
+        }
+        
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -128,7 +128,7 @@ impl Command for Kill {
                 .stderr(Stdio::null());
         }
 
-        cmd.status().expect("failed to execute shell command");
+        let output = cmd.output().expect("failed to execute shell command");
         let val = String::from(String::from_utf8(output.stdout).expect("failed to convert output to string").trim_end());
         if val.is_empty() {
             Ok(Value::Nothing { span: call.head }.into_pipeline_data())

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -129,17 +129,17 @@ impl Command for Kill {
         }
 
         cmd.status().expect("failed to execute shell command");
-        // let val = String::from(String::from_utf8(output.stdout).expect("failed to convert output to string").trim_end());
-        //if val.is_empty() {
+        let val = String::from(String::from_utf8(output.stdout).expect("failed to convert output to string").trim_end());
+        if val.is_empty() {
             Ok(Value::Nothing { span: call.head }.into_pipeline_data())
-        // } else {
-        //     Ok(vec![Value::String {
-        //         val,
-        //         span: call.head,
-        //     }]
-        //     .into_iter()
-        //     .into_pipeline_data(engine_state.ctrlc.clone()))
-        // }
+        } else {
+            Ok(vec![Value::String {
+                val,
+                span: call.head,
+            }]
+            .into_iter()
+            .into_pipeline_data(engine_state.ctrlc.clone()))
+        }
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -2,8 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{ast::Call, span};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
-    Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
+    Signature, Spanned, SyntaxShape, Value,
 };
 use std::process::{Command as CommandSys, Stdio};
 
@@ -128,15 +128,18 @@ impl Command for Kill {
                 .stderr(Stdio::null());
         }
 
-        let output = cmd.output().expect("failed to execute shell command");
-        let val = String::from(String::from_utf8(output.stdout).unwrap().trim_end());
-        
-        if val.is_empty() {
+        cmd.status().expect("failed to execute shell command");
+        // let val = String::from(String::from_utf8(output.stdout).expect("failed to convert output to string").trim_end());
+        //if val.is_empty() {
             Ok(Value::Nothing { span: call.head }.into_pipeline_data())
-        } else {
-            Ok(vec![Value::String { val, span: call.head, }].into_iter().into_pipeline_data(engine_state.ctrlc.clone()))
-        }
-        
+        // } else {
+        //     Ok(vec![Value::String {
+        //         val,
+        //         span: call.head,
+        //     }]
+        //     .into_iter()
+        //     .into_pipeline_data(engine_state.ctrlc.clone()))
+        // }
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
#4392

# Description

Fixed the implementation of `kill` to display the output correctly
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass

Unfortunately there seems to be 17 failing tests but appears to be my machine is causing the problem, all tests pass on WSL2 Ubuntu machine