### PR TITLE
Another batch of command tests

### DIFF
--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -24,7 +24,7 @@ impl Command for WithEnv {
             )
             .required(
                 "block",
-                SyntaxShape::Block(Some(vec![SyntaxShape::Any])),
+                SyntaxShape::Block(Some(vec![])),
                 "the block to run once the variable is set",
             )
             .category(Category::Env)

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -164,7 +164,7 @@ fn get_cellpath_columns(keep_cols: Vec<String>, span: Span) -> Vec<CellPath> {
 fn get_keep_columns(mut input: Vec<String>, rejects: Vec<String>) -> Vec<String> {
     for reject in rejects {
         if let Some(index) = input.iter().position(|value| *value == reject) {
-            input.swap_remove(index);
+            input.remove(index);
         }
     }
     input
@@ -173,8 +173,8 @@ fn get_keep_columns(mut input: Vec<String>, rejects: Vec<String>) -> Vec<String>
 fn reject_record_columns(cols: &mut Vec<String>, vals: &mut Vec<Value>, rejects: &[String]) {
     for reject in rejects {
         if let Some(index) = cols.iter().position(|value| value == reject) {
-            cols.swap_remove(index);
-            vals.swap_remove(index);
+            cols.remove(index);
+            vals.remove(index);
         }
     }
 }

--- a/crates/nu-command/src/random/decimal.rs
+++ b/crates/nu-command/src/random/decimal.rs
@@ -70,7 +70,13 @@ fn decimal(
     let range: Option<Range> = call.opt(engine_state, stack, 0)?;
 
     let (min, max) = if let Some(r) = range {
-        (r.from.as_float()?, r.to.as_float()?)
+        if r.is_end_inclusive() {
+            (r.from.as_float()?, r.to.as_float()?)
+        } else if r.to.as_float()? >= 1.0 {
+            (r.from.as_float()?, r.to.as_float()? - 1.0)
+        } else {
+            (0.0, 0.0)
+        }
     } else {
         (0.0, 1.0)
     };

--- a/crates/nu-command/src/random/integer.rs
+++ b/crates/nu-command/src/random/integer.rs
@@ -70,7 +70,13 @@ fn integer(
     let range: Option<Range> = call.opt(engine_state, stack, 0)?;
 
     let (min, max) = if let Some(r) = range {
-        (r.from.as_integer()?, r.to.as_integer()?)
+        if r.is_end_inclusive() {
+            (r.from.as_integer()?, r.to.as_integer()?)
+        } else if r.to.as_integer()? > 0 {
+            (r.from.as_integer()?, r.to.as_integer()? - 1)
+        } else {
+            (0, 0)
+        }
     } else {
         (0, i64::MAX)
     };

--- a/crates/nu-command/tests/commands/every.rs
+++ b/crates/nu-command/tests/commands/every.rs
@@ -80,8 +80,6 @@ fn gets_all_rows_by_every_one() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn gets_no_rows_by_every_skip_one() {
     Playground::setup("every_test_4", |dirs, sandbox| {
@@ -102,7 +100,7 @@ fn gets_no_rows_by_every_skip_one() {
             "#
         ));
 
-        assert_eq!(actual.out, "");
+        assert_eq!(actual.out, "[]");
     })
 }
 

--- a/crates/nu-command/tests/commands/random/decimal.rs
+++ b/crates/nu-command/tests/commands/random/decimal.rs
@@ -1,9 +1,7 @@
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
-fn generates_an_decimal() {
+fn generates_a_decimal() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
@@ -14,8 +12,6 @@ fn generates_an_decimal() {
     assert!(actual.out.contains("42") || actual.out.contains("43"));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn generates_55() {
     let actual = nu!(
@@ -28,8 +24,6 @@ fn generates_55() {
     assert!(actual.out.contains("55"));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn generates_0() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/random/integer.rs
+++ b/crates/nu-command/tests/commands/random/integer.rs
@@ -24,8 +24,6 @@ fn generates_55() {
     assert!(actual.out.contains("55"));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn generates_0() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -1,7 +1,5 @@
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn reduce_table_column() {
     let actual = nu!(
@@ -10,7 +8,7 @@ fn reduce_table_column() {
         echo "[{month:2,total:30}, {month:3,total:10}, {month:4,total:3}, {month:5,total:60}]"
         | from json
         | get total
-        | reduce -f 20 { $it.item + (math eval $"($item.acc)^1.05")}
+        | reduce -f 20 { $it.item + (math eval $"($it.acc)^1.05")}
         | into string -d 1
         "#
         )
@@ -19,15 +17,13 @@ fn reduce_table_column() {
     assert_eq!(actual.out, "180.6");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn reduce_table_column_with_path() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
         [{month:2,total:30}, {month:3,total:10}, {month:4,total:3}, {month:5,total:60}]
-        | reduce -f 20 { $it.item.total + (math eval $"($item.acc)^1.05")}
+        | reduce -f 20 { $it.item.total + (math eval $"($it.acc)^1.05")}
         | into string -d 1
         "#
         )
@@ -36,8 +32,6 @@ fn reduce_table_column_with_path() {
     assert_eq!(actual.out, "180.6");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn reduce_rows_example() {
     let actual = nu!(
@@ -60,7 +54,7 @@ fn reduce_numbered_example() {
         cwd: ".", pipeline(
         r#"
         echo one longest three bar
-        | reduce -n { if ($it.item.item | str length) > ($it.acc.item | str length) {echo $it.item} else {echo $it.acc}}
+        reduce -n { if ($it.item | str length) > ($acc.item | str length) {echo $it} {echo $acc}}
         | get index
         "#
         )
@@ -69,15 +63,13 @@ fn reduce_numbered_example() {
     assert_eq!(actual.out, "1");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn reduce_numbered_integer_addition_example() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
         echo [1 2 3 4]
-        | reduce -n { $it.acc.item + $it.item.item }
+        | reduce -n { $it.acc + $it.item }
         | get item
         "#
         )
@@ -86,8 +78,6 @@ fn reduce_numbered_integer_addition_example() {
     assert_eq!(actual.out, "10");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn folding_with_tables() {
     let actual = nu!(
@@ -96,7 +86,7 @@ fn folding_with_tables() {
         echo [10 20 30 40]
         | reduce -f [] {
             with-env [value $it.item] {
-              echo $acc | append (10 * ($env.value | into int))
+              echo $it.acc | append (10 * ($env.value | into int))
             }
           }
         | math sum
@@ -107,8 +97,6 @@ fn folding_with_tables() {
     assert_eq!(actual.out, "1000");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn error_reduce_fold_type_mismatch() {
     let actual = nu!(
@@ -122,8 +110,6 @@ fn error_reduce_fold_type_mismatch() {
     assert!(actual.err.contains("mismatch"));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn error_reduce_empty() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -17,7 +17,7 @@ fn regular_columns() {
         "#
     ));
 
-    assert_eq!(actual.out, "rusty_at, last_name");
+    assert_eq!(actual.out, "last_name, rusty_at");
 }
 
 // FIXME: needs more work

--- a/crates/nu-command/tests/commands/roll.rs
+++ b/crates/nu-command/tests/commands/roll.rs
@@ -17,14 +17,12 @@ mod rows {
         )
     }
 
-    // FIXME: jt: needs more work
-    #[ignore]
     #[test]
-    fn roll_down_by_default() {
+    fn can_roll_down() {
         let actual = nu!(
         cwd: ".",
         format!("{} | {}", table(), pipeline(r#"
-            roll
+            roll down
             | first
             | get status
         "#)));
@@ -32,14 +30,12 @@ mod rows {
         assert_eq!(actual.out, "HERE");
     }
 
-    // FIXME: jt: needs more work
-    #[ignore]
     #[test]
     fn can_roll_up() {
         let actual = nu!(
         cwd: ".",
         format!("{} | {}", table(), pipeline(r#"
-            roll up 3
+            roll up --by 3
             | first
             | get status
         "#)));
@@ -66,30 +62,26 @@ mod columns {
         )
     }
 
-    // FIXME: jt: needs more work
-    #[ignore]
     #[test]
-    fn roll_left_by_default() {
+    fn can_roll_left() {
         let actual = nu!(
         cwd: ".",
         format!("{} | {}", table(), pipeline(r#"
-            roll column
-            | get
+            roll left
+            | columns
             | str collect "-"
         "#)));
 
         assert_eq!(actual.out, "origin-stars-commit_author");
     }
 
-    // FIXME: jt: needs more work
-    #[ignore]
     #[test]
-    fn can_roll_in_the_opposite_direction() {
+    fn can_roll_right() {
         let actual = nu!(
         cwd: ".",
         format!("{} | {}", table(), pipeline(r#"
-            roll column 2 --opposite
-            | get
+            roll right --by 2
+            | columns
             | str collect "-"
         "#)));
 
@@ -98,8 +90,6 @@ mod columns {
 
     struct ThirtieTwo<'a>(usize, &'a str);
 
-    // FIXME: jt: needs more work
-    #[ignore]
     #[test]
     fn can_roll_the_cells_only_keeping_the_header_names() {
         let four_bitstring = bitstring_to_nu_row_pipeline("00000100");
@@ -107,14 +97,12 @@ mod columns {
 
         let actual = nu!(
             cwd: ".",
-            format!("{} | roll column 3 --opposite --cells-only | get | str collect '-' ", four_bitstring)
+            format!("{} | roll right --by 3 --cells-only | columns | str collect '-' ", four_bitstring)
         );
 
         assert_eq!(actual.out, expected_value.1);
     }
 
-    // FIXME: jt: needs more work
-    #[ignore]
     #[test]
     fn four_in_bitstring_left_shifted_with_three_bits_should_be_32_in_decimal() {
         let four_bitstring = "00000100";
@@ -144,7 +132,7 @@ mod columns {
         // decimal value.
         let nu_row_literal_bitstring_to_decimal_value_pipeline = pipeline(
             r#"
-            pivot bit --ignore-titles
+            transpose bit --ignore-titles
             | get bit
             | reverse
             | each --numbered {
@@ -156,7 +144,7 @@ mod columns {
 
         nu!(
             cwd: ".",
-            format!("{} | roll column 3 | {}", bitstring_as_nu_row_pipeline, nu_row_literal_bitstring_to_decimal_value_pipeline)
+            format!("{} | roll left --by 3 | {}", bitstring_as_nu_row_pipeline, nu_row_literal_bitstring_to_decimal_value_pipeline)
         ).out
     }
 
@@ -167,9 +155,8 @@ mod columns {
             pipeline(
                 r#"
             split chars
-            | each { into int }
-            | rotate counter-clockwise _
-            | reject _
+            | each { $it | into int }
+            | rotate --ccw
             | rename bit1 bit2 bit3 bit4 bit5 bit6 bit7 bit8
         "#
             )

--- a/crates/nu-command/tests/commands/rotate.rs
+++ b/crates/nu-command/tests/commands/rotate.rs
@@ -1,7 +1,5 @@
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn counter_clockwise() {
     let table = pipeline(
@@ -34,7 +32,7 @@ fn counter_clockwise() {
     let actual = nu!(
         cwd: ".",
         format!("{} | {}", table, pipeline(r#"
-            rotate counter-clockwise
+            rotate --ccw
             | where Column0 == EXPECTED
             | get Column1 Column2 Column3
             | str collect "-"

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -290,6 +290,7 @@ impl Value {
     pub fn as_float(&self) -> Result<f64, ShellError> {
         match self {
             Value::Float { val, .. } => Ok(*val),
+            Value::Int { val, .. } => Ok(*val as f64),
             x => Err(ShellError::CantConvert(
                 "float".into(),
                 x.get_type().to_string(),

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -109,8 +109,7 @@ impl Range {
         self.from <= self.to
     }
 
-    #[inline]
-    fn is_end_inclusive(&self) -> bool {
+    pub fn is_end_inclusive(&self) -> bool {
         matches!(self.inclusion, RangeInclusion::Inclusive)
     }
 


### PR DESCRIPTION
# Description

This ports another batch of command tests
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
