### PR TITLE
Remove the pack-in plugins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,28 +106,6 @@ inherits = "release"
 strip = false
 debug = true
 
-# Build plugins
-[[bin]]
-name = "nu_plugin_core_inc"
-path = "src/plugins/nu_plugin_core_inc.rs"
-required-features = ["inc"]
-
-[[bin]]
-name = "nu_plugin_core_example"
-path = "src/plugins/nu_plugin_core_example.rs"
-required-features = ["example"]
-
-# Extra plugins
-[[bin]]
-name = "nu_plugin_extra_gstat"
-path = "src/plugins/nu_plugin_extra_gstat.rs"
-required-features = ["gstat"]
-
-[[bin]]
-name = "nu_plugin_extra_query"
-path = "src/plugins/nu_plugin_extra_query.rs"
-required-features = ["query"]
-
 # Main nu binary
 [[bin]]
 name = "nu"

--- a/src/plugins/nu_plugin_core_example.rs
+++ b/src/plugins/nu_plugin_core_example.rs
@@ -1,6 +1,0 @@
-use nu_plugin::{serve_plugin, CapnpSerializer};
-use nu_plugin_example::Example;
-
-fn main() {
-    serve_plugin(&mut Example {}, CapnpSerializer {})
-}

--- a/src/plugins/nu_plugin_core_inc.rs
+++ b/src/plugins/nu_plugin_core_inc.rs
@@ -1,6 +1,0 @@
-use nu_plugin::{serve_plugin, CapnpSerializer};
-use nu_plugin_inc::Inc;
-
-fn main() {
-    serve_plugin(&mut Inc::new(), CapnpSerializer {})
-}

--- a/src/plugins/nu_plugin_extra_gstat.rs
+++ b/src/plugins/nu_plugin_extra_gstat.rs
@@ -1,6 +1,0 @@
-use nu_plugin::{serve_plugin, CapnpSerializer};
-use nu_plugin_gstat::GStat;
-
-fn main() {
-    serve_plugin(&mut GStat::new(), CapnpSerializer {})
-}

--- a/src/plugins/nu_plugin_extra_query.rs
+++ b/src/plugins/nu_plugin_extra_query.rs
@@ -1,6 +1,0 @@
-use nu_plugin::{serve_plugin, CapnpSerializer};
-use nu_plugin_query::Query;
-
-fn main() {
-    serve_plugin(&mut Query::new(), CapnpSerializer {})
-}


### PR DESCRIPTION
# Description

This removes plugins from being part of `cargo install nu`. We've used this in the past to ensure that important plugins were distributed with nushell. Now, the core plugins are now built into nushell itself as part of features that are part of the install. The optional plugins don't really need to be part of the default install and can be installed via the a separate `cargo install nu-plugin-<plugin name>` step.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
