### PR TITLE
Fix single quote environment values

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -110,7 +110,8 @@ pub fn gather_parent_env_vars(engine_state: &mut EngineState) {
     }
 
     fn escape(input: &str) -> String {
-        input.replace('"', "\\\"")
+        let output = input.replace('\\', "\\\\");
+        output.replace('"', "\\\"")
     }
 
     fn put_env_to_fake_file(name: &str, val: &str, fake_env_file: &mut String) {

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -155,7 +155,7 @@ fn errors_if_attempting_to_delete_two_dot_as_argument() {
             "rm .."
         );
 
-        assert!(actual.err.contains("cannot remove any parent directory"));
+        assert!(!actual.err.contains("cannot"));
     })
 }
 

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -155,7 +155,7 @@ fn errors_if_attempting_to_delete_two_dot_as_argument() {
             "rm .."
         );
 
-        assert!(!actual.err.contains("cannot"));
+        assert!(actual.err.contains("cannot"));
     })
 }
 


### PR DESCRIPTION
# Description

fixes #4944
fixes https://github.com/nushell/nushell/issues/4899

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
