### PR TITLE
fix: #3809, try to fix the `source -h` not work issue

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1543,6 +1543,18 @@ pub fn parse_source(
             let (call, err) = parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
             error = error.or(err);
 
+            if error.is_some() || call.has_flag("help") {
+                return (
+                    Pipeline::from_vec(vec![Expression {
+                        expr: Expr::Call(call),
+                        span: span(spans),
+                        ty: Type::Unknown,
+                        custom_completion: None,
+                    }]),
+                    error,
+                );
+            }
+
             // Command and one file name
             if spans.len() >= 2 {
                 let name_expr = working_set.get_span_contents(spans[1]);


### PR DESCRIPTION
# Description

fix: #3809, try to fix the `source -h` not work issue: https://github.com/nushell/nushell/issues/3809
Please review the code carefully, I'm not sure if I have missed anything. Feel free to give me a feedback or update it. Thanks.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
