### PR TITLE
Change `select` to match 0.44

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -147,9 +147,9 @@ fn select(
                                 cols.push(path.into_string());
                                 vals.push(value);
                             }
-                            Err(error) => {
+                            Err(_) => {
                                 cols.push(path.into_string());
-                                vals.push(Value::Error { error });
+                                vals.push(Value::Nothing { span });
                             }
                         }
                     }


### PR DESCRIPTION
# Description

Rather than return errors in the streaming case for `select`, we switch to using the 0.44 style of returning empty when there isn't a match. You'll need to then check the results after the stream filtering has finished.

fixes https://github.com/nushell/nushell/issues/4475

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
