### PR TITLE
Remove statements, replaced by pipelines

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -27,10 +27,6 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::unclosed_delimiter), url(docsrs))]
     Unclosed(String, #[label("unclosed {0}")] Span),
 
-    #[error("Unknown statement.")]
-    #[diagnostic(code(nu::parser::unknown_statement), url(docsrs))]
-    UnknownStatement(#[label("unknown statement")] Span),
-
     #[error("Parse mismatch during operation.")]
     #[diagnostic(code(nu::parser::parse_mismatch), url(docsrs))]
     Expected(String, #[label("expected {0}")] Span),
@@ -73,7 +69,7 @@ pub enum ParseError {
             "'{0}' keyword is not allowed in pipeline. Use '{0}' by itself, outside of a pipeline."
         )
     )]
-    StatementInPipeline(String, #[label("not allowed in pipeline")] Span),
+    BuiltinCommandInPipeline(String, #[label("not allowed in pipeline")] Span),
 
     #[error("Incorrect value")]
     #[diagnostic(code(nu::parser::incorrect_value), url(docsrs), help("{2}"))]

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -1,6 +1,4 @@
-use nu_protocol::ast::{
-    Block, Expr, Expression, ImportPatternMember, PathMember, Pipeline, Statement,
-};
+use nu_protocol::ast::{Block, Expr, Expression, ImportPatternMember, PathMember, Pipeline};
 use nu_protocol::{engine::StateWorkingSet, Span};
 use std::fmt::{Display, Formatter, Result};
 
@@ -63,20 +61,10 @@ impl Display for FlatShape {
 
 pub fn flatten_block(working_set: &StateWorkingSet, block: &Block) -> Vec<(Span, FlatShape)> {
     let mut output = vec![];
-    for stmt in &block.stmts {
-        output.extend(flatten_statement(working_set, stmt));
+    for pipeline in &block.pipelines {
+        output.extend(flatten_pipeline(working_set, pipeline));
     }
     output
-}
-
-pub fn flatten_statement(
-    working_set: &StateWorkingSet,
-    stmt: &Statement,
-) -> Vec<(Span, FlatShape)> {
-    match stmt {
-        Statement::Pipeline(pipeline) => flatten_pipeline(working_set, pipeline),
-        _ => vec![],
-    }
 }
 
 pub fn flatten_expression(

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -8,9 +8,7 @@ mod parser;
 mod type_check;
 
 pub use errors::ParseError;
-pub use flatten::{
-    flatten_block, flatten_expression, flatten_pipeline, flatten_statement, FlatShape,
-};
+pub use flatten::{flatten_block, flatten_expression, flatten_pipeline, FlatShape};
 pub use known_external::KnownExternal;
 pub use lex::{lex, Token, TokenContents};
 pub use lite_parse::{lite_parse, LiteBlock};

--- a/crates/nu-parser/src/lite_parse.rs
+++ b/crates/nu-parser/src/lite_parse.rs
@@ -31,17 +31,17 @@ impl LiteCommand {
 }
 
 #[derive(Debug)]
-pub struct LiteStatement {
+pub struct LitePipeline {
     pub commands: Vec<LiteCommand>,
 }
 
-impl Default for LiteStatement {
+impl Default for LitePipeline {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl LiteStatement {
+impl LitePipeline {
     pub fn new() -> Self {
         Self { commands: vec![] }
     }
@@ -57,7 +57,7 @@ impl LiteStatement {
 
 #[derive(Debug)]
 pub struct LiteBlock {
-    pub block: Vec<LiteStatement>,
+    pub block: Vec<LitePipeline>,
 }
 
 impl Default for LiteBlock {
@@ -71,7 +71,7 @@ impl LiteBlock {
         Self { block: vec![] }
     }
 
-    pub fn push(&mut self, pipeline: LiteStatement) {
+    pub fn push(&mut self, pipeline: LitePipeline) {
         self.block.push(pipeline);
     }
 
@@ -82,7 +82,7 @@ impl LiteBlock {
 
 pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
     let mut block = LiteBlock::new();
-    let mut curr_pipeline = LiteStatement::new();
+    let mut curr_pipeline = LitePipeline::new();
     let mut curr_command = LiteCommand::new();
 
     let mut last_token = TokenContents::Eol;
@@ -117,7 +117,7 @@ pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
                     if !curr_pipeline.is_empty() {
                         block.push(curr_pipeline);
 
-                        curr_pipeline = LiteStatement::new();
+                        curr_pipeline = LitePipeline::new();
                     }
                 }
 
@@ -138,7 +138,7 @@ pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
                 if !curr_pipeline.is_empty() {
                     block.push(curr_pipeline);
 
-                    curr_pipeline = LiteStatement::new();
+                    curr_pipeline = LitePipeline::new();
                 }
 
                 last_token = TokenContents::Semicolon;

--- a/crates/nu-parser/tests/test_lite_parser.rs
+++ b/crates/nu-parser/tests/test_lite_parser.rs
@@ -109,7 +109,7 @@ fn separated_comments_dont_stack() -> Result<(), ParseError> {
 }
 
 #[test]
-fn multiple_statements() -> Result<(), ParseError> {
+fn multiple_pipelines() -> Result<(), ParseError> {
     // Code:
     // # A comment
     // let a = ( 3 + (

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1,7 +1,7 @@
 use nu_parser::ParseError;
 use nu_parser::*;
 use nu_protocol::{
-    ast::{Expr, Expression, Pipeline, Statement},
+    ast::{Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},
     Signature, SyntaxShape,
 };
@@ -50,19 +50,15 @@ pub fn parse_int() {
 
     assert!(err.is_none());
     assert!(block.len() == 1);
-    match &block[0] {
-        Statement::Pipeline(Pipeline { expressions }) => {
-            assert!(expressions.len() == 1);
-            assert!(matches!(
-                expressions[0],
-                Expression {
-                    expr: Expr::Int(3),
-                    ..
-                }
-            ))
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert!(matches!(
+        expressions[0],
+        Expression {
+            expr: Expr::Int(3),
+            ..
         }
-        _ => panic!("No match"),
-    }
+    ))
 }
 
 #[test]
@@ -78,19 +74,15 @@ pub fn parse_call() {
     assert!(err.is_none());
     assert!(block.len() == 1);
 
-    match &block[0] {
-        Statement::Pipeline(Pipeline { expressions }) => {
-            assert_eq!(expressions.len(), 1);
+    let expressions = &block[0];
+    assert_eq!(expressions.len(), 1);
 
-            if let Expression {
-                expr: Expr::Call(call),
-                ..
-            } = &expressions[0]
-            {
-                assert_eq!(call.decl_id, 0);
-            }
-        }
-        _ => panic!("not a call"),
+    if let Expression {
+        expr: Expr::Call(call),
+        ..
+    } = &expressions[0]
+    {
+        assert_eq!(call.decl_id, 0);
     }
 }
 
@@ -186,19 +178,16 @@ fn test_nothing_comparisson_eq() {
 
     assert!(err.is_none());
     assert!(block.len() == 1);
-    match &block[0] {
-        Statement::Pipeline(Pipeline { expressions }) => {
-            assert!(expressions.len() == 1);
-            assert!(matches!(
-                &expressions[0],
-                Expression {
-                    expr: Expr::BinaryOp(..),
-                    ..
-                }
-            ))
+
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert!(matches!(
+        &expressions[0],
+        Expression {
+            expr: Expr::BinaryOp(..),
+            ..
         }
-        _ => panic!("No match"),
-    }
+    ))
 }
 
 #[test]
@@ -209,19 +198,16 @@ fn test_nothing_comparisson_neq() {
 
     assert!(err.is_none());
     assert!(block.len() == 1);
-    match &block[0] {
-        Statement::Pipeline(Pipeline { expressions }) => {
-            assert!(expressions.len() == 1);
-            assert!(matches!(
-                &expressions[0],
-                Expression {
-                    expr: Expr::BinaryOp(..),
-                    ..
-                }
-            ))
+
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert!(matches!(
+        &expressions[0],
+        Expression {
+            expr: Expr::BinaryOp(..),
+            ..
         }
-        _ => panic!("No match"),
-    }
+    ))
 }
 
 mod range {
@@ -237,27 +223,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::Inclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::Inclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -269,27 +252,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::RightExclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::RightExclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -301,27 +281,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::Inclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::Inclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -333,27 +310,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::RightExclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::RightExclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -367,27 +341,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 2);
-        match &block[1] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::Inclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[1];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::Inclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -401,27 +372,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 2);
-        match &block[1] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::RightExclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[1];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::RightExclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -433,27 +401,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            None,
-                            RangeOperator {
-                                inclusion: RangeInclusion::Inclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    None,
+                    RangeOperator {
+                        inclusion: RangeInclusion::Inclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -465,27 +430,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            None,
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::Inclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    None,
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::Inclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -497,27 +459,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            None,
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::Inclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    None,
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::Inclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]
@@ -529,27 +488,24 @@ mod range {
 
         assert!(err.is_none());
         assert!(block.len() == 1);
-        match &block[0] {
-            Statement::Pipeline(Pipeline { expressions }) => {
-                assert!(expressions.len() == 1);
-                assert!(matches!(
-                    expressions[0],
-                    Expression {
-                        expr: Expr::Range(
-                            Some(_),
-                            Some(_),
-                            Some(_),
-                            RangeOperator {
-                                inclusion: RangeInclusion::Inclusive,
-                                ..
-                            }
-                        ),
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 1);
+        assert!(matches!(
+            expressions[0],
+            Expression {
+                expr: Expr::Range(
+                    Some(_),
+                    Some(_),
+                    Some(_),
+                    RangeOperator {
+                        inclusion: RangeInclusion::Inclusive,
                         ..
                     }
-                ))
+                ),
+                ..
             }
-            _ => panic!("No match"),
-        }
+        ))
     }
 
     #[test]

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -2,12 +2,12 @@ use std::ops::{Index, IndexMut};
 
 use crate::{Signature, Span, VarId};
 
-use super::Statement;
+use super::Pipeline;
 
 #[derive(Debug, Clone)]
 pub struct Block {
     pub signature: Box<Signature>,
-    pub stmts: Vec<Statement>,
+    pub pipelines: Vec<Pipeline>,
     pub captures: Vec<VarId>,
     pub redirect_env: bool,
     pub span: Option<Span>, // None option encodes no span to avoid using test_span()
@@ -15,25 +15,25 @@ pub struct Block {
 
 impl Block {
     pub fn len(&self) -> usize {
-        self.stmts.len()
+        self.pipelines.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.stmts.is_empty()
+        self.pipelines.is_empty()
     }
 }
 
 impl Index<usize> for Block {
-    type Output = Statement;
+    type Output = Pipeline;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.stmts[index]
+        &self.pipelines[index]
     }
 }
 
 impl IndexMut<usize> for Block {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.stmts[index]
+        &mut self.pipelines[index]
     }
 }
 
@@ -47,7 +47,7 @@ impl Block {
     pub fn new() -> Self {
         Self {
             signature: Box::new(Signature::new("")),
-            stmts: vec![],
+            pipelines: vec![],
             captures: vec![],
             redirect_env: false,
             span: None,
@@ -57,12 +57,12 @@ impl Block {
 
 impl<T> From<T> for Block
 where
-    T: Iterator<Item = Statement>,
+    T: Iterator<Item = Pipeline>,
 {
-    fn from(stmts: T) -> Self {
+    fn from(pipelines: T) -> Self {
         Self {
             signature: Box::new(Signature::new("")),
-            stmts: stmts.collect(),
+            pipelines: pipelines.collect(),
             captures: vec![],
             redirect_env: false,
             span: None,

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,4 +1,4 @@
-use super::{Expr, Operator, Statement};
+use super::{Expr, Operator};
 use crate::ast::ImportPattern;
 use crate::{engine::StateWorkingSet, BlockId, Signature, Span, Type, VarId, IN_VARIABLE_ID};
 
@@ -116,7 +116,7 @@ impl Expression {
                     return true;
                 }
 
-                if let Some(Statement::Pipeline(pipeline)) = block.stmts.get(0) {
+                if let Some(pipeline) = block.pipelines.get(0) {
                     match pipeline.expressions.get(0) {
                         Some(expr) => expr.has_in_variable(working_set),
                         None => false,
@@ -218,7 +218,7 @@ impl Expression {
             Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
                 let block = working_set.get_block(*block_id);
 
-                if let Some(Statement::Pipeline(pipeline)) = block.stmts.get(0) {
+                if let Some(pipeline) = block.pipelines.get(0) {
                     if let Some(expr) = pipeline.expressions.get(0) {
                         expr.has_in_variable(working_set)
                     } else {
@@ -261,7 +261,7 @@ impl Expression {
             Expr::Block(block_id) => {
                 let block = working_set.get_block(*block_id);
 
-                let new_expr = if let Some(Statement::Pipeline(pipeline)) = block.stmts.get(0) {
+                let new_expr = if let Some(pipeline) = block.pipelines.get(0) {
                     if let Some(expr) = pipeline.expressions.get(0) {
                         let mut new_expr = expr.clone();
                         new_expr.replace_in_variable(working_set, new_var_id);
@@ -276,7 +276,7 @@ impl Expression {
                 let block = working_set.get_block_mut(*block_id);
 
                 if let Some(new_expr) = new_expr {
-                    if let Some(Statement::Pipeline(pipeline)) = block.stmts.get_mut(0) {
+                    if let Some(pipeline) = block.pipelines.get_mut(0) {
                         if let Some(expr) = pipeline.expressions.get_mut(0) {
                             *expr = new_expr
                         }
@@ -353,7 +353,7 @@ impl Expression {
             Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
                 let block = working_set.get_block(*block_id);
 
-                let new_expr = if let Some(Statement::Pipeline(pipeline)) = block.stmts.get(0) {
+                let new_expr = if let Some(pipeline) = block.pipelines.get(0) {
                     if let Some(expr) = pipeline.expressions.get(0) {
                         let mut new_expr = expr.clone();
                         new_expr.replace_in_variable(working_set, new_var_id);
@@ -368,7 +368,7 @@ impl Expression {
                 let block = working_set.get_block_mut(*block_id);
 
                 if let Some(new_expr) = new_expr {
-                    if let Some(Statement::Pipeline(pipeline)) = block.stmts.get_mut(0) {
+                    if let Some(pipeline) = block.pipelines.get_mut(0) {
                         if let Some(expr) = pipeline.expressions.get_mut(0) {
                             *expr = new_expr
                         }
@@ -420,11 +420,9 @@ impl Expression {
             Expr::Block(block_id) => {
                 let mut block = working_set.get_block(*block_id).clone();
 
-                for stmt in block.stmts.iter_mut() {
-                    if let Statement::Pipeline(pipeline) = stmt {
-                        for expr in pipeline.expressions.iter_mut() {
-                            expr.replace_span(working_set, replaced, new_span)
-                        }
+                for pipeline in block.pipelines.iter_mut() {
+                    for expr in pipeline.expressions.iter_mut() {
+                        expr.replace_span(working_set, replaced, new_span)
                     }
                 }
 
@@ -497,11 +495,9 @@ impl Expression {
             Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
                 let mut block = working_set.get_block(*block_id).clone();
 
-                for stmt in block.stmts.iter_mut() {
-                    if let Statement::Pipeline(pipeline) = stmt {
-                        for expr in pipeline.expressions.iter_mut() {
-                            expr.replace_span(working_set, replaced, new_span)
-                        }
+                for pipeline in block.pipelines.iter_mut() {
+                    for expr in pipeline.expressions.iter_mut() {
+                        expr.replace_span(working_set, replaced, new_span)
                     }
                 }
 

--- a/crates/nu-protocol/src/ast/mod.rs
+++ b/crates/nu-protocol/src/ast/mod.rs
@@ -6,7 +6,6 @@ mod expression;
 mod import_pattern;
 mod operator;
 mod pipeline;
-mod statement;
 
 pub use block::*;
 pub use call::*;
@@ -16,4 +15,3 @@ pub use expression::*;
 pub use import_pattern::*;
 pub use operator::*;
 pub use pipeline::*;
-pub use statement::*;

--- a/crates/nu-protocol/src/ast/pipeline.rs
+++ b/crates/nu-protocol/src/ast/pipeline.rs
@@ -1,3 +1,5 @@
+use std::ops::{Index, IndexMut};
+
 use crate::ast::Expression;
 
 #[derive(Debug, Clone)]
@@ -20,5 +22,27 @@ impl Pipeline {
 
     pub fn from_vec(expressions: Vec<Expression>) -> Pipeline {
         Self { expressions }
+    }
+
+    pub fn len(&self) -> usize {
+        self.expressions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.expressions.is_empty()
+    }
+}
+
+impl Index<usize> for Pipeline {
+    type Output = Expression;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.expressions[index]
+    }
+}
+
+impl IndexMut<usize> for Pipeline {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.expressions[index]
     }
 }

--- a/crates/nu-protocol/src/ast/statement.rs
+++ b/crates/nu-protocol/src/ast/statement.rs
@@ -1,8 +1,0 @@
-use super::Pipeline;
-use crate::DeclId;
-
-#[derive(Debug, Clone)]
-pub enum Statement {
-    Declaration(DeclId),
-    Pipeline(Pipeline),
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
 use nu_parser::parse;
 use nu_protocol::{
-    ast::{Call, Expr, Expression, Pipeline, Statement},
+    ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},
     Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError, Signature, Span,
     Spanned, SyntaxShape, Value, CONFIG_VARIABLE_ID,
@@ -241,11 +241,11 @@ fn parse_commandline_args(
     );
 
     // We should have a successful parse now
-    if let Some(Statement::Pipeline(Pipeline { expressions })) = block.stmts.get(0) {
+    if let Some(pipeline) = block.pipelines.get(0) {
         if let Some(Expression {
             expr: Expr::Call(call),
             ..
-        }) = expressions.get(0)
+        }) = pipeline.expressions.get(0)
         {
             let redirect_stdin = call.get_named_arg("stdin");
             let login_shell = call.get_named_arg("login");


### PR DESCRIPTION
# Description

This removes the unused Statement concept from the engine and parser. I'd originally intended that declarations and pipelines would be kept separate and make it easy to skip over the declarations when running the eval.

In practice, I moved the declarations into the pipeline to make sure they're highlighted in the same way as other commands. Removing the unused Declaration form for Statement then collapsed Statements completely, leaving only the Pipeline concept.

Now, a Block is a vec of Pipelines, and Pipelines hold expressions. We still check that built-in commands that need special treatment, like `import`, still receive special treatment.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
