### PR TITLE
Date parse refactor

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -277,7 +277,7 @@ fn action(
                         span: head,
                     },
                     Err(err) => err,
-                }
+                },
             };
 
             out

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone, Utc};
+use chrono::{DateTime, FixedOffset, Local, TimeZone, Utc};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::ast::CellPath;
@@ -206,7 +206,7 @@ fn action(
     head: Span,
 ) -> Value {
     match input {
-        Value::String { val: s, span, .. } => {
+        Value::String { val: s, span } => {
             let ts = s.parse::<i64>();
             // if timezone if specified, first check if the input is a timestamp.
             if let Some(tz) = timezone {
@@ -271,10 +271,10 @@ fn action(
                 // Tries to automatically parse the date
                 // (i.e. without a format string)
                 // and assumes the system's local timezone if none is specified
-                None => match parse_date_from_string(s, head) {
+                None => match parse_date_from_string(s, *span) {
                     Ok(date) => Value::Date {
                         val: date,
-                        span: head,
+                        span: *span,
                     },
                     Err(err) => err,
                 },

--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -3,10 +3,10 @@ use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
 };
 
-use super::utils::{parse_date_from_string, unsupported_input_error};
+use super::utils::parse_date_from_string;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -112,7 +112,9 @@ fn format_helper(value: Value, formatter: &str, span: Span) -> Value {
                 span,
             }
         }
-        _ => unsupported_input_error(span),
+        _ => Value::Error {
+            error: ShellError::DatetimeParseError(span),
+        },
     }
 }
 
@@ -142,7 +144,9 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
                 span,
             }
         }
-        _ => unsupported_input_error(span),
+        _ => Value::Error {
+            error: ShellError::DatetimeParseError(span),
+        },
     }
 }
 

