### PR TITLE
update so that `--log-level` will work properly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,9 +136,11 @@ fn main() -> Result<()> {
 
             set_is_perf_value(binary_args.perf);
 
-            if binary_args.perf {
-                // if we started in perf mode show only the info logs
-                // TODO: what happens when the config log_level is read?
+            if binary_args.perf || binary_args.log_level.is_some() {
+                // since we're in this section, either perf is true or log_level has been set
+                // if log_level is set, just use it
+                // otherwise if perf is true, set the log_level to `info` which is what
+                // the perf calls are set to.
                 let level = binary_args
                     .log_level
                     .map(|level| level.item)


### PR DESCRIPTION
# Description

Previously we weren't able to use `--log-level trace`. I broke this a while back and now this fixes it.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
