### PR TITLE
created an alternate way to determine line count

### DIFF
--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -960,8 +960,7 @@ mod test {
                 .ok()
                 .and_then(|p| match p.components().next().unwrap() {
                     Component::Prefix(prefix_component) => {
-                        let path = Path::new(prefix_component.as_os_str());
-                        path.join("*");
+                        let path = Path::new(prefix_component.as_os_str()).join("*");
                         Some(path.to_path_buf())
                     }
                     _ => panic!("no prefix in this path"),


### PR DESCRIPTION
# Description

This covers most edge cases that I could come up with to count lines.

Currently will not work with `"one(char nl)two" | size` just as `"one(char nl)two" | lines` doesn't. If someone wants to submit a PR to `lines` and `size` to add this enhancement, we'll probably accept it.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
