### PR TITLE
Strip trailing whitespace in files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 # Description
 
 (description of your pull request here)
-  
+
 # Tests
 
 Make sure you've run and fixed any issues with these commands:

--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -69,7 +69,7 @@ impl Command for ErrorMake {
             description: "Create a custom error for a custom command",
             example: r#"def foo [x] {
       let span = (metadata $x).span;
-      error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } } 
+      error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
     }"#,
             result: None,
         }]

--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -195,7 +195,7 @@ can use the `get` command.
 ls | get name
 ```
 This allows us to get to the list of strings that are the filenames rather
-than having a full table. In some cases, this can make the names easier to 
+than having a full table. In some cases, this can make the names easier to
 work with.
 
 You can continue to learn more about working with cells of the table by
@@ -255,7 +255,7 @@ expressions, but they're wrapped in parentheses `()`.
 ```
 10 * (3 + 4)
 ```
-Here we use parentheses to create a higher math precedence in the math 
+Here we use parentheses to create a higher math precedence in the math
 expression.
 ```
 echo (2 + 3)
@@ -375,7 +375,7 @@ the shorthand path to retrieve only the cell data inside the "cwd" column.
 ```
 (ls).name.4
 ```
-This will retrieve the cell data in the "name" column on the 5th row (note: 
+This will retrieve the cell data in the "name" column on the 5th row (note:
 row numbers are zero-based).
 
 Rows and columns don't need to come in any specific order. You can get the
@@ -388,8 +388,8 @@ same value using:
 
 fn engineq_tutor() -> &'static str {
     r#"
-Engine-q is the upcoming engine for Nushell. Build for speed and correctness, 
-it also comes with a set of changes from Nushell versions prior to 0.60. To 
+Engine-q is the upcoming engine for Nushell. Build for speed and correctness,
+it also comes with a set of changes from Nushell versions prior to 0.60. To
 get ready for engine-q look for some of these changes that might impact your
 current scripts:
 
@@ -398,7 +398,7 @@ current scripts:
 * Environment variables can now contain more than just strings. Structured
   values are converted to strings for external commands using converters.
 * `if` will now use an `else` keyword before the else block.
-* We're moving from "config.toml" to "config.nu". This means startup will 
+* We're moving from "config.toml" to "config.nu". This means startup will
   now be a script file.
 * `config` and its subcommands are being replaced by a record that you can
   update in the shell which contains all the settings under the variable

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -5,10 +5,10 @@ pub fn unsupported_input_error(span: Span) -> Value {
     Value::Error {
         error: ShellError::UnsupportedInput(
             String::from(
-                "Only dates with timezones are supported. The following formats are allowed \n 
-            * %Y-%m-%d %H:%M:%S %z -- 2020-04-12 22:10:57 +02:00 \n 
-            * %Y-%m-%d %H:%M:%S%.6f %z -- 2020-04-12 22:10:57.213231 +02:00 \n 
-            * rfc3339 -- 2020-04-12T22:10:57+02:00 \n 
+                "Only dates with timezones are supported. The following formats are allowed \n
+            * %Y-%m-%d %H:%M:%S %z -- 2020-04-12 22:10:57 +02:00 \n
+            * %Y-%m-%d %H:%M:%S%.6f %z -- 2020-04-12 22:10:57.213231 +02:00 \n
+            * rfc3339 -- 2020-04-12T22:10:57+02:00 \n
             * rfc2822 -- Tue, 1 Jul 2003 10:52:37 +0200",
             ),
             span,

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -77,7 +77,7 @@ impl Command for Empty {
                     Value::List {
                         vals: vec![
                             Value::Record{
-                            cols: vec!["2020/04/16".to_string(), "2020/07/10".to_string(), "2020/11/16".to_string()], 
+                            cols: vec!["2020/04/16".to_string(), "2020/07/10".to_string(), "2020/11/16".to_string()],
                             vals: vec![
                                 Value::List{vals: vec![
                                     Value::Int{val: 33, span: Span::test_data()},

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -77,22 +77,22 @@ impl Command for Flatten {
                 result: Some(Value::List{
                     vals: vec![
                         Value::Record{
-                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()], 
+                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()],
                             vals: vec![Value::test_string("b"), Value::test_int(1), Value::List{vals: vec![Value::test_int(4), Value::test_int(3)], span: Span::test_data()}                            ],
                             span: Span::test_data()
                         },
                         Value::Record{
-                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()], 
+                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()],
                             vals: vec![Value::test_string("b"), Value::test_int(2), Value::List{vals: vec![Value::test_int(4), Value::test_int(3)], span: Span::test_data()}                            ],
                             span: Span::test_data()
                         },
                         Value::Record{
-                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()], 
+                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()],
                             vals: vec![Value::test_string("b"), Value::test_int(3), Value::List{vals: vec![Value::test_int(4), Value::test_int(3)], span: Span::test_data()}                            ],
                             span: Span::test_data()
                         },
                         Value::Record{
-                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()], 
+                            cols: vec!["a".to_string(), "d".to_string(), "e".to_string()],
                             vals: vec![Value::test_string("b"), Value::test_int(4), Value::List{vals: vec![Value::test_int(4), Value::test_int(3)], span: Span::test_data()}                            ],
                             span: Span::test_data()
                         }

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -5,7 +5,7 @@ fn checks_all_rows_are_true() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-                echo  [ "Andrés", "Andrés", "Andrés" ] 
+                echo  [ "Andrés", "Andrés", "Andrés" ]
                 | all? $it == "Andrés"
         "#
     ));

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -5,7 +5,7 @@ fn checks_any_row_is_true() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-                echo  [ "Ecuador", "USA", "New Zealand" ] 
+                echo  [ "Ecuador", "USA", "New Zealand" ]
                 | any? $it == "New Zealand"
         "#
     ));

--- a/crates/nu-command/tests/commands/append.rs
+++ b/crates/nu-command/tests/commands/append.rs
@@ -5,7 +5,7 @@ fn adds_a_row_to_the_end() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-                echo  [ "Andrés N. Robalino", "Jonathan Turner", "Yehuda Katz" ] 
+                echo  [ "Andrés N. Robalino", "Jonathan Turner", "Yehuda Katz" ]
                 | append "pollo loco"
                 | get 3
         "#

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -28,7 +28,7 @@ fn flatten_nested_tables_that_have_many_columns() {
         cwd: ".", pipeline(
         r#"
             echo [[origin, people]; [Ecuador, (echo [[name, meal]; ['Andres', 'arepa']])]]
-                 [[origin, people]; [USA, (echo [[name, meal]; ['Katz', 'nurepa']])]] 
+                 [[origin, people]; [USA, (echo [[name, meal]; ['Katz', 'nurepa']])]]
             | flatten
             | get meal
             | str collect ','

--- a/crates/nu-command/tests/commands/keep/until.rs
+++ b/crates/nu-command/tests/commands/keep/until.rs
@@ -33,10 +33,10 @@ fn condition_is_met() {
             cwd: dirs.test(), pipeline(
             r#"
                 open --raw caballeros.txt
-                | lines 
-                | skip 2 
+                | lines
+                | skip 2
                 | str trim
-                | str collect (char nl) 
+                | str collect (char nl)
                 | from csv
                 | skip while "Chicken Collection" != "Blue Chickens"
                 | keep until "Chicken Collection" == "Red Chickens"

--- a/crates/nu-command/tests/commands/keep/while_.rs
+++ b/crates/nu-command/tests/commands/keep/while_.rs
@@ -33,10 +33,10 @@ fn condition_is_met() {
             cwd: dirs.test(), pipeline(
             r#"
                 open --raw caballeros.txt
-                | lines 
-                | skip 2 
+                | lines
+                | skip 2
                 | str trim
-                | str collect (char nl) 
+                | str collect (char nl)
                 | from csv
                 | skip 1
                 | keep while "Chicken Collection" != "Blue Chickens"

--- a/crates/nu-command/tests/commands/path/basename.rs
+++ b/crates/nu-command/tests/commands/path/basename.rs
@@ -7,7 +7,7 @@ fn returns_basename_of_empty_input() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "" 
+            echo ""
             | path basename
         "#
     ));
@@ -20,7 +20,7 @@ fn replaces_basename_of_empty_input() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "" 
+            echo ""
             | path basename -r newname.txt
         "#
     ));
@@ -33,8 +33,8 @@ fn returns_basename_of_path_ending_with_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/file.txt/." 
-            | path basename 
+            echo "some/file.txt/."
+            | path basename
         "#
     ));
 
@@ -46,7 +46,7 @@ fn replaces_basename_of_path_ending_with_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/file.txt/." 
+            echo "some/file.txt/."
             | path basename -r viking.txt
         "#
     ));
@@ -60,8 +60,8 @@ fn returns_basename_of_path_ending_with_double_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/file.txt/.." 
-            | path basename 
+            echo "some/file.txt/.."
+            | path basename
         "#
     ));
 
