### PR TITLE
update #4455, regenerate commands' docs and update make_docs script

### DIFF
--- a/docs/commands/alias.md
+++ b/docs/commands/alias.md
@@ -21,4 +21,3 @@ Alias ll to ls -l
 ```shell
 > alias ll = ls -l
 ```
-

--- a/docs/commands/all.md
+++ b/docs/commands/all.md
@@ -25,4 +25,3 @@ Check that all values are even
 ```shell
 > echo [2 4 6 8] | all? ($it mod 2) == 0
 ```
-

--- a/docs/commands/ansi.md
+++ b/docs/commands/ansi.md
@@ -43,4 +43,3 @@ Use ansi to color text with a style (blue on red in bold)
 ```shell
 > $"(ansi -e { fg: '#0000ff' bg: '#ff0000' attr: b })Hello Nu World(ansi reset)"
 ```
-

--- a/docs/commands/ansi_gradient.md
+++ b/docs/commands/ansi_gradient.md
@@ -39,4 +39,3 @@ draw text in a gradient by specifying foreground end color - start color is assu
 ```shell
 > echo 'Hello, Nushell! This is a gradient.' | ansi gradient --fgend 0xe81cff
 ```
-

--- a/docs/commands/ansi_strip.md
+++ b/docs/commands/ansi_strip.md
@@ -20,4 +20,3 @@ strip ansi escape sequences from string
 ```shell
 > echo [ (ansi green) (ansi cursor_on) "hello" ] | str collect | ansi strip
 ```
-

--- a/docs/commands/any.md
+++ b/docs/commands/any.md
@@ -25,4 +25,3 @@ Check if any of the values is odd
 ```shell
 > echo [2 4 1 6 8] | any? ($it mod 2) == 1
 ```
-

--- a/docs/commands/append.md
+++ b/docs/commands/append.md
@@ -30,4 +30,3 @@ Append Ints and Strings
 ```shell
 > [0,1] | append [2,nu,4,shell]
 ```
-

--- a/docs/commands/benchmark.md
+++ b/docs/commands/benchmark.md
@@ -20,4 +20,3 @@ Benchmarks a command within a block
 ```shell
 > benchmark { sleep 500ms }
 ```
-

--- a/docs/commands/build-string.md
+++ b/docs/commands/build-string.md
@@ -25,4 +25,3 @@ Builds a string from letters a b c
 ```shell
 > build-string (1 + 2) = one ' ' plus ' ' two
 ```
-

--- a/docs/commands/cal.md
+++ b/docs/commands/cal.md
@@ -35,4 +35,3 @@ This month's calendar with the week starting on monday
 ```shell
 > cal --week-start monday
 ```
-

--- a/docs/commands/cd.md
+++ b/docs/commands/cd.md
@@ -20,4 +20,3 @@ Change to your home directory
 ```shell
 > cd ~
 ```
-

--- a/docs/commands/char.md
+++ b/docs/commands/char.md
@@ -38,4 +38,3 @@ Output multi-byte Unicode character
 ```shell
 > char -u 1F468 200D 1F466 200D 1F466
 ```
-

--- a/docs/commands/clear.md
+++ b/docs/commands/clear.md
@@ -16,4 +16,3 @@ Clear the terminal
 ```shell
 > clear
 ```
-

--- a/docs/commands/collect.md
+++ b/docs/commands/collect.md
@@ -20,4 +20,3 @@ Use the second value in the stream
 ```shell
 > echo 1 2 3 | collect { |x| echo $x.1 }
 ```
-

--- a/docs/commands/columns.md
+++ b/docs/commands/columns.md
@@ -26,4 +26,3 @@ Get the second column from the table
 ```shell
 > [[name,age,grade]; [bill,20,a]] | columns | select 1
 ```
-

