### PR TITLE
Fix for search terms in `help --find`

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -27,7 +27,7 @@ impl Command for Help {
             .named(
                 "find",
                 SyntaxShape::String,
-                "string to find in command usage",
+                "string to find in command names, usage, and search terms",
                 Some('f'),
             )
             .category(Category::Core)
@@ -70,7 +70,7 @@ impl Command for Help {
                 result: None,
             },
             Example {
-                description: "search for string in command usage",
+                description: "search for string in command names, usage and search terms",
                 example: "help --find char",
                 result: None,
             },

--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -103,7 +103,7 @@ fn help(
             let key = sig.name;
             let usage = sig.usage;
             let search_terms = sig.search_terms;
-            let matches_term = if search_terms.is_empty() {
+            let matches_term = if !search_terms.is_empty() {
                 search_terms
                     .iter()
                     .any(|term| term.to_lowercase().contains(&search_string))


### PR DESCRIPTION
# Description

`help --find` wasn't looking at command search terms, due to what I think was just a small typo.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
