### PR TITLE
document environment variable for starship prompt

### DIFF
--- a/docs/3rd_Party_Prompts.md
+++ b/docs/3rd_Party_Prompts.md
@@ -32,10 +32,11 @@ let-env PROMPT_COMMAND = { oh-my-posh --config ~/.poshthemes/M365Princess.omp.js
 
 1. Follow the links above and install starship.
 2. Install nerdfonts depending on your preferences.
-3. If you want the default ticking clock with date & time on the right prompt execut this command `hide PROMPT_COMMAND_RIGHT`
-4. If you don't want the default indicator, you can run this command `let-env PROMPT_INDICATOR = " "`
-5. Set starship as your left prompt with this command `let-env PROMPT_COMMAND = { starship prompt --cmd-duration $env.CMD_DURATION_MS --status $env.LAST_EXIT_CODE | str trim }`. Note that you may not have to use `str trim` in the nushell prompt if you disable starship's default newline setting with this entry in the starship.toml file `add_newline = false`. There have been reports that this might not play nice with nushell prompts. We're still testing.
-6. Since nushell supports a right prompt you can also play around with starship's ability to set a right prompt. Setting the right prompt in nushell is identical to setting the left prompt however you use `PROMPT_COMMAND_RIGHT`.
+3. Set the starship shell environment variable to `nu` by running this commend `let-env STARSHIP_SHELL = "nu"`
+4. If you want the default ticking clock with date & time on the right prompt execut this command `hide PROMPT_COMMAND_RIGHT`
+5. If you don't want the default indicator, you can run this command `let-env PROMPT_INDICATOR = " "`
+6. Set starship as your left prompt with this command `let-env PROMPT_COMMAND = { starship prompt --cmd-duration $env.CMD_DURATION_MS --status $env.LAST_EXIT_CODE | str trim }`. Note that you may not have to use `str trim` in the nushell prompt if you disable starship's default newline setting with this entry in the starship.toml file `add_newline = false`. There have been reports that this might not play nice with nushell prompts. We're still testing.
+7. Since nushell supports a right prompt you can also play around with starship's ability to set a right prompt. Setting the right prompt in nushell is identical to setting the left prompt however you use `PROMPT_COMMAND_RIGHT`.
 
 ## Purs
 


### PR DESCRIPTION
# Description

It would appear that starship needs an environment variable set to output the prompt correctly on a per shell basis.

Without setting `STARSHIP_SHELL` to `"nu"` you get unexpected prompt output. For example, left without the environment variable and right with it set to `"nu"`.
![image](https://user-images.githubusercontent.com/1534676/156263287-525e892b-ca17-4025-9d83-01d4de5c5c3a.png)

This is what starship's own `starship init nu` command does: https://github.com/starship/starship/blob/aabc786dab868d8330c463220c8c70c3a817a825/src/init/starship.nu

It would appear that starship might need to update its owns docs and scripts for working with nu.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] ~`cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)~
- [ ] ~`cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style~
- [ ] ~`cargo build; cargo test --all --all-features` to check that all the tests pass~