--- a/docs/commands/compact.md
+++ b/docs/commands/compact.md
@@ -30,4 +30,3 @@ Filter out all instances of nothing from a list (Returns [1,2]
 ```shell
 > echo [1, $nothing, 2] | compact
 ```
-

--- a/docs/commands/cp.md
+++ b/docs/commands/cp.md
@@ -27,4 +27,3 @@ Recursively copy dir_a to dir_b
 ```shell
 > cp -r dir_a dir_b
 ```
-

--- a/docs/commands/dataframe.md
+++ b/docs/commands/dataframe.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> dataframe ```
-

--- a/docs/commands/date.md
+++ b/docs/commands/date.md
@@ -9,4 +9,3 @@ date
 ## Signature
 
 ```> date ```
-

--- a/docs/commands/date_format.md
+++ b/docs/commands/date_format.md
@@ -36,4 +36,3 @@ Format a given date using a given format string.
 ```shell
 > "2021-10-22 20:00:12 +01:00" | date format "%Y-%m-%d"
 ```
-

--- a/docs/commands/date_humanize.md
+++ b/docs/commands/date_humanize.md
@@ -21,4 +21,3 @@ Print a 'humanized' format for the date, relative to now.
 ```shell
 > "2021-10-22 20:00:12 +01:00" | date humanize
 ```
-

--- a/docs/commands/date_list-timezone.md
+++ b/docs/commands/date_list-timezone.md
@@ -16,4 +16,3 @@ Show timezone(s) that contains 'Shanghai'
 ```shell
 > date list-timezone | where timezone =~ Shanghai
 ```
-

--- a/docs/commands/date_now.md
+++ b/docs/commands/date_now.md
@@ -16,4 +16,3 @@ Get the current date and display it in a given format string.
 ```shell
 > date now | date format "%Y-%m-%d %H:%M:%S"
 ```
-

--- a/docs/commands/date_to-table.md
+++ b/docs/commands/date_to-table.md
@@ -26,4 +26,3 @@ Print the date in a structured table.
 ```shell
 >  '2020-04-12 22:10:57 +0200' | date to-table
 ```
-

--- a/docs/commands/date_to-timezone.md
+++ b/docs/commands/date_to-timezone.md
@@ -35,4 +35,3 @@ Get the current date in Hawaii
 ```shell
 > "2020-10-10 10:00:00 +02:00" | date to-timezone "+0500"
 ```
-

--- a/docs/commands/debug.md
+++ b/docs/commands/debug.md
@@ -20,4 +20,3 @@ Describe the type of a string
 ```shell
 > 'hello' | debug
 ```
-

--- a/docs/commands/decode.md
+++ b/docs/commands/decode.md
@@ -20,4 +20,3 @@ Decode the output of an external command
 ```shell
 > cat myfile.q | decode utf-8
 ```
-

--- a/docs/commands/def-env.md
+++ b/docs/commands/def-env.md
@@ -22,4 +22,3 @@ Set environment variable by call a custom command
 ```shell
 > def-env foo [] { let-env BAR = "BAZ" }; foo; $env.BAR
 ```
-

--- a/docs/commands/def-env.md
+++ b/docs/commands/def-env.md
@@ -16,3 +16,10 @@ Define a custom command, which participates in the caller environment
  -  `params`: parameters
  -  `block`: body of the definition
 
+## Examples
+
+Set environment variable by call a custom command
+```shell
+> def-env foo [] { let-env BAR = "BAZ" }; foo; $env.BAR
+```
+

--- a/docs/commands/def.md
+++ b/docs/commands/def.md
@@ -27,4 +27,3 @@ Define a command and run it with parameter(s)
 ```shell
 > def say-sth [sth: string] { echo $sth }; say-sth hi
 ```
-

--- a/docs/commands/default.md
+++ b/docs/commands/default.md
@@ -21,4 +21,3 @@ Give a default 'target' to all file entries
 ```shell
 > ls -la | default target 'nothing'
 ```
-

--- a/docs/commands/describe.md
+++ b/docs/commands/describe.md
@@ -16,4 +16,3 @@ Describe the type of a string
 ```shell
 > 'hello' | describe
 ```
-

--- a/docs/commands/detect_columns.md
+++ b/docs/commands/detect_columns.md
@@ -26,4 +26,3 @@ Splits a multi-line string into columns with headers detected
 ```shell
 > echo $'c1 c2 c3(char nl)a b c' | detect columns
 ```
-

--- a/docs/commands/dfr.md
+++ b/docs/commands/dfr.md
@@ -9,4 +9,3 @@ Dataframe commands
 ## Signature
 
 ```> dfr ```
-

--- a/docs/commands/dfr_aggregate.md
+++ b/docs/commands/dfr_aggregate.md
@@ -34,4 +34,3 @@ Aggregate sum in series
 ```shell
 > [4 1 5 6] | dfr to-df | dfr aggregate sum
 ```
-

--- a/docs/commands/dfr_aggregate.md
+++ b/docs/commands/dfr_aggregate.md
@@ -12,7 +12,7 @@ Performs an aggregation operation on a dataframe and groupby object
 
 ## Parameters
 
- -  `operation_name`:
+ -  `operation_name`: 
 	Dataframes: mean, sum, min, max, quantile, median, var, std
 	GroupBy: mean, sum, min, max, first, last, nunique, quantile, median, var, std, count
  -  `--quantile {number}`: quantile value for quantile operation

--- a/docs/commands/dfr_all-false.md
+++ b/docs/commands/dfr_all-false.md
@@ -23,4 +23,3 @@ Checks the result from a comparison
     let res = ($s > 9);
     $res | dfr all-false
 ```
-

--- a/docs/commands/dfr_all-true.md
+++ b/docs/commands/dfr_all-true.md
@@ -23,4 +23,3 @@ Checks the result from a comparison
     let res = ($s > 9);
     $res | dfr all-true
 ```
-

--- a/docs/commands/dfr_append.md
+++ b/docs/commands/dfr_append.md
@@ -28,4 +28,3 @@ Appends a dataframe merging at the end of columns
 > let a = ([[a b]; [1 2] [3 4]] | dfr to-df);
     $a | dfr append $a --col
 ```
-

--- a/docs/commands/dfr_arg-max.md
+++ b/docs/commands/dfr_arg-max.md
@@ -16,4 +16,3 @@ Returns index for max value
 ```shell
 > [1 3 2] | dfr to-df | dfr arg-max
 ```
-

--- a/docs/commands/dfr_arg-min.md
+++ b/docs/commands/dfr_arg-min.md
@@ -16,4 +16,3 @@ Returns index for min value
 ```shell
 > [1 3 2] | dfr to-df | dfr arg-min
 ```
-

--- a/docs/commands/dfr_arg-sort.md
+++ b/docs/commands/dfr_arg-sort.md
@@ -25,4 +25,3 @@ Returns indexes for a sorted series
 ```shell
 > [1 2 2 3 3] | dfr to-df | dfr arg-sort -r
 ```
-

--- a/docs/commands/dfr_arg-true.md
+++ b/docs/commands/dfr_arg-true.md
@@ -16,4 +16,3 @@ Returns indexes where values are true
 ```shell
 > [$false $true $false] | dfr to-df | dfr arg-true
 ```
-

--- a/docs/commands/dfr_arg-unique.md
+++ b/docs/commands/dfr_arg-unique.md
@@ -16,4 +16,3 @@ Returns indexes for unique values
 ```shell
 > [1 2 2 3 3] | dfr to-df | dfr arg-unique
 ```
-

--- a/docs/commands/dfr_column.md
+++ b/docs/commands/dfr_column.md
@@ -20,4 +20,3 @@ Returns the selected column as series
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr column a
 ```
-

--- a/docs/commands/dfr_concatenate.md
+++ b/docs/commands/dfr_concatenate.md
@@ -21,4 +21,3 @@ Concatenate string
 > let other = ([za xs cd] | dfr to-df);
     [abc abc abc] | dfr to-df | dfr concatenate $other
 ```
-

--- a/docs/commands/dfr_contains.md
+++ b/docs/commands/dfr_contains.md
@@ -20,4 +20,3 @@ Returns boolean indicating if pattern was found
 ```shell
 > [abc acb acb] | dfr to-df | dfr contains ab
 ```
-

--- a/docs/commands/dfr_count-null.md
+++ b/docs/commands/dfr_count-null.md
@@ -17,4 +17,3 @@ Counts null values
 > let s = ([1 1 0 0 3 3 4] | dfr to-df);
     ($s / $s) | dfr count-null
 ```
-

--- a/docs/commands/dfr_count-unique.md
+++ b/docs/commands/dfr_count-unique.md
@@ -16,4 +16,3 @@ Counts unique values
 ```shell
 > [1 1 2 2 3 3 4] | dfr to-df | dfr count-unique
 ```
-

--- a/docs/commands/dfr_cumulative.md
+++ b/docs/commands/dfr_cumulative.md
@@ -21,4 +21,3 @@ Cumulative sum for a series
 ```shell
 > [1 2 3 4 5] | dfr to-df | dfr cumulative sum
 ```
-

--- a/docs/commands/dfr_describe.md
+++ b/docs/commands/dfr_describe.md
@@ -16,4 +16,3 @@ dataframe description
 ```shell
 > [[a b]; [1 1] [1 1]] | dfr to-df | dfr describe
 ```
-

--- a/docs/commands/dfr_drop-duplicates.md
+++ b/docs/commands/dfr_drop-duplicates.md
@@ -21,4 +21,3 @@ drop duplicates
 ```shell
 > [[a b]; [1 2] [3 4] [1 2]] | dfr to-df | dfr drop-duplicates
 ```
-

--- a/docs/commands/dfr_drop-nulls.md
+++ b/docs/commands/dfr_drop-nulls.md
@@ -29,4 +29,3 @@ drop null values in dataframe
 > let s = ([1 2 0 0 3 4] | dfr to-df);
     ($s / $s) | dfr drop-nulls
 ```
-

--- a/docs/commands/dfr_drop.md
+++ b/docs/commands/dfr_drop.md
@@ -20,4 +20,3 @@ drop column a
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr drop a
 ```
-

--- a/docs/commands/dfr_dtypes.md
+++ b/docs/commands/dfr_dtypes.md
@@ -16,4 +16,3 @@ Dataframe dtypes
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr dtypes
 ```
-

--- a/docs/commands/dfr_filter-with.md
+++ b/docs/commands/dfr_filter-with.md
@@ -21,4 +21,3 @@ Filter dataframe using a bool mask
 > let mask = ([$true $false] | dfr to-df);
     [[a b]; [1 2] [3 4]] | dfr to-df | dfr filter-with $mask
 ```
-

--- a/docs/commands/dfr_first.md
+++ b/docs/commands/dfr_first.md
@@ -20,4 +20,3 @@ Create new dataframe with head rows
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr first 1
 ```
-

--- a/docs/commands/dfr_get-day.md
+++ b/docs/commands/dfr_get-day.md
@@ -18,4 +18,3 @@ Returns day from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-day
 ```
-

--- a/docs/commands/dfr_get-hour.md
+++ b/docs/commands/dfr_get-hour.md
@@ -18,4 +18,3 @@ Returns hour from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-hour
 ```
-

--- a/docs/commands/dfr_get-minute.md
+++ b/docs/commands/dfr_get-minute.md
@@ -18,4 +18,3 @@ Returns minute from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-minute
 ```
-

--- a/docs/commands/dfr_get-month.md
+++ b/docs/commands/dfr_get-month.md
@@ -18,4 +18,3 @@ Returns month from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-month
 ```
-

--- a/docs/commands/dfr_get-nanosecond.md
+++ b/docs/commands/dfr_get-nanosecond.md
@@ -18,4 +18,3 @@ Returns nanosecond from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-nanosecond
 ```
-

--- a/docs/commands/dfr_get-ordinal.md
+++ b/docs/commands/dfr_get-ordinal.md
@@ -18,4 +18,3 @@ Returns ordinal from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-ordinal
 ```
-

--- a/docs/commands/dfr_get-second.md
+++ b/docs/commands/dfr_get-second.md
@@ -18,4 +18,3 @@ Returns second from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-second
 ```
-

--- a/docs/commands/dfr_get-week.md
+++ b/docs/commands/dfr_get-week.md
@@ -18,4 +18,3 @@ Returns week from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-week
 ```
-

--- a/docs/commands/dfr_get-weekday.md
+++ b/docs/commands/dfr_get-weekday.md
@@ -18,4 +18,3 @@ Returns weekday from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-weekday
 ```
-

--- a/docs/commands/dfr_get-year.md
+++ b/docs/commands/dfr_get-year.md
@@ -18,4 +18,3 @@ Returns year from a date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr get-year
 ```
-

--- a/docs/commands/dfr_get.md
+++ b/docs/commands/dfr_get.md
@@ -20,4 +20,3 @@ Creates dataframe with selected columns
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr get a
 ```
-

--- a/docs/commands/dfr_group-by.md
+++ b/docs/commands/dfr_group-by.md
@@ -20,4 +20,3 @@ Grouping by column a
 ```shell
 > [[a b]; [one 1] [one 2]] | dfr to-df | dfr group-by a
 ```
-

--- a/docs/commands/dfr_is-duplicated.md
+++ b/docs/commands/dfr_is-duplicated.md
@@ -16,4 +16,3 @@ Create mask indicating duplicated values
 ```shell
 > [5 6 6 6 8 8 8] | dfr to-df | dfr is-duplicated
 ```
-

--- a/docs/commands/dfr_is-in.md
+++ b/docs/commands/dfr_is-in.md
@@ -21,4 +21,3 @@ Checks if elements from a series are contained in right series
 > let other = ([1 3 6] | dfr to-df);
     [5 6 6 6 8 8 8] | dfr to-df | dfr is-in $other
 ```
-

--- a/docs/commands/dfr_is-not-null.md
+++ b/docs/commands/dfr_is-not-null.md
@@ -18,4 +18,3 @@ Create mask where values are not null
     let res = ($s / $s);
     $res | dfr is-not-null
 ```
-

--- a/docs/commands/dfr_is-null.md
+++ b/docs/commands/dfr_is-null.md
@@ -18,4 +18,3 @@ Create mask where values are null
     let res = ($s / $s);
     $res | dfr is-null
 ```
-

--- a/docs/commands/dfr_is-unique.md
+++ b/docs/commands/dfr_is-unique.md
@@ -16,4 +16,3 @@ Create mask indicating unique values
 ```shell
 > [5 6 6 6 8 8 8] | dfr to-df | dfr is-unique
 ```
-

--- a/docs/commands/dfr_join.md
+++ b/docs/commands/dfr_join.md
@@ -25,4 +25,3 @@ inner join dataframe
 > let right = ([[a b c]; [1 2 5] [3 4 5] [5 6 6]] | dfr to-df);
     $right | dfr join $right -l [a b] -r [a b]
 ```
-

--- a/docs/commands/dfr_last.md
+++ b/docs/commands/dfr_last.md
@@ -20,4 +20,3 @@ Create new dataframe with last rows
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr last 1
 ```
-

--- a/docs/commands/dfr_melt.md
+++ b/docs/commands/dfr_melt.md
@@ -23,4 +23,3 @@ melt dataframe
 ```shell
 > [[a b c d]; [x 1 4 a] [y 2 5 b] [z 3 6 c]] | dfr to-df | dfr melt -c [b c] -v [a d]
 ```
-

--- a/docs/commands/dfr_not.md
+++ b/docs/commands/dfr_not.md
@@ -16,4 +16,3 @@ Inverts boolean mask
 ```shell
 > [$true $false $true] | dfr to-df | dfr not
 ```
-

--- a/docs/commands/dfr_open.md
+++ b/docs/commands/dfr_open.md
@@ -25,4 +25,3 @@ Takes a file name and creates a dataframe
 ```shell
 > dfr open test.csv
 ```
-

--- a/docs/commands/dfr_pivot.md
+++ b/docs/commands/dfr_pivot.md
@@ -22,4 +22,3 @@ Pivot a dataframe on b and aggregation on col c
 ```shell
 > [[a b c]; [one x 1] [two y 2]] | dfr to-df | dfr group-by a | dfr pivot b c sum
 ```
-

--- a/docs/commands/dfr_rename-col.md
+++ b/docs/commands/dfr_rename-col.md
@@ -21,4 +21,3 @@ Renames a dataframe column
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr rename-col a a_new
 ```
-

--- a/docs/commands/dfr_rename.md
+++ b/docs/commands/dfr_rename.md
@@ -20,4 +20,3 @@ Renames a series
 ```shell
 > [5 6 7 8] | dfr to-df | dfr rename new_name
 ```
-

--- a/docs/commands/dfr_replace-all.md
+++ b/docs/commands/dfr_replace-all.md
@@ -21,4 +21,3 @@ Replaces string
 ```shell
 > [abac abac abac] | dfr to-df | dfr replace-all -p a -r A
 ```
-

--- a/docs/commands/dfr_replace.md
+++ b/docs/commands/dfr_replace.md
@@ -21,4 +21,3 @@ Replaces string
 ```shell
 > [abc abc abc] | dfr to-df | dfr replace -p ab -r AB
 ```
-

--- a/docs/commands/dfr_rolling.md
+++ b/docs/commands/dfr_rolling.md
@@ -26,4 +26,3 @@ Rolling max for a series
 ```shell
 > [1 2 3 4 5] | dfr to-df | dfr rolling max 2 | dfr drop-nulls
 ```
-

--- a/docs/commands/dfr_sample.md
+++ b/docs/commands/dfr_sample.md
@@ -27,4 +27,3 @@ Shows sample row using fraction and replace
 ```shell
 > [[a b]; [1 2] [3 4] [5 6]] | dfr to-df | dfr sample -f 0.5 -e
 ```
-

--- a/docs/commands/dfr_set-with-idx.md
+++ b/docs/commands/dfr_set-with-idx.md
@@ -23,4 +23,3 @@ Set value in selected rows from series
     let indices = ([0 2] | dfr to-df);
     $series | dfr set-with-idx 6 -i $indices
 ```
-

--- a/docs/commands/dfr_set.md
+++ b/docs/commands/dfr_set.md
@@ -23,4 +23,3 @@ Shifts the values by a given period
     let mask = ($s | dfr is-null);
     $s | dfr set 0 --mask $mask
 ```
-

--- a/docs/commands/dfr_shape.md
+++ b/docs/commands/dfr_shape.md
@@ -16,4 +16,3 @@ Shows row and column shape
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr shape
 ```
-

--- a/docs/commands/dfr_shift.md
+++ b/docs/commands/dfr_shift.md
@@ -20,4 +20,3 @@ Shifts the values by a given period
 ```shell
 > [1 2 2 3 3] | dfr to-df | dfr shift 2 | dfr drop-nulls
 ```
-

--- a/docs/commands/dfr_slice.md
+++ b/docs/commands/dfr_slice.md
@@ -21,4 +21,3 @@ Create new dataframe from a slice of the rows
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr slice 0 1
 ```
-

--- a/docs/commands/dfr_sort.md
+++ b/docs/commands/dfr_sort.md
@@ -26,4 +26,3 @@ Create new sorted series
 ```shell
 > [3 4 1 2] | dfr to-df | dfr sort
 ```
-

--- a/docs/commands/dfr_str-lengths.md
+++ b/docs/commands/dfr_str-lengths.md
@@ -16,4 +16,3 @@ Returns string lengths
 ```shell
 > [a ab abc] | dfr to-df | dfr str-lengths
 ```
-

--- a/docs/commands/dfr_str-slice.md
+++ b/docs/commands/dfr_str-slice.md
@@ -21,4 +21,3 @@ Creates slices from the strings
 ```shell
 > [abcded abc321 abc123] | dfr to-df | dfr str-slice 1 -l 2
 ```
-

--- a/docs/commands/dfr_strftime.md
+++ b/docs/commands/dfr_strftime.md
@@ -22,4 +22,3 @@ Formats date
     let df = ([$dt $dt] | dfr to-df);
     $df | dfr strftime "%Y/%m/%d"
 ```
-

--- a/docs/commands/dfr_take.md
+++ b/docs/commands/dfr_take.md
@@ -29,4 +29,3 @@ Takes selected rows from series
     let indices = ([0 2] | dfr to-df);
     $series | dfr take $indices
 ```
-

--- a/docs/commands/dfr_to-csv.md
+++ b/docs/commands/dfr_to-csv.md
@@ -27,4 +27,3 @@ Saves dataframe to csv file using other delimiter
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr to-csv test.csv -d '|'
 ```
-

--- a/docs/commands/dfr_to-df.md
+++ b/docs/commands/dfr_to-df.md
@@ -31,4 +31,3 @@ Takes a list of booleans and creates a dataframe
 ```shell
 > [$true $true $false] | dfr to-df
 ```
-

--- a/docs/commands/dfr_to-dummies.md
+++ b/docs/commands/dfr_to-dummies.md
@@ -21,4 +21,3 @@ Create new dataframe with dummy variables from a series
 ```shell
 > [1 2 2 3 3] | dfr to-df | dfr to-dummies
 ```
-

--- a/docs/commands/dfr_to-lowercase.md
+++ b/docs/commands/dfr_to-lowercase.md
@@ -16,4 +16,3 @@ Modifies strings to lowercase
 ```shell
 > [Abc aBc abC] | dfr to-df | dfr to-lowercase
 ```
-

--- a/docs/commands/dfr_to-nu.md
+++ b/docs/commands/dfr_to-nu.md
@@ -26,4 +26,3 @@ Shows tail rows from dataframe
 ```shell
 > [[a b]; [1 2] [3 4] [5 6]] | dfr to-df | dfr to-nu -t -n 1
 ```
-

--- a/docs/commands/dfr_to-parquet.md
+++ b/docs/commands/dfr_to-parquet.md
@@ -20,4 +20,3 @@ Saves dataframe to csv file
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr to-parquet test.parquet
 ```
-

--- a/docs/commands/dfr_to-uppercase.md
+++ b/docs/commands/dfr_to-uppercase.md
@@ -16,4 +16,3 @@ Modifies strings to uppercase
 ```shell
 > [Abc aBc abC] | dfr to-df | dfr to-uppercase
 ```
-

--- a/docs/commands/dfr_unique.md
+++ b/docs/commands/dfr_unique.md
@@ -16,4 +16,3 @@ Returns unique values from a series
 ```shell
 > [2 2 2 2 2] | dfr to-df | dfr unique
 ```
-

--- a/docs/commands/dfr_value-counts.md
+++ b/docs/commands/dfr_value-counts.md
@@ -16,4 +16,3 @@ Calculates value counts
 ```shell
 > [5 5 5 5 6 6] | dfr to-df | dfr value-counts
 ```
-

--- a/docs/commands/dfr_with-column.md
+++ b/docs/commands/dfr_with-column.md
@@ -21,4 +21,3 @@ Adds a series to the dataframe
 ```shell
 > [[a b]; [1 2] [3 4]] | dfr to-df | dfr with-column ([5 6] | dfr to-df) --name c
 ```
-

--- a/docs/commands/do.md
+++ b/docs/commands/do.md
@@ -27,4 +27,3 @@ Run the block and ignore errors
 ```shell
 > do -i { thisisnotarealcommand }
 ```
-

--- a/docs/commands/drop.md
+++ b/docs/commands/drop.md
@@ -30,4 +30,3 @@ Remove the last two items of a list/table
 ```shell
 > [0,1,2,3] | drop 2
 ```
-

--- a/docs/commands/drop_column.md
+++ b/docs/commands/drop_column.md
@@ -20,4 +20,3 @@ Remove the last column of a table
 ```shell
 > echo [[lib, extension]; [nu-lib, rs] [nu-core, rb]] | drop column
 ```
-

--- a/docs/commands/drop_nth.md
+++ b/docs/commands/drop_nth.md
@@ -41,4 +41,3 @@ Drop range rows from second to fourth
 ```shell
 > echo [first second third fourth fifth] | drop nth (1..3)
 ```
-

--- a/docs/commands/du.md
+++ b/docs/commands/du.md
@@ -25,4 +25,3 @@ Disk usage of the current directory
 ```shell
 > du
 ```
-

--- a/docs/commands/each.md
+++ b/docs/commands/each.md
@@ -21,4 +21,3 @@ Multiplies elements in list
 ```shell
 > [1 2 3] | each { |it| 2 * $it }
 ```
-

--- a/docs/commands/each_group.md
+++ b/docs/commands/each_group.md
@@ -21,4 +21,3 @@ Echo the sum of each pair
 ```shell
 > echo [1 2 3 4] | each group 2 { |it| $it.0 + $it.1 }
 ```
-

--- a/docs/commands/each_window.md
+++ b/docs/commands/each_window.md
@@ -27,4 +27,3 @@ A sliding window of two elements, with a stride of 3
 ```shell
 > [1, 2, 3, 4, 5, 6, 7, 8] | each window 2 --stride 3 { |x| $x.0 + $x.1 }
 ```
-

--- a/docs/commands/echo.md
+++ b/docs/commands/echo.md
@@ -25,4 +25,3 @@ Print the value of the special '$nu' variable
 ```shell
 > echo $nu
 ```
-

--- a/docs/commands/empty.md
+++ b/docs/commands/empty.md
@@ -31,4 +31,3 @@ use a block if setting the empty cell contents is wanted
 ```shell
 > [[2020/04/16 2020/07/10 2020/11/16]; ['' [27] [37]]] | empty? 2020/04/16 -b { |_| [33 37] }
 ```
-

--- a/docs/commands/enter.md
+++ b/docs/commands/enter.md
@@ -13,4 +13,3 @@ Enters a new shell at the given path.
 ## Parameters
 
  -  `path`: the path to enter as a new shell
-

--- a/docs/commands/env.md
+++ b/docs/commands/env.md
@@ -26,4 +26,3 @@ Another way to check whether the env variable `PATH` exists
 ```shell
 > 'PATH' in (env).name
 ```
-

--- a/docs/commands/error_make.md
+++ b/docs/commands/error_make.md
@@ -23,4 +23,3 @@ Create a custom error for a custom command
       error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
     }
 ```
-

--- a/docs/commands/every.md
+++ b/docs/commands/every.md
@@ -26,4 +26,3 @@ Skip every second row
 ```shell
 > [1 2 3 4 5] | every 2 --skip
 ```
-

--- a/docs/commands/exec.md
+++ b/docs/commands/exec.md
@@ -26,4 +26,3 @@ Execute 'nautilus'
 ```shell
 > exec nautilus
 ```
-

--- a/docs/commands/exit.md
+++ b/docs/commands/exit.md
@@ -26,4 +26,3 @@ Exit all shells (exiting Nu)
 ```shell
 > exit --now
 ```
-

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -9,4 +9,3 @@ Export custom commands or environment variables from a module.
 ## Signature
 
 ```> export ```
-

--- a/docs/commands/export_def-env.md
+++ b/docs/commands/export_def-env.md
@@ -16,3 +16,10 @@ Define a custom command that participates in the environment and export it from 
  -  `params`: parameters
  -  `block`: body of the definition
 
+## Examples
+
+Define a custom command that participates in the environment in a module and call it
+```shell
+> module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR
+```
+

--- a/docs/commands/export_def-env.md
+++ b/docs/commands/export_def-env.md
@@ -22,4 +22,3 @@ Define a custom command that participates in the environment in a module and cal
 ```shell
 > module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR
 ```
-

--- a/docs/commands/export_def.md
+++ b/docs/commands/export_def.md
@@ -22,4 +22,3 @@ Define a custom command in a module and call it
 ```shell
 > module spam { export def foo [] { "foo" } }; use spam foo; foo
 ```
-

--- a/docs/commands/export_def.md
+++ b/docs/commands/export_def.md
@@ -16,3 +16,10 @@ Define a custom command and export it from a module
  -  `params`: parameters
  -  `block`: body of the definition
 
+## Examples
+
+Define a custom command in a module and call it
+```shell
+> module spam { export def foo [] { "foo" } }; use spam foo; foo
+```
+

--- a/docs/commands/export_env.md
+++ b/docs/commands/export_env.md
@@ -21,4 +21,3 @@ Import and evaluate environment variable from a module
 ```shell
 > module foo { export env FOO_ENV { "BAZ" } }; use foo FOO_ENV; $env.FOO_ENV
 ```
-

--- a/docs/commands/export_env.md
+++ b/docs/commands/export_env.md
@@ -15,3 +15,10 @@ Export a block from a module that will be evaluated as an environment variable w
  -  `name`: name of the environment variable
  -  `block`: body of the environment variable definition
 
+## Examples
+
+Import and evaluate environment variable from a module
+```shell
+> module foo { export env FOO_ENV { "BAZ" } }; use foo FOO_ENV; $env.FOO_ENV
+```
+

--- a/docs/commands/extern.md
+++ b/docs/commands/extern.md
@@ -14,4 +14,3 @@ Define a signature for an external command
 
  -  `def_name`: definition name
  -  `params`: parameters
-

--- a/docs/commands/fetch.md
+++ b/docs/commands/fetch.md
@@ -35,4 +35,3 @@ Fetch content from url.com, with custom header
 ```shell
 > fetch -H [my-header-key my-header-value] url.com
 ```
-

--- a/docs/commands/fetch.md
+++ b/docs/commands/fetch.md
@@ -16,7 +16,7 @@ Fetch the contents from a URL (HTTP GET operation).
  -  `--user {any}`: the username when authenticating
  -  `--password {any}`: the password when authenticating
  -  `--timeout {int}`: timeout period in seconds
- -  `--headers {any}`: custom headers you want to add
+ -  `--headers {any}`: custom headers you want to add 
  -  `--raw`: fetch contents as text rather than a table
 
 ## Examples

--- a/docs/commands/find.md
+++ b/docs/commands/find.md
@@ -46,4 +46,3 @@ Find if a service is not running
 ```shell
 > echo [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | find -p { |it| $it.patch }
 ```
-

--- a/docs/commands/first.md
+++ b/docs/commands/first.md
@@ -25,4 +25,3 @@ Return the first 2 items of a list/table
 ```shell
 > [1 2 3] | first 2
 ```
-

--- a/docs/commands/flatten.md
+++ b/docs/commands/flatten.md
@@ -40,4 +40,3 @@ Flatten inner table
 ```shell
 > { a: b, d: [ 1 2 3 4 ],  e: [ 4 3  ] } | flatten
 ```
-

--- a/docs/commands/flatten.md
+++ b/docs/commands/flatten.md
@@ -18,7 +18,7 @@ Flatten the table.
 
 flatten a table
 ```shell
-> [[N, u, s, h, e, l, l]] | flatten
+> [[N, u, s, h, e, l, l]] | flatten 
 ```
 
 flatten a table, get the first item

--- a/docs/commands/fmt.md
+++ b/docs/commands/fmt.md
@@ -16,4 +16,3 @@ format numbers
 ```shell
 > 42 | fmt
 ```
-

--- a/docs/commands/for.md
+++ b/docs/commands/for.md
@@ -33,4 +33,3 @@ Number each item and echo a message
 ```shell
 > for $it in ['bob' 'fred'] --numbered { $"($it.index) is ($it.item)" }
 ```
-

--- a/docs/commands/format.md
+++ b/docs/commands/format.md
@@ -25,4 +25,3 @@ Print elements from some columns of a table
 ```shell
 > echo [[col1, col2]; [v1, v2] [v3, v4]] | format '{col2}'
 ```
-

--- a/docs/commands/from.md
+++ b/docs/commands/from.md
@@ -9,4 +9,3 @@ Parse a string or binary data into structured data
 ## Signature
 
 ```> from ```
-

--- a/docs/commands/from_csv.md
+++ b/docs/commands/from_csv.md
@@ -36,4 +36,3 @@ Convert semicolon-separated data to a table
 ```shell
 > open data.txt | from csv --separator ';'
 ```
-

--- a/docs/commands/from_eml.md
+++ b/docs/commands/from_eml.md
@@ -33,4 +33,3 @@ To: someone@somewhere.com
 
 Test' | from eml -b 1
 ```
-

--- a/docs/commands/from_ics.md
+++ b/docs/commands/from_ics.md
@@ -17,4 +17,3 @@ Converts ics formatted string to table
 > 'BEGIN:VCALENDAR
 END:VCALENDAR' | from ics
 ```
-

--- a/docs/commands/from_ini.md
+++ b/docs/commands/from_ini.md
@@ -18,4 +18,3 @@ Converts ini formatted string to table
 a=1
 b=2' | from ini
 ```
-

--- a/docs/commands/from_json.md
+++ b/docs/commands/from_json.md
@@ -18,11 +18,11 @@ Convert from json to structured data
 
 Converts json formatted string to table
 ```shell
-> '{ a:1 }' | from json
+> '{ "a": 1 }' | from json
 ```
 
 Converts json formatted string to table
 ```shell
-> '{ a:1, b: [1, 2] }' | from json
+> '{ "a": 1, "b": [1, 2] }' | from json
 ```
 

--- a/docs/commands/from_json.md
+++ b/docs/commands/from_json.md
@@ -25,4 +25,3 @@ Converts json formatted string to table
 ```shell
 > '{ "a": 1, "b": [1, 2] }' | from json
 ```
-

--- a/docs/commands/from_nuon.md
+++ b/docs/commands/from_nuon.md
@@ -1,0 +1,24 @@
+---
+title: from nuon
+layout: command
+version: 0.59.0
+---
+
+Convert from nuon to structured data
+
+## Signature
+
+```> from nuon ```
+
+## Examples
+
+Converts nuon formatted string to table
+```shell
+> '{ a:1 }' | from nuon
+```
+
+Converts nuon formatted string to table
+```shell
+> '{ a:1, b: [1, 2] }' | from nuon
+```
+

--- a/docs/commands/from_nuon.md
+++ b/docs/commands/from_nuon.md
@@ -21,4 +21,3 @@ Converts nuon formatted string to table
 ```shell
 > '{ a:1, b: [1, 2] }' | from nuon
 ```
-

--- a/docs/commands/from_ods.md
+++ b/docs/commands/from_ods.md
@@ -25,4 +25,3 @@ Convert binary .ods data to a table, specifying the tables
 ```shell
 > open test.txt | from ods -s [Spreadsheet1]
 ```
-

--- a/docs/commands/from_ssv.md
+++ b/docs/commands/from_ssv.md
@@ -29,4 +29,3 @@ Converts ssv formatted string to table but not treating the first row as column 
 > 'FOO   BAR
 1   2' | from ssv -n
 ```
-

--- a/docs/commands/from_toml.md
+++ b/docs/commands/from_toml.md
@@ -22,4 +22,3 @@ Converts toml formatted string to table
 > 'a = 1
 b = [1, 2]' | from toml
 ```
-

--- a/docs/commands/from_tsv.md
+++ b/docs/commands/from_tsv.md
@@ -25,4 +25,3 @@ Create a tsv file without header columns and open it
 ```shell
 > echo $'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv -n
 ```
-

--- a/docs/commands/from_tsv.md
+++ b/docs/commands/from_tsv.md
@@ -14,3 +14,15 @@ Parse text as .tsv and create table.
 
  -  `--noheaders`: don't treat the first row as column names
 
+## Examples
+
+Create a tsv file with header columns and open it
+```shell
+> echo $'c1(char tab)c2(char tab)c3(char nl)1(char tab)2(char tab)3' | save tsv-data | open tsv-data | from tsv
+```
+
+Create a tsv file without header columns and open it
+```shell
+> echo $'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv -n
+```
+

--- a/docs/commands/from_url.md
+++ b/docs/commands/from_url.md
@@ -16,4 +16,3 @@ Convert url encoded string into a table
 ```shell
 > 'bread=baguette&cheese=comt%C3%A9&meat=ham&fat=butter' | from url
 ```
-

--- a/docs/commands/from_vcf.md
+++ b/docs/commands/from_vcf.md
@@ -20,4 +20,3 @@ FN:Bar
 EMAIL:foo@bar.com
 END:VCARD' | from vcf
 ```
-

--- a/docs/commands/from_xlsx.md
+++ b/docs/commands/from_xlsx.md
@@ -25,4 +25,3 @@ Convert binary .xlsx data to a table, specifying the tables
 ```shell
 > open test.txt | from xlsx -s [Spreadsheet1]
 ```
-

--- a/docs/commands/from_xml.md
+++ b/docs/commands/from_xml.md
@@ -19,4 +19,3 @@ Converts xml formatted string to table
   <remember>Event</remember>
 </note>' | from xml
 ```
-

--- a/docs/commands/from_yaml.md
+++ b/docs/commands/from_yaml.md
@@ -21,4 +21,3 @@ Converts yaml formatted string to table
 ```shell
 > '[ a: 1, b: [1, 2] ]' | from yaml
 ```
-

--- a/docs/commands/from_yml.md
+++ b/docs/commands/from_yml.md
@@ -21,4 +21,3 @@ Converts yaml formatted string to table
 ```shell
 > '[ a: 1, b: [1, 2] ]' | from yaml
 ```
-

--- a/docs/commands/from_yml.md
+++ b/docs/commands/from_yml.md
@@ -10,3 +10,15 @@ Parse text as .yaml/.yml and create table.
 
 ```> from yml ```
 
+## Examples
+
+Converts yaml formatted string to table
+```shell
+> 'a: 1' | from yaml
+```
+
+Converts yaml formatted string to table
+```shell
+> '[ a: 1, b: [1, 2] ]' | from yaml
+```
+

--- a/docs/commands/g.md
+++ b/docs/commands/g.md
@@ -13,4 +13,3 @@ Switch to a given shell.
 ## Parameters
 
  -  `shell_number`: shell number to change to
-

--- a/docs/commands/get.md
+++ b/docs/commands/get.md
@@ -37,4 +37,3 @@ Extract the cpu list from the sys information record
 ```shell
 > sys | get cpu
 ```
-

--- a/docs/commands/grid.md
+++ b/docs/commands/grid.md
@@ -15,4 +15,3 @@ Renders the output to a textual terminal grid.
  -  `--width {int}`: number of terminal columns wide (not output columns)
  -  `--color`: draw output with color
  -  `--separator {string}`: character to separate grid with
-

--- a/docs/commands/group-by.md
+++ b/docs/commands/group-by.md
@@ -25,4 +25,3 @@ you can also group by raw values by leaving out the argument
 ```shell
 > echo ['1' '3' '1' '3' '2' '1' '1'] | group-by
 ```
-

--- a/docs/commands/hash.md
+++ b/docs/commands/hash.md
@@ -9,4 +9,3 @@ Apply hash function.
 ## Signature
 
 ```> hash ```
-

--- a/docs/commands/hash_base64.md
+++ b/docs/commands/hash_base64.md
@@ -34,4 +34,3 @@ Base64 decode a value
 ```shell
 > echo 'dXNlcm5hbWU6cGFzc3dvcmQ=' | hash base64 --decode
 ```
-

--- a/docs/commands/hash_md5.md
+++ b/docs/commands/hash_md5.md
@@ -25,4 +25,3 @@ md5 encode a file
 ```shell
 > open ./nu_0_24_1_windows.zip | hash md5
 ```
-

--- a/docs/commands/hash_sha256.md
+++ b/docs/commands/hash_sha256.md
@@ -25,4 +25,3 @@ sha256 encode a file
 ```shell
 > open ./nu_0_24_1_windows.zip | hash sha256
 ```
-

--- a/docs/commands/headers.md
+++ b/docs/commands/headers.md
@@ -21,4 +21,3 @@ Don't panic on rows with different headers
 ```shell
 > "a b c|1 2 3|1 2 3 4" | split row "|" | split column " " | headers
 ```
-

--- a/docs/commands/help.md
+++ b/docs/commands/help.md
@@ -41,4 +41,3 @@ search for string in command usage
 ```shell
 > help --find char
 ```
-

--- a/docs/commands/hide.md
+++ b/docs/commands/hide.md
@@ -14,3 +14,20 @@ Hide symbols in the current scope
 
  -  `pattern`: import pattern
 
+## Examples
+
+Hide the alias just defined
+```shell
+> alias lll = ls -l; hide lll
+```
+
+Hide a custom command
+```shell
+> def say-hi [] { echo 'Hi!' }; hide say-hi
+```
+
+Hide an environment variable
+```shell
+> let-env HZ_ENV_ABC = 1; hide HZ_ENV_ABC; 'HZ_ENV_ABC' in (env).name
+```
+

--- a/docs/commands/hide.md
+++ b/docs/commands/hide.md
@@ -30,4 +30,3 @@ Hide an environment variable
 ```shell
 > let-env HZ_ENV_ABC = 1; hide HZ_ENV_ABC; 'HZ_ENV_ABC' in (env).name
 ```
-

--- a/docs/commands/history.md
+++ b/docs/commands/history.md
@@ -30,4 +30,3 @@ Search all the commands from history that contains 'cargo'
 ```shell
 > history | wrap cmd | where cmd =~ cargo
 ```
-

--- a/docs/commands/history.md
+++ b/docs/commands/history.md
@@ -14,3 +14,20 @@ Get the command history
 
  -  `--clear`: Clears out the history entries
 
+## Examples
+
+Get current history length
+```shell
+> history | length
+```
+
+Show last 5 commands you have ran
+```shell
+> history | last 5
+```
+
+Search all the commands from history that contains 'cargo'
+```shell
+> history | wrap cmd | where cmd =~ cargo
+```
+

--- a/docs/commands/if.md
+++ b/docs/commands/if.md
@@ -32,4 +32,3 @@ Chain multiple if's together
 ```shell
 > if 5 < 3 { 'yes!' } else if 4 < 5 { 'no!' } else { 'okay!' }
 ```
-

--- a/docs/commands/ignore.md
+++ b/docs/commands/ignore.md
@@ -16,4 +16,3 @@ Ignore the output of an echo command
 ```shell
 > echo done | ignore
 ```
-

--- a/docs/commands/input.md
+++ b/docs/commands/input.md
@@ -21,4 +21,3 @@ Get input from the user, and assign to a variable
 ```shell
 > let user-input = (input)
 ```
-

--- a/docs/commands/insert.md
+++ b/docs/commands/insert.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> insert ```
-

--- a/docs/commands/into.md
+++ b/docs/commands/into.md
@@ -9,4 +9,3 @@ Apply into function.
 ## Signature
 
 ```> into ```
-

--- a/docs/commands/into_binary.md
+++ b/docs/commands/into_binary.md
@@ -45,4 +45,3 @@ convert a decimal to a nushell binary primitive
 ```shell
 > 1.234 | into binary
 ```
-

--- a/docs/commands/into_bool.md
+++ b/docs/commands/into_bool.md
@@ -40,4 +40,3 @@ convert string to boolean
 ```shell
 > 'true' | into bool
 ```
-

--- a/docs/commands/into_datetime.md
+++ b/docs/commands/into_datetime.md
@@ -44,4 +44,3 @@ Convert timestamp (no larger than 8e+12) to datetime using a specified timezone 
 ```shell
 > '1614434140' | into datetime -o +9
 ```
-

--- a/docs/commands/into_decimal.md
+++ b/docs/commands/into_decimal.md
@@ -30,4 +30,3 @@ Convert decimal to integer
 ```shell
 > '-5.9' | into decimal
 ```
-

--- a/docs/commands/into_filesize.md
+++ b/docs/commands/into_filesize.md
@@ -40,4 +40,3 @@ Convert file size to filesize
 ```shell
 > 4KB | into filesize
 ```
-

--- a/docs/commands/into_int.md
+++ b/docs/commands/into_int.md
@@ -56,4 +56,3 @@ Convert to integer from hex
 ```shell
 > 'FF' |  into int -r 16
 ```
-

--- a/docs/commands/into_string.md
+++ b/docs/commands/into_string.md
@@ -66,4 +66,3 @@ convert filesize to string
 ```shell
 > ls Cargo.toml | get size | into string
 ```
-

--- a/docs/commands/keep.md
+++ b/docs/commands/keep.md
@@ -25,4 +25,3 @@ Keep the first value
 ```shell
 > echo [2 4 6 8] | keep
 ```
-

--- a/docs/commands/keep_until.md
+++ b/docs/commands/keep_until.md
@@ -20,4 +20,3 @@ Keep until the element is positive
 ```shell
 > echo [-1 -2 9 1] | keep until $it > 0
 ```
-

--- a/docs/commands/keep_while.md
+++ b/docs/commands/keep_while.md
@@ -20,4 +20,3 @@ Keep while the element is negative
 ```shell
 > echo [-1 -2 9 1] | keep while $it < 0
 ```
-

--- a/docs/commands/keybindings.md
+++ b/docs/commands/keybindings.md
@@ -9,4 +9,3 @@ Keybindings related commands
 ## Signature
 
 ```> keybindings ```
-

--- a/docs/commands/keybindings_default.md
+++ b/docs/commands/keybindings_default.md
@@ -16,4 +16,3 @@ Get list with default keybindings
 ```shell
 > keybindings default
 ```
-

--- a/docs/commands/keybindings_list.md
+++ b/docs/commands/keybindings_list.md
@@ -34,4 +34,3 @@ Get list with all the available options
 ```shell
 > keybindings list
 ```
-

--- a/docs/commands/keybindings_listen.md
+++ b/docs/commands/keybindings_listen.md
@@ -16,4 +16,3 @@ Type and see key event codes
 ```shell
 > keybindings listen
 ```
-

--- a/docs/commands/kill.md
+++ b/docs/commands/kill.md
@@ -34,4 +34,3 @@ Send INT signal
 ```shell
 > kill -s 2 12345
 ```
-

--- a/docs/commands/last.md
+++ b/docs/commands/last.md
@@ -20,4 +20,3 @@ Get the last 2 items
 ```shell
 > [1,2,3] | last 2
 ```
-

--- a/docs/commands/length.md
+++ b/docs/commands/length.md
@@ -25,4 +25,3 @@ Count the number of columns in the calendar table
 ```shell
 > cal | length -c
 ```
-

--- a/docs/commands/let-env.md
+++ b/docs/commands/let-env.md
@@ -21,4 +21,3 @@ Create an environment variable and display it
 ```shell
 > let-env MY_ENV_VAR = 1; $env.MY_ENV_VAR
 ```
-

--- a/docs/commands/let.md
+++ b/docs/commands/let.md
@@ -31,4 +31,3 @@ Set a variable based on the condition
 ```shell
 > let x = if $false { -1 } else { 1 }
 ```
-

--- a/docs/commands/lines.md
+++ b/docs/commands/lines.md
@@ -20,4 +20,3 @@ Split multi-line string into lines
 ```shell
 > echo $'two(char nl)lines' | lines
 ```
-

--- a/docs/commands/load-env.md
+++ b/docs/commands/load-env.md
@@ -25,4 +25,3 @@ Load variables from an argument
 ```shell
 > load-env {NAME: ABE, AGE: UNKNOWN}; echo $env.NAME
 ```
-

--- a/docs/commands/ls.md
+++ b/docs/commands/ls.md
@@ -35,4 +35,3 @@ List all rust files
 ```shell
 > ls *.rs
 ```
-

--- a/docs/commands/math.md
+++ b/docs/commands/math.md
@@ -9,4 +9,3 @@ Use mathematical functions as aggregate functions on a list of numbers or tables
 ## Signature
 
 ```> math ```
-

--- a/docs/commands/math_abs.md
+++ b/docs/commands/math_abs.md
@@ -16,4 +16,3 @@ Get absolute of each value in a list of numbers
 ```shell
 > [-50 -100.0 25] | math abs
 ```
-

--- a/docs/commands/math_avg.md
+++ b/docs/commands/math_avg.md
@@ -16,4 +16,3 @@ Get the average of a list of numbers
 ```shell
 > [-50 100.0 25] | math avg
 ```
-

--- a/docs/commands/math_ceil.md
+++ b/docs/commands/math_ceil.md
@@ -16,4 +16,3 @@ Apply the ceil function to a list of numbers
 ```shell
 > [1.5 2.3 -3.1] | math ceil
 ```
-

--- a/docs/commands/math_eval.md
+++ b/docs/commands/math_eval.md
@@ -20,4 +20,3 @@ Evalulate math in the pipeline
 ```shell
 > '10 / 4' | math eval
 ```
-

--- a/docs/commands/math_floor.md
+++ b/docs/commands/math_floor.md
@@ -16,4 +16,3 @@ Apply the floor function to a list of numbers
 ```shell
 > [1.5 2.3 -3.1] | math floor
 ```
-

--- a/docs/commands/math_max.md
+++ b/docs/commands/math_max.md
@@ -16,4 +16,3 @@ Find the maximum of list of numbers
 ```shell
 > [-50 100 25] | math max
 ```
-

--- a/docs/commands/math_median.md
+++ b/docs/commands/math_median.md
@@ -16,4 +16,3 @@ Get the median of a list of numbers
 ```shell
 > [3 8 9 12 12 15] | math median
 ```
-

--- a/docs/commands/math_min.md
+++ b/docs/commands/math_min.md
@@ -16,4 +16,3 @@ Get the minimum of a list of numbers
 ```shell
 > [-50 100 25] | math min
 ```
-

--- a/docs/commands/math_mode.md
+++ b/docs/commands/math_mode.md
@@ -16,4 +16,3 @@ Get the mode(s) of a list of numbers
 ```shell
 > [3 3 9 12 12 15] | math mode
 ```
-

--- a/docs/commands/math_product.md
+++ b/docs/commands/math_product.md
@@ -16,4 +16,3 @@ Get the product of a list of numbers
 ```shell
 > [2 3 3 4] | math product
 ```
-

--- a/docs/commands/math_round.md
+++ b/docs/commands/math_round.md
@@ -25,4 +25,3 @@ Apply the round function with precision specified
 ```shell
 > [1.555 2.333 -3.111] | math round -p 2
 ```
-

--- a/docs/commands/math_sqrt.md
+++ b/docs/commands/math_sqrt.md
@@ -16,4 +16,3 @@ Apply the square root function to a list of numbers
 ```shell
 > [9 16] | math sqrt
 ```
-

--- a/docs/commands/math_stddev.md
+++ b/docs/commands/math_stddev.md
@@ -25,4 +25,3 @@ Get the sample stddev of a list of numbers
 ```shell
 > [1 2 3 4 5] | math stddev -s
 ```
-

--- a/docs/commands/math_sum.md
+++ b/docs/commands/math_sum.md
@@ -21,4 +21,3 @@ Get the disk usage for the current directory
 ```shell
 > ls | get size | math sum
 ```
-

--- a/docs/commands/math_variance.md
+++ b/docs/commands/math_variance.md
@@ -25,4 +25,3 @@ Get the sample variance of a list of numbers
 ```shell
 > [1 2 3 4 5] | math variance -s
 ```
-

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -25,4 +25,3 @@ Merge two records
 ```shell
 > {a: 1, b: 2} | merge { {c: 3} }
 ```
-

--- a/docs/commands/metadata.md
+++ b/docs/commands/metadata.md
@@ -25,4 +25,3 @@ Get the metadata of the input
 ```shell
 > ls | metadata
 ```
-

--- a/docs/commands/mkdir.md
+++ b/docs/commands/mkdir.md
@@ -26,4 +26,3 @@ Make multiple directories and show the paths created
 ```shell
 > mkdir -s foo/bar foo2
 ```
-

--- a/docs/commands/module.md
+++ b/docs/commands/module.md
@@ -15,3 +15,20 @@ Define a custom module
  -  `module_name`: module name
  -  `block`: body of the module
 
+## Examples
+
+Define a custom command in a module and call it
+```shell
+> module spam { export def foo [] { "foo" } }; use spam foo; foo
+```
+
+Define an environment variable in a module and evaluate it
+```shell
+> module foo { export env FOO_ENV { "BAZ" } }; use foo FOO_ENV; $env.FOO_ENV
+```
+
+Define a custom command that participates in the environment in a module and call it
+```shell
+> module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR
+```
+

--- a/docs/commands/module.md
+++ b/docs/commands/module.md
@@ -31,4 +31,3 @@ Define a custom command that participates in the environment in a module and cal
 ```shell
 > module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR
 ```
-

--- a/docs/commands/move.md
+++ b/docs/commands/move.md
@@ -32,4 +32,3 @@ Move columns of a record
 ```shell
 > { name: foo, value: a, index: 1 } | move name --before index
 ```
-

--- a/docs/commands/mv.md
+++ b/docs/commands/mv.md
@@ -31,4 +31,3 @@ Move many files into a directory
 ```shell
 > mv *.txt my/subdirectory
 ```
-

--- a/docs/commands/n.md
+++ b/docs/commands/n.md
@@ -9,4 +9,3 @@ Switch to the next shell.
 ## Signature
 
 ```> n ```
-

--- a/docs/commands/nth.md
+++ b/docs/commands/nth.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> nth ```
-

--- a/docs/commands/nu-highlight.md
+++ b/docs/commands/nu-highlight.md
@@ -16,4 +16,3 @@ Describe the type of a string
 ```shell
 > 'let x = 3' | nu-highlight
 ```
-

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -31,4 +31,3 @@ Open a file, using the input to get filename
 ```shell
 > echo 'myfile.txt' | open
 ```
-

--- a/docs/commands/p.md
+++ b/docs/commands/p.md
@@ -9,4 +9,3 @@ Switch to the previous shell.
 ## Signature
 
 ```> p ```
-

--- a/docs/commands/par-each.md
+++ b/docs/commands/par-each.md
@@ -21,4 +21,3 @@ Multiplies elements in list
 ```shell
 > [1 2 3] | par-each { |it| 2 * $it }
 ```
-

--- a/docs/commands/par-each_group.md
+++ b/docs/commands/par-each_group.md
@@ -21,4 +21,3 @@ Multiplies elements in list
 ```shell
 > echo [1 2 3 4] | par-each group 2 { $it.0 + $it.1 }
 ```
-

--- a/docs/commands/parse.md
+++ b/docs/commands/parse.md
@@ -26,4 +26,3 @@ Parse a string using regex pattern
 ```shell
 > echo "hi there" | parse -r "(?P<foo>\w+) (?P<bar>\w+)"
 ```
-

--- a/docs/commands/path.md
+++ b/docs/commands/path.md
@@ -9,4 +9,3 @@ Explore and manipulate paths.
 ## Signature
 
 ```> path ```
-

--- a/docs/commands/path_basename.md
+++ b/docs/commands/path_basename.md
@@ -31,4 +31,3 @@ Replace basename of a path
 ```shell
 > '/home/joe/test.txt' | path basename -r 'spam.png'
 ```
-

--- a/docs/commands/path_dirname.md
+++ b/docs/commands/path_dirname.md
@@ -37,4 +37,3 @@ Replace the part that would be returned with a custom path
 ```shell
 > '/home/joe/code/test.txt' | path dirname -n 2 -r /home/viking
 ```
-

--- a/docs/commands/path_exists.md
+++ b/docs/commands/path_exists.md
@@ -25,4 +25,3 @@ Check if a file exists in a column
 ```shell
 > ls | path exists -c [ name ]
 ```
-

--- a/docs/commands/path_expand.md
+++ b/docs/commands/path_expand.md
@@ -31,4 +31,3 @@ Expand a relative path
 ```shell
 > 'foo/../bar' | path expand
 ```
-

--- a/docs/commands/path_join.md
+++ b/docs/commands/path_join.md
@@ -36,4 +36,3 @@ Join a structured path into a path
 ```shell
 > [[ parent stem extension ]; [ '/home/viking' 'spam' 'txt' ]] | path join
 ```
-

--- a/docs/commands/path_parse.md
+++ b/docs/commands/path_parse.md
@@ -36,4 +36,3 @@ Parse all paths under the 'name' column
 ```shell
 > ls | path parse -c [ name ]
 ```
-

--- a/docs/commands/path_relative-to.md
+++ b/docs/commands/path_relative-to.md
@@ -31,4 +31,3 @@ Find a relative path from two relative paths
 ```shell
 > 'eggs/bacon/sausage/spam' | path relative-to 'eggs/bacon/sausage'
 ```
-

--- a/docs/commands/path_split.md
+++ b/docs/commands/path_split.md
@@ -25,4 +25,3 @@ Split all paths under the 'name' column
 ```shell
 > ls ('.' | path expand) | path split -c [ name ]
 ```
-

--- a/docs/commands/path_type.md
+++ b/docs/commands/path_type.md
@@ -25,4 +25,3 @@ Show type of a filepath in a column
 ```shell
 > ls | path type -c [ name ]
 ```
-

--- a/docs/commands/pivot.md
+++ b/docs/commands/pivot.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> pivot ```
-

--- a/docs/commands/post.md
+++ b/docs/commands/post.md
@@ -18,7 +18,7 @@ Post a body to a URL (HTTP POST operation).
  -  `--password {any}`: the password when authenticating
  -  `--content-type {any}`: the MIME type of content to post
  -  `--content-length {any}`: the length of the content being posted
- -  `--headers {any}`: custom headers you want to add
+ -  `--headers {any}`: custom headers you want to add 
  -  `--raw`: return values as a string instead of a table
  -  `--insecure`: allow insecure server connections when using SSL
 

--- a/docs/commands/post.md
+++ b/docs/commands/post.md
@@ -38,4 +38,3 @@ Post content to url.com, with custom header
 ```shell
 > post -H [my-header-key my-header-value] url.com
 ```
-

--- a/docs/commands/prepend.md
+++ b/docs/commands/prepend.md
@@ -30,4 +30,3 @@ Prepend Ints and Strings
 ```shell
 > [2,nu,4,shell] | prepend [0,1,rocks]
 ```
-

--- a/docs/commands/print.md
+++ b/docs/commands/print.md
@@ -25,4 +25,3 @@ Print the sum of 2 and 3
 ```shell
 > print (2 + 3)
 ```
-

--- a/docs/commands/ps.md
+++ b/docs/commands/ps.md
@@ -20,4 +20,3 @@ List the system processes
 ```shell
 > ps
 ```
-

--- a/docs/commands/random.md
+++ b/docs/commands/random.md
@@ -9,4 +9,3 @@ Generate a random values.
 ## Signature
 
 ```> random ```
-

--- a/docs/commands/random_bool.md
+++ b/docs/commands/random_bool.md
@@ -25,4 +25,3 @@ Generate a random boolean value with a 75% chance of "true"
 ```shell
 > random bool --bias 0.75
 ```
-

--- a/docs/commands/random_chars.md
+++ b/docs/commands/random_chars.md
@@ -25,4 +25,3 @@ Generate random chars with specified length
 ```shell
 > random chars -l 20
 ```
-

--- a/docs/commands/random_decimal.md
+++ b/docs/commands/random_decimal.md
@@ -35,4 +35,3 @@ Generate a random decimal between 1.0 and 1.1
 ```shell
 > random decimal 1.0..1.1
 ```
-

--- a/docs/commands/random_dice.md
+++ b/docs/commands/random_dice.md
@@ -26,4 +26,3 @@ Roll 10 dice with 12 sides each
 ```shell
 > random dice -d 10 -s 12
 ```
-

--- a/docs/commands/random_integer.md
+++ b/docs/commands/random_integer.md
@@ -35,4 +35,3 @@ Generate a random integer between 1 and 10
 ```shell
 > random integer 1..10
 ```
-

--- a/docs/commands/random_uuid.md
+++ b/docs/commands/random_uuid.md
@@ -16,4 +16,3 @@ Generate a random uuid4 string
 ```shell
 > random uuid
 ```
-

--- a/docs/commands/range.md
+++ b/docs/commands/range.md
@@ -30,4 +30,3 @@ Get the next to last 2 items
 ```shell
 > [0,1,2,3,4,5] | range (-3)..-2
 ```
-

--- a/docs/commands/reduce.md
+++ b/docs/commands/reduce.md
@@ -43,4 +43,3 @@ Find the longest string and its index
         }
     }
 ```
-

--- a/docs/commands/register.md
+++ b/docs/commands/register.md
@@ -17,3 +17,15 @@ Register a plugin
  -  `--encoding {string}`: Encoding used to communicate with plugin. Options: [capnp, json]
  -  `--shell {path}`: path of shell used to run plugin (cmd, sh, python, etc)
 
+## Examples
+
+Register `nu_plugin_extra_query` plugin from ~/.cargo/bin/ dir
+```shell
+> register -e capnp ~/.cargo/bin/nu_plugin_extra_query
+```
+
+Register `nu_plugin_extra_query` plugin from `nu -c`(plugin will be available in that nu session only)
+```shell
+> let plugin = ((which nu).path.0 | path dirname | path join 'nu_plugin_extra_query'); nu -c $'register -e capnp ($plugin); version'
+```
+

--- a/docs/commands/register.md
+++ b/docs/commands/register.md
@@ -28,4 +28,3 @@ Register `nu_plugin_extra_query` plugin from `nu -c`(plugin will be available in
 ```shell
 > let plugin = ((which nu).path.0 | path dirname | path join 'nu_plugin_extra_query'); nu -c $'register -e capnp ($plugin); version'
 ```
-

--- a/docs/commands/reject.md
+++ b/docs/commands/reject.md
@@ -25,4 +25,3 @@ Reject the specified field in a record
 ```shell
 > echo {a: 1, b: 2} | reject a
 ```
-

--- a/docs/commands/rename.md
+++ b/docs/commands/rename.md
@@ -31,4 +31,3 @@ Rename a specific column
 ```shell
 > [[a, b, c]; [1, 2, 3]] | rename -c [a ham]
 ```
-

--- a/docs/commands/reverse.md
+++ b/docs/commands/reverse.md
@@ -16,4 +16,3 @@ Reverse the items
 ```shell
 > [0,1,2,3] | reverse
 ```
-

--- a/docs/commands/rm.md
+++ b/docs/commands/rm.md
@@ -40,4 +40,3 @@ Delete a file, and suppress errors if no file is found
 ```shell
 > rm --force file.txt
 ```
-

--- a/docs/commands/roll.md
+++ b/docs/commands/roll.md
@@ -9,4 +9,3 @@ Rolling commands for tables
 ## Signature
 
 ```> roll ```
-

--- a/docs/commands/roll_down.md
+++ b/docs/commands/roll_down.md
@@ -20,4 +20,3 @@ Rolls rows down
 ```shell
 > [[a b]; [1 2] [3 4] [5 6]] | roll down
 ```
-

--- a/docs/commands/roll_left.md
+++ b/docs/commands/roll_left.md
@@ -26,4 +26,3 @@ Rolls columns to the left with fixed headers
 ```shell
 > [[a b c]; [1 2 3] [4 5 6]] | roll left --cells-only
 ```
-

--- a/docs/commands/roll_right.md
+++ b/docs/commands/roll_right.md
@@ -26,4 +26,3 @@ Rolls columns to the right with fixed headers
 ```shell
 > [[a b c]; [1 2 3] [4 5 6]] | roll right --cells-only
 ```
-

--- a/docs/commands/roll_up.md
+++ b/docs/commands/roll_up.md
@@ -20,4 +20,3 @@ Rolls rows up
 ```shell
 > [[a b]; [1 2] [3 4] [5 6]] | roll up
 ```
-

--- a/docs/commands/rotate.md
+++ b/docs/commands/rotate.md
@@ -46,4 +46,3 @@ Rotate table counter-clockwise and change columns names
 ```shell
 > [[a b]; [1 2]] | rotate --ccw col_a col_b
 ```
-

--- a/docs/commands/run-external.md
+++ b/docs/commands/run-external.md
@@ -14,4 +14,3 @@ Runs external command
 
  -  `...rest`: external command to run
  -  `--last-expression`: last-expression
-

--- a/docs/commands/save.md
+++ b/docs/commands/save.md
@@ -13,5 +13,17 @@ Save a file.
 ## Parameters
 
  -  `filename`: the filename to use
- -  `--raw`: open file as raw binary
+ -  `--raw`: save file as raw binary
+
+## Examples
+
+Save a string to foo.txt in current directory
+```shell
+> echo 'save me' | save foo.txt
+```
+
+Save a record to foo.json in current directory
+```shell
+> echo { a: 1, b: 2 } | save foo.json
+```
 

--- a/docs/commands/save.md
+++ b/docs/commands/save.md
@@ -26,4 +26,3 @@ Save a record to foo.json in current directory
 ```shell
 > echo { a: 1, b: 2 } | save foo.json
 ```
-

--- a/docs/commands/select.md
+++ b/docs/commands/select.md
@@ -25,4 +25,3 @@ Select the name and size columns
 ```shell
 > ls | select name size
 ```
-

--- a/docs/commands/seq.md
+++ b/docs/commands/seq.md
@@ -43,4 +43,3 @@ sequence 1 to 10 with pipe separator padded by 2s
 ```shell
 > seq -s ' | ' -w 1 2 10
 ```
-

--- a/docs/commands/seq_date.md
+++ b/docs/commands/seq_date.md
@@ -52,4 +52,3 @@ starting on May 5th, 2020, print the next 10 days in your locale's date format, 
 ```shell
 > seq date -o %x -s ':' -d 10 -b '2020-05-01'
 ```
-

--- a/docs/commands/shells.md
+++ b/docs/commands/shells.md
@@ -9,4 +9,3 @@ Lists all open shells.
 ## Signature
 
 ```> shells ```
-

--- a/docs/commands/shuffle.md
+++ b/docs/commands/shuffle.md
@@ -16,4 +16,3 @@ Shuffle rows randomly (execute it several times and see the difference)
 ```shell
 > echo [[version patch]; [1.0.0 $false] [3.0.1 $true] [2.0.0 $false]] | shuffle
 ```
-

--- a/docs/commands/shuffle.md
+++ b/docs/commands/shuffle.md
@@ -10,3 +10,10 @@ Shuffle rows randomly.
 
 ```> shuffle ```
 
+## Examples
+
+Shuffle rows randomly (execute it several times and see the difference)
+```shell
+> echo [[version patch]; [1.0.0 $false] [3.0.1 $true] [2.0.0 $false]] | shuffle
+```
+

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -21,4 +21,3 @@ Counts Unicode characters correctly in a string
 ```shell
 > "Amélie Amelie" | size
 ```
-

--- a/docs/commands/skip.md
+++ b/docs/commands/skip.md
@@ -25,4 +25,3 @@ Skip the first value
 ```shell
 > echo [2 4 6 8] | skip
 ```
-

--- a/docs/commands/skip_until.md
+++ b/docs/commands/skip_until.md
@@ -20,4 +20,3 @@ Skip until the element is positive
 ```shell
 > echo [-2 0 2 -1] | skip until $it > 0
 ```
-

--- a/docs/commands/skip_while.md
+++ b/docs/commands/skip_while.md
@@ -20,4 +20,3 @@ Skip while the element is negative
 ```shell
 > echo [-2 0 2 -1] | skip while $it < 0
 ```
-

--- a/docs/commands/sleep.md
+++ b/docs/commands/sleep.md
@@ -31,4 +31,3 @@ Send output after 1sec
 ```shell
 > sleep 1sec; echo done
 ```
-

--- a/docs/commands/sort-by.md
+++ b/docs/commands/sort-by.md
@@ -47,4 +47,3 @@ Sort strings (reversed case-insensitive)
 ```shell
 > echo [airplane Truck Car] | sort-by -i -r
 ```
-

--- a/docs/commands/source.md
+++ b/docs/commands/source.md
@@ -30,4 +30,3 @@ Runs foo.nu in current context and call the `main` command automatically, suppos
 ```shell
 > source ./foo.nu
 ```
-

--- a/docs/commands/source.md
+++ b/docs/commands/source.md
@@ -14,3 +14,20 @@ Runs a script file in the current context.
 
  -  `filename`: the filepath to the script file to source
 
+## Examples
+
+Runs foo.nu in the current context
+```shell
+> source foo.nu
+```
+
+Runs foo.nu in current context and call the command defined, suppose foo.nu has content: `def say-hi [] { echo 'Hi!' }`
+```shell
+> source ./foo.nu; say-hi
+```
+
+Runs foo.nu in current context and call the `main` command automatically, suppose foo.nu has content: `def main [] { echo 'Hi!' }`
+```shell
+> source ./foo.nu
+```
+

--- a/docs/commands/split-by.md
+++ b/docs/commands/split-by.md
@@ -18,7 +18,7 @@ Create a new table splitted.
 
 split items by column named "lang"
 ```shell
