### PR TITLE
Add auto-cancelling previous PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ on: [pull_request]
 name: Continuous integration
 
 jobs:
+  cancel:
+    name: auto-cancellation-running-action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fauguste/auto-cancellation-running-action@0.1.4
   ci:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,6 @@ on: [pull_request]
 name: Continuous integration
 
 jobs:
-  cancel:
-    name: auto-cancellation-running-action
-    runs-on: ubuntu-latest
-    steps:
-      - uses: fauguste/auto-cancellation-running-action@0.1.4
   ci:
     strategy:
       fail-fast: false
@@ -36,6 +31,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - name: Setup Rust toolchain


### PR DESCRIPTION
# Description

This adds a github action to auto-cancel other PR actions on the same branch
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
