### PR TITLE
Update README.md for Rust 1.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also find information on more specific topics in our [cookbook](https://
 
 Up-to-date installation instructions can be found in the [installation chapter of the book](https://www.nushell.sh/book/installation.html). **Windows users**: please note that Nu works on Windows 10 and does not currently have Windows 7/8.1 support.
 
-To build Nu, you will need to use the **latest stable (1.51 or later)** version of the compiler.
+To build Nu, you will need to use the **latest stable (1.59 or later)** version of the compiler.
 
 Required dependencies:
 


### PR DESCRIPTION
Since `Cargo.toml` now specifies `strip = ...`, and `strip` is only available in cargo >=1.59, specify that at least this version is required.

# Description

Update `README.md` with the info that at least Rust 1.59 is required.

Ran into this in nixpkgs, where nushell 0.60 doesn't build with Rust 1.58 anymore, see: https://github.com/NixOS/nixpkgs/pull/165473

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass

**Disclaimer**: I haven't run any of the checks mentioned above (just edited the file on github).
