### PR TITLE
Adds the proper workarounds for short flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,14 +98,10 @@ fn main() -> Result<()> {
             if arg == "-c"
                 || arg == "--commands"
                 || arg == "--testbin"
-                || arg == "--develop"
-                || arg == "--debug"
-                || arg == "--loglevel"
-                || arg == "--config"
-                || arg == "--perf"
-                || arg == "--threads"
-                || arg == "--version"
                 || arg == "--log-level"
+                || arg == "--config"
+                || arg == "--threads"
+                || arg == "-t"
             {
                 collect_arg_nushell = true;
             }
@@ -383,11 +379,6 @@ impl Command for Nu {
                 "run the given commands and then exit",
                 Some('c'),
             )
-            .optional(
-                "script file",
-                SyntaxShape::Filepath,
-                "name of the optional script file to run",
-            )
             .named(
                 "config",
                 SyntaxShape::String,
@@ -405,6 +396,11 @@ impl Command for Nu {
                 SyntaxShape::Int,
                 "threads to use for parallel commands",
                 Some('t'),
+            )
+            .optional(
+                "script file",
+                SyntaxShape::Filepath,
+                "name of the optional script file to run",
             )
             .rest(
                 "script args",


### PR DESCRIPTION
# Description

fixes #4602

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
