### PR TITLE
Use environment variable for env_conversions

### DIFF
--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -1,42 +1,8 @@
-use crate::{BlockId, ShellError, Span, Value};
+use crate::{ShellError, Span, Value};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const ANIMATE_PROMPT_DEFAULT: bool = true;
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct EnvConversion {
-    pub from_string: Option<(BlockId, Span)>,
-    pub to_string: Option<(BlockId, Span)>,
-}
-
-impl EnvConversion {
-    pub fn from_record(value: &Value) -> Result<Self, ShellError> {
-        let record = value.as_record()?;
-
-        let mut conv_map = HashMap::new();
-
-        for (k, v) in record.0.iter().zip(record.1) {
-            if (k == "from_string") || (k == "to_string") {
-                conv_map.insert(k.as_str(), (v.as_block()?, v.span()?));
-            } else {
-                return Err(ShellError::UnsupportedConfigValue(
-                    "'from_string' and 'to_string' fields".into(),
-                    k.into(),
-                    value.span()?,
-                ));
-            }
-        }
-
-        let from_string = conv_map.get("from_string").cloned();
-        let to_string = conv_map.get("to_string").cloned();
-
-        Ok(EnvConversion {
-            from_string,
-            to_string,
-        })
-    }
-}
 
 /// Definition of a parsed keybinding from the config object
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -60,7 +26,6 @@ pub struct Config {
     pub filesize_format: String,
     pub use_ansi_coloring: bool,
     pub quick_completions: bool,
-    pub env_conversions: HashMap<String, EnvConversion>,
     pub edit_mode: String,
     pub max_history_size: i64,
     pub log_level: String,
@@ -84,7 +49,6 @@ impl Default for Config {
             filesize_format: "auto".into(),
             use_ansi_coloring: true,
             quick_completions: false,
-            env_conversions: HashMap::new(), // TODO: Add default conversoins
             edit_mode: "emacs".into(),
             max_history_size: 1000,
             log_level: String::new(),
@@ -208,24 +172,6 @@ impl Value {
                             config.filesize_format = v.to_lowercase();
                         } else {
                             eprintln!("$config.filesize_format is not a string")
-                        }
-                    }
-                    "env_conversions" => {
-                        if let Ok((env_vars, conversions)) = value.as_record() {
-                            let mut env_conversions = HashMap::new();
-
-                            for (env_var, record) in env_vars.iter().zip(conversions) {
-                                // println!("{}: {:?}", env_var, record);
-                                if let Ok(conversion) = EnvConversion::from_record(record) {
-                                    env_conversions.insert(env_var.into(), conversion);
-                                } else {
-                                    eprintln!("$config.env_conversions has incorrect conversion")
-                                }
-                            }
-
-                            config.env_conversions = env_conversions;
-                        } else {
-                            eprintln!("$config.env_conversions is not a record")
                         }
                     }
                     "edit_mode" => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -89,7 +89,7 @@ pub(crate) fn evaluate(
     }
 
     // Translate environment variables from Strings to Values
-    if let Some(e) = convert_env_values(engine_state, &stack, &config) {
+    if let Some(e) = convert_env_values(engine_state, &stack) {
         let working_set = StateWorkingSet::new(engine_state);
         report_error(&working_set, &e);
         std::process::exit(1);

--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -28,6 +28,20 @@ let-env PROMPT_INDICATOR_VI_INSERT = ": "
 let-env PROMPT_INDICATOR_VI_NORMAL = "〉"
 let-env PROMPT_MULTILINE_INDICATOR = "::: "
 
+# Specifies how environment variables are:
+# - converted from a string to a value on Nushell startup (from_string)
+# - converted from a value back to a string when running extrnal commands (to_string)
+let-env ENV_CONVERSIONS = {
+  "PATH": {
+    from_string: { |s| $s | split row (char esep) }
+    to_string: { |v| $v | str collect (char esep) }
+  }
+  "Path": {
+    from_string: { |s| $s | split row (char esep) }
+    to_string: { |v| $v | str collect (char esep) }
+  }
+}
+
 let $config = {
   filesize_metric: $true
   table_mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
@@ -58,12 +72,6 @@ let $config = {
   float_precision: 2
   use_ansi_coloring: $true
   filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
-  env_conversions: {
-    "PATH": {
-        from_string: { |s| $s | split row (char esep) }
-        to_string: { |v| $v | str collect (char esep) }
-        }
-  }
   edit_mode: emacs # emacs, vi
   max_history_size: 10000
   menu_config: {
@@ -76,7 +84,7 @@ let $config = {
   }
   history_config: {
    page_size: 10
-   selector: ":"                                                                                                                          
+   selector: ":"
    text_style: green
    selected_text_style: green_reverse
    marker: "? "

--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -107,7 +107,7 @@ extern "git push" [
   --ipv6(-6)                                 # use IPv6 addresses only
 ]
 
-# The default config record. This is where much of your global configuration is setup. 
+# The default config record. This is where much of your global configuration is setup.
 let $config = {
   filesize_metric: $false
   table_mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
@@ -149,11 +149,11 @@ let $config = {
     marker: "| "
   }
   history_config: {
-   page_size: 10
-   selector: ":"
-   text_style: green
-   selected_text_style: green_reverse
-   marker: "? "
+    page_size: 10
+    selector: ":"
+    text_style: green
+    selected_text_style: green_reverse
+    marker: "? "
   }
   keybindings: [
     {

--- a/src/eval_file.rs
+++ b/src/eval_file.rs
@@ -34,18 +34,8 @@ pub(crate) fn evaluate(
         },
     );
 
-    let config = match stack.get_config() {
-        Ok(config) => config,
-        Err(e) => {
-            let working_set = StateWorkingSet::new(engine_state);
-
-            report_error(&working_set, &e);
-            Config::default()
-        }
-    };
-
     // Translate environment variables from Strings to Values
-    if let Some(e) = convert_env_values(engine_state, &stack, &config) {
+    if let Some(e) = convert_env_values(engine_state, &stack) {
         let working_set = StateWorkingSet::new(engine_state);
         report_error(&working_set, &e);
         std::process::exit(1);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -59,17 +59,6 @@ pub(crate) fn evaluate(
     config_files::read_config_file(engine_state, &mut stack, config_file);
     let history_path = config_files::create_history_path();
 
-    // Load config struct form config variable
-    let config = match stack.get_config() {
-        Ok(config) => config,
-        Err(e) => {
-            let working_set = StateWorkingSet::new(engine_state);
-
-            report_error(&working_set, &e);
-            Config::default()
-        }
-    };
-
     // logger(|builder| {
     //     configure(&config.log_level, builder)?;
     //     // trace_filters(self, builder)?;
@@ -88,7 +77,7 @@ pub(crate) fn evaluate(
     }
 
     // Translate environment variables from Strings to Values
-    if let Some(e) = convert_env_values(engine_state, &stack, &config) {
+    if let Some(e) = convert_env_values(engine_state, &stack) {
         let working_set = StateWorkingSet::new(engine_state);
         report_error(&working_set, &e);
     }


### PR DESCRIPTION
# Description

Fixes #4545.

Now, the ENV_CONVERSIONS environment variable is used instead of the config setting. Default config has been updated accordingly.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
