### PR TITLE
Set visibility to true only when calling `use`

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -328,6 +328,7 @@ pub fn parse_def(
     let block = call.positional.get(2).expect("def call already checked");
 
     let mut error = None;
+
     if let (Some(name), Some(mut signature), Some(block_id)) =
         (&name_expr.as_string(), sig.as_signature(), block.as_block())
     {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -743,7 +743,6 @@ impl<'a> StateWorkingSet<'a> {
             .expect("internal error: missing required scope frame");
 
         scope_frame.decls.insert(name, decl_id);
-        scope_frame.visibility.use_decl_id(&decl_id);
 
         decl_id
     }
@@ -790,7 +789,6 @@ impl<'a> StateWorkingSet<'a> {
 
         if let Some(decl_id) = scope_frame.predecls.remove(name) {
             scope_frame.decls.insert(name.into(), decl_id);
-            scope_frame.visibility.use_decl_id(&decl_id);
 
             return Some(decl_id);
         }


### PR DESCRIPTION
# Description

When defining a new command with `def`, it will no longer set visibility to true. Since no visibility value is treated as true by default, it does not change anything but makes the Visibility data structure noticeably smaller.

Fixes: nothing

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
