### PR TITLE
Add more multiline pipeline forms

### DIFF
--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,5 +1,6 @@
 extern crate nu_test_support;
 
+mod parsing;
 mod path;
 mod plugins;
 mod shell;

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -1,0 +1,46 @@
+use nu_test_support::nu;
+
+#[test]
+fn run_nu_script_single_line() {
+    let actual = nu!(cwd: "tests/parsing/samples", r#"
+        nu single_line.nu
+        "#);
+
+    assert_eq!(actual.out, "5");
+}
+
+#[test]
+fn run_nu_script_multiline_start_pipe() {
+    let actual = nu!(cwd: "tests/parsing/samples", r#"
+        nu multiline_start_pipe.nu
+        "#);
+
+    assert_eq!(actual.out, "4");
+}
+
+#[test]
+fn run_nu_script_multiline_start_pipe_win() {
+    let actual = nu!(cwd: "tests/parsing/samples", r#"
+        nu multiline_start_pipe_win.nu
+        "#);
+
+    assert_eq!(actual.out, "3");
+}
+
+#[test]
+fn run_nu_script_multiline_end_pipe() {
+    let actual = nu!(cwd: "tests/parsing/samples", r#"
+        nu multiline_end_pipe.nu
+        "#);
+
+    assert_eq!(actual.out, "2");
+}
+
+#[test]
+fn run_nu_script_multiline_end_pipe_win() {
+    let actual = nu!(cwd: "tests/parsing/samples", r#"
+        nu multiline_end_pipe_win.nu
+        "#);
+
+    assert_eq!(actual.out, "3");
+}

--- a/tests/parsing/samples/multiline_end_pipe.nu
+++ b/tests/parsing/samples/multiline_end_pipe.nu
@@ -1,0 +1,2 @@
+echo "hi" |
+str length

--- a/tests/parsing/samples/multiline_end_pipe_win.nu
+++ b/tests/parsing/samples/multiline_end_pipe_win.nu
@@ -1,0 +1,2 @@
+echo "how" |
+str length

--- a/tests/parsing/samples/multiline_start_pipe.nu
+++ b/tests/parsing/samples/multiline_start_pipe.nu
@@ -1,0 +1,2 @@
+echo "four"
+| str length

--- a/tests/parsing/samples/multiline_start_pipe_win.nu
+++ b/tests/parsing/samples/multiline_start_pipe_win.nu
@@ -1,0 +1,2 @@
+echo "one"
+| str length

--- a/tests/parsing/samples/single_line.nu
+++ b/tests/parsing/samples/single_line.nu
@@ -1,0 +1,1 @@
+echo "hello" | str length


### PR DESCRIPTION
# Description

This allows three ways for a pipeline to be written:

```
all | on | one | line
```

And in multilines:
```
with |
ending |
pipes
```

And, now in scripts, you can use:

```
with
| starting
| pipes
```

We currently require the pipeline not be separated by more than one line for the parser to understand that it's all coming from one pipeline.

fixes https://github.com/nushell/nushell/issues/4059

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
