### PR TITLE
fix case insensitive sort

### DIFF
--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -144,8 +144,19 @@ pub fn sort(
             vals: _input_vals,
             ..
         } => {
+            if columns.is_empty() {
+                println!("sort-by requires a column name to sort table data");
+                return Err(ShellError::CantFindColumn(call.head, call.head));
+            }
+
+            if column_does_not_exist(columns.clone(), cols.to_vec()) {
+                return Err(ShellError::CantFindColumn(call.head, call.head));
+            }
+
             // check to make sure each value in each column in the record
-            // that we asked for is a string
+            // that we asked for is a string. So, first collect all the columns
+            // that we asked for into vals, then later make sure they're all
+            // strings.
             let mut vals = vec![];
             for item in vec.iter() {
                 for col in &columns {
@@ -161,15 +172,6 @@ pub fn sort(
                 && vals
                     .iter()
                     .all(|x| matches!(x.get_type(), nu_protocol::Type::String));
-
-            if columns.is_empty() {
-                println!("sort-by requires a column name to sort table data");
-                return Err(ShellError::CantFindColumn(call.head, call.head));
-            }
-
-            if column_does_not_exist(columns.clone(), cols.to_vec()) {
-                return Err(ShellError::CantFindColumn(call.head, call.head));
-            }
 
             vec.sort_by(|a, b| {
                 process(

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -113,7 +113,7 @@ fn ls_sort_by_name_insensitive() {
         "#
     ));
 
-    let json_output = r#"[{"name": "B.txt"},{"name": "C"},{"name": "a.txt"}]"#;
+    let json_output = r#"[{"name": "a.txt"},{"name": "B.txt"},{"name": "C"}]"#;
     assert_eq!(actual.out, json_output);
 }
 


### PR DESCRIPTION
# Description

fixed the case-insensitive search for things like `ls | sort name -i`
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
