### PR TITLE
Ensure exit codes in more cases

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -19,13 +19,22 @@ pub fn print_pipeline_data(
     let stdout = std::io::stdout();
 
     if let PipelineData::ExternalStream {
-        stdout: Some(stream),
+        stdout: stream,
+        exit_code,
         ..
     } = input
     {
-        for s in stream {
-            let _ = stdout.lock().write_all(s?.as_binary()?);
+        if let Some(stream) = stream {
+            for s in stream {
+                let _ = stdout.lock().write_all(s?.as_binary()?);
+            }
         }
+
+        // Make sure everything has finished
+        if let Some(exit_code) = exit_code {
+            let _: Vec<_> = exit_code.into_iter().collect();
+        }
+
         return Ok(());
     }
 


### PR DESCRIPTION
# Description

This adds more guards to ensure that we've seen an exit code before we move on. There were a few places in the repl and script runner that might have moved on before the external and fully completed. In theory, waiting on the exit code should help.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
