### PR TITLE
Fix env var shorthand when value contains `=`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4117,7 +4117,7 @@ pub fn parse_expression(
         // Check if there is any environment shorthand
         let name = working_set.get_span_contents(spans[pos]);
 
-        let split = name.split(|x| *x == b'=');
+        let split = name.splitn(2, |x| *x == b'=');
         let split: Vec<_> = split.collect();
         if split.len() == 2 && !split[0].is_empty() {
             let point = split[0].len() + 1;

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -14,8 +14,6 @@ fn env_shorthand() {
     assert_eq!(actual.out, "bar");
 }
 
-// FIXME: shorthand breaks when there's an equals sign in the env var
-#[ignore]
 #[test]
 fn env_shorthand_with_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -24,8 +22,6 @@ fn env_shorthand_with_equals() {
     assert_eq!(actual.out, "my_module=info");
 }
 
-// FIXME: shorthand breaks when there's an equals sign in the env var
-#[ignore]
 #[test]
 fn env_shorthand_with_comma_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -34,8 +30,6 @@ fn env_shorthand_with_comma_equals() {
     assert_eq!(actual.out, "info,my_module=info");
 }
 
-// FIXME: shorthand breaks when there's an equals sign in the env var
-#[ignore]
 #[test]
 fn env_shorthand_with_comma_colons_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -44,8 +38,6 @@ fn env_shorthand_with_comma_colons_equals() {
     assert_eq!(actual.out, "info,my_module=info,lib_crate::lib_mod=trace");
 }
 
-// FIXME: shorthand breaks when there's an equals sign in the env var
-#[ignore]
 #[test]
 fn env_shorthand_multi_second_with_comma_colons_equals() {
     let actual = nu!(cwd: ".", r#"
@@ -57,8 +49,6 @@ fn env_shorthand_multi_second_with_comma_colons_equals() {
     );
 }
 
-// FIXME: shorthand breaks when there's an equals sign in the env var
-#[ignore]
 #[test]
 fn env_shorthand_multi_first_with_comma_colons_equals() {
     let actual = nu!(cwd: ".", r#"


### PR DESCRIPTION
# Description

This PR fixes a small parser regression and re-enables relevant tests. Seems like the functionality from https://github.com/nushell/nushell/pull/3869 got lost in the engine-q migration.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
