### PR TITLE
nu-cli/completions: fix file completions filtering, clippy fixes

### DIFF
--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -97,6 +97,11 @@ impl Completer for FileCompletion {
 
         non_hidden
     }
+
+    // Replace base filter with no filter once all the results are already based in the current path
+    fn filter(&self, _: Vec<u8>, items: Vec<Suggestion>, _: CompletionOptions) -> Vec<Suggestion> {
+        items
+    }
 }
 
 pub fn file_path_completion(

--- a/crates/nu-json/src/de.rs
+++ b/crates/nu-json/src/de.rs
@@ -70,7 +70,7 @@ where
         }
     }
 
-    fn is_punctuator_char(&mut self, ch: u8) -> bool {
+    fn is_punctuator_char(&self, ch: u8) -> bool {
         matches!(ch, b'{' | b'}' | b'[' | b']' | b',' | b':')
     }
 


### PR DESCRIPTION
# Description

Fixes the file completion by removing the default filtering, once all the suggestions already contains the prefix.

Also one small error that clippy is returning for `nu-json`.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
