### PR TITLE
Ls colors metadata

### DIFF
--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -37,6 +37,7 @@ impl Command for Collect {
         let block = engine_state.get_block(capture_block.block_id).clone();
         let mut stack = stack.captures_to_stack(&capture_block.captures);
 
+        let metadata = input.metadata();
         let input: Value = input.into_value(call.head);
 
         if let Some(var) = block.signature.get_positional(0) {
@@ -53,6 +54,7 @@ impl Command for Collect {
             call.redirect_stdout,
             call.redirect_stderr,
         )
+        .map(|res| res.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -54,7 +54,7 @@ impl Command for Collect {
             call.redirect_stdout,
             call.redirect_stderr,
         )
-        .map(|res| res.set_metadata(metadata))
+        .map(|x| x.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -113,6 +113,7 @@ impl Command for Each {
         let numbered = call.has_flag("numbered");
         let keep_empty = call.has_flag("keep-empty");
 
+        let metadata = input.metadata();
         let ctrlc = engine_state.ctrlc.clone();
         let outer_ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
@@ -243,6 +244,7 @@ impl Command for Each {
                 outer_ctrlc,
             )
         })
+        .map(|x| x.set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/every.rs
+++ b/crates/nu-command/src/filters/every.rs
@@ -69,6 +69,8 @@ impl Command for Every {
 
         let skip = call.has_flag("skip");
 
+        let metadata = input.metadata();
+
         Ok(input
             .into_iter()
             .enumerate()
@@ -79,7 +81,8 @@ impl Command for Every {
                     None
                 }
             })
-            .into_pipeline_data(engine_state.ctrlc.clone()))
+            .into_pipeline_data(engine_state.ctrlc.clone())
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -112,11 +112,14 @@ fn flatten(
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
     let tag = call.head;
     let columns: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+    let metadata = input.metadata().clone();
 
-    input.flat_map(
-        move |item| flat_value(&columns, &item, tag),
-        engine_state.ctrlc.clone(),
-    )
+    input
+        .flat_map(
+            move |item| flat_value(&columns, &item, tag),
+            engine_state.ctrlc.clone(),
+        )
+        .map(|x| x.set_metadata(metadata))
 }
 
 enum TableInside<'a> {

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -112,7 +112,7 @@ fn flatten(
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
     let tag = call.head;
     let columns: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
-    let metadata = input.metadata().clone();
+    let metadata = input.metadata();
 
     input
         .flat_map(

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -81,7 +81,8 @@ impl Command for Get {
             }
 
             Ok(output.into_iter().into_pipeline_data(ctrlc))
-        }.map(|x| x.set_metadata(metadata))
+        }
+        .map(|x| x.set_metadata(metadata))
     }
     fn examples(&self) -> Vec<Example> {
         vec![

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -46,6 +46,7 @@ impl Command for Get {
         let rest: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
         let ignore_errors = call.has_flag("ignore-errors");
         let ctrlc = engine_state.ctrlc.clone();
+        let metadata = input.metadata();
 
         if rest.is_empty() {
             let output = input
@@ -80,7 +81,7 @@ impl Command for Get {
             }
 
             Ok(output.into_iter().into_pipeline_data(ctrlc))
-        }
+        }.map(|x| x.set_metadata(metadata))
     }
     fn examples(&self) -> Vec<Example> {
         vec![

--- a/crates/nu-command/src/filters/group.rs
+++ b/crates/nu-command/src/filters/group.rs
@@ -73,6 +73,7 @@ impl Command for Group {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let group_size: Spanned<usize> = call.req(engine_state, stack, 0)?;
         let ctrlc = engine_state.ctrlc.clone();
+        let metadata = input.metadata();
 
         //FIXME: add in support for external redirection when engine-q supports it generally
 
@@ -82,7 +83,9 @@ impl Command for Group {
             span: call.head,
         };
 
-        Ok(each_group_iterator.into_pipeline_data(ctrlc))
+        Ok(each_group_iterator
+            .into_pipeline_data(ctrlc)
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -77,11 +77,12 @@ impl Command for Headers {
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
         let config = stack.get_config()?;
+        let metadata = input.metadata();
         let value = input.into_value(call.head);
         let headers = extract_headers(&value, &config)?;
         let new_headers = replace_headers(value, &headers)?;
 
-        Ok(new_headers.into_pipeline_data())
+        Ok(new_headers.into_pipeline_data().set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -61,6 +61,7 @@ impl Command for ParEach {
         let capture_block: CaptureBlock = call.req(engine_state, stack, 0)?;
 
         let numbered = call.has_flag("numbered");
+        let metadata = input.metadata();
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
         let block_id = capture_block.block_id;
@@ -287,7 +288,7 @@ impl Command for ParEach {
                     redirect_stderr,
                 )
             }
-        }
+        }.map(|res| res.set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -288,7 +288,8 @@ impl Command for ParEach {
                     redirect_stderr,
                 )
             }
-        }.map(|res| res.set_metadata(metadata))
+        }
+        .map(|res| res.set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -82,12 +82,14 @@ impl Command for Prepend {
     ) -> Result<PipelineData, ShellError> {
         let val: Value = call.req(engine_state, stack, 0)?;
         let vec: Vec<Value> = process_value(val);
+        let metadata = input.metadata();
 
         Ok(vec
             .into_iter()
             .chain(input)
             .into_iter()
-            .into_pipeline_data(engine_state.ctrlc.clone()))
+            .into_pipeline_data(engine_state.ctrlc.clone())
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -65,6 +65,7 @@ impl Command for Range {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let metadata = input.metadata();
         let rows: nu_protocol::Range = call.req(engine_state, stack, 0)?;
 
         let rows_from = get_range_val(rows.from);
@@ -112,6 +113,7 @@ impl Command for Range {
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
             }
         }
+        .map(|x| x.set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -72,6 +72,7 @@ fn reject(
     if columns.is_empty() {
         return Err(ShellError::CantFindColumn(span, span));
     }
+    let metadata = input.metadata();
 
     let mut keep_columns = vec![];
 
@@ -160,6 +161,7 @@ fn reject(
         }
         x => Ok(x),
     }
+    .map(|x| x.set_metadata(metadata))
 }
 
 fn get_input_cols(input: Vec<Value>) -> Vec<String> {

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -112,49 +112,50 @@ fn rename(
     let columns: Vec<String> = call.rest(engine_state, stack, 0)?;
     let metadata = input.metadata();
 
-    input.map(
-        move |item| match item {
-            Value::Record {
-                mut cols,
-                vals,
-                span,
-            } => {
-                match &specified_column {
-                    Some(c) => {
-                        // check if the specified column to be renamed exists
-                        if !cols.contains(&c[0]) {
-                            return Value::Error {
-                                error: ShellError::UnsupportedInput(
-                                    "The specified column does not exist".to_string(),
-                                    specified_col_span.unwrap_or(span),
-                                ),
-                            };
+    input
+        .map(
+            move |item| match item {
+                Value::Record {
+                    mut cols,
+                    vals,
+                    span,
+                } => {
+                    match &specified_column {
+                        Some(c) => {
+                            // check if the specified column to be renamed exists
+                            if !cols.contains(&c[0]) {
+                                return Value::Error {
+                                    error: ShellError::UnsupportedInput(
+                                        "The specified column does not exist".to_string(),
+                                        specified_col_span.unwrap_or(span),
+                                    ),
+                                };
+                            }
+                            for (idx, val) in cols.iter_mut().enumerate() {
+                                if *val == c[0] {
+                                    cols[idx] = c[1].to_string();
+                                    break;
+                                }
+                            }
                         }
-                        for (idx, val) in cols.iter_mut().enumerate() {
-                            if *val == c[0] {
-                                cols[idx] = c[1].to_string();
-                                break;
+                        None => {
+                            for (idx, val) in columns.iter().enumerate() {
+                                if idx >= cols.len() {
+                                    // skip extra new columns names if we already reached the final column
+                                    break;
+                                }
+                                cols[idx] = val.clone();
                             }
                         }
                     }
-                    None => {
-                        for (idx, val) in columns.iter().enumerate() {
-                            if idx >= cols.len() {
-                                // skip extra new columns names if we already reached the final column
-                                break;
-                            }
-                            cols[idx] = val.clone();
-                        }
-                    }
-                }
 
-                Value::Record { cols, vals, span }
-            }
-            x => x,
-        },
-        engine_state.ctrlc.clone(),
-    )
-    .map(|x| x.set_metadata(metadata))
+                    Value::Record { cols, vals, span }
+                }
+                x => x,
+            },
+            engine_state.ctrlc.clone(),
+        )
+        .map(|x| x.set_metadata(metadata))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -110,6 +110,7 @@ fn rename(
     }
 
     let columns: Vec<String> = call.rest(engine_state, stack, 0)?;
+    let metadata = input.metadata();
 
     input.map(
         move |item| match item {
@@ -153,6 +154,7 @@ fn rename(
         },
         engine_state.ctrlc.clone(),
     )
+    .map(|x| x.set_metadata(metadata))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/rotate.rs
+++ b/crates/nu-command/src/filters/rotate.rs
@@ -205,6 +205,7 @@ pub fn rotate(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
+    let metadata = input.metadata();
     let col_given_names: Vec<String> = call.rest(engine_state, stack, 0)?;
     let mut values = input.into_iter().collect::<Vec<_>>();
     let mut old_column_names = vec![];
@@ -288,7 +289,8 @@ pub fn rotate(
             }],
             span: call.head,
         }
-        .into_pipeline_data());
+        .into_pipeline_data()
+        .set_metadata(metadata));
     }
 
     // holder for the new records
@@ -344,7 +346,8 @@ pub fn rotate(
         vals: final_values,
         span: call.head,
     }
-    .into_pipeline_data())
+    .into_pipeline_data()
+    .set_metadata(metadata))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -133,6 +133,7 @@ pub fn transpose(
     };
 
     let ctrlc = engine_state.ctrlc.clone();
+    let metadata = input.metadata();
     let input: Vec<_> = input.into_iter().collect();
     let args = transpose_args;
 
@@ -226,7 +227,7 @@ pub fn transpose(
             span: name,
         }
     }))
-    .into_pipeline_data(ctrlc))
+    .into_pipeline_data(ctrlc).set_metadata(metadata))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -227,7 +227,8 @@ pub fn transpose(
             span: name,
         }
     }))
