### PR TITLE
Improve comparison errors

### DIFF
--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -1,7 +1,9 @@
 use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, Signature, SyntaxShape, Value,
+};
 
 #[derive(Clone)]
 pub struct Where;
@@ -39,29 +41,35 @@ impl Command for Where {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
-        input
-            .filter(
-                move |value| {
-                    if let Some(var) = block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(*var_id, value.clone());
+        Ok(input
+            .into_iter()
+            .filter_map(move |value| {
+                if let Some(var) = block.signature.get_positional(0) {
+                    if let Some(var_id) = &var.var_id {
+                        stack.add_var(*var_id, value.clone());
+                    }
+                }
+                let result = eval_block_with_redirect(
+                    &engine_state,
+                    &mut stack,
+                    &block,
+                    PipelineData::new(span),
+                );
+
+                match result {
+                    Ok(result) => {
+                        let result = result.into_value(span);
+                        if result.is_true() {
+                            Some(value)
+                        } else {
+                            None
                         }
                     }
-                    let result = eval_block_with_redirect(
-                        &engine_state,
-                        &mut stack,
-                        &block,
-                        PipelineData::new(span),
-                    );
-
-                    match result {
-                        Ok(result) => result.into_value(span).is_true(),
-                        _ => false,
-                    }
-                },
-                ctrlc,
-            )
-            .map(|x| x.set_metadata(metadata))
+                    Err(err) => Some(Value::Error { error: err }),
+                }
+            })
+            .into_pipeline_data(ctrlc))
+        .map(|x| x.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -127,7 +127,7 @@ fn converts_to_int() {
             | into int number_as_string
             | rename number
             | where number == 1
-            | get number
+            | get number.0
 
         "#
     ));

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1537,6 +1537,13 @@ impl Value {
             return lhs.operation(*span, Operator::LessThan, op, rhs);
         }
 
+        if !type_compatible(self.get_type(), rhs.get_type())
+            && (self.get_type() != Type::Unknown)
+            && (rhs.get_type() != Type::Unknown)
+        {
+            return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
+        }
+
         match self.partial_cmp(rhs) {
             Some(ordering) => Ok(Value::Bool {
                 val: matches!(ordering, Ordering::Less),
@@ -1556,6 +1563,13 @@ impl Value {
 
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::LessThanOrEqual, op, rhs);
+        }
+
+        if !type_compatible(self.get_type(), rhs.get_type())
+            && (self.get_type() != Type::Unknown)
+            && (rhs.get_type() != Type::Unknown)
+        {
+            return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
         }
 
         match self.partial_cmp(rhs) {
@@ -1579,6 +1593,13 @@ impl Value {
             return lhs.operation(*span, Operator::GreaterThan, op, rhs);
         }
 
+        if !type_compatible(self.get_type(), rhs.get_type())
+            && (self.get_type() != Type::Unknown)
+            && (rhs.get_type() != Type::Unknown)
+        {
+            return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
+        }
+
         match self.partial_cmp(rhs) {
             Some(ordering) => Ok(Value::Bool {
                 val: matches!(ordering, Ordering::Greater),
@@ -1598,6 +1619,13 @@ impl Value {
 
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::GreaterThanOrEqual, op, rhs);
+        }
+
+        if !type_compatible(self.get_type(), rhs.get_type())
+            && (self.get_type() != Type::Unknown)
+            && (rhs.get_type() != Type::Unknown)
+        {
+            return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
         }
 
         match self.partial_cmp(rhs) {
@@ -1983,6 +2011,14 @@ impl From<Spanned<HashMap<String, Value>>> for Value {
 
         Value::Record { cols, vals, span }
     }
+}
+
+fn type_compatible(a: Type, b: Type) -> bool {
+    if a == b {
+        return true;
+    }
+
+    matches!((a, b), (Type::Int, Type::Float) | (Type::Float, Type::Int))
 }
 
 /// Create a Value::Record from a spanned indexmap


### PR DESCRIPTION
# Description

This improves comparison errors to not allow comparisons between incompatible types. I also fixed `where`, as it was allowing errors to slip through without reporting them.

Now, you'll get:

```
> [1, 2, 3] | where (date now) < 365day
Error: nu::shell::type_mismatch (link)

  × Type mismatch
   ╭─[entry #1:1:1]
 1 │ [1, 2, 3] | where (date now) < 365day
   ·                              ┬
   ·                              ╰── needs compatible type
   ╰────
```
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
