### PR TITLE
Add record, list, and table to signature types

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2487,6 +2487,9 @@ pub fn parse_shape_name(
         b"signature" => SyntaxShape::Signature,
         b"string" => SyntaxShape::String,
         b"variable" => SyntaxShape::Variable,
+        b"record" => SyntaxShape::Record,
+        b"list" => SyntaxShape::List(Box::new(SyntaxShape::Any)),
+        b"table" => SyntaxShape::Table,
         _ => {
             if bytes.contains(&b'@') {
                 let str = String::from_utf8_lossy(bytes);


### PR DESCRIPTION
# Description

Now you can write `def foo [x: <xxx>] { }`, where `<xxx>` is:
* `record`,
* `list`,
* or `table`

For some reason `list` and `table` shapes accept a record, which to me is not clear why, but otherwise seems to work fine.

Related issue: https://github.com/nushell/nushell/issues/5030

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
