### PR TITLE
Added real index column to history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#7c5f20d25248901872a91da6c235ae942e815b03"
+source = "git+https://github.com/nushell/reedline?branch=main#0d6e26276abd8792ee631581a073126d0f845445"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/nu-command/src/core_commands/history.rs
+++ b/crates/nu-command/src/core_commands/history.rs
@@ -53,8 +53,19 @@ impl Command for History {
                 if let Ok(contents) = contents {
                     Ok(contents
                         .lines()
-                        .map(move |x| Value::String {
-                            val: decode_newlines(x),
+                        .enumerate()
+                        .map(move |(index, command)| Value::Record {
+                            cols: vec!["command".to_string(), "index".to_string()],
+                            vals: vec![
+                                Value::String {
+                                    val: decode_newlines(command),
+                                    span: head,
+                                },
+                                Value::Int {
+                                    val: index as i64,
+                                    span: head,
+                                },
+                            ],
                             span: head,
                         })
                         .collect::<Vec<_>>()


### PR DESCRIPTION
# Description

The index shown in the history column was the nushell row counter. This index changes when a filter was done on the table making it hard to use `!` command
A new column that matches the real history index is introduced to make use of the `!` reedline parsing. This index doesnt change when performing filtering on the table.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
