### PR TITLE
Let 'each' also send input to block

### DIFF
--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, Signature, Span, SyntaxShape,
-    Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
+    Span, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -150,13 +150,13 @@ impl Command for Each {
                                                 val: idx as i64,
                                                 span,
                                             },
-                                            x,
+                                            x.clone(),
                                         ],
                                         span,
                                     },
                                 );
                             } else {
-                                stack.add_var(*var_id, x);
+                                stack.add_var(*var_id, x.clone());
                             }
                         }
                     }
@@ -165,7 +165,7 @@ impl Command for Each {
                         &engine_state,
                         &mut stack,
                         &block,
-                        PipelineData::new(span),
+                        x.into_pipeline_data(),
                         redirect_stdout,
                         redirect_stderr,
                     ) {
@@ -201,13 +201,13 @@ impl Command for Each {
                                                 val: idx as i64,
                                                 span,
                                             },
-                                            x,
+                                            x.clone(),
                                         ],
                                         span,
                                     },
                                 );
                             } else {
-                                stack.add_var(*var_id, x);
+                                stack.add_var(*var_id, x.clone());
                             }
                         }
                     }
@@ -216,7 +216,7 @@ impl Command for Each {
                         &engine_state,
                         &mut stack,
                         &block,
-                        PipelineData::new(span),
+                        x.into_pipeline_data(),
                         redirect_stdout,
                         redirect_stderr,
                     ) {
@@ -228,7 +228,7 @@ impl Command for Each {
             PipelineData::Value(x, ..) => {
                 if let Some(var) = block.signature.get_positional(0) {
                     if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, x);
+                        stack.add_var(*var_id, x.clone());
                     }
                 }
 
@@ -236,7 +236,7 @@ impl Command for Each {
                     &engine_state,
                     &mut stack,
                     &block,
-                    PipelineData::new(span),
+                    x.into_pipeline_data(),
                     redirect_stdout,
                     redirect_stderr,
                 )


### PR DESCRIPTION
# Description

Companion with #5135 

This changes `each` so that it also sends each item as a single-element stream to the block. This lets you either use the parameter, if you want, or to work over each element as a single-element input.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
