### PR TITLE
nu-cli/completions: removed default filter for command

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -266,4 +266,9 @@ impl<'a> Completer for CommandCompletion<'a> {
 
         (output, options)
     }
+
+    // Replace base filter with no filter once all the results are already based in the current path
+    fn filter(&self, _: Vec<u8>, items: Vec<Suggestion>, _: CompletionOptions) -> Vec<Suggestion> {
+        items
+    }
 }


### PR DESCRIPTION
# Description

Removes the default filter for command completions due to issues with commands like `ls`.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
