### PR TITLE
Fix string interpolation escaping

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1477,8 +1477,18 @@ pub fn parse_string_interpolation(
                     end,
                 };
                 let str_contents = working_set.get_span_contents(span);
+
+                let str_contents = if double_quote {
+                    let (str_contents, err) = unescape_string(str_contents, span);
+                    error = error.or(err);
+
+                    str_contents
+                } else {
+                    str_contents.to_vec()
+                };
+
                 output.push(Expression {
-                    expr: Expr::String(String::from_utf8_lossy(str_contents).to_string()),
+                    expr: Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
                     span,
                     ty: Type::String,
                     custom_completion: None,

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -219,6 +219,11 @@ fn string_interpolation_paren_test3() -> TestResult {
 }
 
 #[test]
+fn string_interpolation_escaping() -> TestResult {
+    run_test(r#"$"hello\nworld" | lines | length"#, "2")
+}
+
+#[test]
 fn capture_multiple_commands() -> TestResult {
     run_test(
         r#"


### PR DESCRIPTION
# Description

Fixes string interpolation escaping not working for the last text section

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
