### PR TITLE
Fix stream printing on Windows

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -198,11 +198,11 @@ fn print_pipeline_data(
 
     let config = stack.get_config().unwrap_or_default();
 
-    let mut stdout = std::io::stdout();
+    let stdout = std::io::stdout();
 
     if let PipelineData::RawStream(stream, _, _) = input {
         for s in stream {
-            let _ = stdout.write(s?.as_binary()?);
+            let _ = stdout.lock().write_all(s?.as_binary()?);
         }
         return Ok(());
     }


### PR DESCRIPTION
# Description

Streams with certain characters would fail to print correctly on Windows. This fixes that issue. Might be a very slight performance regression but only with very long `RawStream` instances.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