->
+> 
                 {
                     '2019': [
                       { name: 'andres', lang: 'rb', year: '2019' },
@@ -28,6 +28,6 @@ split items by column named "lang"
                       { name: 'storm', lang: 'rs', 'year': '2021' }
                     ]
                 } | split-by lang
-
+                
 ```
 

--- a/docs/commands/split-by.md
+++ b/docs/commands/split-by.md
@@ -30,4 +30,3 @@ split items by column named "lang"
                 } | split-by lang
                 
 ```
-

--- a/docs/commands/split.md
+++ b/docs/commands/split.md
@@ -9,4 +9,3 @@ Split contents across desired subcommand (like row, column) via the separator.
 ## Signature
 
 ```> split ```
-

--- a/docs/commands/split_chars.md
+++ b/docs/commands/split_chars.md
@@ -16,4 +16,3 @@ Split the string's characters into separate rows
 ```shell
 > 'hello' | split chars
 ```
-

--- a/docs/commands/split_column.md
+++ b/docs/commands/split_column.md
@@ -27,4 +27,3 @@ Split a string into columns of char and remove the empty columns
 ```shell
 > echo 'abc' | split column -c ''
 ```
-

--- a/docs/commands/split_row.md
+++ b/docs/commands/split_row.md
@@ -25,4 +25,3 @@ Split a string into rows by the specified separator
 ```shell
 > echo 'a--b--c' | split row '--'
 ```
