### PR TITLE
Add or update examples for some commands

### DIFF
--- a/crates/nu-command/src/core_commands/alias.rs
+++ b/crates/nu-command/src/core_commands/alias.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape};
 
 #[derive(Clone)]
 pub struct Alias;
@@ -33,5 +33,13 @@ impl Command for Alias {
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Alias ll to ls -l",
+            example: "alias ll = ls -l",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -61,6 +61,11 @@ impl Command for Let {
                 example: "let x = 10 + 100",
                 result: None,
             },
+            Example {
+                description: "Set a variable based on the condition",
+                example: "let x = if $false { -1 } else { 1 }",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/date/now.rs
+++ b/crates/nu-command/src/date/now.rs
@@ -35,12 +35,10 @@ impl Command for SubCommand {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![
-            Example {
-                description: "Get the current date and display it in a given format string.",
-                example: r#"date now | date format "%Y-%m-%d %H:%M:%S""#,
-                result: None,
-            },
-        ]
+        vec![Example {
+            description: "Get the current date and display it in a given format string.",
+            example: r#"date now | date format "%Y-%m-%d %H:%M:%S""#,
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/date/now.rs
+++ b/crates/nu-command/src/date/now.rs
@@ -1,7 +1,7 @@
 use chrono::Local;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, IntoPipelineData, PipelineData, Signature, Value};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Value};
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -32,5 +32,15 @@ impl Command for SubCommand {
             span: head,
         }
         .into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Get the current date and display it in a given format string.",
+                example: r#"date now | date format "%Y-%m-%d %H:%M:%S""#,
+                result: None,
+            },
+        ]
     }
 }

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -50,6 +50,10 @@ impl Command for Update {
             result: Some(Value::Record { cols: vec!["name".into(), "stars".into()], vals: vec![Value::test_string("Nushell"), Value::test_int(5)], span: Span::test_data()}),
         }, Example {
             description: "Use in block form for more involved updating logic",
+            example: "echo [[count fruit]; [1 'apple']] | update count {|f| $f.count + 1}",
+            result: Some(Value::List { vals: vec![Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(2), Value::test_string("apple")], span: Span::test_data()}], span: Span::test_data()}),
+        }, Example {
+            description: "Use in block form for more involved updating logic",
             example: "echo [[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors { get authors | str collect ',' }",
             result: Some(Value::List { vals: vec![Value::Record { cols: vec!["project".into(), "authors".into()], vals: vec![Value::test_string("nu"), Value::test_string("Andrés,JT,Yehuda")], span: Span::test_data()}], span: Span::test_data()}),
         }]

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -1,7 +1,7 @@
 use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape};
 
 #[derive(Clone)]
 pub struct Where;
@@ -62,5 +62,30 @@ impl Command for Where {
                 ctrlc,
             )
             .map(|x| x.set_metadata(metadata))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "List all files in the current directory with sizes greater than 2kb",
+                example: "ls | where size > 2kb",
+                result: None,
+            },
+            Example {
+                description: "List only the files in the current directory",
+                example: "ls | where type == file",
+                result: None,
+            },
+            Example {
+                description: "List all files with names that contain \"Car\"",
+                example: "ls | where name =~ \"Car\"",
+                result: None,
+            },
+            Example {
+                description: "List all files that were modified in the last two weeks",
+                example: "ls | where modified <= 2wk",
+                result: None,
+            },
+        ]
     }
 }

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -2,8 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
-    SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
+    Span, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -63,5 +63,13 @@ impl Command for Wrap {
             }
             .into_pipeline_data()),
         }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Wrap a list into a table with a given column name",
+            example: "echo [1 2 3] | wrap num",
+            result: Some(Value::List { vals: vec![Value::Record { cols: vec!["num".into()], vals: vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)], span: Span::test_data()}], span: Span::test_data()}),
+        }]
     }
 }

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -69,7 +69,14 @@ impl Command for Wrap {
         vec![Example {
             description: "Wrap a list into a table with a given column name",
             example: "echo [1 2 3] | wrap num",
-            result: Some(Value::List { vals: vec![Value::Record { cols: vec!["num".into()], vals: vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)], span: Span::test_data()}], span: Span::test_data()}),
+            result: Some(Value::List {
+                vals: vec![Value::Record {
+                    cols: vec!["num".into()],
+                    vals: vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)],
+                    span: Span::test_data(),
+                }],
+                span: Span::test_data(),
+            }),
         }]
     }
 }

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -1,7 +1,7 @@
 use nu_engine::{current_dir, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape, Value};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -96,5 +96,20 @@ impl Command for Exit {
 
             Ok(PipelineData::new(call.head))
         }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Exit the current shell",
+                example: "exit",
+                result: None,
+            },
+            Example {
+                description: "Exit all shells (exiting Nu)",
+                example: "exit --now",
+                result: None,
+            },
+        ]
     }
 }

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -76,16 +76,16 @@ fn test_no_color_flag() {
 }
 
 #[test]
-fn test_html_color_where_flag_dark_false() {
+fn test_html_color_cd_flag_dark_false() {
     let actual = nu!(
         cwd: ".", pipeline(
             r#"
-                where --help | to html --html-color
+                cd --help | to html --html-color
             "#
         )
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Filter values based on a condition.<br><br>Usage:<br>  &gt; where &lt;cond&gt; <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  cond: condition<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path: the path to change to<br><br></body></html>"
     );
 }


### PR DESCRIPTION
# Description

Add or update examples for some commands
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
