### PR TITLE
Use external exceptions in path strings

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -301,6 +301,13 @@ pub fn external_exceptions(engine_state: &EngineState, stack: &Stack) -> Vec<Vec
                                         executables.push(name);
                                     }
                                 }
+                                if let Some(name) = item.path().file_stem() {
+                                    let name = name.to_string_lossy();
+                                    let name = name.as_bytes().to_vec();
+                                    if nu_parser::is_math_expression_like(&name) {
+                                        executables.push(name);
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
# Description

Oops, we probably also want to make exceptions for the file stems in the case where the path we're looking at is a string instead of a list

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
