### PR TITLE
Document Visual C++ requirement on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Optional dependencies:
 
 To install Nu via cargo (make sure you have installed [rustup](https://rustup.rs/) and the latest stable compiler via `rustup install stable`):
 
+For Windows users, you may also need to install the [Microsoft Visual C++ 2015 Redistributables](https://www.microsoft.com/en-us/download/details.aspx?id=52685).
+
 ```shell
 cargo install nu
 ```


### PR DESCRIPTION
Should fix #4563.

# Description

Documents a VC Redist requirement in the readme, where people are typically looking for install instructions.

# Tests

(N/A this is just a readme change)

**Note**: I should probably open a related issue in nushell/nushell.github.io. Will go do that now.
