### PR TITLE
Better ls paths

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -73,12 +73,15 @@ impl Command for Ls {
             Some(p) => {
                 let p_tag = p.span;
                 let mut p = PathBuf::from(p.item);
-                if p.is_dir() {
+
+                let expanded = nu_path::expand_path_with(&p, &cwd);
+                if expanded.is_dir() {
                     if permission_denied(&p) {
                         #[cfg(unix)]
                         let error_msg = format!(
                             "The permissions of {:o} do not allow access for this user",
-                            p.metadata()
+                            expanded
+                                .metadata()
                                 .expect(
                                     "this shouldn't be called since we already know there is a dir"
                                 )
@@ -94,7 +97,7 @@ impl Command for Ls {
                             p_tag,
                         ));
                     }
-                    if is_empty_dir(&p) {
+                    if is_empty_dir(&expanded) {
                         return Ok(Value::nothing(call_span).into_pipeline_data());
                     }
                     p.push("*");

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -25,11 +25,7 @@ pub fn glob_from(
     ShellError,
 > {
     let path = PathBuf::from(&pattern.item);
-    let path = if path.is_relative() {
-        expand_path_with(path, cwd)
-    } else {
-        path
-    };
+    let path = expand_path_with(path, cwd);
 
     let (prefix, pattern) = if path.to_string_lossy().contains('*') {
         // Path is a glob pattern => do not check for existence


### PR DESCRIPTION
# Description

Don't auto-expand glob paths for `ls`, let `ls` do its own thing.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
