### PR TITLE
ensure exit codes in more cases

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -93,9 +93,20 @@ impl PipelineData {
                 vals: s.collect(),
                 span, // FIXME?
             },
-            PipelineData::ExternalStream { stdout: None, .. } => Value::Nothing { span },
+            PipelineData::ExternalStream {
+                stdout: None,
+                exit_code,
+                ..
+            } => {
+                // Make sure everything has finished
+                if let Some(exit_code) = exit_code {
+                    let _: Vec<_> = exit_code.into_iter().collect();
+                }
+                Value::Nothing { span }
+            }
             PipelineData::ExternalStream {
                 stdout: Some(mut s),
+                exit_code,
                 ..
             } => {
                 let mut items = vec![];
@@ -109,6 +120,11 @@ impl PipelineData {
                             return Value::Error { error: e };
                         }
                     }
+                }
+
+                // Make sure everything has finished
+                if let Some(exit_code) = exit_code {
+                    let _: Vec<_> = exit_code.into_iter().collect();
                 }
 
                 if s.is_binary {


### PR DESCRIPTION
# Description

Another attempt to see if we can fix a potential cause for #4800 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
