### PR TITLE
Treat span overlap as span contains

### DIFF
--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -49,7 +49,8 @@ impl Span {
     }
 
     pub fn contains_span(&self, span: Span) -> bool {
-        span.start >= self.start && span.end <= self.end
+        (span.start >= self.start && span.start < self.end)
+            || (span.end >= self.start && span.end < self.end)
     }
 
     /// Point to the space just past this span, useful for missing


### PR DESCRIPTION
# Description

Needs some testing, but I think treating overlap as a span contains will help the alias perform well in more cases.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
