### PR TITLE
Put completions in their own module

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -54,73 +54,78 @@ let-env NU_PLUGIN_DIRS = [
     ($nu.config-path | path dirname | path join 'plugins')
 ]
 
-# Custom completions for external commands (those outside of Nushell)
-# Each completions has two parts: the form of the external command, including its flags and parameters
-# and a helper command that knows how to complete values for those flags and parameters
-#
-# This is a simplified version of completions for git branches and git remotes
-def "nu-complete git branches" [] {
-  ^git branch | lines | each { |line| $line | str find-replace '\* ' '' | str trim }
+module completions {
+  # Custom completions for external commands (those outside of Nushell)
+  # Each completions has two parts: the form of the external command, including its flags and parameters
+  # and a helper command that knows how to complete values for those flags and parameters
+  #
+  # This is a simplified version of completions for git branches and git remotes
+  def "nu-complete git branches" [] {
+    ^git branch | lines | each { |line| $line | str find-replace '\* ' '' | str trim }
+  }
+
+  def "nu-complete git remotes" [] {
+    ^git remote | lines | each { |line| $line | str trim }
+  }
+
+  export extern "git checkout" [
+    branch?: string@"nu-complete git branches" # name of the branch to checkout
+    -b: string                                 # create and checkout a new branch
+    -B: string                                 # create/reset and checkout a branch
+    -l                                         # create reflog for new branch
+    --guess                                    # second guess 'git checkout <no-such-branch>' (default)
+    --overlay                                  # use overlay mode (default)
+    --quiet(-q)                                # suppress progress reporting
+    --recurse-submodules: string               # control recursive updating of submodules
+    --progress                                 # force progress reporting
+    --merge(-m)                                # perform a 3-way merge with the new branch
+    --conflict: string                         # conflict style (merge or diff3)
+    --detach(-d)                               # detach HEAD at named commit
+    --track(-t)                                # set upstream info for new branch
+    --force(-f)                                # force checkout (throw away local modifications)
+    --orphan: string                           # new unparented branch
+    --overwrite-ignore                         # update ignored files (default)
+    --ignore-other-worktrees                   # do not check if another worktree is holding the given ref
+    --ours(-2)                                 # checkout our version for unmerged files
+    --theirs(-3)                               # checkout their version for unmerged files
+    --patch(-p)                                # select hunks interactively
+    --ignore-skip-worktree-bits                # do not limit pathspecs to sparse entries only
+    --pathspec-from-file: string               # read pathspec from file
+  ]
+
+  export extern "git push" [
+    remote?: string@"nu-complete git remotes", # the name of the remote
+    refspec?: string@"nu-complete git branches"# the branch / refspec
+    --verbose(-v)                              # be more verbose
+    --quiet(-q)                                # be more quiet
+    --repo: string                             # repository
+    --all                                      # push all refs
+    --mirror                                   # mirror all refs
+    --delete(-d)                               # delete refs
+    --tags                                     # push tags (can't be used with --all or --mirror)
+    --dry-run(-n)                              # dry run
+    --porcelain                                # machine-readable output
+    --force(-f)                                # force updates
+    --force-with-lease: string                 # require old value of ref to be at this value
+    --recurse-submodules: string               # control recursive pushing of submodules
+    --thin                                     # use thin pack
+    --receive-pack: string                     # receive pack program
+    --exec: string                             # receive pack program
+    --set-upstream(-u)                         # set upstream for git pull/status
+    --progress                                 # force progress reporting
+    --prune                                    # prune locally removed refs
+    --no-verify                                # bypass pre-push hook
+    --follow-tags                              # push missing but relevant tags
+    --signed: string                           # GPG sign the push
+    --atomic                                   # request atomic transaction on remote side
+    --push-option(-o): string                  # option to transmit
+    --ipv4(-4)                                 # use IPv4 addresses only
+    --ipv6(-6)                                 # use IPv6 addresses only
+  ]
 }
 
-def "nu-complete git remotes" [] {
-  ^git remote | lines | each { |line| $line | str trim }
-}
-
-extern "git checkout" [
-  branch?: string@"nu-complete git branches" # name of the branch to checkout
-  -b: string                                 # create and checkout a new branch
-  -B: string                                 # create/reset and checkout a branch
-  -l                                         # create reflog for new branch
-  --guess                                    # second guess 'git checkout <no-such-branch>' (default)
-  --overlay                                  # use overlay mode (default)
-  --quiet(-q)                                # suppress progress reporting
-  --recurse-submodules: string               # control recursive updating of submodules
-  --progress                                 # force progress reporting
-  --merge(-m)                                # perform a 3-way merge with the new branch
-  --conflict: string                         # conflict style (merge or diff3)
-  --detach(-d)                               # detach HEAD at named commit
-  --track(-t)                                # set upstream info for new branch
-  --force(-f)                                # force checkout (throw away local modifications)
-  --orphan: string                           # new unparented branch
-  --overwrite-ignore                         # update ignored files (default)
-  --ignore-other-worktrees                   # do not check if another worktree is holding the given ref
-  --ours(-2)                                 # checkout our version for unmerged files
-  --theirs(-3)                               # checkout their version for unmerged files
-  --patch(-p)                                # select hunks interactively
-  --ignore-skip-worktree-bits                # do not limit pathspecs to sparse entries only
-  --pathspec-from-file: string               # read pathspec from file
-]
-
-extern "git push" [
-  remote?: string@"nu-complete git remotes", # the name of the remote
-  refspec?: string@"nu-complete git branches"# the branch / refspec
-  --verbose(-v)                              # be more verbose
-  --quiet(-q)                                # be more quiet
-  --repo: string                             # repository
-  --all                                      # push all refs
-  --mirror                                   # mirror all refs
-  --delete(-d)                               # delete refs
-  --tags                                     # push tags (can't be used with --all or --mirror)
-  --dry-run(-n)                              # dry run
-  --porcelain                                # machine-readable output
-  --force(-f)                                # force updates
-  --force-with-lease: string                 # require old value of ref to be at this value
-  --recurse-submodules: string               # control recursive pushing of submodules
-  --thin                                     # use thin pack
-  --receive-pack: string                     # receive pack program
-  --exec: string                             # receive pack program
-  --set-upstream(-u)                         # set upstream for git pull/status
-  --progress                                 # force progress reporting
-  --prune                                    # prune locally removed refs
-  --no-verify                                # bypass pre-push hook
-  --follow-tags                              # push missing but relevant tags
-  --signed: string                           # GPG sign the push
-  --atomic                                   # request atomic transaction on remote side
-  --push-option(-o): string                  # option to transmit
-  --ipv4(-4)                                 # use IPv4 addresses only
-  --ipv6(-6)                                 # use IPv6 addresses only
-]
+# Get just the extern definitions without the custom completion commands
+use completions *
 
 # for more information on themes see
 # https://github.com/nushell/nushell/blob/main/docs/How_To_Coloring_and_Theming.md


### PR DESCRIPTION
# Description

Put completions in their own module in the default config, so that the helper commands don't pollute the global namespace.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
