### PR TITLE
Allow passing block literals to do

### DIFF
--- a/crates/nu-command/src/core_commands/do_.rs
+++ b/crates/nu-command/src/core_commands/do_.rs
@@ -18,11 +18,7 @@ impl Command for Do {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("do")
             .desc(self.usage())
-            .required(
-                "block",
-                SyntaxShape::Block(Some(vec![])),
-                "the block to run",
-            )
+            .required("block", SyntaxShape::Any, "the block to run")
             .switch(
                 "ignore-errors",
                 "ignore errors as the block runs",
@@ -115,6 +111,20 @@ impl Command for Do {
                 example: r#"do -i { thisisnotarealcommand }"#,
                 result: None,
             },
+            Example {
+                description: "Run the block, with a positional parameter",
+                example: r#"do {|x| 100 + $x } 50"#,
+                result: Some(Value::test_int(150)),
+            },
         ]
+    }
+}
+
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::Do;
+        use crate::test_examples;
+        test_examples(Do {})
     }
 }


### PR DESCRIPTION
# Description

fixes #4522 
fixes #4660 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
