### PR TITLE
Fix single quote external interpolation

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -263,7 +263,11 @@ pub fn parse_external_call(
         let contents = working_set.get_span_contents(*span);
 
         if contents.starts_with(b"$") || contents.starts_with(b"(") {
-            let (arg, err) = parse_expression(working_set, &[*span], true);
+            let (arg, err) = parse_dollar_expr(working_set, *span);
+            error = error.or(err);
+            args.push(arg);
+        } else if contents.starts_with(b"(") {
+            let (arg, err) = parse_full_cell_path(working_set, None, *span);
             error = error.or(err);
             args.push(arg);
         } else {

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -83,8 +83,13 @@ fn execute_binary_in_string() {
     assert_eq!(actual.out, "$0");
 }
 
-//FIXME: jt - this is blocked on https://github.com/nushell/engine-q/issues/875
-#[ignore]
+#[test]
+fn single_quote_dollar_external() {
+    let actual = nu!(cwd: ".", r#"let author = 'JT'; ^echo $'foo=($author)'"#);
+
+    assert_eq!(actual.out, "foo=JT");
+}
+
 #[test]
 fn redirects_custom_command_external() {
     let actual = nu!(cwd: ".", r#"def foo [] { nu --testbin cococo foo bar }; foo | str length"#);


### PR DESCRIPTION
# Description

This should allow single quote string interpolation in external args. Should help with https://github.com/nushell/nushell/issues/4860#issuecomment-1072061331

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
