### PR TITLE
Fix external completions relying on external commands

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -12,11 +12,15 @@ const SEP: char = std::path::MAIN_SEPARATOR;
 #[derive(Clone)]
 pub struct NuCompleter {
     engine_state: EngineState,
+    config: Option<Value>,
 }
 
 impl NuCompleter {
-    pub fn new(engine_state: EngineState) -> Self {
-        Self { engine_state }
+    pub fn new(engine_state: EngineState, config: Option<Value>) -> Self {
+        Self {
+            engine_state,
+            config,
+        }
     }
 
     fn external_command_completion(&self, prefix: &str) -> Vec<String> {
@@ -235,14 +239,19 @@ impl NuCompleter {
 
                                 let mut stack = Stack::new();
                                 // Set up our initial config to start from
-                                stack.vars.insert(
-                                    CONFIG_VARIABLE_ID,
-                                    Value::Record {
-                                        cols: vec![],
-                                        vals: vec![],
-                                        span: Span { start: 0, end: 0 },
-                                    },
-                                );
+                                if let Some(conf) = &self.config {
+                                    stack.vars.insert(CONFIG_VARIABLE_ID, conf.clone());
+                                } else {
+                                    stack.vars.insert(
+                                        CONFIG_VARIABLE_ID,
+                                        Value::Record {
+                                            cols: vec![],
+                                            vals: vec![],
+                                            span: Span { start: 0, end: 0 },
+                                        },
+                                    );
+                                }
+
                                 let result = eval_block(
                                     &self.engine_state,
                                     &mut stack,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -138,7 +138,10 @@ pub(crate) fn evaluate(engine_state: &mut EngineState) -> Result<()> {
             .with_validator(Box::new(NuValidator {
                 engine_state: engine_state.clone(),
             }))
-            .with_completer(Box::new(NuCompleter::new(engine_state.clone())))
+            .with_completer(Box::new(NuCompleter::new(
+                engine_state.clone(),
+                stack.vars.get(&CONFIG_VARIABLE_ID).cloned(),
+            )))
             .with_quick_completions(config.quick_completions)
             .with_ansi_colors(config.use_ansi_coloring);
 


### PR DESCRIPTION
# Description

Fixes https://github.com/nushell/nushell/issues/4463

The problem was that the completer was getting empty config which didn't have `env_conversions`, therefore `PATH` was not translated correctly from list into a string.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
