### PR TITLE
Fix path join on streams

### DIFF
--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -5,8 +5,8 @@ use std::{
 
 use nu_engine::CallExt;
 use nu_protocol::{
-    engine::Command, Example, ListStream, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value,
+    engine::Command, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
+    Value,
 };
 
 use super::PathSubcommandArguments;
@@ -63,16 +63,15 @@ the output of 'path parse' and 'path split' subcommands."#
             append: call.opt(engine_state, stack, 0)?,
         };
 
+        let metadata = input.metadata();
+
         match input {
             PipelineData::Value(val, md) => {
                 Ok(PipelineData::Value(handle_value(val, &args, head), md))
             }
-            PipelineData::ListStream(stream, md) => Ok(PipelineData::ListStream(
-                ListStream::from_stream(
-                    stream.map(move |val| handle_value(val, &args, head)),
-                    engine_state.ctrlc.clone(),
-                ),
-                md,
+            PipelineData::ListStream(..) => Ok(PipelineData::Value(
+                handle_value(input.into_value(head), &args, head),
+                metadata,
             )),
             _ => Err(ShellError::UnsupportedInput(
                 "Input data is not supported by this command.".to_string(),

--- a/crates/nu-command/tests/commands/path/join.rs
+++ b/crates/nu-command/tests/commands/path/join.rs
@@ -32,6 +32,18 @@ fn returns_path_joined_from_list() {
 }
 
 #[test]
+fn drop_one_path_join() {
+    let actual = nu!(
+        cwd: "tests", pipeline(
+            r#"[a, b, c] | drop 1 | path join
+        "#
+    ));
+
+    let expected = join_path_sep(&["a", "b"]);
+    assert_eq!(actual.out, expected);
+}
+
+#[test]
 fn appends_slash_when_joined_with_empty_path() {
     let actual = nu!(
         cwd: "tests", pipeline(


### PR DESCRIPTION
# Description

Rather than mapping over a stream, change `path join` to treat the whole stream as something to join.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
