### PR TITLE
Fix #4942, and add a table sorting example for `sort-by` command

### DIFF
--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -351,7 +351,7 @@ ls | each {|x| $x.name}
 ```
 The above will create a list of the filenames in the directory.
 ```
-if true { echo "it's true" } { echo "it's not true" }
+if true { echo "it's true" } else { echo "it's not true" }
 ```
 This `if` call will run the first block if the expression is true, or the
 second block if the expression is false.

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -98,7 +98,7 @@ impl Command for SortBy {
                 }),
             },
             Example {
-                description: "Sort a table by it's column (reversed order)",
+                description: "Sort a table by its column (reversed order)",
                 example: "[[fruit count]; [apple 9] [pear 3] [orange 7]] | sort-by fruit -r",
                 result: Some(Value::List {
                     vals: vec![

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -97,6 +97,27 @@ impl Command for SortBy {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Sort a table by it's column (reversed order)",
+                example: "[[fruit count]; [apple 9] [pear 3] [orange 7]] | sort-by fruit -r",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_record(
+                            vec!["fruit", "count"],
+                            vec![Value::test_string("pear"), Value::test_int(3)],
+                        ),
+                        Value::test_record(
+                            vec!["fruit", "count"],
+                            vec![Value::test_string("orange"), Value::test_int(7)],
+                        ),
+                        Value::test_record(
+                            vec!["fruit", "count"],
+                            vec![Value::test_string("apple"), Value::test_int(9)],
+                        ),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 


### PR DESCRIPTION
# Description

Fix #4942, and add a table sorting example for `sort-by` command

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
