### PR TITLE
Add more exit code support

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -84,11 +84,13 @@ pub(crate) fn evaluate(
             if let Err(e) = engine_state.merge_delta(StateDelta::new(), Some(&mut stack), cwd) {
                 let working_set = StateWorkingSet::new(engine_state);
                 report_error(&working_set, &e);
+                std::process::exit(1);
             }
         }
         Err(e) => {
             let working_set = StateWorkingSet::new(engine_state);
             report_error(&working_set, &e);
+            std::process::exit(1);
         }
     }
 
@@ -107,7 +109,6 @@ pub(crate) fn evaluate(
             let working_set = StateWorkingSet::new(engine_state);
 
             report_error(&working_set, &err);
-
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
# Description

Adds exit code support to a few more places

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
