### PR TITLE
Fix external extra

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -18,7 +18,11 @@ pub fn print_pipeline_data(
 
     let stdout = std::io::stdout();
 
-    if let PipelineData::ExternalStream { stdout: stream, .. } = input {
+    if let PipelineData::ExternalStream {
+        stdout: Some(stream),
+        ..
+    } = input
+    {
         for s in stream {
             let _ = stdout.lock().write_all(s?.as_binary()?);
         }

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -99,7 +99,15 @@ fn into_binary(
     let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
 
     match input {
-        PipelineData::ExternalStream { stdout: stream, .. } => {
+        PipelineData::ExternalStream { stdout: None, .. } => Ok(Value::Binary {
+            val: vec![],
+            span: head,
+        }
+        .into_pipeline_data()),
+        PipelineData::ExternalStream {
+            stdout: Some(stream),
+            ..
+        } => {
             // TODO: in the future, we may want this to stream out, converting each to bytes
             let output = stream.into_bytes()?;
             Ok(Value::Binary {

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -150,7 +150,15 @@ fn string_helper(
     }
 
     match input {
-        PipelineData::ExternalStream { stdout: stream, .. } => {
+        PipelineData::ExternalStream { stdout: None, .. } => Ok(Value::String {
+            val: String::new(),
+            span: head,
+        }
+        .into_pipeline_data()),
+        PipelineData::ExternalStream {
+            stdout: Some(stream),
+            ..
+        } => {
             // TODO: in the future, we may want this to stream out, converting each to bytes
             let output = stream.into_string()?;
             Ok(Value::String {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -121,11 +121,11 @@ impl Command for Open {
             let buf_reader = BufReader::new(file);
 
             let output = PipelineData::ExternalStream {
-                stdout: RawStream::new(
+                stdout: Some(RawStream::new(
                     Box::new(BufferedReader { input: buf_reader }),
                     ctrlc,
                     call_span,
-                ),
+                )),
                 stderr: None,
                 exit_code: None,
                 span: call_span,

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -169,7 +169,11 @@ impl Command for Each {
                     }
                 })
                 .into_pipeline_data(ctrlc)),
-            PipelineData::ExternalStream { stdout: stream, .. } => Ok(stream
+            PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(call.head)),
+            PipelineData::ExternalStream {
+                stdout: Some(stream),
+                ..
+            } => Ok(stream
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -213,7 +213,11 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
-            PipelineData::ExternalStream { stdout: stream, .. } => Ok(stream
+            PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(call.head)),
+            PipelineData::ExternalStream {
+                stdout: Some(stream),
+                ..
+            } => Ok(stream
                 .enumerate()
                 .par_bridge()
                 .map(move |(idx, x)| {

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -77,7 +77,7 @@ impl Command for Skip {
 
         match input {
             PipelineData::ExternalStream {
-                stdout: stream,
+                stdout: Some(stream),
                 span: bytes_span,
                 metadata,
                 ..

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -357,13 +357,13 @@ fn response_to_buffer(
     let buffered_input = BufReader::new(response);
 
     PipelineData::ExternalStream {
-        stdout: RawStream::new(
+        stdout: Some(RawStream::new(
             Box::new(BufferedReader {
                 input: buffered_input,
             }),
             engine_state.ctrlc.clone(),
             span,
-        ),
+        )),
         stderr: None,
         exit_code: None,
         span,

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -418,13 +418,13 @@ fn response_to_buffer(
     let buffered_input = BufReader::new(response);
 
     PipelineData::ExternalStream {
-        stdout: RawStream::new(
+        stdout: Some(RawStream::new(
             Box::new(BufferedReader {
                 input: buffered_input,
             }),
             engine_state.ctrlc.clone(),
             span,
-        ),
+        )),
         stderr: None,
         exit_code: None,
         span,

--- a/crates/nu-command/src/strings/decode.rs
+++ b/crates/nu-command/src/strings/decode.rs
@@ -44,7 +44,11 @@ impl Command for Decode {
         let encoding: Spanned<String> = call.req(engine_state, stack, 0)?;
 
         match input {
-            PipelineData::ExternalStream { stdout: stream, .. } => {
+            PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(call.head)),
+            PipelineData::ExternalStream {
+                stdout: Some(stream),
+                ..
+            } => {
                 let bytes: Vec<u8> = stream.into_bytes()?.item;
 
                 let encoding = match Encoding::for_label(encoding.item.as_bytes()) {

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -34,21 +34,24 @@ impl Command for Complete {
                 exit_code,
                 ..
             } => {
-                let mut cols = vec!["stdout".to_string()];
+                let mut cols = vec![];
                 let mut vals = vec![];
 
-                let stdout = stdout.into_bytes()?;
-                if let Ok(st) = String::from_utf8(stdout.item.clone()) {
-                    vals.push(Value::String {
-                        val: st,
-                        span: stdout.span,
-                    })
-                } else {
-                    vals.push(Value::Binary {
-                        val: stdout.item,
-                        span: stdout.span,
-                    })
-                };
+                if let Some(stdout) = stdout {
+                    cols.push("stdout".to_string());
+                    let stdout = stdout.into_bytes()?;
+                    if let Ok(st) = String::from_utf8(stdout.item.clone()) {
+                        vals.push(Value::String {
+                            val: st,
+                            span: stdout.span,
+                        })
+                    } else {
+                        vals.push(Value::Binary {
+                            val: stdout.item,
+                            span: stdout.span,
+                        })
+                    }
+                }
 
                 if let Some(stderr) = stderr {
                     cols.push("stderr".to_string());

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -307,7 +307,15 @@ impl ExternalCommand {
                 let exit_code_receiver = ValueReceiver::new(exit_code_rx);
 
                 Ok(PipelineData::ExternalStream {
-                    stdout: RawStream::new(Box::new(stdout_receiver), output_ctrlc.clone(), head),
+                    stdout: if redirect_stdout {
+                        Some(RawStream::new(
+                            Box::new(stdout_receiver),
+                            output_ctrlc.clone(),
+                            head,
+                        ))
+                    } else {
+                        None
+                    },
                     stderr: Some(RawStream::new(
                         Box::new(stderr_receiver),
                         output_ctrlc.clone(),

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -67,7 +67,7 @@ impl Command for Table {
             PipelineData::ExternalStream { .. } => Ok(input),
             PipelineData::Value(Value::Binary { val, .. }, ..) => {
                 Ok(PipelineData::ExternalStream {
-                    stdout: RawStream::new(
+                    stdout: Some(RawStream::new(
                         Box::new(
                             vec![Ok(format!("{}\n", nu_pretty_hex::pretty_hex(&val))
                                 .as_bytes()
@@ -76,7 +76,7 @@ impl Command for Table {
                         ),
                         ctrlc,
                         head,
-                    ),
+                    )),
                     stderr: None,
                     exit_code: None,
                     span: head,
@@ -269,7 +269,7 @@ fn handle_row_stream(
     let head = call.head;
 
     Ok(PipelineData::ExternalStream {
-        stdout: RawStream::new(
+        stdout: Some(RawStream::new(
             Box::new(PagingTableCreator {
                 row_offset,
                 config,
@@ -279,7 +279,7 @@ fn handle_row_stream(
             }),
             ctrlc,
             head,
-        ),
+        )),
         stderr: None,
         exit_code: None,
         span: head,

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -47,6 +47,7 @@ mod reverse;
 mod rm;
 mod roll;
 mod rotate;
+mod run_external;
 mod save;
 mod select;
 mod semicolon;

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -1,0 +1,15 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn better_empty_redirection() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            ls | each { |it| nu --testbin cococo $it.name }
+        "#
+    ));
+
+    eprintln!("out: {}", actual.out);
+
+    assert!(!actual.out.contains('2'));
+}

--- a/src/eval_file.rs
+++ b/src/eval_file.rs
@@ -100,7 +100,12 @@ pub fn print_table_or_error(
             );
 
             match table {
-                Ok(table) => {
+                Ok(mut table) => {
+                    let exit_code = match &mut table {
+                        PipelineData::ExternalStream { exit_code, .. } => exit_code.take(),
+                        _ => None,
+                    };
+
                     for item in table {
                         let stdout = std::io::stdout();
 
@@ -119,6 +124,10 @@ pub fn print_table_or_error(
                             Ok(_) => (),
                             Err(err) => eprintln!("{}", err),
                         };
+                    }
+
+                    if let Some(exit_code) = exit_code {
+                        let _: Vec<_> = exit_code.into_iter().collect();
                     }
                 }
                 Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,11 +172,11 @@ fn main() -> Result<()> {
                 let buf_reader = BufReader::new(stdin);
 
                 PipelineData::ExternalStream {
-                    stdout: RawStream::new(
+                    stdout: Some(RawStream::new(
                         Box::new(BufferedReader::new(buf_reader)),
                         Some(ctrlc),
                         redirect_stdin.span,
-                    ),
+                    )),
                     stderr: None,
                     exit_code: None,
                     span: redirect_stdin.span,


### PR DESCRIPTION
# Description

This fixes the empty table coming from running external commands inside of a loop.

fixes #4774 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
