### PR TITLE
allow record as text style

### DIFF
--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -272,7 +272,7 @@ fn create_map(value: &Value, config: &Config) -> Result<HashMap<String, Value>, 
     Ok(hm)
 }
 
-fn color_value_string(
+pub fn color_value_string(
     span: &Span,
     inner_cols: &[String],
     inner_vals: &[Value],


### PR DESCRIPTION
# Description

allows records and text as style option for menus

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
