### PR TITLE
Add streaming support to save for ExternalStream data

### DIFF
--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -1,35 +1,7 @@
-use nu_test_support::fs::{file_contents, Stub::FileWithContent};
+use nu_test_support::fs::file_contents;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use std::io::Write;
-
-#[test]
-fn figures_out_intelligently_where_to_write_out_with_metadata() {
-    Playground::setup("save_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
-            "cargo_sample.toml",
-            r#"
-                [package]
-                name = "nu"
-                version = "0.1.1"
-                authors = ["Yehuda Katz <wycats@gmail.com>"]
-                description = "A shell for the GitHub era"
-                license = "ISC"
-                edition = "2018"
-            "#,
-        )]);
-
-        let subject_file = dirs.test().join("cargo_sample.toml");
-
-        nu!(
-            cwd: dirs.root(),
-            "open save_test_1/cargo_sample.toml | save"
-        );
-
-        let actual = file_contents(&subject_file);
-        assert!(actual.contains("0.1.1"));
-    })
-}
 
 #[test]
 fn writes_out_csv() {


### PR DESCRIPTION
# Description

Prior to this change, save would collect data from an ExternalStream (data
originating from externals) consuming memory for the full amount of data piped
to it,

This change adds streaming support to save for ExternalStream allowing saving 
of arbitrarily large files and bounding memory usage.

This also removes a broken test:

```
running 1 test
=== stderr
Error: nu::parser::missing_positional (https://docs.rs/nu-parser/0.60.0/nu-parser/enum.ParseError.html#variant.MissingPositional)

  × Missing required positional argument.
   ╭─[source:1:1]
 1 │ open save_test_1/cargo_sample.toml | save
   ·                                          ▲
   ·                                          ╰── missing filename
   ╰────
  help: Usage: save {flags} <filename>

test commands::save::figures_out_intelligently_where_to_write_out_with_metadata ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 515 filtered out; finished in 0.10s
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
