### PR TITLE
Make 'for' implicitly filter out nothings

### DIFF
--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -109,6 +109,7 @@ impl Command for For {
                         Err(error) => Value::Error { error },
                     }
                 })
+                .filter(|x| !x.is_nothing())
                 .into_pipeline_data(ctrlc)),
             Value::Range { val, .. } => Ok(val
                 .into_range_iter()?
@@ -146,6 +147,7 @@ impl Command for For {
                         Err(error) => Value::Error { error },
                     }
                 })
+                .filter(|x| !x.is_nothing())
                 .into_pipeline_data(ctrlc)),
             x => {
                 stack.add_var(var_id, x);

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -562,6 +562,10 @@ impl Value {
         }
     }
 
+    pub fn is_nothing(&self) -> bool {
+        matches!(self, Value::Nothing { .. })
+    }
+
     /// Create a new `Nothing` value
     pub fn nothing(span: Span) -> Value {
         Value::Nothing { span }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -149,7 +149,7 @@ fn proper_variable_captures_with_nesting() -> TestResult {
 
 #[test]
 fn proper_variable_for() -> TestResult {
-    run_test(r#"for x in 1..3 { if $x == 2 { "bob" } } | get 1"#, "bob")
+    run_test(r#"for x in 1..3 { if $x == 2 { "bob" } } | get 0"#, "bob")
 }
 
 #[test]


### PR DESCRIPTION
# Description

Tweak how `for` handles `$nothing` values that are passed down the pipeline. This should help prevent the case where a lot of empty rows are output in a table after the `for` loop runs when it's been written as more of a way to work with data, but not create new streams.

```
> for x in $nothing { $x }
> for _ in 1..3 { $nothing }
> 
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