@@ -73,7 +73,7 @@ fn replaces_basename_of_path_ending_with_double_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/file.txt/.." 
+            echo "some/file.txt/.."
             | path basename -r eggs
         "#
     ));

--- a/crates/nu-command/tests/commands/path/dirname.rs
+++ b/crates/nu-command/tests/commands/path/dirname.rs
@@ -7,7 +7,7 @@ fn returns_dirname_of_empty_input() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "" 
+            echo ""
             | path dirname
         "#
     ));
@@ -20,7 +20,7 @@ fn replaces_dirname_of_empty_input() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "" 
+            echo ""
             | path dirname -r newdir
         "#
     ));
@@ -33,8 +33,8 @@ fn returns_dirname_of_path_ending_with_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/dir/." 
-            | path dirname 
+            echo "some/dir/."
+            | path dirname
         "#
     ));
 
@@ -46,7 +46,7 @@ fn replaces_dirname_of_path_ending_with_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/dir/." 
+            echo "some/dir/."
             | path dirname -r eggs
         "#
     ));
@@ -60,8 +60,8 @@ fn returns_dirname_of_path_ending_with_double_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/dir/.." 
-            | path dirname 
+            echo "some/dir/.."
+            | path dirname
         "#
     ));
 
@@ -73,7 +73,7 @@ fn replaces_dirname_of_path_with_double_dot() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "some/dir/.." 
+            echo "some/dir/.."
             | path dirname -r eggs
         "#
     ));

