### PR TITLE
Fix open ended ranges

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -138,6 +138,11 @@ impl Command for Table {
                 let base_pipeline = val.to_base_value(span)?.into_pipeline_data();
                 self.run(engine_state, stack, call, base_pipeline)
             }
+            PipelineData::Value(x @ Value::Range { .. }, ..) => Ok(Value::String {
+                val: x.into_string("", &config),
+                span: call.head,
+            }
+            .into_pipeline_data()),
             x => Ok(x),
         }
     }

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -37,12 +37,12 @@ impl Range {
         let to = if let Value::Nothing { .. } = to {
             if let Ok(Value::Bool { val: true, .. }) = next.lt(expr_span, &from) {
                 Value::Int {
-                    val: -100i64,
+                    val: i64::MIN,
                     span: expr_span,
                 }
             } else {
                 Value::Int {
-                    val: 100i64,
+                    val: i64::MAX,
                     span: expr_span,
                 }
             }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -272,3 +272,8 @@ fn shortcircuiting_and() -> TestResult {
 fn shortcircuiting_or() -> TestResult {
     run_test(r#"$true || (5 / 0; $false)"#, "true")
 }
+
+#[test]
+fn open_ended_range() -> TestResult {
+    run_test(r#"1.. | first 100000 | length"#, "100000")
+}


### PR DESCRIPTION
# Description

Fixes open ended ranges to be open ended rather than stopping at 100.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
