### PR TITLE
remove the hard coded escaping from split row and split column

### DIFF
--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -114,12 +114,10 @@ fn split_column_helper(
     head: Span,
 ) -> Vec<Value> {
     if let Ok(s) = v.as_string() {
-        let splitter = separator.item.replace("\\n", "\n");
-
         let split_result: Vec<_> = if collapse_empty {
-            s.split(&splitter).filter(|s| !s.is_empty()).collect()
+            s.split(&separator.item).filter(|s| !s.is_empty()).collect()
         } else {
-            s.split(&splitter).collect()
+            s.split(&separator.item).collect()
         };
 
         let positional: Vec<_> = rest.iter().map(|f| f.item.clone()).collect();

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -86,8 +86,7 @@ fn split_row_helper(v: &Value, separator: &Spanned<String>, name: Span) -> Vec<V
     match v.span() {
         Ok(v_span) => {
             if let Ok(s) = v.as_string() {
-                let splitter = separator.item.replace("\\n", "\n");
-                s.split(&splitter)
+                s.split(&separator.item)
                     .filter_map(|s| {
                         if s.trim() != "" {
                             Some(Value::string(s, v_span))


### PR DESCRIPTION
# Description

I had a hard time splitting text line "one\ntwo\nthree" when it was in a file. Turns out there were some hard-coded escaping going on under the hood. This PR removes that.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
