### PR TITLE
Add support for single value row conditions

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3993,7 +3993,7 @@ pub fn parse_math_expression(
     let mut last_prec = 1000000;
 
     let mut error = None;
-    let (lhs, err) = parse_value(
+    let (mut lhs, err) = parse_value(
         working_set,
         spans[0],
         &SyntaxShape::Any,
@@ -4001,6 +4001,13 @@ pub fn parse_math_expression(
     );
     error = error.or(err);
     idx += 1;
+
+    if idx >= spans.len() {
+        // We already found the one part of our expression, so let's expand
+        if let Some(row_var_id) = lhs_row_var_id {
+            expand_to_cell_path(working_set, &mut lhs, row_var_id, expand_aliases_denylist);
+        }
+    }
 
     expr_stack.push(lhs);
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -367,3 +367,11 @@ fn proper_rest_types() -> TestResult {
         "not verbose!",
     )
 }
+
+#[test]
+fn single_value_row_condition() -> TestResult {
+    run_test(
+        r#"[[a, b]; [true, false], [true, true]] | where a | length"#,
+        "2",
+    )
+}


### PR DESCRIPTION
# Description

Adds support for being able to do a single word that expands to a row condition. Example:

```
> $nu.scope.commands | where is_builtin
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
