### PR TITLE
Add back in default keybindings

### DIFF
--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -227,7 +227,12 @@ let $config = {
       modifier: control
       keycode: char_z
       mode: emacs # emacs vi_normal vi_insert
-      event: { send: menupageprevious }
+      event: {
+        until: [
+          { send: menupageprevious }
+          { send: edit, cmd: undo }
+        ]
+      }
     }
   ]
 }

--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -403,6 +403,17 @@ fn event_from_record(
             let menu = extract_value("name", cols, vals, span)?;
             Ok(ReedlineEvent::Menu(menu.into_string("", config)))
         }
+        "edit" => {
+            let edit_command = parse_edit(
+                &Value::Record {
+                    cols: cols.to_vec(),
+                    vals: vals.to_vec(),
+                    span: *span,
+                },
+                config,
+            )?;
+            Ok(ReedlineEvent::Edit(vec![edit_command]))
+        }
         v => Err(ShellError::UnsupportedConfigValue(
             "Reedline event".to_string(),
             v.to_string(),

--- a/src/reedline_config.rs
+++ b/src/reedline_config.rs
@@ -123,6 +123,41 @@ pub(crate) fn add_history_menu(line_editor: Reedline, config: &Config) -> Reedli
     line_editor.with_menu(Box::new(history_menu))
 }
 
+fn add_menu_keybindings(keybindings: &mut Keybindings) {
+    keybindings.add_binding(
+        KeyModifiers::CONTROL,
+        KeyCode::Char('x'),
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("history_menu".to_string()),
+            ReedlineEvent::MenuPageNext,
+        ]),
+    );
+
+    keybindings.add_binding(
+        KeyModifiers::CONTROL,
+        KeyCode::Char('z'),
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::MenuPagePrevious,
+            ReedlineEvent::Edit(vec![EditCommand::Undo]),
+        ]),
+    );
+
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
+        ]),
+    );
+
+    keybindings.add_binding(
+        KeyModifiers::SHIFT,
+        KeyCode::BackTab,
+        ReedlineEvent::MenuPrevious,
+    );
+}
+
 pub enum KeybindingsMode {
     Emacs(Keybindings),
     Vi {
@@ -137,6 +172,8 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
         "emacs" => {
             let mut keybindings = default_emacs_keybindings();
 
+            add_menu_keybindings(&mut keybindings);
+
             for parsed_keybinding in parsed_keybindings {
                 if parsed_keybinding.mode.into_string("", config).as_str() == "emacs" {
                     add_keybinding(&mut keybindings, parsed_keybinding, config)?
@@ -148,6 +185,9 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
         _ => {
             let mut insert_keybindings = default_vi_insert_keybindings();
             let mut normal_keybindings = default_vi_normal_keybindings();
+
+            add_menu_keybindings(&mut insert_keybindings);
+            add_menu_keybindings(&mut normal_keybindings);
 
             for parsed_keybinding in parsed_keybindings {
                 if parsed_keybinding.mode.into_string("", config).as_str() == "vi_insert" {


### PR DESCRIPTION
# Description

This adds back in the default keybindings into the built-in settings, so that they match the defaults in default_config.nu

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
