### PR TITLE
Limit mem usage + back-pressure via bounded channels

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -17,6 +17,7 @@ use pathdiff::diff_paths;
 use regex::Regex;
 
 const OUTPUT_BUFFER_SIZE: usize = 1024;
+const OUTPUT_BUFFERS_IN_FLIGHT: usize = 3;
 
 #[derive(Clone)]
 pub struct External;
@@ -187,8 +188,8 @@ impl ExternalCommand {
                 let redirect_stderr = self.redirect_stderr;
                 let span = self.name.span;
                 let output_ctrlc = ctrlc.clone();
-                let (stdout_tx, stdout_rx) = mpsc::channel();
-                let (stderr_tx, stderr_rx) = mpsc::channel();
+                let (stdout_tx, stdout_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
+                let (stderr_tx, stderr_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
                 let (exit_code_tx, exit_code_rx) = mpsc::channel();
 
                 std::thread::spawn(move || {


### PR DESCRIPTION

# Description

Prior to this change, a pipeline of externals would result in high memory
usage if any of the producers in the chain, produced data faster than
the consumers.

For example a pipeline:

  > fast-producer | slow-consumer

Would cause a build up of `Value::{String,Binary}`'s in the mpsc channels
between each command as values are added to the channels faster than they
are consumed, eventually OOM'ing depnding on system resources, the volume
of data and speed diff. between fast v's slow.

This change replaces the unbounded channels with bounded channels
to limit the number of values that can build up and providing
back-pressure to limit ram usage.

I randomly select a small value of `3` buffers in flight, this could probably be tuned
further. 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
