### PR TITLE
Make sure to apply captures when setting prompt

### DIFF
--- a/src/prompt_update.rs
+++ b/src/prompt_update.rs
@@ -68,12 +68,17 @@ fn get_prompt_string(
     stack
         .get_env_var(engine_state, prompt)
         .and_then(|v| match v {
-            Value::Block { val: block_id, .. } => {
+            Value::Block {
+                val: block_id,
+                captures,
+                ..
+            } => {
                 let block = engine_state.get_block(block_id);
+                let mut stack = stack.captures_to_stack(&captures);
                 // Use eval_subexpression to force a redirection of output, so we can use everything in prompt
                 let ret_val = eval_subexpression(
                     engine_state,
-                    stack,
+                    &mut stack,
                     block,
                     PipelineData::new(Span::new(0, 0)), // Don't try this at home, 0 span is ignored
                 )


### PR DESCRIPTION
# Description

Ensures that we also apply the captures we know for the block we use for `PROMPT_COMMAND`. This allows that block to capture variables and then later be able to recall the values it saw when doing the captures.

Fixes #4278 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
