### PR TITLE
Support binary data to stdin of run-external

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -168,12 +168,13 @@ impl ExternalCommand {
 
                             if let Ok(input) = input {
                                 for value in input.into_iter() {
-                                    if let Value::String { val, span: _ } = value {
-                                        if stdin_write.write(val.as_bytes()).is_err() {
-                                            return Ok(());
-                                        }
-                                    } else {
-                                        return Err(());
+                                    let buf = match value {
+                                        Value::String { val, .. } => val.into_bytes(),
+                                        Value::Binary { val, .. } => val,
+                                        _ => return Err(()),
+                                    };
+                                    if stdin_write.write(&buf).is_err() {
+                                        return Ok(());
                                     }
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,8 @@ fn main() -> Result<()> {
                     "echo_env" => test_bins::echo_env(),
                     "cococo" => test_bins::cococo(),
                     "meow" => test_bins::meow(),
+                    "meowb" => test_bins::meowb(),
+                    "relay" => test_bins::relay(),
                     "iecho" => test_bins::iecho(),
                     "fail" => test_bins::fail(),
                     "nonu" => test_bins::nonu(),

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -34,6 +34,25 @@ pub fn meow() {
     }
 }
 
+// A binary version of meow
+pub fn meowb() {
+    let args: Vec<String> = args();
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+
+    for arg in args.iter().skip(1) {
+        let buf = std::fs::read(arg).expect("Expected a filepath");
+        handle.write_all(&buf).expect("failed to write to stdout");
+    }
+}
+
+// Relays anything received on stdin to stdout
+pub fn relay() {
+    io::copy(&mut io::stdin().lock(), &mut io::stdout().lock())
+        .expect("failed to copy stdin to stdout");
+}
+
 pub fn nonu() {
     args().iter().skip(1).for_each(|arg| print!("{}", arg));
 }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -97,7 +97,6 @@ fn redirects_custom_command_external() {
     assert_eq!(actual.out, "8");
 }
 
-#[ignore]
 #[test]
 fn passes_binary_data_between_externals() {
     let actual = nu!(cwd: "tests/fixtures/formats", r#"nu --testbin meowb sample.db | nu --testbin relay | hash sha256"#);

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -97,6 +97,17 @@ fn redirects_custom_command_external() {
     assert_eq!(actual.out, "8");
 }
 
+#[ignore]
+#[test]
+fn passes_binary_data_between_externals() {
+    let actual = nu!(cwd: "tests/fixtures/formats", r#"nu --testbin meowb sample.db | nu --testbin relay | hash sha256"#);
+
+    assert_eq!(
+        actual.out,
+        "2f5050e7eea415c1f3d80b5d93355efd15043ec9157a2bb167a9e73f2ae651f2"
+    )
+}
+
 mod it_evaluation {
     use super::nu;
     use nu_test_support::fs::Stub::{EmptyFile, FileWithContent, FileWithContentToBeTrimmed};


### PR DESCRIPTION
# Description

Prior to this change, any pipeline producing binary data from an 
external (not detected as string) then feed into an external would be 
ignored due to run-external only supporting `Value::String` on stdin.

This change adds binary stdin support for externals allowing something
like this for example:

  〉^cat /dev/urandom | ^head -c 1MiB | ^pv -b | ignore
  1.00MiB

This would previously output `0.00 B [0.00 B/s]` due to the data not
being pushed to stdin at each stage.

Also adds a test for passing binary data between externals via the
pipeline and some testbins to make that possible in a platform 
independent way. 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
