### PR TITLE
Adds tab indentation option for JSON files.

### DIFF
--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -22,6 +22,12 @@ impl Command for ToJson {
                 "specify indentation width",
                 Some('i'),
             )
+            .named(
+                "tabs",
+                SyntaxShape::Number,
+                "specify indentation tab quantity",
+                Some('t'),
+            )
             .category(Category::Formats)
     }
 
@@ -37,6 +43,7 @@ impl Command for ToJson {
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
         let raw = call.has_flag("raw");
+        let use_tabs = call.has_flag("tabs");
 
         let span = call.head;
         let value = input.into_value(span);
@@ -44,9 +51,11 @@ impl Command for ToJson {
 
         let json_result = if raw {
             nu_json::to_string_raw(&json_value)
+        } else if use_tabs {
+            let tab_count: usize = call.get_flag(engine_state, stack, "tabs")?.unwrap_or(1);
+            nu_json::to_string_with_tab_indentation(&json_value, tab_count)
         } else {
             let indent: usize = call.get_flag(engine_state, stack, "indent")?.unwrap_or(2);
-
             nu_json::to_string_with_indent(&json_value, indent)
         };
 

--- a/crates/nu-json/src/lib.rs
+++ b/crates/nu-json/src/lib.rs
@@ -3,7 +3,8 @@ pub use self::de::{
 };
 pub use self::error::{Error, ErrorCode, Result};
 pub use self::ser::{
-    to_string, to_string_raw, to_string_with_indent, to_vec, to_writer, Serializer,
+    to_string, to_string_raw, to_string_with_indent, to_string_with_tab_indentation, to_vec,
+    to_writer, Serializer,
 };
 pub use self::value::{from_value, to_value, Map, Value};
 

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -948,6 +948,19 @@ where
 
 /// Encode the specified struct into a Hjson `[u8]` writer.
 #[inline]
+pub fn to_writer_with_tab_indentation<W, T>(writer: &mut W, value: &T, tabs: usize) -> Result<()>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    let indent_string = "\t".repeat(tabs);
+    let mut ser = Serializer::with_indent(writer, indent_string.as_bytes());
+    value.serialize(&mut ser)?;
+    Ok(())
+}
+
+/// Encode the specified struct into a Hjson `[u8]` writer.
+#[inline]
 pub fn to_writer_with_indent<W, T>(writer: &mut W, value: &T, indent: usize) -> Result<()>
 where
     W: io::Write,
@@ -969,6 +982,19 @@ where
     // the error.
     let mut writer = Vec::with_capacity(128);
     to_writer(&mut writer, value)?;
+    Ok(writer)
+}
+
+/// Encode the specified struct into a Hjson `[u8]` buffer.
+#[inline]
+pub fn to_vec_with_tab_indentation<T>(value: &T, tabs: usize) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    // We are writing to a Vec, which doesn't fail. So we can ignore
+    // the error.
+    let mut writer = Vec::with_capacity(128);
+    to_writer_with_tab_indentation(&mut writer, value, tabs)?;
     Ok(writer)
 }
 
@@ -1003,6 +1029,17 @@ where
     T: ser::Serialize,
 {
     let vec = to_vec_with_indent(value, indent)?;
+    let string = String::from_utf8(vec)?;
+    Ok(string)
+}
+
+/// Encode the specified struct into a Hjson `String` buffer.
+#[inline]
+pub fn to_string_with_tab_indentation<T>(value: &T, tabs: usize) -> Result<String>
+where
+    T: ser::Serialize,
+{
+    let vec = to_vec_with_tab_indentation(value, tabs)?;
     let string = String::from_utf8(vec)?;
     Ok(string)
 }


### PR DESCRIPTION
# Description

Adds an option to use tabs for indentation instead of spaces, as discussed in #4644. This only adds tab support for JSON, but I can work on the other formats that make sense to have this option as well.

I'm quite new to rust, and contributing to open source. Apologies for any incorrectness in code or in process. 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
