### PR TITLE
Fix operator precedence parser

### DIFF
--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -68,6 +68,30 @@ fn precedence_of_operators2() {
 }
 
 #[test]
+fn precedence_of_operators3() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            5 - 5 * 10 + 5
+        "#
+    ));
+
+    assert_eq!(actual.out, "-40");
+}
+
+#[test]
+fn precedence_of_operators4() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            5 - (5 * 10) + 5
+        "#
+    ));
+
+    assert_eq!(actual.out, "-40");
+}
+
+#[test]
 fn division_of_ints() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4019,7 +4019,7 @@ pub fn parse_math_expression(
         );
         error = error.or(err);
 
-        if op_prec <= last_prec && expr_stack.len() > 1 {
+        while op_prec <= last_prec && expr_stack.len() > 1 {
             // Collapse the right associated operations first
             // so that we can get back to a stack with a lower precedence
             let mut rhs = expr_stack
@@ -4028,6 +4028,14 @@ pub fn parse_math_expression(
             let mut op = expr_stack
                 .pop()
                 .expect("internal error: expression stack empty");
+
+            last_prec = op.precedence();
+
+            if last_prec < op_prec {
+                expr_stack.push(op);
+                expr_stack.push(rhs);
+                break;
+            }
 
             let mut lhs = expr_stack
                 .pop()


### PR DESCRIPTION
# Description

fixes https://github.com/nushell/nushell/issues/4945

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
