### PR TITLE
Add newline after version printout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -294,10 +294,11 @@ fn parse_commandline_args(
             }
 
             if call.has_flag("version") {
+                let version = env!("CARGO_PKG_VERSION").to_string();
                 let _ = std::panic::catch_unwind(move || {
                     let stdout = std::io::stdout();
                     let mut stdout = stdout.lock();
-                    let _ = stdout.write_all(env!("CARGO_PKG_VERSION").to_string().as_bytes());
+                    let _ = stdout.write_all(format!("{}\n", version).as_bytes());
                 });
 
                 std::process::exit(0);


### PR DESCRIPTION
# Description

Adds new line after printing out the version. See #4506
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
