### PR TITLE
add LAST_EXIT_CODE variable

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -86,11 +86,19 @@ pub(crate) fn evaluate(
     let exceptions = crate::utils::external_exceptions(engine_state, &stack);
     engine_state.external_exceptions = exceptions;
 
-    // seed the cmd_duration_ms env var
+    // seed env vars
     stack.add_env_var(
         "CMD_DURATION_MS".into(),
         Value::String {
             val: "0823".to_string(),
+            span: Span { start: 0, end: 0 },
+        },
+    );
+
+    stack.add_env_var(
+        "LAST_EXIT_CODE".into(),
+        Value::Int {
+            val: 0,
             span: Span { start: 0, end: 0 },
         },
     );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -227,7 +227,13 @@ pub(crate) fn eval_source(
     }
 
     match eval_block(engine_state, stack, &block, input, false, false) {
-        Ok(pipeline_data) => {
+        Ok(mut pipeline_data) => {
+            if let PipelineData::ExternalStream { exit_code, .. } = &mut pipeline_data {
+                if let Some(exit_code) = exit_code.take().and_then(|it| it.last()) {
+                    stack.add_env_var("LAST_EXIT_CODE".to_string(), exit_code);
+                }
+            }
+
             if let Err(err) = print_pipeline_data(pipeline_data, engine_state, stack) {
                 let working_set = StateWorkingSet::new(engine_state);
 


### PR DESCRIPTION
# Description

This PR adds an environment variable called LAST_EXIT_CODE that will be set by nu after every command that the user has executed manually.

This implements a part of the behaviour I requested in #4648. It doesn't include a variable for the prompt mode, as this seems to require changes in reedline.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
    - This one fails, but not because of my code.
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
