### PR TITLE
Add examples for command: use,module,export def,export env and export def-env

### DIFF
--- a/crates/nu-command/src/core_commands/export_def.rs
+++ b/crates/nu-command/src/core_commands/export_def.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, Span, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct ExportDef;
@@ -34,5 +34,16 @@ impl Command for ExportDef {
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Define a custom command in a module and call it",
+            example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
+            result: Some(Value::String {
+                val: "foo".to_string(),
+                span: Span::test_data(),
+            }),
+        }]
     }
 }

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, Span, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct ExportDefEnv;
@@ -34,5 +34,16 @@ impl Command for ExportDefEnv {
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Define a custom command that participates in the environment in a module and call it",
+            example: r#"module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
+            result: Some(Value::String {
+                val: "BAZ".to_string(),
+                span: Span::test_data(),
+            }),
+        }]
     }
 }

--- a/crates/nu-command/src/core_commands/export_env.rs
+++ b/crates/nu-command/src/core_commands/export_env.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, Span, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct ExportEnv;
@@ -38,5 +38,16 @@ impl Command for ExportEnv {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         //TODO: Add the env to stack
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Import and evaluate environment variable from a module",
+            example: r#"module foo { export env FOO_ENV { "BAZ" } }; use foo FOO_ENV; $env.FOO_ENV"#,
+            result: Some(Value::String {
+                val: "BAZ".to_string(),
+                span: Span::test_data(),
+            }),
+        }]
     }
 }

--- a/crates/nu-command/src/core_commands/module.rs
+++ b/crates/nu-command/src/core_commands/module.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, Span, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct Module;
@@ -33,5 +33,34 @@ impl Command for Module {
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Define a custom command in a module and call it",
+                example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
+                result: Some(Value::String {
+                    val: "foo".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Define an environment variable in a module and evaluate it",
+                example: r#"module foo { export env FOO_ENV { "BAZ" } }; use foo FOO_ENV; $env.FOO_ENV"#,
+                result: Some(Value::String {
+                    val: "BAZ".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Define a custom command that participates in the environment in a module and call it",
+                example: r#"module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
+                result: Some(Value::String {
+                    val: "BAZ".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+        ]
     }
 }

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -1,7 +1,9 @@
 use nu_engine::eval_block;
 use nu_protocol::ast::{Call, Expr, Expression, ImportPatternMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+};
 
 #[derive(Clone)]
 pub struct Use;
@@ -113,5 +115,34 @@ impl Command for Use {
         }
 
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Define a custom command in a module and call it",
+                example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
+                result: Some(Value::String {
+                    val: "foo".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Define an environment variable in a module and evaluate it",
+                example: r#"module foo { export env FOO_ENV { "BAZ" } }; use foo FOO_ENV; $env.FOO_ENV"#,
+                result: Some(Value::String {
+                    val: "BAZ".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Define a custom command that participates in the environment in a module and call it",
+                example: r#"module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
+                result: Some(Value::String {
+                    val: "BAZ".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+        ]
     }
 }


### PR DESCRIPTION
# Description

Add examples for command: use,module,export def,export env and export def-env

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
