### PR TITLE
Change update help+examples for creating new columns

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -19,7 +19,7 @@ impl Command for Update {
             .required(
                 "field",
                 SyntaxShape::CellPath,
-                "the name of the column to update",
+                "the name of the column to update or create",
             )
             .required(
                 "replacement value",
@@ -30,7 +30,7 @@ impl Command for Update {
     }
 
     fn usage(&self) -> &str {
-        "Update an existing column to have a new value."
+        "Update an existing column to have a new value, or create a new column."
     }
 
     fn run(
@@ -48,6 +48,10 @@ impl Command for Update {
             description: "Update a column value",
             example: "echo {'name': 'nu', 'stars': 5} | update name 'Nushell'",
             result: Some(Value::Record { cols: vec!["name".into(), "stars".into()], vals: vec![Value::test_string("Nushell"), Value::test_int(5)], span: Span::test_data()}),
+        }, Example {
+            description: "Add a new column",
+            example: "echo {'name': 'nu', 'stars': 5} | update language 'Rust'",
+            result: Some(Value::Record { cols: vec!["name".into(), "stars".into(), "language".into()], vals: vec![Value::test_string("nu"), Value::test_int(5), Value::test_string("Rust")], span: Span::test_data()}),
         }, Example {
             description: "Use in block form for more involved updating logic",
             example: "echo [[count fruit]; [1 'apple']] | update count {|f| $f.count + 1}",

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -58,7 +58,7 @@ impl Command for Update {
             result: Some(Value::List { vals: vec![Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(2), Value::test_string("apple")], span: Span::test_data()}], span: Span::test_data()}),
         }, Example {
             description: "Use in block form for more involved updating logic",
-            example: "echo [[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors { get authors | str collect ',' }",
+            example: "echo [[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors {|a| $a.authors | str collect ','}",
             result: Some(Value::List { vals: vec![Value::Record { cols: vec!["project".into(), "authors".into()], vals: vec![Value::test_string("nu"), Value::test_string("Andrés,JT,Yehuda")], span: Span::test_data()}], span: Span::test_data()}),
         }]
     }
@@ -137,5 +137,17 @@ fn update(
             },
             ctrlc,
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(Update {})
     }
 }


### PR DESCRIPTION
# Description

`update` has taken over `insert`'s duties (it can now create columns instead of just changing existing ones). Adjusting the help+examples to reflect that.

# Notes

FWIW I find the new behavior unintuitive and error-prone (easy to accidentally create a new column when you want to update an existing one). Might be worth revisiting in the future?

I initially tried enabling example tests for `update`, but one of the existing examples fails with an `ExternalNotSupported` error:

```
input: echo [[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors { get authors | str collect ',' }
result: List { vals: [Error { error: ExternalNotSupported(Span { start: 260, end: 263 }) }], span: Span { start: 0, end: 0 } }
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass