### PR TITLE
equal comparisson series string

### DIFF
--- a/crates/nu-command/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/between_values.rs
@@ -266,6 +266,10 @@ pub(super) fn compute_series_single_value(
             Value::Float { val, .. } => {
                 compare_series_decimal(&lhs, *val, ChunkedArray::equal, lhs_span)
             }
+            Value::String { val, .. } => {
+                let equal_pattern = format!("^{}$", val);
+                contains_series_pat(&lhs, &equal_pattern, lhs_span)
+            }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
                 lhs_ty: left.get_type(),


### PR DESCRIPTION
# Description

Allows strict comparison between series and str

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
