### PR TITLE
Move completions to DeclId

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -24,7 +24,7 @@ pub fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
     }
 }
 
-fn eval_call(
+pub fn eval_call(
     engine_state: &EngineState,
     caller_stack: &mut Stack,
     call: &Call,

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -10,6 +10,7 @@ pub use column::get_columns;
 pub use documentation::{generate_docs, get_brief_help, get_documentation, get_full_help};
 pub use env::*;
 pub use eval::{
-    eval_block, eval_expression, eval_expression_with_input, eval_operator, eval_subexpression,
+    eval_block, eval_call, eval_expression, eval_expression_with_input, eval_operator,
+    eval_subexpression,
 };
 pub use glob_from::glob_from;

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -1,4 +1,5 @@
 use nu_protocol::ast::{Block, Expr, Expression, ImportPatternMember, PathMember, Pipeline};
+use nu_protocol::DeclId;
 use nu_protocol::{engine::StateWorkingSet, Span};
 use std::fmt::{Display, Formatter, Result};
 
@@ -28,7 +29,7 @@ pub enum FlatShape {
     GlobPattern,
     Variable,
     Flag,
-    Custom(String),
+    Custom(DeclId),
 }
 
 impl Display for FlatShape {
@@ -76,7 +77,7 @@ pub fn flatten_expression(
     expr: &Expression,
 ) -> Vec<(Span, FlatShape)> {
     if let Some(custom_completion) = &expr.custom_completion {
-        return vec![(expr.span, FlatShape::Custom(custom_completion.clone()))];
+        return vec![(expr.span, FlatShape::Custom(*custom_completion))];
     }
 
     match &expr.expr {

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use super::{Expr, Operator};
-use crate::DeclId;
 use crate::ast::ImportPattern;
+use crate::DeclId;
 use crate::{engine::StateWorkingSet, BlockId, Signature, Span, Type, VarId, IN_VARIABLE_ID};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::{Expr, Operator};
+use crate::DeclId;
 use crate::ast::ImportPattern;
 use crate::{engine::StateWorkingSet, BlockId, Signature, Span, Type, VarId, IN_VARIABLE_ID};
 
@@ -9,7 +10,7 @@ pub struct Expression {
     pub expr: Expr,
     pub span: Span,
     pub ty: Type,
-    pub custom_completion: Option<String>,
+    pub custom_completion: Option<DeclId>,
 }
 
 impl Expression {

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{Type, DeclId};
+use crate::{DeclId, Type};
 
 /// The syntactic shapes that values must match to be passed into a command. You can think of this as the type-checking that occurs when you call a function.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::Type;
+use crate::{Type, DeclId};
 
 /// The syntactic shapes that values must match to be passed into a command. You can think of this as the type-checking that occurs when you call a function.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -90,7 +90,7 @@ pub enum SyntaxShape {
     Record,
 
     /// A custom shape with custom completion logic
-    Custom(Box<SyntaxShape>, String),
+    Custom(Box<SyntaxShape>, DeclId),
 }
 
 impl SyntaxShape {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -51,7 +51,7 @@ impl Type {
             Type::Unknown => SyntaxShape::Any,
             Type::Error => SyntaxShape::Any,
             Type::Binary => SyntaxShape::Binary,
-            Type::Custom => SyntaxShape::Custom(Box::new(SyntaxShape::Any), String::new()),
+            Type::Custom => SyntaxShape::Any,
             Type::Signature => SyntaxShape::Signature,
         }
     }


### PR DESCRIPTION
# Description

This will bind the name after the `@` for custom completions to a universal DeclId that can later be used.

This should allow you to export externs and use completions that are inside the module.

Fixes #4785

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
