### PR TITLE
Remove record iteration

### DIFF
--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block_with_redirect, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
-    Span, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, Signature, Span, SyntaxShape,
+    Value,
 };
 
 #[derive(Clone)]
@@ -161,64 +161,66 @@ impl Command for Each {
                     }
                 })
                 .into_pipeline_data(ctrlc)),
-            PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
-                let mut output_cols = vec![];
-                let mut output_vals = vec![];
+            // JT: we'll turn this off for now until we get a better design
+            // leaving it here, but commented-out, for the time being
+            // PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
+            //     let mut output_cols = vec![];
+            //     let mut output_vals = vec![];
 
-                for (col, val) in cols.into_iter().zip(vals.into_iter()) {
-                    //let block = engine_state.get_block(block_id);
+            //     for (col, val) in cols.into_iter().zip(vals.into_iter()) {
+            //         //let block = engine_state.get_block(block_id);
 
-                    stack.with_env(&orig_env_vars, &orig_env_hidden);
+            //         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
-                    if let Some(var) = block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(
-                                *var_id,
-                                Value::Record {
-                                    cols: vec!["column".into(), "value".into()],
-                                    vals: vec![
-                                        Value::String {
-                                            val: col.clone(),
-                                            span: call.head,
-                                        },
-                                        val,
-                                    ],
-                                    span: call.head,
-                                },
-                            );
-                        }
-                    }
+            //         if let Some(var) = block.signature.get_positional(0) {
+            //             if let Some(var_id) = &var.var_id {
+            //                 stack.add_var(
+            //                     *var_id,
+            //                     Value::Record {
+            //                         cols: vec!["column".into(), "value".into()],
+            //                         vals: vec![
+            //                             Value::String {
+            //                                 val: col.clone(),
+            //                                 span: call.head,
+            //                             },
+            //                             val,
+            //                         ],
+            //                         span: call.head,
+            //                     },
+            //                 );
+            //             }
+            //         }
 
-                    match eval_block_with_redirect(
-                        &engine_state,
-                        &mut stack,
-                        &block,
-                        PipelineData::new(span),
-                    )? {
-                        PipelineData::Value(
-                            Value::Record {
-                                mut cols, mut vals, ..
-                            },
-                            ..,
-                        ) => {
-                            // TODO check that the lengths match when traversing record
-                            output_cols.append(&mut cols);
-                            output_vals.append(&mut vals);
-                        }
-                        x => {
-                            output_cols.push(col);
-                            output_vals.push(x.into_value(span));
-                        }
-                    }
-                }
+            //         match eval_block_with_redirect(
+            //             &engine_state,
+            //             &mut stack,
+            //             &block,
+            //             PipelineData::new(span),
+            //         )? {
+            //             PipelineData::Value(
+            //                 Value::Record {
+            //                     mut cols, mut vals, ..
+            //                 },
+            //                 ..,
+            //             ) => {
+            //                 // TODO check that the lengths match when traversing record
+            //                 output_cols.append(&mut cols);
+            //                 output_vals.append(&mut vals);
+            //             }
+            //             x => {
+            //                 output_cols.push(col);
+            //                 output_vals.push(x.into_value(span));
+            //             }
+            //         }
+            //     }
 
-                Ok(Value::Record {
-                    cols: output_cols,
-                    vals: output_vals,
-                    span: call.head,
-                }
-                .into_pipeline_data())
-            }
+            //     Ok(Value::Record {
+            //         cols: output_cols,
+            //         vals: output_vals,
+            //         span: call.head,
+            //     }
+            //     .into_pipeline_data())
+            // }
             PipelineData::Value(x, ..) => {
                 //let block = engine_state.get_block(block_id);
 

--- a/src/tests/test_iteration.rs
+++ b/src/tests/test_iteration.rs
@@ -17,11 +17,6 @@ fn row_iteration() -> TestResult {
 }
 
 #[test]
-fn record_iteration() -> TestResult {
-    run_test("([[name, level]; [aa, 100], [bb, 200]] | each { |it| $it | each { |x| if $x.column == \"level\" { $x.value + 100 } else { $x.value } } }).level | get 1", "300")
-}
-
-#[test]
 fn row_condition1() -> TestResult {
     run_test(
         "([[name, size]; [a, 1], [b, 2], [c, 3]] | where size < 3).name | get 1",


### PR DESCRIPTION
# Description

Removes record iteration from `each` until we have a better design. I noticed some folks were getting confused when they accidentally used it. It probably should be its own command at the very least.
  
You can still use the 0.44 record iteration style:
```
> {a: 1, b: 2, c: 3} | transpose
╭───┬─────────┬─────────╮
│ # │ column0 │ column1 │
├───┼─────────┼─────────┤
│ 0 │ a       │       1 │
│ 1 │ b       │       2 │
│ 2 │ c       │       3 │
╰───┴─────────┴─────────╯
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
