### PR TITLE
Add quiet and feedback to mv command

### DIFF
--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -6,7 +6,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
+    Spanned, SyntaxShape, Type, Value,
 };
 
 const GLOB_PARAMS: nu_glob::MatchOptions = nu_glob::MatchOptions {
@@ -40,6 +41,7 @@ impl Command for Mv {
                 SyntaxShape::Filepath,
                 "the location to move files/directories to",
             )
+            .switch("quiet", "suppress output showing files moved", Some('q'))
             // .switch("interactive", "ask user to confirm action", Some('i'))
             // .switch("force", "suppress error when no file", Some('f'))
             .category(Category::FileSystem)
@@ -55,8 +57,11 @@ impl Command for Mv {
         // TODO: handle invalid directory or insufficient permissions when moving
         let spanned_source: Spanned<String> = call.req(engine_state, stack, 0)?;
         let spanned_destination: Spanned<String> = call.req(engine_state, stack, 1)?;
+        let quiet = call.has_flag("quiet");
         // let interactive = call.has_flag("interactive");
         // let force = call.has_flag("force");
+
+        let ctrlc = engine_state.ctrlc.clone();
 
         let path = current_dir(engine_state, stack)?;
         let source = path.join(spanned_source.item.as_str());
@@ -116,20 +121,36 @@ impl Command for Mv {
                 .collect();
         }
 
-        for entry in sources.into_iter().flatten() {
-            move_file(
-                Spanned {
-                    item: entry,
-                    span: spanned_source.span,
-                },
-                Spanned {
-                    item: destination.clone(),
-                    span: spanned_destination.span,
-                },
-            )?
-        }
-
-        Ok(PipelineData::new(call.head))
+        let span = call.head;
+        Ok(sources
+            .into_iter()
+            .flatten()
+            .map(move |entry| {
+                let result = move_file(
+                    Spanned {
+                        item: entry.clone(),
+                        span: spanned_source.span,
+                    },
+                    Spanned {
+                        item: destination.clone(),
+                        span: spanned_destination.span,
+                    },
+                );
+                if let Err(error) = result {
+                    Value::Error { error }
+                } else if quiet {
+                    Value::Nothing { span }
+                } else {
+                    let val = format!(
+                        "moved {:} to {:}",
+                        entry.to_string_lossy(),
+                        destination.to_string_lossy()
+                    );
+                    Value::String { val, span }
+                }
+            })
+            .filter(|x| !matches!(x.get_type(), Type::Nothing))
+            .into_pipeline_data(ctrlc))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -7,7 +7,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
-    Spanned, SyntaxShape, Type, Value,
+    Spanned, SyntaxShape, Value,
 };
 
 const GLOB_PARAMS: nu_glob::MatchOptions = nu_glob::MatchOptions {
@@ -125,7 +125,7 @@ impl Command for Mv {
         Ok(sources
             .into_iter()
             .flatten()
-            .map(move |entry| {
+            .filter_map(move |entry| {
                 let result = move_file(
                     Spanned {
                         item: entry.clone(),
@@ -137,19 +137,18 @@ impl Command for Mv {
                     },
                 );
                 if let Err(error) = result {
-                    Value::Error { error }
+                    Some(Value::Error { error })
                 } else if quiet {
-                    Value::Nothing { span }
+                    None
                 } else {
                     let val = format!(
                         "moved {:} to {:}",
                         entry.to_string_lossy(),
                         destination.to_string_lossy()
                     );
-                    Value::String { val, span }
+                    Some(Value::String { val, span })
                 }
             })
-            .filter(|x| !matches!(x.get_type(), Type::Nothing))
             .into_pipeline_data(ctrlc))
     }
 


### PR DESCRIPTION
# Description
Adds a quiet flag and feedback to the `mv` command similar to that of the `rm` command, partially addressing issue #4952 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
