### PR TITLE
Don't consume pipeline with in

### DIFF
--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -1,7 +1,9 @@
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape, Value};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, Signature, SyntaxShape, Value,
+};
 
 #[derive(Clone)]
 pub struct Collect;
@@ -42,7 +44,7 @@ impl Command for Collect {
 
         if let Some(var) = block.signature.get_positional(0) {
             if let Some(var_id) = &var.var_id {
-                stack.add_var(*var_id, input);
+                stack.add_var(*var_id, input.clone());
             }
         }
 
@@ -50,7 +52,7 @@ impl Command for Collect {
             engine_state,
             &mut stack,
             &block,
-            PipelineData::new(call.head),
+            input.into_pipeline_data(),
             call.redirect_stdout,
             call.redirect_stderr,
         )


### PR DESCRIPTION
# Description

An experiment: if you use `$in`, also keep the same value as input to the command in the pipeline.

For example, now this would work: `ls | take (($in | length) - 3)`

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
