### PR TITLE
Experiment: Change true/false to keywords

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -70,9 +70,7 @@ impl NuCompleter {
     ) -> Vec<(reedline::Span, String)> {
         let mut output = vec![];
 
-        let builtins = [
-            "$nu", "$scope", "$in", "$config", "$env", "$true", "$false", "$nothing",
-        ];
+        let builtins = ["$nu", "$scope", "$in", "$config", "$env", "$nothing"];
 
         for builtin in builtins {
             if builtin.as_bytes().starts_with(prefix) {

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -61,7 +61,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "convert a boolean to a nushell binary primitive",
-                example: "$true | into binary",
+                example: "true | into binary",
                 result: Some(Value::Binary {
                     val: i64::from(1).to_le_bytes().to_vec(),
                     span: Span::test_data(),

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -42,7 +42,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Convert value to boolean in table",
-                example: "echo [[value]; ['false'] ['1'] [0] [1.0] [$true]] | into bool value",
+                example: "echo [[value]; ['false'] ['1'] [0] [1.0] [true]] | into bool value",
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {
@@ -76,7 +76,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert bool to boolean",
-                example: "$true | into bool",
+                example: "true | into bool",
                 result: Some(Value::boolean(true, span)),
             },
             Example {

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -75,7 +75,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert bool to integer",
-                example: "[$false, $true] | into int",
+                example: "[false, true] | into int",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(0), Value::test_int(1)],
                     span: Span::test_data(),

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -103,7 +103,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "convert boolean to string",
-                example: "$true | into string",
+                example: "true | into string",
                 result: Some(Value::String {
                     val: "true".to_string(),
                     span: Span::test_data(),

--- a/crates/nu-command/src/core_commands/debug.rs
+++ b/crates/nu-command/src/core_commands/debug.rs
@@ -60,8 +60,7 @@ impl Command for Debug {
             },
             Example {
                 description: "Print the value of a table",
-                example:
-                    "echo [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | debug",
+                example: "echo [[version patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | debug",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string("{version: 0.1.0, patch: false}"),

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -70,7 +70,7 @@ impl Command for Let {
             },
             Example {
                 description: "Set a variable based on the condition",
-                example: "let x = if $false { -1 } else { 1 }",
+                example: "let x = if false { -1 } else { 1 }",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -351,7 +351,7 @@ ls | each {|x| $x.name}
 ```
 The above will create a list of the filenames in the directory.
 ```
-if $true { echo "it's true" } { echo "it's not true" }
+if true { echo "it's true" } { echo "it's not true" }
 ```
 This `if` call will run the first block if the expression is true, or the
 second block if the expression is false.

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -28,7 +28,7 @@ impl Command for FilterWith {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Filter dataframe using a bool mask",
-            example: r#"let mask = ([$true $false] | dfr to-df);
+            example: r#"let mask = ([true false] | dfr to-df);
     [[a b]; [1 2] [3 4]] | dfr to-df | dfr filter-with $mask"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -86,7 +86,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list of booleans and creates a dataframe",
-                example: "[$true $true $false] | dfr to-df",
+                example: "[true true false] | dfr to-df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -26,7 +26,7 @@ impl Command for AllFalse {
         vec![
             Example {
                 description: "Returns true if all values are false",
-                example: "[$false $false $false] | dfr to-df | dfr all-false",
+                example: "[false false false] | dfr to-df | dfr all-false",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_false".to_string(),

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -26,7 +26,7 @@ impl Command for AllTrue {
         vec![
             Example {
                 description: "Returns true if all values are true",
-                example: "[$true $true $true] | dfr to-df | dfr all-true",
+                example: "[true true true] | dfr to-df | dfr all-true",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_true".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -26,7 +26,7 @@ impl Command for ArgTrue {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns indexes where values are true",
-            example: "[$false $true $false] | dfr to-df | dfr arg-true",
+            example: "[false true false] | dfr to-df | dfr arg-true",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_true".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -28,7 +28,7 @@ impl Command for NotSeries {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Inverts boolean mask",
-            example: "[$true $false $true] | dfr to-df | dfr not",
+            example: "[true false true] | dfr to-df | dfr not",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -91,7 +91,7 @@ impl Command for Find {
             },
             Example {
                 description: "Find if a service is not running",
-                example: "[[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | find -p { |it| $it.patch }",
+                example: "[[version patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | find -p { |it| $it.patch }",
                 result: Some(Value::List {
                     vals: vec![Value::test_record(
                             vec!["version", "patch"],

--- a/crates/nu-command/src/filters/shuffle.rs
+++ b/crates/nu-command/src/filters/shuffle.rs
@@ -38,7 +38,7 @@ impl Command for Shuffle {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shuffle rows randomly (execute it several times and see the difference)",
-            example: r#"echo [[version patch]; [1.0.0 $false] [3.0.1 $true] [2.0.0 $false]] | shuffle"#,
+            example: r#"echo [[version patch]; [1.0.0 false] [3.0.1 true] [2.0.0 false]] | shuffle"#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -65,9 +65,9 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
         )),
         Value::Bool { val, .. } => {
             if *val {
-                Ok("$true".to_string())
+                Ok("true".to_string())
             } else {
-                Ok("$false".to_string())
+                Ok("false".to_string())
             }
         }
         Value::CellPath { .. } => Err(ShellError::UnsupportedInput(

--- a/crates/nu-command/src/shells/shells_.rs
+++ b/crates/nu-command/src/shells/shells_.rs
@@ -79,7 +79,7 @@ impl Command for Shells {
             },
             Example {
                 description: "Show currently active shell",
-                example: r#"shells | where active == $true"#,
+                example: r#"shells | where active == true"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -169,7 +169,7 @@ prints out the list properly."#
             },
             Example {
                 description: "Render a table with 'name' column in it to a grid",
-                example: "[[name patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | grid",
+                example: "[[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid",
                 result: Some(Value::String {
                     val: "0.1.0 │ 0.1.1 │ 0.2.0".to_string(),
                     span: Span::test_data(),

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -45,7 +45,7 @@ fn from_boolean() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo $true | into string
+        echo true | into string
         "#
         )
     );

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -65,7 +65,7 @@ fn to_nuon_bool() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            $false
+            false
             | to nuon
             | from nuon
         "#

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -49,6 +49,10 @@ pub fn is_math_expression_like(bytes: &[u8]) -> bool {
         return false;
     }
 
+    if bytes == b"true" || bytes == b"false" {
+        return true;
+    }
+
     let b = bytes[0];
 
     b == b'0'
@@ -1478,27 +1482,7 @@ pub fn parse_variable_expr(
 ) -> (Expression, Option<ParseError>) {
     let contents = working_set.get_span_contents(span);
 
-    if contents == b"$true" {
-        return (
-            Expression {
-                expr: Expr::Bool(true),
-                span,
-                ty: Type::Bool,
-                custom_completion: None,
-            },
-            None,
-        );
-    } else if contents == b"$false" {
-        return (
-            Expression {
-                expr: Expr::Bool(false),
-                span,
-                ty: Type::Bool,
-                custom_completion: None,
-            },
-            None,
-        );
-    } else if contents == b"$nothing" {
+    if contents == b"$nothing" {
         return (
             Expression {
                 expr: Expr::Nothing,
@@ -3258,6 +3242,41 @@ pub fn parse_value(
         return parse_variable_expr(working_set, span);
     }
 
+    if bytes == b"true" {
+        if matches!(shape, SyntaxShape::Boolean) || matches!(shape, SyntaxShape::Any) {
+            return (
+                Expression {
+                    expr: Expr::Bool(true),
+                    span,
+                    ty: Type::Bool,
+                    custom_completion: None,
+                },
+                None,
+            );
+        } else {
+            return (
+                Expression::garbage(span),
+                Some(ParseError::Expected("non-boolean value".into(), span)),
+            );
+        }
+    } else if bytes == b"false" {
+        if matches!(shape, SyntaxShape::Boolean) || matches!(shape, SyntaxShape::Any) {
+            return (
+                Expression {
+                    expr: Expr::Bool(false),
+                    span,
+                    ty: Type::Bool,
+                    custom_completion: None,
+                },
+                None,
+            );
+        } else {
+            return (
+                Expression::garbage(span),
+                Some(ParseError::Expected("non-boolean value".into(), span)),
+            );
+        }
+    }
     match bytes[0] {
         b'$' => return parse_dollar_expr(working_set, span),
         b'(' => {
@@ -3381,7 +3400,7 @@ pub fn parse_value(
         }
         SyntaxShape::Boolean => {
             // Redundant, though we catch bad boolean parses here
-            if bytes == b"$true" || bytes == b"$false" {
+            if bytes == b"true" || bytes == b"false" {
                 (
                     Expression {
                         expr: Expr::Bool(true),
@@ -3603,6 +3622,7 @@ pub fn parse_expression(
     while pos < spans.len() {
         // Check if there is any environment shorthand
         let name = working_set.get_span_contents(spans[pos]);
+
         let split = name.split(|x| *x == b'=');
         let split: Vec<_> = split.collect();
         if split.len() == 2 && !split[0].is_empty() {

--- a/docs/How_To_Coloring_and_Theming.md
+++ b/docs/How_To_Coloring_and_Theming.md
@@ -459,15 +459,15 @@ let base16_theme = {
 # now let's apply our regular config settings but also apply the "color_config:" theme that we specified above.
 
 let config = {
-  filesize_metric: $true
+  filesize_metric: true
   table_mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-  use_ls_colors: $true
+  use_ls_colors: true
   color_config: $base16_theme # <-- this is the theme
-  use_grid_icons: $true
+  use_grid_icons: true
   footer_mode: always #always, never, number_of_rows, auto
-  animate_prompt: $false
+  animate_prompt: false
   float_precision: 2
-  without_color: $false
+  without_color: false
   filesize_format: "b" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
   edit_mode: emacs # vi
   max_history_size: 10000

--- a/docs/commands/debug.md
+++ b/docs/commands/debug.md
@@ -23,5 +23,5 @@ Print the value of a string
 
 Print the value of a table
 ```shell
-> echo [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | debug
+> echo [[version patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | debug
 ```

--- a/docs/commands/dfr_all-false.md
+++ b/docs/commands/dfr_all-false.md
@@ -14,7 +14,7 @@ Returns true if all values are false
 
 Returns true if all values are false
 ```shell
-> [$false $false $false] | dfr to-df | dfr all-false
+> [false false false] | dfr to-df | dfr all-false
 ```
 
 Checks the result from a comparison

--- a/docs/commands/dfr_all-true.md
+++ b/docs/commands/dfr_all-true.md
@@ -14,7 +14,7 @@ Returns true if all values are true
 
 Returns true if all values are true
 ```shell
-> [$true $true $true] | dfr to-df | dfr all-true
+> [true true true] | dfr to-df | dfr all-true
 ```
 
 Checks the result from a comparison

--- a/docs/commands/dfr_arg-true.md
+++ b/docs/commands/dfr_arg-true.md
@@ -14,5 +14,5 @@ Returns indexes where values are true
 
 Returns indexes where values are true
 ```shell
-> [$false $true $false] | dfr to-df | dfr arg-true
+> [false true false] | dfr to-df | dfr arg-true
 ```

--- a/docs/commands/dfr_filter-with.md
+++ b/docs/commands/dfr_filter-with.md
@@ -18,6 +18,6 @@ Filters dataframe using a mask as reference
 
 Filter dataframe using a bool mask
 ```shell
-> let mask = ([$true $false] | dfr to-df);
+> let mask = ([true false] | dfr to-df);
     [[a b]; [1 2] [3 4]] | dfr to-df | dfr filter-with $mask
 ```

--- a/docs/commands/dfr_not.md
+++ b/docs/commands/dfr_not.md
@@ -14,5 +14,5 @@ Inverts boolean mask
 
 Inverts boolean mask
 ```shell
-> [$true $false $true] | dfr to-df | dfr not
+> [true false true] | dfr to-df | dfr not
 ```

--- a/docs/commands/dfr_to-df.md
+++ b/docs/commands/dfr_to-df.md
@@ -29,5 +29,5 @@ Takes a list and creates a dataframe
 
 Takes a list of booleans and creates a dataframe
 ```shell
-> [$true $true $false] | dfr to-df
+> [true true false] | dfr to-df
 ```

--- a/docs/commands/find.md
+++ b/docs/commands/find.md
@@ -49,7 +49,7 @@ Find odd values
 
 Find if a service is not running
 ```shell
-> [[version patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | find -p { |it| $it.patch }
+> [[version patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | find -p { |it| $it.patch }
 ```
 
 Find using regex

--- a/docs/commands/grid.md
+++ b/docs/commands/grid.md
@@ -40,5 +40,5 @@ Render a list of records to a grid
 
 Render a table with 'name' column in it to a grid
 ```shell
-> [[name patch]; [0.1.0 $false] [0.1.1 $true] [0.2.0 $false]] | grid
+> [[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid
 ```

--- a/docs/commands/into_binary.md
+++ b/docs/commands/into_binary.md
@@ -28,7 +28,7 @@ convert a number to a nushell binary primitive
 
 convert a boolean to a nushell binary primitive
 ```shell
-> $true | into binary
+> true | into binary
 ```
 
 convert a filesize to a nushell binary primitive

--- a/docs/commands/into_bool.md
+++ b/docs/commands/into_bool.md
@@ -18,12 +18,12 @@ Convert value to boolean
 
 Convert value to boolean in table
 ```shell
-> echo [[value]; ['false'] ['1'] [0] [1.0] [$true]] | into bool value
+> echo [[value]; ['false'] ['1'] [0] [1.0] [true]] | into bool value
 ```
 
 Convert bool to boolean
 ```shell
-> $true | into bool
+> true | into bool
 ```
 
 convert integer to boolean

--- a/docs/commands/into_int.md
+++ b/docs/commands/into_int.md
@@ -44,7 +44,7 @@ Convert file size to integer
 
 Convert bool to integer
 ```shell
-> [$false, $true] | into int
+> [false, true] | into int
 ```
 
 Convert to integer from binary

--- a/docs/commands/into_string.md
+++ b/docs/commands/into_string.md
@@ -49,7 +49,7 @@ convert string to string
 
 convert boolean to string
 ```shell
-> $true | into string
+> true | into string
 ```
 
 convert date to string

--- a/docs/commands/let.md
+++ b/docs/commands/let.md
@@ -29,5 +29,5 @@ Set a variable to the result of an expression
 
 Set a variable based on the condition
 ```shell
-> let x = if $false { -1 } else { 1 }
+> let x = if false { -1 } else { 1 }
 ```

--- a/docs/commands/shells.md
+++ b/docs/commands/shells.md
@@ -19,5 +19,5 @@ Enter a new shell at parent path '..' and show all opened shells
 
 Show currently active shell
 ```shell
-> shells | where active == $true
+> shells | where active == true
 ```

--- a/docs/commands/shuffle.md
+++ b/docs/commands/shuffle.md
@@ -14,5 +14,5 @@ Shuffle rows randomly.
 
 Shuffle rows randomly (execute it several times and see the difference)
 ```shell
-> echo [[version patch]; [1.0.0 $false] [3.0.1 $true] [2.0.0 $false]] | shuffle
+> echo [[version patch]; [1.0.0 false] [3.0.1 true] [2.0.0 false]] | shuffle
 ```

--- a/docs/make_docs.nu
+++ b/docs/make_docs.nu
@@ -1,6 +1,6 @@
 let vers = (version).version
 
-for command in ($scope.commands | where is_custom == $false && is_extern == $false) {
+for command in ($scope.commands | where is_custom == false && is_extern == false) {
     let top = $"---
 title: ($command.command)
 layout: command

--- a/docs/sample_plugins/powershell/nu_plugin_mylen_filter.ps1
+++ b/docs/sample_plugins/powershell/nu_plugin_mylen_filter.ps1
@@ -139,9 +139,9 @@ function end_filter {
 function Write-TraceMessage {
     Param
     (
-        [Parameter(Mandatory = $false, Position = 0)]
+        [Parameter(Mandatory = false, Position = 0)]
         [string] $label,
-        [Parameter(Mandatory = $false, Position = 1)]
+        [Parameter(Mandatory = false, Position = 1)]
         [string] $message
     )
 
@@ -196,9 +196,9 @@ function Get-PipedData {
     param(
         [Parameter(
             Position = 0,
-            Mandatory = $true,
-            ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true)
+            Mandatory = true,
+            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)
         ]
         [Alias('piped')]
         [String]$piped_input

--- a/src/default_config.nu
+++ b/src/default_config.nu
@@ -162,17 +162,17 @@ let default_theme = {
 
 # The default config record. This is where much of your global configuration is setup.
 let $config = {
-  filesize_metric: $false
+  filesize_metric: false
   table_mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-  use_ls_colors: $true
-  rm_always_trash: $false
+  use_ls_colors: true
+  rm_always_trash: false
   color_config: $default_theme
-  use_grid_icons: $true
+  use_grid_icons: true
   footer_mode: "25" # always, never, number_of_rows, auto
-  quick_completions: $true  # set this to $false to prevent auto-selecting completions when only one remains
-  animate_prompt: $false # redraw the prompt every second
+  quick_completions: true  # set this to false to prevent auto-selecting completions when only one remains
+  animate_prompt: false # redraw the prompt every second
   float_precision: 2
-  use_ansi_coloring: $true
+  use_ansi_coloring: true
   filesize_format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
   edit_mode: emacs # emacs, vi
   max_history_size: 10000

--- a/src/tests/test_conditionals.rs
+++ b/src/tests/test_conditionals.rs
@@ -2,22 +2,22 @@ use crate::tests::{run_test, TestResult};
 
 #[test]
 fn if_test1() -> TestResult {
-    run_test("if $true { 10 } else { 20 } ", "10")
+    run_test("if true { 10 } else { 20 } ", "10")
 }
 
 #[test]
 fn if_test2() -> TestResult {
-    run_test("if $false { 10 } else { 20 } ", "20")
+    run_test("if false { 10 } else { 20 } ", "20")
 }
 
 #[test]
 fn simple_if() -> TestResult {
-    run_test("if $true { 10 } ", "10")
+    run_test("if true { 10 } ", "10")
 }
 
 #[test]
 fn simple_if2() -> TestResult {
-    run_test("if $false { 10 } ", "")
+    run_test("if false { 10 } ", "")
 }
 
 #[test]

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -3,7 +3,7 @@ use crate::tests::{fail_test, run_test, TestResult};
 #[test]
 fn no_scope_leak1() -> TestResult {
     fail_test(
-        "if $false { let $x = 10 } else { let $x = 20 }; $x",
+        "if false { let $x = 10 } else { let $x = 20 }; $x",
         "Variable not found",
     )
 }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -17,7 +17,7 @@ fn proper_shadow() -> TestResult {
 fn config_filesize_format_with_metric_true() -> TestResult {
     // Note: this tests both the config variable and that it is properly captured into a block
     run_test(
-        r#"let config = {"filesize_metric": $true "filesize_format": "kib" }; do { 40kb | into string } "#,
+        r#"let config = {"filesize_metric": true "filesize_format": "kib" }; do { 40kb | into string } "#,
         "39.1 KiB",
     )
 }
@@ -26,7 +26,7 @@ fn config_filesize_format_with_metric_true() -> TestResult {
 fn config_filesize_format_with_metric_false_kib() -> TestResult {
     // Note: this tests both the config variable and that it is properly captured into a block
     run_test(
-        r#"let config = {"filesize_metric": $false "filesize_format": "kib" }; do { 40kb | into string } "#,
+        r#"let config = {"filesize_metric": false "filesize_format": "kib" }; do { 40kb | into string } "#,
         "39.1 KiB",
     )
 }
@@ -35,7 +35,7 @@ fn config_filesize_format_with_metric_false_kib() -> TestResult {
 fn config_filesize_format_with_metric_false_kb() -> TestResult {
     // Note: this tests both the config variable and that it is properly captured into a block
     run_test(
-        r#"let config = {"filesize_metric": $false "filesize_format": "kb" }; do { 40kb | into string } "#,
+        r#"let config = {"filesize_metric": false "filesize_format": "kb" }; do { 40kb | into string } "#,
         "40.0 KB",
     )
 }
@@ -265,12 +265,12 @@ fn datetime_literal() -> TestResult {
 
 #[test]
 fn shortcircuiting_and() -> TestResult {
-    run_test(r#"$false && (5 / 0; $false)"#, "false")
+    run_test(r#"false && (5 / 0; false)"#, "false")
 }
 
 #[test]
 fn shortcircuiting_or() -> TestResult {
-    run_test(r#"$true || (5 / 0; $false)"#, "true")
+    run_test(r#"true || (5 / 0; false)"#, "true")
 }
 
 #[test]

--- a/src/tests/test_math.rs
+++ b/src/tests/test_math.rs
@@ -27,12 +27,12 @@ fn modulo2() -> TestResult {
 
 #[test]
 fn and() -> TestResult {
-    run_test("$true && $false", "false")
+    run_test("true && false", "false")
 }
 
 #[test]
 fn or() -> TestResult {
-    run_test("$true || $false", "true")
+    run_test("true || false", "true")
 }
 
 #[test]

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -4,7 +4,7 @@ use super::run_test_contains;
 
 #[test]
 fn env_shorthand() -> TestResult {
-    run_test("FOO=BAR if $false { 3 } else { 4 }", "4")
+    run_test("FOO=BAR if false { 3 } else { 4 }", "4")
 }
 
 #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -285,7 +285,7 @@ pub(crate) fn eval_source(
 }
 
 fn seems_like_number(bytes: &[u8]) -> bool {
-    if bytes.len() == 0 {
+    if bytes.is_empty() {
         false
     } else {
         let b = bytes[0];

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -284,6 +284,32 @@ pub(crate) fn eval_source(
     true
 }
 
+fn seems_like_number(bytes: &[u8]) -> bool {
+    if bytes.len() == 0 {
+        false
+    } else {
+        let b = bytes[0];
+
+        b == b'0'
+            || b == b'1'
+            || b == b'2'
+            || b == b'3'
+            || b == b'4'
+            || b == b'5'
+            || b == b'6'
+            || b == b'7'
+            || b == b'8'
+            || b == b'9'
+            || b == b'('
+            || b == b'{'
+            || b == b'['
+            || b == b'$'
+            || b == b'"'
+            || b == b'\''
+            || b == b'-'
+    }
+}
+
 /// Finds externals that have names that look like math expressions
 pub fn external_exceptions(engine_state: &EngineState, stack: &Stack) -> Vec<Vec<u8>> {
     let mut executables = vec![];
@@ -299,16 +325,16 @@ pub fn external_exceptions(engine_state: &EngineState, stack: &Stack) -> Vec<Vec
                             while let Some(Ok(item)) = contents.next() {
                                 if is_executable::is_executable(&item.path()) {
                                     if let Ok(name) = item.file_name().into_string() {
-                                        let name = name.as_bytes().to_vec();
-                                        if nu_parser::is_math_expression_like(&name) {
+                                        if seems_like_number(name.as_bytes()) {
+                                            let name = name.as_bytes().to_vec();
                                             executables.push(name);
                                         }
                                     }
 
                                     if let Some(name) = item.path().file_stem() {
                                         let name = name.to_string_lossy();
-                                        let name = name.as_bytes().to_vec();
-                                        if nu_parser::is_math_expression_like(&name) {
+                                        if seems_like_number(name.as_bytes()) {
+                                            let name = name.as_bytes().to_vec();
                                             executables.push(name);
                                         }
                                     }
@@ -326,15 +352,15 @@ pub fn external_exceptions(engine_state: &EngineState, stack: &Stack) -> Vec<Vec
                         while let Some(Ok(item)) = contents.next() {
                             if is_executable::is_executable(&item.path()) {
                                 if let Ok(name) = item.file_name().into_string() {
-                                    let name = name.as_bytes().to_vec();
-                                    if nu_parser::is_math_expression_like(&name) {
+                                    if seems_like_number(name.as_bytes()) {
+                                        let name = name.as_bytes().to_vec();
                                         executables.push(name);
                                     }
                                 }
                                 if let Some(name) = item.path().file_stem() {
                                     let name = name.to_string_lossy();
-                                    let name = name.as_bytes().to_vec();
-                                    if nu_parser::is_math_expression_like(&name) {
+                                    if seems_like_number(name.as_bytes()) {
+                                        let name = name.as_bytes().to_vec();
                                         executables.push(name);
                                     }
                                 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -563,7 +563,7 @@ fn proper_shadow_let_aliases() {
     let actual = nu!(
         cwd: ".",
         r#"
-        let DEBUG = $false; echo $DEBUG | table; do { let DEBUG = $true; echo $DEBUG } | table; echo $DEBUG
+        let DEBUG = false; echo $DEBUG | table; do { let DEBUG = true; echo $DEBUG } | table; echo $DEBUG
         "#
     );
     assert_eq!(actual.out, "falsetruefalse");


### PR DESCRIPTION
# Description

Experiment: make `$true` => `true` and `$false` => `false`.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
