### PR TITLE
Add some command search terms

### DIFF
--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -35,6 +35,10 @@ impl Command for Tutor {
         "Run the tutorial. To begin, run: tutor"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["help", "learn", "tutorial"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -27,6 +27,10 @@ impl Command for Ls {
         "List the files in a directory."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["dir"]
+    }
+
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("ls")
             // Using a string instead of a glob pattern shape so it won't auto-expand

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -25,7 +25,7 @@ impl Command for Append {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["concatenate"]
+        vec!["add", "concatenate"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -28,6 +28,10 @@ impl Command for DropColumn {
         "Remove the last number of columns. If you want to remove columns by name, try 'reject'."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["delete"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -29,6 +29,10 @@ impl Command for Drop {
         "Remove the last number of rows or columns."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["delete"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -31,6 +31,10 @@ impl Command for DropNth {
         "Drop the selected rows."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["delete"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -18,6 +18,10 @@ impl Command for Each {
         "Run a block on each element of input"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["for", "loop", "iterate"]
+    }
+
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("each")
             .required(

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -33,6 +33,10 @@ impl Command for Insert {
         "Insert a new column."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["add"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -29,7 +29,7 @@ impl Command for Prepend {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["concatenate"]
+        vec!["add", "concatenate"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -44,6 +44,10 @@ impl Command for Transpose {
         "Transposes the table contents so rows become columns and columns become rows."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["pivot"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -35,6 +35,10 @@ impl Command for Uniq {
         "Return the unique rows."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["distinct", "deduplicate"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -33,6 +33,10 @@ impl Command for Upsert {
         "Update an existing column to have a new value, or insert a new column."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["add"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/input.rs
+++ b/crates/nu-command/src/platform/input.rs
@@ -19,6 +19,10 @@ impl Command for Input {
         "Get input from the user."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["prompt", "interactive"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build("input")
             .optional("prompt", SyntaxShape::String, "prompt to show the user")

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -171,6 +171,10 @@ impl Command for Char {
         "Output special characters (e.g., 'newline')."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["line break", "newline", "Unicode"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {

--- a/crates/nu-command/src/strings/str_/downcase.rs
+++ b/crates/nu-command/src/strings/str_/downcase.rs
@@ -27,6 +27,10 @@ impl Command for SubCommand {
         "downcases text"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["lower case", "lowercase"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/upcase.rs
+++ b/crates/nu-command/src/strings/str_/upcase.rs
@@ -24,6 +24,10 @@ impl Command for SubCommand {
         "upcases text"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["uppercase", "upper case"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -32,6 +32,10 @@ impl Command for Table {
         "Render the table."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["display", "render"]
+    }
+
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("table")
             .named(


### PR DESCRIPTION
# Description

An initial pass to add search terms to some commands. I skimmed all commands and added terms that make sense to me; many are drawn from learning Nu recently and not being able to find commands :) Helps with #5093. 

|Command|Search terms added|
|-|-|
|append|add|
|char|line break, newline, Unicode|
|drop|delete|
|drop column|delete|
|drop nth|delete|
|each|for, loop, iterate|
|input|prompt, interactive|
|insert|add|
|ls|dir|
|prepend|add|
|str downcase|lowercase, lower case|
|str upcase|uppercase, upper case|
|table|display, render|
|transpose|pivot|
|tutor|help, tutorial, learn|
|uniq|distinct, deduplicate|
|upsert|add|

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
