### PR TITLE
feat: add --suppress-output (-s) to input command

### DIFF
--- a/crates/nu-command/src/platform/input.rs
+++ b/crates/nu-command/src/platform/input.rs
@@ -97,8 +97,6 @@ impl Command for Input {
                             // TODO: maintain keycode parity with existing command
                             KeyCode::Char(_) if k.modifiers != KeyModifiers::NONE => continue,
                             KeyCode::Char(c) => buf.push(c),
-
-                            // TODO: handle cursor position?
                             KeyCode::Backspace => {
                                 let _ = buf.pop();
                             }


### PR DESCRIPTION
# Description

Per #4943, this adds `--suppress-output (-s)` to the `input` command.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
