### PR TITLE
Add raw strings, use raw strings for env

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -109,19 +109,14 @@ pub fn gather_parent_env_vars(engine_state: &mut EngineState) {
         );
     }
 
-    fn escape(input: &str) -> String {
-        let output = input.replace('\\', "\\\\");
-        output.replace('"', "\\\"")
-    }
-
     fn put_env_to_fake_file(name: &str, val: &str, fake_env_file: &mut String) {
-        fake_env_file.push('"');
-        fake_env_file.push_str(&escape(name));
-        fake_env_file.push('"');
+        fake_env_file.push('`');
+        fake_env_file.push_str(name);
+        fake_env_file.push('`');
         fake_env_file.push('=');
-        fake_env_file.push('"');
-        fake_env_file.push_str(&escape(val));
-        fake_env_file.push('"');
+        fake_env_file.push('`');
+        fake_env_file.push_str(val);
+        fake_env_file.push('`');
         fake_env_file.push('\n');
     }
 

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -147,7 +147,7 @@ pub fn lex_item(
         } else if is_special_item(&block_level, c, special_tokens) && token_start == *curr_offset {
             *curr_offset += 1;
             break;
-        } else if c == b'\'' || c == b'"' {
+        } else if c == b'\'' || c == b'"' || c == b'`' {
             // We encountered the opening quote of a string literal.
             quote_start = Some(c);
         } else if c == b'[' {


### PR DESCRIPTION
# Description

Adds backtick as a way of creating a raw string. We go ahead and use this when creating the fake env source as we import the external environment.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
