### PR TITLE
Fix unsupported type message for some math related commands

### DIFF
--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -75,7 +75,10 @@ impl Command for LoadEnv {
                     }
                     Ok(PipelineData::new(call.head))
                 }
-                _ => Err(ShellError::UnsupportedInput("Record not supported".into(), span)),
+                _ => Err(ShellError::UnsupportedInput(
+                    "Record not supported".into(),
+                    span,
+                )),
             },
         }
     }

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -75,7 +75,7 @@ impl Command for LoadEnv {
                     }
                     Ok(PipelineData::new(call.head))
                 }
-                _ => Err(ShellError::UnsupportedInput("Record".into(), span)),
+                _ => Err(ShellError::UnsupportedInput("Record not supported".into(), span)),
             },
         }
     }

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -95,7 +95,10 @@ impl Command for Save {
 
                     Ok(PipelineData::new(span))
                 }
-                v => Err(ShellError::UnsupportedInput(format!("{:?} not supported", v.get_type()), span)),
+                v => Err(ShellError::UnsupportedInput(
+                    format!("{:?} not supported", v.get_type()),
+                    span,
+                )),
             }
         } else {
             match input.into_value(span) {
@@ -113,7 +116,10 @@ impl Command for Save {
 
                     Ok(PipelineData::new(span))
                 }
-                v => Err(ShellError::UnsupportedInput(format!("{:?} not supported", v.get_type()), span)),
+                v => Err(ShellError::UnsupportedInput(
+                    format!("{:?} not supported", v.get_type()),
+                    span,
+                )),
             }
         }
     }

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -95,7 +95,7 @@ impl Command for Save {
 
                     Ok(PipelineData::new(span))
                 }
-                v => Err(ShellError::UnsupportedInput(v.get_type().to_string(), span)),
+                v => Err(ShellError::UnsupportedInput(format!("{:?} not supported", v.get_type()), span)),
             }
         } else {
             match input.into_value(span) {
@@ -113,7 +113,7 @@ impl Command for Save {
 
                     Ok(PipelineData::new(span))
                 }
-                v => Err(ShellError::UnsupportedInput(v.get_type().to_string(), span)),
+                v => Err(ShellError::UnsupportedInput(format!("{:?} not supported", v.get_type()), span)),
             }
         }
     }

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -46,8 +46,14 @@ impl Command for ToNuon {
 
 fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
     match v {
-        Value::Binary { .. } => Err(ShellError::UnsupportedInput("binary not supported".into(), span)),
-        Value::Block { .. } => Err(ShellError::UnsupportedInput("block not supported".into(), span)),
+        Value::Binary { .. } => Err(ShellError::UnsupportedInput(
+            "binary not supported".into(),
+            span,
+        )),
+        Value::Block { .. } => Err(ShellError::UnsupportedInput(
+            "block not supported".into(),
+            span,
+        )),
         Value::Bool { val, .. } => {
             if *val {
                 Ok("$true".to_string())
@@ -55,11 +61,20 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
                 Ok("$false".to_string())
             }
         }
-        Value::CellPath { .. } => Err(ShellError::UnsupportedInput("cellpath not supported".to_string(), span)),
-        Value::CustomValue { .. } => Err(ShellError::UnsupportedInput("custom not supported".to_string(), span)),
+        Value::CellPath { .. } => Err(ShellError::UnsupportedInput(
+            "cellpath not supported".to_string(),
+            span,
+        )),
+        Value::CustomValue { .. } => Err(ShellError::UnsupportedInput(
+            "custom not supported".to_string(),
+            span,
+        )),
         Value::Date { val, .. } => Ok(val.to_rfc3339()),
         Value::Duration { val, .. } => Ok(format!("{}ns", *val)),
-        Value::Error { .. } => Err(ShellError::UnsupportedInput("error not supported".to_string(), span)),
+        Value::Error { .. } => Err(ShellError::UnsupportedInput(
+            "error not supported".to_string(),
+            span,
+        )),
         Value::Filesize { val, .. } => Ok(format!("{}b", *val)),
         Value::Float { val, .. } => Ok(format!("{}", *val)),
         Value::Int { val, .. } => Ok(format!("{}", *val)),

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -46,8 +46,8 @@ impl Command for ToNuon {
 
 fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
     match v {
-        Value::Binary { .. } => Err(ShellError::UnsupportedInput("binary".into(), span)),
-        Value::Block { .. } => Err(ShellError::UnsupportedInput("block".into(), span)),
+        Value::Binary { .. } => Err(ShellError::UnsupportedInput("binary not supported".into(), span)),
+        Value::Block { .. } => Err(ShellError::UnsupportedInput("block not supported".into(), span)),
         Value::Bool { val, .. } => {
             if *val {
                 Ok("$true".to_string())
@@ -55,11 +55,11 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
                 Ok("$false".to_string())
             }
         }
-        Value::CellPath { .. } => Err(ShellError::UnsupportedInput("cellpath".to_string(), span)),
-        Value::CustomValue { .. } => Err(ShellError::UnsupportedInput("custom".to_string(), span)),
+        Value::CellPath { .. } => Err(ShellError::UnsupportedInput("cellpath not supported".to_string(), span)),
+        Value::CustomValue { .. } => Err(ShellError::UnsupportedInput("custom not supported".to_string(), span)),
         Value::Date { val, .. } => Ok(val.to_rfc3339()),
         Value::Duration { val, .. } => Ok(format!("{}ns", *val)),
-        Value::Error { .. } => Err(ShellError::UnsupportedInput("error".to_string(), span)),
+        Value::Error { .. } => Err(ShellError::UnsupportedInput("error not supported".to_string(), span)),
         Value::Filesize { val, .. } => Ok(format!("{}b", *val)),
         Value::Float { val, .. } => Ok(format!("{}", *val)),
         Value::Int { val, .. } => Ok(format!("{}", *val)),

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -62,9 +62,12 @@ fn abs_helper(val: Value, head: Span) -> Value {
             val: val.abs(),
             span,
         },
-        _ => Value::Error {
+        other => Value::Error {
             error: ShellError::UnsupportedInput(
-                String::from("Only numerical values are supported"),
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
                 head,
             ),
         },

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -53,7 +53,10 @@ fn operate(value: Value, head: Span) -> Value {
         },
         other => Value::Error {
             error: ShellError::UnsupportedInput(
-                String::from("Only numerical values are supported"),
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
                 other.span().unwrap_or(head),
             ),
         },

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -53,7 +53,10 @@ fn operate(value: Value, head: Span) -> Value {
         },
         other => Value::Error {
             error: ShellError::UnsupportedInput(
-                String::from("Only numerical values are supported"),
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
                 other.span().unwrap_or(head),
             ),
         },

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -94,7 +94,10 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
         Value::Int { .. } => value,
         other => Value::Error {
             error: ShellError::UnsupportedInput(
-                String::from("Only numerical values are supported"),
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
                 other.span().unwrap_or(head),
             ),
         },

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -62,7 +62,10 @@ fn operate(value: Value, head: Span) -> Value {
         }
         other => Value::Error {
             error: ShellError::UnsupportedInput(
-                String::from("Only numerical values are supported"),
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
                 other.span().unwrap_or(head),
             ),
         },

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -152,7 +152,7 @@ pub enum ShellError {
 
     #[error("Unsupported input")]
     #[diagnostic(code(nu::shell::unsupported_input), url(docsrs))]
-    UnsupportedInput(String, #[label("{0} not supported")] Span),
+    UnsupportedInput(String, #[label("{0}")] Span),
 
     #[error("Unable to parse datetime")]
     #[diagnostic(


### PR DESCRIPTION
# Description

Fix unsupported type message of some math related commands

Before:
```
$> '-2' | math abs
Error: nu::shell::unsupported_input (link)

  × Unsupported input
   ╭─[entry #6:1:1]
 1 │ '-2' | math abs
   ·        ────┬───
   ·            ╰── Only numerical values are supported not supported
   ╰────
```

After:

```
$> '-2' | math abs
Error: nu::shell::unsupported_input (link)

  × Unsupported input
   ╭─[entry #11:1:1]
 1 │ '-2' | math abs
   ·        ────┬───
   ·            ╰── Only numerical values are supported, input type: String not supported
   ╰────
```
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
