### PR TITLE
Fix rest parsing

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -126,3 +126,39 @@ fn binary_roundtrip() {
 
     assert_eq!(actual.out, "0x[1FFF]");
 }
+
+#[test]
+fn read_binary_data() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open sample.nuon | get 5.3
+        "#
+    ));
+
+    assert_eq!(actual.out, "31")
+}
+
+#[test]
+fn read_record() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open sample.nuon | get 4.name
+        "#
+    ));
+
+    assert_eq!(actual.out, "Bobby")
+}
+
+#[test]
+fn read_bool() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open sample.nuon | get 3 | $in == $true
+        "#
+    ));
+
+    assert_eq!(actual.out, "true")
+}

--- a/crates/nu-engine/src/column.rs
+++ b/crates/nu-engine/src/column.rs
@@ -11,6 +11,8 @@ pub fn get_columns(input: &[Value]) -> Vec<String> {
                     columns.push(col.to_string());
                 }
             }
+        } else {
+            return vec![];
         }
     }
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -339,3 +339,13 @@ fn string_escape() -> TestResult {
 fn string_escape_interpolation() -> TestResult {
     run_test(r#"$"\u015B(char hamburger)abc""#, "ś≡abc")
 }
+
+#[test]
+fn proper_rest_types() -> TestResult {
+    run_test(
+        r#"def foo [--verbose(-v): bool, # my test flag
+                   ...rest: int # my rest comment
+                ] { if $verbose { print "verbose!" } else { print "not verbose!" } }; foo"#,
+        "not verbose!",
+    )
+}

--- a/tests/fixtures/formats/sample.nuon
+++ b/tests/fixtures/formats/sample.nuon
@@ -1,0 +1,20 @@
+# Some sample nuon values
+[
+    # The nuon compact table format
+    [[a, nuon, table]; [1, 2, 3], [4, 5, 6]],
+
+    # A filesize
+    100kib,
+
+    # A duration
+    100sec
+
+    # A boolean
+    true,
+
+    # A record
+    {name: "Bobby", age: 99}
+
+    # Binary data
+    0x[11, ff, ee, 1f]
+]


### PR DESCRIPTION
# Description

This fixes an issue where a `...rest` arg, if it has a specified type, overwrote the type of a previous argument in the signature.

Signatures of this form should now work:

```
def foo [
  --verbose(-v): bool, # my test flag
  ...rest: int # my rest comment
] {
  if $verbose {
    print "verbose!"
  } else {
    print "not verbose!" 
  }
}
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
