### PR TITLE
Improve missing param error span

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -114,7 +114,10 @@ pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseEr
                 } else {
                     return Some(ParseError::MissingPositional(
                         argument.name.clone(),
-                        command,
+                        Span {
+                            start: command.end,
+                            end: command.end,
+                        },
                         sig.call_signature(),
                     ));
                 }
@@ -134,7 +137,10 @@ pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseEr
         } else {
             Some(ParseError::MissingPositional(
                 missing.name.clone(),
-                command,
+                Span {
+                    start: command.end,
+                    end: command.end,
+                },
                 sig.call_signature(),
             ))
         }


### PR DESCRIPTION
# Description

This improves the error span to no longer point at the command if a parameter wasn't found.

Before:
```
Error: nu::parser::missing_positional (link)
  × Missing required positional argument.
   ╭─[<commandline>:1:1]
 1 │ main 
   · ──┬─
   ·   ╰── missing name
   ╰────
  help: Usage: main <name>
```

Now:
```
Error: nu::parser::missing_positional (link)

  × Missing required positional argument.
   ╭─[<commandline>:1:1]
 1 │ main 
   ·     ▲
   ·     ╰── missing name
   ╰────
  help: Usage: main <name>
```
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
