### PR TITLE
feat: update #4518, Add command examples for def, do, cp, mv, mkdir and ls

### DIFF
--- a/crates/nu-command/src/core_commands/def.rs
+++ b/crates/nu-command/src/core_commands/def.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct Def;
@@ -34,5 +34,20 @@ impl Command for Def {
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Define a command and run it",
+                example: r#"def say-hi [] { echo 'hi' }; say-hi"#,
+                result: Some(Value::test_string("hi")),
+            },
+            Example {
+                description: "Define a command and run it with parameter(s)",
+                example: r#"def say-sth [sth: string] { echo $sth }; say-sth hi"#,
+                result: Some(Value::test_string("hi")),
+            },
+        ]
     }
 }

--- a/crates/nu-command/src/core_commands/do_.rs
+++ b/crates/nu-command/src/core_commands/do_.rs
@@ -1,7 +1,7 @@
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape, Value};
+use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct Do;
@@ -94,5 +94,20 @@ impl Command for Do {
         } else {
             result
         }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Run the block",
+                example: r#"do { echo hello }"#,
+                result: Some(Value::test_string("hello")),
+            },
+            Example {
+                description: "Run the block and ignore errors",
+                example: r#"do -i { thisisnotarealcommand }"#,
+                result: None,
+            },
+        ]
     }
 }

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -5,7 +5,7 @@ use nu_engine::CallExt;
 use nu_path::canonicalize_with;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature, Spanned, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape};
 
 use crate::filesystem::util::FileStructure;
 
@@ -175,6 +175,21 @@ impl Command for Cp {
         }
 
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Copy myfile to dir_b",
+                example: "cp myfile dir_b",
+                result: None,
+            },
+            Example {
+                description: "Recursively copy dir_a to dir_b",
+                example: "cp -r dir_a dir_b",
+                result: None,
+            },
+        ]
     }
 
     //     let mut sources =

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -6,7 +6,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, DataSource, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
+    Category, DataSource, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     PipelineMetadata, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
 use pathdiff::diff_paths;
@@ -204,6 +204,26 @@ impl Command for Ls {
                 },
                 engine_state.ctrlc.clone(),
             ))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "List all files in the current directory",
+                example: "ls",
+                result: None,
+            },
+            Example {
+                description: "List all files in a subdirectory",
+                example: "ls subdir",
+                result: None,
+            },
+            Example {
+                description: "List all rust files",
+                example: "ls *.rs",
+                result: None,
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -5,8 +5,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, SyntaxShape,
-    Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature,
+    SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -76,5 +76,20 @@ impl Command for Mkdir {
         Ok(stream
             .into_iter()
             .into_pipeline_data(engine_state.ctrlc.clone()))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Make a directory named foo",
+                example: "mkdir foo",
+                result: None,
+            },
+            Example {
+                description: "Make multiple directories and show the paths created",
+                example: "mkdir -s foo/bar foo2",
+                result: None,
+            },
+        ]
     }
 }

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -5,7 +5,9 @@ use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
+};
 
 const GLOB_PARAMS: glob::MatchOptions = glob::MatchOptions {
     case_sensitive: true,
@@ -128,6 +130,26 @@ impl Command for Mv {
         }
 
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Rename a file",
+                example: "mv before.txt after.txt",
+                result: None,
+            },
+            Example {
+                description: "Move a file into a directory",
+                example: "mv test.txt my/subdirectory",
+                result: None,
+            },
+            Example {
+                description: "Move many files into a directory",
+                example: "mv *.txt my/subdirectory",
+                result: None,
+            },
+        ]
     }
 }
 


### PR DESCRIPTION


# Description

Add command examples for def, do, cp, mv, mkdir and ls
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
