### PR TITLE
this little hack allows the color to be whatever the default is

### DIFF
--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -112,7 +112,7 @@ extern "git push" [
 let default_theme = {
     # color for nushell primitives
     separator: white
-    leading_trailing_space_bg: white
+    leading_trailing_space_bg: { attr: b }
     header: green_bold
     empty: blue
     bool: white


### PR DESCRIPTION
# Description

change `leading_trailing_space_bg` to `{ attr: b }` which is really telling it to use the default foreground and background color and make it bold.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
