### PR TITLE
bump csv crate to the latest version 1.1.6

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 chrono-humanize = "0.2.1"
 chrono-tz = "0.6.0"
 crossterm = "0.23.0"
-csv = "1.1.3"
+csv = "1.1.6"
 dialoguer = "0.9.0"
 digest = "0.10.0"
 dtparse = "1.2.0"


### PR DESCRIPTION

This updates the csv crate to the latest version 1.1.6