-

--- a/docs/commands/str.md
+++ b/docs/commands/str.md
@@ -9,4 +9,3 @@ Various commands for working with string data.
 ## Signature
 
 ```> str ```
-

--- a/docs/commands/str_camel-case.md
+++ b/docs/commands/str_camel-case.md
@@ -35,4 +35,3 @@ convert a column from a table to camelCase
 ```shell
 > [[lang, gems]; [nu_test, 100]] | str camel-case lang
 ```
-

--- a/docs/commands/str_capitalize.md
+++ b/docs/commands/str_capitalize.md
@@ -30,4 +30,3 @@ Capitalize a column in a table
 ```shell
 > [[lang, gems]; [nu_test, 100]] | str capitalize lang
 ```
-

--- a/docs/commands/str_collect.md
+++ b/docs/commands/str_collect.md
@@ -25,4 +25,3 @@ Create a string from input with a separator
 ```shell
 > ['nu', 'shell'] | str collect '-'
 ```
-

--- a/docs/commands/str_contains.md
+++ b/docs/commands/str_contains.md
@@ -47,4 +47,3 @@ Check if string contains pattern
 ```shell
 > 'hello' | str contains 'banana'
 ```
-

--- a/docs/commands/str_downcase.md
+++ b/docs/commands/str_downcase.md
@@ -35,4 +35,3 @@ Downcase contents
 ```shell
 > [[ColA ColB]; [Test ABC]] | str downcase ColA ColB
 ```
