### PR TITLE
Look up predecl only in the working set

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -331,7 +331,7 @@ pub fn parse_def(
     if let (Some(name), Some(mut signature), Some(block_id)) =
         (&name_expr.as_string(), sig.as_signature(), block.as_block())
     {
-        if let Some(decl_id) = working_set.find_decl(name.as_bytes()) {
+        if let Some(decl_id) = working_set.find_predecl(name.as_bytes()) {
             let declaration = working_set.get_decl_mut(decl_id);
 
             signature.name = name.clone();
@@ -430,7 +430,7 @@ pub fn parse_extern(
 
     if let (Some(name_expr), Some(sig)) = (name_expr, sig) {
         if let (Some(name), Some(mut signature)) = (&name_expr.as_string(), sig.as_signature()) {
-            if let Some(decl_id) = working_set.find_decl(name.as_bytes()) {
+            if let Some(decl_id) = working_set.find_predecl(name.as_bytes()) {
                 let declaration = working_set.get_decl_mut(decl_id);
 
                 signature.name = name.clone();

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -999,6 +999,16 @@ impl<'a> StateWorkingSet<'a> {
         self.delta.exit_scope();
     }
 
+    pub fn find_predecl(&self, name: &[u8]) -> Option<DeclId> {
+        for scope in self.delta.scope.iter().rev() {
+            if let Some(decl_id) = scope.predecls.get(name) {
+                return Some(*decl_id);
+            }
+        }
+
+        None
+    }
+
     pub fn find_decl(&self, name: &[u8]) -> Option<DeclId> {
         let mut visibility: Visibility = Visibility::new();
 


### PR DESCRIPTION
# Description

Previously, the parser tried to look up the predecl also in the
permanent state and if a definition with that name already existed, it
would try to update it, which is illegal.

Fixes https://github.com/nushell/nushell/issues/4287

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
