### PR TITLE
Plugins without file

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -19,12 +19,10 @@ const PLUGIN_FILE: &str = "plugin.nu";
 pub(crate) fn read_plugin_file(engine_state: &mut EngineState, stack: &mut Stack) {
     // Reading signatures from signature file
     // The plugin.nu file stores the parsed signature collected from each registered plugin
-    if let Some(mut plugin_path) = nu_path::config_dir() {
-        // Path to store plugins signatures
-        plugin_path.push(NUSHELL_FOLDER);
-        plugin_path.push(PLUGIN_FILE);
-        engine_state.plugin_signatures = Some(plugin_path.clone());
+    add_plugin_file(engine_state);
 
+    let plugin_path = engine_state.plugin_signatures.clone();
+    if let Some(plugin_path) = plugin_path {
         let plugin_filename = plugin_path.to_string_lossy().to_owned();
 
         if let Ok(contents) = std::fs::read(&plugin_path) {
@@ -37,8 +35,19 @@ pub(crate) fn read_plugin_file(engine_state: &mut EngineState, stack: &mut Stack
             );
         }
     }
+
     if is_perf_true() {
         info!("read_plugin_file {}:{}:{}", file!(), line!(), column!());
+    }
+}
+
+#[cfg(feature = "plugin")]
+pub(crate) fn add_plugin_file(engine_state: &mut EngineState) {
+    if let Some(mut plugin_path) = nu_path::config_dir() {
+        // Path to store plugins signatures
+        plugin_path.push(NUSHELL_FOLDER);
+        plugin_path.push(PLUGIN_FILE);
+        engine_state.plugin_signatures = Some(plugin_path.clone());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,9 @@ fn main() -> Result<()> {
 
                 ret_val
             } else if !script_name.is_empty() && binary_args.interactive_shell.is_none() {
+                #[cfg(feature = "plugin")]
+                config_files::add_plugin_file(&mut engine_state);
+
                 let ret_val =
                     eval_file::evaluate(script_name, &args_to_script, &mut engine_state, input);
                 if is_perf_true() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,9 @@ fn main() -> Result<()> {
             }
 
             if let Some(commands) = &binary_args.commands {
+                #[cfg(feature = "plugin")]
+                config_files::add_plugin_file(&mut engine_state);
+
                 let ret_val = commands::evaluate(commands, &init_cwd, &mut engine_state, input);
                 if is_perf_true() {
                     info!("-c command execution {}:{}:{}", file!(), line!(), column!());


### PR DESCRIPTION
# Description

Adds location of plugin file when running in script mode

closes #4406

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
