### PR TITLE
Add aliases to command completions

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -141,7 +141,7 @@ impl NuCompleter {
     ) -> Vec<(reedline::Span, String)> {
         let prefix = working_set.get_span_contents(span);
 
-        let mut results = working_set
+        let results = working_set
             .find_commands_by_prefix(prefix)
             .into_iter()
             .map(move |x| {
@@ -152,8 +152,23 @@ impl NuCompleter {
                     },
                     String::from_utf8_lossy(&x).to_string(),
                 )
-            })
-            .collect::<Vec<_>>();
+            });
+
+        let results_aliases =
+            working_set
+                .find_aliases_by_prefix(prefix)
+                .into_iter()
+                .map(move |x| {
+                    (
+                        reedline::Span {
+                            start: span.start - offset,
+                            end: span.end - offset,
+                        },
+                        String::from_utf8_lossy(&x).to_string(),
+                    )
+                });
+
+        let mut results = results.chain(results_aliases).collect::<Vec<_>>();
 
         let prefix = working_set.get_span_contents(span);
         let prefix = String::from_utf8_lossy(prefix).to_string();

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -462,6 +462,16 @@ impl EngineState {
         output
     }
 
+    pub fn find_aliases_by_prefix(&self, name: &[u8]) -> Vec<Vec<u8>> {
+        self.scope
+            .iter()
+            .rev()
+            .flat_map(|scope| &scope.aliases)
+            .filter(|decl| decl.0.starts_with(name))
+            .map(|decl| decl.0.clone())
+            .collect()
+    }
+
     pub fn get_span_contents(&self, span: &Span) -> &[u8] {
         for (contents, start, finish) in &self.file_contents {
             if span.start >= *start && span.end <= *finish {
@@ -1246,6 +1256,18 @@ impl<'a> StateWorkingSet<'a> {
         output.append(&mut permanent);
 
         output
+    }
+
+    pub fn find_aliases_by_prefix(&self, name: &[u8]) -> Vec<Vec<u8>> {
+        self.delta
+            .scope
+            .iter()
+            .rev()
+            .flat_map(|scope| &scope.aliases)
+            .filter(|decl| decl.0.starts_with(name))
+            .map(|decl| decl.0.clone())
+            .chain(self.permanent_state.find_aliases_by_prefix(name))
+            .collect()
     }
 
     pub fn get_block(&self, block_id: BlockId) -> &Block {


### PR DESCRIPTION
# Description

Adds aliases to the completion list for commands.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
