### PR TITLE
Auto-hide aliases to prevent recursion

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -851,7 +851,10 @@ pub fn parse_call(
                     new_spans.extend(&spans[(pos + 1)..]);
                 }
 
+                working_set.enter_scope();
+                working_set.hide_alias(&name);
                 let (mut result, err) = parse_expression(working_set, &new_spans, false);
+                working_set.exit_scope();
 
                 result.replace_span(working_set, expansion_span, orig_span);
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -34,6 +34,11 @@ fn alias_2_multi_word() -> TestResult {
 }
 
 #[test]
+fn alias_recursion() -> TestResult {
+    run_test_contains(r#"alias ls = (ls | sort-by type name -i); ls"#, " ")
+}
+
+#[test]
 fn block_param1() -> TestResult {
     run_test("[3] | each { $it + 10 } | get 0", "13")
 }


### PR DESCRIPTION
# Description

This auto-hides an alias so it can't see its own definition.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
