### PR TITLE
Update docs for open and decode command, regenerate all docs

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -20,7 +20,7 @@ impl Command for Open {
     }
 
     fn usage(&self) -> &str {
-        "Load a file into a cell, convert to table if possible (avoid by appending '--raw')."
+        "Load a file into a cell, converting to table if possible (avoid by appending '--raw')."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -20,7 +20,7 @@ impl Command for Open {
     }
 
     fn usage(&self) -> &str {
-        "Opens a file."
+        "Load a file into a cell, convert to table if possible (avoid by appending '--raw')."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -170,6 +170,11 @@ impl Command for Open {
             Example {
                 description: "Open a file, using the input to get filename",
                 example: "echo 'myfile.txt' | open",
+                result: None,
+            },
+            Example {
+                description: "Open a file, and decode it by the specified encoding",
+                example: "open myfile.txt --raw | decode utf-8",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/strings/decode.rs
+++ b/crates/nu-command/src/strings/decode.rs
@@ -25,6 +25,14 @@ impl Command for Decode {
             .category(Category::Strings)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"Multiple encodings are supported, here is an example of a few:
+big5, euc-jp, euc-kr, gbk, iso-8859-1, utf-16, cp1252, latin5
+
+For a more complete list of encodings please refer to the encoding_rs
+documentation link at https://docs.rs/encoding_rs/0.8.28/encoding_rs/#statics"#
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Decode the output of an external command",

--- a/docs/commands/default.md
+++ b/docs/commands/default.md
@@ -8,16 +8,21 @@ Sets a default row's column if missing.
 
 ## Signature
 
-```> default (column name) (column value)```
+```> default (default value) (column name)```
 
 ## Parameters
 
+ -  `default value`: the value to use as a default
  -  `column name`: the name of the column
- -  `column value`: the value of the column to default
 
 ## Examples
 
-Give a default 'target' to all file entries
+Give a default 'target' column to all file entries
 ```shell
-> ls -la | default target 'nothing'
+> ls -la | default 'nothing' target
+```
+
+Default the `$nothing` value in a list
+```shell
+> [1, 2, $nothing, 4] | default 3
 ```

--- a/docs/commands/do.md
+++ b/docs/commands/do.md
@@ -27,3 +27,8 @@ Run the block and ignore errors
 ```shell
 > do -i { thisisnotarealcommand }
 ```
+
+Run the block, with a positional parameter
+```shell
+> do {|x| 100 + $x } 50
+```

--- a/docs/commands/empty.md
+++ b/docs/commands/empty.md
@@ -8,26 +8,25 @@ Check for empty values.
 
 ## Signature
 
-```> empty? ...rest --block```
+```> empty? ...rest```
 
 ## Parameters
 
  -  `...rest`: the names of the columns to check emptiness
- -  `--block {block}`: an optional block to replace if empty
 
 ## Examples
 
-Check if a value is empty
+Check if a string is empty
 ```shell
 > '' | empty?
 ```
 
-more than one column
+Check if a list is empty
 ```shell
-> [[meal size]; [arepa small] [taco '']] | empty? meal size
+> [] | empty?
 ```
 
-use a block if setting the empty cell contents is wanted
+Check if more than one column are empty
 ```shell
-> [[2020/04/16 2020/07/10 2020/11/16]; ['' [27] [37]]] | empty? 2020/04/16 -b { |_| [33 37] }
+> [[meal size]; [arepa small] [taco '']] | empty? meal size
 ```

--- a/docs/commands/match.md
+++ b/docs/commands/match.md
@@ -1,0 +1,11 @@
+---
+title: match
+layout: command
+version: 0.59.1
+---
+
+Deprecated command
+
+## Signature
+
+```> match ```

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -4,7 +4,7 @@ layout: command
 version: 0.59.1
 ---
 
-Opens a file.
+Load a file into a cell, convert to table if possible (avoid by appending '--raw').
 
 ## Signature
 
@@ -30,4 +30,9 @@ Open a file, as raw bytes
 Open a file, using the input to get filename
 ```shell
 > echo 'myfile.txt' | open
+```
+
+Open a file, and decode it by the specified encoding
+```shell
+> open myfile.txt --raw | decode utf-8
 ```

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -4,7 +4,7 @@ layout: command
 version: 0.59.1
 ---
 
-Load a file into a cell, convert to table if possible (avoid by appending '--raw').
+Load a file into a cell, converting to table if possible (avoid by appending '--raw').
 
 ## Signature
 

--- a/docs/commands/reduce.md
+++ b/docs/commands/reduce.md
@@ -36,10 +36,10 @@ Replace selected characters in a string with 'X'
 Find the longest string and its index
 ```shell
 > [ one longest three bar ] | reduce -n { |it, acc|
-        if ($it.item | str length) > ($acc | str length) {
-            $it.item
-        } else {
-            $acc
-        }
-    }
+                    if ($it.item | str length) > ($acc | str length) {
+                        $it.item
+                    } else {
+                        $acc
+                    }
+                }
 ```


### PR DESCRIPTION
# Description

Update docs for open and decode command, regenerate all docs
Fix #4809

I have checked all the other `extra_usage` in nu v0.44, most of them were added in nu 0.59, except `enter`, `autoenv`, `reduce`. We don't support enter a file and `autoenv` yet, so they both could be ignored.  And I don't understand the `extra_usage` of command `reduce` very well

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
