### PR TITLE
Trim newline from `input` result

### DIFF
--- a/crates/nu-command/src/platform/input.rs
+++ b/crates/nu-command/src/platform/input.rs
@@ -117,8 +117,14 @@ impl Command for Input {
                 .into_pipeline_data());
             }
 
-            // Just read a normal line of text
+            // Just read a normal line of text, and trim the newline at the end
             let input = std::io::stdin().read_line(&mut buf);
+            if buf.ends_with('\n') {
+                buf.pop();
+                if buf.ends_with('\r') {
+                    buf.pop();
+                }
+            }
 
             match input {
                 Ok(_) => Ok(Value::String {


### PR DESCRIPTION
# Description

`input` reads a line from stdin by default, and it happens to include the newline at the end. Let's trim the newline so users don't have to `str trim` every time.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
