### PR TITLE
Set the minimum Rust version to 1.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 name = "nu"
 readme = "README.md"
 repository = "https://github.com/nushell/nushell"
+rust-version = "1.59"
 version = "0.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
# Description

nushell uses the strip option in two of its profiles in Cargo.toml.
This option is new in Rust 1.59[0], so this commit adjusts Cargo.toml to
mark 1.59 as the minimum supported Rust version[1].

[0] https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html
[1] https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>


# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
