### PR TITLE
Improve the 'use' and 'source' errors

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -227,11 +227,19 @@ pub enum ParseError {
 
     #[error("File not found")]
     #[diagnostic(
-        code(nu::parser::file_not_found),
+        code(nu::parser::sourced_file_not_found),
         url(docsrs),
         help("sourced files need to be available before your script is run")
     )]
     SourcedFileNotFound(String, #[label("File not found: {0}")] Span),
+
+    #[error("File not found")]
+    #[diagnostic(
+        code(nu::parser::registered_file_not_found),
+        url(docsrs),
+        help("registered files need to be available before your script is run")
+    )]
+    RegisteredFileNotFound(String, #[label("File not found: {0}")] Span),
 
     #[error("File not found")]
     #[diagnostic(code(nu::parser::file_not_found), url(docsrs))]
@@ -287,6 +295,7 @@ impl ParseError {
             ParseError::WrongImportPattern(s) => *s,
             ParseError::ExportNotFound(s) => *s,
             ParseError::SourcedFileNotFound(_, s) => *s,
+            ParseError::RegisteredFileNotFound(_, s) => *s,
             ParseError::FileNotFound(_, s) => *s,
             ParseError::LabeledError(_, _, s) => *s,
         }

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -95,7 +95,11 @@ pub enum ParseError {
     VariableNotValid(#[label = "variable name can't contain spaces or quotes"] Span),
 
     #[error("Module not found.")]
-    #[diagnostic(code(nu::parser::module_not_found), url(docsrs))]
+    #[diagnostic(
+        code(nu::parser::module_not_found),
+        url(docsrs),
+        help("module files need to be available before your script is run")
+    )]
     ModuleNotFound(#[label = "module not found"] Span),
 
     #[error("Not found.")]
@@ -222,6 +226,14 @@ pub enum ParseError {
     ExportNotFound(#[label = "could not find imports"] Span),
 
     #[error("File not found")]
+    #[diagnostic(
+        code(nu::parser::file_not_found),
+        url(docsrs),
+        help("sourced files need to be available before your script is run")
+    )]
+    SourcedFileNotFound(String, #[label("File not found: {0}")] Span),
+
+    #[error("File not found")]
     #[diagnostic(code(nu::parser::file_not_found), url(docsrs))]
     FileNotFound(String, #[label("File not found: {0}")] Span),
 
@@ -274,6 +286,7 @@ impl ParseError {
             ParseError::MissingImportPattern(s) => *s,
             ParseError::WrongImportPattern(s) => *s,
             ParseError::ExportNotFound(s) => *s,
+            ParseError::SourcedFileNotFound(_, s) => *s,
             ParseError::FileNotFound(_, s) => *s,
             ParseError::LabeledError(_, _, s) => *s,
         }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1853,7 +1853,7 @@ pub fn parse_source(
                             }
                         }
                     } else {
-                        error = error.or(Some(ParseError::FileNotFound(filename, spans[1])));
+                        error = error.or(Some(ParseError::SourcedFileNotFound(filename, spans[1])));
                     }
                 } else {
                     return (garbage_pipeline(spans), Some(ParseError::NonUtf8(spans[1])));

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1959,14 +1959,17 @@ pub fn parse_register(
                     if let Some(p) = find_in_dirs(&name, working_set, &cwd, PLUGIN_DIRS_ENV) {
                         Ok(p)
                     } else {
-                        Err(ParseError::FileNotFound(name, expr.span))
+                        Err(ParseError::RegisteredFileNotFound(name, expr.span))
                     }
                 })
                 .and_then(|path| {
                     if path.exists() & path.is_file() {
                         Ok(path)
                     } else {
-                        Err(ParseError::FileNotFound(format!("{:?}", path), expr.span))
+                        Err(ParseError::RegisteredFileNotFound(
+                            format!("{:?}", path),
+                            expr.span,
+                        ))
                     }
                 })
         })
@@ -2007,13 +2010,17 @@ pub fn parse_register(
         String::from_utf8(shell_expr.to_vec())
             .map_err(|_| ParseError::NonUtf8(expr.span))
             .and_then(|name| {
-                canonicalize_with(&name, cwd).map_err(|_| ParseError::FileNotFound(name, expr.span))
+                canonicalize_with(&name, cwd)
+                    .map_err(|_| ParseError::RegisteredFileNotFound(name, expr.span))
             })
             .and_then(|path| {
                 if path.exists() & path.is_file() {
                     Ok(path)
                 } else {
-                    Err(ParseError::FileNotFound(format!("{:?}", path), expr.span))
+                    Err(ParseError::RegisteredFileNotFound(
+                        format!("{:?}", path),
+                        expr.span,
+                    ))
                 }
             })
     });


### PR DESCRIPTION
# Description

Adds notes to `use` and `source` to help explain that these files need to be available before the script runs.

```
/Users/jt/Source/nushell〉use foo.nu bar
Error: nu::parser::module_not_found (link)

  × Module not found.
   ╭─[entry #2:1:1]
 1 │ use foo.nu bar
   ·     ───┬──
   ·        ╰── module not found
   ╰────
  help: module files need to be available before your script is run

/Users/jt/Source/nushell〉source foo.nu
Error: nu::parser::file_not_found (link)

  × File not found
   ╭─[entry #3:1:1]
 1 │ source foo.nu
   ·        ───┬──
   ·           ╰── File not found: foo.nu
   ╰────
  help: sourced files need to be available before your script is run

/Users/jt/Source/nushell〉register foo.nu --encoding json
Error: nu::parser::registered_file_not_found (link)

  × File not found
   ╭─[entry #1:1:1]
 1 │ register foo.nu --encoding json
   ·          ───┬──
   ·             ╰── File not found: foo.nu
   ╰────
  help: registered files need to be available before your script is run
```
# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
