### PR TITLE
Simplify `empty?`, improve `default`

### DIFF
--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -40,8 +40,16 @@ impl Command for Empty {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Check if a value is empty",
+                description: "Check if a string is empty",
                 example: "'' | empty?",
+                result: Some(Value::Bool {
+                    val: true,
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Check if a list is empty",
+                example: "[] | empty?",
                 result: Some(Value::Bool {
                     val: true,
                     span: Span::test_data(),

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -1,8 +1,8 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -19,12 +19,6 @@ impl Command for Empty {
                 "rest",
                 SyntaxShape::CellPath,
                 "the names of the columns to check emptiness",
-            )
-            .named(
-                "block",
-                SyntaxShape::Block(Some(vec![SyntaxShape::Any])),
-                "an optional block to replace if empty",
-                Some('b'),
             )
             .category(Category::Filters)
     }
@@ -54,46 +48,13 @@ impl Command for Empty {
                 }),
             },
             Example {
-                description: "more than one column",
+                description: "Check if more than one column are empty",
                 example: "[[meal size]; [arepa small] [taco '']] | empty? meal size",
-                result: Some(
-                    Value::List {
-                        vals: vec![
-                            Value::Record{cols: vec!["meal".to_string(), "size".to_string()], vals: vec![
-                                Value::Bool{val: false, span: Span::test_data()},
-                                Value::Bool{val: false, span: Span::test_data()}
-                            ], span: Span::test_data()},
-                            Value::Record{cols: vec!["meal".to_string(), "size".to_string()], vals: vec![
-                                Value::Bool{val: false, span: Span::test_data()},
-                                Value::Bool{val: true, span: Span::test_data()}
-                            ], span: Span::test_data()}
-                        ], span: Span::test_data()
-                    })
+                result: Some(Value::Bool {
+                    val: false,
+                    span: Span::test_data(),
+                }),
             },
-            Example {
-                description: "use a block if setting the empty cell contents is wanted",
-                example: "[[2020/04/16 2020/07/10 2020/11/16]; ['' [27] [37]]] | empty? 2020/04/16 -b { |_| [33 37] }",
-                result: Some(
-                    Value::List {
-                        vals: vec![
-                            Value::Record{
-                            cols: vec!["2020/04/16".to_string(), "2020/07/10".to_string(), "2020/11/16".to_string()],
-                            vals: vec![
-                                Value::List{vals: vec![
-                                    Value::Int{val: 33, span: Span::test_data()},
-                                    Value::Int{val: 37, span: Span::test_data()}
-                                ], span: Span::test_data()},
-                                Value::List{vals: vec![
-                                    Value::Int{val: 27, span: Span::test_data()},
-                                ], span: Span::test_data()},
-                                Value::List{vals: vec![
-                                    Value::Int{val: 37, span: Span::test_data()},
-                                ], span: Span::test_data()},
-                            ], span: Span::test_data()}
-                        ], span: Span::test_data()
-                    }
-                )
-            }
         ]
     }
 }