-

--- a/docs/commands/str_ends-with.md
+++ b/docs/commands/str_ends-with.md
@@ -26,4 +26,3 @@ Checks if string ends with '.txt' pattern
 ```shell
 > 'my_library.rb' | str ends-with '.txt'
 ```
-

--- a/docs/commands/str_find-replace.md
+++ b/docs/commands/str_find-replace.md
@@ -33,4 +33,3 @@ Find and replace all occurrences of find string in table
 ```shell
 > [[ColA ColB ColC]; [abc abc ads]] | str find-replace -a 'b' 'z' ColA ColC
 ```
-

--- a/docs/commands/str_index-of.md
+++ b/docs/commands/str_index-of.md
@@ -48,4 +48,3 @@ Returns index of pattern in string
 ```shell
 >  '/this/is/some/path/file.txt' | str index-of '/' -e
 ```
-

--- a/docs/commands/str_kebab-case.md
+++ b/docs/commands/str_kebab-case.md
@@ -35,4 +35,3 @@ convert a column from a table to kebab-case
 ```shell
 > [[lang, gems]; [nuTest, 100]] | str kebab-case lang
 ```
-

--- a/docs/commands/str_length.md
+++ b/docs/commands/str_length.md
@@ -25,4 +25,3 @@ Return the lengths of multiple strings
 ```shell
 > ['hi' 'there'] | str length
 ```
