### PR TITLE
fix: typo in default config

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -27,7 +27,7 @@ let-env PROMPT_MULTILINE_INDICATOR = "::: "
 
 # Specifies how environment variables are:
 # - converted from a string to a value on Nushell startup (from_string)
-# - converted from a value back to a string when running extrnal commands (to_string)
+# - converted from a value back to a string when running external commands (to_string)
 # Note: The conversions happen *after* config.nu is loaded
 let-env ENV_CONVERSIONS = {
   "PATH": {


### PR DESCRIPTION
# Description

Just fixing a typo in the comment

# Tests

No test because this is just fixing a typo in the comment. 🌷 