### PR TITLE
draft restore flatten test

### DIFF
--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -78,8 +78,6 @@ fn flatten_row_column_explicitly() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn flatten_row_columns_having_same_column_names_flats_separately() {
     Playground::setup("flatten_test_2", |dirs, sandbox| {


### PR DESCRIPTION
Is 4 still the expected output?

`nu` currently prints 2 entries from the sample test data.

`2` seems incorrect.

# Description

(description of your pull request here)

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
