### PR TITLE
commands are either custom or builtin, not both

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -970,13 +970,8 @@ pub fn create_scope(
 
             cols.push("is_builtin".to_string());
             // we can only be a is_builtin or is_custom, not both
-            let is_builtin = if decl.get_block_id().is_some() {
-                false
-            } else {
-                true
-            };
             vals.push(Value::Bool {
-                val: is_builtin,
+                val: decl.get_block_id().is_none(),
                 span,
             });
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -969,8 +969,14 @@ pub fn create_scope(
             });
 
             cols.push("is_builtin".to_string());
+            // we can only be a is_builtin or is_custom, not both
+            let is_builtin = if decl.get_block_id().is_some() {
+                false
+            } else {
+                true
+            };
             vals.push(Value::Bool {
-                val: decl.is_builtin(),
+                val: is_builtin,
                 span,
             });
 


### PR DESCRIPTION
# Description

Commands can either be custom or built in.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
