### PR TITLE
don't use table compaction in to nuon if not a table

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -65,7 +65,7 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
         Value::Int { val, .. } => Ok(format!("{}", *val)),
         Value::List { vals, .. } => {
             let headers = get_columns(vals);
-            if vals.iter().all(|x| x.columns() == headers) {
+            if !headers.is_empty() && vals.iter().all(|x| x.columns() == headers) {
                 // Table output
                 let headers_output = headers.join(", ");
 

--- a/crates/nu-command/tests/format_conversions/mod.rs
+++ b/crates/nu-command/tests/format_conversions/mod.rs
@@ -5,6 +5,7 @@ mod html;
 mod ics;
 mod json;
 mod markdown;
+mod nuon;
 mod ods;
 mod sqlite;
 mod ssv;

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -14,3 +14,91 @@ fn to_nuon_correct_compaction() {
 
     assert_eq!(actual.out, "true");
 }
+
+#[test]
+fn to_nuon_list_of_numbers() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [1, 2, 3, 4]
+            | to nuon
+            | from nuon
+            | $in == [1, 2, 3, 4]
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn to_nuon_list_of_strings() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [abc, xyz, def]
+            | to nuon
+            | from nuon
+            | $in == [abc, xyz, def]
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn to_nuon_table() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [[my, columns]; [abc, xyz], [def, ijk]]
+            | to nuon
+            | from nuon
+            | $in == [[my, columns]; [abc, xyz], [def, ijk]]
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn to_nuon_bool() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            $false
+            | to nuon
+            | from nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "false");
+}
+
+#[test]
+fn to_nuon_negative_int() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            -1
+            | to nuon
+            | from nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "-1");
+}
+
+#[test]
+fn to_nuon_records() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            {name: "foo bar", age: 100, height: 10}
+            | to nuon
+            | from nuon
+            | $in == {name: "foo bar", age: 100, height: 10}
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -1,0 +1,16 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn to_nuon_correct_compaction() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open appveyor.yml 
+            | to nuon 
+            | str length 
+            | $in > 500
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}

--- a/src/tests/test_converters.rs
+++ b/src/tests/test_converters.rs
@@ -45,11 +45,3 @@ fn to_json_escaped() -> TestResult {
         r#"{"foo":{"bar": "[{\"a\":\"b\",\"c\": 2}]"}}"#,
     )
 }
-
-#[test]
-fn to_nuon_correct_compaction() -> TestResult {
-    run_test(
-        r#"open ./tests/fixtures/formats/appveyor.yml | to nuon | str length | $in > 500"#,
-        "true",
-    )
-}

--- a/src/tests/test_converters.rs
+++ b/src/tests/test_converters.rs
@@ -45,3 +45,11 @@ fn to_json_escaped() -> TestResult {
         r#"{"foo":{"bar": "[{\"a\":\"b\",\"c\": 2}]"}}"#,
     )
 }
+
+#[test]
+fn to_nuon_correct_compaction() -> TestResult {
+    run_test(
+        r#"open ./tests/fixtures/formats/appveyor.yml | to nuon | str length | $in > 500"#,
+        "true",
+    )
+}


### PR DESCRIPTION
# Description

Ooops, was accidentally using the more compact table mode in `to nuon` when we just had a list of values. Now, we check to make sure it's a table before we switch to table mode.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
