### PR TITLE
Fix reporting of `which` and `$nu.scope`

### DIFF
--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -58,7 +58,7 @@ fn multiple_reports_for_alias_def_custom() {
 // See: parse_definition, line 2187 for reference.
 #[ignore]
 #[test]
-fn one_report_of_multiple_aliases() {
+fn correctly_report_of_shadowed_alias() {
     let actual = nu!(
         cwd: ".",
         r#"alias xaz = echo alias1

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -58,38 +58,69 @@ fn multiple_reports_for_alias_def_custom() {
 // See: parse_definition, line 2187 for reference.
 #[ignore]
 #[test]
-fn multiple_reports_of_multiple_alias() {
+fn one_report_of_multiple_aliases() {
     let actual = nu!(
         cwd: ".",
-        "alias xaz = echo alias1; def helper [] {alias xaz = echo alias2; which -a xaz}; helper | length"
+        r#"alias xaz = echo alias1
+        def helper [] {
+            alias xaz = echo alias2
+            which -a xaz
+        }
+        helper | get path | str contains alias2"#
     );
 
-    let length: i32 = actual.out.parse().unwrap();
-    assert_eq!(length, 2);
+    assert_eq!(actual.out, "true");
 }
 
 #[test]
-fn multiple_reports_of_multiple_defs() {
+fn one_report_of_multiple_defs() {
     let actual = nu!(
         cwd: ".",
-        "def xaz [] {echo def1}; def helper [] { def xaz [] { echo def2 }; which -a xaz }; helper | length"
+        r#"def xaz [] { echo def1 }
+        def helper [] {
+            def xaz [] { echo def2 }
+            which -a xaz
+        }
+        helper | length"#
     );
 
     let length: i32 = actual.out.parse().unwrap();
-    assert_eq!(length, 2);
+    assert_eq!(length, 1);
 }
 
-//Fails due to ParserScope::add_definition
-// frame.custom_commands.insert(name.clone(), block.clone());
-// frame.commands.insert(name, whole_stream_command(block));
-#[ignore]
 #[test]
 fn def_only_seen_once() {
     let actual = nu!(
         cwd: ".",
         "def xaz [] {echo def1}; which -a xaz | length"
     );
-    //length is 2. One custom_command (def) one built in ("wrongly" added)
+
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 1);
+}
+
+#[test]
+fn do_not_show_hidden_aliases() {
+    let actual = nu!(
+        cwd: ".",
+        r#"alias foo = echo foo
+        hide foo
+        which foo | length"#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 0);
+}
+
+#[test]
+fn do_not_show_hidden_commands() {
+    let actual = nu!(
+        cwd: ".",
+        r#"def foo [] { echo foo }
+        hide foo
+        which foo | length"#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 0);
 }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -377,35 +377,6 @@ impl EngineState {
         }
     }
 
-    pub fn find_aliases(&self, name: &str) -> Vec<&[Span]> {
-        let mut output = vec![];
-
-        for frame in &self.scope {
-            if let Some(alias_id) = frame.aliases.get(name.as_bytes()) {
-                let alias = self.get_alias(*alias_id);
-                output.push(alias.as_ref());
-            }
-        }
-
-        output
-    }
-
-    pub fn find_custom_commands(&self, name: &str) -> Vec<Block> {
-        let mut output = vec![];
-
-        for frame in &self.scope {
-            if let Some(decl_id) = frame.decls.get(name.as_bytes()) {
-                let decl = self.get_decl(*decl_id);
-
-                if let Some(block_id) = decl.get_block_id() {
-                    output.push(self.get_block(block_id).clone());
-                }
-            }
-        }
-
-        output
-    }
-
     pub fn find_decl(&self, name: &[u8]) -> Option<DeclId> {
         let mut visibility: Visibility = Visibility::new();
 
@@ -415,6 +386,22 @@ impl EngineState {
             if let Some(decl_id) = scope.decls.get(name) {
                 if visibility.is_decl_id_visible(decl_id) {
                     return Some(*decl_id);
+                }
+            }
+        }
+
+        None
+    }
+
+    pub fn find_alias(&self, name: &[u8]) -> Option<AliasId> {
+        let mut visibility: Visibility = Visibility::new();
+
+        for scope in self.scope.iter().rev() {
+            visibility.append(&scope.visibility);
+
+            if let Some(alias_id) = scope.aliases.get(name) {
+                if visibility.is_alias_id_visible(alias_id) {
+                    return Some(*alias_id);
                 }
             }
         }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -20,24 +20,24 @@ static PWD_ENV: &str = "PWD";
 
 // Tells whether a decl etc. is visible or not
 #[derive(Debug, Clone)]
-struct Visibility {
+pub struct Visibility {
     decl_ids: HashMap<DeclId, bool>,
     alias_ids: HashMap<AliasId, bool>,
 }
 
 impl Visibility {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Visibility {
             decl_ids: HashMap::new(),
             alias_ids: HashMap::new(),
         }
     }
 
-    fn is_decl_id_visible(&self, decl_id: &DeclId) -> bool {
+    pub fn is_decl_id_visible(&self, decl_id: &DeclId) -> bool {
         *self.decl_ids.get(decl_id).unwrap_or(&true) // by default it's visible
     }
 
-    fn is_alias_id_visible(&self, alias_id: &AliasId) -> bool {
+    pub fn is_alias_id_visible(&self, alias_id: &AliasId) -> bool {
         *self.alias_ids.get(alias_id).unwrap_or(&true) // by default it's visible
     }
 
@@ -57,7 +57,7 @@ impl Visibility {
         self.alias_ids.insert(*alias_id, true);
     }
 
-    fn merge_with(&mut self, other: Visibility) {
+    pub fn merge_with(&mut self, other: Visibility) {
         // overwrite own values with the other
         self.decl_ids.extend(other.decl_ids);
         self.alias_ids.extend(other.alias_ids);
@@ -80,6 +80,12 @@ impl Visibility {
     }
 }
 
+impl Default for Visibility {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ScopeFrame {
     pub vars: HashMap<Vec<u8>, VarId>,
@@ -88,7 +94,7 @@ pub struct ScopeFrame {
     pub aliases: HashMap<Vec<u8>, AliasId>,
     pub env_vars: HashMap<Vec<u8>, BlockId>,
     pub overlays: HashMap<Vec<u8>, OverlayId>,
-    visibility: Visibility,
+    pub visibility: Visibility,
 }
 
 impl ScopeFrame {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -3,4 +3,5 @@ extern crate nu_test_support;
 mod parsing;
 mod path;
 mod plugins;
+mod scope;
 mod shell;

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -1,0 +1,104 @@
+use nu_test_support::nu;
+
+#[test]
+fn scope_shows_alias() {
+    let actual = nu!(
+        cwd: ".",
+        r#"alias xaz = echo alias1
+        $nu.scope.aliases | find xaz | length
+        "#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 1);
+}
+
+#[test]
+fn scope_shows_command() {
+    let actual = nu!(
+        cwd: ".",
+        r#"def xaz [] { echo xaz }
+        $nu.scope.commands | find xaz | length
+        "#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 1);
+}
+
+#[test]
+fn scope_doesnt_show_scoped_hidden_alias() {
+    let actual = nu!(
+        cwd: ".",
+        r#"alias xaz = echo alias1
+        do {
+            hide xaz
+            $nu.scope.aliases | find xaz | length
+        }
+        "#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 0);
+}
+
+#[test]
+fn scope_doesnt_show_hidden_alias() {
+    let actual = nu!(
+        cwd: ".",
+        r#"alias xaz = echo alias1
+        hide xaz
+        $nu.scope.aliases | find xaz | length
+        "#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 0);
+}
+
+#[test]
+fn scope_doesnt_show_scoped_hidden_command() {
+    let actual = nu!(
+        cwd: ".",
+        r#"def xaz [] { echo xaz }
+        do {
+            hide xaz
+            $nu.scope.commands | find xaz | length
+        }
+        "#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 0);
+}
+
+#[test]
+fn scope_doesnt_show_hidden_command() {
+    let actual = nu!(
+        cwd: ".",
+        r#"def xaz [] { echo xaz }
+        hide xaz
+        $nu.scope.commands | find xaz | length
+        "#
+    );
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 0);
+}
+
+// same problem as 'which' command
+#[ignore]
+#[test]
+fn correctly_report_of_shadowed_alias() {
+    let actual = nu!(
+        cwd: ".",
+        r#"alias xaz = echo alias1
+        def helper [] {
+            alias xaz = echo alias2
+            $nu.scope.aliases
+        }
+        helper | where alias == xaz | get expansion.0"#
+    );
+
+    assert_eq!(actual.out, "echo alias2");
+}


### PR DESCRIPTION
# Description

Previously, they were showing hidden items. No more! Also, fixes duplicate entries of `which` and cleans it up a bit.

Fixes #4550
Fixes #4504
Fixes #4820

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
