### PR TITLE
Allow 'error make' to make simple errors

### DIFF
--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -65,14 +65,23 @@ impl Command for ErrorMake {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Create a custom error for a custom command",
-            example: r#"def foo [x] {
+        vec![
+            Example {
+                description: "Create a custom error for a custom command",
+                example: r#"def foo [x] {
       let span = (metadata $x).span;
       error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
     }"#,
-            result: None,
-        }]
+                result: None,
+            },
+            Example {
+                description: "Create a simple custom error for a custom command",
+                example: r#"def foo [x] {
+      error make {msg: "this is fishy"}
+    }"#,
+                result: None,
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -105,6 +105,9 @@ fn make_error(value: &Value) -> Option<ShellError> {
                     _ => None,
                 }
             }
+            (Some(Value::String { val: message, .. }), None) => {
+                Some(ShellError::UnlabeledError(message))
+            }
             _ => None,
         }
     } else {

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -315,6 +315,9 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[diagnostic(help("{1}"))]
     LabeledError(String, String),
 
+    #[error("{0}")]
+    UnlabeledError(String),
+
     #[error("{1}")]
     #[diagnostic()]
     OutsideSpannedLabeledError(#[source_code] String, String, String, #[label("{2}")] Span),


### PR DESCRIPTION
# Description

This allows you to create an error that doesn't need a label.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
