### PR TITLE
Remove unused `ntdef.h` include

### DIFF
--- a/assets/nushell.rc
+++ b/assets/nushell.rc
@@ -1,5 +1,4 @@
 #include <winver.h>
-#include <ntdef.h>
 
 #define VER_FILEVERSION 0,59,1,0
 #define VER_FILEVERSION_STR "0.59.1"


### PR DESCRIPTION
# Description

`ntdef.h` wasn't actually used and  caused a compiler error on at least one machine. This removes the unnecessary include. Keep in mind for later in case `winver.h` also causes issues, in which case we'd need to copy paste the relevant definitions from that into the `.rc` file here.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