-    .into_pipeline_data(ctrlc).set_metadata(metadata))
+    .into_pipeline_data(ctrlc)
+    .set_metadata(metadata))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/update_cells.rs
+++ b/crates/nu-command/src/filters/update_cells.rs
@@ -129,6 +129,7 @@ impl Command for UpdateCells {
         let orig_env_vars = stack.env_vars.clone();
         let orig_env_hidden = stack.env_hidden.clone();
 
+        let metadata = input.metadata();
         let ctrlc = engine_state.ctrlc.clone();
         let block: Block = engine_state.get_block(block.block_id).clone();
 
@@ -163,7 +164,8 @@ impl Command for UpdateCells {
             redirect_stderr,
             span,
         }
-        .into_pipeline_data(ctrlc))
+        .into_pipeline_data(ctrlc)
+        .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -144,6 +144,7 @@ impl Command for Window {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let group_size: Spanned<usize> = call.req(engine_state, stack, 0)?;
         let ctrlc = engine_state.ctrlc.clone();
+        let metadata = input.metadata();
         let stride: Option<usize> = call.get_flag(engine_state, stack, "stride")?;
 
         let stride = stride.unwrap_or(1);
@@ -158,7 +159,9 @@ impl Command for Window {
             stride,
         };
 
-        Ok(each_group_iterator.into_pipeline_data(ctrlc))
+        Ok(each_group_iterator
+            .into_pipeline_data(ctrlc)
+            .set_metadata(metadata))
     }
 }
 

