### PR TITLE
fix strip trailing whitespace for make_docs script

### DIFF
--- a/docs/commands/dfr_aggregate.md
+++ b/docs/commands/dfr_aggregate.md
@@ -12,7 +12,7 @@ Performs an aggregation operation on a dataframe and groupby object
 
 ## Parameters
 
- -  `operation_name`: 
+ -  `operation_name`:
 	Dataframes: mean, sum, min, max, quantile, median, var, std
 	GroupBy: mean, sum, min, max, first, last, nunique, quantile, median, var, std, count
  -  `--quantile {number}`: quantile value for quantile operation

--- a/docs/commands/each.md
+++ b/docs/commands/each.md
@@ -8,11 +8,12 @@ Run a block on each element of input
 
 ## Signature
 
-```> each (block) --numbered```
+```> each (block) --keep-empty --numbered```
 
 ## Parameters
 
  -  `block`: the block to run
+ -  `--keep-empty`: keep empty result cells
  -  `--numbered`: iterate with an index
 
 ## Examples
@@ -20,4 +21,14 @@ Run a block on each element of input
 Multiplies elements in list
 ```shell
 > [1 2 3] | each { |it| 2 * $it }
+```
+
+Iterate over each element, keeping only values that succeed
+```shell
+> [1 2 3] | each { |it| if $it == 2 { echo "found 2!"} }
+```
+
+Iterate over each element, keeping all results
+```shell
+> [1 2 3] | each --keep-empty { |it| if $it == 2 { echo "found 2!"} }
 ```

--- a/docs/commands/fetch.md
+++ b/docs/commands/fetch.md
@@ -16,7 +16,7 @@ Fetch the contents from a URL (HTTP GET operation).
  -  `--user {any}`: the username when authenticating
  -  `--password {any}`: the password when authenticating
  -  `--timeout {int}`: timeout period in seconds
- -  `--headers {any}`: custom headers you want to add 
+ -  `--headers {any}`: custom headers you want to add
  -  `--raw`: fetch contents as text rather than a table
 
 ## Examples

--- a/docs/commands/flatten.md
+++ b/docs/commands/flatten.md
@@ -18,7 +18,7 @@ Flatten the table.
 
 flatten a table
 ```shell
-> [[N, u, s, h, e, l, l]] | flatten 
+> [[N, u, s, h, e, l, l]] | flatten
 ```
 
 flatten a table, get the first item

--- a/docs/commands/post.md
+++ b/docs/commands/post.md
@@ -18,7 +18,7 @@ Post a body to a URL (HTTP POST operation).
  -  `--password {any}`: the password when authenticating
  -  `--content-type {any}`: the MIME type of content to post
  -  `--content-length {any}`: the length of the content being posted
- -  `--headers {any}`: custom headers you want to add 
+ -  `--headers {any}`: custom headers you want to add
  -  `--raw`: return values as a string instead of a table
  -  `--insecure`: allow insecure server connections when using SSL
 

--- a/docs/commands/run-external.md
+++ b/docs/commands/run-external.md
@@ -8,9 +8,10 @@ Runs external command
 
 ## Signature
 
-```> run-external ...rest --last-expression```
+```> run-external ...rest --redirect-stdout --redirect-stderr```
 
 ## Parameters
 
  -  `...rest`: external command to run
- -  `--last-expression`: last-expression
+ -  `--redirect-stdout`: redirect-stdout
+ -  `--redirect-stderr`: redirect-stderr

--- a/docs/commands/split-by.md
+++ b/docs/commands/split-by.md
@@ -18,7 +18,7 @@ Create a new table splitted.
 
 split items by column named "lang"
 ```shell
-> 
+>
                 {
                     '2019': [
                       { name: 'andres', lang: 'rb', year: '2019' },
@@ -28,5 +28,5 @@ split items by column named "lang"
                       { name: 'storm', lang: 'rs', 'year': '2021' }
                     ]
                 } | split-by lang
-                
+
 ```

--- a/docs/commands/to_csv.md
+++ b/docs/commands/to_csv.md
@@ -4,7 +4,7 @@ layout: command
 version: 0.59.0
 ---
 
-Convert table into .csv text 
+Convert table into .csv text
 
 ## Signature
 
@@ -24,5 +24,5 @@ Outputs an CSV string representing the contents of this table
 
 Outputs an CSV string representing the contents of this table
 ```shell
-> [[foo bar]; [1 2]] | to csv -s ';' 
+> [[foo bar]; [1 2]] | to csv -s ';'
 ```

--- a/docs/make_docs.nu
+++ b/docs/make_docs.nu
@@ -57,9 +57,12 @@ $"($example.description)
         $example_top + $examples
     } else { "" }
 
-    let doc = (($top + $signature + $parameters + $examples) |
-        each {|it| ($it | str trim -r)} |
-        str collect (char nl)) + (char nl)
+    let doc = (
+            ($top + $signature + $parameters + $examples) |
+            lines |
+            each {|it| ($it | str trim -r) } |
+            str collect (char nl)
+        )
 
     let safe_name = ($command.command | str find-replace '\?' '' | str find-replace ' ' '_')
     $doc | save --raw $"./docs/commands/($safe_name).md"


### PR DESCRIPTION
# Description

fix strip trailing whitespace for make_docs script

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
