### PR TITLE
Check for external exceptions more often

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,6 +19,10 @@ pub(crate) fn evaluate(
     // First, set up env vars as strings only
     gather_parent_env_vars(engine_state);
 
+    // Make a note of the exceptions we see for externals that look like math expressions
+    let exceptions = crate::utils::external_exceptions();
+    engine_state.external_exceptions = exceptions;
+
     // Run a command (or commands) given to us by the user
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);

--- a/src/eval_file.rs
+++ b/src/eval_file.rs
@@ -22,6 +22,10 @@ pub(crate) fn evaluate(
     // First, set up env vars as strings only
     gather_parent_env_vars(engine_state);
 
+    // Make a note of the exceptions we see for externals that look like math expressions
+    let exceptions = crate::utils::external_exceptions();
+    engine_state.external_exceptions = exceptions;
+
     let mut stack = nu_protocol::engine::Stack::new();
 
     // Set up our initial config to start from

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,6 @@ fn main() -> Result<()> {
     };
     let _ = engine_state.merge_delta(delta, None, &init_cwd);
 
-    // Make a note of the exceptions we see for externals that look like math expressions
-    let exceptions = crate::utils::external_exceptions();
-    engine_state.external_exceptions = exceptions;
-
     // TODO: make this conditional in the future
     // Ctrl-c protection section
     let ctrlc = Arc::new(AtomicBool::new(false));

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -35,6 +35,10 @@ pub(crate) fn evaluate(
     // First, set up env vars as strings only
     gather_parent_env_vars(engine_state);
 
+    // Make a note of the exceptions we see for externals that look like math expressions
+    let exceptions = crate::utils::external_exceptions();
+    engine_state.external_exceptions = exceptions;
+
     // Set up our initial config to start from
     stack.vars.insert(
         CONFIG_VARIABLE_ID,
@@ -316,6 +320,10 @@ pub(crate) fn evaluate(
                     let _ = std::env::set_current_dir(path);
                     engine_state.env_vars.insert("PWD".into(), cwd);
                 }
+
+                // Make a note of the exceptions we see for externals that look like math expressions
+                let exceptions = crate::utils::external_exceptions();
+                engine_state.external_exceptions = exceptions;
             }
             Ok(Signal::CtrlC) => {
                 // `Reedline` clears the line content. New prompt is shown


### PR DESCRIPTION
# Description

Check for math-like external command name exceptions after every repl run rather than just on nu startup.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
