### PR TITLE
Fix Python plugin (missing search terms)

### DIFF
--- a/crates/nu_plugin_python/plugin.py
+++ b/crates/nu_plugin_python/plugin.py
@@ -95,6 +95,7 @@ def signatures():
                         "var_id": None,
                     },
                 ],
+                "search_terms": ["Python", "Example"],
                 "is_filter": False,
                 "creates_scope": False,
                 "category": "Experimental",

--- a/crates/nu_plugin_python/plugin.py
+++ b/crates/nu_plugin_python/plugin.py
@@ -1,9 +1,9 @@
-# Example of using python as script to create plugins for nushell
+# Example of using a Python script as a Nushell plugin
 #
 # The example uses JSON encoding but it should be a similar process using
-# capnp proto to move data betwee nushell and the plugin. The only difference
+# Cap'n Proto to move data between Nushell and the plugin. The only difference
 # would be that you need to compile the schema file in order have the objects
-# that decode and encode information that is read and written to stdin and stdour
+# that decode and encode information that is read and written to stdin and stdout
 #
 # To register the plugin use:
 # 	register <path-to-py-file> -e json
@@ -13,12 +13,12 @@
 # point to the beginning of the contents vector. We strongly suggest using the span
 # found in the plugin call head
 #
-# The plugin will be run using the active python implementation. If you are in
-# a python environment, that is the python version that is used
+# The plugin will be run using the active Python implementation. If you are in
+# a Python environment, that is the Python version that is used
 #
 # Note: To keep the plugin simple and without dependencies, the dictionaries that
-#   represent the data transferred between nushell and the plugin are kept as
-#   native python dictionaries. The encoding and decoding process could be improved
+#   represent the data transferred between Nushell and the plugin are kept as
+#   native Python dictionaries. The encoding and decoding process could be improved
 #   by using libraries like pydantic and marshmallow
 #
 # This plugin uses python3
@@ -29,8 +29,8 @@ import json
 
 def signatures():
     """
-    Multiple signatures can be sent to nushell. Each signature will be registered
-    as a different plugin function in nushell.
+    Multiple signatures can be sent to Nushell. Each signature will be registered
+    as a different plugin function in Nushell.
 
     In your plugin logic you can use the name of the signature to indicate what
     operation should be done with the plugin
@@ -39,7 +39,7 @@ def signatures():
         "Signature": [
             {
                 "name": "nu-python",
-                "usage": "Signature test for python",
+                "usage": "Signature test for Python",
                 "extra_usage": "",
                 "required_positional": [
                     {
@@ -110,7 +110,7 @@ def process_call(plugin_call):
     It should contain:
             - The name of the call
             - The call data which includes the positional and named values
-            - The input from the pippeline
+            - The input from the pipeline
 
     Use this information to implement your plugin logic
     """
@@ -118,7 +118,7 @@ def process_call(plugin_call):
     sys.stderr.write(json.dumps(plugin_call, indent=4))
     sys.stderr.write("\n")
 
-    # Creates a Value of type List that will be encoded and sent to nushell
+    # Creates a Value of type List that will be encoded and sent to Nushell
     return {
         "Value": {
             "List": {
@@ -403,7 +403,7 @@ def plugin():
         sys.stdout.write(json.dumps(response))
 
     else:
-        # Use this error format if you want to return an error back to nushell
+        # Use this error format if you want to return an error back to Nushell
         error = {
             "Error": {
                 "label": "ERROR from plugin",


### PR DESCRIPTION
# Description

Registering the Python plugin currently fails on `main` because it doesn't include search terms in its signature:

```
> register --encoding=json C:\Users\reill\github\nushell\crates\nu_plugin_python\plugin.py
Error:
  × Error getting signatures
   ╭─[entry #27:1:1]
 1 │ register --encoding=json C:\Users\reill\github\nushell\crates\nu_plugin_python\plugin.py
   · ────┬───
   ·     ╰── Plugin failed to encode: missing field `search_terms` at line 1 column 909
   ╰────
```

While I was in the area I did a quick spelling+wording pass over the comments in the file.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
