### PR TITLE
Update reedline to new constructor API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.3.1"
-source = "git+https://github.com/nushell/reedline?branch=main#0f92985c69efca2567ad40ebc0381864e91aff8c"
+source = "git+https://github.com/nushell/reedline?branch=main#60386ac6107e8c5b4cdbdc415011c0f4fe2f0f77"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -128,7 +128,7 @@ pub fn evaluate_repl(
     if is_perf_true {
         info!("setup reedline {}:{}:{}", file!(), line!(), column!());
     }
-    let mut line_editor = Reedline::create().into_diagnostic()?;
+    let mut line_editor = Reedline::create();
     if let Some(history_path) = history_path.as_deref() {
         if is_perf_true {
             info!("setup history {}:{}:{}", file!(), line!(), column!());
@@ -140,7 +140,7 @@ pub fn evaluate_repl(
             )
             .into_diagnostic()?,
         );
-        line_editor = line_editor.with_history(history).into_diagnostic()?;
+        line_editor = line_editor.with_history(history);
     };
 
     loop {


### PR DESCRIPTION
# Description

Reedline after merging nushell/reedline#367

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
