### PR TITLE
add a display of what the colors look like in `ansi --list`

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -419,13 +419,25 @@ fn generate_ansi_code_list(
 ) -> Result<nu_protocol::PipelineData, ShellError> {
     return Ok(CODE_LIST
         .iter()
-        .map(move |ansi_code| {
-            let cols = vec!["name".into(), "short name".into(), "code".into()];
+        .enumerate()
+        .map(move |(i, ansi_code)| {
+            let cols = vec![
+                "name".into(),
+                "color".into(),
+                "short name".into(),
+                "code".into(),
+            ];
             let name: Value = Value::string(String::from(ansi_code.long_name), call_span);
             let short_name = Value::string(ansi_code.short_name.unwrap_or(""), call_span);
+            // The first 96 items in the ansi array are colors
+            let color = if i < 96 {
+                Value::string(format!("{}NUSHELL\u{1b}[0m", &ansi_code.code), call_span)
+            } else {
+                Value::string("\u{1b}[0m", call_span)
+            };
             let code_string = String::from(&ansi_code.code.replace('\u{1b}', ""));
             let code = Value::string(code_string, call_span);
-            let vals = vec![name, short_name, code];
+            let vals = vec![name, color, short_name, code];
             Value::Record {
                 cols,
                 vals,


### PR DESCRIPTION
# Description

Thought I'd add a splash of color to `ansi --list`. Thoughts? Should I change the `NUSHELL` string to something else?
<img width="990" alt="Screen Shot 2022-03-17 at 8 53 21 PM" src="https://user-images.githubusercontent.com/343840/158922874-54b7bdfc-c506-4653-a0e8-9d1130bdb19c.png">


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
