### PR TITLE
Soften the block arity checking

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3630,7 +3630,7 @@ pub fn parse_block_expression(
     // TODO: Finish this
     if let SyntaxShape::Block(Some(v)) = shape {
         if let Some((sig, sig_span)) = &signature {
-            if sig.num_positionals() != v.len() {
+            if sig.num_positionals() > v.len() {
                 error = error.or_else(|| {
                     Some(ParseError::Expected(
                         format!(
@@ -3657,20 +3657,6 @@ pub fn parse_block_expression(
                     });
                 }
             }
-        } else if !v.is_empty() {
-            error = error.or_else(|| {
-                Some(ParseError::Expected(
-                    format!(
-                        "{} block parameter{}",
-                        v.len(),
-                        if v.len() > 1 { "s" } else { "" }
-                    ),
-                    Span {
-                        start: span.start + 1,
-                        end: span.start + 1,
-                    },
-                ))
-            });
         }
     }
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -330,16 +330,6 @@ fn proper_missing_param() -> TestResult {
 
 #[test]
 fn block_arity_check1() -> TestResult {
-    fail_test(r#"ls | each { 1 }"#, "expected 1 block parameter")
-}
-
-#[test]
-fn block_arity_check2() -> TestResult {
-    fail_test(r#"ls | reduce { 1 }"#, "expected 2 block parameters")
-}
-
-#[test]
-fn block_arity_check3() -> TestResult {
     fail_test(r#"ls | each { |x, y| 1}"#, "expected 1 block parameter")
 }
 


### PR DESCRIPTION
# Description

This softens the block arity checking. Now, we only error if you say the block takes in more parameters than what will be provided:

```
> ls | each { 4 }  # now okay, we're just ignoring the parameter
```
```
> ls | each { |x, y| $y } # still errors, we don't have two parameters to give the block
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
