### PR TITLE
Fix more command tests

### DIFF
--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -115,7 +115,15 @@ fn extract_headers(value: &Value, config: &Config) -> Result<Vec<String>, ShellE
     match value {
         Value::Record { vals, .. } => Ok(vals
             .iter()
-            .map(|value| value.into_string("", config))
+            .enumerate()
+            .map(|(idx, value)| {
+                let col = value.into_string("", config);
+                if col.is_empty() {
+                    format!("Column{}", idx)
+                } else {
+                    col
+                }
+            })
             .collect::<Vec<String>>()),
         Value::List { vals, span } => vals
             .iter()

--- a/crates/nu-command/tests/commands/headers.rs
+++ b/crates/nu-command/tests/commands/headers.rs
@@ -1,7 +1,5 @@
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn headers_uses_first_row_as_header() {
     let actual = nu!(
@@ -11,14 +9,12 @@ fn headers_uses_first_row_as_header() {
             | get Sheet1
             | headers
             | get header0
-            | from json"#
+            | to json --raw"#
     ));
 
-    assert_eq!(actual.out, "r1c0r2c0")
+    assert_eq!(actual.out, r#"["r1c0","r2c0"]"#)
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn headers_adds_missing_column_name() {
     let actual = nu!(
@@ -28,8 +24,8 @@ fn headers_adds_missing_column_name() {
             | get Sheet1
             | headers
             | get Column1
-            | from json"#
+            | to json --raw"#
     ));
 
-    assert_eq!(actual.out, "r1c1r2c1")
+    assert_eq!(actual.out, r#"["r1c1","r2c1"]"#)
 }

--- a/crates/nu-command/tests/commands/math/eval.rs
+++ b/crates/nu-command/tests/commands/math/eval.rs
@@ -1,7 +1,5 @@
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn evaluates_two_plus_two() {
     let actual = nu!(
@@ -11,11 +9,9 @@ fn evaluates_two_plus_two() {
         "#
     ));
 
-    assert!(actual.out.contains("4.0"));
+    assert!(actual.out.contains('4'));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn evaluates_two_to_the_power_four() {
     let actual = nu!(
@@ -25,11 +21,9 @@ fn evaluates_two_to_the_power_four() {
         "#
     ));
 
-    assert!(actual.out.contains("16.0"));
+    assert!(actual.out.contains("16"));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn evaluates_three_multiplied_by_five() {
     let actual = nu!(
@@ -39,11 +33,9 @@ fn evaluates_three_multiplied_by_five() {
         "#
     ));
 
-    assert!(actual.out.contains("15.0"));
+    assert!(actual.out.contains("15"));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn evaluates_twenty_four_divided_by_two() {
     let actual = nu!(
@@ -53,7 +45,7 @@ fn evaluates_twenty_four_divided_by_two() {
         "#
     ));
 
-    assert!(actual.out.contains("12.0"));
+    assert!(actual.out.contains("12"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -1,7 +1,5 @@
 use nu_test_support::nu;
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn can_sqrt_numbers() {
     let actual = nu!(
@@ -9,11 +7,9 @@ fn can_sqrt_numbers() {
         "echo [0.25 2 4] | math sqrt | math sum"
     );
 
-    assert_eq!(actual.out, "3.914213562373095048801688724209698078569671875376948073176679737990732478462107038850387534327641573");
+    assert_eq!(actual.out, "3.914213562373095");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn can_sqrt_irrational() {
     let actual = nu!(
@@ -21,7 +17,7 @@ fn can_sqrt_irrational() {
         "echo 2 | math sqrt"
     );
 
-    assert_eq!(actual.out, "1.414213562373095048801688724209698078569671875376948073176679737990732478462107038850387534327641573");
+    assert_eq!(actual.out, "1.4142135623730951");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -75,8 +75,6 @@ fn compute_sum_of_table() -> Result<(), String> {
     Ok(())
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn sum_of_a_row_containing_a_table_is_an_error() {
     let actual = nu!(
@@ -85,5 +83,5 @@ fn sum_of_a_row_containing_a_table_is_an_error() {
     );
     assert!(actual
         .err
-        .contains("Attempted to compute values that can't be operated on"));
+        .contains("Attempted to compute the sum of a value that cannot be summed"));
 }


### PR DESCRIPTION
# Description

Fixes another handful of the command tests (https://github.com/nushell/nushell/issues/4314)
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
