### PR TITLE
Track call arguments in a single list

### DIFF
--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -1,7 +1,7 @@
 use crate::completions::{Completer, CompletionOptions, SortBy};
 use nu_engine::eval_call;
 use nu_protocol::{
-    ast::{Call, Expr, Expression},
+    ast::{Argument, Call, Expr, Expression},
     engine::{EngineState, Stack, StateWorkingSet},
     PipelineData, Span, Type, Value, CONFIG_VARIABLE_ID,
 };
@@ -92,21 +92,20 @@ impl Completer for CustomCompletion {
             &Call {
                 decl_id: self.decl_id,
                 head: span,
-                positional: vec![
-                    Expression {
+                arguments: vec![
+                    Argument::Positional(Expression {
                         span: Span { start: 0, end: 0 },
                         ty: Type::String,
                         expr: Expr::String(self.line.clone()),
                         custom_completion: None,
-                    },
-                    Expression {
+                    }),
+                    Argument::Positional(Expression {
                         span: Span { start: 0, end: 0 },
                         ty: Type::Int,
                         expr: Expr::Int(line_pos as i64),
                         custom_completion: None,
-                    },
+                    }),
                 ],
-                named: vec![],
                 redirect_stdout: true,
                 redirect_stderr: true,
             },

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -61,12 +61,16 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let head = call.head;
-        let var_id = call.positional_iter().nth(0)
+        let var_id = call
+            .positional_iter()
+            .nth(0)
             .expect("internal error: missing variable")
             .as_var()
             .expect("internal error: missing variable");
 
-        let keyword_expr = call.positional_iter().nth(1)
+        let keyword_expr = call
+            .positional_iter()
+            .nth(1)
             .expect("internal error: missing variable")
             .as_keyword()
             .expect("internal error: missing keyword");

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -62,16 +62,14 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let head = call.head;
         let var_id = call
-            .positional_iter()
-            .nth(0)
-            .expect("internal error: missing variable")
+            .positional_nth(0)
+            .expect("checked through parser")
             .as_var()
             .expect("internal error: missing variable");
 
         let keyword_expr = call
-            .positional_iter()
-            .nth(1)
-            .expect("internal error: missing variable")
+            .positional_nth(1)
+            .expect("checked through parser")
             .as_keyword()
             .expect("internal error: missing keyword");
         let values = eval_expression(engine_state, stack, keyword_expr)?;

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -61,11 +61,13 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let head = call.head;
-        let var_id = call.positional[0]
+        let var_id = call.positional_iter().nth(0)
+            .expect("internal error: missing variable")
             .as_var()
             .expect("internal error: missing variable");
 
-        let keyword_expr = call.positional[1]
+        let keyword_expr = call.positional_iter().nth(1)
+            .expect("internal error: missing variable")
             .as_keyword()
             .expect("internal error: missing keyword");
         let values = eval_expression(engine_state, stack, keyword_expr)?;

--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -44,7 +44,7 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         let import_pattern = if let Some(Expression {
             expr: Expr::ImportPattern(pat),
             ..
-        }) = call.nth(0)
+        }) = call.positional_nth(0)
         {
             pat
         } else {
@@ -115,7 +115,11 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
                 };
 
                 if stack.remove_env_var(engine_state, &name).is_none() {
-                    return Err(ShellError::NotFound(call.nth(0).unwrap().span));
+                    return Err(ShellError::NotFound(
+                        call.positional_nth(0)
+                            .expect("already checked for present positional")
+                            .span,
+                    ));
                 }
             }
         } else if !import_pattern.hidden.contains(&import_pattern.head.name)

--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -44,7 +44,7 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         let import_pattern = if let Some(Expression {
             expr: Expr::ImportPattern(pat),
             ..
-        }) = call.positional.get(0)
+        }) = call.nth(0)
         {
             pat
         } else {
@@ -115,7 +115,7 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
                 };
 
                 if stack.remove_env_var(engine_state, &name).is_none() {
-                    return Err(ShellError::NotFound(call.positional[0].span));
+                    return Err(ShellError::NotFound(call.nth(0).unwrap().span));
                 }
             }
         } else if !import_pattern.hidden.contains(&import_pattern.head.name)

--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -50,9 +50,9 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let cond = call.positional_iter().nth(0).unwrap();
+        let cond = call.positional_nth(0).expect("checked through parser");
         let then_block: CaptureBlock = call.req(engine_state, stack, 1)?;
