### PR TITLE
add more examples to the sys command

### DIFF
--- a/crates/nu-command/src/system/sys.rs
+++ b/crates/nu-command/src/system/sys.rs
@@ -35,11 +35,23 @@ impl Command for Sys {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Show info about the system",
-            example: "sys",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "Show info about the system",
+                example: "sys",
+                result: None,
+            },
+            Example {
+                description: "Show the os system name with get",
+                example: "(sys).host | get name",
+                result: None,
+            },
+            Example {
+                description: "Show the os system name",
+                example: "(sys).host.name",
+                result: None,
+            },
+        ]
     }
 }
 


### PR DESCRIPTION

As I was going through the weather script I saw how easy it was
to get the os name and noticed it wasn't an example in sys.

So for future reference I decided to add it in as one of the examples
of sys.  And currently there was only one rhetorical example in there.