### PR TITLE
Test support fixes

### DIFF
--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -26,8 +26,8 @@ impl Outcome {
 
 pub fn pipeline(commands: &str) -> String {
     commands
+        .trim()
         .lines()
-        .skip(1)
         .map(|line| line.trim())
         .collect::<Vec<&str>>()
         .join(" ")

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -23,10 +23,8 @@ macro_rules! nu {
 
         // let commands = &*format!(
         //     "
-        //                     cd \"{}\"
         //                     {}
         //                     exit",
-        //     $crate::fs::in_directory($cwd),
         //     $crate::fs::DisplayPath::display_path(&$path)
         // );
 
@@ -51,13 +49,16 @@ macro_rules! nu {
             Err(_) => panic!("Couldn't join paths for PATH var."),
         };
 
+        let target_cwd = $crate::fs::in_directory(&$cwd);
+
         let mut process = match Command::new($crate::fs::executable_path())
+            .env("PWD", &target_cwd)  // setting PWD is enough to set cwd
             .env(NATIVE_PATH_ENV_VAR, paths_joined)
             // .arg("--skip-plugins")
             // .arg("--no-history")
             // .arg("--config-file")
             // .arg($crate::fs::DisplayPath::display_path(&$crate::fs::fixtures().join("playground/config/default.toml")))
-            .arg(format!("-c 'cd {}; {}'", $crate::fs::in_directory($cwd), $crate::fs::DisplayPath::display_path(&path)))
+            .arg(format!("-c '{}'", $crate::fs::DisplayPath::display_path(&path)))
             .stdout(Stdio::piped())
             // .stdin(Stdio::piped())
             .stderr(Stdio::piped())
@@ -109,10 +110,8 @@ macro_rules! nu_with_plugins {
 
         let commands = &*format!(
             "
-                            cd \"{}\"
                             {}
                             exit",
-            $crate::fs::in_directory($cwd),
             $crate::fs::DisplayPath::display_path(&$path)
         );
 
@@ -133,7 +132,10 @@ macro_rules! nu_with_plugins {
             Err(_) => panic!("Couldn't join paths for PATH var."),
         };
 
+        let target_cwd = $crate::fs::in_directory(&$cwd);
+
         let mut process = match Command::new($crate::fs::executable_path())
+            .env("PWD", &target_cwd)  // setting PWD is enough to set cwd
             .env(NATIVE_PATH_ENV_VAR, paths_joined)
             .stdout(Stdio::piped())
             .stdin(Stdio::piped())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ use nu_protocol::{
 };
 use std::{io::Write, path::PathBuf};
 
-// This fill collect environment variables from std::env and adds them to a stack.
+// This will collect environment variables from std::env and adds them to a stack.
 //
 // In order to ensure the values have spans, it first creates a dummy file, writes the collected
 // env vars into it (in a "NAME"="value" format, quite similar to the output of the Unix 'env'


### PR DESCRIPTION
# Description

Fixes two things in `nu-test-support`:
* Correctly entering current working directory
* Not skipping first line of the pipeline anymore
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
