### PR TITLE
add last exit code to starship parameters

### DIFF
--- a/docs/3rd_Party_Prompts.md
+++ b/docs/3rd_Party_Prompts.md
@@ -34,7 +34,7 @@ let-env PROMPT_COMMAND = { oh-my-posh --config ~/.poshthemes/M365Princess.omp.js
 2. Install nerdfonts depending on your preferences.
 3. If you want the default ticking clock with date & time on the right prompt execut this command `hide PROMPT_COMMAND_RIGHT`
 4. If you don't want the default indicator, you can run this command `let-env PROMPT_INDICATOR = " "`
-5. Set starship as your left prompt with this command `let-env PROMPT_COMMAND = { starship prompt --cmd-duration $env.CMD_DURATION_MS | str trim }`. Note that you may not have to use `str trim` in the nushell prompt if you disable starship's default newline setting with this entry in the starship.toml file `add_newline = false`. There have been reports that this might not play nice with nushell prompts. We're still testing.
+5. Set starship as your left prompt with this command `let-env PROMPT_COMMAND = { starship prompt --cmd-duration $env.CMD_DURATION_MS --status $env.LAST_EXIT_CODE | str trim }`. Note that you may not have to use `str trim` in the nushell prompt if you disable starship's default newline setting with this entry in the starship.toml file `add_newline = false`. There have been reports that this might not play nice with nushell prompts. We're still testing.
 6. Since nushell supports a right prompt you can also play around with starship's ability to set a right prompt. Setting the right prompt in nushell is identical to setting the left prompt however you use `PROMPT_COMMAND_RIGHT`.
 
 ## Purs


### PR DESCRIPTION
# Description

add `$env.LAST_EXIT_CODE` to documentation for starship.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
