### PR TITLE
Add support for var decl spans

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -761,7 +761,7 @@ pub fn create_scope(
         for var in &frame.vars {
             let var_name = Value::string(String::from_utf8_lossy(var.0).to_string(), span);
 
-            let var_type = Value::string(engine_state.get_var(*var.1).to_string(), span);
+            let var_type = Value::string(engine_state.get_var(*var.1).ty.to_string(), span);
 
             let var_value = if let Ok(val) = stack.get_var(*var.1, span) {
                 val

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -12,7 +12,7 @@ mod span;
 mod syntax_shape;
 mod ty;
 mod value;
-pub use value::Value;
+mod variable;
 
 pub use config::*;
 pub use engine::{CONFIG_VARIABLE_ID, ENV_VARIABLE_ID, IN_VARIABLE_ID, NU_VARIABLE_ID};
@@ -26,5 +26,5 @@ pub use signature::*;
 pub use span::*;
 pub use syntax_shape::*;
 pub use ty::*;
-pub use value::CustomValue;
 pub use value::*;
+pub use variable::*;

--- a/crates/nu-protocol/src/variable.rs
+++ b/crates/nu-protocol/src/variable.rs
@@ -1,0 +1,16 @@
+use crate::{Span, Type};
+
+#[derive(Clone, Debug)]
+pub struct Variable {
+    pub declaration_span: Span,
+    pub ty: Type,
+}
+
+impl Variable {
+    pub fn new(declaration_span: Span, ty: Type) -> Variable {
+        Self {
+            declaration_span,
+            ty,
+        }
+    }
+}


### PR DESCRIPTION
# Description

Remembers the var decl span in the variable's record. This helps us do better when getting the spans for an `error make` so we don't accidentally get the span of the closure.

fixes #4784 #4460

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
