### PR TITLE
Accept `--bool-flag=false`

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -7,7 +7,7 @@ use nu_protocol::ast::{Block, Call, Expr, Expression, Operator};
 use nu_protocol::engine::{EngineState, Stack, Visibility};
 use nu_protocol::{
     IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Range, ShellError, Span,
-    Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
+    Spanned, SyntaxShape, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
 
 use crate::{current_dir_str, get_full_help};
@@ -137,6 +137,8 @@ pub fn eval_call(
                         let result = eval_expression(engine_state, caller_stack, arg)?;
 
                         callee_stack.add_var(var_id, result);
+                    } else if named.arg == Some(SyntaxShape::Boolean) {
+                        callee_stack.add_var(var_id, Value::boolean(false, call.head))
                     } else {
                         callee_stack.add_var(var_id, Value::Nothing { span: call.head })
                     }


### PR DESCRIPTION
# Description

Was:

```
> def ready [--ready: bool] { if $ready { 'Ready!' } else { 'Not ready!' } }
> ready
Not ready!
> ready --ready
Ready!
> ready --ready=true
Ready!
> ready --ready=false ### bug ###
Ready!
> ready --help
Usage:
  > ready {flags}

Flags:
  -h, --help
      Display this help message
  --ready
```

Now:

```
> def ready [--ready: bool] { if $ready { 'Ready!' } else { 'Not ready!' } }
> ready
Not ready!
> ready --ready
Ready!
> ready --ready=true
Ready!
> ready --ready=false ### fixed ###
Not ready!
> ready --help
Usage:
  > ready {flags}

Flags:
  -h, --help
      Display this help message
  --ready <Boolean> ### now type is shown ###
```

Fixes https://github.com/nushell/nushell/issues/4702

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
