### PR TITLE
remove the boolean vars `$true` and `$false`

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -156,7 +156,7 @@ fn read_bool() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            open sample.nuon | get 3 | $in == $true
+            open sample.nuon | get 3 | $in == true
         "#
     ));
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1590,27 +1590,7 @@ pub fn parse_variable_expr(
 ) -> (Expression, Option<ParseError>) {
     let contents = working_set.get_span_contents(span);
 
-    if contents == b"$true" {
-        return (
-            Expression {
-                expr: Expr::Bool(true),
-                span,
-                ty: Type::Bool,
-                custom_completion: None,
-            },
-            None,
-        );
-    } else if contents == b"$false" {
-        return (
-            Expression {
-                expr: Expr::Bool(false),
-                span,
-                ty: Type::Bool,
-                custom_completion: None,
-            },
-            None,
-        );
-    } else if contents == b"$nothing" {
+    if contents == b"$nothing" {
         return (
             Expression {
                 expr: Expr::Nothing,

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -279,16 +279,6 @@ fn open_ended_range() -> TestResult {
 }
 
 #[test]
-fn bool_variable() -> TestResult {
-    run_test(r#"$true"#, "true")
-}
-
-#[test]
-fn bool_variable2() -> TestResult {
-    run_test(r#"$false"#, "false")
-}
-
-#[test]
 fn default_value1() -> TestResult {
     run_test(r#"def foo [x = 3] { $x }; foo"#, "3")
 }


### PR DESCRIPTION
# Description

Removing `$true` and `$false` in favour of `true` and `false`.

fixes https://github.com/nushell/nushell/issues/4700

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
