### PR TITLE
refactor: change column names from 'Column*' to 'column*'

### DIFF
--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -119,7 +119,7 @@ fn extract_headers(value: &Value, config: &Config) -> Result<Vec<String>, ShellE
             .map(|(idx, value)| {
                 let col = value.into_string("", config);
                 if col.is_empty() {
-                    format!("Column{}", idx)
+                    format!("column{}", idx)
                 } else {
                     col
                 }

--- a/crates/nu-command/src/filters/rotate.rs
+++ b/crates/nu-command/src/filters/rotate.rs
@@ -37,12 +37,12 @@ impl Command for Rotate {
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {
-                            cols: vec!["Column0".to_string(), "Column1".to_string()],
+                            cols: vec!["column0".to_string(), "column1".to_string()],
                             vals: vec![Value::test_int(1), Value::test_string("a")],
                             span: Span::test_data(),
                         },
                         Value::Record {
-                            cols: vec!["Column0".to_string(), "Column1".to_string()],
+                            cols: vec!["column0".to_string(), "column1".to_string()],
                             vals: vec![Value::test_int(2), Value::test_string("b")],
                             span: Span::test_data(),
                         },
@@ -57,10 +57,10 @@ impl Command for Rotate {
                     vals: vec![
                         Value::Record {
                             cols: vec![
-                                "Column0".to_string(),
-                                "Column1".to_string(),
-                                "Column2".to_string(),
-                                "Column3".to_string(),
+                                "column0".to_string(),
+                                "column1".to_string(),
+                                "column2".to_string(),
+                                "column3".to_string(),
                             ],
                             vals: vec![
                                 Value::test_int(5),
@@ -72,10 +72,10 @@ impl Command for Rotate {
                         },
                         Value::Record {
                             cols: vec![
-                                "Column0".to_string(),
-                                "Column1".to_string(),
-                                "Column2".to_string(),
-                                "Column3".to_string(),
+                                "column0".to_string(),
+                                "column1".to_string(),
+                                "column2".to_string(),
+                                "column3".to_string(),
                             ],
                             vals: vec![
                                 Value::test_int(6),
@@ -114,12 +114,12 @@ impl Command for Rotate {
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {
-                            cols: vec!["Column0".to_string(), "Column1".to_string()],
+                            cols: vec!["column0".to_string(), "column1".to_string()],
                             vals: vec![Value::test_string("b"), Value::test_int(2)],
                             span: Span::test_data(),
                         },
                         Value::Record {
-                            cols: vec!["Column0".to_string(), "Column1".to_string()],
+                            cols: vec!["column0".to_string(), "column1".to_string()],
                             vals: vec![Value::test_string("a"), Value::test_int(1)],
                             span: Span::test_data(),
                         },
@@ -134,10 +134,10 @@ impl Command for Rotate {
                     vals: vec![
                         Value::Record {
                             cols: vec![
-                                "Column0".to_string(),
-                                "Column1".to_string(),
-                                "Column2".to_string(),
-                                "Column3".to_string(),
+                                "column0".to_string(),
+                                "column1".to_string(),
+                                "column2".to_string(),
+                                "column3".to_string(),
                             ],
                             vals: vec![
                                 Value::test_string("b"),
@@ -149,10 +149,10 @@ impl Command for Rotate {
                         },
                         Value::Record {
                             cols: vec![
-                                "Column0".to_string(),
-                                "Column1".to_string(),
-                                "Column2".to_string(),
-                                "Column3".to_string(),
+                                "column0".to_string(),
+                                "column1".to_string(),
+                                "column2".to_string(),
+                                "column3".to_string(),
                             ],
                             vals: vec![
                                 Value::test_string("a"),
@@ -260,11 +260,11 @@ pub fn rotate(
         *total_rows -= 1;
     }
 
-    // holder for the new column names, particularly if none are provided by the user we create names as Column0, Column1, etc.
+    // holder for the new column names, particularly if none are provided by the user we create names as column0, column1, etc.
     let mut new_column_names = {
         let mut res = vec![];
         for idx in 0..(*total_rows + 1) {
-            res.push(format!("Column{}", idx));
+            res.push(format!("column{}", idx));
         }
         res.to_vec()
     };

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -63,12 +63,12 @@ impl Command for Transpose {
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {
-                            cols: vec!["Column0".to_string(), "Column1".to_string()],
+                            cols: vec!["column0".to_string(), "column1".to_string()],
                             vals: vec![Value::test_string("c1"), Value::test_int(1)],
                             span,
                         },
                         Value::Record {
-                            cols: vec!["Column0".to_string(), "Column1".to_string()],
+                            cols: vec!["column0".to_string(), "column1".to_string()],
                             vals: vec![Value::test_string("c2"), Value::test_int(2)],
                             span,
                         },
@@ -184,7 +184,7 @@ pub fn transpose(
             if let Some(name) = args.rest.get(i) {
                 headers.push(name.item.clone())
             } else {
-                headers.push(format!("Column{}", i));
+                headers.push(format!("column{}", i));
             }
         }
     }

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -14,7 +14,7 @@ fn from_delimited_string_to_value(
 
     let headers = if noheaders {
         (1..=reader.headers()?.len())
-            .map(|i| format!("Column{}", i))
+            .map(|i| format!("column{}", i))
             .collect::<Vec<String>>()
     } else {
         reader.headers()?.iter().map(String::from).collect()

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -146,7 +146,7 @@ fn from_ods(
                         _ => Value::nothing(head),
                     };
 
-                    row_output.insert(format!("Column{}", i), value);
+                    row_output.insert(format!("column{}", i), value);
                 }
 
                 let (cols, vals) =

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -49,7 +49,7 @@ impl Command for FromSsv {
 1   2' | from ssv -n"#,
             description: "Converts ssv formatted string to table but not treating the first row as column names",
             result: Some(
-                Value::List { vals: vec![Value::Record { cols: vec!["Column1".to_string(), "Column2".to_string()], vals: vec![Value::String { val: "FOO".to_string(), span: Span::test_data() }, Value::String { val: "BAR".to_string(), span: Span::test_data() }], span: Span::test_data() }, Value::Record { cols: vec!["Column1".to_string(), "Column2".to_string()], vals: vec![Value::String { val: "1".to_string(), span: Span::test_data() }, Value::String { val: "2".to_string(), span: Span::test_data() }], span: Span::test_data() }], span: Span::test_data() }),
+                Value::List { vals: vec![Value::Record { cols: vec!["column1".to_string(), "column2".to_string()], vals: vec![Value::String { val: "FOO".to_string(), span: Span::test_data() }, Value::String { val: "BAR".to_string(), span: Span::test_data() }], span: Span::test_data() }, Value::Record { cols: vec!["column1".to_string(), "column2".to_string()], vals: vec![Value::String { val: "1".to_string(), span: Span::test_data() }, Value::String { val: "2".to_string(), span: Span::test_data() }], span: Span::test_data() }], span: Span::test_data() }),
         }]
     }
 
@@ -150,7 +150,7 @@ fn parse_aligned_columns<'a>(
         let headers: Vec<(String, usize)> = indices
             .iter()
             .enumerate()
-            .map(|(i, position)| (format!("Column{}", i + 1), *position))
+            .map(|(i, position)| (format!("column{}", i + 1), *position))
             .collect();
 
         construct(ls.iter().map(|s| s.to_owned()), headers)
@@ -196,7 +196,7 @@ fn parse_separated_columns<'a>(
         let num_columns = ls.iter().map(|r| r.len()).max().unwrap_or(0);
 
         let headers = (1..=num_columns)
-            .map(|i| format!("Column{}", i))
+            .map(|i| format!("column{}", i))
             .collect::<Vec<String>>();
         collect(headers, ls.into_iter(), separator)
     };
@@ -337,9 +337,9 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                vec![owned("Column1", "a"), owned("Column2", "b")],
-                vec![owned("Column1", "1"), owned("Column2", "2")],
-                vec![owned("Column1", "3"), owned("Column2", "4")]
+                vec![owned("column1", "a"), owned("column2", "b")],
+                vec![owned("column1", "1"), owned("column2", "2")],
+                vec![owned("column1", "3"), owned("column2", "4")]
             ]
         );
     }
@@ -451,25 +451,25 @@ mod tests {
             result,
             vec![
                 vec![
-                    owned("Column1", "a multi-word value"),
-                    owned("Column2", "b"),
-                    owned("Column3", ""),
-                    owned("Column4", "d"),
-                    owned("Column5", "")
+                    owned("column1", "a multi-word value"),
+                    owned("column2", "b"),
+                    owned("column3", ""),
+                    owned("column4", "d"),
+                    owned("column5", "")
                 ],
                 vec![
-                    owned("Column1", "1"),
-                    owned("Column2", ""),
-                    owned("Column3", "3-3"),
-                    owned("Column4", "4"),
-                    owned("Column5", "")
+                    owned("column1", "1"),
+                    owned("column2", ""),
+                    owned("column3", "3-3"),
+                    owned("column4", "4"),
+                    owned("column5", "")
                 ],
                 vec![
-                    owned("Column1", ""),
-                    owned("Column2", ""),
-                    owned("Column3", ""),
-                    owned("Column4", ""),
-                    owned("Column5", "last")
+                    owned("column1", ""),
+                    owned("column2", ""),
+                    owned("column3", ""),
+                    owned("column4", ""),
+                    owned("column5", "last")
                 ],
             ]
         );

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -146,7 +146,7 @@ fn from_xlsx(
                         _ => Value::nothing(head),
                     };
 
-                    row_output.insert(format!("Column{}", i), value);
+                    row_output.insert(format!("column{}", i), value);
                 }
 
                 let (cols, vals) =

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -54,9 +54,9 @@ impl Command for DetectColumns {
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec![
-                            "Column0".to_string(),
-                            "Column1".to_string(),
-                            "Column2".to_string(),
+                            "column0".to_string(),
+                            "column1".to_string(),
+                            "column2".to_string(),
                         ],
                         vals: vec![
                             Value::test_string("a"),
@@ -105,7 +105,7 @@ fn detect_columns(
 
         if noheader {
             for header in headers.iter_mut().enumerate() {
-                header.1.item = format!("Column{}", header.0);
+                header.1.item = format!("column{}", header.0);
             }
         }
 

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -51,9 +51,9 @@ impl Command for SubCommand {
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec![
-                            "Column1".to_string(),
-                            "Column2".to_string(),
-                            "Column3".to_string(),
+                            "column1".to_string(),
+                            "column2".to_string(),
+                            "column3".to_string(),
                         ],
                         vals: vec![
                             Value::test_string("a"),
@@ -71,9 +71,9 @@ impl Command for SubCommand {
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec![
-                            "Column1".to_string(),
-                            "Column2".to_string(),
-                            "Column3".to_string(),
+                            "column1".to_string(),
+                            "column2".to_string(),
+                            "column3".to_string(),
                         ],
                         vals: vec![
                             Value::test_string("a"),
@@ -131,7 +131,7 @@ fn split_column_helper(
         if positional.is_empty() {
             let mut gen_columns = vec![];
             for i in 0..split_result.len() {
-                gen_columns.push(format!("Column{}", i + 1));
+                gen_columns.push(format!("column{}", i + 1));
             }
 
             for (&k, v) in split_result.iter().zip(&gen_columns) {

--- a/crates/nu-command/tests/commands/headers.rs
+++ b/crates/nu-command/tests/commands/headers.rs
@@ -23,7 +23,7 @@ fn headers_adds_missing_column_name() {
             open sample_headers.xlsx
             | get Sheet1
             | headers
-            | get Column1
+            | get column1
             | to json --raw"#
     ));
 

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -11,7 +11,7 @@ fn lines() {
             | skip 1
             | first 1
             | split column "="
-            | get Column1.0
+            | get column1.0
             | str trim
         "#
     ));

--- a/crates/nu-command/tests/commands/path/parse.rs
+++ b/crates/nu-command/tests/commands/path/parse.rs
@@ -122,7 +122,7 @@ fn parses_into_correct_number_of_columns() {
             echo 'home/viking/spam.txt'
             | path parse
             | transpose
-            | get Column0
+            | get column0
             | length
         "#
     ));

--- a/crates/nu-command/tests/commands/roll.rs
+++ b/crates/nu-command/tests/commands/roll.rs
@@ -8,10 +8,10 @@ mod rows {
             r#"
             echo [
                 [service, status];
-            
-                [ruby,      DOWN] 
-                [db,        DOWN] 
-                [nud,       DOWN] 
+
+                [ruby,      DOWN]
+                [db,        DOWN]
+                [nud,       DOWN]
                 [expected,  HERE]
             ]"#,
         )
@@ -52,10 +52,10 @@ mod columns {
             r#"
             echo [
                 [commit_author, origin,      stars];
-            
-                [     "Andres",     EC, amarillito] 
-                [     "Darren",     US,      black] 
-                [   "Jonathan",     US,      black] 
+
+                [     "Andres",     EC, amarillito]
+                [     "Darren",     US,      black]
+                [   "Jonathan",     US,      black]
                 [     "Yehuda",     US,      black]
                 [      "Jason",     CA,       gold]
             ]"#,
@@ -122,7 +122,7 @@ mod columns {
         //
         // output:
         //  [
-        //   [Column1, Column2, Column3, Column4, Column5, Column6, Column7, Column8];
+        //   [column1, column2, column3, column4, column5, column6, column7, column8];
         //   [      0,       0,       0,       0,       0,       1,       0,       0]
         //  ]
         //

--- a/crates/nu-command/tests/commands/rotate.rs
+++ b/crates/nu-command/tests/commands/rotate.rs
@@ -6,7 +6,7 @@ fn counter_clockwise() {
         r#"
         echo [
             [col1, col2, EXPECTED];
-          
+
             [---, "|||",      XX1]
             [---, "|||",      XX2]
             [---, "|||",      XX3]
@@ -17,14 +17,14 @@ fn counter_clockwise() {
     let expected = nu!(cwd: ".", pipeline(
         r#"
         echo [
-            [  Column0, Column1, Column2, Column3];
+            [  column0, column1, column2, column3];
 
             [ EXPECTED,    XX1,      XX2,     XX3]
             [     col2,  "|||",    "|||",   "|||"]
             [     col1,    ---,      ---,     ---]
         ]
-        | where Column0 == EXPECTED
-        | get Column1 Column2 Column3
+        | where column0 == EXPECTED
+        | get column1 column2 column3
         | str collect "-"
         "#,
     ));
@@ -33,8 +33,8 @@ fn counter_clockwise() {
         cwd: ".",
         format!("{} | {}", table, pipeline(r#"
             rotate --ccw
-            | where Column0 == EXPECTED
-            | get Column1 Column2 Column3
+            | where column0 == EXPECTED
+            | get column1 column2 column3
             | str collect "-"
         "#)));
 
@@ -47,7 +47,7 @@ fn clockwise() {
         r#"
         echo [
             [col1,  col2, EXPECTED];
-          
+
             [ ---, "|||",      XX1]
             [ ---, "|||",      XX2]
             [ ---, "|||",      XX3]
@@ -58,14 +58,14 @@ fn clockwise() {
     let expected = nu!(cwd: ".", pipeline(
         r#"
         echo [
-            [ Column0, Column1, Column2,  Column3];
+            [ column0, column1, column2,  column3];
 
             [     ---,     ---,     ---,     col1]
             [   "|||",   "|||",   "|||",     col2]
             [     XX3,     XX2,     XX1, EXPECTED]
         ]
-        | where Column3 == EXPECTED
-        | get Column0 Column1 Column2
+        | where column3 == EXPECTED
+        | get column0 column1 column2
         | str collect "-"
         "#,
     ));
@@ -74,8 +74,8 @@ fn clockwise() {
         cwd: ".",
         format!("{} | {}", table, pipeline(r#"
             rotate
-            | where Column3 == EXPECTED
-            | get Column0 Column1 Column2
+            | where column3 == EXPECTED
+            | get column0 column1 column2
             | str collect "-"
         "#)));
 

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -10,10 +10,10 @@ fn by_column() {
             | skip 1
             | first 4
             | split column "="
-            | sort-by Column1
+            | sort-by column1
             | skip 1
             | first 1
-            | get Column1
+            | get column1
             | str trim
         "#
     ));
@@ -36,7 +36,7 @@ fn by_invalid_column() {
             | sort-by ColumnThatDoesNotExist
             | skip 1
             | first 1
-            | get Column1
+            | get column1
             | str trim
         "#
     ));

--- a/crates/nu-command/tests/commands/split_column.rs
+++ b/crates/nu-command/tests/commands/split_column.rs
@@ -19,7 +19,7 @@ fn to_column() {
                 | lines
                 | str trim
                 | split column ","
-                | get Column2
+                | get column2
             "#
         ));
 

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -199,7 +199,7 @@ fn from_csv_text_skipping_headers_to_table() {
             r#"
                 open los_tres_amigos.txt
                 | from csv --noheaders
-                | get Column3
+                | get column3
                 | length
             "#
         ));

--- a/crates/nu-command/tests/format_conversions/ods.rs
+++ b/crates/nu-command/tests/format_conversions/ods.rs
@@ -8,7 +8,7 @@ fn from_ods_file_to_table() {
             open sample_data.ods
             | get SalesOrders
             | get 4
-            | get Column2
+            | get column2
         "#
     ));
 

--- a/crates/nu-command/tests/format_conversions/ssv.rs
+++ b/crates/nu-command/tests/format_conversions/ssv.rs
@@ -74,7 +74,7 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
                 open oc_get_svc.txt
                 | from ssv --noheaders -a
                 | first
-                | get Column1
+                | get column1
             "#
         ));
 
@@ -84,8 +84,8 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
                 open oc_get_svc.txt
                 | from ssv --noheaders
                 | first
-                | get Column1
-                
+                | get column1
+
             "#
         ));
 

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -122,7 +122,7 @@ fn from_tsv_text_skipping_headers_to_table() {
             r#"
                 open los_tres_amigos.txt
                 | from tsv --noheaders
-                | get Column3
+                | get column3
                 | length
             "#
         ));

--- a/crates/nu-command/tests/format_conversions/xlsx.rs
+++ b/crates/nu-command/tests/format_conversions/xlsx.rs
@@ -8,7 +8,7 @@ fn from_excel_file_to_table() {
             open sample_data.xlsx
             | get SalesOrders
             | get 4
-            | get Column2
+            | get column2
         "#
     ));
 

--- a/crates/nu_plugin_query/src/query_web.rs
+++ b/crates/nu_plugin_query/src/query_web.rs
@@ -180,7 +180,7 @@ fn retrieve_table(mut table: WebTable, columns: &Value, span: Span) -> Value {
         let mut vals = vec![];
         for row in &table_with_no_empties {
             for (counter, cell) in row.iter().enumerate() {
-                cols.push(format!("Column{}", counter));
+                cols.push(format!("column{}", counter));
                 vals.push(Value::string(cell.to_string(), span))
             }
         }

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -180,7 +180,7 @@ fn split_row() -> TestResult {
 #[test]
 fn split_column() -> TestResult {
     run_test(
-        r#""hello world" | split column " " | get "Column1".0"#,
+        r#""hello world" | split column " " | get "column1".0"#,
         "hello",
     )
 }


### PR DESCRIPTION
# Description

#### Change column names from 'Column*' to 'column*' 

I'm not sure whether this PR will be accepted or not. According to the naming conventions mentioned before in this [PR](https://github.com/nushell/nushell/pull/4509), I changed all the column names to lower case. Personally speaking, I feel uncomfortable with column names start with uppercase, and lowercase is morn beautiful, IMO, that's why I send this PR.

Since lots of code has been changed, although all the tests passed successfully, I'm not sure whether I have missed anything. If the PR hasn't been accepted that will be okay, and feel free to update it or give me a feedback. Thanks
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
