### PR TITLE
allow list to keybinding mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.2.0"
-source = "git+https://github.com/nushell/reedline?branch=main#87a32d51476222026ed514da11914de6cb3059ab"
+source = "git+https://github.com/nushell/reedline?branch=main#4e5a20d127d84f4722e1d39d1852ccb42aa973f6"
 dependencies = [
  "chrono",
  "crossterm",

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -198,7 +198,7 @@ let $config = {
       name: completion_menu
       modifier: none
       keycode: tab
-      mode: emacs # emacs vi_normal vi_insert
+      mode: emacs # Options: emacs vi_normal vi_insert
       event: {
         until: [
           { send: menu name: completion_menu }
@@ -210,14 +210,14 @@ let $config = {
       name: completion_previous
       modifier: shift
       keycode: backtab
-      mode: emacs # emacs vi_normal vi_insert
+      mode: [emacs, vi_normal, vi_insert] # Note: You can add the same keybinding to all modes by using a list
       event: { send: menuprevious }
     }
     {
       name: history_menu
       modifier: control
       keycode: char_x
-      mode: emacs # emacs vi_normal vi_insert
+      mode: emacs
       event: {
         until: [
           { send: menu name: history_menu }
@@ -229,7 +229,7 @@ let $config = {
       name: history_previous
       modifier: control
       keycode: char_z
-      mode: emacs # emacs vi_normal vi_insert
+      mode: emacs 
       event: {
         until: [
           { send: menupageprevious }


### PR DESCRIPTION
# Description

we can assign the same keybinding to all modes by using a list instead of a string in the keybinding mode

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
