### PR TITLE
add module name to `$nu.scope.commands` info

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -794,11 +794,26 @@ pub fn create_scope(
             let mut cols = vec![];
             let mut vals = vec![];
 
+            let mut overlay_commands = vec![];
+            for overlay in &overlays_map {
+                let overlay_name = String::from_utf8_lossy(*overlay.0).to_string();
+                let overlay_id = engine_state.find_overlay(*overlay.0);
+                if let Some(overlay_id) = overlay_id {
+                    let overlay = engine_state.get_overlay(overlay_id);
+                    if overlay.has_decl(command_name) {
+                        overlay_commands.push(overlay_name);
+                    }
+                }
+            }
+
             cols.push("command".into());
             vals.push(Value::String {
                 val: String::from_utf8_lossy(command_name).to_string(),
                 span,
             });
+
+            cols.push("module_name".into());
+            vals.push(Value::string(overlay_commands.join(", "), span));
 
             let decl = engine_state.get_decl(*decl_id);
             let signature = decl.signature();


### PR DESCRIPTION
# Description

The PR adds the `module_name` to the `$nu.scope.commands` table so you can see if your `def` comes from a `module` and what it's name is if it does.
<img width="1686" alt="Screen Shot 2022-03-19 at 10 11 40 AM" src="https://user-images.githubusercontent.com/343840/159126714-1b3727f8-de27-4db8-b641-2500acde3793.png">


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
