### PR TITLE
Add an alias denylist for expansions

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -31,7 +31,7 @@ pub fn evaluate_commands(
             (commands.item.as_bytes(), commands.span.start)
         };
 
-        let (output, err) = parse(&mut working_set, None, input, false);
+        let (output, err) = parse(&mut working_set, None, input, false, &[]);
         if let Some(err) = err {
             report_error(&working_set, &err);
 

--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -206,7 +206,13 @@ impl NuCompleter {
         let mut line = line.to_string();
         line.insert(pos, 'a');
         let pos = offset + pos;
-        let (output, _err) = parse(&mut working_set, Some("completer"), line.as_bytes(), false);
+        let (output, _err) = parse(
+            &mut working_set,
+            Some("completer"),
+            line.as_bytes(),
+            false,
+            &[],
+        );
 
         for pipeline in output.pipelines.into_iter() {
             for expr in pipeline.expressions {

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -36,7 +36,7 @@ pub fn evaluate_file(
     let mut working_set = StateWorkingSet::new(engine_state);
     trace!("parsing file: {}", path);
 
-    let _ = parse(&mut working_set, Some(&path), &file, false);
+    let _ = parse(&mut working_set, Some(&path), &file, false, &[]);
 
     if working_set.find_decl(b"main").is_some() {
         let args = format!("main {}", args.join(" "));

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -104,7 +104,7 @@ fn get_prompt_string(
             }
             Value::String { val: source, .. } => {
                 let mut working_set = StateWorkingSet::new(engine_state);
-                let (block, _) = parse(&mut working_set, None, source.as_bytes(), true);
+                let (block, _) = parse(&mut working_set, None, source.as_bytes(), true, &[]);
                 // Use eval_subexpression to force a redirection of output, so we can use everything in prompt
                 let ret_val = eval_subexpression(
                     engine_state,

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -17,7 +17,7 @@ impl Highlighter for NuHighlighter {
 
         let (shapes, global_span_offset) = {
             let mut working_set = StateWorkingSet::new(&self.engine_state);
-            let (block, _) = parse(&mut working_set, None, line.as_bytes(), false);
+            let (block, _) = parse(&mut working_set, None, line.as_bytes(), false, &[]);
 
             let shapes = flatten_block(&working_set, &block);
             (shapes, self.engine_state.next_span_start())

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -287,6 +287,7 @@ pub fn eval_source(
             Some(fname), // format!("entry #{}", entry_num)
             source,
             false,
+            &[],
         );
         if let Some(err) = err {
             report_error(&working_set, &err);

--- a/crates/nu-cli/src/validation.rs
+++ b/crates/nu-cli/src/validation.rs
@@ -9,7 +9,7 @@ pub struct NuValidator {
 impl Validator for NuValidator {
     fn validate(&self, line: &str) -> ValidationResult {
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        let (_, err) = parse(&mut working_set, None, line.as_bytes(), false);
+        let (_, err) = parse(&mut working_set, None, line.as_bytes(), false, &[]);
 
         if matches!(err, Some(ParseError::UnexpectedEof(..))) {
             ValidationResult::Incomplete

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -44,7 +44,13 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
 
         let (block, delta) = {
             let mut working_set = StateWorkingSet::new(&*engine_state);
-            let (output, err) = parse(&mut working_set, None, example.example.as_bytes(), false);
+            let (output, err) = parse(
+                &mut working_set,
+                None,
+                example.example.as_bytes(),
+                false,
+                &[],
+            );
 
             if let Some(err) = err {
                 panic!("test parse error in `{}`: {:?}", example.example, err)

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -84,7 +84,13 @@ pub fn test_examples(cmd: impl Command + 'static) {
 
         let (block, delta) = {
             let mut working_set = StateWorkingSet::new(&*engine_state);
-            let (output, err) = parse(&mut working_set, None, example.example.as_bytes(), false);
+            let (output, err) = parse(
+                &mut working_set,
+                None,
+                example.example.as_bytes(),
+                false,
+                &[],
+            );
 
             if let Some(err) = err {
                 panic!("test parse error in `{}`: {:?}", example.example, err)

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -89,7 +89,7 @@ impl Command for FromNuon {
         let (lite_block, err) = nu_parser::lite_parse(&lexed);
         error = error.or(err);
 
-        let (mut block, err) = nu_parser::parse_block(&mut working_set, &lite_block, true);
+        let (mut block, err) = nu_parser::parse_block(&mut working_set, &lite_block, true, &[]);
         error = error.or(err);
 
         if let Some(pipeline) = block.pipelines.get(1) {

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -19,7 +19,7 @@ fn quickcheck_parse(data: String) -> bool {
             let mut working_set = StateWorkingSet::new(&context);
             working_set.add_file("quickcheck".into(), data.as_bytes());
 
-            let _ = nu_parser::parse_block(&mut working_set, &lite_block, false);
+            let _ = nu_parser::parse_block(&mut working_set, &lite_block, false, &[]);
         }
     }
     true

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -51,7 +51,7 @@ impl Command for KnownExternal {
 
         let spans: Vec<_> = lexed.into_iter().map(|x| x.span).collect();
         let mut working_set = StateWorkingSet::new(&engine_state);
-        let (external_call, _) = crate::parse_external_call(&mut working_set, &spans);
+        let (external_call, _) = crate::parse_external_call(&mut working_set, &spans, &[]);
         let delta = working_set.render();
         engine_state.merge_delta(delta, None, ".")?;
 

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -46,7 +46,7 @@ pub fn parse_int() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let (block, err) = parse(&mut working_set, None, b"3", true);
+    let (block, err) = parse(&mut working_set, None, b"3", true, &[]);
 
     assert!(err.is_none());
     assert!(block.len() == 1);
@@ -69,7 +69,7 @@ pub fn parse_call() {
     let sig = Signature::build("foo").named("--jazz", SyntaxShape::Int, "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
 
-    let (block, err) = parse(&mut working_set, None, b"foo", true);
+    let (block, err) = parse(&mut working_set, None, b"foo", true, &[]);
 
     assert!(err.is_none());
     assert!(block.len() == 1);
@@ -94,7 +94,7 @@ pub fn parse_call_missing_flag_arg() {
     let sig = Signature::build("foo").named("jazz", SyntaxShape::Int, "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
 
-    let (_, err) = parse(&mut working_set, None, b"foo --jazz", true);
+    let (_, err) = parse(&mut working_set, None, b"foo --jazz", true, &[]);
     assert!(matches!(err, Some(ParseError::MissingFlagParam(..))));
 }
 
@@ -106,7 +106,7 @@ pub fn parse_call_missing_short_flag_arg() {
     let sig = Signature::build("foo").named("--jazz", SyntaxShape::Int, "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
 
-    let (_, err) = parse(&mut working_set, None, b"foo -j", true);
+    let (_, err) = parse(&mut working_set, None, b"foo -j", true, &[]);
     assert!(matches!(err, Some(ParseError::MissingFlagParam(..))));
 }
 
@@ -119,7 +119,7 @@ pub fn parse_call_too_many_shortflag_args() {
         .named("--jazz", SyntaxShape::Int, "jazz!!", Some('j'))
         .named("--math", SyntaxShape::Int, "math!!", Some('m'));
     working_set.add_decl(sig.predeclare());
-    let (_, err) = parse(&mut working_set, None, b"foo -mj", true);
+    let (_, err) = parse(&mut working_set, None, b"foo -mj", true, &[]);
     assert!(matches!(
         err,
         Some(ParseError::ShortFlagBatchCantTakeArg(..))
@@ -133,7 +133,7 @@ pub fn parse_call_unknown_shorthand() {
 
     let sig = Signature::build("foo").switch("--jazz", "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
-    let (_, err) = parse(&mut working_set, None, b"foo -mj", true);
+    let (_, err) = parse(&mut working_set, None, b"foo -mj", true, &[]);
     assert!(matches!(err, Some(ParseError::UnknownFlag(..))));
 }
 
@@ -144,7 +144,7 @@ pub fn parse_call_extra_positional() {
 
     let sig = Signature::build("foo").switch("--jazz", "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
-    let (_, err) = parse(&mut working_set, None, b"foo -j 100", true);
+    let (_, err) = parse(&mut working_set, None, b"foo -j 100", true, &[]);
     assert!(matches!(err, Some(ParseError::ExtraPositional(..))));
 }
 
@@ -155,7 +155,7 @@ pub fn parse_call_missing_req_positional() {
 
     let sig = Signature::build("foo").required("jazz", SyntaxShape::Int, "jazz!!");
     working_set.add_decl(sig.predeclare());
-    let (_, err) = parse(&mut working_set, None, b"foo", true);
+    let (_, err) = parse(&mut working_set, None, b"foo", true, &[]);
     assert!(matches!(err, Some(ParseError::MissingPositional(..))));
 }
 
@@ -166,7 +166,7 @@ pub fn parse_call_missing_req_flag() {
 
     let sig = Signature::build("foo").required_named("--jazz", SyntaxShape::Int, "jazz!!", None);
     working_set.add_decl(sig.predeclare());
-    let (_, err) = parse(&mut working_set, None, b"foo", true);
+    let (_, err) = parse(&mut working_set, None, b"foo", true, &[]);
     assert!(matches!(err, Some(ParseError::MissingRequiredFlag(..))));
 }
 
@@ -174,7 +174,7 @@ pub fn parse_call_missing_req_flag() {
 fn test_nothing_comparisson_eq() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
-    let (block, err) = parse(&mut working_set, None, b"2 == $nothing", true);
+    let (block, err) = parse(&mut working_set, None, b"2 == $nothing", true, &[]);
 
     assert!(err.is_none());
     assert!(block.len() == 1);
@@ -194,7 +194,7 @@ fn test_nothing_comparisson_eq() {
 fn test_nothing_comparisson_neq() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
-    let (block, err) = parse(&mut working_set, None, b"2 != $nothing", true);
+    let (block, err) = parse(&mut working_set, None, b"2 != $nothing", true, &[]);
 
     assert!(err.is_none());
     assert!(block.len() == 1);
@@ -219,7 +219,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"0..10", true);
+        let (block, err) = parse(&mut working_set, None, b"0..10", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -248,7 +248,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"0..<10", true);
+        let (block, err) = parse(&mut working_set, None, b"0..<10", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -277,7 +277,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"10..0", true);
+        let (block, err) = parse(&mut working_set, None, b"10..0", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -306,7 +306,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"(3 - 3)..<(8 + 2)", true);
+        let (block, err) = parse(&mut working_set, None, b"(3 - 3)..<(8 + 2)", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -337,7 +337,7 @@ mod range {
 
         working_set.add_decl(Box::new(Let));
 
-        let (block, err) = parse(&mut working_set, None, b"let a = 2; $a..10", true);
+        let (block, err) = parse(&mut working_set, None, b"let a = 2; $a..10", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 2);
@@ -368,7 +368,13 @@ mod range {
 
         working_set.add_decl(Box::new(Let));
 
-        let (block, err) = parse(&mut working_set, None, b"let a = 2; $a..<($a + 10)", true);
+        let (block, err) = parse(
+            &mut working_set,
+            None,
+            b"let a = 2; $a..<($a + 10)",
+            true,
+            &[],
+        );
 
         assert!(err.is_none());
         assert!(block.len() == 2);
@@ -397,7 +403,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"0..", true);
+        let (block, err) = parse(&mut working_set, None, b"0..", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -426,7 +432,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"..10", true);
+        let (block, err) = parse(&mut working_set, None, b"..10", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -455,7 +461,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"-10..-3", true);
+        let (block, err) = parse(&mut working_set, None, b"-10..-3", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -484,7 +490,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, b"2.0..4.0..10.0", true);
+        let (block, err) = parse(&mut working_set, None, b"2.0..4.0..10.0", true, &[]);
 
         assert!(err.is_none());
         assert!(block.len() == 1);
@@ -513,7 +519,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (_, err) = parse(&mut working_set, None, b"(0)..\"a\"", true);
+        let (_, err) = parse(&mut working_set, None, b"(0)..\"a\"", true, &[]);
 
         assert!(err.is_some());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,13 @@ fn parse_commandline_args(
         let mut working_set = StateWorkingSet::new(engine_state);
         working_set.add_decl(Box::new(Nu));
 
-        let (output, err) = parse(&mut working_set, None, commandline_args.as_bytes(), false);
+        let (output, err) = parse(
+            &mut working_set,
+            None,
+            commandline_args.as_bytes(),
+            false,
+            &[],
+        );
         if let Some(err) = err {
             report_error(&working_set, &err);
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -582,6 +582,17 @@ fn block_params_override() {
 }
 
 #[test]
+fn alias_reuse() {
+    let actual = nu!(
+        cwd: ".",
+        r#"alias foo = echo bob; foo; foo"#
+    );
+
+    assert!(actual.out.contains("bob"));
+    assert!(actual.err.is_empty());
+}
+
+#[test]
 fn block_params_override_correct() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
# Description

This threads an alias denylist through most of the parser. This should help us more accurately deny expansion while also allowing hiding of the same aliases. While I was working on this, I think this also corrects a fair number of subtle hiding bugs where we should have been checking a denylist in more places but weren't.

Fixes #4868 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
