### PR TITLE
Pass redirects into call

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -133,7 +133,14 @@ fn eval_call(
             }
         }
 
-        let result = eval_block(engine_state, &mut callee_stack, block, input, call.redirect_stdout, call.redirect_stderr);
+        let result = eval_block(
+            engine_state,
+            &mut callee_stack,
+            block,
+            input,
+            call.redirect_stdout,
+            call.redirect_stderr,
+        );
 
         if block.redirect_env {
             let caller_env_vars = caller_stack.get_env_var_names(engine_state);

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -133,7 +133,7 @@ fn eval_call(
             }
         }
 
-        let result = eval_block(engine_state, &mut callee_stack, block, input, false, true);
+        let result = eval_block(engine_state, &mut callee_stack, block, input, call.redirect_stdout, call.redirect_stderr);
 
         if block.redirect_env {
             let caller_env_vars = caller_stack.get_env_var_names(engine_state);


### PR DESCRIPTION
# Description

Fix issue where `eval_call` doesn't pass its redirects down into the block it's running.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
