### PR TITLE
Clean up which/which-support Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,13 +74,13 @@ embed-resource = "1"
 
 [features]
 plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
-default = ["plugin", "which", "zip-support", "trash-support"]
+default = ["plugin", "which-support", "zip-support", "trash-support"]
 stable = ["default"]
 extra = ["default", "dataframe"]
 wasi = []
 
 # Stable (Default)
-which = ["nu-command/which"]
+which-support = ["nu-command/which"]
 zip-support = ["nu-command/zip"]
 trash-support = ["nu-command/trash-support"]
 

--- a/crates/nu-command/src/core_commands/version.rs
+++ b/crates/nu-command/src/core_commands/version.rs
@@ -256,7 +256,7 @@ fn features_enabled() -> Vec<String> {
         names.push("uuid".to_string());
     }
 
-    #[cfg(feature = "which")]
+    #[cfg(feature = "which-support")]
     {
         names.push("which".to_string());
     }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -142,7 +142,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             Sys,
         };
 
-        #[cfg(feature = "which")]
+        #[cfg(feature = "which-support")]
         bind_command! { Which };
 
         // Strings

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -128,7 +128,7 @@ fn get_entries_in_nu(
     all_entries
 }
 
-#[cfg(feature = "which")]
+#[cfg(feature = "which-support")]
 fn get_first_entry_in_path(
     item: &str,
     span: Span,
@@ -140,7 +140,7 @@ fn get_first_entry_in_path(
         .ok()
 }
 
-#[cfg(not(feature = "which"))]
+#[cfg(not(feature = "which-support"))]
 fn get_first_entry_in_path(
     _item: &str,
     _span: Span,
@@ -150,7 +150,7 @@ fn get_first_entry_in_path(
     None
 }
 
-#[cfg(feature = "which")]
+#[cfg(feature = "which-support")]
 fn get_all_entries_in_path(
     item: &str,
     span: Span,
@@ -165,7 +165,7 @@ fn get_all_entries_in_path(
         .unwrap_or_default()
 }
 
-#[cfg(not(feature = "which"))]
+#[cfg(not(feature = "which-support"))]
 fn get_all_entries_in_path(
     _item: &str,
     _span: Span,

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -66,7 +66,7 @@ mod update;
 mod upsert;
 mod use_;
 mod where_;
-#[cfg(feature = "which")]
+#[cfg(feature = "which-support")]
 mod which;
 mod with_env;
 mod wrap;

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -14,6 +14,8 @@ fn env_shorthand() {
     assert_eq!(actual.out, "bar");
 }
 
+// FIXME: shorthand breaks when there's an equals sign in the env var
+#[ignore]
 #[test]
 fn env_shorthand_with_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -22,6 +24,8 @@ fn env_shorthand_with_equals() {
     assert_eq!(actual.out, "my_module=info");
 }
 
+// FIXME: shorthand breaks when there's an equals sign in the env var
+#[ignore]
 #[test]
 fn env_shorthand_with_comma_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -30,6 +34,8 @@ fn env_shorthand_with_comma_equals() {
     assert_eq!(actual.out, "info,my_module=info");
 }
 
+// FIXME: shorthand breaks when there's an equals sign in the env var
+#[ignore]
 #[test]
 fn env_shorthand_with_comma_colons_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -38,6 +44,8 @@ fn env_shorthand_with_comma_colons_equals() {
     assert_eq!(actual.out, "info,my_module=info,lib_crate::lib_mod=trace");
 }
 
+// FIXME: shorthand breaks when there's an equals sign in the env var
+#[ignore]
 #[test]
 fn env_shorthand_multi_second_with_comma_colons_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -49,6 +57,8 @@ fn env_shorthand_multi_second_with_comma_colons_equals() {
     );
 }
 
+// FIXME: shorthand breaks when there's an equals sign in the env var
+#[ignore]
 #[test]
 fn env_shorthand_multi_first_with_comma_colons_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -68,6 +78,8 @@ fn env_shorthand_multi() {
     assert_eq!(actual.out, "barbaz");
 }
 
+// FIXME: for some reason Nu is attempting to execute foo in `let-env FOO = foo`
+#[ignore]
 #[test]
 fn passes_let_env_env_var_to_external_process() {
     let actual = nu!(cwd: ".", r#"
@@ -85,6 +97,8 @@ fn passes_with_env_env_var_to_external_process() {
     assert_eq!(actual.out, "foo");
 }
 
+// FIXME: autoenv not currently implemented
+#[ignore]
 #[test]
 #[serial]
 fn passes_env_from_local_cfg_to_external_process() {

--- a/tests/shell/environment/mod.rs
+++ b/tests/shell/environment/mod.rs
@@ -1,5 +1,7 @@
 mod env;
-mod nu_env;
+
+// FIXME: nu_env tests depend on autoenv which hasn't been ported yet
+// mod nu_env;
 
 pub mod support {
     use nu_test_support::{nu, playground::*, Outcome};

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,6 +1,6 @@
 use nu_test_support::nu;
 
-#[cfg(feature = "which")]
+#[cfg(feature = "which-support")]
 #[test]
 fn shows_error_for_command_not_found() {
     let actual = nu!(
@@ -11,7 +11,7 @@ fn shows_error_for_command_not_found() {
     assert!(!actual.err.is_empty());
 }
 
-#[cfg(feature = "which")]
+#[cfg(feature = "which-support")]
 #[test]
 fn shows_error_for_command_not_found_in_pipeline() {
     let actual = nu!(
@@ -23,7 +23,7 @@ fn shows_error_for_command_not_found_in_pipeline() {
 }
 
 #[ignore] // jt: we can't test this using the -c workaround currently
-#[cfg(feature = "which")]
+#[cfg(feature = "which-support")]
 #[test]
 fn automatically_change_directory() {
     use nu_test_support::playground::Playground;

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -647,7 +647,7 @@ fn run_dynamic_blocks() {
     assert_eq!(actual.out, "holaaaa");
 }
 
-#[cfg(feature = "which")]
+#[cfg(feature = "which-support")]
 #[test]
 fn argument_subexpression_reports_errors() {
     let actual = nu!(


### PR DESCRIPTION
# Description

Renaming the `which` Cargo feature to `which-support`. This makes feature naming a bit more consistent and re-enables tests in `tests/shell/environment` (which were already using `#[cfg(feature = "which-support")]`).

Some of the re-enabled tests are failing so they've been ignored/disabled. Failing tests fall into 2 categories:

- Tests that use env shorthand to set an env var with an `=` in it (ex: `RUST_LOG=my_module=info $env.RUST_LOG`)
- Tests that use autoenv, which has not (yet?) been ported

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
