### PR TITLE
remove `$nu.cwd`

### DIFF
--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -368,10 +368,10 @@ rows, columns, or cells inside of the table.
 Shorthand paths are made from rows numbers, column names, or both. You can use
 them on any variable or subexpression.
 ```
-$nu.cwd
+$env.PWD
 ```
-The above accesses the built-in `$nu` variable, gets its table, and then uses
-the shorthand path to retrieve only the cell data inside the "cwd" column.
+The above accesses the built-in `$env` variable, gets its table, and then uses
+the shorthand path to retrieve only the cell data inside the "PWD" column.
 ```
 (ls).name.4
 ```

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1125,12 +1125,6 @@ pub fn eval_variable(
                 }
             }
 
-            // since the env var PWD doesn't exist on all platforms
-            // lets just get the current directory
-            let cwd = current_dir_str(engine_state, stack)?;
-            output_cols.push("cwd".into());
-            output_vals.push(Value::String { val: cwd, span });
-
             output_cols.push("scope".into());
             output_vals.push(create_scope(engine_state, stack, span)?);
 

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -1,7 +1,7 @@
 # Nushell Config File
 
 def create_left_prompt [] {
-    let path_segment = ($nu.cwd)
+    let path_segment = ($env.PWD)
 
     $path_segment
 }


### PR DESCRIPTION
# Description

This removes the build-in `$nu.cwd` to get the current working directory. This leaves us with one way to rule them all, which is `$env.PWD`.

closed #4775 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
