### PR TITLE
Better keybinding parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#8c565e4f1de2c6dd4f67b18876d011756bfbe16d"
+source = "git+https://github.com/nushell/reedline?branch=main#42ec23f08399519e79077921a08901420e27b05c"
 dependencies = [
  "chrono",
  "crossterm",


### PR DESCRIPTION
# Description

It introduces the `until` type for keybindings. 

The parser now allows the next until event for the keybindings. The until event will execute all the events in the list until one is successfully executed

```
    {
        name: "until found event"
        modifier: control
        keycode: char_r
        mode: emacs
        event: { until: [
            { send: historyhintcomplete }
            { send: menu name: context_menu }
            { send: menunext }
        ]
      }
```

This is now a valid event as well
```
    {
        name: "complete"
        modifier: control
        keycode: char_r
        mode: emacs
        event: { send: historyhintcomplete }
      }
```
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
