### PR TITLE
Allow quotes in a `register` call

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1703,6 +1703,8 @@ pub fn parse_register(
         .get(0)
         .map(|expr| {
             let name_expr = working_set.get_span_contents(expr.span);
+
+            let name_expr = trim_quotes(name_expr);
             String::from_utf8(name_expr.to_vec())
                 .map_err(|_| ParseError::NonUtf8(expr.span))
                 .and_then(move |name| {


### PR DESCRIPTION
# Description

fixes #4693

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
