### PR TITLE
Fix shorthand env duplicates

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3551,14 +3551,16 @@ pub fn parse_expression(
                 },
             ];
 
+            let expr = Expr::Call(Box::new(Call {
+                head: Span { start: 0, end: 0 },
+                decl_id,
+                named: vec![],
+                positional,
+            }));
+
             (
                 Expression {
-                    expr: Expr::Call(Box::new(Call {
-                        head: span(spans),
-                        decl_id,
-                        named: vec![],
-                        positional,
-                    })),
+                    expr,
                     custom_completion: None,
                     span: span(spans),
                     ty: Type::Unknown,


### PR DESCRIPTION
# Description

Fixes the dupes in the highlighting when shorthand env was used.

fixes #4355 #4384 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
