### PR TITLE
Fix ignore to run side effects of previous command

### DIFF
--- a/crates/nu-command/src/core_commands/ignore.rs
+++ b/crates/nu-command/src/core_commands/ignore.rs
@@ -23,8 +23,9 @@ impl Command for Ignore {
         _engine_state: &EngineState,
         _stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        input.into_value(call.head);
         Ok(PipelineData::new(call.head))
     }
 


### PR DESCRIPTION
# Description

Ignore didn't run side effects of a preceding `each`. This fixes that issue.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
