### PR TITLE
Improve full help for flags

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -299,7 +299,7 @@ pub fn get_flags_section(signature: &Signature) -> String {
                     flag.long, arg, flag.desc
                 )
             } else {
-                format!("  --{} {:?}\n      {}\n", flag.long, arg, flag.desc)
+                format!("  --{} <{:?}>\n      {}\n", flag.long, arg, flag.desc)
             }
         } else if let Some(short) = flag.short {
             if flag.required {


### PR DESCRIPTION
# Description

A small tweak to how we display help for flags with an argument.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
