### PR TITLE
Externals shouldn't expand aliases

### DIFF
--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -436,14 +436,14 @@ fn test_count_counts_codepoints() {
 
     let counters = [Counter::CodePoints];
 
-    let counts = uwc_count(&counters[..], &one);
+    let counts = uwc_count(&counters[..], one);
 
     let mut correct_counts = BTreeMap::new();
     correct_counts.insert(Counter::CodePoints, 1);
 
     assert_eq!(correct_counts, counts);
 
-    let counts = uwc_count(&counters[..], &two);
+    let counts = uwc_count(&counters[..], two);
 
     let mut correct_counts = BTreeMap::new();
     correct_counts.insert(Counter::CodePoints, 2);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -210,6 +210,8 @@ pub fn parse_external_call(
     spans: &[Span],
     expand_aliases_denylist: &[usize],
 ) -> (Expression, Option<ParseError>) {
+    trace!("parse external");
+
     let mut args = vec![];
 
     let head_contents = working_set.get_span_contents(spans[0]);
@@ -224,33 +226,6 @@ pub fn parse_external_call(
     };
 
     let head_contents = working_set.get_span_contents(head_span).to_vec();
-
-    // If the word is an alias, expand it and re-parse the expression
-    if let Some(alias_id) = working_set.find_alias(&head_contents) {
-        let expansion = working_set.get_alias(alias_id);
-        let expansion_span = span(expansion);
-
-        let orig_span = span(&[spans[0], spans[0]]);
-        let mut new_spans: Vec<Span> = expansion.to_vec();
-        if spans.len() > 1 {
-            new_spans.extend(&spans[1..])
-        }
-
-        let expand_aliases_denylist = if let Some(alias_id) = working_set.find_alias(&head_contents)
-        {
-            let mut expand_aliases_denylist = expand_aliases_denylist.to_vec();
-            expand_aliases_denylist.push(alias_id);
-            expand_aliases_denylist
-        } else {
-            expand_aliases_denylist.to_vec()
-        };
-
-        let (mut result, err) =
-            parse_external_call(working_set, &new_spans, &expand_aliases_denylist);
-        result.replace_span(working_set, expansion_span, orig_span);
-
-        return (result, err);
-    }
 
     let mut error = None;
 
@@ -939,6 +914,7 @@ pub fn parse_call(
                     comments: vec![],
                     parts: new_spans.clone(),
                 };
+
                 let (mut result, err) =
                     parse_builtin_commands(working_set, &lite_command, &expand_aliases_denylist);
 


### PR DESCRIPTION
# Description

For some reason, not sure why, externals had their own alias expansion logic in the parser. In case where you were expanding to an alias with the same name, you'd loop forever. This removes the secondary expansion logic, leaving the primary one only.

fixes #4888

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