--- a/crates/nu-command/tests/commands/path/expand.rs
+++ b/crates/nu-command/tests/commands/path/expand.rs
@@ -14,7 +14,7 @@ fn expands_path_with_dot() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                echo "menu/./spam.txt" 
+                echo "menu/./spam.txt"
                 | path expand
             "#
         ));
@@ -34,7 +34,7 @@ fn expands_path_with_double_dot() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                echo "menu/../menu/spam.txt" 
+                echo "menu/../menu/spam.txt"
                 | path expand
             "#
         ));

--- a/crates/nu-command/tests/commands/path/type_.rs
+++ b/crates/nu-command/tests/commands/path/type_.rs
@@ -7,7 +7,7 @@ fn returns_type_of_missing_file() {
     let actual = nu!(
         cwd: "tests", pipeline(
         r#"
-            echo "spam.txt" 
+            echo "spam.txt"
             | path type
         "#
     ));
@@ -27,7 +27,7 @@ fn returns_type_of_existing_file() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                echo "menu" 
+                echo "menu"
                 | path type
             "#
         ));
@@ -48,7 +48,7 @@ fn returns_type_of_existing_directory() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                echo "menu/spam.txt" 
+                echo "menu/spam.txt"
                 | path type
             "#
         ));

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -32,11 +32,11 @@ fn condition_is_met() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                open --raw ./caballeros.txt 
-                | lines 
-                | skip 2 
+                open --raw ./caballeros.txt
+                | lines
+                | skip 2
                 | str trim
