### PR TITLE
reorganize features a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,17 +70,17 @@ embed-resource = "1"
 
 [features]
 plugin = ["nu-plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
-default = ["plugin", "which"]
+default = ["plugin", "which", "zip-support", "trash-support"]
 stable = ["default"]
-extra = ["default", "dataframe", "zip-support", "trash-support"]
+extra = ["default", "dataframe"]
 wasi = []
-trash-support = ["nu-command/trash-support"]
 
 # Stable (Default)
 which = ["nu-command/which"]
+zip-support = ["nu-command/zip"]
+trash-support = ["nu-command/trash-support"]
 
 # Extra
-zip-support = ["nu-command/zip"]
 
 # Dataframe feature for nushell
 dataframe = ["nu-command/dataframe"]
@@ -88,7 +88,7 @@ dataframe = ["nu-command/dataframe"]
 [profile.release]
 opt-level = "s" # Optimize for size
 strip = "debuginfo"
-lto = "fat"
+lto = "thin"
 
 # build with `cargo build --profile profiling` 
 # to analyze performance with tooling like linux perf


### PR DESCRIPTION
# Description

I think `zip-support` needs to be part of `default` since it's used in to html (part of extracting themes from the binary), and i think `trash-support` should be part of `default`, just because. which would leave only `dataframes` in `extra`. let me know if you disagree.

also changed lto to thin

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
