### PR TITLE
remove cmd from edit

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -247,7 +247,7 @@ let $config = {
       event: {
         until: [
           { send: menupageprevious }
-          { edit: { cmd: undo } }
+          { edit: undo }
         ]
       }
     }


### PR DESCRIPTION
# Description

Removes the field cmd for edit type events

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
