### PR TITLE
Help menu improvements

### DIFF
--- a/crates/nu-cli/src/help_menu.rs
+++ b/crates/nu-cli/src/help_menu.rs
@@ -93,7 +93,7 @@ impl Default for NuHelpMenu {
             values: Vec::new(),
             col_pos: 0,
             row_pos: 0,
-            marker: "| ".to_string(),
+            marker: "? ".to_string(),
             event: None,
             input: None,
             examples: Vec::new(),

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -222,7 +222,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyModifiers::NONE,
         KeyCode::Tab,
         ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Menu("completer_menu".to_string()),
+            ReedlineEvent::Menu("completion_menu".to_string()),
             ReedlineEvent::MenuNext,
         ]),
     );
@@ -255,7 +255,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
     // Help menu keybinding
     keybindings.add_binding(
         KeyModifiers::CONTROL,
-        KeyCode::Char('i'),
+        KeyCode::Char('q'),
         ReedlineEvent::Menu("help_menu".to_string()),
     );
 }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -221,7 +221,7 @@ let $config = {
     text_style: green
     selected_text_style: green_reverse
     description_text_style: yellow
-    marker: "% "
+    marker: "? "
   }
   keybindings: [
     {


### PR DESCRIPTION
# Description

A couple touch-ups for help menus:

- Switch from ctrl+i to ctrl+q
- Use `?` as the indicator
- Sort results by levenshtein distance so commands close to what you type show up first 

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
