### PR TITLE
Strip '+ ' decoration in git branch list

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -61,7 +61,7 @@ module completions {
   #
   # This is a simplified version of completions for git branches and git remotes
   def "nu-complete git branches" [] {
-    ^git branch | lines | each { |line| $line | str find-replace '\* ' '' | str trim }
+    ^git branch | lines | each { |line| $line | str find-replace '[\*\+] ' '' | str trim }
   }
 
   def "nu-complete git remotes" [] {


### PR DESCRIPTION
Add '+' to the pattern to be stripped from the branch names, '+' is the prefix for the current branch in some worktree.

Closes #5014

# Description

I use `git worktree` in most projects, testing `nu` completion i saw a strange output:

```
+ some-branch
some-other-branch
current-branch 
```

`some-branch` was the current HEAD in a worktree beside the one I was in.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