--- a/crates/nu-command/src/filters/zip_.rs
+++ b/crates/nu-command/src/filters/zip_.rs
@@ -87,6 +87,7 @@ impl Command for Zip {
         let other: Value = call.req(engine_state, stack, 0)?;
         let head = call.head;
         let ctrlc = engine_state.ctrlc.clone();
+        let metadata = input.metadata();
 
         Ok(input
             .into_iter()
@@ -95,7 +96,8 @@ impl Command for Zip {
                 vals: vec![x, y],
                 span: head,
             })
-            .into_pipeline_data(ctrlc))
+            .into_pipeline_data(ctrlc)
+            .set_metadata(metadata))
     }
 }
 


### PR DESCRIPTION
# Description
This PR passes metadata for more filtering commands. Progress on #4763.

## Verified with:

| command        |      |     |
|----------------|------|-----|
| `collect`      | `ls \| collect { \| x\| $x }` | |
| `compact`      | `ls -l \| compact` | `ls -l \| compact target` |
| `each`         | `ls \| each { \|it\| $it }` | `ls \| each -n { \|it\| $it.item }` |
| `every`        | `ls \| every 2` | `ls \| every 2 \| every 2` |
| `flatten`      | `ls \| flatten` | |
| `get`          | `ls \| group 5 \| get 0` | `ls \| window 5 \| get 0` |
| `headers`      | verified with `transpose`, `rotate` | |
| `group`        | `ls \| group 5 \| flatten` | |
| `par-each`     | `ls \| par-each { \|it\| $it }` | |
| `prepend`      | `ls \| prepend [[ name type size ]; ["name", dir, 0b]]` | |
| `range`        | `ls \| range 0..6`     | `ls \| range (-5)..(-1)` |
| `reject`       | `ls \| reject type == dir` | |
| `rename`       | `ls \| rename name type filesize` | |
| `rotate`       | `ls \| rotate \| headers \| rotate \| headers \| rotate \| headers \| rotate \| headers` | |
| `select`       | `ls \| select`| `ls \| select name` | |
| `transpose`    | `ls \| transpose \| headers \| transpose \| headers` | |
| `update`       | `ls \| update type dir` | |
| `update cells` | `ls -l \| update cells -c [target] { \|_\| 'None' }` | |
| `window`       | `ls \| window 2 \| flatten` | `ls \| window 2 \| flatten \| uniq` |
| `zip`          | `ls \| zip 1..15 \| each { \|it\| $it.0 }` | |

## Notes

### `record.name` doesn't retain colors:

I would expect these to have the same output:
* ```ls | each { |it| $it.name }``` no colours
* ```ls | each { |it| $it } | select name``` has colours

Should most likely open a new ticket for this

### Should commands that change header info expect to have colors?
* `get` -- seems like it shouldn't, since we remove column info here
* `reduce` -- I'm not sure about this one
* `transpose` -- I'm not sure about this one

### Further refactor?

Consuming methods on `PipelineData` data returning `Result<PipelineData, ShellError>` currently strip the metadata,
which many of the filtering commands use. Perhaps a more robust solution, instead of copying and setting the metadata at
each command invocation, would be to include the metadata here?

Here which methods are used in each command:

* `PipelineData::map`:
* `PipelineData::flat_map`:
* `PipelineData::filter`: 


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
