### PR TITLE
enables find to search records with regex

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -194,14 +194,14 @@ fn find_with_regex(
                     .iter()
                     .map(|v| re.is_match(v.into_string(" ", &config).as_str()) != invert)
                     .collect();
-                matches.iter().any(|b| *b == true)
+                matches.iter().any(|b| *b)
             }
             Value::List { vals, .. } => {
                 let matches: Vec<bool> = vals
                     .iter()
                     .map(|v| re.is_match(v.into_string(" ", &config).as_str()) != invert)
                     .collect();
-                matches.iter().any(|b| *b == true)
+                matches.iter().any(|b| *b)
             }
             _ => false,
         },


### PR DESCRIPTION
# Description

This enables one to search like this:
![image](https://user-images.githubusercontent.com/343840/161785801-c83137c5-c327-48a7-b8ae-c7e0dae1a1e0.png)

![image](https://user-images.githubusercontent.com/343840/161785886-8ef74c04-6fe6-427d-bdcb-41cc5a7e1c50.png)

previously, the string being searched would look like this:
`"{name: zip usage: Combine a stream with the input}"`, in record form, and would fail to find appropriate results.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
