### PR TITLE
fix: lose `ls_colors` in some filters commands

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -71,7 +71,7 @@ fn first_helper(
     };
 
     let ctrlc = engine_state.ctrlc.clone();
-    let metadata = input.metadata().clone();
+    let metadata = input.metadata();
 
     let mut input_peek = input.into_iter().peekable();
     if input_peek.peek().is_some() {

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -47,6 +47,8 @@ impl Command for Last {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let metadata = input.metadata();
+
         let rows: Option<i64> = call.opt(engine_state, stack, 0)?;
         let v: Vec<_> = input.into_iter().collect();
         let vlen: i64 = v.len() as i64;
@@ -54,7 +56,9 @@ impl Command for Last {
 
         let iter = v.into_iter().skip(beginning_rows_to_skip as usize);
 
-        Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
+        Ok(iter
+            .into_pipeline_data(engine_state.ctrlc.clone())
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/reverse.rs
+++ b/crates/nu-command/src/filters/reverse.rs
@@ -44,10 +44,14 @@ impl Command for Reverse {
         _call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let metadata = input.metadata();
+
         #[allow(clippy::needless_collect)]
         let v: Vec<_> = input.into_iter().collect();
         let iter = v.into_iter().rev();
-        Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
+        Ok(iter
+            .into_pipeline_data(engine_state.ctrlc.clone())
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -60,6 +60,7 @@ impl Command for Skip {
     ) -> Result<PipelineData, ShellError> {
         let n: Option<Value> = call.opt(engine_state, stack, 0)?;
         let span = call.head;
+        let metadata = input.metadata();
 
         let n: usize = match n {
             Some(Value::Int { val, span }) => val.try_into().map_err(|err| {
@@ -74,7 +75,11 @@ impl Command for Skip {
 
         let ctrlc = engine_state.ctrlc.clone();
 
-        Ok(input.into_iter().skip(n).into_pipeline_data(ctrlc))
+        Ok(input
+            .into_iter()
+            .skip(n)
+            .into_pipeline_data(ctrlc)
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -47,6 +47,7 @@ impl Command for SkipUntil {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
+        let metadata = input.metadata();
 
         let capture_block: CaptureBlock = call.req(engine_state, stack, 0)?;
 
@@ -69,7 +70,8 @@ impl Command for SkipUntil {
                         pipeline_data.into_value(span).is_true()
                     })
             })
-            .into_pipeline_data(ctrlc))
+            .into_pipeline_data(ctrlc)
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -47,6 +47,7 @@ impl Command for SkipWhile {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
+        let metadata = input.metadata();
 
         let capture_block: CaptureBlock = call.req(engine_state, stack, 0)?;
 
@@ -69,7 +70,8 @@ impl Command for SkipWhile {
                         pipeline_data.into_value(span).is_true()
                     })
             })
-            .into_pipeline_data(ctrlc))
+            .into_pipeline_data(ctrlc)
+            .set_metadata(metadata))
     }
 }
 


### PR DESCRIPTION
This PR related to #4444, #4306, #4309

# Description

Currently,`Ls_colors` is not applied due to missing `metadata` from some commands related to `filters`.
This bug appears not only in `first` and `skip` filters, but also in `reverse`, `get`, etc.

Therefore, for `Ls_colors`, each filter will have to return `PipelineData` including `metadata`.

**Expected Behavior:**
![스크린샷 2022-02-18 오후 8 41 36](https://user-images.githubusercontent.com/32578710/154678083-64a34f2d-9584-43cc-a4c1-3b6929838915.png)

**Task:**
- [x] first
- [x] skip
- [x] last
- [x] reverse

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
