### PR TITLE
Fix view-source command

### DIFF
--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -35,12 +35,16 @@ impl Command for ViewSource {
         let arg_span = arg.span()?;
 
         match arg {
-            Value::Block { span, .. } => {
-                let contents = engine_state.get_span_contents(&span);
-                Ok(
-                    Value::string(String::from_utf8_lossy(contents), call.head)
-                        .into_pipeline_data(),
-                )
+            Value::Block { val: block_id, .. } => {
+                let block = engine_state.get_block(block_id);
+
+                if let Some(span) = block.span {
+                    let contents = engine_state.get_span_contents(&span);
+                    Ok(Value::string(String::from_utf8_lossy(contents), call.head)
+                        .into_pipeline_data())
+                } else {
+                    Ok(Value::string("<internal command>", call.head).into_pipeline_data())
+                }
             }
             Value::String { val, .. } => {
                 if let Some(decl_id) = engine_state.find_decl(val.as_bytes()) {


### PR DESCRIPTION
# Description

This improves the logic for viewing the source on a block to not rely on the variable's span, but instead to look up the actual block. If this block has contents, we can show them, otherwise we let the user know that the block was pointing to something that was internal.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
