### PR TITLE
Don't include trailing separator when expanding tilde

### DIFF
--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -78,6 +78,15 @@ mod tests {
         check_not_expanded("1~1");
     }
 
+    #[test]
+    fn path_does_not_include_trailing_separator() {
+        let home = Path::new("/home");
+        let buf = Some(PathBuf::from(home));
+        let expanded = expand_tilde_with_home(Path::new("~"), buf);
+        let expanded_str = expanded.to_str().unwrap();
+        assert!(!expanded_str.ends_with("/"));
+    }
+
     #[cfg(windows)]
     #[test]
     fn string_with_tilde_backslash() {

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -16,7 +16,14 @@ fn expand_tilde_with_home(path: impl AsRef<Path>, home: Option<PathBuf>) -> Path
                 path.strip_prefix("~").unwrap_or(path).into()
             } else {
                 if let Ok(p) = path.strip_prefix("~/") {
-                    h.push(p)
+                    // Corner case: `p` is empty;
+                    // Don't append extra '/', just keep `h` as is.
+                    // This happens because PathBuf.push will always
+                    // add a separator if the pushed path is relative,
+                    // even if it's empty
+                    if p != Path::new("") {
+                        h.push(p)
+                    }
                 }
                 h
             }

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -40,6 +40,7 @@ pub fn expand_tilde(path: impl AsRef<Path>) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::MAIN_SEPARATOR;
 
     fn check_expanded(s: &str) {
         let home = Path::new("/home");
@@ -84,7 +85,7 @@ mod tests {
         let buf = Some(PathBuf::from(home));
         let expanded = expand_tilde_with_home(Path::new("~"), buf);
         let expanded_str = expanded.to_str().unwrap();
-        assert!(!expanded_str.ends_with("/"));
+        assert!(!expanded_str.ends_with(MAIN_SEPARATOR));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
# Description

Fixes #4902 

Expanding tilde with no other relative paths would result in `$HOME/` instead of `$HOME`. This occurs when users run `cd` with no extra arguments. In that case, the user's PWD would include the trailing separator. This does not happen when explicitly passing a value, such as `cd ~`, because in that case, the path would be canonicalized. I assume some custom prompts would also remove the trailing slash.

This happens because `std::path::PathBuf::push` always adds a separator, even if adding an empty path, which is what happens when `cd` with no argument is invoked. [Relevant part of stdlib](https://github.com/rust-lang/rust/blob/2882c2023d6e1dee4128611e89fcde0cf6199f6d/library/std/src/path.rs#L1342).

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
