### PR TITLE
Remove is_private from $nu.scope.commands

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -30,10 +30,6 @@ impl Command for External {
         "Runs external command"
     }
 
-    fn is_private(&self) -> bool {
-        true
-    }
-
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build(self.name())
             .switch("redirect-stdout", "redirect-stdout", None)

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -977,12 +977,6 @@ pub fn create_scope(
                 span,
             });
 
-            cols.push("is_private".to_string());
-            vals.push(Value::Bool {
-                val: decl.is_private(),
-                span,
-            });
-
             cols.push("is_builtin".to_string());
             // we can only be a is_builtin or is_custom, not both
             vals.push(Value::Bool {

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -27,11 +27,6 @@ pub trait Command: Send + Sync + CommandClone {
         false
     }
 
-    // Commands that are not meant to be run by users
-    fn is_private(&self) -> bool {
-        false
-    }
-
     fn examples(&self) -> Vec<Example> {
         Vec::new()
     }


### PR DESCRIPTION
# Description

It was used only for `run-external` which seems like a legit command now.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
