### PR TITLE
bump cargo crate sys-locale to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,9 +4137,9 @@ dependencies = [
 
 [[package]]
 name = "sys-locale"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f89ebb59fa30d4f65fafc2d68e94f6975256fd87e812dd99cb6e020c8563df"
+checksum = "3913c5a3d30054d7f77cf07cdd800c8103ace15c6e44437c5db66a43dd3a92cf"
 dependencies = [
  "cc",
  "cstr_core",

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1.0", optional = true }
 nu-json = { path = "../nu-json", version = "0.60.0"  }
 typetag = "0.1.8"
 num-format = "0.4.0"
-sys-locale = "0.1.0"
+sys-locale = "0.2.0"
 
 [features]
 plugin = ["serde_json"]


### PR DESCRIPTION

The sys-locale crate is only used in nu-protocol.

It is used for formatting filesizes....

