### PR TITLE
add keep deprecated commands

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -371,6 +371,9 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             NthDeprecated,
             UnaliasDeprecated,
             StrFindReplaceDeprecated,
+            KeepDeprecated,
+            KeepUntilDeprecated,
+            KeepWhileDeprecated,
         };
 
         #[cfg(feature = "dataframe")]

--- a/crates/nu-command/src/deprecated/keep_.rs
+++ b/crates/nu-command/src/deprecated/keep_.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct KeepDeprecated;
+
+impl Command for KeepDeprecated {
+    fn name(&self) -> &str {
+        "keep"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "take".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/keep_until.rs
+++ b/crates/nu-command/src/deprecated/keep_until.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct KeepUntilDeprecated;
+
+impl Command for KeepUntilDeprecated {
+    fn name(&self) -> &str {
+        "keep until"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "take until".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/keep_while.rs
+++ b/crates/nu-command/src/deprecated/keep_while.rs
@@ -1,0 +1,36 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, PipelineData, Signature,
+};
+
+#[derive(Clone)]
+pub struct KeepWhileDeprecated;
+
+impl Command for KeepWhileDeprecated {
+    fn name(&self) -> &str {
+        "keep while"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Deprecated)
+    }
+
+    fn usage(&self) -> &str {
+        "Deprecated command"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Err(nu_protocol::ShellError::DeprecatedCommand(
+            self.name().to_string(),
+            "take while".to_string(),
+            call.head,
+        ))
+    }
+}

--- a/crates/nu-command/src/deprecated/mod.rs
+++ b/crates/nu-command/src/deprecated/mod.rs
@@ -1,3 +1,6 @@
+mod keep_;
+mod keep_until;
+mod keep_while;
 mod match_;
 mod nth;
 mod pivot;
@@ -7,6 +10,9 @@ mod str_find_replace;
 mod str_int;
 mod unalias;
 
+pub use keep_::KeepDeprecated;
+pub use keep_until::KeepUntilDeprecated;
+pub use keep_while::KeepWhileDeprecated;
 pub use match_::MatchDeprecated;
 pub use nth::NthDeprecated;
 pub use pivot::PivotDeprecated;


### PR DESCRIPTION
# Description

Adds a deprecated notice to the `keep`, `keep until`, and `keep while` commands.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
