### PR TITLE
allow int and float as strings for arguments

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -58,7 +58,7 @@ impl Command for External {
         let config = stack.get_config().unwrap_or_default();
         let env_vars_str = env_to_strings(engine_state, stack, &config)?;
 
-        fn value_as_spanned(value: &Value) -> Result<Spanned<String>, ShellError> {
+        fn value_as_spanned(value: Value) -> Result<Spanned<String>, ShellError> {
             let span = value.span()?;
 
             value
@@ -74,10 +74,10 @@ impl Command for External {
         }
 
         let args = args
-            .iter()
+            .into_iter()
             .flat_map(|arg| match arg {
                 Value::List { vals, .. } => vals
-                    .iter()
+                    .into_iter()
                     .map(value_as_spanned)
                     .collect::<Vec<Result<Spanned<String>, ShellError>>>(),
                 val => vec![value_as_spanned(val)],

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -58,43 +58,35 @@ impl Command for External {
         let config = stack.get_config().unwrap_or_default();
         let env_vars_str = env_to_strings(engine_state, stack, &config)?;
 
-        let mut args_strs = vec![];
+        fn value_as_spanned(value: &Value) -> Result<Spanned<String>, ShellError> {
+            let span = value.span()?;
 
-        for arg in args {
-            let span = if let Ok(span) = arg.span() {
-                span
-            } else {
-                Span { start: 0, end: 0 }
-            };
-
-            if let Ok(s) = arg.as_string() {
-                args_strs.push(Spanned { item: s, span });
-            } else if let Value::List { vals, span } = arg {
-                // Interpret a list as a series of arguments
-                for val in vals {
-                    if let Ok(s) = val.as_string() {
-                        args_strs.push(Spanned { item: s, span });
-                    } else {
-                        return Err(ShellError::ExternalCommand(
-                            "Cannot convert argument to a string".into(),
-                            "All arguments to an external command need to be string-compatible"
-                                .into(),
-                            val.span()?,
-                        ));
-                    }
-                }
-            } else {
-                return Err(ShellError::ExternalCommand(
-                    "Cannot convert argument to a string".into(),
-                    "All arguments to an external command need to be string-compatible".into(),
-                    arg.span()?,
-                ));
-            }
+            value
+                .as_string()
+                .map(|item| Spanned { item, span })
+                .map_err(|_| {
+                    ShellError::ExternalCommand(
+                        "Cannot convert argument to a string".into(),
+                        "All arguments to an external command need to be string-compatible".into(),
+                        span,
+                    )
+                })
         }
+
+        let args = args
+            .iter()
+            .flat_map(|arg| match arg {
+                Value::List { vals, .. } => vals
+                    .iter()
+                    .map(value_as_spanned)
+                    .collect::<Vec<Result<Spanned<String>, ShellError>>>(),
+                val => vec![value_as_spanned(val)],
+            })
+            .collect::<Result<Vec<Spanned<String>>, ShellError>>()?;
 
         let command = ExternalCommand {
             name,
-            args: args_strs,
+            args,
             redirect_stdout,
             redirect_stderr,
             env_vars: env_vars_str,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -173,6 +173,8 @@ impl Clone for Value {
 impl Value {
     pub fn as_string(&self) -> Result<String, ShellError> {
         match self {
+            Value::Int { val, .. } => Ok(val.to_string()),
+            Value::Float { val, .. } => Ok(val.to_string()),
             Value::String { val, .. } => Ok(val.to_string()),
             Value::Binary { val, .. } => Ok(match std::str::from_utf8(val) {
                 Ok(s) => s.to_string(),


### PR DESCRIPTION
# Description

Closes #4610

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
