### PR TITLE
Alias to keywords (eg `source`)

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -1,0 +1,13 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn echo_range_is_lazy() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        alias bar = source sample_def.nu; bar; greet
+        "#
+    ));
+
+    assert_eq!(actual.out, "hello");
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -1,3 +1,4 @@
+mod alias;
 mod all;
 mod any;
 mod append;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -897,10 +897,19 @@ pub fn parse_call(
                     new_spans.extend(&spans[(pos + 1)..]);
                 }
 
-                working_set.enter_scope();
-                working_set.hide_alias(&name);
-                let (mut result, err) = parse_expression(working_set, &new_spans, false);
-                working_set.exit_scope();
+                let alias_id = working_set.hide_alias(&name);
+                let lite_command = LiteCommand {
+                    comments: vec![],
+                    parts: new_spans.clone(),
+                };
+                let (mut result, err) = parse_builtin_commands(working_set, &lite_command);
+                if let Some(frame) = working_set.delta.scope.last_mut() {
+                    if let Some(alias_id) = alias_id {
+                        frame.aliases.insert(name.clone(), alias_id);
+                    }
+                }
+
+                let mut result = result.expressions.remove(0);
 
                 result.replace_span(working_set, expansion_span, orig_span);
 

--- a/tests/fixtures/formats/sample_def.nu
+++ b/tests/fixtures/formats/sample_def.nu
@@ -1,0 +1,3 @@
+def greet [] {
+  "hello"
+}


### PR DESCRIPTION
# Description

This allows you to `alias` to a reserve keyword like `source`.

fixes #4822 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
