### PR TITLE
enable to-nu to include the whole dfr if rows is not specified

### DIFF
--- a/crates/nu-command/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-command/src/dataframe/eager/to_nu.rs
@@ -71,7 +71,12 @@ fn command(
     let values = if tail {
         df.tail(rows, call.head)?
     } else {
-        df.head(rows, call.head)?
+        // if rows is specified, return those rows, otherwise return everything
+        if rows.is_some() {
+            df.head(rows, call.head)?
+        } else {
+            df.head(Some(df.height()), call.head)?
+        }
     };
 
     let value = Value::List {

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/mod.rs
@@ -275,6 +275,10 @@ impl NuDataFrame {
         }
     }
 
+    pub fn height(&self) -> usize {
+        self.0.height()
+    }
+
     pub fn head(&self, rows: Option<usize>, span: Span) -> Result<Vec<Value>, ShellError> {
         let to_row = rows.unwrap_or(5);
         let values = self.to_rows(0, to_row, span)?;


### PR DESCRIPTION
# Description

Before this PR, `to-nu` would only return 5 rows if rows was not specified. This PR changes that to allow `to-nu` to return the entire dfr unless rows is specified.

closed #4752 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
