### PR TITLE
correct line size for string

### DIFF
--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -46,7 +46,7 @@ impl Command for Size {
                     ],
                     vals: vec![
                         Value::Int {
-                            val: 0,
+                            val: 1,
                             span: Span::test_data(),
                         },
                         Value::Int {
@@ -77,7 +77,7 @@ impl Command for Size {
                     ],
                     vals: vec![
                         Value::Int {
-                            val: 0,
+                            val: 1,
                             span: Span::test_data(),
                         },
                         Value::Int {
@@ -118,7 +118,7 @@ fn size(
 }
 
 fn count(contents: &str, span: Span) -> Value {
-    let mut lines: i64 = 0;
+    let mut lines: i64 = if contents.is_empty() { 0 } else { 1 };
     let mut words: i64 = 0;
     let mut chars: i64 = 0;
     let bytes = contents.len() as i64;


### PR DESCRIPTION
# Description

The size command returns 0 lines when it should return 1

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