-

--- a/docs/commands/str_lpad.md
+++ b/docs/commands/str_lpad.md
@@ -37,4 +37,3 @@ Use lpad to pad Unicode
 ```shell
 > '▉' | str lpad -l 10 -c '▉'
 ```
-

--- a/docs/commands/str_pascal-case.md
+++ b/docs/commands/str_pascal-case.md
@@ -35,4 +35,3 @@ convert a column from a table to PascalCase
 ```shell
 > [[lang, gems]; [nu_test, 100]] | str pascal-case lang
 ```
-

--- a/docs/commands/str_reverse.md
+++ b/docs/commands/str_reverse.md
@@ -20,4 +20,3 @@ Return the reversals of multiple strings
 ```shell
 > 'Nushell' | str reverse
 ```
-

--- a/docs/commands/str_rpad.md
+++ b/docs/commands/str_rpad.md
@@ -37,4 +37,3 @@ Use rpad to pad Unicode
 ```shell
 > '▉' | str rpad -l 10 -c '▉'
 ```
-

--- a/docs/commands/str_screaming-snake-case.md
+++ b/docs/commands/str_screaming-snake-case.md
@@ -35,4 +35,3 @@ convert a column from a table to SCREAMING_SNAKE_CASE
 ```shell
 > [[lang, gems]; [nu_test, 100]] | str screaming-snake-case lang
 ```
