### PR TITLE
Fix load-env unsupported input error message

### DIFF
--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -76,7 +76,7 @@ impl Command for LoadEnv {
                     Ok(PipelineData::new(call.head))
                 }
                 _ => Err(ShellError::UnsupportedInput(
-                    "Record not supported".into(),
+                    "'load-env' expects a single record".into(),
                     span,
                 )),
             },


### PR DESCRIPTION
# Description

Closes #5033. "Record not supported" is a little misleading when the command fails because it received something other than a single record.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