-                | str collect (char nl) 
+                | str collect (char nl)
                 | from csv
                 | skip until "Chicken Collection" == "Red Chickens"
                 | skip 1

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -33,10 +33,10 @@ fn condition_is_met() {
             cwd: dirs.test(), pipeline(
             r#"
                 open --raw caballeros.txt
-                | lines 
-                | skip 2 
+                | lines
+                | skip 2
                 | str trim
-                | str collect (char nl) 
+                | str collect (char nl)
                 | from csv
                 | skip while "Chicken Collection" != "Red Chickens"
                 | skip 1

--- a/crates/nu-command/tests/commands/zip.rs
+++ b/crates/nu-command/tests/commands/zip.rs
@@ -41,15 +41,15 @@ fn zips_two_tables() {
             &format!(
                 r#"
                 source {} ;
-        
+
                 let contributors = ([
                   [name, commits];
                   [andres,    10]
                   [    jt,    20]
                 ]);
-                        
+
                 let actual = ($contributors | add-commits 10);
-                        
+
                 expect $actual --to-eq [[name, commits]; [andres, 20] [jt, 30]]
                 "#,
                 dirs.test().join("zip_test.nu").display()

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -4,7 +4,7 @@ description = "Fork of serde-hjson"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.59.0" 
+version = "0.59.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -4,7 +4,7 @@ description = "Path handling library for Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.59.0" 
+version = "0.59.0"
 
 [dependencies]
 dirs-next = "2.0.0"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -4,7 +4,7 @@ description = "Support for writing Nushell tests"
 edition = "2018"
 license = "MIT"
 name = "nu-test-support"
-version = "0.59.0" 
+version = "0.59.0"
 
 [lib]
 doctest = false

--- a/docs/How_To_Coloring_and_Theming.md
+++ b/docs/How_To_Coloring_and_Theming.md
@@ -206,8 +206,8 @@ The `full "#hex"` format is a take on the `"#hex"` format but allows one to spec
 
 Example: `{ fg: "#ff0000" bg: "#0000ff" attr: b }`
 
-* foreground of red in "#hex" format 
-* background of blue in "#hex" format 
+* foreground of red in "#hex" format
+* background of blue in "#hex" format
 * attribute of bold abbreviated
 
 ## `Primitive values`

--- a/docs/commands/dfr_aggregate.md
+++ b/docs/commands/dfr_aggregate.md
@@ -12,7 +12,7 @@ Performs an aggregation operation on a dataframe and groupby object
 
 ## Parameters
 
- -  `operation_name`: 
+ -  `operation_name`:
 	Dataframes: mean, sum, min, max, quantile, median, var, std
 	GroupBy: mean, sum, min, max, first, last, nunique, quantile, median, var, std, count
  -  `--quantile {number}`: quantile value for quantile operation

--- a/docs/commands/error_make.md
+++ b/docs/commands/error_make.md
@@ -20,7 +20,7 @@ Create a custom error for a custom command
 ```shell
 > def foo [x] {
       let span = (metadata $x).span;
-      error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } } 
+      error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
     }
 ```
 

--- a/docs/commands/fetch.md
+++ b/docs/commands/fetch.md
@@ -16,7 +16,7 @@ Fetch the contents from a URL (HTTP GET operation).
  -  `--user {any}`: the username when authenticating
  -  `--password {any}`: the password when authenticating
  -  `--timeout {int}`: timeout period in seconds
- -  `--headers {any}`: custom headers you want to add 
+ -  `--headers {any}`: custom headers you want to add
  -  `--raw`: fetch contents as text rather than a table
 
 ## Examples

--- a/docs/commands/flatten.md
+++ b/docs/commands/flatten.md
@@ -18,7 +18,7 @@ Flatten the table.
 
 flatten a table
 ```shell
-> [[N, u, s, h, e, l, l]] | flatten 
+> [[N, u, s, h, e, l, l]] | flatten
 ```
 
 flatten a table, get the first item

--- a/docs/commands/post.md
+++ b/docs/commands/post.md
@@ -18,7 +18,7 @@ Post a body to a URL (HTTP POST operation).
  -  `--password {any}`: the password when authenticating
  -  `--content-type {any}`: the MIME type of content to post
  -  `--content-length {any}`: the length of the content being posted
- -  `--headers {any}`: custom headers you want to add 
+ -  `--headers {any}`: custom headers you want to add
  -  `--raw`: return values as a string instead of a table
  -  `--insecure`: allow insecure server connections when using SSL
 

--- a/docs/commands/split-by.md
+++ b/docs/commands/split-by.md
@@ -18,7 +18,7 @@ Create a new table splitted.
 
 split items by column named "lang"
 ```shell
-> 
+>
                 {
                     '2019': [
                       { name: 'andres', lang: 'rb', year: '2019' },
@@ -28,6 +28,6 @@ split items by column named "lang"
                       { name: 'storm', lang: 'rs', 'year': '2021' }
                     ]
                 } | split-by lang
-                
+
 ```
 

--- a/docs/commands/to_csv.md
+++ b/docs/commands/to_csv.md
@@ -4,7 +4,7 @@ layout: command
 version: 0.59.0
 ---
 
-Convert table into .csv text 
+Convert table into .csv text
 
 ## Signature
 
@@ -24,6 +24,6 @@ Outputs an CSV string representing the contents of this table
 
 Outputs an CSV string representing the contents of this table
 ```shell
-> [[foo bar]; [1 2]] | to csv -s ';' 
+> [[foo bar]; [1 2]] | to csv -s ';'
 ```
 

--- a/docs/implementing_a_command.md
+++ b/docs/implementing_a_command.md
@@ -140,7 +140,7 @@ error: aborting due to previous error
 
 That's not certainly what we expected.
 
-It happens that Nu needs to know more about the command, including it's name and signature. We didn't do any of that and the compiler is telling us so. We seem to be missing implementing the `WholeStreamCommand` trait. This is the trait that, when implemented, allows us to state it's name, signature, and the like. 
+It happens that Nu needs to know more about the command, including it's name and signature. We didn't do any of that and the compiler is telling us so. We seem to be missing implementing the `WholeStreamCommand` trait. This is the trait that, when implemented, allows us to state it's name, signature, and the like.
 
 ## WholeStreamCommand
 

--- a/docs/make_docs.nu
+++ b/docs/make_docs.nu
@@ -10,7 +10,7 @@ version: ($vers)
 ($command.usage)
 
 "
-    let sig = ($command.signature | each { |param| 
+    let sig = ($command.signature | each { |param|
         if $param.parameter_type == "positional" {
             $"('(')($param.parameter_name)(')')"
         } else if $param.parameter_type == "switch" {
@@ -56,7 +56,7 @@ $"($example.description)
 
         $example_top + $examples
     } else { "" }
-    
+
     let doc = ($top + $signature + $parameters + $examples)
 
     let safe_name = ($command.command | str find-replace '\?' '' | str find-replace ' ' '_')

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -232,8 +232,8 @@ def 'call-me' [] {
     echo $CONST_A
 }
 
-[(say-hi) (call-me)] | str collect    
-    
+[(say-hi) (call-me)] | str collect
+
     "#,
         "HelloHello",
     )
@@ -253,8 +253,8 @@ def 'say-hi' [] {
     echo (call-me)
 }
 
-[(say-hi) (call-me)] | str collect    
-    
+[(say-hi) (call-me)] | str collect
+
     "#,
         "HelloHello",
     )
@@ -274,8 +274,8 @@ def 'call-me' [] {
     echo $CONST_A
 }
 
-[(call-me) (say-hi)] | str collect    
-    
+[(call-me) (say-hi)] | str collect
+
     "#,
         "HelloHello",
     )
@@ -295,8 +295,8 @@ def 'say-hi' [] {
     echo (call-me)
 }
 
-[(call-me) (say-hi)] | str collect    
-    
+[(call-me) (say-hi)] | str collect
+
     "#,
         "HelloHello",
     )


### PR DESCRIPTION
# Description

Kind of a silly clean up, but these were popping up in my diffs, since I usually configure whatever editor I'm using to strip trailing whitespace on file save, so I just ran [lineman](https://github.com/JosephTLyons/lineman) across the main file types in the repo.  Some showed up in generated markdown, but it wasn't consistent, which is a bit confusing: I'm not sure if its part of the doc generation script or if they came about after the files were generated.  
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
