### PR TITLE
Add some more builtin var completions

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -71,7 +71,9 @@ impl NuCompleter {
     ) -> Vec<(reedline::Span, String)> {
         let mut output = vec![];
 
-        let builtins = ["$nu", "$scope", "$in", "$config", "$env"];
+        let builtins = [
+            "$nu", "$scope", "$in", "$config", "$env", "$true", "$false", "$nothing",
+        ];
 
         for builtin in builtins {
             if builtin.as_bytes().starts_with(prefix) {


### PR DESCRIPTION
# Description

This adds a few more built-in vars to our variable completions
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
