### PR TITLE
Fix which command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ extra = ["default", "dataframe"]
 wasi = []
 
 # Stable (Default)
-which-support = ["nu-command/which"]
+which-support = ["nu-command/which-support"]
 zip-support = ["nu-command/zip"]
 trash-support = ["nu-command/trash-support"]
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -101,6 +101,7 @@ features = [
 
 [features]
 trash-support = ["trash"]
+which-support = ["which"]
 plugin = ["nu-parser/plugin"]
 dataframe = ["polars", "num"]
 


### PR DESCRIPTION
# Description

[My recent change to the `which-support` feature](https://github.com/nushell/nushell/pull/5019) unintentionally disabled the `which` internal command. I didn't fully understand how the Cargo feature was passed to the `nu-command` crate and used to conditionally enable [the `which` dependency](https://crates.io/crates/which). My bad, good learning experience at least :)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
