### PR TITLE
Use default_config.nu by default

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -92,15 +92,24 @@ pub(crate) fn read_config_file(
                 .read_line(&mut answer)
                 .expect("Failed to read user input");
 
+            let config_file = include_str!("default_config.nu");
+
             match answer.to_lowercase().trim() {
                 "y" | "" => {
                     let mut output = File::create(&config_path).expect("Unable to create file");
-                    let config_file = include_str!("default_config.nu");
                     write!(output, "{}", config_file).expect("Unable to write to config file");
                     println!("Config file created at: {}", config_path.to_string_lossy());
                 }
                 _ => {
                     println!("Continuing without config file");
+                    // Just use the contents of "default_config.nu"
+                    eval_source(
+                        engine_state,
+                        stack,
+                        config_file.as_bytes(),
+                        "default_config.nu",
+                        PipelineData::new(Span::new(0, 0)),
+                    );
                     return;
                 }
             }


### PR DESCRIPTION
# Description

This sources `default_config.nu` if the user asks us not to create one. This lets us keep all the defaults in one place instead of spread between nushell and rust code.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
