### PR TITLE
Fix wrong FlatShape name of List

### DIFF
--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -46,7 +46,7 @@ impl Display for FlatShape {
             FlatShape::Signature => write!(f, "flatshape_signature"),
             FlatShape::String => write!(f, "flatshape_string"),
             FlatShape::StringInterpolation => write!(f, "flatshape_string_interpolation"),
-            FlatShape::List => write!(f, "flatshape_string_interpolation"),
+            FlatShape::List => write!(f, "flatshape_list"),
             FlatShape::Table => write!(f, "flatshape_table"),
             FlatShape::Record => write!(f, "flatshape_record"),
             FlatShape::Block => write!(f, "flatshape_block"),


### PR DESCRIPTION
# Description

Seems like FlatShape::List had a wrong formatted name
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
