### PR TITLE
Add support for math-like externals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,7 @@ dependencies = [
  "crossterm_winapi",
  "ctrlc",
  "hamcrest2",
+ "is_executable",
  "itertools",
  "log",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.59.0"  }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+is_executable = "1.0.1"
+
 # mimalloc = { version = "*", default-features = false }
 
 # Plugins

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -13,7 +13,9 @@ pub use known_external::KnownExternal;
 pub use lex::{lex, Token, TokenContents};
 pub use lite_parse::{lite_parse, LiteBlock};
 
-pub use parser::{parse, parse_block, parse_external_call, trim_quotes, Import};
+pub use parser::{
+    is_math_expression_like, parse, parse_block, parse_external_call, trim_quotes, Import,
+};
 
 #[cfg(feature = "plugin")]
 pub use parse_keywords::parse_register;

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -169,6 +169,9 @@ pub struct EngineState {
     pub env_vars: im::HashMap<String, Value>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
+
+    // A list of external commands that look like math expressions
+    pub external_exceptions: Vec<Vec<u8>>,
 }
 
 pub const NU_VARIABLE_ID: usize = 0;
@@ -199,6 +202,7 @@ impl EngineState {
             env_vars: im::HashMap::new(),
             #[cfg(feature = "plugin")]
             plugin_signatures: None,
+            external_exceptions: vec![],
         }
     }
 
@@ -633,6 +637,7 @@ impl Default for EngineState {
 pub struct StateWorkingSet<'a> {
     pub permanent_state: &'a EngineState,
     pub delta: StateDelta,
+    pub external_commands: Vec<Vec<u8>>,
 }
 
 /// A delta (or change set) between the current global state and a possible future global state. Deltas
@@ -707,6 +712,7 @@ impl<'a> StateWorkingSet<'a> {
         Self {
             delta: StateDelta::new(),
             permanent_state,
+            external_commands: vec![],
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,10 @@ fn main() -> Result<()> {
     };
     let _ = engine_state.merge_delta(delta, None, &init_cwd);
 
+    // Make a note of the exceptions we see for externals that look like math expressions
+    let exceptions = crate::utils::external_exceptions();
+    engine_state.external_exceptions = exceptions;
+
     // TODO: make this conditional in the future
     // Ctrl-c protection section
     let ctrlc = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
# Description

This gives externals with math-like names (eg `7z`) precedence. We check for them on startup and create a list of these exceptions to be used whenever we're parsing.

fixes #3934
fixes #4593

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
