### PR TITLE
feature: Add some context to completions

### DIFF
--- a/completion.nu
+++ b/completion.nu
@@ -1,7 +1,0 @@
-def "nu-complete test" [context: string, offset: int] {
-    [ $"prev ($context)" "two", $"offset ($offset)" ]
-}
-
-export extern "kubectl something" [
-    target?: string@"nu-complete test"
-]

--- a/completion.nu
+++ b/completion.nu
@@ -1,0 +1,7 @@
+def "nu-complete test" [context: string, offset: int] {
+    [ $"prev ($context)" "two", $"offset ($offset)" ]
+}
+
+export extern "kubectl something" [
+    target?: string@"nu-complete test"
+]

--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -217,7 +217,7 @@ impl NuCompleter {
     fn completion_helper(&self, line: &str, pos: usize) -> Vec<Suggestion> {
         let mut working_set = StateWorkingSet::new(&self.engine_state);
         let offset = working_set.next_span_start();
-        let current_line_str = line.clone().trim().to_string();
+        let current_line_str = line.trim().to_string();
         let mut line = line.to_string();
         line.insert(pos, 'a');
         let line_pos = pos;

--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -1,9 +1,9 @@
 use nu_engine::eval_call;
 use nu_parser::{flatten_expression, parse, trim_quotes, FlatShape};
 use nu_protocol::{
-    ast::{Call, Expr},
+    ast::{Call, Expr, Expression},
     engine::{EngineState, Stack, StateWorkingSet},
-    levenshtein_distance, PipelineData, Span, Value, CONFIG_VARIABLE_ID,
+    levenshtein_distance, PipelineData, Span, Type, Value, CONFIG_VARIABLE_ID,
 };
 use reedline::{Completer, Suggestion};
 
@@ -219,6 +219,7 @@ impl NuCompleter {
         let offset = working_set.next_span_start();
         let mut line = line.to_string();
         line.insert(pos, 'a');
+        let line_pos = pos;
         let pos = offset + pos;
         let (output, _err) = parse(
             &mut working_set,
@@ -321,7 +322,20 @@ impl NuCompleter {
                                     &Call {
                                         decl_id: *decl_id,
                                         head: new_span,
-                                        positional: vec![],
+                                        positional: vec![
+                                            Expression {
+                                                span: Span { start: 0, end: 0 },
+                                                ty: Type::String,
+                                                expr: Expr::String(line.clone()),
+                                                custom_completion: None,
+                                            },
+                                            Expression {
+                                                span: Span { start: 0, end: 0 },
+                                                ty: Type::Int,
+                                                expr: Expr::Int(line_pos as i64),
+                                                custom_completion: None,
+                                            },
+                                        ],
                                         named: vec![],
                                         redirect_stdout: true,
                                         redirect_stderr: true,

--- a/crates/nu-cli/src/completions.rs
+++ b/crates/nu-cli/src/completions.rs
@@ -217,6 +217,7 @@ impl NuCompleter {
     fn completion_helper(&self, line: &str, pos: usize) -> Vec<Suggestion> {
         let mut working_set = StateWorkingSet::new(&self.engine_state);
         let offset = working_set.next_span_start();
+        let current_line_str = line.clone().trim().to_string();
         let mut line = line.to_string();
         line.insert(pos, 'a');
         let line_pos = pos;
@@ -326,7 +327,7 @@ impl NuCompleter {
                                             Expression {
                                                 span: Span { start: 0, end: 0 },
                                                 ty: Type::String,
-                                                expr: Expr::String(line.clone()),
+                                                expr: Expr::String(current_line_str),
                                                 custom_completion: None,
                                             },
                                             Expression {


### PR DESCRIPTION
# Description
There are some completions that depends on some context (what was typed before) in order to correctly work. One example of this is using `kubectl get svc`.

If it should list all the available service names in the current namespace but if the user has specified `--namespace` or `-n` (e.g: `kubectl -n myns get svc`) the completion needs to use the `myns` namespace instead of the current one.

The purpose of this PR is to send two positional arguments to the completion functions:
* The current line str
* The current position

With those two arguments would be possible to make some parsing and detect some context in order to correct create some completions.


# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