--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -96,7 +96,7 @@ fn format_helper(value: Value, formatter: &str, span: Span) -> Value {
             val,
             span: val_span,
         } => {
-            let dt = parse_date_from_string(val, val_span);
+            let dt = parse_date_from_string(&val, val_span);
             match dt {
                 Ok(x) => Value::String {
                     val: x.format(formatter).to_string(),
@@ -126,7 +126,7 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
             val,
             span: val_span,
         } => {
-            let dt = parse_date_from_string(val, val_span);
+            let dt = parse_date_from_string(&val, val_span);
             match dt {
                 Ok(x) => Value::String {
                     val: x.to_rfc2822(),

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -77,10 +77,7 @@ fn helper(value: Value, head: Span) -> Value {
             span: head,
         },
         _ => Value::Error {
-            error: ShellError::UnsupportedInput(
-                String::from("Date cannot be parsed / date format is not supported"),
-                head,
-            ),
+            error: ShellError::DatetimeParseError(head),
         },
     }
 }

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -63,7 +63,7 @@ fn helper(value: Value, head: Span) -> Value {
             val,
             span: val_span,
         } => {
-            let dt = parse_date_from_string(val, val_span);
+            let dt = parse_date_from_string(&val, val_span);
             match dt {
                 Ok(x) => Value::String {
                     val: humanize_date(x),

--- a/crates/nu-command/src/date/mod.rs
+++ b/crates/nu-command/src/date/mod.rs
@@ -10,10 +10,10 @@ mod utils;
 
 pub use date_::Date;
 pub(crate) use format::generate_strftime_list;
-pub(crate) use utils::parse_date_from_string;
 pub use format::SubCommand as DateFormat;
 pub use humanize::SubCommand as DateHumanize;
 pub use list_timezone::SubCommand as DateListTimezones;
 pub use now::SubCommand as DateNow;
 pub use to_table::SubCommand as DateToTable;
 pub use to_timezone::SubCommand as DateToTimezone;
+pub(crate) use utils::parse_date_from_string;

--- a/crates/nu-command/src/date/mod.rs
+++ b/crates/nu-command/src/date/mod.rs
@@ -10,6 +10,7 @@ mod utils;
 
 pub use date_::Date;
 pub(crate) use format::generate_strftime_list;
+pub(crate) use utils::parse_date_from_string;
 pub use format::SubCommand as DateFormat;
 pub use humanize::SubCommand as DateHumanize;
 pub use list_timezone::SubCommand as DateListTimezones;

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -140,7 +140,7 @@ fn helper(val: Value, head: Span) -> Value {
             val,
             span: val_span,
         } => {
-            let date = parse_date_from_string(val, val_span);
+            let date = parse_date_from_string(&val, val_span);
             parse_date_into_table(date, head)
         }
         Value::Nothing { span: _ } => {

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -1,8 +1,10 @@
-use crate::date::utils::{parse_date_from_string, unsupported_input_error};
+use crate::date::utils::parse_date_from_string;
 use chrono::{DateTime, Datelike, FixedOffset, Local, Timelike};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, Signature, Span, Value};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError::DatetimeParseError, Signature, Span, Value,
+};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -149,7 +151,9 @@ fn helper(val: Value, head: Span) -> Value {
             parse_date_into_table(Ok(n), head)
         }
         Value::Date { val, span: _ } => parse_date_into_table(Ok(val), head),
-        _ => unsupported_input_error(head),
+        _ => Value::Error {
+            error: DatetimeParseError(head),
+        },
     }
 }
 

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -93,7 +93,7 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             val,
             span: val_span,
         } => {
-            let time = parse_date_from_string(val, val_span);
+            let time = parse_date_from_string(&val, val_span);
             match time {
                 Ok(dt) => _to_timezone(dt, timezone, head),
                 Err(e) => e,

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -1,5 +1,5 @@
 use super::parser::datetime_in_timezone;
-use crate::date::utils::{parse_date_from_string, unsupported_input_error};
+use crate::date::utils::parse_date_from_string;
 use chrono::{DateTime, Local};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -104,7 +104,9 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             let dt = Local::now();
             _to_timezone(dt.with_timezone(dt.offset()), timezone, head)
         }
-        _ => unsupported_input_error(head),
+        _ => Value::Error {
+            error: ShellError::DatetimeParseError(head),
+        },
     }
 }
 

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -5,11 +5,7 @@ pub fn unsupported_input_error(span: Span) -> Value {
     Value::Error {
         error: ShellError::UnsupportedInput(
             String::from(
-                "Only dates with timezones are supported. The following formats are allowed \n
-            * %Y-%m-%d %H:%M:%S %z -- 2020-04-12 22:10:57 +02:00 \n
-            * %Y-%m-%d %H:%M:%S%.6f %z -- 2020-04-12 22:10:57.213231 +02:00 \n
-            * rfc3339 -- 2020-04-12T22:10:57+02:00 \n
-            * rfc2822 -- Tue, 1 Jul 2003 10:52:37 +0200",
+                "Unable to parse into datetime.",
             ),
             span,
         ),
@@ -41,7 +37,7 @@ pub(crate) fn parse_date_from_string(input: &str, span: Span) -> Result<DateTime
         Err(_) => {
             Err(Value::Error {
                 error: ShellError::UnsupportedInput(
-                    "Cannot convert input string as datetime. Might be missing timezone or offset".to_string(),
+                    "Cannot parse input string as datetime. Might be be using unsupported timezone or offset.".to_string(),
                     span,
                 ),
             })

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -3,16 +3,14 @@ use nu_protocol::{ShellError, Span, Value};
 
 pub fn unsupported_input_error(span: Span) -> Value {
     Value::Error {
-        error: ShellError::UnsupportedInput(
-            String::from(
-                "Unable to parse into datetime.",
-            ),
-            span,
-        ),
+        error: ShellError::UnsupportedInput(String::from("Unable to parse into datetime."), span),
     }
 }
 
-pub(crate) fn parse_date_from_string(input: &str, span: Span) -> Result<DateTime<FixedOffset>, Value> {
+pub(crate) fn parse_date_from_string(
+    input: &str,
+    span: Span,
+) -> Result<DateTime<FixedOffset>, Value> {
     match dtparse::parse(input) {
         Ok((native_dt, fixed_offset)) => {
             let offset = match fixed_offset {

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -1,12 +1,6 @@
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone};
 use nu_protocol::{ShellError, Span, Value};
 
-pub fn unsupported_input_error(span: Span) -> Value {
-    Value::Error {
-        error: ShellError::UnsupportedInput(String::from("Unable to parse into datetime."), span),
-    }
-}
-
 pub(crate) fn parse_date_from_string(
     input: &str,
     span: Span,
@@ -20,25 +14,13 @@ pub(crate) fn parse_date_from_string(
             match offset.from_local_datetime(&native_dt) {
                 LocalResult::Single(d) => Ok(d),
                 LocalResult::Ambiguous(d, _) => Ok(d),
-                LocalResult::None => {
-                    Err(Value::Error {
-                        error: ShellError::CantConvert(
-                            "could not convert to a timezone-aware datetime"
-                                .to_string(),
-                            "local time representation is invalid".to_string(),
-                            span,
-                        )
-                    })
-                }
+                LocalResult::None => Err(Value::Error {
+                    error: ShellError::DatetimeParseError(span),
+                }),
             }
         }
-        Err(_) => {
-            Err(Value::Error {
-                error: ShellError::UnsupportedInput(
-                    "Cannot parse input string as datetime. Might be be using unsupported timezone or offset.".to_string(),
-                    span,
-                ),
-            })
-        }
+        Err(_) => Err(Value::Error {
+            error: ShellError::DatetimeParseError(span),
+        }),
     }
 }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -154,6 +154,22 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::unsupported_input), url(docsrs))]
     UnsupportedInput(String, #[label("{0} not supported")] Span),
 
+    #[error("Unable to parse datetime")]
+    #[diagnostic(
+        code(nu::shell::datetime_parse_error),
+        url(docsrs),
+        help(
+            r#"Examples of supported inputs:
+ * "5 pm"
+ * "2020/12/4"
+ * "2020.12.04 22:10 +2"
+ * "2020-04-12 22:10:57 +02:00"
+ * "2020-04-12T22:10:57.213231+02:00"
+ * "Tue, 1 Jul 2003 10:52:37 +0200""#
+        )
+    )]
+    DatetimeParseError(#[label("datetime parsing failed")] Span),
+
     #[error("Network failure")]
     #[diagnostic(code(nu::shell::network_failure), url(docsrs))]
     NetworkFailure(String, #[label("{0}")] Span),


### PR DESCRIPTION
# Description

* Refactors datetime parsing to be more consistent and DRY. Now, both `"5pm" | into datetime | date format` and `"5pm" | date format` will have the same output.

* This means commands like `date format` and `date humanize` now can parse more formats (and I checked to make sure this caused no regressions -- i.e., the formats that were supported before this PR are still supported).

* When a timezone is omitted, the new behavior is to use the system's current time zone. The old behavior of assuming UTC+00:00 can still be achieved, e.g. by ending the string with `z`, `+0`, `UTC`, etc.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
