### PR TITLE
Add command descriptions to completions

### DIFF
--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -150,8 +150,8 @@ impl NuCompleter {
             .find_commands_by_prefix(prefix)
             .into_iter()
             .map(move |x| Suggestion {
-                value: String::from_utf8_lossy(&x).to_string(),
-                description: None,
+                value: String::from_utf8_lossy(&x.0).to_string(),
+                description: x.1,
                 span: reedline::Span {
                     start: span.start - offset,
                     end: span.end - offset,

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -443,13 +443,14 @@ impl EngineState {
         None
     }
 
-    pub fn find_commands_by_prefix(&self, name: &[u8]) -> Vec<Vec<u8>> {
+    pub fn find_commands_by_prefix(&self, name: &[u8]) -> Vec<(Vec<u8>, Option<String>)> {
         let mut output = vec![];
 
         for scope in self.scope.iter().rev() {
             for decl in &scope.decls {
                 if decl.0.starts_with(name) {
-                    output.push(decl.0.clone());
+                    let command = self.get_decl(*decl.1);
+                    output.push((decl.0.clone(), Some(command.usage().to_string())));
                 }
             }
         }
@@ -1296,13 +1297,14 @@ impl<'a> StateWorkingSet<'a> {
         }
     }
 
-    pub fn find_commands_by_prefix(&self, name: &[u8]) -> Vec<Vec<u8>> {
+    pub fn find_commands_by_prefix(&self, name: &[u8]) -> Vec<(Vec<u8>, Option<String>)> {
         let mut output = vec![];
 
         for scope in self.delta.scope.iter().rev() {
             for decl in &scope.decls {
                 if decl.0.starts_with(name) {
-                    output.push(decl.0.clone());
+                    let command = self.get_decl(*decl.1);
+                    output.push((decl.0.clone(), Some(command.usage().to_string())));
                 }
             }
         }


### PR DESCRIPTION
# Description

Adds command descriptions to completions

![image](https://user-images.githubusercontent.com/547158/161324053-4eb31f77-cb92-472f-920c-65930342cf06.png)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