@@ -106,126 +67,77 @@ fn empty(
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
     let head = call.head;
     let columns: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
-    let has_block = call.has_flag("block");
 
-    let block = if has_block {
-        let block_expr = call
-            .get_flag_expr("block")
-            .expect("internal error: expected block");
+    if !columns.is_empty() {
+        for val in input {
+            for column in &columns {
+                let val = val.clone();
+                match val.follow_cell_path(&column.members) {
+                    Ok(Value::Nothing { .. }) => {}
+                    Ok(_) => {
+                        return Ok(Value::Bool {
+                            val: false,
+                            span: head,
+                        }
+                        .into_pipeline_data())
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        }
 
-        let block_id = block_expr
-            .as_block()
-            .ok_or_else(|| ShellError::TypeMismatch("expected row condition".to_owned(), head))?;
-
-        let b = engine_state.get_block(block_id);
-        let evaluated_block = eval_block(
-            engine_state,
-            stack,
-            b,
-            PipelineData::new(head),
-            call.redirect_stdout,
-            call.redirect_stderr,
-        )?;
-        Some(evaluated_block.into_value(head))
+        Ok(Value::Bool {
+            val: true,
+            span: head,
+        }
+        .into_pipeline_data())
     } else {
-        None
-    };
+        match input {
+            PipelineData::ExternalStream { stdout, .. } => match stdout {
+                Some(s) => {
+                    let bytes = s.into_bytes();
 
-    input.map(
-        move |value| {
-            let columns = columns.clone();
-
-            process_row(value, block.as_ref(), columns, head)
-        },
-        engine_state.ctrlc.clone(),
-    )
-}
-
-fn process_row(
-    input: Value,
-    default_block: Option<&Value>,
-    column_paths: Vec<CellPath>,
-    head: Span,
-) -> Value {
-    match input {
-        Value::Record {
-            cols: _,
-            ref vals,
-            span,
-        } => {
-            if column_paths.is_empty() {
-                let is_empty = vals.iter().all(|v| v.clone().is_empty());
-                if default_block.is_some() {
-                    if is_empty {
-                        Value::Bool { val: true, span }
-                    } else {
-                        input.clone()
-                    }
-                } else {
-                    Value::Bool {
-                        val: is_empty,
-                        span,
-                    }
-                }
-            } else {
-                let mut obj = input.clone();
-                for column in column_paths {
-                    let path = column.into_string();
-                    let data = input.get_data_by_key(&path);
-                    let is_empty = match data {
-                        Some(x) => x.is_empty(),
-                        None => true,
-                    };
-
-                    let default = if let Some(x) = default_block {
-                        if is_empty {
-                            x.clone()
-                        } else {
-                            Value::Bool { val: true, span }
+                    match bytes {
+                        Ok(s) => Ok(Value::Bool {
+                            val: s.item.is_empty(),
+                            span: head,
                         }
-                    } else {
-                        Value::Bool {
-                            val: is_empty,
-                            span,
-                        }
-                    };
-                    let r = obj.update_cell_path(&column.members, Box::new(move |_| default));
-                    if let Err(error) = r {
-                        return Value::Error { error };
+                        .into_pipeline_data()),
+                        Err(err) => Err(err),
                     }
                 }
-                obj
-            }
-        }
-        Value::List { vals, .. } if vals.iter().all(|v| v.as_record().is_ok()) => {
-            {
-                // we have records
-                if column_paths.is_empty() {
-                    let is_empty = vals.is_empty() && vals.iter().all(|v| v.clone().is_empty());
-
-                    Value::Bool {
-                        val: is_empty,
-                        span: head,
-                    }
-                } else {
-                    Value::Bool {
-                        val: true,
-                        span: head,
-                    }
+                None => Ok(Value::Bool {
+                    val: true,
+                    span: head,
                 }
-            }
-        }
-        Value::List { vals, .. } => {
-            let empty = vals.iter().all(|v| v.clone().is_empty());
-            Value::Bool {
-                val: empty,
+                .into_pipeline_data()),
+            },
+            PipelineData::ListStream(s, ..) => Ok(Value::Bool {
+                val: s.count() == 0,
                 span: head,
             }
+            .into_pipeline_data()),
+            PipelineData::Value(value, ..) => {
+                let answer = is_empty(value);
+
+                Ok(Value::Bool {
+                    val: answer,
+                    span: head,
+                }
+                .into_pipeline_data())
+            }
         }
-        other => Value::Bool {
-            val: other.is_empty(),
-            span: head,
-        },
+    }
+}
+
+pub fn is_empty(value: Value) -> bool {
+    match value {
+        Value::List { vals, .. } => vals.is_empty(),
+        Value::String { val, .. } => val.is_empty(),
+        Value::Binary { val, .. } => val.is_empty(),
+        Value::Nothing { .. } => true,
+        Value::Record { cols, .. } => cols.is_empty(),
+        _ => false,
     }
 }
 

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -50,7 +50,7 @@ fn keeps_remaining_original_names_given_less_new_names_than_total_original_names
                 open los_cuatro_mosqueteros.txt
                 | lines
                 | wrap name
-                | default hit "arepa!"
+                | default "arepa!" hit
                 | rename mosqueteros
                 | get hit
                 | length

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -235,7 +235,7 @@ fn length_for_rows() -> TestResult {
 #[test]
 fn length_defaulted_columns() -> TestResult {
     run_test(
-        r#"echo [[name, age]; [test, 10]] | default age 11 | get 0 | columns | length"#,
+        r#"echo [[name, age]; [test, 10]] | default 11 age | get 0 | columns | length"#,
         "2",
     )
 }


### PR DESCRIPTION
# Description

Simplifies `empty?` to not take in a block and expands `default` to support lists as well as tables. Note: this changes the order of the arguments to `default`.

fixes #4786
fixes #4634
fixes #3903 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
