### PR TITLE
more strict nuon handling, better nuon errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fdfdf2b0939ff2da40668429092a9bb409af6d176673fe70d7b4f0e645ef37"
+checksum = "634ab44733e6bc9b1aef1a628a92b882edbc1ded2bd6c1fb337e6c7b53c6349a"
 dependencies = [
  "atty",
  "backtrace",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33eb3f9f781611d588da4adf55d1886506e0a17033a74c38b78cda40a2a4c5b0"
+checksum = "a90e3c6812fbfa0837645b73aa220bb07795066a037b611b4274f3219c1efec2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "3.3.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2adcfcced5d625bf90a958a82ae5b93231f57f3df1383fee28c9b5096d35ed"
+checksum = "f5fdfdf2b0939ff2da40668429092a9bb409af6d176673fe70d7b4f0e645ef37"
 dependencies = [
  "atty",
  "backtrace",
@@ -1950,13 +1950,14 @@ dependencies = [
  "terminal_size",
  "textwrap",
  "thiserror",
+ "unicode-width",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "3.3.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a8b61312d367ce87956bb686731f87e4c6dd5dbc550e8f06e3c24fb1f67f"
+checksum = "33eb3f9f781611d588da4adf55d1886506e0a17033a74c38b78cda40a2a4c5b0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ crossterm_winapi = "0.9.0"
 ctrlc = "3.2.1"
 # lazy_static = "1.4.0"
 log = "0.4"
-miette = "3.0.0"
+miette = "4.0.1"
 nu-ansi-term = "0.42.0"
 nu-cli = { path="./crates/nu-cli", version = "0.59.0"  }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.59.0"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ crossterm_winapi = "0.9.0"
 ctrlc = "3.2.1"
 # lazy_static = "1.4.0"
 log = "0.4"
-miette = "4.0.1"
+miette = "4.1.0"
 nu-ansi-term = "0.42.0"
 nu-cli = { path="./crates/nu-cli", version = "0.59.0"  }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.59.0"  }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -13,7 +13,7 @@ nu-ansi-term = "0.42.0"
 
 nu-color-config = { path = "../nu-color-config" }
 
-miette = { version = "3.0.0", features = ["fancy"] }
+miette = { version = "4.0.1", features = ["fancy"] }
 thiserror = "1.0.29"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -13,7 +13,7 @@ nu-ansi-term = "0.42.0"
 
 nu-color-config = { path = "../nu-color-config" }
 
-miette = { version = "4.0.1", features = ["fancy"] }
+miette = { version = "4.1.0", features = ["fancy"] }
 thiserror = "1.0.29"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 

--- a/crates/nu-cli/src/errors.rs
+++ b/crates/nu-cli/src/errors.rs
@@ -41,6 +41,10 @@ impl<'src> miette::Diagnostic for CliError<'src> {
 
     // Finally, we redirect the source_code method to our own source.
     fn source_code(&self) -> Option<&dyn SourceCode> {
-        Some(&self.1)
+        if let Some(source_code) = self.0.source_code() {
+            Some(source_code)
+        } else {
+            Some(&self.1)
+        }
     }
 }

--- a/crates/nu-cli/src/errors.rs
+++ b/crates/nu-cli/src/errors.rs
@@ -47,4 +47,8 @@ impl<'src> miette::Diagnostic for CliError<'src> {
             Some(&self.1)
         }
     }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+        self.0.related()
+    }
 }

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -1,11 +1,8 @@
-use std::collections::HashMap;
-
-use nu_engine::{current_dir, eval_expression};
 use nu_protocol::ast::{Call, Expr, Expression};
 use nu_protocol::engine::{Command, EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Type, Value,
-    CONFIG_VARIABLE_ID,
+    Category, Example, IntoPipelineData, PipelineData, Range, ShellError, Signature, Span, Type,
+    Unit, Value,
 };
 #[derive(Clone)]
 pub struct FromNuon;
