### PR TITLE
Tweak append+prepend help

### DIFF
--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -16,12 +16,16 @@ impl Command for Append {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("append")
-            .required("row", SyntaxShape::Any, "the row to append")
+            .required("row", SyntaxShape::Any, "the row (or list/table) to append")
             .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {
-        "Append a row to the table."
+        "Append any number of rows to a table."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["concatenate"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -16,7 +16,7 @@ impl Command for Append {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("append")
-            .required("row", SyntaxShape::Any, "the row (or list/table) to append")
+            .required("row", SyntaxShape::Any, "the row, list, or table to append")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -19,7 +19,7 @@ impl Command for Prepend {
             .required(
                 "row",
                 SyntaxShape::Any,
-                "the row (or list/table) to prepend",
+                "the row, list, or table to prepend",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -16,12 +16,20 @@ impl Command for Prepend {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("prepend")
-            .required("row", SyntaxShape::Any, "the row to prepend")
+            .required(
+                "row",
+                SyntaxShape::Any,
+                "the row (or list/table) to prepend",
+            )
             .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {
-        "Prepend a row to the table."
+        "Prepend any number of rows to a table."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["concatenate"]
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
# Description

`append` + `prepend` can be used to concatenate one list to another, but their signature+usage only mention working with a singular row. Fixed.

Also added "concatenate" as a search term to each, that was the first word that came to mind when I was looking for functionality like this.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
