### PR TITLE
Add parser keywords to help messages

### DIFF
--- a/crates/nu-command/src/core_commands/alias.rs
+++ b/crates/nu-command/src/core_commands/alias.rs
@@ -25,6 +25,15 @@ impl Command for Alias {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/def.rs
+++ b/crates/nu-command/src/core_commands/def.rs
@@ -26,6 +26,15 @@ impl Command for Def {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/def_env.rs
+++ b/crates/nu-command/src/core_commands/def_env.rs
@@ -26,6 +26,15 @@ impl Command for DefEnv {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/export.rs
+++ b/crates/nu-command/src/core_commands/export.rs
@@ -21,6 +21,15 @@ impl Command for ExportCommand {
         "Export custom commands or environment variables from a module."
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/export_alias.rs
+++ b/crates/nu-command/src/core_commands/export_alias.rs
@@ -25,6 +25,15 @@ impl Command for ExportAlias {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/export_def.rs
+++ b/crates/nu-command/src/core_commands/export_def.rs
@@ -26,6 +26,15 @@ impl Command for ExportDef {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -26,6 +26,15 @@ impl Command for ExportDefEnv {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/export_env.rs
+++ b/crates/nu-command/src/core_commands/export_env.rs
@@ -29,6 +29,15 @@ impl Command for ExportEnv {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/export_extern.rs
+++ b/crates/nu-command/src/core_commands/export_extern.rs
@@ -21,6 +21,15 @@ impl Command for ExportExtern {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/extern_.rs
+++ b/crates/nu-command/src/core_commands/extern_.rs
@@ -21,6 +21,15 @@ impl Command for Extern {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -44,6 +44,15 @@ impl Command for For {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -23,7 +23,15 @@ impl Command for Hide {
     }
 
     fn extra_usage(&self) -> &str {
-        "Symbols are hidden by priority: First aliases, then custom commands, then environment variables."
+        r#"Symbols are hidden by priority: First aliases, then custom commands, then environment variables.
+
+This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
+            "#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
     }
 
     fn run(

--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -34,6 +34,15 @@ impl Command for If {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -26,6 +26,15 @@ impl Command for Let {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/module.rs
+++ b/crates/nu-command/src/core_commands/module.rs
@@ -25,6 +25,15 @@ impl Command for Module {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/register.rs
+++ b/crates/nu-command/src/core_commands/register.rs
@@ -41,6 +41,15 @@ impl Command for Register {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/source.rs
+++ b/crates/nu-command/src/core_commands/source.rs
@@ -26,6 +26,15 @@ impl Command for Source {
         "Runs a script file in the current context."
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -23,6 +23,15 @@ impl Command for Use {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check
+https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1008,6 +1008,12 @@ pub fn create_scope(
                 span,
             });
 
+            cols.push("is_keyword".into());
+            vals.push(Value::Bool {
+                val: decl.is_parser_keyword(),
+                span,
+            });
+
             cols.push("is_extern".to_string());
             vals.push(Value::Bool {
                 val: decl.is_known_external(),

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -51,6 +51,11 @@ pub trait Command: Send + Sync + CommandClone {
         self.name().contains(' ')
     }
 
+    // Is a parser keyword (source, def, etc.)
+    fn is_parser_keyword(&self) -> bool {
+        false
+    }
+
     // Is a plugin command (returns plugin's path, encoding and type of shell
     // if the declaration is a plugin)
     fn is_plugin(&self) -> Option<(&PathBuf, &str, &Option<PathBuf>)> {


### PR DESCRIPTION
# Description

This  PR adds note about parser keywords to the help messages.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
