### PR TITLE
add `$nu.pid`

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1147,6 +1147,10 @@ pub fn eval_variable(
                 })
             }
 
+            let pid = std::process::id();
+            output_cols.push("pid".into());
+            output_vals.push(Value::int(pid as i64, span));
+
             Ok(Value::Record {
                 cols: output_cols,
                 vals: output_vals,


### PR DESCRIPTION
# Description

This PR adds nushell's current pid like `$nu.pid`.
closes #3881

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
