### PR TITLE
Add unary not

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -111,6 +111,7 @@ impl Command for Glob {
             }
         };
 
+        #[allow(clippy::needless_collect)]
         let glob_results: Vec<Value> = glob
             .walk(path, folder_depth)
             .flatten()

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -195,6 +195,12 @@ fn convert_to_value(
             "binary operators not supported in nuon".into(),
             expr.span,
         )),
+        Expr::UnaryNot(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "unary operators not supported in nuon".into(),
+            expr.span,
+        )),
         Expr::Block(..) => Err(ShellError::OutsideSpannedLabeledError(
             original_text.to_string(),
             "Error when loading".into(),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -319,6 +319,16 @@ pub fn eval_expression(
             span: expr.span,
         }),
         Expr::Operator(_) => Ok(Value::Nothing { span: expr.span }),
+        Expr::UnaryNot(expr) => {
+            let lhs = eval_expression(engine_state, stack, expr)?;
+            match lhs {
+                Value::Bool { val, .. } => Ok(Value::Bool {
+                    val: !val,
+                    span: expr.span,
+                }),
+                _ => Err(ShellError::TypeMismatch("bool".to_string(), expr.span)),
+            }
+        }
         Expr::BinaryOp(lhs, op, rhs) => {
             let op_span = op.span;
             let lhs = eval_expression(engine_state, stack, lhs)?;

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -88,6 +88,17 @@ pub fn flatten_expression(
             output.extend(flatten_expression(working_set, rhs));
             output
         }
+        Expr::UnaryNot(inner_expr) => {
+            let mut output = vec![(
+                Span {
+                    start: expr.span.start,
+                    end: expr.span.start + 3,
+                },
+                FlatShape::Operator,
+            )];
+            output.extend(flatten_expression(working_set, inner_expr));
+            output
+        }
         Expr::Block(block_id) | Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
             let outer_span = expr.span;
 

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -22,6 +22,7 @@ pub enum Expr {
     ExternalCall(Box<Expression>, Vec<Expression>),
     Operator(Operator),
     RowCondition(BlockId),
+    UnaryNot(Box<Expression>),
     BinaryOp(Box<Expression>, Box<Expression>, Box<Expression>), //lhs, op, rhs
     Subexpression(BlockId),
     Block(BlockId),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -113,6 +113,7 @@ impl Expression {
             Expr::BinaryOp(left, _, right) => {
                 left.has_in_variable(working_set) || right.has_in_variable(working_set)
             }
+            Expr::UnaryNot(expr) => expr.has_in_variable(working_set),
             Expr::Block(block_id) => {
                 let block = working_set.get_block(*block_id);
 
@@ -263,6 +264,9 @@ impl Expression {
             Expr::BinaryOp(left, _, right) => {
                 left.replace_in_variable(working_set, new_var_id);
                 right.replace_in_variable(working_set, new_var_id);
+            }
+            Expr::UnaryNot(expr) => {
+                expr.replace_in_variable(working_set, new_var_id);
             }
             Expr::Block(block_id) => {
                 let block = working_set.get_block(*block_id);
@@ -424,6 +428,9 @@ impl Expression {
             Expr::BinaryOp(left, _, right) => {
                 left.replace_span(working_set, replaced, new_span);
                 right.replace_span(working_set, replaced, new_span);
+            }
+            Expr::UnaryNot(expr) => {
+                expr.replace_span(working_set, replaced, new_span);
             }
             Expr::Block(block_id) => {
                 let mut block = working_set.get_block(*block_id).clone();

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -375,3 +375,39 @@ fn single_value_row_condition() -> TestResult {
         "2",
     )
 }
+
+#[test]
+fn unary_not_1() -> TestResult {
+    run_test(r#"not false"#, "true")
+}
+
+#[test]
+fn unary_not_2() -> TestResult {
+    run_test(r#"not (false)"#, "true")
+}
+
+#[test]
+fn unary_not_3() -> TestResult {
+    run_test(r#"(not false)"#, "true")
+}
+
+#[test]
+fn unary_not_4() -> TestResult {
+    run_test(r#"if not false { "hello" } else { "world" }"#, "hello")
+}
+
+#[test]
+fn unary_not_5() -> TestResult {
+    run_test(
+        r#"if not not not not false { "hello" } else { "world" }"#,
+        "world",
+    )
+}
+
+#[test]
+fn unary_not_6() -> TestResult {
+    run_test(
+        r#"[[name, present]; [abc, true], [def, false]] | where not present | get name.0"#,
+        "def",
+    )
+}


### PR DESCRIPTION
# Description

Adds `not` as a keyword in Nushell, for unary not.

`not true` ==> false

fixes #3814 (albeit with slightly different syntax)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
