### PR TITLE
Use join over custom join code

### DIFF
--- a/crates/nu-system/src/linux.rs
+++ b/crates/nu-system/src/linux.rs
@@ -194,17 +194,7 @@ impl ProcessInfo {
     pub fn command(&self) -> String {
         if let Ok(cmd) = &self.curr_proc.cmdline() {
             if !cmd.is_empty() {
-                let mut cmd = cmd
-                    .iter()
-                    .cloned()
-                    .map(|mut x| {
-                        x.push(' ');
-                        x
-                    })
-                    .collect::<String>();
-                cmd.pop();
-                cmd = cmd.replace("\n", " ").replace("\t", " ");
-                cmd
+                cmd.join(" ").replace("\n", " ").replace("\t", " ")
             } else {
                 self.curr_proc.stat().comm.clone()
             }

--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -316,18 +316,7 @@ impl ProcessInfo {
     pub fn command(&self) -> String {
         if let Some(path) = &self.curr_path {
             if !path.cmd.is_empty() {
-                let mut cmd = path
-                    .cmd
-                    .iter()
-                    .cloned()
-                    .map(|mut x| {
-                        x.push(' ');
-                        x
-                    })
-                    .collect::<String>();
-                cmd.pop();
-                cmd = cmd.replace("\n", " ").replace("\t", " ");
-                cmd
+                path.cmd.join(" ").replace("\n", " ").replace("\t", " ")
             } else {
                 String::from("")
             }


### PR DESCRIPTION
# Description

While working on https://github.com/nushell/nushell/pull/4544, I waw some code that looked like it was doing what `join` does, so I swapped it out.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
