### PR TITLE
let a simple last be a single value

### DIFF
--- a/crates/nu-command/tests/commands/path/split.rs
+++ b/crates/nu-command/tests/commands/path/split.rs
@@ -20,7 +20,6 @@ fn splits_correctly_single_path() {
             'home/viking/spam.txt'
             | path split
             | last
-            | get 0
         "#
     ));
 

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -44,7 +44,7 @@ fn flatten_table_get() -> TestResult {
 #[test]
 fn flatten_table_column_get_last() -> TestResult {
     run_test(
-        "[[origin, crate, versions]; [World, ([[name]; ['nu-cli']]), ['0.21', '0.22']]] | flatten versions | last | get versions.0",
+        "[[origin, crate, versions]; [World, ([[name]; ['nu-cli']]), ['0.21', '0.22']]] | flatten versions | last | get versions",
         "0.22",
     )
 }


### PR DESCRIPTION
# Description

before:

```
> [1, 2, 3] | last
[3]
```

now:
```
> [1, 2, 3] | last
3
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
