### PR TITLE
finish hooking up completion descriptions

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -257,6 +257,7 @@ impl NuCompleter {
                                 let mut output = vec![];
 
                                 for named in &sig.named {
+                                    let flag_desc = &named.desc;
                                     if let Some(short) = named.short {
                                         let mut named = vec![0; short.len_utf8()];
                                         short.encode_utf8(&mut named);
@@ -264,7 +265,7 @@ impl NuCompleter {
                                         if named.starts_with(&prefix) {
                                             output.push(Suggestion {
                                                 value: String::from_utf8_lossy(&named).to_string(),
-                                                description: None,
+                                                description: Some(flag_desc.to_string()),
                                                 span: reedline::Span {
                                                     start: new_span.start - offset,
                                                     end: new_span.end - offset,
@@ -283,7 +284,7 @@ impl NuCompleter {
                                     if named.starts_with(&prefix) {
                                         output.push(Suggestion {
                                             value: String::from_utf8_lossy(&named).to_string(),
-                                            description: None,
+                                            description: Some(flag_desc.to_string()),
                                             span: reedline::Span {
                                                 start: new_span.start - offset,
                                                 end: new_span.end - offset,


### PR DESCRIPTION
# Description

Finish hooking up @elferherrera's excellent completion descriptions.

In the screenshot below I did `ansi --<tab>`
![image](https://user-images.githubusercontent.com/343840/161094884-8af7ce86-7da4-48da-aced-5c130cf396ed.png)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
