### PR TITLE
Add env.nu file for environment config

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1142,6 +1142,7 @@ pub fn eval_variable(
 
             if let Some(mut config_path) = nu_path::config_dir() {
                 config_path.push("nushell");
+                let mut env_config_path = config_path.clone();
 
                 let mut history_path = config_path.clone();
 
@@ -1158,6 +1159,14 @@ pub fn eval_variable(
                 output_cols.push("config-path".into());
                 output_vals.push(Value::String {
                     val: config_path.to_string_lossy().to_string(),
+                    span,
+                });
+
+                env_config_path.push("env.nu");
+
+                output_cols.push("env-path".into());
+                output_vals.push(Value::String {
+                    val: env_config_path.to_string_lossy().to_string(),
                     span,
                 });
             }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -1,59 +1,5 @@
 # Nushell Config File
 
-def create_left_prompt [] {
-    let path_segment = ($env.PWD)
-
-    $path_segment
-}
-
-def create_right_prompt [] {
-    let time_segment = ([
-        (date now | date format '%m/%d/%Y %r')
-    ] | str collect)
-
-    $time_segment
-}
-
-# Use nushell functions to define your right and left prompt
-let-env PROMPT_COMMAND = { create_left_prompt }
-let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
-
-# The prompt indicators are environmental variables that represent
-# the state of the prompt
-let-env PROMPT_INDICATOR = { "〉" }
-let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
-let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
-let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
-
-# Specifies how environment variables are:
-# - converted from a string to a value on Nushell startup (from_string)
-# - converted from a value back to a string when running external commands (to_string)
-# Note: The conversions happen *after* config.nu is loaded
-let-env ENV_CONVERSIONS = {
-  "PATH": {
-    from_string: { |s| $s | split row (char esep) }
-    to_string: { |v| $v | str collect (char esep) }
-  }
-  "Path": {
-    from_string: { |s| $s | split row (char esep) }
-    to_string: { |v| $v | str collect (char esep) }
-  }
-}
-
-# Directories to search for scripts when calling source or use
-#
-# By default, <nushell-config-dir>/scripts is added
-let-env NU_LIB_DIRS = [
-    ($nu.config-path | path dirname | path join 'scripts')
-]
-
-# Directories to search for plugin binaries when calling register
-#
-# By default, <nushell-config-dir>/plugins is added
-let-env NU_PLUGIN_DIRS = [
-    ($nu.config-path | path dirname | path join 'plugins')
-]
-
 module completions {
   # Custom completions for external commands (those outside of Nushell)
   # Each completions has two parts: the form of the external command, including its flags and parameters
@@ -259,7 +205,7 @@ let $config = {
         type: {
             layout: columnar
             columns: 4
-            col_width: 20   
+            col_width: 20
             col_padding: 2
         }
         style: {
@@ -267,9 +213,9 @@ let $config = {
             selected_text: green_reverse
             description_text: yellow
         }
-        source: { |buffer, position| 
-            $nu.scope.commands 
-            | where command =~ $buffer 
+        source: { |buffer, position|
+            $nu.scope.commands
+            | where command =~ $buffer
             | each { |it| {value: $it.command description: $it.usage} }
         }
       }
@@ -286,10 +232,10 @@ let $config = {
             selected_text: green_reverse
             description_text: yellow
         }
-        source: { |buffer, position| 
-            $nu.scope.vars 
-            | where name =~ $buffer 
-            | sort-by name 
+        source: { |buffer, position|
+            $nu.scope.vars
+            | where name =~ $buffer
+            | sort-by name
             | each { |it| {value: $it.name description: $it.type} }
         }
       }
@@ -300,7 +246,7 @@ let $config = {
         type: {
             layout: description
             columns: 4
-            col_width: 20   
+            col_width: 20
             col_padding: 2
             selection_rows: 4
             description_rows: 10
@@ -310,9 +256,9 @@ let $config = {
             selected_text: green_reverse
             description_text: yellow
         }
-        source: { |buffer, position| 
-            $nu.scope.commands 
-            | where command =~ $buffer 
+        source: { |buffer, position|
+            $nu.scope.commands
+            | where command =~ $buffer
             | each { |it| {value: $it.command description: $it.usage} }
         }
       }
@@ -366,21 +312,21 @@ let $config = {
       name: commands_menu
       modifier: control
       keycode: char_t
-      mode: [emacs, vi_normal, vi_insert] 
+      mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: commands_menu }
     }
     {
       name: commands_menu
       modifier: control
       keycode: char_y
-      mode: [emacs, vi_normal, vi_insert] 
+      mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: vars_menu }
     }
     {
       name: commands_with_description
       modifier: control
       keycode: char_u
-      mode: [emacs, vi_normal, vi_insert] 
+      mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: commands_with_description }
     }
   ]

--- a/docs/sample_config/default_env.nu
+++ b/docs/sample_config/default_env.nu
@@ -1,0 +1,55 @@
+# Nushell Environment Config File
+
+def create_left_prompt [] {
+    let path_segment = ($env.PWD)
+
+    $path_segment
+}
+
+def create_right_prompt [] {
+    let time_segment = ([
+        (date now | date format '%m/%d/%Y %r')
+    ] | str collect)
+
+    $time_segment
+}
+
+# Use nushell functions to define your right and left prompt
+let-env PROMPT_COMMAND = { create_left_prompt }
+let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
+
+# The prompt indicators are environmental variables that represent
+# the state of the prompt
+let-env PROMPT_INDICATOR = { "〉" }
+let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
+let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
+let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
+
+# Specifies how environment variables are:
+# - converted from a string to a value on Nushell startup (from_string)
+# - converted from a value back to a string when running external commands (to_string)
+# Note: The conversions happen *after* config.nu is loaded
+let-env ENV_CONVERSIONS = {
+  "PATH": {
+    from_string: { |s| $s | split row (char esep) }
+    to_string: { |v| $v | str collect (char esep) }
+  }
+  "Path": {
+    from_string: { |s| $s | split row (char esep) }
+    to_string: { |v| $v | str collect (char esep) }
+  }
+}
+
+# Directories to search for scripts when calling source or use
+#
+# By default, <nushell-config-dir>/scripts is added
+let-env NU_LIB_DIRS = [
+    ($nu.config-path | path dirname | path join 'scripts')
+]
+
+# Directories to search for plugin binaries when calling register
+#
+# By default, <nushell-config-dir>/plugins is added
+let-env NU_PLUGIN_DIRS = [
+    ($nu.config-path | path dirname | path join 'plugins')
+]

--- a/docs/sample_config/default_env.nu
+++ b/docs/sample_config/default_env.nu
@@ -53,3 +53,6 @@ let-env NU_LIB_DIRS = [
 let-env NU_PLUGIN_DIRS = [
     ($nu.config-path | path dirname | path join 'plugins')
 ]
+
+# To add entries to PATH (on Windows you might use Path), you can use the following pattern:
+# let-env PATH = ($env.PATH | prepend '/some/path')

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ fn main() -> Result<()> {
                 || arg == "--testbin"
                 || arg == "--log-level"
                 || arg == "--config"
+                || arg == "--env-config"
                 || arg == "--threads"
                 || arg == "-t"
             {

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,12 @@ fn main() -> Result<()> {
 
                 ret_val
             } else {
-                setup_config(&mut engine_state, &mut stack, binary_args.config_file);
+                setup_config(
+                    &mut engine_state,
+                    &mut stack,
+                    binary_args.config_file,
+                    binary_args.env_file,
+                );
                 let history_path = config_files::create_history_path();
 
                 let ret_val =
@@ -261,6 +266,7 @@ fn setup_config(
     engine_state: &mut EngineState,
     stack: &mut Stack,
     config_file: Option<Spanned<String>>,
+    env_file: Option<Spanned<String>>,
 ) {
     #[cfg(feature = "plugin")]
     read_plugin_file(engine_state, stack, NUSHELL_FOLDER, is_perf_true());
@@ -269,7 +275,8 @@ fn setup_config(
         info!("read_config_file {}:{}:{}", file!(), line!(), column!());
     }
 
-    config_files::read_config_file(engine_state, stack, config_file, is_perf_true());
+    config_files::read_config_file(engine_state, stack, env_file, is_perf_true(), true);
+    config_files::read_config_file(engine_state, stack, config_file, is_perf_true(), false);
 }
 
 fn parse_commandline_args(
@@ -324,6 +331,7 @@ fn parse_commandline_args(
             let testbin: Option<Expression> = call.get_flag_expr("testbin");
             let perf = call.has_flag("perf");
             let config_file: Option<Expression> = call.get_flag_expr("config");
+            let env_file: Option<Expression> = call.get_flag_expr("env-config");
             let log_level: Option<Expression> = call.get_flag_expr("log-level");
             let threads: Option<Value> = call.get_flag(engine_state, &mut stack, "threads")?;
 
@@ -344,6 +352,7 @@ fn parse_commandline_args(
             let commands = extract_contents(commands, engine_state);
             let testbin = extract_contents(testbin, engine_state);
             let config_file = extract_contents(config_file, engine_state);
+            let env_file = extract_contents(env_file, engine_state);
             let log_level = extract_contents(log_level, engine_state);
 
             let help = call.has_flag("help");
@@ -379,6 +388,7 @@ fn parse_commandline_args(
                 commands,
                 testbin,
                 config_file,
+                env_file,
                 log_level,
                 perf,
                 threads,
@@ -400,6 +410,7 @@ struct NushellCliArgs {
     commands: Option<Spanned<String>>,
     testbin: Option<Spanned<String>>,
     config_file: Option<Spanned<String>>,
+    env_file: Option<Spanned<String>>,
     log_level: Option<Spanned<String>>,
     perf: bool,
     threads: Option<Value>,
@@ -441,6 +452,12 @@ impl Command for Nu {
                 "config",
                 SyntaxShape::String,
                 "start with an alternate config file",
+                None,
+            )
+            .named(
+                "env-config",
+                SyntaxShape::String,
+                "start with an alternate environment config file",
                 None,
             )
             .named(


### PR DESCRIPTION
# Description

This PR adds a new `env.nu` file that sits next to `config.nu` where you can set up your environment and use it in `config.nu`. Due to the parse and eval steps being separate, any environment variables defined in `config.nu` are not usable inside the file.

You can look at the `default_config.nu` and `default_env.nu` files in `docs/sample_config` as an example.

On Nushell startup, first the `env.nu` is loaded, the engine state is updated, then `config.nu` is loaded with any changes made in `env.nu` visible.

Fixes https://github.com/nushell/nushell/issues/4901
Related issues: https://github.com/nushell/nushell/issues/3176 (comments)
Related discussions: https://github.com/nushell/nushell/discussions/5044, https://github.com/nushell/nushell/discussions/4905

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
