### PR TITLE
Add support for stderr and exit code

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -18,7 +18,7 @@ pub fn print_pipeline_data(
 
     let stdout = std::io::stdout();
 
-    if let PipelineData::RawStream(stream, _, _) = input {
+    if let PipelineData::ExternalStream { stdout: stream, .. } = input {
         for s in stream {
             let _ = stdout.lock().write_all(s?.as_binary()?);
         }

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -99,7 +99,7 @@ fn into_binary(
     let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
 
     match input {
-        PipelineData::RawStream(stream, ..) => {
+        PipelineData::ExternalStream { stdout: stream, .. } => {
             // TODO: in the future, we may want this to stream out, converting each to bytes
             let output = stream.into_bytes()?;
             Ok(Value::Binary {

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -150,7 +150,7 @@ fn string_helper(
     }
 
     match input {
-        PipelineData::RawStream(stream, ..) => {
+        PipelineData::ExternalStream { stdout: stream, .. } => {
             // TODO: in the future, we may want this to stream out, converting each to bytes
             let output = stream.into_string()?;
             Ok(Value::String {

--- a/crates/nu-command/src/core_commands/describe.rs
+++ b/crates/nu-command/src/core_commands/describe.rs
@@ -28,7 +28,7 @@ impl Command for Describe {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        if matches!(input, PipelineData::RawStream(..)) {
+        if matches!(input, PipelineData::ExternalStream { .. }) {
             Ok(PipelineData::Value(
                 Value::string("raw input", call.head),
                 None,

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -132,6 +132,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         // System
         bind_command! {
             Benchmark,
+            Complete,
             Exec,
             External,
             Ps,

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -120,15 +120,17 @@ impl Command for Open {
 
             let buf_reader = BufReader::new(file);
 
-            let output = PipelineData::RawStream(
-                RawStream::new(
+            let output = PipelineData::ExternalStream {
+                stdout: RawStream::new(
                     Box::new(BufferedReader { input: buf_reader }),
                     ctrlc,
                     call_span,
                 ),
-                call_span,
-                None,
-            );
+                stderr: None,
+                exit_code: None,
+                span: call_span,
+                metadata: None,
+            };
 
             let ext = if raw {
                 None

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -86,7 +86,7 @@ fn getcol(
             .into_iter()
             .map(move |x| Value::String { val: x, span })
             .into_pipeline_data(engine_state.ctrlc.clone())),
-        PipelineData::Value(..) | PipelineData::RawStream(..) => {
+        PipelineData::Value(..) | PipelineData::ExternalStream { .. } => {
             let cols = vec![];
             let vals = vec![];
             Ok(Value::Record { cols, vals, span }.into_pipeline_data())

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -158,7 +158,7 @@ impl Command for Each {
                     }
                 })
                 .into_pipeline_data(ctrlc)),
-            PipelineData::RawStream(stream, ..) => Ok(stream
+            PipelineData::ExternalStream { stdout: stream, .. } => Ok(stream
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -111,7 +111,7 @@ fn getcol(
                 .map(move |x| Value::String { val: x, span })
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
-        PipelineData::Value(..) | PipelineData::RawStream(..) => {
+        PipelineData::Value(..) | PipelineData::ExternalStream { .. } => {
             let cols = vec![];
             let vals = vec![];
             Ok(Value::Record { cols, vals, span }.into_pipeline_data())

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -110,7 +110,7 @@ impl Command for Lines {
                 format!("Not supported input: {}", val.as_string()?),
                 call.head,
             )),
-            PipelineData::RawStream(..) => {
+            PipelineData::ExternalStream { .. } => {
                 let config = stack.get_config()?;
 
                 //FIXME: Make sure this can fail in the future to let the user

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -200,7 +200,7 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            PipelineData::RawStream(stream, ..) => Ok(stream
+            PipelineData::ExternalStream { stdout: stream, .. } => Ok(stream
                 .enumerate()
                 .par_bridge()
                 .map(move |(idx, x)| {

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -76,7 +76,12 @@ impl Command for Skip {
         let ctrlc = engine_state.ctrlc.clone();
 
         match input {
-            PipelineData::RawStream(stream, bytes_span, metadata) => {
+            PipelineData::ExternalStream {
+                stdout: stream,
+                span: bytes_span,
+                metadata,
+                ..
+            } => {
                 let mut remaining = n;
                 let mut output = vec![];
 

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -50,7 +50,7 @@ impl Command for Wrap {
                     span,
                 })
                 .into_pipeline_data(engine_state.ctrlc.clone())),
-            PipelineData::RawStream(..) => Ok(Value::Record {
+            PipelineData::ExternalStream { .. } => Ok(Value::Record {
                 cols: vec![name],
                 vals: vec![input.into_value(call.head)],
                 span,

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -356,17 +356,19 @@ fn response_to_buffer(
 ) -> nu_protocol::PipelineData {
     let buffered_input = BufReader::new(response);
 
-    PipelineData::RawStream(
-        RawStream::new(
+    PipelineData::ExternalStream {
+        stdout: RawStream::new(
             Box::new(BufferedReader {
                 input: buffered_input,
             }),
             engine_state.ctrlc.clone(),
             span,
         ),
+        stderr: None,
+        exit_code: None,
         span,
-        None,
-    )
+        metadata: None,
+    }
 }
 
 // Only panics if the user agent is invalid but we define it statically so either

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -378,17 +378,19 @@ fn response_to_buffer(
 ) -> nu_protocol::PipelineData {
     let buffered_input = BufReader::new(response);
 
-    PipelineData::RawStream(
-        RawStream::new(
+    PipelineData::ExternalStream {
+        stdout: RawStream::new(
             Box::new(BufferedReader {
                 input: buffered_input,
             }),
             engine_state.ctrlc.clone(),
             span,
         ),
+        stderr: None,
+        exit_code: None,
         span,
-        None,
-    )
+        metadata: None,
+    }
 }
 // Only panics if the user agent is invalid but we define it statically so either
 // it always or never fails

--- a/crates/nu-command/src/strings/decode.rs
+++ b/crates/nu-command/src/strings/decode.rs
@@ -44,7 +44,7 @@ impl Command for Decode {
         let encoding: Spanned<String> = call.req(engine_state, stack, 0)?;
 
         match input {
-            PipelineData::RawStream(stream, ..) => {
+            PipelineData::ExternalStream { stdout: stream, .. } => {
                 let bytes: Vec<u8> = stream.into_bytes()?.item;
 
                 let encoding = match Encoding::for_label(encoding.item.as_bytes()) {

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -1,0 +1,100 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+};
+
+#[derive(Clone)]
+pub struct Complete;
+
+impl Command for Complete {
+    fn name(&self) -> &str {
+        "complete"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("complete").category(Category::System)
+    }
+
+    fn usage(&self) -> &str {
+        "Complete the external piped in, collecting outputs and exit code"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        match input {
+            PipelineData::ExternalStream {
+                stdout,
+                stderr,
+                exit_code,
+                ..
+            } => {
+                let mut cols = vec!["stdout".to_string()];
+                let mut vals = vec![];
+
+                let stdout = stdout.into_bytes()?;
+                if let Ok(st) = String::from_utf8(stdout.item.clone()) {
+                    vals.push(Value::String {
+                        val: st,
+                        span: stdout.span,
+                    })
+                } else {
+                    vals.push(Value::Binary {
+                        val: stdout.item,
+                        span: stdout.span,
+                    })
+                };
+
+                if let Some(stderr) = stderr {
+                    cols.push("stderr".to_string());
+                    let stderr = stderr.into_bytes()?;
+                    if let Ok(st) = String::from_utf8(stderr.item.clone()) {
+                        vals.push(Value::String {
+                            val: st,
+                            span: stderr.span,
+                        })
+                    } else {
+                        vals.push(Value::Binary {
+                            val: stderr.item,
+                            span: stderr.span,
+                        })
+                    };
+                }
+
+                if let Some(exit_code) = exit_code {
+                    let mut v: Vec<_> = exit_code.collect();
+
+                    if let Some(v) = v.pop() {
+                        cols.push("exit_code".to_string());
+                        vals.push(v);
+                    }
+                }
+
+                Ok(Value::Record {
+                    cols,
+                    vals,
+                    span: call.head,
+                }
+                .into_pipeline_data())
+            }
+            _ => Err(ShellError::SpannedLabeledError(
+                "Complete only works with external streams".to_string(),
+                "complete only works on external streams".to_string(),
+                call.head,
+            )),
+        }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Run the external completion",
+            example: "^external arg1 | complete",
+            result: None,
+        }]
+    }
+}

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,4 +1,5 @@
 mod benchmark;
+mod complete;
 mod exec;
 mod ps;
 mod run_external;
@@ -6,6 +7,7 @@ mod sys;
 mod which_;
 
 pub use benchmark::Benchmark;
+pub use complete::Complete;
 pub use exec::Exec;
 pub use ps::Ps;
 pub use run_external::{External, ExternalCommand};

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -62,21 +62,25 @@ impl Command for Table {
         };
 
         match input {
-            PipelineData::RawStream(..) => Ok(input),
-            PipelineData::Value(Value::Binary { val, .. }, ..) => Ok(PipelineData::RawStream(
-                RawStream::new(
-                    Box::new(
-                        vec![Ok(format!("{}\n", nu_pretty_hex::pretty_hex(&val))
-                            .as_bytes()
-                            .to_vec())]
-                        .into_iter(),
+            PipelineData::ExternalStream { .. } => Ok(input),
+            PipelineData::Value(Value::Binary { val, .. }, ..) => {
+                Ok(PipelineData::ExternalStream {
+                    stdout: RawStream::new(
+                        Box::new(
+                            vec![Ok(format!("{}\n", nu_pretty_hex::pretty_hex(&val))
+                                .as_bytes()
+                                .to_vec())]
+                            .into_iter(),
+                        ),
+                        ctrlc,
+                        head,
                     ),
-                    ctrlc,
-                    head,
-                ),
-                head,
-                None,
-            )),
+                    stderr: None,
+                    exit_code: None,
+                    span: head,
+                    metadata: None,
+                })
+            }
             PipelineData::Value(Value::List { vals, .. }, metadata) => handle_row_stream(
                 engine_state,
                 stack,
@@ -255,8 +259,8 @@ fn handle_row_stream(
 
     let head = call.head;
 
-    Ok(PipelineData::RawStream(
-        RawStream::new(
+    Ok(PipelineData::ExternalStream {
+        stdout: RawStream::new(
             Box::new(PagingTableCreator {
                 row_offset,
                 config,
@@ -267,9 +271,11 @@ fn handle_row_stream(
             ctrlc,
             head,
         ),
-        head,
-        None,
-    ))
+        stderr: None,
+        exit_code: None,
+        span: head,
+        metadata: None,
+    })
 }
 
 fn convert_to_table(

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -39,6 +39,9 @@ impl Command for KnownExternal {
         let call_span = call.span();
         let contents = engine_state.get_span_contents(&call_span);
 
+        let redirect_stdout = call.redirect_stdout;
+        let redirect_stderr = call.redirect_stderr;
+
         let (lexed, _) = crate::lex(contents, call_span.start, &[], &[], true);
 
         let spans: Vec<_> = lexed.into_iter().map(|x| x.span).collect();
@@ -61,7 +64,7 @@ impl Command for KnownExternal {
                     call.positional.push(arg.clone())
                 }
 
-                if call.redirect_stdout {
+                if redirect_stdout {
                     call.named.push((
                         Spanned {
                             item: "redirect-stdout".into(),
@@ -71,7 +74,7 @@ impl Command for KnownExternal {
                     ))
                 }
 
-                if call.redirect_stderr {
+                if redirect_stderr {
                     call.named.push((
                         Spanned {
                             item: "redirect-stderr".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,15 +171,17 @@ fn main() -> Result<()> {
                 let stdin = std::io::stdin();
                 let buf_reader = BufReader::new(stdin);
 
-                PipelineData::RawStream(
-                    RawStream::new(
+                PipelineData::ExternalStream {
+                    stdout: RawStream::new(
                         Box::new(BufferedReader::new(buf_reader)),
                         Some(ctrlc),
                         redirect_stdin.span,
                     ),
-                    redirect_stdin.span,
-                    None,
-                )
+                    stderr: None,
+                    exit_code: None,
+                    span: redirect_stdin.span,
+                    metadata: None,
+                }
             } else {
                 PipelineData::new(Span::new(0, 0))
             };


### PR DESCRIPTION
# Description

This adds support to take the stream from an external and drain it, which completes the run of the external. For now, we can call it `complete` (we may come up with a better name in the future).

As an external stream completes, `complete` will take in the stdout/stderr/exit code of that external and turn them into a table for later use. This allows you a way to optional take an external to completion without always having to (for the infinite stream case). As an external has to complete to have an exit code, this becomes a part of this functions ability.

![image](https://user-images.githubusercontent.com/547158/155773077-f3e96b6e-8b59-43ac-b3d5-847856b27c85.png)

![image](https://user-images.githubusercontent.com/547158/155773313-8cbae77a-da0b-45c7-8a98-9b4397ffcd3c.png)


Redirection of stderr is done via something like `do -i { ... }`. Used in combination with `complete`, this allows stderr to redirect and then drain into a table for later use.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
