### PR TITLE
Fix alias import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,5 +71,5 @@ cargo build
 - To view verbose logs when developing, enable the `trace` log level.
 
   ```shell
-  cargo build --release --features=extra && cargo run --release --features=extra -- --loglevel trace
+  cargo build --release --features=extra && cargo run --release --features=extra -- --log-level trace
   ```

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -779,7 +779,7 @@ impl<'a> StateWorkingSet<'a> {
 
         for (name, alias_id) in aliases {
             scope_frame.aliases.insert(name, alias_id);
-            scope_frame.visibility.use_decl_id(&alias_id);
+            scope_frame.visibility.use_alias_id(&alias_id);
         }
     }
 

--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -297,6 +297,71 @@ fn hides_def_import_6() -> TestResult {
 }
 
 #[test]
+fn hides_def_import_then_reimports() -> TestResult {
+    run_test(
+        r#"module spam { export def foo [] { "foo" } }; use spam foo; hide foo; use spam foo; foo"#,
+        "foo",
+    )
+}
+
+#[test]
+fn hides_alias_import_1() -> TestResult {
+    fail_test(
+        r#"module spam { export alias foo = "foo" }; use spam; hide spam foo; spam foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_import_2() -> TestResult {
+    fail_test(
+        r#"module spam { export alias foo = "foo" }; use spam; hide spam; spam foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_import_3() -> TestResult {
+    fail_test(
+        r#"module spam { export alias foo = "foo" }; use spam; hide spam [foo]; spam foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_import_4() -> TestResult {
+    fail_test(
+        r#"module spam { export alias foo = "foo" }; use spam foo; hide foo; foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_import_5() -> TestResult {
+    fail_test(
+        r#"module spam { export alias foo = "foo" }; use spam *; hide foo; foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_import_6() -> TestResult {
+    fail_test(
+        r#"module spam { export alias foo = "foo" }; use spam *; hide spam *; foo"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_alias_import_then_reimports() -> TestResult {
+    run_test(
+        r#"module spam { export alias foo = "foo" }; use spam foo; hide foo; use spam foo; foo"#,
+        "foo",
+    )
+}
+
+
+#[test]
 fn hides_env_import_1() -> TestResult {
     fail_test(
         r#"module spam { export env foo { "foo" } }; use spam; hide spam foo; $env.'spam foo'"#,

--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -360,7 +360,6 @@ fn hides_alias_import_then_reimports() -> TestResult {
     )
 }
 
-
 #[test]
 fn hides_env_import_1() -> TestResult {
     fail_test(


### PR DESCRIPTION
Alias importing was registering the alias id as a decl instead of alias.
This caused issues when hiding and then reimporting the alias.

# Description

A typo was causing issues when importing aliases. This led to errors when reimporting a hidden alias.

Fixes #4963 

I added the same tests that were used for `def`s for aliases and added tests for both for reimporting. If those tests are redundant, I can remove them. It now occurs to me that the same reimporting check might be useful for env vars.

Also, I fixed a small typo in `CONTRIBUTING.md`

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
