### PR TITLE
Use real stack during custom completion

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -28,13 +28,15 @@ impl Default for CompletionOptions {
 #[derive(Clone)]
 pub struct NuCompleter {
     engine_state: EngineState,
+    stack: Stack,
     config: Option<Value>,
 }
 
 impl NuCompleter {
-    pub fn new(engine_state: EngineState, config: Option<Value>) -> Self {
+    pub fn new(engine_state: EngineState, stack: Stack, config: Option<Value>) -> Self {
         Self {
             engine_state,
+            stack,
             config,
         }
     }
@@ -296,9 +298,8 @@ impl NuCompleter {
 
                         match &flat.1 {
                             FlatShape::Custom(decl_id) => {
-                                //let prefix = working_set.get_span_contents(flat.0).to_vec();
+                                let mut stack = self.stack.clone();
 
-                                let mut stack = Stack::new();
                                 // Set up our initial config to start from
                                 if let Some(conf) = &self.config {
                                     stack.vars.insert(CONFIG_VARIABLE_ID, conf.clone());

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -27,13 +27,11 @@ pub fn evaluate_repl(
     history_path: Option<PathBuf>,
     is_perf_true: bool,
 ) -> Result<()> {
-    // use crate::logger::{configure, logger};
     use reedline::{FileBackedHistory, Reedline, Signal};
 
     let mut entry_num = 0;
 
     let mut nu_prompt = NushellPrompt::new();
-    // let mut stack = nu_protocol::engine::Stack::new();
 
     // First, set up env vars as strings only
     // gather_parent_env_vars(engine_state);
@@ -147,6 +145,7 @@ pub fn evaluate_repl(
             }))
             .with_completer(Box::new(NuCompleter::new(
                 engine_state.clone(),
+                stack.clone(),
                 stack.vars.get(&CONFIG_VARIABLE_ID).cloned(),
             )))
             .with_quick_completions(config.quick_completions)


### PR DESCRIPTION
# Description

fixes #5007 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
