### PR TITLE
Fix expansion of row condition implied it

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1752,7 +1752,7 @@ pub fn parse_full_cell_path(
             (
                 Expression {
                     expr: Expr::Var(var_id),
-                    span,
+                    span: Span::new(0, 0),
                     ty: Type::Unknown,
                     custom_completion: None,
                 },


### PR DESCRIPTION
# Description

When we make a synthetic `$it` for row conditions, don't give it the full span (this messes up highlighting)

fixes #4645 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
