### PR TITLE
finish up with examples

### DIFF
--- a/crates/nu-command/src/core_commands/export.rs
+++ b/crates/nu-command/src/core_commands/export.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span, Value,
 };
 
 #[derive(Clone)]
@@ -38,5 +38,16 @@ impl Command for ExportCommand {
             span: call.head,
         }
         .into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Export a definition from a module",
+            example: r#"module utils { export def my-command [] { "hello" } }; use utils my-command; my-command"#,
+            result: Some(Value::String {
+                val: "hello".to_string(),
+                span: Span::test_data(),
+            }),
+        }]
     }
 }

--- a/crates/nu-command/src/core_commands/extern_.rs
+++ b/crates/nu-command/src/core_commands/extern_.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape};
 
 #[derive(Clone)]
 pub struct Extern;
@@ -29,5 +29,13 @@ impl Command for Extern {
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Write a signature for an external command",
+            example: r#"extern echo [text: string]"#,
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc;
 use nu_engine::env_to_strings;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::{ast::Call, engine::Command, ShellError, Signature, SyntaxShape, Value};
-use nu_protocol::{Category, PipelineData, RawStream, Span, Spanned};
+use nu_protocol::{Category, Example, PipelineData, RawStream, Span, Spanned};
 
 use itertools::Itertools;
 
@@ -92,6 +92,14 @@ impl Command for External {
             env_vars: env_vars_str,
         };
         command.run_with_input(engine_state, stack, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Run an external command",
+            example: r#"run-external "echo" "-n" "hello""#,
+            result: None,
+        }]
     }
 }
 


### PR DESCRIPTION
# Description

Finishes the last of the commands that need examples.

Fixes https://github.com/nushell/nushell/issues/4518

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
