### PR TITLE
Add profiling build profile and symbol strip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ dataframe = ["nu-command/dataframe"]
 
 [profile.release]
 opt-level = "s" # Optimize for size
-strip = true
+strip = "debuginfo"
 
 # build with `cargo build --profile profiling` 
 # to analyze performance with tooling like linux perf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,14 @@ dataframe = ["nu-command/dataframe"]
 
 [profile.release]
 opt-level = "s" # Optimize for size
+strip = true
+
+# build with `cargo build --profile profiling` 
+# to analyze performance with tooling like linux perf
+[profile.profiling]
+inherits = "release"
+strip = false
+debug = true
 
 # Build plugins
 [[bin]]


### PR DESCRIPTION
# Description

Stripping the symbols (of the std library) for the release build improves the size of the
binary significantly

Adds a custom build profile for performance profiling that includes all
symbols for analysis.

Can be used via

```
cargo build --profile profiling
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
