### PR TITLE
Make date values more readable

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -428,7 +428,7 @@ impl Value {
             Value::Float { val, .. } => val.to_string(),
             Value::Filesize { val, .. } => format_filesize(*val, config),
             Value::Duration { val, .. } => format_duration(*val),
-            Value::Date { val, .. } => HumanTime::from(*val).to_string(),
+            Value::Date { val, .. } => format!("{} ({})", val.to_rfc2822(), HumanTime::from(*val)),
             Value::Range { val, .. } => {
                 format!(
                     "{}..{}",


### PR DESCRIPTION
# Description

Before:
```
> date now
now
```

Now:
```
> date now
Wed, 09 Mar 2022 04:56:09 -0500 (now)
```

fixes #4698 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
