### PR TITLE
Improve `$in` handling

### DIFF
--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -1,7 +1,9 @@
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, Signature, SyntaxShape, Value};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, Signature, SyntaxShape, Value,
+};
 
 #[derive(Clone)]
 pub struct Collect;
@@ -42,7 +44,7 @@ impl Command for Collect {
 
         if let Some(var) = block.signature.get_positional(0) {
             if let Some(var_id) = &var.var_id {
-                stack.add_var(*var_id, input);
+                stack.add_var(*var_id, input.clone());
             }
         }
 
@@ -50,7 +52,7 @@ impl Command for Collect {
             engine_state,
             &mut stack,
             &block,
-            PipelineData::new(call.head),
+            input.into_pipeline_data(),
             call.redirect_stdout,
             call.redirect_stderr,
         )

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -89,7 +89,8 @@ impl Command for FromNuon {
         let (lite_block, err) = nu_parser::lite_parse(&lexed);
         error = error.or(err);
 
-        let (mut block, err) = nu_parser::parse_block(&mut working_set, &lite_block, true, &[]);
+        let (mut block, err) =
+            nu_parser::parse_block(&mut working_set, &lite_block, true, &[], false);
         error = error.or(err);
 
         if let Some(pipeline) = block.pipelines.get(1) {

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -19,7 +19,7 @@ fn quickcheck_parse(data: String) -> bool {
             let mut working_set = StateWorkingSet::new(&context);
             working_set.add_file("quickcheck".into(), data.as_bytes());
 
-            let _ = nu_parser::parse_block(&mut working_set, &lite_block, false, &[]);
+            let _ = nu_parser::parse_block(&mut working_set, &lite_block, false, &[], false);
         }
     }
     true

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1776,7 +1776,8 @@ pub fn parse_full_cell_path(
             let (output, err) = lite_parse(&output);
             error = error.or(err);
 
-            let (output, err) = parse_block(working_set, &output, true, expand_aliases_denylist);
+            let (output, err) =
+                parse_block(working_set, &output, true, expand_aliases_denylist, true);
             error = error.or(err);
 
             let block_id = working_set.add_block(output);
@@ -3674,7 +3675,8 @@ pub fn parse_block_expression(
         }
     }
 
-    let (mut output, err) = parse_block(working_set, &output, false, expand_aliases_denylist);
+    let (mut output, err) =
+        parse_block(working_set, &output, false, expand_aliases_denylist, false);
     error = error.or(err);
 
     if let Some(signature) = signature {
@@ -4584,6 +4586,7 @@ pub fn parse_block(
     lite_block: &LiteBlock,
     scoped: bool,
     expand_aliases_denylist: &[usize],
+    is_subexpression: bool,
 ) -> (Block, Option<ParseError>) {
     trace!("parsing block: {:?}", lite_block);
 
@@ -4628,9 +4631,17 @@ pub fn parse_block(
                     })
                     .collect::<Vec<Expression>>();
 
-                for expr in output.iter_mut().skip(1) {
-                    if expr.has_in_variable(working_set) {
-                        *expr = wrap_expr_with_collect(working_set, expr);
+                if is_subexpression {
+                    for expr in output.iter_mut().skip(1) {
+                        if expr.has_in_variable(working_set) {
+                            *expr = wrap_expr_with_collect(working_set, expr);
+                        }
+                    }
+                } else {
+                    for expr in output.iter_mut() {
+                        if expr.has_in_variable(working_set) {
+                            *expr = wrap_expr_with_collect(working_set, expr);
+                        }
                     }
                 }
 
@@ -4670,7 +4681,11 @@ pub fn parse_block(
                                             }
                                         }
                                         continue;
+                                    } else if expr.has_in_variable(working_set) {
+                                        *expr = wrap_expr_with_collect(working_set, expr);
                                     }
+                                } else if expr.has_in_variable(working_set) {
+                                    *expr = wrap_expr_with_collect(working_set, expr);
                                 }
                             }
                         }
@@ -5040,7 +5055,8 @@ pub fn parse(
     let (output, err) = lite_parse(&output);
     error = error.or(err);
 
-    let (mut output, err) = parse_block(working_set, &output, scoped, expand_aliases_denylist);
+    let (mut output, err) =
+        parse_block(working_set, &output, scoped, expand_aliases_denylist, false);
     error = error.or(err);
 
     let mut seen = vec![];

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4667,10 +4667,11 @@ pub fn parse_block(
                                             }
                                         }
                                         continue;
-                                    } else if expr.has_in_variable(working_set) {
+                                    } else if expr.has_in_variable(working_set) && !is_subexpression
+                                    {
                                         *expr = wrap_expr_with_collect(working_set, expr);
                                     }
-                                } else if expr.has_in_variable(working_set) {
+                                } else if expr.has_in_variable(working_set) && !is_subexpression {
                                     *expr = wrap_expr_with_collect(working_set, expr);
                                 }
                             }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -350,3 +350,19 @@ fn loose_each() -> TestResult {
 fn in_means_input() -> TestResult {
     run_test(r#"def shl [] { $in * 2 }; 2 | shl"#, "4")
 }
+
+#[test]
+fn in_iteration() -> TestResult {
+    run_test(
+        r#"[3, 4, 5] | each { echo $"hi ($in)" } | str collect"#,
+        "hi 3hi 4hi 5",
+    )
+}
+
+#[test]
+fn reuseable_in() -> TestResult {
+    run_test(
+        r#"[1, 2, 3, 4] | take (($in | length) - 1) | math sum"#,
+        "6",
+    )
+}

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -340,3 +340,13 @@ fn default_value11() -> TestResult {
 fn default_value12() -> TestResult {
     fail_test(r#"def foo [--x:int = "a"] { $x }"#, "default value not int")
 }
+
+#[test]
+fn loose_each() -> TestResult {
+    run_test(r#"[[1, 2, 3], [4, 5, 6]] | each { $in.1 } | math sum"#, "7")
+}
+
+#[test]
+fn in_means_input() -> TestResult {
+    run_test(r#"def shl [] { $in * 2 }; 2 | shl"#, "4")
+}


### PR DESCRIPTION
# Description

With this PR (and #5136  and #5135), we hopefully take a step towards `$in` being a bit more universal and easier to predict.

Examples that now work:

```
> [1, 2, 3] | do { $in.1 }
> [1, 2, 3] | $in.2
> [3, 4, 5] | each { print $"hi ($in)" }
> ls | take (($in | length) - 13)
> def second [] { $in.1 }
```

This also now works:
```
> def shl [] { $in * 2 }; 2 | shl
```

Basically when you say `$in` you can mean the input coming into that position. This improves on the previous design in a few ways:

* Using `$in` does not remove the previous input. Now, you can use both `$in` and still have the input (allowing you to do that `take` example above. This doesn't change anything after the first statement (which would not have the input given to the block)
* Using `$in` at the start of a block now works, and will take in the input given to the block.

fixes #4459

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
