### PR TITLE
modify wording slightly on build-all-maclin.sh

### DIFF
--- a/build-all-maclin.sh
+++ b/build-all-maclin.sh
@@ -1,31 +1,31 @@
 #!/bin/sh
 
 echo "-------------------------------------------------------------------"
-echo "Building nushell (nu.exe) with --features=extra and all the plugins"
+echo "Building nushell (nu) with --features=extra and all the plugins"
 echo "-------------------------------------------------------------------"
 echo ""
 
-echo "Building nushell.exe"
+echo "Building nushell"
 cargo build --features=extra
 echo ""
 
 cd crates/nu_plugin_example
-echo "Building nu_plugin_example.exe"
+echo "Building nu_plugin_example"
 cargo build
 echo ""
 
 cd ../../crates/nu_plugin_gstat
-echo "Building nu_plugin_gstat.exe"
+echo "Building nu_plugin_gstat"
 cargo build
 echo ""
 
 cd ../../crates/nu_plugin_inc
-echo "Building nu_plugin_inc.exe"
+echo "Building nu_plugin_inc"
 cargo build
 echo ""
 
 cd ../../crates/nu_plugin_query
-echo "Building nu_plugin_query.exe"
+echo "Building nu_plugin_query"
 cargo build
 echo ""
 


### PR DESCRIPTION

On Mac and Linux the concept of an .exe does not exist, that is purely
windows terminology so I am simply am removing the .exe extension names
just to be consistent on what is actually being built.
