### PR TITLE
allow `dfr open` to open `tsv` files

### DIFF
--- a/crates/nu-command/src/dataframe/eager/open.rs
+++ b/crates/nu-command/src/dataframe/eager/open.rs
@@ -89,11 +89,11 @@ fn command(
 
     match file.item.extension() {
         Some(e) => match e.to_str() {
-            Some("csv") => from_csv(engine_state, stack, call),
+            Some("csv") | Some("tsv") => from_csv(engine_state, stack, call),
             Some("parquet") => from_parquet(engine_state, stack, call),
             Some("json") => from_json(engine_state, stack, call),
             _ => Err(ShellError::FileNotFoundCustom(
-                "Not a csv, parquet or json file".into(),
+                "Not a csv, tsv, parquet or json file".into(),
                 file.span,
             )),
         },


### PR DESCRIPTION
# Description

allow `dfr open` to open `tsv` files.
closes #4256 
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
