### PR TITLE
Treat `ls` for absolute paths as-is

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -151,7 +151,7 @@ impl Command for Ls {
 
                     let display_name = if short_names {
                         path.file_name().map(|os| os.to_string_lossy().to_string())
-                    } else if full_paths {
+                    } else if full_paths || !path.is_relative() {
                         Some(path.to_string_lossy().to_string())
                     } else if let Some(prefix) = &prefix {
                         if let Ok(remainder) = path.strip_prefix(&prefix) {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -71,7 +71,7 @@ impl Command for Ls {
         let cwd = current_dir(engine_state, stack)?;
         let pattern_arg = call.opt::<Spanned<String>>(engine_state, stack, 0)?;
 
-        let (path, p_tag) = match pattern_arg {
+        let (path, p_tag, absolute_path) = match pattern_arg {
             Some(p) => {
                 let p_tag = p.span;
                 let mut p = PathBuf::from(p.item);
@@ -101,13 +101,14 @@ impl Command for Ls {
                     }
                     p.push("*");
                 }
-                (p, p_tag)
+                let absolute_path = p.is_absolute();
+                (p, p_tag, absolute_path)
             }
             None => {
                 if is_empty_dir(current_dir(engine_state, stack)?) {
                     return Ok(Value::nothing(call_span).into_pipeline_data());
                 } else {
-                    (PathBuf::from("./*"), call_span)
+                    (PathBuf::from("./*"), call_span, false)
                 }
             }
         };
@@ -151,7 +152,7 @@ impl Command for Ls {
 
                     let display_name = if short_names {
                         path.file_name().map(|os| os.to_string_lossy().to_string())
-                    } else if full_paths || !path.is_relative() {
+                    } else if full_paths || absolute_path {
                         Some(path.to_string_lossy().to_string())
                     } else if let Some(prefix) = &prefix {
                         if let Ok(remainder) = path.strip_prefix(&prefix) {


### PR DESCRIPTION
# Description

With this, `ls` no longer tries to come up with a relative path if you give it an absolute path to start from.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
