### PR TITLE
Mark `match` as deprecated command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -361,6 +361,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             StrDatetimeDeprecated,
             StrDecimalDeprecated,
             StrIntDeprecated,
+            MatchDeprecated,
             NthDeprecated,
             UnaliasDeprecated,
         };

--- a/crates/nu-command/src/deprecated/match_.rs
+++ b/crates/nu-command/src/deprecated/match_.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct MatchDeprecated;
+
+impl Command for MatchDeprecated {
+    fn name(&self) -> &str {
+        "match"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "find".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/mod.rs
+++ b/crates/nu-command/src/deprecated/mod.rs
@@ -1,4 +1,5 @@
 mod insert;
+mod match_;
 mod nth;
 mod pivot;
 mod str_datetime;
@@ -7,6 +8,7 @@ mod str_int;
 mod unalias;
 
 pub use insert::InsertDeprecated;
+pub use match_::MatchDeprecated;
 pub use nth::NthDeprecated;
 pub use pivot::PivotDeprecated;
 pub use str_datetime::StrDatetimeDeprecated;


### PR DESCRIPTION
# Description

Mark `match` as deprecated command

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
