### PR TITLE
menu keybindings in default file

### DIFF
--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -224,8 +224,8 @@ let $config = {
     }
     {
       name: history_previous
-      modifier: "control | shift"
-      keycode: char_x
+      modifier: control
+      keycode: char_z
       mode: emacs # emacs vi_normal vi_insert
       event: { send: menupageprevious }
     }

--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -192,11 +192,42 @@ let $config = {
   }
   keybindings: [
     {
-      name: completion
+      name: completion_menu
+      modifier: none
+      keycode: tab
+      mode: emacs # emacs vi_normal vi_insert
+      event: { 
+        until: [
+          { send: menu name: completion_menu }
+          { send: menunext }
+        ]
+      }
+    }
+    {
+      name: completion_previous
+      modifier: shift
+      keycode: backtab
+      mode: emacs # emacs vi_normal vi_insert
+      event: { send: menuprevious }
+    }
+    {
+      name: history_menu
       modifier: control
-      keycode: char_t
-      mode: vi_insert # emacs vi_normal vi_insert
-      event: { send: menu name: context_menu }
+      keycode: char_x
+      mode: emacs # emacs vi_normal vi_insert
+      event: { 
+        until: [
+          { send: menu name: history_menu }
+          { send: menupagenext }
+        ]
+      }
+    }
+    {
+      name: history_previous
+      modifier: "control | shift"
+      keycode: char_x
+      mode: emacs # emacs vi_normal vi_insert
+      event: { send: menupageprevious }
     }
   ]
 }

--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -123,38 +123,6 @@ pub(crate) fn add_history_menu(line_editor: Reedline, config: &Config) -> Reedli
     line_editor.with_menu(Box::new(history_menu))
 }
 
-fn add_menu_keybindings(keybindings: &mut Keybindings) {
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('x'),
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Menu("history_menu".to_string()),
-            ReedlineEvent::MenuPageNext,
-        ]),
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
-        KeyCode::Char('x'),
-        ReedlineEvent::MenuPagePrevious,
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::NONE,
-        KeyCode::Tab,
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Menu("completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
-        ]),
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::SHIFT,
-        KeyCode::BackTab,
-        ReedlineEvent::MenuPrevious,
-    );
-}
-
 pub enum KeybindingsMode {
     Emacs(Keybindings),
     Vi {
@@ -168,17 +136,6 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
     match config.edit_mode.as_str() {
         "emacs" => {
             let mut keybindings = default_emacs_keybindings();
-            add_menu_keybindings(&mut keybindings);
-
-            // temporal keybinding with multiple events
-            keybindings.add_binding(
-                KeyModifiers::SHIFT,
-                KeyCode::BackTab,
-                ReedlineEvent::Multiple(vec![
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar('p')]),
-                    ReedlineEvent::Enter,
-                ]),
-            );
 
             for parsed_keybinding in parsed_keybindings {
                 if parsed_keybinding.mode.into_string("", config).as_str() == "emacs" {
@@ -186,14 +143,13 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
                 }
             }
 
+            println!("test");
+
             Ok(KeybindingsMode::Emacs(keybindings))
         }
         _ => {
             let mut insert_keybindings = default_vi_insert_keybindings();
             let mut normal_keybindings = default_vi_normal_keybindings();
-
-            add_menu_keybindings(&mut insert_keybindings);
-            add_menu_keybindings(&mut normal_keybindings);
 
             for parsed_keybinding in parsed_keybindings {
                 if parsed_keybinding.mode.into_string("", config).as_str() == "vi_insert" {

--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -143,8 +143,6 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
                 }
             }
 
-            println!("test");
-
             Ok(KeybindingsMode::Emacs(keybindings))
         }
         _ => {


### PR DESCRIPTION
# Description
Menu keybindings are added in the default config file. 

Note: Without defining the menu events in your config file, the menus will not appear 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
