### PR TITLE
Require block params

### DIFF
--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -303,7 +303,7 @@ The `each` command gives us a way of working with each individual row or
 element of a list one at a time. It reads these in from the pipeline and
 runs a block on each element. A block is a group of pipelines.
 ```
-echo 1 2 3 | each { $it + 10}
+echo 1 2 3 | each { |it| $it + 10}
 ```
 This example iterates over each element sent by `echo`, giving us three new
 values that are the original value + 10. Here, the `$it` is a variable that

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -46,7 +46,7 @@ impl Command for Each {
         ];
 
         vec![Example {
-            example: "[1 2 3] | each { 2 * $it }",
+            example: "[1 2 3] | each { |it| 2 * $it }",
             description: "Multiplies elements in list",
             result: Some(Value::List {
                 vals: stream_test_1,

--- a/crates/nu-command/src/filters/each_group.rs
+++ b/crates/nu-command/src/filters/each_group.rs
@@ -42,7 +42,7 @@ impl Command for EachGroup {
         ];
 
         vec![Example {
-            example: "echo [1 2 3 4] | each group 2 { $it.0 + $it.1 }",
+            example: "echo [1 2 3 4] | each group 2 { |it| $it.0 + $it.1 }",
             description: "Echo the sum of each pair",
             result: Some(Value::List {
                 vals: stream_test_1,

--- a/crates/nu-command/src/filters/each_window.rs
+++ b/crates/nu-command/src/filters/each_window.rs
@@ -68,7 +68,7 @@ impl Command for EachWindow {
 
         vec![
             Example {
-                example: "echo [1 2 3 4] | each window 2 { $it.0 + $it.1 }",
+                example: "echo [1 2 3 4] | each window 2 { |it| $it.0 + $it.1 }",
                 description: "A sliding window of two elements",
                 result: Some(Value::List {
                     vals: stream_test_1,

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -72,7 +72,7 @@ impl Command for Empty {
             },
             Example {
                 description: "use a block if setting the empty cell contents is wanted",
-                example: "[[2020/04/16 2020/07/10 2020/11/16]; ['' [27] [37]]] | empty? 2020/04/16 -b { [33 37] }",
+                example: "[[2020/04/16 2020/07/10 2020/11/16]; ['' [27] [37]]] | empty? 2020/04/16 -b { |_| [33 37] }",
                 result: Some(
                     Value::List {
                         vals: vec![

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -60,7 +60,7 @@ impl Command for Find {
             },
             Example {
                 description: "Find the first odd value",
-                example: "echo [2 4 3 6 5 8] | find --predicate { ($it mod 2) == 1 }",
+                example: "echo [2 4 3 6 5 8] | find --predicate { |it| ($it mod 2) == 1 }",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(3), Value::test_int(5)],
                     span: Span::test_data()
@@ -68,7 +68,7 @@ impl Command for Find {
             },
             Example {
                 description: "Find if a service is not running",
-                example: "echo [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | find -p { $it.patch }",
+                example: "echo [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | find -p { |it| $it.patch }",
                 result: Some(Value::List {
                     vals: vec![Value::test_record(
                             vec!["version", "patch"],

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -32,7 +32,7 @@ impl Command for ParEach {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            example: "[1 2 3] | par-each { 2 * $it }",
+            example: "[1 2 3] | par-each { |it| 2 * $it }",
             description: "Multiplies elements in list",
             result: None,
         }]

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -5,7 +5,7 @@ fn each_works_separately() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3] | each { echo $it 10 | math sum } | to json -r
+        echo [1 2 3] | each { |it| echo $it 10 | math sum } | to json -r
         "#
     ));
 
@@ -17,7 +17,7 @@ fn each_group_works() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3 4 5 6] | each group 3 { $it } | to json --raw
+        echo [1 2 3 4 5 6] | each group 3 { |it| $it } | to json --raw
         "#
     ));
 
@@ -29,7 +29,7 @@ fn each_window() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3 4] | each window 3 { $it } | to json --raw
+        echo [1 2 3 4] | each window 3 { |it| $it } | to json --raw
         "#
     ));
 
@@ -41,7 +41,7 @@ fn each_window_stride() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [1 2 3 4 5 6] | each window 3 -s 2 { echo $it } | to json --raw
+        echo [1 2 3 4 5 6] | each window 3 -s 2 { |it| echo $it } | to json --raw
         "#
     ));
 
@@ -65,7 +65,7 @@ fn each_implicit_it_in_block() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [[foo bar]; [a b] [c d] [e f]] | each { nu --testbin cococo $it.foo } | str collect
+        echo [[foo bar]; [a b] [c d] [e f]] | each { |it| nu --testbin cococo $it.foo } | str collect
         "#
     ));
 

--- a/crates/nu-command/tests/commands/echo.rs
+++ b/crates/nu-command/tests/commands/echo.rs
@@ -17,7 +17,7 @@ fn echo_range_handles_inclusive() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo 1..3 | each { $it } | to json --raw
+        echo 1..3 | each { |x| $x } | to json --raw
         "#
     ));
 
@@ -29,7 +29,7 @@ fn echo_range_handles_exclusive() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo 1..<3 | each { $it } | to json --raw
+        echo 1..<3 | each { |x| $x } | to json --raw
         "#
     ));
 
@@ -41,7 +41,7 @@ fn echo_range_handles_inclusive_down() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo 3..1 | each { $it } | to json --raw
+        echo 3..1 | each { |it| $it } | to json --raw
         "#
     ));
 
@@ -53,7 +53,7 @@ fn echo_range_handles_exclusive_down() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo 3..<1 | each { $it } | to json --raw
+        echo 3..<1 | each { |it| $it } | to json --raw
         "#
     ));
 

