### PR TITLE
Add starts with operator

### DIFF
--- a/crates/nu-command/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/between_values.rs
@@ -376,6 +376,19 @@ pub(super) fn compute_series_single_value(
                 rhs_span: right.span()?,
             }),
         },
+        Operator::StartsWith => match &right {
+            Value::String { val, .. } => {
+                let starts_with_pattern = format!("^{}", val);
+                contains_series_pat(&lhs, &starts_with_pattern, lhs_span)
+            }
+            _ => Err(ShellError::OperatorMismatch {
+                op_span: operator.span,
+                lhs_ty: left.get_type(),
+                lhs_span: left.span()?,
+                rhs_ty: right.get_type(),
+                rhs_span: right.span()?,
+            }),
+        },
         _ => Err(ShellError::OperatorMismatch {
             op_span: operator.span,
             lhs_ty: left.get_type(),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -411,6 +411,10 @@ pub fn eval_expression(
                     let rhs = eval_expression(engine_state, stack, rhs)?;
                     lhs.pow(op_span, &rhs)
                 }
+                Operator::StartsWith => {
+                    let rhs = eval_expression(engine_state, stack, rhs)?;
+                    lhs.starts_with(op_span, &rhs)
+                }
             }
         }
         Expr::Subexpression(block_id) => {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3940,6 +3940,7 @@ pub fn parse_operator(
         b">" => Operator::GreaterThan,
         b">=" => Operator::GreaterThanOrEqual,
         b"=~" => Operator::Contains,
+        b"=^" => Operator::StartsWith,
         b"!~" => Operator::NotContains,
         b"+" => Operator::Plus,
         b"-" => Operator::Minus,

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -319,6 +319,24 @@ pub fn math_result_type(
                     )
                 }
             },
+            Operator::StartsWith => match (&lhs.ty, &rhs.ty) {
+                (Type::String, Type::String) => (Type::Bool, None),
+                (Type::Unknown, _) => (Type::Bool, None),
+                (_, Type::Unknown) => (Type::Bool, None),
+                _ => {
+                    *op = Expression::garbage(op.span);
+                    (
+                        Type::Unknown,
+                        Some(ParseError::UnsupportedOperation(
+                            op.span,
+                            lhs.span,
+                            lhs.ty.clone(),
+                            rhs.span,
+                            rhs.ty.clone(),
+                        )),
+                    )
+                }
+            },
             Operator::In => match (&lhs.ty, &rhs.ty) {
                 (t, Type::List(u)) if type_compatible(t, u) => (Type::Bool, None),
                 (Type::Int | Type::Float, Type::Range) => (Type::Bool, None),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -34,6 +34,7 @@ impl Expression {
                     Operator::Plus | Operator::Minus => 90,
                     Operator::NotContains
                     | Operator::Contains
+                    | Operator::StartsWith
                     | Operator::LessThan
                     | Operator::LessThanOrEqual
                     | Operator::GreaterThan

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -23,6 +23,7 @@ pub enum Operator {
     And,
     Or,
     Pow,
+    StartsWith,
 }
 
 impl Display for Operator {
@@ -46,6 +47,7 @@ impl Display for Operator {
             Operator::Pow => write!(f, "**"),
             Operator::LessThanOrEqual => write!(f, "<="),
             Operator::GreaterThanOrEqual => write!(f, ">="),
+            Operator::StartsWith => write!(f, "=^"),
         }
     }
 }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2031,6 +2031,27 @@ impl Value {
         }
     }
 
+    pub fn starts_with(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
+        let span = span(&[self.span()?, rhs.span()?]);
+
+        match (self, rhs) {
+            (Value::String { val: lhs, .. }, Value::String { val: rhs, .. }) => Ok(Value::Bool {
+                val: lhs.starts_with(rhs),
+                span,
+            }),
+            (Value::CustomValue { val: lhs, span }, rhs) => {
+                lhs.operation(*span, Operator::StartsWith, op, rhs)
+            }
+            _ => Err(ShellError::OperatorMismatch {
+                op_span: op,
+                lhs_ty: self.get_type(),
+                lhs_span: self.span()?,
+                rhs_ty: rhs.get_type(),
+                rhs_span: rhs.span()?,
+            }),
+        }
+    }
+
     pub fn not_contains(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
         let span = span(&[self.span()?, rhs.span()?]);
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -316,6 +316,14 @@ fn capture_row_condition() -> TestResult {
 }
 
 #[test]
+fn starts_with_operator_succeeds() -> TestResult {
+    run_test(
+        r#"[Moe Larry Curly] | where $it =^ L | str collect"#,
+        "Larry",
+    )
+}
+
+#[test]
 fn proper_missing_param() -> TestResult {
     fail_test(r#"def foo [x y z w] { }; foo a b c"#, "missing w")
 }


### PR DESCRIPTION
# Description

Add a starts with operator so it's easier to do things like this.
![image](https://user-images.githubusercontent.com/343840/161270373-b595ec81-7e5d-4340-bae1-e38c324c3fec.png)
or this
![image](https://user-images.githubusercontent.com/343840/161270663-9e6716d1-0dd7-4e62-9839-43ac324a6338.png)
or this
```
> [Moe Larry Curly] | where $it =^ L
╭───┬───────╮
│ 0 │ Larry │
╰───┴───────╯
```
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
