### PR TITLE
Add binary literals

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -55,6 +55,13 @@ impl Highlighter for NuHighlighter {
                     get_shape_color(shape.1.to_string(), &self.config),
                     next_token,
                 )),
+                FlatShape::Binary => {
+                    // nushell ?
+                    output.push((
+                        get_shape_color(shape.1.to_string(), &self.config),
+                        next_token,
+                    ))
+                }
                 FlatShape::Bool => {
                     // nushell ?
                     output.push((

--- a/crates/nu-color-config/src/shape_color.rs
+++ b/crates/nu-color-config/src/shape_color.rs
@@ -10,6 +10,7 @@ pub fn get_shape_color(shape: String, conf: &Config) -> Style {
         },
         None => match shape.as_ref() {
             "shape_garbage" => Style::new().fg(Color::White).on(Color::Red).bold(),
+            "shape_binary" => Style::new().fg(Color::Purple).bold(),
             "shape_bool" => Style::new().fg(Color::LightCyan),
             "shape_int" => Style::new().fg(Color::Purple).bold(),
             "shape_float" => Style::new().fg(Color::Purple).bold(),

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -201,6 +201,7 @@ fn convert_to_value(
             "blocks not supported in nuon".into(),
             expr.span,
         )),
+        Expr::Binary(val) => Ok(Value::Binary { val, span }),
         Expr::Bool(val) => Ok(Value::Bool { val, span }),
         Expr::Call(..) => Err(ShellError::OutsideSpannedLabeledError(
             original_text.to_string(),

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -102,3 +102,27 @@ fn to_nuon_records() {
 
     assert_eq!(actual.out, "true");
 }
+
+#[test]
+fn binary_to() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            0x[ab cd ef] | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "0x[ABCDEF]");
+}
+
+#[test]
+fn binary_roundtrip() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "0x[1f ff]" | from nuon | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "0x[1FFF]");
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -227,6 +227,10 @@ pub fn eval_expression(
             val: *f,
             span: expr.span,
         }),
+        Expr::Binary(b) => Ok(Value::Binary {
+            val: b.clone(),
+            span: expr.span,
+        }),
         Expr::ValueWithUnit(e, unit) => match eval_expression(engine_state, stack, e)? {
             Value::Int { val, .. } => Ok(compute(val, unit.item, unit.span)),
             x => Err(ShellError::CantConvert(

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -7,6 +7,7 @@ pub enum FlatShape {
     Garbage,
     Nothing,
     Bool,
+    Binary,
     Int,
     Float,
     Range,
@@ -35,6 +36,7 @@ impl Display for FlatShape {
         match self {
             FlatShape::Garbage => write!(f, "shape_garbage"),
             FlatShape::Nothing => write!(f, "shape_nothing"),
+            FlatShape::Binary => write!(f, "shape_binary"),
             FlatShape::Bool => write!(f, "shape_bool"),
             FlatShape::Int => write!(f, "shape_int"),
             FlatShape::Float => write!(f, "shape_float"),
@@ -188,6 +190,9 @@ pub fn flatten_expression(
         }
         Expr::DateTime(_) => {
             vec![(expr.span, FlatShape::DateTime)]
+        }
+        Expr::Binary(_) => {
+            vec![(expr.span, FlatShape::Binary)]
         }
         Expr::Int(_) => {
             vec![(expr.span, FlatShape::Int)]

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -8,6 +8,7 @@ pub enum Expr {
     Bool(bool),
     Int(i64),
     Float(f64),
+    Binary(Vec<u8>),
     Range(
         Option<Box<Expression>>, // from
         Option<Box<Expression>>, // next value after "from"

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -125,6 +125,7 @@ impl Expression {
                     false
                 }
             }
+            Expr::Binary(_) => false,
             Expr::Bool(_) => false,
             Expr::Call(call) => {
                 for positional in &call.positional {
@@ -290,6 +291,7 @@ impl Expression {
                     .map(|x| if *x != IN_VARIABLE_ID { *x } else { new_var_id })
                     .collect();
             }
+            Expr::Binary(_) => {}
             Expr::Bool(_) => {}
             Expr::Call(call) => {
                 for positional in &mut call.positional {
@@ -430,6 +432,7 @@ impl Expression {
 
                 *block_id = working_set.add_block(block);
             }
+            Expr::Binary(_) => {}
             Expr::Bool(_) => {}
             Expr::Call(call) => {
                 if replaced.contains_span(call.head) {

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -40,6 +40,9 @@ pub enum SyntaxShape {
     /// A module path pattern used for imports
     ImportPattern,
 
+    /// A binary literal
+    Binary,
+
     /// A block is allowed, eg `{start this thing}`
     Block(Option<Vec<SyntaxShape>>),
 
@@ -95,6 +98,7 @@ impl SyntaxShape {
         match self {
             SyntaxShape::Any => Type::Unknown,
             SyntaxShape::Block(_) => Type::Block,
+            SyntaxShape::Binary => Type::Binary,
             SyntaxShape::CellPath => Type::Unknown,
             SyntaxShape::Custom(custom, _) => custom.to_type(),
             SyntaxShape::DateTime => Type::Date,
@@ -144,6 +148,7 @@ impl Display for SyntaxShape {
             SyntaxShape::GlobPattern => write!(f, "glob"),
             SyntaxShape::ImportPattern => write!(f, "import"),
             SyntaxShape::Block(_) => write!(f, "block"),
+            SyntaxShape::Binary => write!(f, "binary"),
             SyntaxShape::Table => write!(f, "table"),
             SyntaxShape::List(x) => write!(f, "list<{}>", x),
             SyntaxShape::Record => write!(f, "record"),

--- a/docs/commands/complete.md
+++ b/docs/commands/complete.md
@@ -1,0 +1,18 @@
+---
+title: complete
+layout: command
+version: 0.59.0
+---
+
+Complete the external piped in, collecting outputs and exit code
+
+## Signature
+
+```> complete ```
+
+## Examples
+
+Run the external completion
+```shell
+> ^external arg1 | complete
+```

--- a/docs/commands/dfr_describe.md
+++ b/docs/commands/dfr_describe.md
@@ -8,7 +8,11 @@ Describes dataframes numeric columns
 
 ## Signature
 
-```> dfr describe ```
+```> dfr describe --quantiles```
+
+## Parameters
+
+ -  `--quantiles {table}`: optional quantiles for describe
 
 ## Examples
 

--- a/docs/commands/find.md
+++ b/docs/commands/find.md
@@ -8,12 +8,17 @@ Searches terms in the input or for elements of the input that satisfies the pred
 
 ## Signature
 
-```> find ...rest --predicate```
+```> find ...rest --predicate --regex --insensitive --multiline --dotall --invert```
 
 ## Parameters
 
  -  `...rest`: terms to search
  -  `--predicate {block}`: the predicate to satisfy
+ -  `--regex {string}`: regex to match with
+ -  `--insensitive`: case-insensitive search for regex (?i)
+ -  `--multiline`: multi-line mode: ^ and $ match begin/end of line for regex (?m)
+ -  `--dotall`: dotall mode: allow a dot . to match newline character \n for regex (?s)
+ -  `--invert`: invert the match
 
 ## Examples
 
@@ -37,12 +42,27 @@ Search a char in a list of string
 > [moe larry curly] | find l
 ```
 
-Find the first odd value
+Find odd values
 ```shell
-> echo [2 4 3 6 5 8] | find --predicate { |it| ($it mod 2) == 1 }
+> [2 4 3 6 5 8] | find --predicate { |it| ($it mod 2) == 1 }
 ```
 
 Find if a service is not running
 ```shell
-> echo [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | find -p { |it| $it.patch }
+> [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | find -p { |it| $it.patch }
+```
+
+Find using regex
+```shell
+> [abc bde arc abf] | find --regex "ab"
+```
+
+Find using regex case insensitive
+```shell
+> [aBc bde Arc abf] | find --regex "ab" -i
+```
+
+Find value in records
+```shell
+> [[version name]; [0.1.0 nushell] [0.1.1 fish] [0.2.0 zsh]] | find -r "nu"
 ```

--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -134,6 +134,7 @@ let default_theme = {
 
     # shapes are used to change the cli syntax highlighting
     shape_garbage: { fg: "#FFFFFF" bg: "#FF0000" attr: b}
+    shape_binary: purple_bold
     shape_bool: light_cyan
     shape_int: purple_bold
     shape_float: purple_bold


### PR DESCRIPTION
# Description

This adds binary literals to nushell, using the form `0x[ab cd]`. Spaces, commas and newlines are considered whitespace. It also adds corresponding support to nuon.

A few doc updates also needed to go out, so I snuck them into this.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
