### PR TITLE
add windows build script

### DIFF
--- a/build-all-windows.cmd
+++ b/build-all-windows.cmd
@@ -1,0 +1,32 @@
+@echo off
+@echo -------------------------------------------------------------------
+@echo Building nushell (nu.exe) with --features=extra and all the plugins
+@echo -------------------------------------------------------------------
+@echo.
+
+echo Building nushell.exe
+cargo build --features=extra
+@echo.
+
+@cd crates\nu_plugin_example
+echo Building nu_plugin_example.exe
+cargo build
+@echo.
+
+@cd ..\..\crates\nu_plugin_gstat
+echo Building nu_plugin_gstat.exe
+cargo build
+@echo.
+
+@cd ..\..\crates\nu_plugin_inc
+echo Building nu_plugin_inc.exe
+cargo build
+@echo.
+
+@cd ..\..\crates\nu_plugin_query
+
+echo Building nu_plugin_query.exe
+cargo build
+@echo.
+
+@cd ..\..


### PR DESCRIPTION
# Description

This quick batch/cmd file allows one to build nushell and all the plugins with one command.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