-        let else_case = call.positional_iter().nth(2);
+        let else_case = call.positional_nth(2);
 
         let result = eval_expression(engine_state, stack, cond)?;
         match &result {

--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -50,9 +50,9 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let cond = &call.positional[0];
+        let cond = call.positional_iter().nth(0).unwrap();
         let then_block: CaptureBlock = call.req(engine_state, stack, 1)?;
-        let else_case = call.positional.get(2);
+        let else_case = call.positional_iter().nth(2);
 
         let result = eval_expression(engine_state, stack, cond)?;
         match &result {

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -42,11 +42,11 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let var_id = call.positional[0]
+        let var_id = call.positional_iter().nth(0).unwrap()
             .as_var()
             .expect("internal error: missing variable");
 
-        let keyword_expr = call.positional[1]
+        let keyword_expr = call.positional_iter().nth(1).unwrap()
             .as_keyword()
             .expect("internal error: missing keyword");
 

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -42,11 +42,17 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let var_id = call.positional_iter().nth(0).unwrap()
+        let var_id = call
+            .positional_iter()
+            .nth(0)
+            .unwrap()
             .as_var()
             .expect("internal error: missing variable");
 
-        let keyword_expr = call.positional_iter().nth(1).unwrap()
+        let keyword_expr = call
+            .positional_iter()
+            .nth(1)
+            .unwrap()
             .as_keyword()
             .expect("internal error: missing keyword");
 

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -43,16 +43,14 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let var_id = call
-            .positional_iter()
-            .nth(0)
-            .unwrap()
+            .positional_nth(0)
+            .expect("checked through parser")
             .as_var()
             .expect("internal error: missing variable");
 
         let keyword_expr = call
-            .positional_iter()
-            .nth(1)
-            .unwrap()
+            .positional_nth(1)
+            .expect("checked through parser")
             .as_keyword()
             .expect("internal error: missing keyword");
 

--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -35,7 +35,7 @@ impl Command for Metadata {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let arg = call.positional.get(0);
+        let arg = call.positional_iter().nth(0);
         let head = call.head;
 
         match arg {

--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -35,7 +35,7 @@ impl Command for Metadata {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let arg = call.positional_iter().nth(0);
+        let arg = call.positional_nth(0);
         let head = call.head;
 
         match arg {

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -42,7 +42,7 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         let import_pattern = if let Some(Expression {
             expr: Expr::ImportPattern(pat),
             ..
-        }) = call.positional_iter().nth(0)
+        }) = call.positional_nth(0)
         {
             pat
         } else {

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -42,7 +42,7 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         let import_pattern = if let Some(Expression {
             expr: Expr::ImportPattern(pat),
             ..
-        }) = call.positional.get(0)
+        }) = call.positional_iter().nth(0)
         {
             pat
         } else {

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -36,9 +36,8 @@ impl Command for LetEnv {
         let env_var = call.req(engine_state, stack, 0)?;
 
         let keyword_expr = call
-            .positional_iter()
-            .nth(1)
-            .unwrap()
+            .positional_nth(1)
+            .expect("checked through parser")
             .as_keyword()
             .expect("internal error: missing keyword");
 

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -35,7 +35,8 @@ impl Command for LetEnv {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let env_var = call.req(engine_state, stack, 0)?;
 
-        let keyword_expr = call.positional[1]
+        let keyword_expr = call.positional_iter().nth(1)
+            .unwrap()
             .as_keyword()
             .expect("internal error: missing keyword");
 

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -35,7 +35,9 @@ impl Command for LetEnv {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let env_var = call.req(engine_state, stack, 0)?;
 
-        let keyword_expr = call.positional_iter().nth(1)
+        let keyword_expr = call
+            .positional_iter()
+            .nth(1)
             .unwrap()
             .as_keyword()
             .expect("internal error: missing keyword");

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -99,7 +99,7 @@ fn with_env(
                         return Err(ShellError::CantConvert(
                             "string list or single row".into(),
                             x.get_type().to_string(),
-                            call.positional[1].span,
+                            call.positional_iter().nth(1).unwrap().span,
                         ));
                     }
                 }
@@ -123,7 +123,7 @@ fn with_env(
             return Err(ShellError::CantConvert(
                 "string list or single row".into(),
                 x.get_type().to_string(),
-                call.positional[1].span,
+                call.positional_iter().nth(1).unwrap().span,
             ));
         }
     };

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -99,7 +99,9 @@ fn with_env(
                         return Err(ShellError::CantConvert(
                             "string list or single row".into(),
                             x.get_type().to_string(),
-                            call.positional_nth(1).expect("already checked through .req").span,
+                            call.positional_nth(1)
+                                .expect("already checked through .req")
+                                .span,
                         ));
                     }
                 }
@@ -123,7 +125,9 @@ fn with_env(
             return Err(ShellError::CantConvert(
                 "string list or single row".into(),
                 x.get_type().to_string(),
-                call.positional_nth(1).expect("already checked through .req").span,
+                call.positional_nth(1)
+                    .expect("already checked through .req")
+                    .span,
             ));
         }
     };

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -99,7 +99,7 @@ fn with_env(
                         return Err(ShellError::CantConvert(
                             "string list or single row".into(),
                             x.get_type().to_string(),
-                            call.positional_iter().nth(1).unwrap().span,
+                            call.positional_nth(1).expect("already checked through .req").span,
                         ));
                     }
                 }
@@ -123,7 +123,7 @@ fn with_env(
             return Err(ShellError::CantConvert(
                 "string list or single row".into(),
                 x.get_type().to_string(),
-                call.positional_iter().nth(1).unwrap().span,
+                call.positional_nth(1).expect("already checked through .req").span,
             ));
         }
     };

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -28,7 +28,7 @@ impl Command for Cd {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let raw_path = call.nth(0);
+        let raw_path = call.positional_nth(0);
         let path_val: Option<Value> = call.opt(engine_state, stack, 0)?;
         let cwd = current_dir(engine_state, stack)?;
 

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -57,13 +57,18 @@ impl Command for Mkdir {
         }
 
         for (i, dir) in directories.enumerate() {
-            let span = call.positional_nth(i).expect("already checked through directories").span;
+            let span = call
+                .positional_nth(i)
+                .expect("already checked through directories")
+                .span;
             let dir_res = std::fs::create_dir_all(&dir);
 
             if let Err(reason) = dir_res {
                 return Err(ShellError::CreateNotPossible(
                     format!("failed to create directory: {}", reason),
-                    call.positional_nth(i).expect("already checked through directories").span,
+                    call.positional_nth(i)
+                        .expect("already checked through directories")
+                        .span,
                 ));
             }
 

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -57,13 +57,13 @@ impl Command for Mkdir {
         }
 
         for (i, dir) in directories.enumerate() {
-            let span = call.positional[i].span;
+            let span = call.positional_iter().nth(i).unwrap().span;
             let dir_res = std::fs::create_dir_all(&dir);
 
             if let Err(reason) = dir_res {
                 return Err(ShellError::CreateNotPossible(
                     format!("failed to create directory: {}", reason),
-                    call.positional[i].span,
+                    call.positional_iter().nth(i).unwrap().span,
                 ));
             }
 

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -57,13 +57,13 @@ impl Command for Mkdir {
         }
 
         for (i, dir) in directories.enumerate() {
-            let span = call.positional_iter().nth(i).unwrap().span;
+            let span = call.positional_nth(i).expect("already checked through directories").span;
             let dir_res = std::fs::create_dir_all(&dir);
 
             if let Err(reason) = dir_res {
                 return Err(ShellError::CreateNotPossible(
                     format!("failed to create directory: {}", reason),
-                    call.positional_iter().nth(i).unwrap().span,
+                    call.positional_nth(i).expect("already checked through directories").span,
                 ));
             }
 

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -239,7 +239,7 @@ impl Command for Touch {
             if let Err(err) = OpenOptions::new().write(true).create(true).open(&item) {
                 return Err(ShellError::CreateNotPossible(
                     format!("Failed to create file: {}", err),
-                    call.positional_iter().nth(index).unwrap().span,
+                    call.positional_nth(index).expect("already checked positional").span,
                 ));
             };
 
@@ -251,7 +251,7 @@ impl Command for Touch {
                 ) {
                     return Err(ShellError::ChangeModifiedTimeNotPossible(
                         format!("Failed to change the modified time: {}", err),
-                        call.positional_iter().nth(index).unwrap().span,
+                        call.positional_nth(index).expect("already checked positional").span,
                     ));
                 };
             }
@@ -268,7 +268,7 @@ impl Command for Touch {
                     ) {
                         return Err(ShellError::ChangeAccessTimeNotPossible(
                             format!("Failed to change the access time: {}", err),
-                            call.positional_iter().nth(index).unwrap().span,
+                            call.positional_nth(index).expect("already checked positional").span,
                         ));
                     };
                 } else {
@@ -279,7 +279,7 @@ impl Command for Touch {
                     ) {
                         return Err(ShellError::ChangeAccessTimeNotPossible(
                             format!("Failed to change the access time: {}", err),
-                            call.positional_iter().nth(index).unwrap().span,
+                            call.positional_nth(index).expect("already checked positional").span,
                         ));
                     };
                 }

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -239,7 +239,7 @@ impl Command for Touch {
             if let Err(err) = OpenOptions::new().write(true).create(true).open(&item) {
                 return Err(ShellError::CreateNotPossible(
                     format!("Failed to create file: {}", err),
-                    call.positional[index].span,
+                    call.positional_iter().nth(index).unwrap().span,
                 ));
             };
 
@@ -251,7 +251,7 @@ impl Command for Touch {
                 ) {
                     return Err(ShellError::ChangeModifiedTimeNotPossible(
                         format!("Failed to change the modified time: {}", err),
-                        call.positional[index].span,
+                        call.positional_iter().nth(index).unwrap().span,
                     ));
                 };
             }
@@ -268,7 +268,7 @@ impl Command for Touch {
                     ) {
                         return Err(ShellError::ChangeAccessTimeNotPossible(
                             format!("Failed to change the access time: {}", err),
-                            call.positional[index].span,
+                            call.positional_iter().nth(index).unwrap().span,
                         ));
                     };
                 } else {
@@ -279,7 +279,7 @@ impl Command for Touch {
                     ) {
                         return Err(ShellError::ChangeAccessTimeNotPossible(
                             format!("Failed to change the access time: {}", err),
-                            call.positional[index].span,
+                            call.positional_iter().nth(index).unwrap().span,
                         ));
                     };
                 }

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -239,7 +239,9 @@ impl Command for Touch {
             if let Err(err) = OpenOptions::new().write(true).create(true).open(&item) {
                 return Err(ShellError::CreateNotPossible(
                     format!("Failed to create file: {}", err),
-                    call.positional_nth(index).expect("already checked positional").span,
+                    call.positional_nth(index)
+                        .expect("already checked positional")
+                        .span,
                 ));
             };
 
@@ -251,7 +253,9 @@ impl Command for Touch {
                 ) {
                     return Err(ShellError::ChangeModifiedTimeNotPossible(
                         format!("Failed to change the modified time: {}", err),
-                        call.positional_nth(index).expect("already checked positional").span,
+                        call.positional_nth(index)
+                            .expect("already checked positional")
+                            .span,
                     ));
                 };
             }
@@ -268,7 +272,9 @@ impl Command for Touch {
                     ) {
                         return Err(ShellError::ChangeAccessTimeNotPossible(
                             format!("Failed to change the access time: {}", err),
-                            call.positional_nth(index).expect("already checked positional").span,
+                            call.positional_nth(index)
+                                .expect("already checked positional")
+                                .span,
                         ));
                     };
                 } else {
@@ -279,7 +285,9 @@ impl Command for Touch {
                     ) {
                         return Err(ShellError::ChangeAccessTimeNotPossible(
                             format!("Failed to change the access time: {}", err),
-                            call.positional_nth(index).expect("already checked positional").span,
+                            call.positional_nth(index)
+                                .expect("already checked positional")
+                                .span,
                         ));
                     };
                 }

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -380,7 +380,9 @@ Format: #
                 None => {
                     return Err(ShellError::UnsupportedInput(
                         String::from("Unknown ansi code"),
-                        call.positional_nth(0).expect("Unexpected missing argument").span,
+                        call.positional_nth(0)
+                            .expect("Unexpected missing argument")
+                            .span,
                     ))
                 }
             }

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -380,7 +380,7 @@ Format: #
                 None => {
                     return Err(ShellError::UnsupportedInput(
                         String::from("Unknown ansi code"),
-                        call.nth(0).expect("Unexpected missing argument").span,
+                        call.positional_nth(0).expect("Unexpected missing argument").span,
                     ))
                 }
             }

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
@@ -57,7 +57,7 @@ impl Command for KeybindingsList {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let records = if call.named_iter().count() == 0{
+        let records = if call.named_iter().count() == 0 {
             let all_options = vec!["modifiers", "keycodes", "edits", "modes", "events"];
             all_options
                 .iter()

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
@@ -57,7 +57,7 @@ impl Command for KeybindingsList {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let records = if call.named_iter().count() == 0 {
+        let records = if call.named_len() == 0 {
             let all_options = vec!["modifiers", "keycodes", "edits", "modes", "events"];
             all_options
                 .iter()

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
@@ -57,15 +57,14 @@ impl Command for KeybindingsList {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let records = if call.named.is_empty() {
+        let records = if call.named_iter().count() == 0{
             let all_options = vec!["modifiers", "keycodes", "edits", "modes", "events"];
             all_options
                 .iter()
                 .flat_map(|argument| get_records(argument, &call.head))
                 .collect()
         } else {
-            call.named
-                .iter()
+            call.named_iter()
                 .flat_map(|(argument, _)| get_records(argument.item.as_str(), &call.head))
                 .collect()
         };

--- a/crates/nu-command/src/strings/build_string.rs
+++ b/crates/nu-command/src/strings/build_string.rs
@@ -54,8 +54,7 @@ impl Command for BuildString {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let config = stack.get_config().unwrap_or_default();
         let output = call
-            .positional
-            .iter()
+            .positional_iter()
             .map(|expr| {
                 eval_expression(engine_state, stack, expr).map(|val| val.into_string(", ", &config))
             })

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -245,7 +245,10 @@ impl Command for Char {
             }
             let mut multi_byte = String::new();
             for (i, arg) in args.iter().enumerate() {
-                let span = call.positional_nth(i).expect("Unexpected missing argument").span;
+                let span = call
+                    .positional_nth(i)
+                    .expect("Unexpected missing argument")
+                    .span;
                 multi_byte.push(string_to_unicode_char(arg, &span)?)
             }
             Ok(Value::string(multi_byte, call_span).into_pipeline_data())
@@ -262,7 +265,9 @@ impl Command for Char {
             } else {
                 Err(ShellError::UnsupportedInput(
                     "error finding named character".into(),
-                    call.positional_nth(0).expect("Unexpected missing argument").span,
+                    call.positional_nth(0)
+                        .expect("Unexpected missing argument")
+                        .span,
                 ))
             }
         }

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -245,7 +245,7 @@ impl Command for Char {
             }
             let mut multi_byte = String::new();
             for (i, arg) in args.iter().enumerate() {
-                let span = call.nth(i).expect("Unexpected missing argument").span;
+                let span = call.positional_nth(i).expect("Unexpected missing argument").span;
                 multi_byte.push(string_to_unicode_char(arg, &span)?)
             }
             Ok(Value::string(multi_byte, call_span).into_pipeline_data())
@@ -262,7 +262,7 @@ impl Command for Char {
             } else {
                 Err(ShellError::UnsupportedInput(
                     "error finding named character".into(),
-                    call.nth(0).expect("Unexpected missing argument").span,
+                    call.positional_nth(0).expect("Unexpected missing argument").span,
                 ))
             }
         }

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -73,8 +73,8 @@ impl CallExt for Call {
         stack: &mut Stack,
         pos: usize,
     ) -> Result<Option<T>, ShellError> {
-        if let Some(expr) = self.nth(pos) {
-            let result = eval_expression(engine_state, stack, &expr)?;
+        if let Some(expr) = self.positional_nth(pos) {
+            let result = eval_expression(engine_state, stack, expr)?;
             FromValue::from_value(&result).map(Some)
         } else {
             Ok(None)
@@ -87,12 +87,12 @@ impl CallExt for Call {
         stack: &mut Stack,
         pos: usize,
     ) -> Result<T, ShellError> {
-        if let Some(expr) = self.nth(pos) {
-            let result = eval_expression(engine_state, stack, &expr)?;
+        if let Some(expr) = self.positional_nth(pos) {
+            let result = eval_expression(engine_state, stack, expr)?;
             FromValue::from_value(&result)
         } else {
             Err(ShellError::AccessBeyondEnd(
-                self.positional_iter().count(),
+                self.positional_len(),
                 self.head,
             ))
         }

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -59,7 +59,7 @@ impl CallExt for Call {
     ) -> Result<Vec<T>, ShellError> {
         let mut output = vec![];
 
-        for expr in self.positional.iter().skip(starting_pos) {
+        for expr in self.positional_iter().skip(starting_pos) {
             let result = eval_expression(engine_state, stack, expr)?;
             output.push(FromValue::from_value(&result)?);
         }
@@ -92,7 +92,7 @@ impl CallExt for Call {
             FromValue::from_value(&result)
         } else {
             Err(ShellError::AccessBeyondEnd(
-                self.positional.len(),
+                self.positional_iter().count(),
                 self.head,
             ))
         }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -59,7 +59,7 @@ pub fn eval_call(
                 .var_id
                 .expect("internal error: all custom parameters must have var_ids");
 
-            if let Some(arg) = call.positional_iter().nth(param_idx) {
+            if let Some(arg) = call.positional_nth(param_idx) {
                 let result = eval_expression(engine_state, caller_stack, arg)?;
                 callee_stack.add_var(var_id, result);
             } else if let Some(arg) = &param.default_value {

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -145,10 +145,10 @@ pub fn flatten_expression(
             let mut output = vec![(call.head, FlatShape::InternalCall)];
 
             let mut args = vec![];
-            for positional in &call.positional {
+            for positional in call.positional_iter() {
                 args.extend(flatten_expression(working_set, positional));
             }
-            for named in &call.named {
+            for named in call.named_iter() {
                 args.push((named.0.span, FlatShape::Flag));
                 if let Some(expr) = &named.1 {
                     args.extend(flatten_expression(working_set, expr));

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -1,5 +1,9 @@
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
-use nu_protocol::{ast::{Argument, Call, Expr, Expression}, engine::Command, ShellError, Signature};
+use nu_protocol::{
+    ast::{Argument, Call, Expr, Expression},
+    engine::Command,
+    ShellError, Signature,
+};
 use nu_protocol::{PipelineData, Spanned, Type};
 
 #[derive(Clone)]
@@ -61,7 +65,6 @@ impl Command for KnownExternal {
                 Argument::Named(named) => extern_call.add_named(named.clone()),
             }
         }
-        
 
         if call.redirect_stdout {
             extern_call.add_named((

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -47,9 +47,10 @@ impl Command for KnownExternal {
 
         let mut extern_call = Call::new(head_span);
 
-        let working_state = StateWorkingSet::new(&engine_state);
+        let working_state = StateWorkingSet::new(engine_state);
         let extern_name = working_state.get_span_contents(call.head);
-        let extern_name = String::from_utf8(extern_name.to_vec()).unwrap();
+        let extern_name = String::from_utf8(extern_name.to_vec())
+            .expect("this was already parsed as a command name");
         let arg_extern_name = Expression {
             expr: Expr::String(extern_name),
             span: call.head,
@@ -86,6 +87,6 @@ impl Command for KnownExternal {
             ))
         }
 
-        command.run(&engine_state, stack, &extern_call, input)
+        command.run(engine_state, stack, &extern_call, input)
     }
 }

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -1,7 +1,6 @@
-use nu_protocol::ast::Expr;
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
-use nu_protocol::{ast::Call, engine::Command, ShellError, Signature};
-use nu_protocol::{PipelineData, Spanned};
+use nu_protocol::{ast::{Argument, Call, Expr, Expression}, engine::Command, ShellError, Signature};
+use nu_protocol::{PipelineData, Spanned, Type};
 
 #[derive(Clone)]
 pub struct KnownExternal {
@@ -34,69 +33,56 @@ impl Command for KnownExternal {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        // FIXME: This is a bit of a hack, and it'd be nice for the parser/AST to be able to handle the original
-        // order of the parameters. Until then, we need to recover the original order.
-
-        // FIXME: This is going to be a bit expensive, but we need to do it to ensure any new block/subexpression
-        // we find when parsing the external call is handled properly.
-        let mut engine_state = engine_state.clone();
-
         let call_span = call.span();
-        let contents = engine_state.get_span_contents(&call_span);
+        let head_span = call.head;
+        let decl_id = engine_state
+            .find_decl("run-external".as_bytes())
+            .ok_or(ShellError::ExternalNotSupported(head_span))?;
 
-        let redirect_stdout = call.redirect_stdout;
-        let redirect_stderr = call.redirect_stderr;
+        let command = engine_state.get_decl(decl_id);
 
-        let (lexed, _) = crate::lex(contents, call_span.start, &[], &[], true);
+        let mut extern_call = Call::new(head_span);
 
-        let spans: Vec<_> = lexed.into_iter().map(|x| x.span).collect();
-        let mut working_set = StateWorkingSet::new(&engine_state);
-        let (external_call, _) = crate::parse_external_call(&mut working_set, &spans, &[]);
-        let delta = working_set.render();
-        engine_state.merge_delta(delta, None, ".")?;
+        let working_state = StateWorkingSet::new(&engine_state);
+        let extern_name = working_state.get_span_contents(call.head);
+        let extern_name = String::from_utf8(extern_name.to_vec()).unwrap();
+        let arg_extern_name = Expression {
+            expr: Expr::String(extern_name),
+            span: call.head,
+            ty: Type::String,
+            custom_completion: None,
+        };
 
-        match external_call.expr {
-            Expr::ExternalCall(head, args) => {
-                let decl_id = engine_state
-                    .find_decl("run-external".as_bytes())
-                    .ok_or(ShellError::ExternalNotSupported(head.span))?;
+        extern_call.add_positional(arg_extern_name);
 
-                let command = engine_state.get_decl(decl_id);
-
-                let mut call = Call::new(head.span);
-
-                call.positional.push(*head);
-
-                for arg in args {
-                    call.positional.push(arg.clone())
-                }
-
-                if redirect_stdout {
-                    call.named.push((
-                        Spanned {
-                            item: "redirect-stdout".into(),
-                            span: call_span,
-                        },
-                        None,
-                    ))
-                }
-
-                if redirect_stderr {
-                    call.named.push((
-                        Spanned {
-                            item: "redirect-stderr".into(),
-                            span: call_span,
-                        },
-                        None,
-                    ))
-                }
-
-                command.run(&engine_state, stack, &call, input)
-            }
-            x => {
-                println!("{:?}", x);
-                panic!("internal error: known external not actually external")
+        for arg in &call.arguments {
+            match arg {
+                Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
+                Argument::Named(named) => extern_call.add_named(named.clone()),
             }
         }
+        
+
+        if call.redirect_stdout {
+            extern_call.add_named((
+                Spanned {
+                    item: "redirect-stdout".into(),
+                    span: call_span,
+                },
+                None,
+            ))
+        }
+
+        if call.redirect_stderr {
+            extern_call.add_named((
+                Spanned {
+                    item: "redirect-stderr".into(),
+                    span: call_span,
+                },
+                None,
+            ))
+        }
+
+        command.run(&engine_state, stack, &extern_call, input)
     }
 }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -142,7 +142,7 @@ pub fn parse_for(
             let sig = decl.signature();
 
             // Let's get our block and make sure it has the right signature
-            if let Some(arg) = call.positional_iter().nth(2) {
+            if let Some(arg) = call.positional_nth(2) {
                 match arg {
                     Expression {
                         expr: Expr::Block(block_id),
@@ -317,7 +317,7 @@ pub fn parse_def(
             let sig = decl.signature();
 
             // Let's get our block and make sure it has the right signature
-            if let Some(arg) = call.positional_iter().nth(2) {
+            if let Some(arg) = call.positional_nth(2) {
                 match arg {
                     Expression {
                         expr: Expr::Block(block_id),
@@ -472,8 +472,8 @@ pub fn parse_extern(
             (call, call_span)
         }
     };
-    let name_expr = call.positional_iter().nth(0);
-    let sig = call.positional_iter().nth(1);
+    let name_expr = call.positional_nth(0);
+    let sig = call.positional_nth(1);
 
     if let (Some(name_expr), Some(sig)) = (name_expr, sig) {
         if let (Some(name), Some(mut signature)) = (&name_expr.as_string(), sig.as_signature()) {
@@ -1280,7 +1280,7 @@ pub fn parse_use(
         }
     };
 
-    let import_pattern = if let Some(expr) = call.nth(0) {
+    let import_pattern = if let Some(expr) = call.positional_nth(0) {
         if let Some(pattern) = expr.as_import_pattern() {
             pattern
         } else {
@@ -1508,7 +1508,7 @@ pub fn parse_hide(
         }
     };
 
-    let import_pattern = if let Some(expr) = call.nth(0) {
+    let import_pattern = if let Some(expr) = call.positional_nth(0) {
         if let Some(pattern) = expr.as_import_pattern() {
             pattern
         } else {
@@ -2008,7 +2008,7 @@ pub fn parse_register(
 
     // Signature is an optional value from the call and will be used to decide if
     // the plugin is called to get the signatures or to use the given signature
-    let signature = call.positional_iter().nth(1).map(|expr| {
+    let signature = call.positional_nth(1).map(|expr| {
         let signature = working_set.get_span_contents(expr.span);
         serde_json::from_slice::<Signature>(signature).map_err(|_| {
             ParseError::LabeledError(

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -178,12 +178,8 @@ pub fn parse_for(
     };
 
     // All positional arguments must be in the call positional vector by this point
-    let var_decl = call
-        .positional_nth(0)
-        .expect("for call already checked");
-    let block = call
-        .positional_nth(2)
-        .expect("for call already checked");
+    let var_decl = call.positional_nth(0).expect("for call already checked");
+    let block = call.positional_nth(2).expect("for call already checked");
 
     let error = None;
     if let (Some(var_id), Some(block_id)) = (&var_decl.as_var(), block.as_block()) {
@@ -351,15 +347,9 @@ pub fn parse_def(
     };
 
     // All positional arguments must be in the call positional vector by this point
-    let name_expr = call
-        .positional_nth(0)
-        .expect("def call already checked");
-    let sig = call
-        .positional_nth(1)
-        .expect("def call already checked");
-    let block = call
-        .positional_nth(2)
-        .expect("def call already checked");
+    let name_expr = call.positional_nth(0).expect("def call already checked");
+    let sig = call.positional_nth(1).expect("def call already checked");
+    let block = call.positional_nth(2).expect("def call already checked");
 
     let mut error = None;
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -179,12 +179,10 @@ pub fn parse_for(
 
     // All positional arguments must be in the call positional vector by this point
     let var_decl = call
-        .positional_iter()
-        .nth(0)
+        .positional_nth(0)
         .expect("for call already checked");
     let block = call
-        .positional_iter()
-        .nth(2)
+        .positional_nth(2)
         .expect("for call already checked");
 
     let error = None;
@@ -354,16 +352,13 @@ pub fn parse_def(
 
     // All positional arguments must be in the call positional vector by this point
     let name_expr = call
-        .positional_iter()
-        .nth(0)
+        .positional_nth(0)
         .expect("def call already checked");
     let sig = call
-        .positional_iter()
-        .nth(1)
+        .positional_nth(1)
         .expect("def call already checked");
     let block = call
-        .positional_iter()
-        .nth(2)
+        .positional_nth(2)
         .expect("def call already checked");
 
     let mut error = None;
@@ -1963,8 +1958,7 @@ pub fn parse_register(
     // The ? operator is not used because the error has to be kept to be printed in the shell
     // For that reason the values are kept in a result that will be passed at the end of this call
     let arguments = call
-        .positional_iter()
-        .nth(0)
+        .positional_nth(0)
         .map(|expr| {
             let name_expr = working_set.get_span_contents(expr.span);
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1,8 +1,8 @@
 use nu_path::canonicalize_with;
 use nu_protocol::{
     ast::{
-        Argument, Block, Call, Expr, Expression, ImportPattern, ImportPatternHead, ImportPatternMember,
-        Pipeline,
+        Argument, Block, Call, Expr, Expression, ImportPattern, ImportPatternHead,
+        ImportPatternMember, Pipeline,
     },
     engine::StateWorkingSet,
     span, Exportable, Overlay, PositionalArg, Span, SyntaxShape, Type, CONFIG_VARIABLE_ID,
@@ -178,8 +178,14 @@ pub fn parse_for(
     };
 
     // All positional arguments must be in the call positional vector by this point
-    let var_decl = call.positional_iter().nth(0).expect("for call already checked");
-    let block = call.positional_iter().nth(2).expect("for call already checked");
+    let var_decl = call
+        .positional_iter()
+        .nth(0)
+        .expect("for call already checked");
+    let block = call
+        .positional_iter()
+        .nth(2)
+        .expect("for call already checked");
 
     let error = None;
     if let (Some(var_id), Some(block_id)) = (&var_decl.as_var(), block.as_block()) {
@@ -347,9 +353,18 @@ pub fn parse_def(
     };
 
     // All positional arguments must be in the call positional vector by this point
-    let name_expr = call.positional_iter().nth(0).expect("def call already checked");
-    let sig = call.positional_iter().nth(1).expect("def call already checked");
-    let block = call.positional_iter().nth(2).expect("def call already checked");
+    let name_expr = call
+        .positional_iter()
+        .nth(0)
+        .expect("def call already checked");
+    let sig = call
+        .positional_iter()
+        .nth(1)
+        .expect("def call already checked");
+    let block = call
+        .positional_iter()
+        .nth(2)
+        .expect("def call already checked");
 
     let mut error = None;
 
@@ -1714,7 +1729,10 @@ pub fn parse_let(
                         let call = Box::new(Call {
                             decl_id,
                             head: spans[0],
-                            arguments: vec![Argument::Positional(lvalue), Argument::Positional(rvalue)],
+                            arguments: vec![
+                                Argument::Positional(lvalue),
+                                Argument::Positional(rvalue),
+                            ],
                             redirect_stdout: true,
                             redirect_stderr: false,
                         });

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -8,8 +8,9 @@ use crate::{
 
 use nu_protocol::{
     ast::{
-        Argument, Block, Call, CellPath, Expr, Expression, FullCellPath, ImportPattern, ImportPatternHead,
-        ImportPatternMember, Operator, PathMember, Pipeline, RangeInclusion, RangeOperator,
+        Argument, Block, Call, CellPath, Expr, Expression, FullCellPath, ImportPattern,
+        ImportPatternHead, ImportPatternMember, Operator, PathMember, Pipeline, RangeInclusion,
+        RangeOperator,
     },
     engine::StateWorkingSet,
     span, BlockId, Flag, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type, Unit, VarId,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4401,7 +4401,7 @@ pub fn parse_expression(
             let expr = Expr::Call(Box::new(Call {
                 head: Span { start: 0, end: 0 },
                 decl_id,
-                arguments: arguments,
+                arguments,
                 redirect_stdout: true,
                 redirect_stderr: false,
             }));

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use nu_protocol::{
     ast::{
-        Block, Call, CellPath, Expr, Expression, FullCellPath, ImportPattern, ImportPatternHead,
+        Argument, Block, Call, CellPath, Expr, Expression, FullCellPath, ImportPattern, ImportPatternHead,
         ImportPatternMember, Operator, PathMember, Pipeline, RangeInclusion, RangeOperator,
     },
     engine::StateWorkingSet,
@@ -127,16 +127,16 @@ pub fn trim_quotes(bytes: &[u8]) -> &[u8] {
 
 pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseError> {
     // Allow the call to pass if they pass in the help flag
-    if call.named.iter().any(|(n, _)| n.item == "help") {
+    if call.named_iter().any(|(n, _)| n.item == "help") {
         return None;
     }
 
-    if call.positional.len() < sig.required_positional.len() {
+    if call.positional_iter().count() < sig.required_positional.len() {
         // Comparing the types of all signature positional arguments against the parsed
         // expressions found in the call. If one type is not found then it could be assumed
         // that that positional argument is missing from the parsed call
         for argument in &sig.required_positional {
-            let found = call.positional.iter().fold(false, |ac, expr| {
+            let found = call.positional_iter().fold(false, |ac, expr| {
                 if argument.shape.to_type() == expr.ty || argument.shape == SyntaxShape::Any {
                     true
                 } else {
@@ -144,7 +144,7 @@ pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseEr
                 }
             });
             if !found {
-                if let Some(last) = call.positional.last() {
+                if let Some(last) = call.positional_iter().last() {
                     return Some(ParseError::MissingPositional(
                         argument.name.clone(),
                         Span {
@@ -166,8 +166,8 @@ pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseEr
             }
         }
 
-        let missing = &sig.required_positional[call.positional.len()];
-        if let Some(last) = call.positional.last() {
+        let missing = &sig.required_positional[call.positional_iter().count()];
+        if let Some(last) = call.positional_iter().last() {
             Some(ParseError::MissingPositional(
                 missing.name.clone(),
                 Span {
@@ -188,7 +188,7 @@ pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseEr
         }
     } else {
         for req_flag in sig.named.iter().filter(|x| x.required) {
-            if call.named.iter().all(|(n, _)| n.item != req_flag.long) {
+            if call.named_iter().all(|(n, _)| n.item != req_flag.long) {
                 return Some(ParseError::MissingRequiredFlag(
                     req_flag.long.clone(),
                     command,
@@ -743,7 +743,7 @@ pub fn parse_internal_call(
         if let Some(long_name) = long_name {
             // We found a long flag, like --bar
             error = error.or(err);
-            call.named.push((long_name, arg));
+            call.add_named((long_name, arg));
             spans_idx += 1;
             continue;
         }
@@ -766,7 +766,7 @@ pub fn parse_internal_call(
                             parse_value(working_set, *arg, &arg_shape, expand_aliases_denylist);
                         error = error.or(err);
 
-                        call.named.push((
+                        call.add_named((
                             Spanned {
                                 item: flag.long.clone(),
                                 span: spans[spans_idx],
@@ -783,7 +783,7 @@ pub fn parse_internal_call(
                         })
                     }
                 } else {
-                    call.named.push((
+                    call.add_named((
                         Spanned {
                             item: flag.long.clone(),
                             span: spans[spans_idx],
@@ -844,10 +844,10 @@ pub fn parse_internal_call(
             } else {
                 arg
             };
-            call.positional.push(arg);
+            call.add_positional(arg);
             positional_idx += 1;
         } else {
-            call.positional.push(Expression::garbage(arg_span));
+            call.add_positional(Expression::garbage(arg_span));
             error = error.or_else(|| {
                 Some(ParseError::ExtraPositional(
                     signature.call_signature(),
@@ -4382,26 +4382,25 @@ pub fn parse_expression(
                 env_vars.push(sh.1);
             }
 
-            let positional = vec![
-                Expression {
+            let arguments = vec![
+                Argument::Positional(Expression {
                     expr: Expr::List(env_vars),
                     span: span(&spans[..pos]),
                     ty: Type::Any,
                     custom_completion: None,
-                },
-                Expression {
+                }),
+                Argument::Positional(Expression {
                     expr: Expr::Block(block_id),
                     span: span(&spans[pos..]),
                     ty,
                     custom_completion: None,
-                },
+                }),
             ];
 
             let expr = Expr::Call(Box::new(Call {
                 head: Span { start: 0, end: 0 },
                 decl_id,
-                named: vec![],
-                positional,
+                arguments: arguments,
                 redirect_stdout: true,
                 redirect_stderr: false,
             }));
@@ -4646,7 +4645,7 @@ pub fn parse_block(
                                         if let Some(Expression {
                                             expr: Expr::Keyword(_, _, expr),
                                             ..
-                                        }) = call.positional.get_mut(1)
+                                        }) = call.positional_iter_mut().nth(1)
                                         {
                                             if expr.has_in_variable(working_set) {
                                                 *expr = Box::new(wrap_expr_with_collect(
@@ -4794,14 +4793,14 @@ pub fn discover_captures_in_expr(
                 }
             }
 
-            for named in &call.named {
+            for named in call.named_iter() {
                 if let Some(arg) = &named.1 {
                     let result = discover_captures_in_expr(working_set, arg, seen, seen_blocks);
                     output.extend(&result);
                 }
             }
 
-            for positional in &call.positional {
+            for positional in call.positional_iter() {
                 let result = discover_captures_in_expr(working_set, positional, seen, seen_blocks);
                 output.extend(&result);
             }
@@ -4969,12 +4968,12 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
 
         let block_id = working_set.add_block(block);
 
-        output.push(Expression {
+        output.push(Argument::Positional(Expression {
             expr: Expr::Block(block_id),
             span,
             ty: Type::Any,
             custom_completion: None,
-        });
+        }));
 
         // The containing, synthetic call to `collect`.
         // We don't want to have a real span as it will confuse flattening
@@ -4982,8 +4981,7 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
         Expression {
             expr: Expr::Call(Box::new(Call {
                 head: Span::new(0, 0),
-                named: vec![],
-                positional: output,
+                arguments: output,
                 decl_id,
                 redirect_stdout: true,
                 redirect_stderr: false,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -132,7 +132,7 @@ pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseEr
         return None;
     }
 
-    if call.positional_iter().count() < sig.required_positional.len() {
+    if call.positional_len() < sig.required_positional.len() {
         // Comparing the types of all signature positional arguments against the parsed
         // expressions found in the call. If one type is not found then it could be assumed
         // that that positional argument is missing from the parsed call
@@ -167,7 +167,7 @@ pub fn check_call(command: Span, sig: &Signature, call: &Call) -> Option<ParseEr
             }
         }
 
-        let missing = &sig.required_positional[call.positional_iter().count()];
+        let missing = &sig.required_positional[call.positional_len()];
         if let Some(last) = call.positional_iter().last() {
             Some(ParseError::MissingPositional(
                 missing.name.clone(),

--- a/crates/nu-plugin/src/protocol/evaluated_call.rs
+++ b/crates/nu-plugin/src/protocol/evaluated_call.rs
@@ -28,7 +28,7 @@ impl EvaluatedCall {
             .map(|expr| eval_expression(engine_state, stack, expr))
             .collect::<Result<Vec<Value>, ShellError>>()?;
 
-        let mut named = Vec::with_capacity(call.named_iter().count());
+        let mut named = Vec::with_capacity(call.named_len());
         for (string, expr) in call.named_iter() {
             let value = match expr {
                 None => None,

--- a/crates/nu-plugin/src/protocol/evaluated_call.rs
+++ b/crates/nu-plugin/src/protocol/evaluated_call.rs
@@ -24,13 +24,12 @@ impl EvaluatedCall {
         stack: &mut Stack,
     ) -> Result<Self, ShellError> {
         let positional = call
-            .positional
-            .iter()
+            .positional_iter()
             .map(|expr| eval_expression(engine_state, stack, expr))
             .collect::<Result<Vec<Value>, ShellError>>()?;
 
-        let mut named = Vec::with_capacity(call.named.len());
-        for (string, expr) in call.named.iter() {
+        let mut named = Vec::with_capacity(call.named_iter().count());
+        for (string, expr) in call.named_iter() {
             let value = match expr {
                 None => None,
                 Some(expr) => Some(eval_expression(engine_state, stack, expr)?),

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -68,6 +68,14 @@ impl Call {
         })
     }
 
+    pub fn positional_nth(&self, i: usize) -> Option<&Expression> {
+        self.positional_iter().nth(i)
+    }
+
+    pub fn positional_len(&self) -> usize {
+        self.positional_iter().count()
+    }
+
     pub fn has_flag(&self, flag_name: &str) -> bool {
         for name in self.named_iter() {
             if flag_name == name.0.item {
@@ -96,10 +104,6 @@ impl Call {
         }
 
         None
-    }
-
-    pub fn nth(&self, pos: usize) -> Option<Expression> {
-        self.positional_iter().nth(pos).cloned()
     }
 
     pub fn span(&self) -> Span {

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -3,13 +3,19 @@ use serde::{Deserialize, Serialize};
 use super::Expression;
 use crate::{DeclId, Span, Spanned};
 
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Argument {
+    Positional(Expression),
+    Named((Spanned<String>, Option<Expression>)),
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Call {
     /// identifier of the declaration to call
     pub decl_id: DeclId,
     pub head: Span,
-    pub positional: Vec<Expression>,
-    pub named: Vec<(Spanned<String>, Option<Expression>)>,
+    pub arguments: Vec<Argument>,
     pub redirect_stdout: bool,
     pub redirect_stderr: bool,
 }
@@ -19,15 +25,58 @@ impl Call {
         Self {
             decl_id: 0,
             head,
-            positional: vec![],
-            named: vec![],
+            arguments: vec![],
             redirect_stdout: true,
             redirect_stderr: false,
         }
     }
 
+    pub fn named_iter(&self) -> impl Iterator<Item=&(Spanned<String>, Option<Expression>)> {
+        self.arguments
+            .iter()
+            .filter_map(|arg| match arg {
+                Argument::Named(named) => Some(named),
+                Argument::Positional(_) => None,
+            })
+    }
+
+    pub fn named_iter_mut(&mut self) -> impl Iterator<Item=&mut (Spanned<String>, Option<Expression>)> {
+        self.arguments
+            .iter_mut()
+            .filter_map(|arg| match arg {
+                Argument::Named(named) => Some(named),
+                Argument::Positional(_) => None,
+            })
+    }
+
+    pub fn add_named(&mut self, named: (Spanned<String>, Option<Expression>)) {
+        self.arguments.push(Argument::Named(named));
+    }
+
+    pub fn add_positional(&mut self, positional: Expression) {
+        self.arguments.push(Argument::Positional(positional));
+    }
+
+    pub fn positional_iter(&self) -> impl Iterator<Item=&Expression> {
+        self.arguments
+            .iter()
+            .filter_map(|arg| match arg {
+                Argument::Named(_) => None,
+                Argument::Positional(positional) => Some(positional),
+            })
+    }
+
+    pub fn positional_iter_mut(&mut self) -> impl Iterator<Item=&mut Expression> {
+        self.arguments
+            .iter_mut()
+            .filter_map(|arg| match arg {
+                Argument::Named(_) => None,
+                Argument::Positional(positional) => Some(positional),
+            })
+    }
+
     pub fn has_flag(&self, flag_name: &str) -> bool {
-        for name in &self.named {
+        for name in self.named_iter() {
             if flag_name == name.0.item {
                 return true;
             }
@@ -37,7 +86,7 @@ impl Call {
     }
 
     pub fn get_flag_expr(&self, flag_name: &str) -> Option<Expression> {
-        for name in &self.named {
+        for name in self.named_iter() {
             if flag_name == name.0.item {
                 return name.1.clone();
             }
@@ -47,7 +96,7 @@ impl Call {
     }
 
     pub fn get_named_arg(&self, flag_name: &str) -> Option<Spanned<String>> {
-        for name in &self.named {
+        for name in self.named_iter() {
             if flag_name == name.0.item {
                 return Some(name.0.clone());
             }
@@ -57,19 +106,19 @@ impl Call {
     }
 
     pub fn nth(&self, pos: usize) -> Option<Expression> {
-        self.positional.get(pos).cloned()
+        self.positional_iter().nth(pos).cloned()
     }
 
     pub fn span(&self) -> Span {
         let mut span = self.head;
 
-        for positional in &self.positional {
+        for positional in self.positional_iter() {
             if positional.span.end > span.end {
                 span.end = positional.span.end;
             }
         }
 
-        for (named, val) in &self.named {
+        for (named, val) in self.named_iter() {
             if named.span.end > span.end {
                 span.end = named.span.end;
             }

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -46,6 +46,10 @@ impl Call {
         })
     }
 
+    pub fn named_len(&self) -> usize {
+        self.named_iter().count()
+    }
+
     pub fn add_named(&mut self, named: (Spanned<String>, Option<Expression>)) {
         self.arguments.push(Argument::Named(named));
     }

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use super::Expression;
 use crate::{DeclId, Span, Spanned};
 
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Argument {
     Positional(Expression),
@@ -31,22 +30,20 @@ impl Call {
         }
     }
 
-    pub fn named_iter(&self) -> impl Iterator<Item=&(Spanned<String>, Option<Expression>)> {
-        self.arguments
-            .iter()
-            .filter_map(|arg| match arg {
-                Argument::Named(named) => Some(named),
-                Argument::Positional(_) => None,
-            })
+    pub fn named_iter(&self) -> impl Iterator<Item = &(Spanned<String>, Option<Expression>)> {
+        self.arguments.iter().filter_map(|arg| match arg {
+            Argument::Named(named) => Some(named),
+            Argument::Positional(_) => None,
+        })
     }
 
-    pub fn named_iter_mut(&mut self) -> impl Iterator<Item=&mut (Spanned<String>, Option<Expression>)> {
-        self.arguments
-            .iter_mut()
-            .filter_map(|arg| match arg {
-                Argument::Named(named) => Some(named),
-                Argument::Positional(_) => None,
-            })
+    pub fn named_iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut (Spanned<String>, Option<Expression>)> {
+        self.arguments.iter_mut().filter_map(|arg| match arg {
+            Argument::Named(named) => Some(named),
+            Argument::Positional(_) => None,
+        })
     }
 
     pub fn add_named(&mut self, named: (Spanned<String>, Option<Expression>)) {
@@ -57,22 +54,18 @@ impl Call {
         self.arguments.push(Argument::Positional(positional));
     }
 
-    pub fn positional_iter(&self) -> impl Iterator<Item=&Expression> {
-        self.arguments
-            .iter()
-            .filter_map(|arg| match arg {
-                Argument::Named(_) => None,
-                Argument::Positional(positional) => Some(positional),
-            })
+    pub fn positional_iter(&self) -> impl Iterator<Item = &Expression> {
+        self.arguments.iter().filter_map(|arg| match arg {
+            Argument::Named(_) => None,
+            Argument::Positional(positional) => Some(positional),
+        })
     }
 
-    pub fn positional_iter_mut(&mut self) -> impl Iterator<Item=&mut Expression> {
-        self.arguments
-            .iter_mut()
-            .filter_map(|arg| match arg {
-                Argument::Named(_) => None,
-                Argument::Positional(positional) => Some(positional),
-            })
+    pub fn positional_iter_mut(&mut self) -> impl Iterator<Item = &mut Expression> {
+        self.arguments.iter_mut().filter_map(|arg| match arg {
+            Argument::Named(_) => None,
+            Argument::Positional(positional) => Some(positional),
+        })
     }
 
     pub fn has_flag(&self, flag_name: &str) -> bool {

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -133,12 +133,12 @@ impl Expression {
             Expr::Binary(_) => false,
             Expr::Bool(_) => false,
             Expr::Call(call) => {
-                for positional in &call.positional {
+                for positional in call.positional_iter() {
                     if positional.has_in_variable(working_set) {
                         return true;
                     }
                 }
-                for named in &call.named {
+                for named in call.named_iter() {
                     if let Some(expr) = &named.1 {
                         if expr.has_in_variable(working_set) {
                             return true;
@@ -302,10 +302,10 @@ impl Expression {
             Expr::Binary(_) => {}
             Expr::Bool(_) => {}
             Expr::Call(call) => {
-                for positional in &mut call.positional {
+                for positional in call.positional_iter_mut() {
                     positional.replace_in_variable(working_set, new_var_id);
                 }
-                for named in &mut call.named {
+                for named in call.named_iter_mut() {
                     if let Some(expr) = &mut named.1 {
                         expr.replace_in_variable(working_set, new_var_id)
                     }
@@ -449,10 +449,10 @@ impl Expression {
                 if replaced.contains_span(call.head) {
                     call.head = new_span;
                 }
-                for positional in &mut call.positional {
+                for positional in call.positional_iter_mut() {
                     positional.replace_span(working_set, replaced, new_span);
                 }
-                for named in &mut call.named {
+                for named in call.named_iter_mut() {
                     if let Some(expr) = &mut named.1 {
                         expr.replace_span(working_set, replaced, new_span)
                     }


### PR DESCRIPTION
# Description

This PR proposes a change to the `Call` struct to store both named and positional arguments in a single vector. By doing so, the parser can track the full order in which arguments were passed. Prior to this, we would lose the original order, because we stored named and positional arguments separately.

This PR was prompted by issue #5015 . For known externals, we've so far had to re-parse the command to extract the original order, because that is required by some commands. However, when re-parsing in the context of a block (or command), the parser cannot find the arguments of the block, so they become lost.

Example:

```
extern "bat" [
    filename: string
]

def read-bat [filename] {
    bat $filename
} 

>>> read-bat some-file
Error: nu::shell::external_command (link)

  × External command
   ╭─[entry #5:1:1]
 1 │ def read-bat [filename] { bat $filename }
   ·                            ─┬
   ·                             ╰── Cannot convert argument to a string
   ╰────
  help: All arguments to an external command need to be string-compatible
```

The above error occurs because `$filename` is not found when re-parsing.

With this change, we no longer have to re-parse and can directly read out the original order of the arguments. This fixes the above error (indirectly, by avoiding re-parsing altogether).

A few notes:

- `Call.nth` could return a reference the `nth` positional, instead of a cloned value. We access specific positionals quite often and because `positional` is no longer available, `nth` sounds like a good replacement. We could then call `cloned` at the specific places where we want to clone the value.
- The above would also fix the clippy lints which point out that we should use `iter().next()` instead of `iter().nth(0)`. I don't really agree with this lint right now, because `iter().nth(0)` conveys our intention more accurately.
- 2 tests are failing, but are not related to this PR. I'll rebase on the main branch once those are fixed.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
