### PR TITLE
Update reedline, revert crossterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,15 +611,15 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.23.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b75a27dc8d220f1f8521ea69cd55a34d720a200ebb3a624d9aa19193d3b432"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.0",
+ "parking_lot",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -996,7 +996,7 @@ checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.30.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1832,7 +1832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e9323b3525d4efad2dead1837a105e313253bfdbad1d470994038eededa4d62"
 dependencies = [
  "ansi_term",
- "crossterm",
 ]
 
 [[package]]
@@ -2674,17 +2673,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2699,19 +2688,6 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.2.10",
- "smallvec",
- "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -3338,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#65cfd6bcbd117049a048fdaf6d125880195cd184"
+source = "git+https://github.com/nushell/reedline?branch=main#e314e8491e2e69718af753536deb970884cb2f9b"
 dependencies = [
  "chrono",
  "crossterm",
@@ -3738,7 +3714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot 0.11.2",
+ "parking_lot",
  "serial_test_derive",
 ]
 
@@ -3934,7 +3910,7 @@ checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot 0.11.2",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -4674,24 +4650,11 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
 dependencies = [
- "windows_aarch64_msvc 0.30.0",
- "windows_i686_gnu 0.30.0",
- "windows_i686_msvc 0.30.0",
- "windows_x86_64_gnu 0.30.0",
- "windows_x86_64_msvc 0.30.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
-dependencies = [
- "windows_aarch64_msvc 0.32.0",
- "windows_i686_gnu 0.32.0",
- "windows_i686_msvc 0.32.0",
- "windows_x86_64_gnu 0.32.0",
- "windows_x86_64_msvc 0.32.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4699,12 +4662,6 @@ name = "windows_aarch64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_gen"
@@ -4722,22 +4679,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_macros"
@@ -4756,22 +4701,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [dependencies]
 chrono = "0.4.19"
-crossterm = "0.23"
+crossterm = "0.22.1"
 crossterm_winapi = "0.9.0"
 ctrlc = "3.2.1"
 # lazy_static = "1.4.0"

--- a/crates/nu-cli/src/nu_highlight.rs
+++ b/crates/nu-cli/src/nu_highlight.rs
@@ -40,7 +40,7 @@ impl Command for NuHighlight {
         input.map(
             move |x| match x.as_string() {
                 Ok(line) => {
-                    let highlights = highlighter.highlight(&line);
+                    let highlights = highlighter.highlight(&line, line.len());
 
                     Value::String {
                         val: highlights.render_simple(),

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -12,7 +12,7 @@ pub struct NuHighlighter {
 }
 
 impl Highlighter for NuHighlighter {
-    fn highlight(&self, line: &str) -> StyledText {
+    fn highlight(&self, line: &str, _cursor: usize) -> StyledText {
         trace!("highlighting: {}", line);
 
         let (shapes, global_span_offset) = {

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -30,7 +30,7 @@ calamine = "0.18.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 chrono-humanize = "0.2.1"
 chrono-tz = "0.6.0"
-crossterm = "0.23"
+crossterm = "0.22.1"
 csv = "1.1.3"
 dialoguer = "0.9.0"
 digest = "0.10.0"
@@ -47,7 +47,7 @@ Inflector = "0.11"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 log = "0.4.14"
-lscolors = { version = "0.9.0", features = ["crossterm"] }
+lscolors = { version = "0.9.0"}
 md5 = { package = "md-5", version = "0.10.0" }
 meval = "0.2.0"
 mime = "0.3.16"

--- a/crates/nu-command/src/viewers/lscolor_ansiterm.rs
+++ b/crates/nu-command/src/viewers/lscolor_ansiterm.rs
@@ -1,0 +1,60 @@
+//! Hotpatch to use lscolors without depending on the unmaintained `ansi-term` crate or crossterm
+
+pub trait ToNuAnsiStyle {
+    fn to_nu_ansi_style(&self) -> nu_ansi_term::Style;
+}
+
+pub trait ToNuAnsiColor {
+    fn to_nu_ansi_color(&self) -> nu_ansi_term::Color;
+}
+
+impl ToNuAnsiStyle for lscolors::Style {
+    fn to_nu_ansi_style(&self) -> nu_ansi_term::Style {
+        nu_ansi_term::Style {
+            foreground: self
+                .foreground
+                .as_ref()
+                .map(ToNuAnsiColor::to_nu_ansi_color),
+            background: self
+                .background
+                .as_ref()
+                .map(ToNuAnsiColor::to_nu_ansi_color),
+            is_bold: self.font_style.bold,
+            is_dimmed: self.font_style.dimmed,
+            is_italic: self.font_style.italic,
+            is_underline: self.font_style.underline,
+            is_blink: self.font_style.rapid_blink || self.font_style.slow_blink,
+            is_reverse: self.font_style.reverse,
+            is_hidden: self.font_style.hidden,
+            is_strikethrough: self.font_style.strikethrough,
+        }
+    }
+}
+
+impl ToNuAnsiColor for lscolors::Color {
+    fn to_nu_ansi_color(&self) -> nu_ansi_term::Color {
+        match self {
+            lscolors::Color::RGB(r, g, b) => nu_ansi_term::Color::Rgb(*r, *g, *b),
+            lscolors::Color::Fixed(n) => nu_ansi_term::Color::Fixed(*n),
+            lscolors::Color::Black => nu_ansi_term::Color::Black,
+            lscolors::Color::Red => nu_ansi_term::Color::Red,
+            lscolors::Color::Green => nu_ansi_term::Color::Green,
+            lscolors::Color::Yellow => nu_ansi_term::Color::Yellow,
+            lscolors::Color::Blue => nu_ansi_term::Color::Blue,
+            lscolors::Color::Magenta => nu_ansi_term::Color::Purple,
+            lscolors::Color::Cyan => nu_ansi_term::Color::Cyan,
+            lscolors::Color::White => nu_ansi_term::Color::White,
+
+            // Below items are a rough translations to 256 colors as
+            // we do not have bright varients available on ansi-term
+            lscolors::Color::BrightBlack => nu_ansi_term::Color::Fixed(8),
+            lscolors::Color::BrightRed => nu_ansi_term::Color::Fixed(9),
+            lscolors::Color::BrightGreen => nu_ansi_term::Color::Fixed(10),
+            lscolors::Color::BrightYellow => nu_ansi_term::Color::Fixed(11),
+            lscolors::Color::BrightBlue => nu_ansi_term::Color::Fixed(12),
+            lscolors::Color::BrightMagenta => nu_ansi_term::Color::Fixed(13),
+            lscolors::Color::BrightCyan => nu_ansi_term::Color::Fixed(14),
+            lscolors::Color::BrightWhite => nu_ansi_term::Color::Fixed(15),
+        }
+    }
+}

--- a/crates/nu-command/src/viewers/mod.rs
+++ b/crates/nu-command/src/viewers/mod.rs
@@ -1,5 +1,6 @@
 mod griddle;
 mod icons;
+mod lscolor_ansiterm;
 mod table;
 
 pub use griddle::Griddle;

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1,4 +1,4 @@
-use lscolors::{LsColors, Style};
+use lscolors::LsColors;
 use nu_color_config::{get_color_config, style_primitive};
 use nu_engine::column::get_columns;
 use nu_engine::{env_to_string, CallExt};
@@ -13,6 +13,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use terminal_size::{Height, Width};
+
+use super::lscolor_ansiterm::ToNuAnsiStyle;
 
 const STREAM_PAGE_SIZE: usize = 1000;
 const STREAM_TIMEOUT_CHECK_INTERVAL: usize = 100;
@@ -215,13 +217,13 @@ fn handle_row_stream(
                                                 Some(&metadata),
                                             );
                                             let ansi_style = style
-                                                .map(Style::to_crossterm_style)
+                                                .map(ToNuAnsiStyle::to_nu_ansi_style)
                                                 .unwrap_or_default();
                                             let use_ls_colors = config.use_ls_colors;
 
                                             if use_ls_colors {
                                                 vals[idx] = Value::String {
-                                                    val: ansi_style.apply(path).to_string(),
+                                                    val: ansi_style.paint(path).to_string(),
                                                     span: *span,
                                                 };
                                             }
@@ -229,13 +231,13 @@ fn handle_row_stream(
                                         Err(_) => {
                                             let style = ls_colors.style_for_path(path.clone());
                                             let ansi_style = style
-                                                .map(Style::to_crossterm_style)
+                                                .map(ToNuAnsiStyle::to_nu_ansi_style)
                                                 .unwrap_or_default();
                                             let use_ls_colors = config.use_ls_colors;
 
                                             if use_ls_colors {
                                                 vals[idx] = Value::String {
-                                                    val: ansi_style.apply(path).to_string(),
+                                                    val: ansi_style.paint(path).to_string(),
                                                     span: *span,
                                                 };
                                             }


### PR DESCRIPTION
At the moment `crossterm` apparently has a regression decoding certain important key combinations on Windows. (crossterm-rs/crossterm#636, fix proposed by crossterm-rs/crossterm#629)
Thus reedline reverted to the previous version.

Some changes are necessary to remove the need for `crossterm` in the use of `lscolors`.
Introduces two local conversion traits.

Additionally update the `Highlighter` API to support the cursor
position.
This will enable brace/statement match highlighting.


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
