### PR TITLE
Fix default duplicates column

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -67,9 +67,11 @@ fn default(
                 let mut found = false;
 
                 while idx < cols.len() {
-                    if cols[idx] == column.item && matches!(vals[idx], Value::Nothing { .. }) {
-                        vals[idx] = value.clone();
+                    if cols[idx] == column.item {
                         found = true;
+                        if matches!(vals[idx], Value::Nothing { .. }) {
+                            vals[idx] = value.clone();
+                        }
                     }
                     idx += 1;
                 }

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -233,6 +233,14 @@ fn length_for_rows() -> TestResult {
 }
 
 #[test]
+fn length_defaulted_columns() -> TestResult {
+    run_test(
+        r#"echo [[name, age]; [test, 10]] | default age 11 | get 0 | columns | length"#,
+        "2",
+    )
+}
+
+#[test]
 fn get_fuzzy() -> TestResult {
     run_test("(ls | get -i foo) == $nothing", "true")
 }


### PR DESCRIPTION
# Description

I noticed the `default` command was making a duplicate column when used on an 
already existing column that was only apparent when viewed as a record.

For example, given this record:

```
〉echo [[name, age]; [test, 10]] | get 0 | debug
{name: test, age: 10}
```

If we default the age column, we end up with 2 age columns:

```
〉echo [[name, age]; [test, 10]] | default age 11 | get 0 | debug
{name: test, age: 10, age: 11}
```

This change adds a test for it and a fix, which is to set `found = true` if we find a matching 
column, regardless of if it equals `$nothing` (the conditions needed to be split).

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style (did notice some errors here on nu_json but don't think related)
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
