### PR TITLE
Fix Windows doc comments

### DIFF
--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -32,3 +32,34 @@ fn use_module_file_within_block() {
         assert_eq!(actual.out, "hello world");
     })
 }
+
+#[test]
+fn use_keeps_doc_comments() {
+    Playground::setup("use_doc_comments", |dirs, nu| {
+        let file = AbsolutePath::new(dirs.test().join("spam.nu"));
+
+        nu.with_files(vec![FileWithContent(
+            &file.display_path(),
+            r#"
+                # this is my foo command
+                export def foo [
+                    x:string # this is an x parameter
+                ] {
+                    echo "hello world"
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+                r#"
+                    use spam.nu foo;
+                    help foo
+                "#
+            )
+        );
+
+        assert!(actual.out.contains("this is my foo command"));
+        assert!(actual.out.contains("this is an x parameter"));
+    })
+}

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -52,7 +52,6 @@ fn is_item_terminator(
         && (c == b' '
             || c == b'\t'
             || c == b'\n'
-            || c == b'\r'
             || c == b'|'
             || c == b';'
             || c == b'#'
@@ -112,7 +111,7 @@ pub fn lex_item(
                 break;
             }
             in_comment = true;
-        } else if c == b'\n' || c == b'\r' {
+        } else if c == b'\n' {
             in_comment = false;
             if is_item_terminator(&block_level, c, additional_whitespace, special_tokens) {
                 break;
@@ -259,7 +258,7 @@ pub fn lex(
                 TokenContents::Semicolon,
                 Span::new(span_offset + idx, span_offset + idx + 1),
             ));
-        } else if c == b'\n' || c == b'\r' {
+        } else if c == b'\n' {
             // If the next character is a newline, we're looking at an EOL (end of line) token.
 
             let idx = curr_offset;
@@ -276,7 +275,7 @@ pub fn lex(
             let mut start = curr_offset;
 
             while let Some(input) = input.get(curr_offset) {
-                if *input == b'\n' || *input == b'\r' {
+                if *input == b'\n' {
                     if !skip_comment {
                         output.push(Token::new(
                             TokenContents::Comment,

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -112,7 +112,7 @@ pub fn lex_item(
                 break;
             }
             in_comment = true;
-        } else if c == b'\n' {
+        } else if c == b'\n' || c == b'\r' {
             in_comment = false;
             if is_item_terminator(&block_level, c, additional_whitespace, special_tokens) {
                 break;
@@ -276,7 +276,7 @@ pub fn lex(
             let mut start = curr_offset;
 
             while let Some(input) = input.get(curr_offset) {
-                if *input == b'\n' || *input == b'\r' {
+                if *input == b'\n' {
                     if !skip_comment {
                         output.push(Token::new(
                             TokenContents::Comment,

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -112,7 +112,7 @@ pub fn lex_item(
                 break;
             }
             in_comment = true;
-        } else if c == b'\n' || c == b'\r' {
+        } else if c == b'\n' {
             in_comment = false;
             if is_item_terminator(&block_level, c, additional_whitespace, special_tokens) {
                 break;

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -52,6 +52,7 @@ fn is_item_terminator(
         && (c == b' '
             || c == b'\t'
             || c == b'\n'
+            || c == b'\r'
             || c == b'|'
             || c == b';'
             || c == b'#'
@@ -111,7 +112,7 @@ pub fn lex_item(
                 break;
             }
             in_comment = true;
-        } else if c == b'\n' {
+        } else if c == b'\n' || c == b'\r' {
             in_comment = false;
             if is_item_terminator(&block_level, c, additional_whitespace, special_tokens) {
                 break;
@@ -258,7 +259,7 @@ pub fn lex(
                 TokenContents::Semicolon,
                 Span::new(span_offset + idx, span_offset + idx + 1),
             ));
-        } else if c == b'\n' {
+        } else if c == b'\n' || c == b'\r' {
             // If the next character is a newline, we're looking at an EOL (end of line) token.
 
             let idx = curr_offset;
@@ -275,7 +276,7 @@ pub fn lex(
             let mut start = curr_offset;
 
             while let Some(input) = input.get(curr_offset) {
-                if *input == b'\n' {
+                if *input == b'\n' || *input == b'\r' {
                     if !skip_comment {
                         output.push(Token::new(
                             TokenContents::Comment,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -201,7 +201,7 @@ fn build_usage(working_set: &StateWorkingSet, spans: &[Span]) -> String {
     for comment_part in spans {
         let contents = working_set.get_span_contents(*comment_part);
 
-        let comment_line = if first {
+        let mut comment_line = if first {
             // Count the number of spaces still at the front, skipping the '#'
             let mut pos = 1;
             while pos < contents.len() {
@@ -235,6 +235,10 @@ fn build_usage(working_set: &StateWorkingSet, spans: &[Span]) -> String {
 
         if !usage.is_empty() {
             usage.push('\n');
+        }
+
+        if comment_line.ends_with('\r') {
+            comment_line.pop();
         }
         usage.push_str(&comment_line);
     }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -201,7 +201,7 @@ fn build_usage(working_set: &StateWorkingSet, spans: &[Span]) -> String {
     for comment_part in spans {
         let contents = working_set.get_span_contents(*comment_part);
 
-        let mut comment_line = if first {
+        let comment_line = if first {
             // Count the number of spaces still at the front, skipping the '#'
             let mut pos = 1;
             while pos < contents.len() {
@@ -235,10 +235,6 @@ fn build_usage(working_set: &StateWorkingSet, spans: &[Span]) -> String {
 
         if !usage.is_empty() {
             usage.push('\n');
-        }
-
-        if comment_line.ends_with('\r') {
-            comment_line.pop();
         }
         usage.push_str(&comment_line);
     }


### PR DESCRIPTION
# Description

Allows Windows to also have doc comments

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
