### PR TITLE
Add escapes to 'to nuon'

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -137,8 +137,13 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
             }
             Ok(format!("{{{}}}", collection.join(", ")))
         }
-        Value::String { val, .. } => Ok(format!("\"{}\"", val)),
+        Value::String { val, .. } => Ok(format!("\"{}\"", escape(val))),
     }
+}
+
+fn escape(input: &str) -> String {
+    let output = input.replace('\\', "\\\\");
+    output.replace('"', "\\\"")
 }
 
 fn to_nuon(call: &Call, input: PipelineData) -> Result<String, ShellError> {

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -75,6 +75,34 @@ fn to_nuon_bool() {
 }
 
 #[test]
+fn to_nuon_escaping() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "hello\"world"
+            | to nuon
+            | from nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "hello\"world");
+}
+
+#[test]
+fn to_nuon_escaping2() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "hello\\world"
+            | to nuon
+            | from nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "hello\\world");
+}
+
+#[test]
 fn to_nuon_negative_int() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(


### PR DESCRIPTION
# Description

Adds escaping to `to nuon` so that the basic things we'd want to escape are supported (we may need to add more as we find them)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
