### PR TITLE
evaluate indicators as commands

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -12,10 +12,10 @@ use {
 pub struct NushellPrompt {
     left_prompt_string: Option<String>,
     right_prompt_string: Option<String>,
-    default_prompt_indicator: String,
-    default_vi_insert_prompt_indicator: String,
-    default_vi_normal_prompt_indicator: String,
-    default_multiline_indicator: String,
+    default_prompt_indicator: Option<String>,
+    default_vi_insert_prompt_indicator: Option<String>,
+    default_vi_normal_prompt_indicator: Option<String>,
+    default_multiline_indicator: Option<String>,
 }
 
 impl Default for NushellPrompt {
@@ -29,10 +29,10 @@ impl NushellPrompt {
         NushellPrompt {
             left_prompt_string: None,
             right_prompt_string: None,
-            default_prompt_indicator: "〉".to_string(),
-            default_vi_insert_prompt_indicator: ": ".to_string(),
-            default_vi_normal_prompt_indicator: "〉".to_string(),
-            default_multiline_indicator: "::: ".to_string(),
+            default_prompt_indicator: None,
+            default_vi_insert_prompt_indicator: None,
+            default_vi_normal_prompt_indicator: None,
+            default_multiline_indicator: None,
         }
     }
 
@@ -44,19 +44,19 @@ impl NushellPrompt {
         self.right_prompt_string = prompt_string;
     }
 
-    pub fn update_prompt_indicator(&mut self, prompt_indicator_string: String) {
+    pub fn update_prompt_indicator(&mut self, prompt_indicator_string: Option<String>) {
         self.default_prompt_indicator = prompt_indicator_string;
     }
 
-    pub fn update_prompt_vi_insert(&mut self, prompt_vi_insert_string: String) {
+    pub fn update_prompt_vi_insert(&mut self, prompt_vi_insert_string: Option<String>) {
         self.default_vi_insert_prompt_indicator = prompt_vi_insert_string;
     }
 
-    pub fn update_prompt_vi_normal(&mut self, prompt_vi_normal_string: String) {
+    pub fn update_prompt_vi_normal(&mut self, prompt_vi_normal_string: Option<String>) {
         self.default_vi_normal_prompt_indicator = prompt_vi_normal_string;
     }
 
-    pub fn update_prompt_multiline(&mut self, prompt_multiline_indicator_string: String) {
+    pub fn update_prompt_multiline(&mut self, prompt_multiline_indicator_string: Option<String>) {
         self.default_multiline_indicator = prompt_multiline_indicator_string;
     }
 
@@ -64,18 +64,19 @@ impl NushellPrompt {
         &mut self,
         left_prompt_string: Option<String>,
         right_prompt_string: Option<String>,
-        prompt_indicator_string: String,
-        prompt_multiline_indicator_string: String,
-        prompt_vi: (String, String),
+        prompt_indicator_string: Option<String>,
+        prompt_multiline_indicator_string: Option<String>,
+        prompt_vi: (Option<String>, Option<String>),
     ) {
         let (prompt_vi_insert_string, prompt_vi_normal_string) = prompt_vi;
 
         self.left_prompt_string = left_prompt_string;
         self.right_prompt_string = right_prompt_string;
         self.default_prompt_indicator = prompt_indicator_string;
+        self.default_multiline_indicator = prompt_multiline_indicator_string;
+
         self.default_vi_insert_prompt_indicator = prompt_vi_insert_string;
         self.default_vi_normal_prompt_indicator = prompt_vi_normal_string;
-        self.default_multiline_indicator = prompt_multiline_indicator_string;
     }
 
     fn default_wrapped_custom_string(&self, str: String) -> String {
@@ -112,18 +113,33 @@ impl Prompt for NushellPrompt {
 
     fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
         match edit_mode {
-            PromptEditMode::Default => self.default_prompt_indicator.as_str().into(),
-            PromptEditMode::Emacs => self.default_prompt_indicator.as_str().into(),
+            PromptEditMode::Default => match &self.default_prompt_indicator {
+                Some(indicator) => indicator.as_str().into(),
+                None => "(build-string 〉)".into(),
+            },
+            PromptEditMode::Emacs => match &self.default_prompt_indicator {
+                Some(indicator) => indicator.as_str().into(),
+                None => "(build-string 〉)".into(),
+            },
             PromptEditMode::Vi(vi_mode) => match vi_mode {
-                PromptViMode::Normal => self.default_vi_normal_prompt_indicator.as_str().into(),
-                PromptViMode::Insert => self.default_vi_insert_prompt_indicator.as_str().into(),
+                PromptViMode::Normal => match &self.default_vi_normal_prompt_indicator {
+                    Some(indicator) => indicator.as_str().into(),
+                    None => "(build-string : )".into(),
+                },
+                PromptViMode::Insert => match &self.default_vi_insert_prompt_indicator {
+                    Some(indicator) => indicator.as_str().into(),
+                    None => "(build-string 〉)".into(),
+                },
             },
             PromptEditMode::Custom(str) => self.default_wrapped_custom_string(str).into(),
         }
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
-        Cow::Borrowed(self.default_multiline_indicator.as_str())
+        match &self.default_multiline_indicator {
+            Some(indicator) => indicator.as_str().into(),
+            None => "::: ".into(),
+        }
     }
 
     fn render_prompt_history_search_indicator(

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -138,7 +138,7 @@ impl Prompt for NushellPrompt {
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
         match &self.default_multiline_indicator {
             Some(indicator) => indicator.as_str().into(),
-            None => "::: ".into(),
+            None => "(build-string ::: )".into(),
         }
     }
 

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -115,20 +115,20 @@ impl Prompt for NushellPrompt {
         match edit_mode {
             PromptEditMode::Default => match &self.default_prompt_indicator {
                 Some(indicator) => indicator.as_str().into(),
-                None => "(build-string 〉)".into(),
+                None => "〉".into(),
             },
             PromptEditMode::Emacs => match &self.default_prompt_indicator {
                 Some(indicator) => indicator.as_str().into(),
-                None => "(build-string 〉)".into(),
+                None => "〉".into(),
             },
             PromptEditMode::Vi(vi_mode) => match vi_mode {
                 PromptViMode::Normal => match &self.default_vi_normal_prompt_indicator {
                     Some(indicator) => indicator.as_str().into(),
-                    None => "(build-string : )".into(),
+                    None => ": ".into(),
                 },
                 PromptViMode::Insert => match &self.default_vi_insert_prompt_indicator {
                     Some(indicator) => indicator.as_str().into(),
-                    None => "(build-string 〉)".into(),
+                    None => "〉".into(),
                 },
             },
             PromptEditMode::Custom(str) => self.default_wrapped_custom_string(str).into(),
@@ -138,7 +138,7 @@ impl Prompt for NushellPrompt {
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
         match &self.default_multiline_indicator {
             Some(indicator) => indicator.as_str().into(),
-            None => "(build-string ::: )".into(),
+            None => "::: ".into(),
         }
     }
 

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -17,49 +17,6 @@ pub(crate) const PROMPT_INDICATOR_VI_INSERT: &str = "PROMPT_INDICATOR_VI_INSERT"
 pub(crate) const PROMPT_INDICATOR_VI_NORMAL: &str = "PROMPT_INDICATOR_VI_NORMAL";
 pub(crate) const PROMPT_MULTILINE_INDICATOR: &str = "PROMPT_MULTILINE_INDICATOR";
 
-pub(crate) fn get_prompt_indicators(
-    config: &Config,
-    engine_state: &EngineState,
-    stack: &Stack,
-    is_perf_true: bool,
-) -> (String, String, String, String) {
-    let prompt_indicator = match stack.get_env_var(engine_state, PROMPT_INDICATOR) {
-        Some(pi) => pi.into_string("", config),
-        None => "〉".to_string(),
-    };
-
-    let prompt_vi_insert = match stack.get_env_var(engine_state, PROMPT_INDICATOR_VI_INSERT) {
-        Some(pvii) => pvii.into_string("", config),
-        None => ": ".to_string(),
-    };
-
-    let prompt_vi_normal = match stack.get_env_var(engine_state, PROMPT_INDICATOR_VI_NORMAL) {
-        Some(pviv) => pviv.into_string("", config),
-        None => "〉".to_string(),
-    };
-
-    let prompt_multiline = match stack.get_env_var(engine_state, PROMPT_MULTILINE_INDICATOR) {
-        Some(pm) => pm.into_string("", config),
-        None => "::: ".to_string(),
-    };
-
-    if is_perf_true {
-        info!(
-            "get_prompt_indicators {}:{}:{}",
-            file!(),
-            line!(),
-            column!()
-        );
-    }
-
-    (
-        prompt_indicator,
-        prompt_vi_insert,
-        prompt_vi_normal,
-        prompt_multiline,
-    )
-}
-
 fn get_prompt_string(
     prompt: &str,
     config: &Config,
@@ -153,32 +110,60 @@ pub(crate) fn update_prompt<'prompt>(
     nu_prompt: &'prompt mut NushellPrompt,
     is_perf_true: bool,
 ) -> &'prompt dyn Prompt {
-    // get the other indicators
-    let (
-        prompt_indicator_string,
-        prompt_vi_insert_string,
-        prompt_vi_normal_string,
-        prompt_multiline_string,
-    ) = get_prompt_indicators(config, engine_state, stack, is_perf_true);
-
     let mut stack = stack.clone();
+
+    let left_prompt_string = get_prompt_string(
+        PROMPT_COMMAND,
+        config,
+        engine_state,
+        &mut stack,
+        is_perf_true,
+    );
+
+    let right_prompt_string = get_prompt_string(
+        PROMPT_COMMAND_RIGHT,
+        config,
+        engine_state,
+        &mut stack,
+        is_perf_true,
+    );
+
+    let prompt_indicator_string = get_prompt_string(
+        PROMPT_INDICATOR,
+        config,
+        engine_state,
+        &mut stack,
+        is_perf_true,
+    );
+
+    let prompt_multiline_string = get_prompt_string(
+        PROMPT_MULTILINE_INDICATOR,
+        config,
+        engine_state,
+        &mut stack,
+        is_perf_true,
+    );
+
+    let prompt_vi_insert_string = get_prompt_string(
+        PROMPT_INDICATOR_VI_INSERT,
+        config,
+        engine_state,
+        &mut stack,
+        is_perf_true,
+    );
+
+    let prompt_vi_normal_string = get_prompt_string(
+        PROMPT_INDICATOR_VI_NORMAL,
+        config,
+        engine_state,
+        &mut stack,
+        is_perf_true,
+    );
 
     // apply the other indicators
     nu_prompt.update_all_prompt_strings(
-        get_prompt_string(
-            PROMPT_COMMAND,
-            config,
-            engine_state,
-            &mut stack,
-            is_perf_true,
-        ),
-        get_prompt_string(
-            PROMPT_COMMAND_RIGHT,
-            config,
-            engine_state,
-            &mut stack,
-            is_perf_true,
-        ),
+        left_prompt_string,
+        right_prompt_string,
         prompt_indicator_string,
         prompt_multiline_string,
         (prompt_vi_insert_string, prompt_vi_normal_string),

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -20,10 +20,10 @@ let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-let-env PROMPT_INDICATOR = { build-string 〉}
-let-env PROMPT_INDICATOR_VI_INSERT = { build-string :}
-let-env PROMPT_INDICATOR_VI_NORMAL = { build-string 〉}
-let-env PROMPT_MULTILINE_INDICATOR = { build-string :::}
+let-env PROMPT_INDICATOR = { "〉" }
+let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
+let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
+let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
 
 # Specifies how environment variables are:
 # - converted from a string to a value on Nushell startup (from_string)

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -20,10 +20,10 @@ let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-let-env PROMPT_INDICATOR = "〉"
-let-env PROMPT_INDICATOR_VI_INSERT = ": "
-let-env PROMPT_INDICATOR_VI_NORMAL = "〉"
-let-env PROMPT_MULTILINE_INDICATOR = "::: "
+let-env PROMPT_INDICATOR = { build-string 〉}
+let-env PROMPT_INDICATOR_VI_INSERT = { build-string :}
+let-env PROMPT_INDICATOR_VI_NORMAL = { build-string 〉}
+let-env PROMPT_MULTILINE_INDICATOR = { build-string :::}
 
 # Specifies how environment variables are:
 # - converted from a string to a value on Nushell startup (from_string)


### PR DESCRIPTION
# Description

The indicators were evaluated only once and not updated in the same way the right and left command prompt are working

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
