### PR TITLE
add ansi escape

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2176,6 +2176,38 @@ pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>
                     output.push(b')');
                     idx += 1;
                 }
+                Some(b'{') => {
+                    output.push(b'{');
+                    idx += 1;
+                }
+                Some(b'}') => {
+                    output.push(b'}');
+                    idx += 1;
+                }
+                Some(b'$') => {
+                    output.push(b'$');
+                    idx += 1;
+                }
+                Some(b'^') => {
+                    output.push(b'^');
+                    idx += 1;
+                }
+                Some(b'#') => {
+                    output.push(b'#');
+                    idx += 1;
+                }
+                Some(b'|') => {
+                    output.push(b'|');
+                    idx += 1;
+                }
+                Some(b'~') => {
+                    output.push(b'~');
+                    idx += 1;
+                }
+                Some(b'a') => {
+                    output.push(0x7);
+                    idx += 1;
+                }
                 Some(b'b') => {
                     output.push(0x8);
                     idx += 1;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2172,6 +2172,10 @@ pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>
                     output.push(0x8);
                     idx += 1;
                 }
+                Some(b'e') => {
+                    output.push(0x1b);
+                    idx += 1;
+                }
                 Some(b'f') => {
                     output.push(0xc);
                     idx += 1;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2168,6 +2168,14 @@ pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>
                     output.push(b'/');
                     idx += 1;
                 }
+                Some(b'(') => {
+                    output.push(b'(');
+                    idx += 1;
+                }
+                Some(b')') => {
+                    output.push(b')');
+                    idx += 1;
+                }
                 Some(b'b') => {
                     output.push(0x8);
                     idx += 1;


### PR DESCRIPTION
# Description

add one more escape in order to help with coloring. this allows you to do things like `"\e[91mNushell\e[0m"`.
also added escaping of left and right paren.

![image](https://user-images.githubusercontent.com/343840/157124078-54f78a2e-10d4-46aa-bf31-19a247948c49.png)


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
