### PR TITLE
fix ls when file is a socket on mac

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -462,6 +462,8 @@ pub(crate) fn dir_entry_dict(
             } else {
                 vals.push(Value::nothing(span));
             }
+        } else {
+            vals.push(Value::nothing(span));
         }
     } else {
         vals.push(Value::nothing(span));


### PR DESCRIPTION
# Description

Prints `nothing` in the file size when file is a socket or other unrecognized type.

Before (I was in /private/var/run here)
<img width="1011" alt="Screen Shot 2022-03-26 at 7 31 19 PM" src="https://user-images.githubusercontent.com/343840/160261545-e50bfe02-11b5-455b-b9db-96da2027612c.png">

After
<img width="1166" alt="Screen Shot 2022-03-26 at 7 29 23 PM" src="https://user-images.githubusercontent.com/343840/160261521-37b1ba41-6396-489b-b76a-acce5a4a7b00.png">

Related #4975 

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
