### PR TITLE
Case-insensitive search in did_you_mean

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -360,6 +360,15 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for ShellError {
 }
 
 pub fn did_you_mean(possibilities: &[String], tried: &str) -> Option<String> {
+    // First see if we can find the same string just cased differently
+    let great_match_index = possibilities
+        .iter()
+        .position(|word| word.to_lowercase() == tried.to_lowercase());
+
+    if let Some(index) = great_match_index {
+        return Some(possibilities[index].to_owned());
+    }
+
     let mut possible_matches: Vec<_> = possibilities
         .iter()
         .map(|word| {


### PR DESCRIPTION
# Description

Small improvement to the "did you mean X?" suggestion: look for the exact same string in a different case. I noticed that `$env.pwd` was suggesting `$env.OS` instead of `$env.PWD` and this seemed like an easy thing to fix up.

I'm a relative newbie when it comes to Rust, just let me know if I've missed a better way to implement this.

**Before:**
![image](https://user-images.githubusercontent.com/26268125/160268358-8bf78008-9f8f-4e49-9add-e9e8e8815ff1.png)

**After:**
![image](https://user-images.githubusercontent.com/26268125/160268418-aca0f965-9879-4584-8db4-f038964604de.png)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass