### PR TITLE
remove ignore for sort_by command test by_column which is now passing

### DIFF
--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -1,7 +1,5 @@
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn by_column() {
     let actual = nu!(


### PR DESCRIPTION

by_column is now passing
I removed the ignore flag...

so the only remaining tests left are the ones

```rust
 assert!(actual.err.contains("some test text in here"));
```
