### PR TITLE
Add pipeline redirection support

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -278,6 +278,8 @@ impl NuCompleter {
                                     &mut stack,
                                     &block,
                                     PipelineData::new(new_span),
+                                    true,
+                                    true,
                                 );
 
                                 let v: Vec<_> = match result {

--- a/crates/nu-command/src/core_commands/do_.rs
+++ b/crates/nu-command/src/core_commands/do_.rs
@@ -84,7 +84,14 @@ impl Command for Do {
                 )
             }
         }
-        let result = eval_block(engine_state, &mut stack, block, input);
+        let result = eval_block(
+            engine_state,
+            &mut stack,
+            block,
+            input,
+            call.redirect_stdout,
+            ignore_errors,
+        );
 
         if ignore_errors {
             match result {

--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -51,7 +51,14 @@ impl Command for If {
                 if *val {
                     let block = engine_state.get_block(then_block.block_id);
                     let mut stack = stack.captures_to_stack(&then_block.captures);
-                    eval_block(engine_state, &mut stack, block, input)
+                    eval_block(
+                        engine_state,
+                        &mut stack,
+                        block,
+                        input,
+                        call.redirect_stdout,
+                        call.redirect_stderr,
+                    )
                 } else if let Some(else_case) = else_case {
                     if let Some(else_expr) = else_case.as_keyword() {
                         if let Some(block_id) = else_expr.as_block() {
@@ -60,7 +67,14 @@ impl Command for If {
 
                             let mut stack = stack.captures_to_stack(&else_block.captures);
                             let block = engine_state.get_block(block_id);
-                            eval_block(engine_state, &mut stack, block, input)
+                            eval_block(
+                                engine_state,
+                                &mut stack,
+                                block,
+                                input,
+                                call.redirect_stdout,
+                                call.redirect_stderr,
+                            )
                         } else {
                             eval_expression(engine_state, stack, else_expr)
                                 .map(|x| x.into_pipeline_data())

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -41,7 +41,14 @@ impl Command for Let {
             .as_keyword()
             .expect("internal error: missing keyword");
 
-        let rhs = eval_expression_with_input(engine_state, stack, keyword_expr, input, false)?;
+        let rhs = eval_expression_with_input(
+            engine_state,
+            stack,
+            keyword_expr,
+            input,
+            call.redirect_stdout,
+            call.redirect_stderr,
+        )?;
 
         //println!("Adding: {:?} to {}", rhs, var_id);
 

--- a/crates/nu-command/src/core_commands/source.rs
+++ b/crates/nu-command/src/core_commands/source.rs
@@ -38,7 +38,14 @@ impl Command for Source {
         let block_id: i64 = call.req(engine_state, stack, 1)?;
 
         let block = engine_state.get_block(block_id as usize).clone();
-        eval_block(engine_state, stack, &block, input)
+        eval_block(
+            engine_state,
+            stack,
+            &block,
+            input,
+            call.redirect_stdout,
+            call.redirect_stderr,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -96,8 +96,15 @@ impl Command for Use {
 
                 // TODO: Add string conversions (e.g. int to string)
                 // TODO: Later expand env to take all Values
-                let val = eval_block(engine_state, stack, block, PipelineData::new(call.head))?
-                    .into_value(call.head);
+                let val = eval_block(
+                    engine_state,
+                    stack,
+                    block,
+                    PipelineData::new(call.head),
+                    false,
+                    true,
+                )?
+                .into_value(call.head);
 
                 stack.add_env_var(name, val);
             }

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -72,6 +72,8 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
             &mut stack,
             &block,
             PipelineData::new(Span::test_data()),
+            true,
+            true,
         ) {
             Err(err) => panic!("test eval error in `{}`: {:?}", example.example, err),
             Ok(result) => {

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -39,8 +39,9 @@ impl Command for LetEnv {
             .as_keyword()
             .expect("internal error: missing keyword");
 
-        let rhs = eval_expression_with_input(engine_state, stack, keyword_expr, input, false)?
-            .into_value(call.head);
+        let rhs =
+            eval_expression_with_input(engine_state, stack, keyword_expr, input, false, true)?
+                .into_value(call.head);
 
         if env_var == "PWD" {
             let cwd = current_dir(engine_state, stack)?;

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -132,7 +132,14 @@ fn with_env(
         stack.add_env_var(k, v);
     }
 
-    eval_block(engine_state, &mut stack, block, input)
+    eval_block(
+        engine_state,
+        &mut stack,
+        block,
+        input,
+        call.redirect_stdout,
+        call.redirect_stderr,
+    )
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -121,6 +121,8 @@ pub fn test_examples(cmd: impl Command + 'static) {
             &mut stack,
             &block,
             PipelineData::new(Span::test_data()),
+            true,
+            true,
         ) {
             Err(err) => panic!("test eval error in `{}`: {:?}", example.example, err),
             Ok(result) => {

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -68,10 +68,17 @@ impl Command for All {
                     stack.add_var(var_id, value);
                 }
 
-                eval_block(&engine_state, &mut stack, block, PipelineData::new(span))
-                    .map_or(false, |pipeline_data| {
-                        pipeline_data.into_value(span).is_true()
-                    })
+                eval_block(
+                    &engine_state,
+                    &mut stack,
+                    block,
+                    PipelineData::new(span),
+                    call.redirect_stdout,
+                    call.redirect_stderr,
+                )
+                .map_or(false, |pipeline_data| {
+                    pipeline_data.into_value(span).is_true()
+                })
             }),
             span,
         }

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -67,10 +67,17 @@ impl Command for Any {
                     stack.add_var(var_id, value);
                 }
 
-                eval_block(&engine_state, &mut stack, block, PipelineData::new(span))
-                    .map_or(false, |pipeline_data| {
-                        pipeline_data.into_value(span).is_true()
-                    })
+                eval_block(
+                    &engine_state,
+                    &mut stack,
+                    block,
+                    PipelineData::new(span),
+                    call.redirect_stdout,
+                    call.redirect_stderr,
+                )
+                .map_or(false, |pipeline_data| {
+                    pipeline_data.into_value(span).is_true()
+                })
             }),
             span,
         }

--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -50,6 +50,8 @@ impl Command for Collect {
             &mut stack,
             &block,
             PipelineData::new(call.head),
+            call.redirect_stdout,
+            call.redirect_stderr,
         )
     }
 

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -118,7 +118,14 @@ fn empty(
             .ok_or_else(|| ShellError::TypeMismatch("expected row condition".to_owned(), head))?;
 
         let b = engine_state.get_block(block_id);
-        let evaluated_block = eval_block(engine_state, stack, b, PipelineData::new(head))?;
+        let evaluated_block = eval_block(
+            engine_state,
+            stack,
+            b,
+            PipelineData::new(head),
+            call.redirect_stdout,
+            call.redirect_stderr,
+        )?;
         Some(evaluated_block.into_value(head))
     } else {
         None

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -93,6 +93,9 @@ impl Command for Find {
         let metadata = input.metadata();
         let config = stack.get_config()?;
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         match call.get_flag::<CaptureBlock>(&engine_state, stack, "predicate")? {
             Some(predicate) => {
                 let capture_block = predicate;
@@ -121,6 +124,8 @@ impl Command for Find {
                             &mut stack,
                             &block,
                             PipelineData::new_with_metadata(metadata.clone(), span),
+                            redirect_stdout,
+                            redirect_stderr,
                         )
                         .map_or(false, |pipeline_data| {
                             pipeline_data.into_value(span).is_true()

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -119,8 +119,14 @@ pub fn group_by(
                 if let Some(capture_block) = &block {
                     let mut stack = stack.captures_to_stack(&capture_block.captures);
                     let block = engine_state.get_block(capture_block.block_id);
-                    let pipeline =
-                        eval_block(engine_state, &mut stack, block, value.into_pipeline_data());
+                    let pipeline = eval_block(
+                        engine_state,
+                        &mut stack,
+                        block,
+                        value.into_pipeline_data(),
+                        call.redirect_stdout,
+                        call.redirect_stderr,
+                    );
 
                     match pipeline {
                         Ok(s) => {

--- a/crates/nu-command/src/filters/keep/keep_until.rs
+++ b/crates/nu-command/src/filters/keep/keep_until.rs
@@ -58,6 +58,9 @@ impl Command for KeepUntil {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         Ok(input
             .into_iter()
             .take_while(move |value| {
@@ -65,10 +68,17 @@ impl Command for KeepUntil {
                     stack.add_var(var_id, value.clone());
                 }
 
-                !eval_block(&engine_state, &mut stack, &block, PipelineData::new(span))
-                    .map_or(false, |pipeline_data| {
-                        pipeline_data.into_value(span).is_true()
-                    })
+                !eval_block(
+                    &engine_state,
+                    &mut stack,
+                    &block,
+                    PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
+                )
+                .map_or(false, |pipeline_data| {
+                    pipeline_data.into_value(span).is_true()
+                })
             })
             .into_pipeline_data(ctrlc))
     }

--- a/crates/nu-command/src/filters/keep/keep_while.rs
+++ b/crates/nu-command/src/filters/keep/keep_while.rs
@@ -58,6 +58,9 @@ impl Command for KeepWhile {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         Ok(input
             .into_iter()
             .take_while(move |value| {
@@ -65,10 +68,17 @@ impl Command for KeepWhile {
                     stack.add_var(var_id, value.clone());
                 }
 
-                eval_block(&engine_state, &mut stack, &block, PipelineData::new(span))
-                    .map_or(false, |pipeline_data| {
-                        pipeline_data.into_value(span).is_true()
-                    })
+                eval_block(
+                    &engine_state,
+                    &mut stack,
+                    &block,
+                    PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
+                )
+                .map_or(false, |pipeline_data| {
+                    pipeline_data.into_value(span).is_true()
+                })
             })
             .into_pipeline_data(ctrlc))
     }

--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -82,6 +82,8 @@ impl Command for Merge {
             &mut stack,
             block,
             PipelineData::new(call.head),
+            call.redirect_stdout,
+            call.redirect_stderr,
         );
 
         let table = match result {

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -252,59 +252,6 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            // PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
-            //     let mut output_cols = vec![];
-            //     let mut output_vals = vec![];
-
-            //     for (col, val) in cols.into_iter().zip(vals.into_iter()) {
-            //         let block = engine_state.get_block(block_id);
-
-            //         let mut stack = stack.clone();
-
-            //         if let Some(var) = block.signature.get_positional(0) {
-            //             if let Some(var_id) = &var.var_id {
-            //                 stack.add_var(
-            //                     *var_id,
-            //                     Value::Record {
-            //                         cols: vec!["column".into(), "value".into()],
-            //                         vals: vec![
-            //                             Value::String {
-            //                                 val: col.clone(),
-            //                                 span: call.head,
-            //                             },
-            //                             val,
-            //                         ],
-            //                         span: call.head,
-            //                     },
-            //                 );
-            //             }
-            //         }
-
-            //         match eval_block(&engine_state, &mut stack, block, PipelineData::new(span))? {
-            //             PipelineData::Value(
-            //                 Value::Record {
-            //                     mut cols, mut vals, ..
-            //                 },
-            //                 ..,
-            //             ) => {
-            //                 // TODO check that the lengths match when traversing record
-            //                 output_cols.append(&mut cols);
-            //                 output_vals.append(&mut vals);
-            //             }
-            //             x => {
-            //                 output_cols.push(col);
-            //                 output_vals.push(x.into_value(span));
-            //             }
-            //         }
-            //     }
-
-            //     Ok(Value::Record {
-            //         cols: output_cols,
-            //         vals: output_vals,
-            //         span: call.head,
-            //     }
-            //     .into_pipeline_data())
-            // }
             PipelineData::Value(x, ..) => {
                 let block = engine_state.get_block(block_id);
 

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block_with_redirect, CallExt};
+use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
@@ -53,6 +53,8 @@ impl Command for ParEach {
         let block_id = capture_block.block_id;
         let mut stack = stack.captures_to_stack(&capture_block.captures);
         let span = call.head;
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
 
         match input {
             PipelineData::Value(Value::Range { val, .. }, ..) => Ok(val
@@ -87,11 +89,13 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block_with_redirect(
+                    match eval_block(
                         &engine_state,
                         &mut stack,
                         block,
                         PipelineData::new(span),
+                        redirect_stdout,
+                        redirect_stderr,
                     ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
@@ -133,11 +137,13 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block_with_redirect(
+                    match eval_block(
                         &engine_state,
                         &mut stack,
                         block,
                         PipelineData::new(span),
+                        redirect_stdout,
+                        redirect_stderr,
                     ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
@@ -178,11 +184,13 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block_with_redirect(
+                    match eval_block(
                         &engine_state,
                         &mut stack,
                         block,
                         PipelineData::new(span),
+                        redirect_stdout,
+                        redirect_stderr,
                     ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
@@ -228,11 +236,13 @@ impl Command for ParEach {
                         }
                     }
 
-                    match eval_block_with_redirect(
+                    match eval_block(
                         &engine_state,
                         &mut stack,
                         block,
                         PipelineData::new(span),
+                        redirect_stdout,
+                        redirect_stderr,
                     ) {
                         Ok(v) => v,
                         Err(error) => Value::Error { error }.into_pipeline_data(),
@@ -242,64 +252,59 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
-                let mut output_cols = vec![];
-                let mut output_vals = vec![];
+            // PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
+            //     let mut output_cols = vec![];
+            //     let mut output_vals = vec![];
 
-                for (col, val) in cols.into_iter().zip(vals.into_iter()) {
-                    let block = engine_state.get_block(block_id);
+            //     for (col, val) in cols.into_iter().zip(vals.into_iter()) {
+            //         let block = engine_state.get_block(block_id);
 
-                    let mut stack = stack.clone();
+            //         let mut stack = stack.clone();
 
-                    if let Some(var) = block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(
-                                *var_id,
-                                Value::Record {
-                                    cols: vec!["column".into(), "value".into()],
-                                    vals: vec![
-                                        Value::String {
-                                            val: col.clone(),
-                                            span: call.head,
-                                        },
-                                        val,
-                                    ],
-                                    span: call.head,
-                                },
-                            );
-                        }
-                    }
+            //         if let Some(var) = block.signature.get_positional(0) {
+            //             if let Some(var_id) = &var.var_id {
+            //                 stack.add_var(
+            //                     *var_id,
+            //                     Value::Record {
+            //                         cols: vec!["column".into(), "value".into()],
+            //                         vals: vec![
+            //                             Value::String {
+            //                                 val: col.clone(),
+            //                                 span: call.head,
+            //                             },
+            //                             val,
+            //                         ],
+            //                         span: call.head,
+            //                     },
+            //                 );
+            //             }
+            //         }
 
-                    match eval_block_with_redirect(
-                        &engine_state,
-                        &mut stack,
-                        block,
-                        PipelineData::new(span),
-                    )? {
-                        PipelineData::Value(
-                            Value::Record {
-                                mut cols, mut vals, ..
-                            },
-                            ..,
-                        ) => {
-                            // TODO check that the lengths match when traversing record
-                            output_cols.append(&mut cols);
-                            output_vals.append(&mut vals);
-                        }
-                        x => {
-                            output_cols.push(col);
-                            output_vals.push(x.into_value(span));
-                        }
-                    }
-                }
+            //         match eval_block(&engine_state, &mut stack, block, PipelineData::new(span))? {
+            //             PipelineData::Value(
+            //                 Value::Record {
+            //                     mut cols, mut vals, ..
+            //                 },
+            //                 ..,
+            //             ) => {
+            //                 // TODO check that the lengths match when traversing record
+            //                 output_cols.append(&mut cols);
+            //                 output_vals.append(&mut vals);
+            //             }
+            //             x => {
+            //                 output_cols.push(col);
+            //                 output_vals.push(x.into_value(span));
+            //             }
+            //         }
+            //     }
 
-                Ok(Value::Record {
-                    cols: output_cols,
-                    vals: output_vals,
-                    span: call.head,
-                }
-                .into_pipeline_data())
-            }
+            //     Ok(Value::Record {
+            //         cols: output_cols,
+            //         vals: output_vals,
+            //         span: call.head,
+            //     }
+            //     .into_pipeline_data())
+            // }
             PipelineData::Value(x, ..) => {
                 let block = engine_state.get_block(block_id);
 
@@ -309,7 +314,14 @@ impl Command for ParEach {
                     }
                 }
 
-                eval_block_with_redirect(&engine_state, &mut stack, block, PipelineData::new(span))
+                eval_block(
+                    &engine_state,
+                    &mut stack,
+                    block,
+                    PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
+                )
             }
         }
     }

--- a/crates/nu-command/src/filters/par_each_group.rs
+++ b/crates/nu-command/src/filters/par_each_group.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block_with_redirect, CallExt};
+use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
@@ -49,6 +49,8 @@ impl Command for ParEachGroup {
         let capture_block: CaptureBlock = call.req(engine_state, stack, 1)?;
         let ctrlc = engine_state.ctrlc.clone();
         let span = call.head;
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
 
         let stack = stack.captures_to_stack(&capture_block.captures);
 
@@ -72,11 +74,13 @@ impl Command for ParEachGroup {
                     }
                 }
 
-                match eval_block_with_redirect(
+                match eval_block(
                     engine_state,
                     &mut stack,
                     block,
                     PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
                 ) {
                     Ok(v) => v.into_value(span),
                     Err(error) => Value::Error { error },

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -109,6 +109,9 @@ impl Command for Reduce {
         let orig_env_vars = stack.env_vars.clone();
         let orig_env_hidden = stack.env_hidden.clone();
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         let mut input_iter = input.into_iter();
 
         let (off, start_val) = if let Some(val) = fold {
@@ -170,7 +173,14 @@ impl Command for Reduce {
                     }
                 }
 
-                let v = match eval_block(engine_state, &mut stack, block, PipelineData::new(span)) {
+                let v = match eval_block(
+                    engine_state,
+                    &mut stack,
+                    block,
+                    PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
+                ) {
                     Ok(v) => v.into_value(span),
                     Err(error) => Value::Error { error },
                 };

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -58,6 +58,9 @@ impl Command for SkipUntil {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         Ok(input
             .into_iter()
             .skip_while(move |value| {
@@ -65,10 +68,17 @@ impl Command for SkipUntil {
                     stack.add_var(var_id, value.clone());
                 }
 
-                !eval_block(&engine_state, &mut stack, &block, PipelineData::new(span))
-                    .map_or(false, |pipeline_data| {
-                        pipeline_data.into_value(span).is_true()
-                    })
+                !eval_block(
+                    &engine_state,
+                    &mut stack,
+                    &block,
+                    PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
+                )
+                .map_or(false, |pipeline_data| {
+                    pipeline_data.into_value(span).is_true()
+                })
             })
             .into_pipeline_data(ctrlc)
             .set_metadata(metadata))

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -58,6 +58,9 @@ impl Command for SkipWhile {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         Ok(input
             .into_iter()
             .skip_while(move |value| {
@@ -65,10 +68,17 @@ impl Command for SkipWhile {
                     stack.add_var(var_id, value.clone());
                 }
 
-                eval_block(&engine_state, &mut stack, &block, PipelineData::new(span))
-                    .map_or(false, |pipeline_data| {
-                        pipeline_data.into_value(span).is_true()
-                    })
+                eval_block(
+                    &engine_state,
+                    &mut stack,
+                    &block,
+                    PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
+                )
+                .map_or(false, |pipeline_data| {
+                    pipeline_data.into_value(span).is_true()
+                })
             })
             .into_pipeline_data(ctrlc)
             .set_metadata(metadata))

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -70,6 +70,10 @@ fn update(
 
     let cell_path: CellPath = call.req(engine_state, stack, 0)?;
     let replacement: Value = call.req(engine_state, stack, 1)?;
+
+    let redirect_stdout = call.redirect_stdout;
+    let redirect_stderr = call.redirect_stderr;
+
     let engine_state = engine_state.clone();
     let ctrlc = engine_state.ctrlc.clone();
 
@@ -97,6 +101,8 @@ fn update(
                     &mut stack,
                     &block,
                     input.clone().into_pipeline_data(),
+                    redirect_stdout,
+                    redirect_stderr,
                 );
 
                 match output {

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block_with_redirect, CallExt};
+use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
@@ -41,6 +41,9 @@ impl Command for Where {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         Ok(input
             .into_iter()
             .filter_map(move |value| {
@@ -49,11 +52,13 @@ impl Command for Where {
                         stack.add_var(*var_id, value.clone());
                     }
                 }
-                let result = eval_block_with_redirect(
+                let result = eval_block(
                     &engine_state,
                     &mut stack,
                     &block,
                     PipelineData::new(span),
+                    redirect_stdout,
+                    redirect_stderr,
                 );
 
                 match result {

--- a/crates/nu-command/src/system/benchmark.rs
+++ b/crates/nu-command/src/system/benchmark.rs
@@ -39,6 +39,9 @@ impl Command for Benchmark {
         let capture_block: CaptureBlock = call.req(engine_state, stack, 0)?;
         let block = engine_state.get_block(capture_block.block_id);
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         let mut stack = stack.captures_to_stack(&capture_block.captures);
         let start_time = Instant::now();
         eval_block(
@@ -46,6 +49,8 @@ impl Command for Benchmark {
             &mut stack,
             block,
             PipelineData::new(call.head),
+            redirect_stdout,
+            redirect_stderr,
         )?
         .into_value(call.head);
 

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -84,7 +84,8 @@ fn exec(
         name,
         args,
         env_vars,
-        last_expression: true,
+        redirect_stdout: true,
+        redirect_stderr: false,
     };
 
     let mut command = external_command.spawn_simple_command(&cwd.to_string_lossy().to_string())?;

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -181,8 +181,12 @@ impl ExternalCommand {
 
                     // If the external is not the last command, its output will get piped
                     // either as a string or binary
-                    if !self.last_expression {
+                    if self.redirect_stdout {
                         process.stdout(Stdio::piped());
+                    }
+
+                    if self.redirect_stderr {
+                        process.stderr(Stdio::piped());
                     }
 
                     // If there is an input from the pipeline. The stdin from the process

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -354,3 +354,15 @@ fn str_reverse() {
 
     assert!(actual.out.contains("llehsun"));
 }
+
+#[test]
+fn test_redirection_trim() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        let x = (nu --testbin cococo niceone); $x | str trim | str length
+        "#
+    ));
+
+    assert_eq!(actual.out, "7");
+}

--- a/crates/nu-command/tests/commands/with_env.rs
+++ b/crates/nu-command/tests/commands/with_env.rs
@@ -55,6 +55,16 @@ fn with_env_and_shorthand_same_result() {
     assert_eq!(actual_shorthand.out, actual_normal.out);
 }
 
+#[test]
+fn test_redirection2() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "let x = (FOO=BAR nu --testbin cococo niceenvvar); $x | str trim | str length"
+    );
+
+    assert_eq!(actual.out, "10");
+}
+
 // FIXME: jt: needs more work
 #[ignore]
 #[test]

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -161,8 +161,14 @@ fn get_converted_value(
                     stack.add_var(*var_id, orig_val.clone());
                 }
 
-                let result =
-                    eval_block(engine_state, &mut stack, block, PipelineData::new(val_span));
+                let result = eval_block(
+                    engine_state,
+                    &mut stack,
+                    block,
+                    PipelineData::new(val_span),
+                    true,
+                    true,
+                );
 
                 match result {
                     Ok(data) => ConversionResult::Ok(data.into_value(val_span)),

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -10,7 +10,6 @@ pub use column::get_columns;
 pub use documentation::{generate_docs, get_brief_help, get_documentation, get_full_help};
 pub use env::*;
 pub use eval::{
-    eval_block, eval_block_with_redirect, eval_expression, eval_expression_with_input,
-    eval_operator, eval_subexpression,
+    eval_block, eval_expression, eval_expression_with_input, eval_operator, eval_subexpression,
 };
 pub use glob_from::glob_from;

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -1,7 +1,7 @@
 use nu_protocol::ast::Expr;
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
-use nu_protocol::PipelineData;
 use nu_protocol::{ast::Call, engine::Command, ShellError, Signature};
+use nu_protocol::{PipelineData, Spanned};
 
 #[derive(Clone)]
 pub struct KnownExternal {
@@ -61,15 +61,25 @@ impl Command for KnownExternal {
                     call.positional.push(arg.clone())
                 }
 
-                // if last_expression {
-                //     call.named.push((
-                //         Spanned {
-                //             item: "last-expression".into(),
-                //             span: head.span,
-                //         },
-                //         None,
-                //     ))
-                // }
+                if call.redirect_stdout {
+                    call.named.push((
+                        Spanned {
+                            item: "redirect-stdout".into(),
+                            span: call_span,
+                        },
+                        None,
+                    ))
+                }
+
+                if call.redirect_stderr {
+                    call.named.push((
+                        Spanned {
+                            item: "redirect-stderr".into(),
+                            span: call_span,
+                        },
+                        None,
+                    ))
+                }
 
                 command.run(engine_state, stack, &call, input)
             }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -578,6 +578,8 @@ pub fn parse_export(
         decl_id: export_decl_id,
         positional: vec![],
         named: vec![],
+        redirect_stdout: true,
+        redirect_stderr: false,
     });
 
     let exportable = if let Some(kw_span) = spans.get(1) {
@@ -985,6 +987,8 @@ pub fn parse_module(
             decl_id: module_decl_id,
             positional: vec![module_name_expr, block_expr],
             named: vec![],
+            redirect_stdout: true,
+            redirect_stderr: false,
         });
 
         (
@@ -1199,6 +1203,8 @@ pub fn parse_use(
         decl_id: use_decl_id,
         positional: vec![import_pattern_expr],
         named: vec![],
+        redirect_stdout: true,
+        redirect_stderr: false,
     });
 
     (
@@ -1398,6 +1404,8 @@ pub fn parse_hide(
             decl_id: hide_decl_id,
             positional: vec![import_pattern_expr],
             named: vec![],
+            redirect_stdout: true,
+            redirect_stderr: false,
         });
 
         (
@@ -1479,6 +1487,8 @@ pub fn parse_let(
                             head: spans[0],
                             positional: vec![lvalue, rvalue],
                             named: vec![],
+                            redirect_stdout: true,
+                            redirect_stderr: false,
                         });
 
                         return (

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3420,7 +3420,7 @@ pub fn parse_expression(
                 (
                     Expression {
                         expr: Expr::String(String::new()),
-                        span: spans[pos],
+                        span: Span { start: 0, end: 0 },
                         ty: Type::Nothing,
                         custom_completion: None,
                     },
@@ -3556,6 +3556,8 @@ pub fn parse_expression(
                 decl_id,
                 named: vec![],
                 positional,
+                redirect_stdout: true,
+                redirect_stderr: false,
             }));
 
             (
@@ -4108,6 +4110,8 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
                 named: vec![],
                 positional: output,
                 decl_id,
+                redirect_stdout: true,
+                redirect_stderr: false,
             })),
             span,
             ty: Type::String,

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -8,6 +8,8 @@ pub struct Call {
     pub head: Span,
     pub positional: Vec<Expression>,
     pub named: Vec<(Spanned<String>, Option<Expression>)>,
+    pub redirect_stdout: bool,
+    pub redirect_stderr: bool,
 }
 
 impl Call {
@@ -17,6 +19,8 @@ impl Call {
             head,
             positional: vec![],
             named: vec![],
+            redirect_stdout: true,
+            redirect_stderr: false,
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -95,7 +95,7 @@ pub(crate) fn evaluate(
         std::process::exit(1);
     }
 
-    match eval_block(engine_state, &mut stack, &block, input) {
+    match eval_block(engine_state, &mut stack, &block, input, false, false) {
         Ok(pipeline_data) => {
             crate::eval_file::print_table_or_error(engine_state, &mut stack, pipeline_data, &config)
         }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -251,3 +251,25 @@ fn with_env_shorthand_nested_quotes() -> TestResult {
         "-arg \"hello world\"",
     )
 }
+
+#[test]
+fn test_redirection() -> TestResult {
+    run_test(
+        r#"let x = (nu --testbin cococo niceone); $x | str trim | str length"#,
+        "7",
+    )
+}
+
+#[test]
+fn test_redirection2() -> TestResult {
+    run_test(
+        r#"let x = (FOO=BAR nu --testbin cococo niceenvvar); $x | str trim | str length"#,
+        "10",
+    )
+}
+
+#[test]
+fn test_redirection3() -> TestResult {
+    // try a nonsense binary
+    run_test(r#"do -i { asdjw4j5cnaabw44rd }; echo done"#, "done")
+}

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -253,23 +253,7 @@ fn with_env_shorthand_nested_quotes() -> TestResult {
 }
 
 #[test]
-fn test_redirection() -> TestResult {
-    run_test(
-        r#"let x = (nu --testbin cococo niceone); $x | str trim | str length"#,
-        "7",
-    )
-}
-
-#[test]
-fn test_redirection2() -> TestResult {
-    run_test(
-        r#"let x = (FOO=BAR nu --testbin cococo niceenvvar); $x | str trim | str length"#,
-        "10",
-    )
-}
-
-#[test]
-fn test_redirection3() -> TestResult {
+fn test_redirection_stderr() -> TestResult {
     // try a nonsense binary
     run_test(r#"do -i { asdjw4j5cnaabw44rd }; echo done"#, "done")
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -226,7 +226,7 @@ pub(crate) fn eval_source(
         report_error(&working_set, &err);
     }
 
-    match eval_block(engine_state, stack, &block, input) {
+    match eval_block(engine_state, stack, &block, input, false, false) {
         Ok(pipeline_data) => {
             if let Err(err) = print_pipeline_data(pipeline_data, engine_state, stack) {
                 let working_set = StateWorkingSet::new(engine_state);


### PR DESCRIPTION
# Description

This adds the ability to redirect stdout and stderr inside the pipeline engine (not yet exposed as syntax). This allows things like `with-env` to properly redirect based on context, `do -i { .. }` to be able to ignore stderr, and more.

fixes #4384 
fixes #4316 
fixes #3541 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
