### PR TITLE
feat: mark str to-datetime as deprecated command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -354,6 +354,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         bind_command! {
             InsertDeprecated,
             PivotDeprecated,
+            StrDatetimeDeprecated,
             StrDecimalDeprecated,
             StrIntDeprecated,
             NthDeprecated,

--- a/crates/nu-command/src/deprecated/mod.rs
+++ b/crates/nu-command/src/deprecated/mod.rs
@@ -1,6 +1,7 @@
 mod insert;
 mod nth;
 mod pivot;
+mod str_datetime;
 mod str_decimal;
 mod str_int;
 mod unalias;
@@ -8,6 +9,7 @@ mod unalias;
 pub use insert::InsertDeprecated;
 pub use nth::NthDeprecated;
 pub use pivot::PivotDeprecated;
+pub use str_datetime::StrDatetimeDeprecated;
 pub use str_decimal::StrDecimalDeprecated;
 pub use str_int::StrIntDeprecated;
 pub use unalias::UnaliasDeprecated;

--- a/crates/nu-command/src/deprecated/str_datetime.rs
+++ b/crates/nu-command/src/deprecated/str_datetime.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct StrDatetimeDeprecated;
+
+impl Command for StrDatetimeDeprecated {
+    fn name(&self) -> &str {
+        "str to-datetime"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "into datetime".to_string(),
+            call.head,
+        ))
+    }
+}


### PR DESCRIPTION
# Description

Mark str to-datetime as deprecated command
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
