### PR TITLE
nu-cli/completions: added a cache layer for fetching completions

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -9,20 +9,20 @@ use nu_protocol::{
 use reedline::Suggestion;
 use std::sync::Arc;
 
-pub struct CommandCompletion {
+pub struct CommandCompletion<'a> {
     engine_state: Arc<EngineState>,
-    flattened: Vec<(Span, FlatShape)>,
+    flattened: &'a [(Span, FlatShape)],
     flat_idx: usize,
-    flat_shape: FlatShape,
+    flat_shape: &'a FlatShape,
 }
 
-impl CommandCompletion {
+impl<'a> CommandCompletion<'a> {
     pub fn new(
         engine_state: Arc<EngineState>,
         _: &StateWorkingSet,
-        flattened: Vec<(Span, FlatShape)>,
+        flattened: &'a [(Span, FlatShape)],
         flat_idx: usize,
-        flat_shape: FlatShape,
+        flat_shape: &'a FlatShape,
     ) -> Self {
         Self {
             engine_state,
@@ -146,7 +146,7 @@ impl CommandCompletion {
     }
 }
 
-impl Completer for CommandCompletion {
+impl<'a> Completer for CommandCompletion<'a> {
     fn fetch(
         &mut self,
         working_set: &StateWorkingSet,


### PR DESCRIPTION
# Description

Initial implementation of a caching layer for fetching completion results, it doesn't affect the other layers and it's quite useful specially for custom completions (which can rely on external calls).

The cache stays there while the user is typing and it's invalidated if the user doesn't type anything after 1 second*

The 1 second is a very arbitrary value, in the future we could move it into the config or even the custom completion could return some more information about how the caching layer for it should work.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