-

--- a/docs/commands/str_snake-case.md
+++ b/docs/commands/str_snake-case.md
@@ -35,4 +35,3 @@ convert a column from a table to snake-case
 ```shell
 > [[lang, gems]; [nuTest, 100]] | str snake-case lang
 ```
-

--- a/docs/commands/str_starts-with.md
+++ b/docs/commands/str_starts-with.md
@@ -31,4 +31,3 @@ Checks if string starts with 'my' pattern
 ```shell
 > 'Cargo.toml' | str starts-with '.toml'
 ```
-

--- a/docs/commands/str_substring.md
+++ b/docs/commands/str_substring.md
@@ -41,4 +41,3 @@ Get the characters from the beginning until ending index
 ```shell
 >  'good nushell' | str substring ',7'
 ```
-

--- a/docs/commands/str_to-datetime.md
+++ b/docs/commands/str_to-datetime.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> str to-datetime ```
-

--- a/docs/commands/str_to-decimal.md
+++ b/docs/commands/str_to-decimal.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> str to-decimal ```
-

--- a/docs/commands/str_to-int.md
+++ b/docs/commands/str_to-int.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> str to-int ```
-

--- a/docs/commands/str_trim.md
+++ b/docs/commands/str_trim.md
@@ -56,4 +56,3 @@ Trim a specific character
 ```shell
 > '=== Nu shell ===' | str trim -r -c '='
 ```
-

--- a/docs/commands/str_upcase.md
+++ b/docs/commands/str_upcase.md
@@ -20,4 +20,3 @@ Upcase contents
 ```shell
 > 'nu' | str upcase
 ```
-

--- a/docs/commands/sys.md
+++ b/docs/commands/sys.md
@@ -26,4 +26,3 @@ Show the os system name
 ```shell
 > (sys).host.name
 ```
-

--- a/docs/commands/table.md
+++ b/docs/commands/table.md
@@ -25,4 +25,3 @@ Render data in table view
 ```shell
 > echo [[a b]; [1 2] [3 4]] | table
 ```
-

--- a/docs/commands/table.md
+++ b/docs/commands/table.md
@@ -14,3 +14,15 @@ Render the table.
 
  -  `--start-number {int}`: row number to start viewing from
 
+## Examples
+
+List the files in current directory with index number start from 1.
+```shell
+> ls | table -n 1
+```
+
+Render data in table view
+```shell
+> echo [[a b]; [1 2] [3 4]] | table
+```
+

--- a/docs/commands/term_size.md
+++ b/docs/commands/term_size.md
@@ -31,4 +31,3 @@ Return the height (rows) of the terminal
 ```shell
 > term size -r
 ```
-

--- a/docs/commands/to.md
+++ b/docs/commands/to.md
@@ -9,4 +9,3 @@ Translate structured data to a format
 ## Signature
 
 ```> to ```
-

--- a/docs/commands/to_csv.md
+++ b/docs/commands/to_csv.md
@@ -4,7 +4,7 @@ layout: command
 version: 0.59.0
 ---
 
-Convert table into .csv text
+Convert table into .csv text 
 
 ## Signature
 
@@ -24,6 +24,6 @@ Outputs an CSV string representing the contents of this table
 
 Outputs an CSV string representing the contents of this table
 ```shell
