### PR TITLE
Improve json errors a bit

### DIFF
--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -190,7 +190,7 @@ fn convert_string_to_value(string_input: String, span: Span) -> Result<Value, Sh
                     span,
                     vec![ShellError::OutsideSpannedLabeledError(
                         string_input,
-                        "Error while parson JSON text".into(),
+                        "Error while parsing JSON text".into(),
                         label,
                         label_span,
                     )],


### PR DESCRIPTION
# Description

Use miette to highlight errors in json text.

Before:

![image](https://user-images.githubusercontent.com/547158/154939418-a76b7375-0845-40f5-9cf0-53218260ed5f.png)

After:

![image](https://user-images.githubusercontent.com/547158/154939514-df68cf13-09b9-46fb-9894-45ab13756ef1.png)

  
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
