### PR TITLE
Improve escaping in string interpolation

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1438,7 +1438,14 @@ pub fn parse_string_interpolation(
 
     #[allow(clippy::needless_range_loop)]
     while b != end {
-        if contents[b - start] == b'(' && mode == InterpolationMode::String {
+        if contents[b - start] == b'('
+            && (if double_quote && (b - start) > 0 {
+                contents[b - start - 1] != b'\\'
+            } else {
+                true
+            })
+            && mode == InterpolationMode::String
+        {
             mode = InterpolationMode::Expression;
             if token_start < b {
                 let span = Span {

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -346,6 +346,11 @@ fn string_escape_interpolation() -> TestResult {
 }
 
 #[test]
+fn string_escape_interpolation2() -> TestResult {
+    run_test(r#"$"2 + 2 is \(2 + 2)""#, "2 + 2 is (2 + 2)")
+}
+
+#[test]
 fn proper_rest_types() -> TestResult {
     run_test(
         r#"def foo [--verbose(-v): bool, # my test flag


### PR DESCRIPTION
# Description

fixes the parser so we don't have https://github.com/nushell/nushell.github.io/pull/345

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