-> [[foo bar]; [1 2]] | to csv -s ';'
+> [[foo bar]; [1 2]] | to csv -s ';' 
 ```
 

--- a/docs/commands/to_csv.md
+++ b/docs/commands/to_csv.md
@@ -26,4 +26,3 @@ Outputs an CSV string representing the contents of this table
 ```shell
 > [[foo bar]; [1 2]] | to csv -s ';' 
 ```
-

--- a/docs/commands/to_html.md
+++ b/docs/commands/to_html.md
@@ -35,4 +35,3 @@ Optionally, output the string with a dark background
 ```shell
 > [[foo bar]; [1 2]] | to html --dark
 ```
-

--- a/docs/commands/to_json.md
+++ b/docs/commands/to_json.md
@@ -31,4 +31,3 @@ Outputs an unformatted JSON string representing the contents of this table
 ```shell
 > [1 2 3] | to json -r
 ```
-

--- a/docs/commands/to_json.md
+++ b/docs/commands/to_json.md
@@ -8,16 +8,27 @@ Converts table data into JSON text.
 
 ## Signature
 
-```> to json --raw```
+```> to json --raw --indent```
 
 ## Parameters
 
  -  `--raw`: remove all of the whitespace
+ -  `--indent {number}`: specify indentation width
 
 ## Examples
 
+Outputs a JSON string, with default indentation, representing the contents of this table
+```shell
+> [a b c] | to json
+```
+
+Outputs a JSON string, with 4-space indentation, representing the contents of this table
+```shell
+> [Joe Bob Sam] | to json -i 4
+```
+
 Outputs an unformatted JSON string representing the contents of this table
 ```shell
-> [1 2 3] | to json
+> [1 2 3] | to json -r
 ```
 

--- a/docs/commands/to_md.md
+++ b/docs/commands/to_md.md
@@ -31,4 +31,3 @@ Treat each row as a markdown element
 ```shell
 > [{"H1": "Welcome to Nushell" } [[foo bar]; [1 2]]] | to md --per-element --pretty
 ```
-

--- a/docs/commands/to_nuon.md
+++ b/docs/commands/to_nuon.md
@@ -16,4 +16,3 @@ Outputs a nuon string representing the contents of this table
 ```shell
 > [1 2 3] | to nuon
 ```
-

--- a/docs/commands/to_nuon.md
+++ b/docs/commands/to_nuon.md
@@ -1,0 +1,19 @@
+---
+title: to nuon
+layout: command
+version: 0.59.0
+---
+
+Converts table data into Nuon (Nushell Object Notation) text.
+
+## Signature
+
+```> to nuon ```
+
+## Examples
+
+Outputs a nuon string representing the contents of this table
+```shell
+> [1 2 3] | to nuon
+```
+

--- a/docs/commands/to_toml.md
+++ b/docs/commands/to_toml.md
@@ -16,4 +16,3 @@ Outputs an TOML string representing the contents of this table
 ```shell
 > [[foo bar]; ["1" "2"]] | to toml
 ```
-

--- a/docs/commands/to_tsv.md
+++ b/docs/commands/to_tsv.md
@@ -20,4 +20,3 @@ Outputs an TSV string representing the contents of this table
 ```shell
 > [[foo bar]; [1 2]] | to tsv
 ```
-

--- a/docs/commands/to_url.md
+++ b/docs/commands/to_url.md
@@ -16,4 +16,3 @@ Outputs an URL string representing the contents of this table
 ```shell
 > [[foo bar]; ["1" "2"]] | to url
 ```
-

--- a/docs/commands/to_xml.md
+++ b/docs/commands/to_xml.md
@@ -25,4 +25,3 @@ Optionally, formats the text with a custom indentation setting
 ```shell
 > { "note": { "children": [{ "remember": {"attributes" : {}, "children": [Event]}}], "attributes": {} } } | to xml -p 3
 ```
-

--- a/docs/commands/to_yaml.md
+++ b/docs/commands/to_yaml.md
@@ -16,4 +16,3 @@ Outputs an YAML string representing the contents of this table
 ```shell
 > [[foo bar]; ["1" "2"]] | to yaml
 ```
-

--- a/docs/commands/touch.md
+++ b/docs/commands/touch.md
@@ -26,4 +26,3 @@ Creates files a, b and c
 ```shell
 > touch a b c
 ```
-

--- a/docs/commands/transpose.md
+++ b/docs/commands/transpose.md
@@ -32,4 +32,3 @@ Transposes the table without column names and specify a new column name
 ```shell
 > echo [[c1 c2]; [1 2]] | transpose -i val
 ```
-

--- a/docs/commands/tutor.md
+++ b/docs/commands/tutor.md
@@ -26,4 +26,3 @@ Search a tutorial by phrase
 ```shell
 > tutor -f "$in"
 ```
-

--- a/docs/commands/unalias.md
+++ b/docs/commands/unalias.md
@@ -9,4 +9,3 @@ Deprecated command
 ## Signature
 
 ```> unalias ```
-

--- a/docs/commands/uniq.md
+++ b/docs/commands/uniq.md
@@ -43,4 +43,3 @@ Remove duplicate rows and show counts of a list/table
 ```shell
 > [1 2 2] | uniq -c
 ```
-

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -31,4 +31,3 @@ Use in block form for more involved updating logic
 ```shell
 > echo [[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors { get authors | str collect ',' }
 ```
-

--- a/docs/commands/update_cells.md
+++ b/docs/commands/update_cells.md
@@ -44,4 +44,3 @@ Update the zero value cells to empty strings in 2 last columns.
         }
 }
 ```
-

--- a/docs/commands/url.md
+++ b/docs/commands/url.md
@@ -9,4 +9,3 @@ Apply url function.
 ## Signature
 
 ```> url ```
-

--- a/docs/commands/url_host.md
+++ b/docs/commands/url_host.md
@@ -20,4 +20,3 @@ Get host of a url
 ```shell
 > echo 'http://www.example.com/foo/bar' | url host
 ```
-

--- a/docs/commands/url_path.md
+++ b/docs/commands/url_path.md
@@ -25,4 +25,3 @@ A trailing slash will be reflected in the path
 ```shell
 > echo 'http://www.example.com' | url path
 ```
-

--- a/docs/commands/url_query.md
+++ b/docs/commands/url_query.md
@@ -25,4 +25,3 @@ No query gives the empty string
 ```shell
 > echo 'http://www.example.com/' | url query
 ```
-

--- a/docs/commands/url_scheme.md
+++ b/docs/commands/url_scheme.md
@@ -25,4 +25,3 @@ You get an empty string if there is no scheme
 ```shell
 > echo 'test' | url scheme
 ```
-

--- a/docs/commands/use.md
+++ b/docs/commands/use.md
@@ -30,4 +30,3 @@ Define a custom command that participates in the environment in a module and cal
 ```shell
 > module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR
 ```
-

--- a/docs/commands/use.md
+++ b/docs/commands/use.md
@@ -14,3 +14,20 @@ Use definitions from a module
 
  -  `pattern`: import pattern
 
+## Examples
+
+Define a custom command in a module and call it
+```shell
+> module spam { export def foo [] { "foo" } }; use spam foo; foo
+```
+
+Define an environment variable in a module and evaluate it
+```shell
+> module foo { export env FOO_ENV { "BAZ" } }; use foo FOO_ENV; $env.FOO_ENV
+```
+
+Define a custom command that participates in the environment in a module and call it
+```shell
+> module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR
+```
+

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -16,4 +16,3 @@ Display Nu version
 ```shell
 > version
 ```
-

--- a/docs/commands/view-source.md
+++ b/docs/commands/view-source.md
@@ -13,4 +13,3 @@ View a block, module, or a definition
 ## Parameters
 
  -  `item`: name or block to view
-

--- a/docs/commands/where.md
+++ b/docs/commands/where.md
@@ -35,4 +35,3 @@ List all files that were modified in the last two weeks
 ```shell
 > ls | where modified <= 2wk
 ```
-

--- a/docs/commands/which.md
+++ b/docs/commands/which.md
@@ -22,4 +22,3 @@ Find if the 'myapp' application is available
 ```shell
 > which myapp
 ```
-

--- a/docs/commands/with-env.md
+++ b/docs/commands/with-env.md
@@ -36,4 +36,3 @@ Set by row(e.g. `open x.json` or `from json`)
 ```shell
 > echo '{"X":"Y","W":"Z"}'|from json|with-env $in { echo $env.X $env.W }
 ```
-

--- a/docs/commands/wrap.md
+++ b/docs/commands/wrap.md
@@ -20,4 +20,3 @@ Wrap a list into a table with a given column name
 ```shell
 > echo [1 2 3] | wrap num
 ```
-

--- a/docs/commands/zip.md
+++ b/docs/commands/zip.md
@@ -20,4 +20,3 @@ Zip multiple streams and get one of the results
 ```shell
 > 1..3 | zip 4..6
 ```
-

--- a/docs/make_docs.nu
+++ b/docs/make_docs.nu
@@ -1,6 +1,6 @@
 let vers = (version).version
 
-for command in ($scope.commands | where is_custom == $false && is_external == $false) {
+for command in ($scope.commands | where is_custom == $false && is_extern == $false) {
     let top = $"---
 title: ($command.command)
 layout: command

--- a/docs/make_docs.nu
+++ b/docs/make_docs.nu
@@ -57,7 +57,9 @@ $"($example.description)
         $example_top + $examples
     } else { "" }
 
-    let doc = ($top + $signature + $parameters + $examples)
+    let doc = (($top + $signature + $parameters + $examples) |
+        each {|it| ($it | str trim -r)} |
+        str collect (char nl)) + (char nl)
 
     let safe_name = ($command.command | str find-replace '\?' '' | str find-replace ' ' '_')
     $doc | save --raw $"./docs/commands/($safe_name).md"


### PR DESCRIPTION
# Description

Regenerate commands' docs and update make_docs.nu script: 
1. Fix command filter; 
2. Trim whitespaces at line end; 
3. Keep one blank line only for each doc file

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
