### PR TITLE
Nu ansi term update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,8 @@ dependencies = [
 [[package]]
 name = "nu-ansi-term"
 version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7bca0d33a384280d1563b97f49cb95303df9fa22588739a04b7d8015c1ccd50"
 dependencies = [
  "overload",
  "winapi",
@@ -3423,6 +3425,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.3.1"
+source = "git+https://github.com/nushell/reedline#bc528de132e74594fdd5a9202cf32aee51e921e8"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,9 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280affd8593c03f90633b7305cee7a3b55ddab9fbad95041a39bda689f7b64f7"
+version = "0.45.1"
 dependencies = [
  "overload",
  "winapi",
@@ -3424,9 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ba0eb9271feb2de4b1516d651c96d80c892df24388e2711ef2495acc6ed9ce"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ crossterm_winapi = "0.9.0"
 ctrlc = "3.2.1"
 log = "0.4"
 miette = "4.1.0"
-# nu-ansi-term = "0.45.0"
-nu-ansi-term = { path="../nu-ansi-term", version = "0.45.1" }
+nu-ansi-term = "0.45.1"
 nu-cli = { path="./crates/nu-cli", version = "0.60.0"  }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.60.0"  }
 nu-command = { path="./crates/nu-command", version = "0.60.0"  }
@@ -56,8 +55,7 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.60.0"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.60.0" }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
-# reedline = "0.3.0"
-reedline = { path = "../reedline", version = "0.3.1" }
+reedline = { git = "https://github.com/nushell/reedline" }
 is_executable = "1.0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ crossterm_winapi = "0.9.0"
 ctrlc = "3.2.1"
 log = "0.4"
 miette = "4.1.0"
-nu-ansi-term = "0.45.0"
+# nu-ansi-term = "0.45.0"
+nu-ansi-term = { path="../nu-ansi-term", version = "0.45.1" }
 nu-cli = { path="./crates/nu-cli", version = "0.60.0"  }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.60.0"  }
 nu-command = { path="./crates/nu-command", version = "0.60.0"  }
@@ -55,7 +56,8 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.60.0"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.60.0" }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
-reedline = "0.3.0"
+# reedline = "0.3.0"
+reedline = { path = "../reedline", version = "0.3.1" }
 is_executable = "1.0.1"
 
 [dev-dependencies]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -12,18 +12,13 @@ nu-path = { path = "../nu-path", version = "0.60.0"  }
 nu-parser = { path = "../nu-parser", version = "0.60.0"  }
 nu-protocol = { path = "../nu-protocol", version = "0.60.0"  }
 nu-utils = { path = "../nu-utils", version = "0.60.0"  }
-# nu-ansi-term = "0.45.0"
-nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
+nu-ansi-term = "0.45.1"
 nu-color-config = { path = "../nu-color-config", version = "0.60.0"  }
-
 crossterm = "0.23.0"
 crossterm_winapi = "0.9.0"
 miette = { version = "4.1.0", features = ["fancy"] }
 thiserror = "1.0.29"
-# reedline = "0.3.0"
-reedline = { path = "../../../reedline", version = "0.3.1" }
-
-
+reedline = { git = "https://github.com/nushell/reedline" }
 log = "0.4"
 is_executable = "1.0.1"
 

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -12,15 +12,17 @@ nu-path = { path = "../nu-path", version = "0.60.0"  }
 nu-parser = { path = "../nu-parser", version = "0.60.0"  }
 nu-protocol = { path = "../nu-protocol", version = "0.60.0"  }
 nu-utils = { path = "../nu-utils", version = "0.60.0"  }
-nu-ansi-term = "0.45.0"
-
+# nu-ansi-term = "0.45.0"
+nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.60.0"  }
 
 crossterm = "0.23.0"
 crossterm_winapi = "0.9.0"
 miette = { version = "4.1.0", features = ["fancy"] }
 thiserror = "1.0.29"
-reedline = "0.3.0"
+# reedline = "0.3.0"
+reedline = { path = "../../../reedline", version = "0.3.1" }
+
 
 log = "0.4"
 is_executable = "1.0.1"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -8,10 +8,7 @@ version = "0.60.0"
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.60.0"  }
-# nu-ansi-term = "0.45.0"
-nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
-
+nu-ansi-term = "0.45.1"
 nu-json = { path = "../nu-json", version = "0.60.0"  }
 nu-table = { path = "../nu-table", version = "0.60.0"  }
-
 serde = { version="1.0.123", features=["derive"] }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -8,7 +8,8 @@ version = "0.60.0"
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.60.0"  }
-nu-ansi-term = "0.45.0"
+# nu-ansi-term = "0.45.0"
+nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
 
 nu-json = { path = "../nu-json", version = "0.60.0"  }
 nu-table = { path = "../nu-table", version = "0.60.0"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -23,7 +23,8 @@ nu-table = { path = "../nu-table", version = "0.60.0"  }
 nu-term-grid = { path = "../nu-term-grid", version = "0.60.0"  }
 nu-test-support = { path = "../nu-test-support", version = "0.60.0"  }
 nu-utils = { path = "../nu-utils", version = "0.60.0" }
-nu-ansi-term = "0.45.0"
+# nu-ansi-term = "0.45.0"
+nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
 
 # Potential dependencies for extras
 base64 = "0.13.0"
@@ -78,7 +79,8 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-reedline = "0.3.0"
+# reedline = "0.3.0"
+reedline = { path = "../../../reedline", version = "0.3.1" }
 zip = { version="0.5.9", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -23,8 +23,7 @@ nu-table = { path = "../nu-table", version = "0.60.0"  }
 nu-term-grid = { path = "../nu-term-grid", version = "0.60.0"  }
 nu-test-support = { path = "../nu-test-support", version = "0.60.0"  }
 nu-utils = { path = "../nu-utils", version = "0.60.0" }
-# nu-ansi-term = "0.45.0"
-nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
+nu-ansi-term = "0.45.1"
 
 # Potential dependencies for extras
 base64 = "0.13.0"
@@ -78,8 +77,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-# reedline = "0.3.0"
-reedline = { path = "../../../reedline", version = "0.3.1" }
+reedline = { git = "https://github.com/nushell/reedline" }
 zip = { version="0.5.9", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -130,6 +130,13 @@ lazy_static! {
     AnsiCode{ short_name: Some("dgrd"), long_name: "dark_gray_dimmed", code: Color::DarkGray.dimmed().prefix().to_string()},
     AnsiCode{ short_name: Some("dgrr"), long_name: "dark_gray_reverse", code: Color::DarkGray.reverse().prefix().to_string()},
 
+    AnsiCode{ short_name: Some("der"), long_name: "default", code: Color::Default.prefix().to_string()},
+    AnsiCode{ short_name: Some("deb"), long_name: "default_bold", code: Color::Default.bold().prefix().to_string()},
+    AnsiCode{ short_name: Some("deu"), long_name: "default_underline", code: Color::Default.underline().prefix().to_string()},
+    AnsiCode{ short_name: Some("dei"), long_name: "default_italic", code: Color::Default.italic().prefix().to_string()},
+    AnsiCode{ short_name: Some("ded"), long_name: "default_dimmed", code: Color::Default.dimmed().prefix().to_string()},
+    AnsiCode{ short_name: Some("der"), long_name: "default_reverse", code: Color::Default.reverse().prefix().to_string()},
+
     AnsiCode{ short_name: None, long_name: "reset", code: "\x1b[0m".to_owned()},
     // Reference for ansi codes https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
     // Another good reference http://ascii-table.com/ansi-escape-sequences.php
@@ -247,6 +254,7 @@ following values:
     35/95    magenta            45/105    magenta
     36/96    cyan               46/106    cyan
     37/97    white              47/107    white
+    39       default            49        default
     https://en.wikipedia.org/wiki/ANSI_escape_code
 
 OSC: '\x1b]' is not required for --osc parameter
@@ -435,8 +443,8 @@ fn generate_ansi_code_list(
             };
             let name: Value = Value::string(String::from(ansi_code.long_name), call_span);
             let short_name = Value::string(ansi_code.short_name.unwrap_or(""), call_span);
-            // The first 96 items in the ansi array are colors
-            let preview = if i < 96 {
+            // The first 102 items in the ansi array are colors
+            let preview = if i < 102 {
                 Value::string(format!("{}NUSHELL\u{1b}[0m", &ansi_code.code), call_span)
             } else {
                 Value::string("\u{1b}[0m", call_span)

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -16,7 +16,8 @@ name = "nu_pretty_hex"
 path = "src/main.rs"
 
 [dependencies]
-nu-ansi-term = "0.45.0"
+# nu-ansi-term = "0.45.0"
+nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
 
 rand = "0.8.3"
 

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -16,9 +16,7 @@ name = "nu_pretty_hex"
 path = "src/main.rs"
 
 [dependencies]
-# nu-ansi-term = "0.45.0"
-nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
-
+nu-ansi-term = "0.45.1"
 rand = "0.8.3"
 
 [dev-dependencies]

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -12,7 +12,9 @@ name = "table"
 path = "src/main.rs"
 
 [dependencies]
-nu-ansi-term = "0.45.0"
+# nu-ansi-term = "0.45.0"
+nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
+
 nu-protocol = { path = "../nu-protocol", version = "0.60.0" }
 regex = "1.4"
 unicode-width = "0.1.8"

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -12,9 +12,7 @@ name = "table"
 path = "src/main.rs"
 
 [dependencies]
-# nu-ansi-term = "0.45.0"
-nu-ansi-term = { path="../../../nu-ansi-term", version = "0.45.1" }
-
+nu-ansi-term = "0.45.1"
 nu-protocol = { path = "../nu-protocol", version = "0.60.0" }
 regex = "1.4"
 unicode-width = "0.1.8"


### PR DESCRIPTION
# Description

This adds a new default color using ansi escape 39 foreground and 49 background, which now exist in the published nu-ansi-term 0.45.1 crate. reedline was also updated to 0.3.1, pointing to nu-ansi-term 0.45.1. The nushell cargo.toml reedline references once again point to the git path for reedline instead of crates.io. I know Fernando has some updates to reedline incoming so it isn't a good time to push for reedline to be published to crates.io yet.

closed #4973 

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
