### PR TITLE
Allow save to accept a list of strings

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -95,6 +95,20 @@ impl Command for Save {
 
                     Ok(PipelineData::new(span))
                 }
+                Value::List { vals, .. } => {
+                    let val = vals
+                        .into_iter()
+                        .map(|it| it.as_string())
+                        .collect::<Result<Vec<String>, ShellError>>()?
+                        .join("\n")
+                        + "\n";
+
+                    if let Err(err) = file.write_all(val.as_bytes()) {
+                        return Err(ShellError::IOError(err.to_string()));
+                    }
+
+                    Ok(PipelineData::new(span))
+                }
                 v => Err(ShellError::UnsupportedInput(
                     format!("{:?} not supported", v.get_type()),
                     span,
@@ -111,6 +125,20 @@ impl Command for Save {
                 }
                 Value::Binary { val, .. } => {
                     if let Err(err) = file.write_all(&val) {
+                        return Err(ShellError::IOError(err.to_string()));
+                    }
+
+                    Ok(PipelineData::new(span))
+                }
+                Value::List { vals, .. } => {
+                    let val = vals
+                        .into_iter()
+                        .map(|it| it.as_string())
+                        .collect::<Result<Vec<String>, ShellError>>()?
+                        .join("\n")
+                        + "\n";
+
+                    if let Err(err) = file.write_all(val.as_bytes()) {
                         return Err(ShellError::IOError(err.to_string()));
                     }
 

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -48,6 +48,24 @@ fn writes_out_csv() {
     })
 }
 
+#[test]
+fn writes_out_list() {
+    Playground::setup("save_test_3", |dirs, sandbox| {
+        sandbox.with_files(vec![]);
+
+        let expected_file = dirs.test().join("list_sample.txt");
+
+        nu!(
+            cwd: dirs.root(),
+            r#"echo [a b c d] | save save_test_3/list_sample.txt"#,
+        );
+
+        let actual = file_contents(expected_file);
+        println!("{actual}");
+        assert_eq!(actual, "a\nb\nc\nd\n")
+    })
+}
+
 // FIXME: jt: needs more work
 #[ignore]
 #[test]


### PR DESCRIPTION
# Description

Save now accepts a list of strings and will treat it as a list of lines.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
