### PR TITLE
Improve describe to be more accurate

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -166,7 +166,7 @@ pub fn parse_for(
                     Expression {
                         expr: Expr::Call(call),
                         span: call_span,
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     },
                     err,
@@ -201,7 +201,7 @@ pub fn parse_for(
         Expression {
             expr: Expr::Call(call),
             span: call_span,
-            ty: Type::Unknown,
+            ty: Type::Any,
             custom_completion: None,
         },
         error,
@@ -335,7 +335,7 @@ pub fn parse_def(
                     Pipeline::from_vec(vec![Expression {
                         expr: Expr::Call(call),
                         span: call_span,
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     }]),
                     err,
@@ -393,7 +393,7 @@ pub fn parse_def(
         Pipeline::from_vec(vec![Expression {
             expr: Expr::Call(call),
             span: call_span,
-            ty: Type::Unknown,
+            ty: Type::Any,
             custom_completion: None,
         }]),
         error,
@@ -501,7 +501,7 @@ pub fn parse_extern(
         Pipeline::from_vec(vec![Expression {
             expr: Expr::Call(call),
             span: call_span,
-            ty: Type::Unknown,
+            ty: Type::Any,
             custom_completion: None,
         }]),
         error,
@@ -561,7 +561,7 @@ pub fn parse_alias(
                 Pipeline::from_vec(vec![Expression {
                     expr: Expr::Call(call),
                     span: span(spans),
-                    ty: Type::Unknown,
+                    ty: Type::Any,
                     custom_completion: None,
                 }]),
                 err,
@@ -989,7 +989,7 @@ pub fn parse_export(
         Pipeline::from_vec(vec![Expression {
             expr: Expr::Call(call),
             span: span(spans),
-            ty: Type::Unknown,
+            ty: Type::Any,
             custom_completion: None,
         }]),
         exportable,
@@ -1194,7 +1194,7 @@ pub fn parse_module(
             Pipeline::from_vec(vec![Expression {
                 expr: Expr::Call(call),
                 span: span(spans),
-                ty: Type::Unknown,
+                ty: Type::Any,
                 custom_completion: None,
             }]),
             error,
@@ -1244,7 +1244,7 @@ pub fn parse_use(
                     Pipeline::from_vec(vec![Expression {
                         expr: Expr::Call(call),
                         span: call_span,
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     }]),
                     err,
@@ -1311,7 +1311,7 @@ pub fn parse_use(
                             Pipeline::from_vec(vec![Expression {
                                 expr: Expr::Call(call),
                                 span: call_span,
-                                ty: Type::Unknown,
+                                ty: Type::Any,
                                 custom_completion: None,
                             }]),
                             Some(ParseError::ModuleNotFound(spans[1])),
@@ -1350,7 +1350,7 @@ pub fn parse_use(
                             Pipeline::from_vec(vec![Expression {
                                 expr: Expr::Call(call),
                                 span: call_span,
-                                ty: Type::Unknown,
+                                ty: Type::Any,
                                 custom_completion: None,
                             }]),
                             Some(ParseError::ModuleNotFound(spans[1])),
@@ -1432,7 +1432,7 @@ pub fn parse_use(
         Pipeline::from_vec(vec![Expression {
             expr: Expr::Call(call),
             span: span(spans),
-            ty: Type::Unknown,
+            ty: Type::Any,
             custom_completion: None,
         }]),
         error,
@@ -1473,7 +1473,7 @@ pub fn parse_hide(
                     Pipeline::from_vec(vec![Expression {
                         expr: Expr::Call(call),
                         span: call_span,
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     }]),
                     err,
@@ -1640,7 +1640,7 @@ pub fn parse_hide(
             Pipeline::from_vec(vec![Expression {
                 expr: Expr::Call(call),
                 span: span(spans),
-                ty: Type::Unknown,
+                ty: Type::Any,
                 custom_completion: None,
             }]),
             error,
@@ -1725,7 +1725,7 @@ pub fn parse_let(
                             Pipeline::from_vec(vec![Expression {
                                 expr: Expr::Call(call),
                                 span: nu_protocol::span(spans),
-                                ty: Type::Unknown,
+                                ty: Type::Any,
                                 custom_completion: None,
                             }]),
                             error,
@@ -1746,7 +1746,7 @@ pub fn parse_let(
                     expressions: vec![Expression {
                         expr: Expr::Call(call),
                         span: nu_protocol::span(spans),
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     }],
                 },
@@ -1790,7 +1790,7 @@ pub fn parse_source(
                     Pipeline::from_vec(vec![Expression {
                         expr: Expr::Call(call),
                         span: span(spans),
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     }]),
                     error,
@@ -1820,7 +1820,7 @@ pub fn parse_source(
                                     Pipeline::from_vec(vec![Expression {
                                         expr: Expr::Call(call),
                                         span: span(&spans[1..]),
-                                        ty: Type::Unknown,
+                                        ty: Type::Any,
                                         custom_completion: None,
                                     }]),
                                     // Return the file parse error
@@ -1837,7 +1837,7 @@ pub fn parse_source(
                                 call_with_block.positional.push(Expression {
                                     expr: Expr::Int(block_id as i64),
                                     span: spans[1],
-                                    ty: Type::Unknown,
+                                    ty: Type::Any,
                                     custom_completion: None,
                                 });
 
@@ -1845,7 +1845,7 @@ pub fn parse_source(
                                     Pipeline::from_vec(vec![Expression {
                                         expr: Expr::Call(call_with_block),
                                         span: span(spans),
-                                        ty: Type::Unknown,
+                                        ty: Type::Any,
                                         custom_completion: None,
                                     }]),
                                     None,
@@ -1863,7 +1863,7 @@ pub fn parse_source(
                 Pipeline::from_vec(vec![Expression {
                     expr: Expr::Call(call),
                     span: span(spans),
-                    ty: Type::Unknown,
+                    ty: Type::Any,
                     custom_completion: None,
                 }]),
                 error,
@@ -1932,7 +1932,7 @@ pub fn parse_register(
                     Pipeline::from_vec(vec![Expression {
                         expr: Expr::Call(call),
                         span: call_span,
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     }]),
                     err,
@@ -2034,7 +2034,7 @@ pub fn parse_register(
                     Pipeline::from_vec(vec![Expression {
                         expr: Expr::Call(call),
                         span: call_span,
-                        ty: Type::Unknown,
+                        ty: Type::Any,
                         custom_completion: None,
                     }]),
                     Some(err),

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -10,8 +10,8 @@ pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
         (Type::List(c), Type::List(d)) => type_compatible(c, d),
         (Type::Number, Type::Int) => true,
         (Type::Number, Type::Float) => true,
-        (Type::Unknown, _) => true,
-        (_, Type::Unknown) => true,
+        (Type::Any, _) => true,
+        (_, Type::Any) => true,
         (lhs, rhs) => lhs == rhs,
     }
 }
@@ -35,13 +35,13 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Duration, None),
                 (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
 
-                (Type::Unknown, _) => (Type::Unknown, None),
-                (_, Type::Unknown) => (Type::Unknown, None),
+                (Type::Any, _) => (Type::Any, None),
+                (_, Type::Any) => (Type::Any, None),
                 (Type::Int, _) => {
                     let ty = rhs.ty.clone();
                     *rhs = Expression::garbage(rhs.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -54,7 +54,7 @@ pub fn math_result_type(
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -74,12 +74,12 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Duration, None),
                 (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
 
-                (Type::Unknown, _) => (Type::Unknown, None),
-                (_, Type::Unknown) => (Type::Unknown, None),
+                (Type::Any, _) => (Type::Any, None),
+                (_, Type::Any) => (Type::Any, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -101,12 +101,12 @@ pub fn math_result_type(
                 (Type::Duration, Type::Int) => (Type::Filesize, None),
                 (Type::Int, Type::Duration) => (Type::Filesize, None),
 
-                (Type::Unknown, _) => (Type::Unknown, None),
-                (_, Type::Unknown) => (Type::Unknown, None),
+                (Type::Any, _) => (Type::Any, None),
+                (_, Type::Any) => (Type::Any, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -123,12 +123,12 @@ pub fn math_result_type(
                 (Type::Int, Type::Float) => (Type::Float, None),
                 (Type::Float, Type::Float) => (Type::Float, None),
 
-                (Type::Unknown, _) => (Type::Unknown, None),
-                (_, Type::Unknown) => (Type::Unknown, None),
+                (Type::Any, _) => (Type::Any, None),
+                (_, Type::Any) => (Type::Any, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -150,12 +150,12 @@ pub fn math_result_type(
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
 
-                (Type::Unknown, _) => (Type::Unknown, None),
-                (_, Type::Unknown) => (Type::Unknown, None),
+                (Type::Any, _) => (Type::Any, None),
+                (_, Type::Any) => (Type::Any, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -169,12 +169,12 @@ pub fn math_result_type(
             Operator::And | Operator::Or => match (&lhs.ty, &rhs.ty) {
                 (Type::Bool, Type::Bool) => (Type::Bool, None),
 
-                (Type::Unknown, _) => (Type::Unknown, None),
-                (_, Type::Unknown) => (Type::Unknown, None),
+                (Type::Any, _) => (Type::Any, None),
+                (_, Type::Any) => (Type::Any, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -193,12 +193,12 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
 
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -217,12 +217,12 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
 
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -241,12 +241,12 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
 
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -265,12 +265,12 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
 
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -285,12 +285,12 @@ pub fn math_result_type(
             Operator::NotEqual => (Type::Bool, None),
             Operator::Contains => match (&lhs.ty, &rhs.ty) {
                 (Type::String, Type::String) => (Type::Bool, None),
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -303,12 +303,12 @@ pub fn math_result_type(
             },
             Operator::NotContains => match (&lhs.ty, &rhs.ty) {
                 (Type::String, Type::String) => (Type::Bool, None),
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -321,12 +321,12 @@ pub fn math_result_type(
             },
             Operator::StartsWith => match (&lhs.ty, &rhs.ty) {
                 (Type::String, Type::String) => (Type::Bool, None),
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -343,12 +343,12 @@ pub fn math_result_type(
                 (Type::String, Type::String) => (Type::Bool, None),
                 (Type::String, Type::Record(_)) => (Type::Bool, None),
 
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -365,12 +365,12 @@ pub fn math_result_type(
                 (Type::String, Type::String) => (Type::Bool, None),
                 (Type::String, Type::Record(_)) => (Type::Bool, None),
 
-                (Type::Unknown, _) => (Type::Bool, None),
-                (_, Type::Unknown) => (Type::Bool, None),
+                (Type::Any, _) => (Type::Bool, None),
+                (_, Type::Any) => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (
-                        Type::Unknown,
+                        Type::Any,
                         Some(ParseError::UnsupportedOperation(
                             op.span,
                             lhs.span,
@@ -386,7 +386,7 @@ pub fn math_result_type(
             *op = Expression::garbage(op.span);
 
             (
-                Type::Unknown,
+                Type::Any,
                 Some(ParseError::IncompleteMathExpression(op.span)),
             )
         }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -18,7 +18,7 @@ impl Expression {
         Expression {
             expr: Expr::Garbage,
             span,
-            ty: Type::Unknown,
+            ty: Type::Any,
             custom_completion: None,
         }
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -192,11 +192,11 @@ impl EngineState {
             files: im::vector![],
             file_contents: im::vector![],
             vars: im::vector![
-                Variable::new(Span::new(0, 0), Type::Unknown),
-                Variable::new(Span::new(0, 0), Type::Unknown),
-                Variable::new(Span::new(0, 0), Type::Unknown),
-                Variable::new(Span::new(0, 0), Type::Unknown),
-                Variable::new(Span::new(0, 0), Type::Unknown)
+                Variable::new(Span::new(0, 0), Type::Any),
+                Variable::new(Span::new(0, 0), Type::Any),
+                Variable::new(Span::new(0, 0), Type::Any),
+                Variable::new(Span::new(0, 0), Type::Any),
+                Variable::new(Span::new(0, 0), Type::Any)
             ],
             decls: im::vector![],
             aliases: im::vector![],

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -96,37 +96,37 @@ pub enum SyntaxShape {
 impl SyntaxShape {
     pub fn to_type(&self) -> Type {
         match self {
-            SyntaxShape::Any => Type::Unknown,
+            SyntaxShape::Any => Type::Any,
             SyntaxShape::Block(_) => Type::Block,
             SyntaxShape::Binary => Type::Binary,
-            SyntaxShape::CellPath => Type::Unknown,
+            SyntaxShape::CellPath => Type::Any,
             SyntaxShape::Custom(custom, _) => custom.to_type(),
             SyntaxShape::DateTime => Type::Date,
             SyntaxShape::Duration => Type::Duration,
-            SyntaxShape::Expression => Type::Unknown,
+            SyntaxShape::Expression => Type::Any,
             SyntaxShape::Filepath => Type::String,
             SyntaxShape::Filesize => Type::Filesize,
-            SyntaxShape::FullCellPath => Type::Unknown,
+            SyntaxShape::FullCellPath => Type::Any,
             SyntaxShape::GlobPattern => Type::String,
-            SyntaxShape::ImportPattern => Type::Unknown,
+            SyntaxShape::ImportPattern => Type::Any,
             SyntaxShape::Int => Type::Int,
             SyntaxShape::List(x) => {
                 let contents = x.to_type();
                 Type::List(Box::new(contents))
             }
             SyntaxShape::Keyword(_, expr) => expr.to_type(),
-            SyntaxShape::MathExpression => Type::Unknown,
+            SyntaxShape::MathExpression => Type::Any,
             SyntaxShape::Number => Type::Number,
-            SyntaxShape::Operator => Type::Unknown,
-            SyntaxShape::Range => Type::Unknown,
+            SyntaxShape::Operator => Type::Any,
+            SyntaxShape::Range => Type::Any,
             SyntaxShape::Record => Type::Record(vec![]), // FIXME: Add actual record type
             SyntaxShape::RowCondition => Type::Bool,
             SyntaxShape::Boolean => Type::Bool,
             SyntaxShape::Signature => Type::Signature,
             SyntaxShape::String => Type::String,
-            SyntaxShape::Table => Type::List(Box::new(Type::Unknown)), // FIXME: Tables should have better types
-            SyntaxShape::VarWithOptType => Type::Unknown,
-            SyntaxShape::Variable => Type::Unknown,
+            SyntaxShape::Table => Type::List(Box::new(Type::Any)), // FIXME: Tables should have better types
+            SyntaxShape::VarWithOptType => Type::Any,
+            SyntaxShape::Variable => Type::Any,
         }
     }
 }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -20,9 +20,9 @@ pub enum Type {
     Number,
     Nothing,
     Record(Vec<(String, Type)>),
-    Table,
+    Table(Vec<(String, Type)>),
     ListStream,
-    Unknown,
+    Any,
     Error,
     Binary,
     Custom,
@@ -46,9 +46,9 @@ impl Type {
             Type::Number => SyntaxShape::Number,
             Type::Nothing => SyntaxShape::Any,
             Type::Record(_) => SyntaxShape::Record,
-            Type::Table => SyntaxShape::Table,
+            Type::Table(_) => SyntaxShape::Table,
             Type::ListStream => SyntaxShape::List(Box::new(SyntaxShape::Any)),
-            Type::Unknown => SyntaxShape::Any,
+            Type::Any => SyntaxShape::Any,
             Type::Error => SyntaxShape::Any,
             Type::Binary => SyntaxShape::Binary,
             Type::Custom => SyntaxShape::Any,
@@ -78,13 +78,21 @@ impl Display for Type {
                     .collect::<Vec<String>>()
                     .join(", "),
             ),
-            Type::Table => write!(f, "table"),
+            Type::Table(columns) => write!(
+                f,
+                "table<{}>",
+                columns
+                    .iter()
+                    .map(|(x, y)| format!("{}: {}", x, y))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
             Type::List(l) => write!(f, "list<{}>", l),
             Type::Nothing => write!(f, "nothing"),
             Type::Number => write!(f, "number"),
             Type::String => write!(f, "string"),
             Type::ListStream => write!(f, "list stream"),
-            Type::Unknown => write!(f, "unknown"),
+            Type::Any => write!(f, "any"),
             Type::Error => write!(f, "error"),
             Type::Binary => write!(f, "binary"),
             Type::Custom => write!(f, "custom"),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -378,7 +378,26 @@ impl Value {
                     .map(|(x, y)| (x.clone(), y.get_type()))
                     .collect(),
             ),
-            Value::List { .. } => Type::List(Box::new(Type::Unknown)), // FIXME
+            Value::List { vals, .. } => {
+                let mut ty = None;
+                for val in vals {
+                    let val_ty = val.get_type();
+                    match &ty {
+                        Some(x) => {
+                            if &val_ty != x {
+                                ty = Some(Type::Any)
+                            }
+                        }
+                        None => ty = Some(val_ty),
+                    }
+                }
+
+                match ty {
+                    Some(Type::Record(columns)) => Type::Table(columns),
+                    Some(ty) => Type::List(Box::new(ty)),
+                    None => Type::List(Box::new(ty.unwrap_or(Type::Any))),
+                }
+            }
             Value::Nothing { .. } => Type::Nothing,
             Value::Block { .. } => Type::Block,
             Value::Error { .. } => Type::Error,
@@ -1735,8 +1754,8 @@ impl Value {
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())
-            && (self.get_type() != Type::Unknown)
-            && (rhs.get_type() != Type::Unknown)
+            && (self.get_type() != Type::Any)
+            && (rhs.get_type() != Type::Any)
         {
             return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
         }
@@ -1763,8 +1782,8 @@ impl Value {
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())
-            && (self.get_type() != Type::Unknown)
-            && (rhs.get_type() != Type::Unknown)
+            && (self.get_type() != Type::Any)
+            && (rhs.get_type() != Type::Any)
         {
             return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
         }
@@ -1791,8 +1810,8 @@ impl Value {
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())
-            && (self.get_type() != Type::Unknown)
-            && (rhs.get_type() != Type::Unknown)
+            && (self.get_type() != Type::Any)
+            && (rhs.get_type() != Type::Any)
         {
             return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
         }
@@ -1819,8 +1838,8 @@ impl Value {
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())
-            && (self.get_type() != Type::Unknown)
-            && (rhs.get_type() != Type::Unknown)
+            && (self.get_type() != Type::Any)
+            && (rhs.get_type() != Type::Any)
         {
             return Err(ShellError::TypeMismatch("compatible type".to_string(), op));
         }


### PR DESCRIPTION
# Description

improves the type shown by `describe`. 

```
> [[a, b]; [1, 2], [3, 4]] | describe
table<a: int, b: int>
```

```
> [1, 2, 3] | describe
list<int>
```

Also changes the "unknown" type to "any". I think it'll be more familiar to folks.

fixes https://github.com/nushell/nushell/issues/4746

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
