### PR TITLE
Termux/Android target support for v0.60.0

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -71,7 +71,6 @@ terminal_size = "0.1.17"
 thiserror = "1.0.29"
 titlecase = "1.1.0"
 toml = "0.5.8"
-trash = { version = "2.0.2", optional = true }
 unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["v4"] }
@@ -82,6 +81,10 @@ zip = { version="0.5.9", optional = true }
 [target.'cfg(unix)'.dependencies]
 umask = "1.0.0"
 users = "0.11.0"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
+version = "2.0.2"
+optional = true
 
 [dependencies.polars]
 version = "0.20.0"

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -921,7 +921,12 @@ mod test {
     // this test assumes that there is a /root directory and that
     // the user running this test is not root or otherwise doesn't
     // have permission to read its contents
-    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "android"), not(target_os = "ios")))]
+    #[cfg(all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "android"),
+        not(target_os = "ios")
+    ))]    
     #[test]
     fn test_iteration_errors() {
         use std::io;

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -921,7 +921,7 @@ mod test {
     // this test assumes that there is a /root directory and that
     // the user running this test is not root or otherwise doesn't
     // have permission to read its contents
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "android"), not(target_os = "ios")))]
     #[test]
     fn test_iteration_errors() {
         use std::io;

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -926,7 +926,7 @@ mod test {
         not(target_os = "macos"),
         not(target_os = "android"),
         not(target_os = "ios")
-    ))]    
+    ))]
     #[test]
     fn test_iteration_errors() {
         use std::io;

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs  = "0.12.0"
 users = "0.11"
 which = "4"

--- a/crates/nu-system/src/lib.rs
+++ b/crates/nu-system/src/lib.rs
@@ -1,11 +1,11 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "windows")]
 mod windows;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use self::linux::*;
 #[cfg(target_os = "macos")]
 pub use self::macos::*;


### PR DESCRIPTION
# Description
v0.60.0 currently doesn't run on Termux, aka target aarch64-linux-android aka `target_os = "android"`. This branch compiles and works on Termux when compiled with

~~~
cargo build --no-default-features --features plugin,which,zip-support
~~~
(Termux/Android [has no standard trash feature](https://github.com/Byron/trash-rs/issues/10#issuecomment-610378167))

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass

Cargo test fails because of the `trash-support` feature-issue, the output is:

```
Compiling parquet2 v0.10.3
   Compiling trash v2.0.4
   Compiling nu-plugin v0.60.0 (/data/data/com.termux/files/home/nushell/crates/nu-plugin)
   Compiling nu-table v0.60.0 (/data/data/com.termux/files/home/nushell/crates/nu-table)
   Compiling nu-color-config v0.60.0 (/data/data/com.termux/files/home/nushell/crates/nu-color-config)
   Compiling nu-command v0.60.0 (/data/data/com.termux/files/home/nushell/crates/nu-command)
   Compiling reqwest v0.11.9
error[E0433]: failed to resolve: use of undeclared crate or module `platform`
  --> /data/data/com.termux/files/home/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.4/src/lib.rs:63:24
   |
63 |     platform_specific: platform::PlatformTrashContext,
   |                        ^^^^^^^^ use of undeclared crate or module `platform`

error[E0433]: failed to resolve: use of undeclared crate or module `platform`
  --> /data/data/com.termux/files/home/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.4/src/lib.rs:67:35
   |
67 |         Self { platform_specific: platform::PlatformTrashContext::new() }
   |                                   ^^^^^^^^ use of undeclared crate or module `platform`

error[E0599]: no method named `delete_all_canonicalized` found for reference `&TrashContext` in the current scope
   --> /data/data/com.termux/files/home/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.4/src/lib.rs:112:14
    |
112 |         self.delete_all_canonicalized(full_paths)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `&TrashContext`

error[E0283]: type annotations needed
  --> /data/data/com.termux/files/home/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.4/src/lib.rs:63:5
   |
60 | #[derive(Clone, Default, Debug)]
   |                 ------- in this derive macro expansion
...
63 |     platform_specific: platform::PlatformTrashContext,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
   |
   = note: cannot satisfy `_: Default`
   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)

Some errors have detailed explanations: E0283, E0433, E0599.
For more information about an error, try `rustc --explain E0283`.
error: could not compile `trash` due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```
