### PR TITLE
Move and enable with-env test

### DIFF
--- a/crates/nu-command/tests/commands/with_env.rs
+++ b/crates/nu-command/tests/commands/with_env.rs
@@ -58,18 +58,6 @@ fn with_env_and_shorthand_same_result() {
 // FIXME: jt: needs more work
 #[ignore]
 #[test]
-fn with_env_shorthand_nested_quotes() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats",
-        "FOO='-arg \"hello world\"' echo $env | get FOO"
-    );
-
-    assert_eq!(actual.out, "-arg \"hello world\"");
-}
-
-// FIXME: jt: needs more work
-#[ignore]
-#[test]
 fn with_env_hides_variables_in_parent_scope() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -243,3 +243,11 @@ fn reduce_spans() -> TestResult {
         "right here",
     )
 }
+
+#[test]
+fn with_env_shorthand_nested_quotes() -> TestResult {
+    run_test(
+        r#"FOO='-arg "hello world"' echo $env | get FOO"#,
+        "-arg \"hello world\"",
+    )
+}


### PR DESCRIPTION
# Description

Moved one of the with-env tests to a different part of the test suite and enabled it.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