@@ -69,7 +66,7 @@ impl Command for FromNuon {
 
     fn run(
         &self,
-        engine_state: &EngineState,
+        _engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
         input: PipelineData,
@@ -77,54 +74,53 @@ impl Command for FromNuon {
         let head = call.head;
         let config = stack.get_config().unwrap_or_default();
         let string_input = input.collect_string("", &config)?;
-        let cwd = current_dir(engine_state, stack)?;
 
-        {
-            let mut engine_state = EngineState::new();
-            let mut working_set = StateWorkingSet::new(&engine_state);
-            let mut stack = stack.captures_to_stack(&HashMap::new());
+        let engine_state = EngineState::new();
 
-            let _ = working_set.add_file("nuon file".to_string(), string_input.as_bytes());
+        let mut working_set = StateWorkingSet::new(&engine_state);
 
-            let mut error = None;
+        let _ = working_set.add_file("nuon file".to_string(), string_input.as_bytes());
 
-            let (lexed, err) =
-                nu_parser::lex(string_input.as_bytes(), 0, &[b'\n', b'\r'], &[], true);
-            error = error.or(err);
+        let mut error = None;
 
-            let (lite_block, err) = nu_parser::lite_parse(&lexed);
-            error = error.or(err);
+        let (lexed, err) = nu_parser::lex(string_input.as_bytes(), 0, &[b'\n', b'\r'], &[], true);
+        error = error.or(err);
 
-            let (block, err) = nu_parser::parse_block(&mut working_set, &lite_block, true);
-            error = error.or(err);
+        let (lite_block, err) = nu_parser::lite_parse(&lexed);
+        error = error.or(err);
 
-            if block.pipelines.get(1).is_some() {
+        let (block, err) = nu_parser::parse_block(&mut working_set, &lite_block, true);
+        error = error.or(err);
+
+        if let Some(pipeline) = block.pipelines.get(1) {
+            if let Some(expr) = pipeline.expressions.get(0) {
+                return Err(ShellError::OutsideSpannedLabeledError(
+                    string_input,
+                    "error when loading".into(),
+                    "excess values when loading".into(),
+                    expr.span,
+                ));
+            } else {
                 return Err(ShellError::SpannedLabeledError(
                     "error when loading".into(),
                     "excess values when loading".into(),
                     head,
                 ));
             }
+        }
 
-            let expr = if let Some(pipeline) = block.pipelines.get(0) {
-                if pipeline.expressions.get(1).is_some() {
-                    return Err(ShellError::SpannedLabeledError(
-                        "error when loading".into(),
-                        "detected a pipeline in nuon file".into(),
-                        head,
-                    ));
-                }
+        let expr = if let Some(pipeline) = block.pipelines.get(0) {
+            if let Some(expr) = pipeline.expressions.get(1) {
+                return Err(ShellError::OutsideSpannedLabeledError(
+                    string_input,
+                    "error when loading".into(),
+                    "detected a pipeline in nuon file".into(),
+                    expr.span,
+                ));
+            }
 
-                if let Some(expr) = pipeline.expressions.get(0) {
-                    expr.clone()
-                } else {
-                    Expression {
-                        expr: Expr::Nothing,
-                        span: head,
-                        custom_completion: None,
-                        ty: Type::Nothing,
-                    }
-                }
+            if let Some(expr) = pipeline.expressions.get(0) {
+                expr.clone()
             } else {
                 Expression {
                     expr: Expr::Nothing,
@@ -132,45 +128,352 @@ impl Command for FromNuon {
                     custom_completion: None,
                     ty: Type::Nothing,
                 }
-            };
-
-            if let Some(err) = error {
-                return Err(ShellError::SpannedLabeledError(
-                    "error when loading".into(),
-                    err.to_string(),
-                    head,
-                ));
             }
+        } else {
+            Expression {
+                expr: Expr::Nothing,
+                span: head,
+                custom_completion: None,
+                ty: Type::Nothing,
+            }
+        };
 
-            let delta = working_set.render();
+        if let Some(err) = error {
+            return Err(ShellError::OutsideSpannedLabeledError(
+                string_input,
+                "error when loading".into(),
+                err.to_string(),
+                err.span(),
+            ));
+        }
 
-            engine_state.merge_delta(delta, Some(&mut stack), &cwd)?;
+        let result = convert_to_value(expr, head, &string_input);
 
-            stack.add_var(
-                CONFIG_VARIABLE_ID,
-                Value::Record {
-                    cols: vec![],
-                    vals: vec![],
-                    span: head,
-                },
-            );
+        match result {
+            Ok(result) => Ok(result.into_pipeline_data()),
+            Err(err) => Err(err),
+        }
+    }
+}
 
-            let result = eval_expression(&engine_state, &mut stack, &expr);
-
-            match result {
-                Ok(result) => Ok(result.into_pipeline_data()),
-                Err(ShellError::ExternalNotSupported(..)) => Err(ShellError::SpannedLabeledError(
-                    "error when loading".into(),
-                    "running commands not supported in nuon".into(),
-                    head,
-                )),
-                Err(err) => Err(ShellError::SpannedLabeledError(
-                    "error when loading".into(),
-                    err.to_string(),
-                    head,
-                )),
+fn convert_to_value(
+    expr: Expression,
+    span: Span,
+    original_text: &str,
+) -> Result<Value, ShellError> {
+    match expr.expr {
+        Expr::BinaryOp(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "binary operators not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Block(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "blocks not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Bool(val) => Ok(Value::Bool { val, span }),
+        Expr::Call(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "calls not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::CellPath(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "subexpressions and cellpaths not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::ExternalCall(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "calls not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Filepath(val) => Ok(Value::String { val, span }),
+        Expr::Float(val) => Ok(Value::Float { val, span }),
+        Expr::FullCellPath(full_cell_path) => {
+            if !full_cell_path.tail.is_empty() {
+                Err(ShellError::OutsideSpannedLabeledError(
+                    original_text.to_string(),
+                    "Error when loading".into(),
+                    "subexpressions and cellpaths not supported in nuon".into(),
+                    expr.span,
+                ))
+            } else {
+                convert_to_value(full_cell_path.head, span, original_text)
             }
         }
+
+        Expr::Garbage => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "extra tokens in input file".into(),
+            expr.span,
+        )),
+        Expr::GlobPattern(val) => Ok(Value::String { val, span }),
+        Expr::ImportPattern(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "imports not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Int(val) => Ok(Value::Int { val, span }),
+        Expr::Keyword(kw, ..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            format!("{} not supported in nuon", String::from_utf8_lossy(&kw)),
+            expr.span,
+        )),
+        Expr::List(vals) => {
+            let mut output = vec![];
+            for val in vals {
+                output.push(convert_to_value(val, span, original_text)?);
+            }
+
+            Ok(Value::List { vals: output, span })
+        }
+        Expr::Nothing => Ok(Value::Nothing { span }),
+        Expr::Operator(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "operators not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Range(from, next, to, operator) => {
+            let from = if let Some(f) = from {
+                convert_to_value(*f, span, original_text)?
+            } else {
+                Value::Nothing { span: expr.span }
+            };
+
+            let next = if let Some(s) = next {
+                convert_to_value(*s, span, original_text)?
+            } else {
+                Value::Nothing { span: expr.span }
+            };
+
+            let to = if let Some(t) = to {
+                convert_to_value(*t, span, original_text)?
+            } else {
+                Value::Nothing { span: expr.span }
+            };
+
+            Ok(Value::Range {
+                val: Box::new(Range::new(expr.span, from, next, to, &operator)?),
+                span: expr.span,
+            })
+        }
+        Expr::Record(key_vals) => {
+            let mut cols = vec![];
+            let mut vals = vec![];
+
+            for (key, val) in key_vals {
+                let key_str = match key.expr {
+                    Expr::String(key_str) => key_str,
+                    _ => {
+                        return Err(ShellError::OutsideSpannedLabeledError(
+                            original_text.to_string(),
+                            "Error when loading".into(),
+                            "only strings can be keys".into(),
+                            key.span,
+                        ))
+                    }
+                };
+
+                let value = convert_to_value(val, span, original_text)?;
+
+                cols.push(key_str);
+                vals.push(value);
+            }
+
+            Ok(Value::Record { cols, vals, span })
+        }
+        Expr::RowCondition(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "row conditions not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Signature(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "signatures not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::String(s) => Ok(Value::String { val: s, span }),
+        Expr::StringInterpolation(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "string interpolation not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Subexpression(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "subexpressions not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::Table(headers, cells) => {
+            let mut cols = vec![];
+
+            let mut output = vec![];
+
+            for key in headers {
+                let key_str = match key.expr {
+                    Expr::String(key_str) => key_str,
+                    _ => {
+                        return Err(ShellError::OutsideSpannedLabeledError(
+                            original_text.to_string(),
+                            "Error when loading".into(),
+                            "only strings can be keys".into(),
+                            expr.span,
+                        ))
+                    }
+                };
+
+                cols.push(key_str);
+            }
+
+            for row in cells {
+                let mut vals = vec![];
+
+                for cell in row {
+                    vals.push(convert_to_value(cell, span, original_text)?);
+                }
+
+                if cols.len() != vals.len() {
+                    return Err(ShellError::OutsideSpannedLabeledError(
+                        original_text.to_string(),
+                        "Error when loading".into(),
+                        "table has mismatched columns".into(),
+                        expr.span,
+                    ));
+                }
+
+                output.push(Value::Record {
+                    cols: cols.clone(),
+                    vals,
+                    span,
+                });
+            }
+
+            Ok(Value::List { vals: output, span })
+        }
+        Expr::ValueWithUnit(val, unit) => {
+            let size = match val.expr {
+                Expr::Int(val) => val,
+                _ => {
+                    return Err(ShellError::OutsideSpannedLabeledError(
+                        original_text.to_string(),
+                        "Error when loading".into(),
+                        "non-integer unit value".into(),
+                        expr.span,
+                    ))
+                }
+            };
+
+            match unit.item {
+                Unit::Byte => Ok(Value::Filesize { val: size, span }),
+                Unit::Kilobyte => Ok(Value::Filesize {
+                    val: size * 1000,
+                    span,
+                }),
+                Unit::Megabyte => Ok(Value::Filesize {
+                    val: size * 1000 * 1000,
+                    span,
+                }),
+                Unit::Gigabyte => Ok(Value::Filesize {
+                    val: size * 1000 * 1000 * 1000,
+                    span,
+                }),
+                Unit::Terabyte => Ok(Value::Filesize {
+                    val: size * 1000 * 1000 * 1000 * 1000,
+                    span,
+                }),
+                Unit::Petabyte => Ok(Value::Filesize {
+                    val: size * 1000 * 1000 * 1000 * 1000 * 1000,
+                    span,
+                }),
+
+                Unit::Kibibyte => Ok(Value::Filesize {
+                    val: size * 1024,
+                    span,
+                }),
+                Unit::Mebibyte => Ok(Value::Filesize {
+                    val: size * 1024 * 1024,
+                    span,
+                }),
+                Unit::Gibibyte => Ok(Value::Filesize {
+                    val: size * 1024 * 1024 * 1024,
+                    span,
+                }),
+                Unit::Tebibyte => Ok(Value::Filesize {
+                    val: size * 1024 * 1024 * 1024 * 1024,
+                    span,
+                }),
+                Unit::Pebibyte => Ok(Value::Filesize {
+                    val: size * 1024 * 1024 * 1024 * 1024 * 1024,
+                    span,
+                }),
+
+                Unit::Nanosecond => Ok(Value::Duration { val: size, span }),
+                Unit::Microsecond => Ok(Value::Duration {
+                    val: size * 1000,
+                    span,
+                }),
+                Unit::Millisecond => Ok(Value::Duration {
+                    val: size * 1000 * 1000,
+                    span,
+                }),
+                Unit::Second => Ok(Value::Duration {
+                    val: size * 1000 * 1000 * 1000,
+                    span,
+                }),
+                Unit::Minute => Ok(Value::Duration {
+                    val: size * 1000 * 1000 * 1000 * 60,
+                    span,
+                }),
+                Unit::Hour => Ok(Value::Duration {
+                    val: size * 1000 * 1000 * 1000 * 60 * 60,
+                    span,
+                }),
+                Unit::Day => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24) {
+                    Some(val) => Ok(Value::Duration { val, span }),
+                    None => Err(ShellError::OutsideSpannedLabeledError(
+                        original_text.to_string(),
+                        "duration too large".into(),
+                        "duration too large".into(),
+                        expr.span,
+                    )),
+                },
+
+                Unit::Week => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 7) {
+                    Some(val) => Ok(Value::Duration { val, span }),
+                    None => Err(ShellError::OutsideSpannedLabeledError(
+                        original_text.to_string(),
+                        "duration too large".into(),
+                        "duration too large".into(),
+                        expr.span,
+                    )),
+                },
+            }
+        }
+        Expr::Var(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "variables not supported in nuon".into(),
+            expr.span,
+        )),
+        Expr::VarDecl(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "variable declarations not supported in nuon".into(),
+            expr.span,
+        )),
     }
 }
 

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -94,28 +94,43 @@ impl Command for FromNuon {
 
         if let Some(pipeline) = block.pipelines.get(1) {
             if let Some(expr) = pipeline.expressions.get(0) {
-                return Err(ShellError::OutsideSpannedLabeledError(
-                    string_input,
-                    "error when loading".into(),
-                    "excess values when loading".into(),
-                    expr.span,
+                return Err(ShellError::SpannedLabeledErrorRelated(
+                    "error when loading nuon text".into(),
+                    "could not load nuon text".into(),
+                    head,
+                    vec![ShellError::OutsideSpannedLabeledError(
+                        string_input,
+                        "error when loading".into(),
+                        "excess values when loading".into(),
+                        expr.span,
+                    )],
                 ));
             } else {
-                return Err(ShellError::SpannedLabeledError(
-                    "error when loading".into(),
-                    "excess values when loading".into(),
+                return Err(ShellError::SpannedLabeledErrorRelated(
+                    "error when loading nuon text".into(),
+                    "could not load nuon text".into(),
                     head,
+                    vec![ShellError::SpannedLabeledError(
+                        "error when loading".into(),
+                        "excess values when loading".into(),
+                        head,
+                    )],
                 ));
             }
         }
 
         let expr = if let Some(pipeline) = block.pipelines.get(0) {
             if let Some(expr) = pipeline.expressions.get(1) {
-                return Err(ShellError::OutsideSpannedLabeledError(
-                    string_input,
-                    "error when loading".into(),
-                    "detected a pipeline in nuon file".into(),
-                    expr.span,
+                return Err(ShellError::SpannedLabeledErrorRelated(
+                    "error when loading nuon text".into(),
+                    "could not load nuon text".into(),
+                    head,
+                    vec![ShellError::OutsideSpannedLabeledError(
+                        string_input,
+                        "error when loading".into(),
+                        "detected a pipeline in nuon file".into(),
+                        expr.span,
+                    )],
                 ));
             }
 
@@ -139,11 +154,16 @@ impl Command for FromNuon {
         };
 
         if let Some(err) = error {
-            return Err(ShellError::OutsideSpannedLabeledError(
-                string_input,
-                "error when loading".into(),
-                err.to_string(),
-                err.span(),
+            return Err(ShellError::SpannedLabeledErrorRelated(
+                "error when parsing nuon text".into(),
+                "could not parse nuon text".into(),
+                head,
+                vec![ShellError::OutsideSpannedLabeledError(
+                    string_input,
+                    "error when parsing".into(),
+                    err.to_string(),
+                    err.span(),
+                )],
             ));
         }
 
@@ -151,7 +171,12 @@ impl Command for FromNuon {
 
         match result {
             Ok(result) => Ok(result.into_pipeline_data()),
-            Err(err) => Err(err),
+            Err(err) => Err(ShellError::SpannedLabeledErrorRelated(
+                "error when loading nuon text".into(),
+                "could not load nuon text".into(),
+                head,
+                vec![err],
+            )),
         }
     }
 }

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.59.0"
 edition = "2021"
 
 [dependencies]
-miette = "4.0.1"
+miette = "4.1.0"
 thiserror = "1.0.29"
 serde_json = "1.0"
 nu-path = {path = "../nu-path"}

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.59.0"
 edition = "2021"
 
 [dependencies]
-miette = "3.0.0"
+miette = "4.0.1"
 thiserror = "1.0.29"
 serde_json = "1.0"
 nu-path = {path = "../nu-path"}

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -222,3 +222,52 @@ pub enum ParseError {
     #[diagnostic()]
     LabeledError(String, String, #[label("{1}")] Span),
 }
+
+impl ParseError {
+    pub fn span(&self) -> Span {
+        match self {
+            ParseError::ExtraTokens(s) => *s,
+            ParseError::ExtraPositional(_, s) => *s,
+            ParseError::UnexpectedEof(_, s) => *s,
+            ParseError::Unclosed(_, s) => *s,
+            ParseError::Expected(_, s) => *s,
+            ParseError::Mismatch(_, _, s) => *s,
+            ParseError::UnsupportedOperation(_, _, _, s, _) => *s,
+            ParseError::ExpectedKeyword(_, s) => *s,
+            ParseError::UnexpectedKeyword(_, s) => *s,
+            ParseError::BuiltinCommandInPipeline(_, s) => *s,
+            ParseError::IncorrectValue(_, s, _) => *s,
+            ParseError::MultipleRestParams(s) => *s,
+            ParseError::VariableNotFound(s) => *s,
+            ParseError::VariableNotValid(s) => *s,
+            ParseError::ModuleNotFound(s) => *s,
+            ParseError::NotFound(s) => *s,
+            ParseError::DuplicateCommandDef(s) => *s,
+            ParseError::UnknownCommand(s) => *s,
+            ParseError::NonUtf8(s) => *s,
+            ParseError::UnknownFlag(_, _, s) => *s,
+            ParseError::UnknownType(s) => *s,
+            ParseError::MissingFlagParam(_, s) => *s,
+            ParseError::ShortFlagBatchCantTakeArg(s) => *s,
+            ParseError::MissingPositional(_, s, _) => *s,
+            ParseError::KeywordMissingArgument(_, _, s) => *s,
+            ParseError::MissingType(s) => *s,
+            ParseError::TypeMismatch(_, _, s) => *s,
+            ParseError::MissingRequiredFlag(_, s) => *s,
+            ParseError::IncompleteMathExpression(s) => *s,
+            ParseError::UnknownState(_, s) => *s,
+            ParseError::InternalError(_, s) => *s,
+            ParseError::IncompleteParser(s) => *s,
+            ParseError::RestNeedsName(s) => *s,
+            ParseError::ParameterMismatchType(_, _, _, s) => *s,
+            ParseError::ExtraColumns(_, s) => *s,
+            ParseError::MissingColumns(_, s) => *s,
+            ParseError::AssignmentMismatch(_, _, s) => *s,
+            ParseError::MissingImportPattern(s) => *s,
+            ParseError::WrongImportPattern(s) => *s,
+            ParseError::ExportNotFound(s) => *s,
+            ParseError::FileNotFound(_, s) => *s,
+            ParseError::LabeledError(_, _, s) => *s,
+        }
+    }
+}

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1.0.29"
-miette = "4.0.1"
+miette = "4.1.0"
 serde = {version = "1.0.130", features = ["derive"]}
 chrono = { version="0.4.19", features=["serde"] }
 indexmap = { version="1.7", features=["serde-1"] }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1.0.29"
-miette = "3.0.0"
+miette = "4.0.1"
 serde = {version = "1.0.130", features = ["derive"]}
 chrono = { version="0.4.19", features=["serde"] }
 indexmap = { version="1.7", features=["serde-1"] }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -269,6 +269,15 @@ pub enum ShellError {
     SpannedLabeledErrorHelp(String, String, #[label("{1}")] Span, String),
 
     #[error("{0}")]
+    #[diagnostic()]
+    SpannedLabeledErrorRelated(
+        String,
+        String,
+        #[label("{1}")] Span,
+        #[related] Vec<ShellError>,
+    ),
+
+    #[error("{0}")]
     #[diagnostic(help("{1}"))]
     LabeledError(String, String),
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -272,6 +272,10 @@ pub enum ShellError {
     #[diagnostic(help("{1}"))]
     LabeledError(String, String),
 
+    #[error("{1}")]
+    #[diagnostic()]
+    OutsideSpannedLabeledError(#[source_code] String, String, String, #[label("{2}")] Span),
+
     #[error("Deprecated command {0}")]
     #[diagnostic(code(nu::shell::deprecated_command), url(docsrs))]
     DeprecatedCommand(


### PR DESCRIPTION
# Description

This moves `from nuon` to no longer evaluate its expression, but instead to have a special converter to convert to the `Value` form. We do this because, though we can limit the evaluator to only safe functions, because having other libraries support nuon would be a lot easier for them if they didn't have to also be able to evaluate arbitrary expressions.

With this approach, we have something we can write into a spec.

Also improved nuon errors to point at the error in the file/source
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
