### PR TITLE
Make sure we have text before json parse

### DIFF
--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -78,6 +78,10 @@ impl Command for FromJson {
         let config = stack.get_config().unwrap_or_default();
         let string_input = input.collect_string("", &config)?;
 
+        if string_input.is_empty() {
+            return Ok(PipelineData::new(span));
+        }
+
         // TODO: turn this into a structured underline of the nu_json error
         if call.has_flag("objects") {
             #[allow(clippy::needless_collect)]


### PR DESCRIPTION
# Description

Make sure we have text before json parse

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