--- a/crates/nu-command/tests/commands/into_int.rs
+++ b/crates/nu-command/tests/commands/into_int.rs
@@ -5,7 +5,7 @@ fn into_int_filesize() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1kb | into int | each { $it / 1000 }
+        echo 1kb | into int | each { |it| $it / 1000 }
         "#
     ));
 
@@ -17,7 +17,7 @@ fn into_int_filesize2() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1kib | into int | each { $it / 1024 }
+        echo 1kib | into int | each { |it| $it / 1024 }
         "#
     ));
 
@@ -29,7 +29,7 @@ fn into_int_int() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1024 | into int | each { $it / 1024 }
+        echo 1024 | into int | each { |it| $it / 1024 }
         "#
     ));
 

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -87,7 +87,7 @@ fn lists_all_files_in_directories_from_stream() {
             cwd: dirs.test(), pipeline(
             r#"
                 echo dir_a dir_b
-                | each { ls $it }
+                | each { |it| ls $it }
                 | flatten | length
             "#
         ));

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -22,7 +22,7 @@ mod simple {
                 r#"
                     open key_value_separated_arepa_ingredients.txt
                     | lines
-                    | each { echo $it | parse "{Name}={Value}" }
+                    | each { |it| echo $it | parse "{Name}={Value}" }
                     | flatten
                     | get 1
                     | get Value

--- a/crates/nu-command/tests/commands/roll.rs
+++ b/crates/nu-command/tests/commands/roll.rs
@@ -135,7 +135,7 @@ mod columns {
             transpose bit --ignore-titles
             | get bit
             | reverse
-            | each --numbered {
+            | each --numbered { |it|
                 $it.item * (2 ** $it.index)
             }
             | math sum
@@ -155,7 +155,7 @@ mod columns {
             pipeline(
                 r#"
             split chars
-            | each { $it | into int }
+            | each { |it| $it | into int }
             | rotate --ccw
             | rename bit1 bit2 bit3 bit4 bit5 bit6 bit7 bit8
         "#

--- a/crates/nu-command/tests/commands/str_/collect.rs
+++ b/crates/nu-command/tests/commands/str_/collect.rs
@@ -44,7 +44,7 @@ fn sum_one_to_four() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        1..4 | each { $it } | into string | str collect "+" | math eval
+        1..4 | each { |it| $it } | into string | str collect "+" | math eval
         "#
         )
     );

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -175,6 +175,15 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::rest_needs_name), url(docsrs))]
     RestNeedsName(#[label = "needs a parameter name"] Span),
 
+    #[error("Parameter not correct type.")]
+    #[diagnostic(code(nu::parser::parameter_mismatch_type), url(docsrs))]
+    ParameterMismatchType(
+        String,
+        String,
+        String,
+        #[label = "parameter {0} needs to be '{1}' instead of '{2}'"] Span,
+    ),
+
     #[error("Extra columns.")]
     #[diagnostic(code(nu::parser::extra_columns), url(docsrs))]
     ExtraColumns(

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2894,7 +2894,7 @@ pub fn parse_block_expression(
     working_set.enter_scope();
 
     // Check to see if we have parameters
-    let (mut signature, amt_to_skip): (Option<Box<Signature>>, usize) = match output.first() {
+    let (signature, amt_to_skip): (Option<Box<Signature>>, usize) = match output.first() {
         Some(Token {
             contents: TokenContents::Pipe,
             span,
@@ -2942,19 +2942,28 @@ pub fn parse_block_expression(
 
     // TODO: Finish this
     if let SyntaxShape::Block(Some(v)) = shape {
-        if signature.is_none() && v.len() == 1 {
-            // We'll assume there's an `$it` present
-            let var_id = working_set.add_variable(b"$it".to_vec(), Type::Unknown);
+        if signature.is_none() && !v.is_empty() {
+            // // We'll assume there's an `$it` present
+            // let var_id = working_set.add_variable(b"$it".to_vec(), Type::Unknown);
 
-            let mut new_sigature = Signature::new("");
-            new_sigature.required_positional.push(PositionalArg {
-                var_id: Some(var_id),
-                name: "$it".into(),
-                desc: String::new(),
-                shape: SyntaxShape::Any,
+            // let mut new_sigature = Signature::new("");
+            // new_sigature.required_positional.push(PositionalArg {
+            //     var_id: Some(var_id),
+            //     name: "$it".into(),
+            //     desc: String::new(),
+            //     shape: SyntaxShape::Any,
+            // });
+
+            // signature = Some(Box::new(new_sigature));
+            error = error.or_else(|| {
+                Some(ParseError::Expected(
+                    format!("block parameter{}", if v.len() > 1 { "s" } else { "" }),
+                    Span {
+                        start: span.start + 1,
+                        end: span.start + 1,
+                    },
+                ))
             });
-
-            signature = Some(Box::new(new_sigature));
         }
     }
 

--- a/docs/commands/each.md
+++ b/docs/commands/each.md
@@ -19,6 +19,6 @@ Run a block on each element of input
 
 Multiplies elements in list
 ```shell
-> [1 2 3] | each { 2 * $it }
+> [1 2 3] | each { |it| 2 * $it }
 ```
 

--- a/docs/commands/par-each.md
+++ b/docs/commands/par-each.md
@@ -19,6 +19,6 @@ Run a block on each element of input in parallel
 
 Multiplies elements in list
 ```shell
-> [1 2 3] | par-each { 2 * $it }
+> [1 2 3] | par-each { |it| 2 * $it }
 ```
 

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -86,7 +86,7 @@ fn scope_variable() -> TestResult {
 #[test]
 fn earlier_errors() -> TestResult {
     fail_test(
-        r#"[1, "bob"] | each { $it + 3 } | each { $it / $it } | table"#,
+        r#"[1, "bob"] | each { |it| $it + 3 } | each { |it| $it / $it } | table"#,
         "int",
     )
 }

--- a/src/tests/test_iteration.rs
+++ b/src/tests/test_iteration.rs
@@ -3,7 +3,7 @@ use crate::tests::{run_test, TestResult};
 #[test]
 fn better_block_types() -> TestResult {
     run_test(
-        r#"([1, 2, 3] | each -n { $"($it.index) is ($it.item)" }).1"#,
+        r#"([1, 2, 3] | each -n { |it| $"($it.index) is ($it.item)" }).1"#,
         "1 is 2",
     )
 }
@@ -11,14 +11,14 @@ fn better_block_types() -> TestResult {
 #[test]
 fn row_iteration() -> TestResult {
     run_test(
-        "[[name, size]; [tj, 100], [rl, 200]] | each { $it.size * 8 } | get 1",
+        "[[name, size]; [tj, 100], [rl, 200]] | each { |it| $it.size * 8 } | get 1",
         "1600",
     )
 }
 
 #[test]
 fn record_iteration() -> TestResult {
-    run_test("([[name, level]; [aa, 100], [bb, 200]] | each { $it | each { |x| if $x.column == \"level\" { $x.value + 100 } else { $x.value } } }).level | get 1", "300")
+    run_test("([[name, level]; [aa, 100], [bb, 200]] | each { |it| $it | each { |x| if $x.column == \"level\" { $x.value + 100 } else { $x.value } } }).level | get 1", "300")
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn for_loops() -> TestResult {
 #[test]
 fn par_each() -> TestResult {
     run_test(
-        r#"1..10 | par-each --numbered { ([[index, item]; [$it.index, ($it.item > 5)]]).0 } | where index == 4 | get item.0"#,
+        r#"1..10 | par-each --numbered { |it| ([[index, item]; [$it.index, ($it.item > 5)]]).0 } | where index == 4 | get item.0"#,
         "false",
     )
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -314,3 +314,18 @@ fn capture_row_condition() -> TestResult {
 fn proper_missing_param() -> TestResult {
     fail_test(r#"def foo [x y z w] { }; foo a b c"#, "missing w")
 }
+
+#[test]
+fn block_arity_check1() -> TestResult {
+    fail_test(r#"ls | each { 1 }"#, "expected 1 block parameter")
+}
+
+#[test]
+fn block_arity_check2() -> TestResult {
+    fail_test(r#"ls | reduce { 1 }"#, "expected 2 block parameters")
+}
+
+#[test]
+fn block_arity_check3() -> TestResult {
+    fail_test(r#"ls | each { |x, y| 1}"#, "expected 1 block parameter")
+}

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -40,7 +40,7 @@ fn alias_recursion() -> TestResult {
 
 #[test]
 fn block_param1() -> TestResult {
-    run_test("[3] | each { $it + 10 } | get 0", "13")
+    run_test("[3] | each { |it| $it + 10 } | get 0", "13")
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn block_param2() -> TestResult {
 
 #[test]
 fn block_param3_list_iteration() -> TestResult {
-    run_test("[1,2,3] | each { $it + 10 } | get 1", "12")
+    run_test("[1,2,3] | each { |it| $it + 10 } | get 1", "12")
 }
 
 #[test]
@@ -70,7 +70,7 @@ fn range_iteration2() -> TestResult {
 
 #[test]
 fn simple_value_iteration() -> TestResult {
-    run_test("4 | each { $it + 10 }", "14")
+    run_test("4 | each { |it| $it + 10 }", "14")
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn bad_var_name() -> TestResult {
 #[test]
 fn long_flag() -> TestResult {
     run_test(
-        r#"([a, b, c] | each --numbered { if $it.index == 1 { 100 } else { 0 } }).1"#,
+        r#"([a, b, c] | each --numbered { |it| if $it.index == 1 { 100 } else { 0 } }).1"#,
         "100",
     )
 }

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -7,13 +7,13 @@ fn build_string1() -> TestResult {
 
 #[test]
 fn build_string2() -> TestResult {
-    run_test("'nu' | each {build-string $it 'shell'}", "nushell")
+    run_test("'nu' | each { |it| build-string $it 'shell'}", "nushell")
 }
 
 #[test]
 fn build_string3() -> TestResult {
     run_test(
-        "build-string 'nu' 'shell' | each {build-string $it ' rocks'}",
+        "build-string 'nu' 'shell' | each { |it| build-string $it ' rocks'}",
         "nushell rocks",
     )
 }
@@ -21,7 +21,7 @@ fn build_string3() -> TestResult {
 #[test]
 fn build_string4() -> TestResult {
     run_test(
-        "['sam','rick','pete'] | each { build-string $it ' is studying'} | get 2",
+        "['sam','rick','pete'] | each { |it| build-string $it ' is studying'} | get 2",
         "pete is studying",
     )
 }

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -23,7 +23,7 @@ fn plugins_are_declared_with_wix() {
                 | where Directory.attributes.Id == "$(var.PlatformProgramFilesFolder)"
                 | get Directory.children.Directory.children.0 | last
                 | get Directory.children.Component.children
-                | each { echo $it | first }
+                | each { |it| echo $it | first }
                 | skip
                 | where File.attributes.Name =~ "nu_plugin"
                 | str substring [_, -4] File.attributes.Name
@@ -32,7 +32,7 @@ fn plugins_are_declared_with_wix() {
                 | wrap wix
             }
             | default wix _
-            | each { if $it.wix != $it.cargo { 1 } { 0 } }
+            | each { |it| if $it.wix != $it.cargo { 1 } { 0 } }
             | math sum
             "#
     ));

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -111,7 +111,7 @@ mod it_evaluation {
                 ls
                 | sort-by name
                 | get name
-                | each { nu --testbin cococo $it }
+                | each { |it| nu --testbin cococo $it }
                 | get 1
                 "#
             ));
@@ -136,7 +136,7 @@ mod it_evaluation {
             r#"
                 open nu_candies.txt
                 | lines
-                | each { nu --testbin chop $it}
+                | each { |it| nu --testbin chop $it}
                 | get 1
                 "#
             ));

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -22,7 +22,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
         r#"
             open nu_times.csv
             | get origin
-            | each { ^echo $it | nu --testbin chop }
+            | each { |it| ^echo $it | nu --testbin chop }
             | get 2
             "#
         ));
@@ -76,7 +76,7 @@ fn argument_subexpression() {
     let actual = nu!(
         cwd: ".",
         r#"
-            echo "foo" | each { echo (echo $it) }
+            echo "foo" | each { |it| echo (echo $it) }
         "#
     );
 
@@ -102,7 +102,7 @@ fn subexpression_handles_dot() {
         r#"
             echo (open nu_times.csv)
             | get name
-            | each { nu --testbin chop $it }
+            | each { |it| nu --testbin chop $it }
             | get 3
             "#
         ));
@@ -116,7 +116,7 @@ fn string_interpolation_with_it() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo "foo" | each { echo $"($it)" }
+                    echo "foo" | each { |it| echo $"($it)" }
             "#
     );
 
@@ -128,7 +128,7 @@ fn string_interpolation_with_it_column_path() {
     let actual = nu!(
         cwd: ".",
         r#"
-                    echo [[name]; [sammie]] | each { echo $"($it.name)" } | get 0
+                    echo [[name]; [sammie]] | each { |it| echo $"($it.name)" } | get 0
         "#
     );
 
@@ -1048,7 +1048,7 @@ fn duration_overflow() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        ls | get modified | each { $it + 10000000000000000day }
+        ls | get modified | each { |it| $it + 10000000000000000day }
         "#)
     );
 
@@ -1060,7 +1060,7 @@ fn date_and_duration_overflow() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        ls | get modified | each { $it + 1000000000day }
+        ls | get modified | each { |it| $it + 1000000000day }
         "#)
     );
 
@@ -1336,17 +1336,17 @@ mod variable_scoping {
                 == "ZZZ"
         );
         test_variable_scope_list!(
-            r#" def test [input] { echo [0 1 2] | each { echo $input } }
+            r#" def test [input] { echo [0 1 2] | each { |_| echo $input } }
                 test ZZZ "#
                 == ["ZZZ", "ZZZ", "ZZZ"]
         );
         test_variable_scope_list!(
-            r#" def test [input] { echo [0 1 2] | each { if $it > 0 {echo $input} else {echo $input}} }
+            r#" def test [input] { echo [0 1 2] | each { |it| if $it > 0 {echo $input} else {echo $input}} }
                 test ZZZ "#
                 == ["ZZZ", "ZZZ", "ZZZ"]
         );
         test_variable_scope_list!(
-            r#" def test [input] { echo [0 1 2] | each { if $input == $input {echo $input} else {echo $input}} }
+            r#" def test [input] { echo [0 1 2] | each { |_| if $input == $input {echo $input} else {echo $input}} }
                 test ZZZ "#
                 == ["ZZZ", "ZZZ", "ZZZ"]
         );


### PR DESCRIPTION
# Description

We've had new folks have difficulty understanding when `$it` should be used and more seasoned folks having trouble debugging larger scripts that use implicit params.

In this PR, we try to address this by requiring that blocks declare and name their params.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
