### PR TITLE
Add LIB_DIRS and PLUGIN_DIRS

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 static LIB_DIRS_ENV: &str = "NU_LIB_DIRS";
+#[cfg(feature = "plugin")]
 static PLUGIN_DIRS_ENV: &str = "NU_PLUGIN_DIRS";
 
 use crate::{

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -16,6 +16,8 @@ use std::path::Path;
 #[cfg(feature = "plugin")]
 use std::path::PathBuf;
 
+static PWD_ENV: &str = "PWD";
+
 // Tells whether a decl etc. is visible or not
 #[derive(Debug, Clone)]
 struct Visibility {
@@ -1175,9 +1177,13 @@ impl<'a> StateWorkingSet<'a> {
         let pwd = self
             .permanent_state
             .env_vars
-            .get("PWD")
+            .get(PWD_ENV)
             .expect("internal error: can't find PWD");
         pwd.as_string().expect("internal error: PWD not a string")
+    }
+
+    pub fn get_env(&self, name: &str) -> Option<&Value> {
+        self.permanent_state.env_vars.get(name)
     }
 
     pub fn set_variable_type(&mut self, var_id: VarId, ty: Type) {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -40,6 +40,20 @@ let-env ENV_CONVERSIONS = {
   }
 }
 
+# Directories to search for scripts when calling source or use
+#
+# By default, <nushell-config-dir>/scripts is added
+let-env NU_LIB_DIRS = [
+    ($nu.config-path | path dirname | path join 'scripts')
+]
+
+# Directories to search for plugin binaries when calling register
+#
+# By default, <nushell-config-dir>/plugins is added
+let-env NU_PLUGIN_DIRS = [
+    ($nu.config-path | path dirname | path join 'plugins')
+]
+
 # Custom completions for external commands (those outside of Nushell)
 # Each completions has two parts: the form of the external command, including its flags and parameters
 # and a helper command that knows how to complete values for those flags and parameters
@@ -229,7 +243,7 @@ let $config = {
       name: history_previous
       modifier: control
       keycode: char_z
-      mode: emacs 
+      mode: emacs
       event: {
         until: [
           { send: menupageprevious }


### PR DESCRIPTION
# Description

* `source` and `use` will look up scripts in `LIB_DIRS` environment variable
* `register` will look up plugins in `PLUGIN_DIRS` environment variable
* Added default directories for both to default config

Didn't add tests yet since there is no support to run scripts in steps in tests (env vars are not updated until parsing is over).

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
