### PR TITLE
Fix known externals, fix operator spans

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -305,13 +305,13 @@ fn find_with_rest(
                 | Value::Block { .. }
                 | Value::Nothing { .. }
                 | Value::Error { .. } => lower_value
-                    .eq(span, term)
+                    .eq(span, term, span)
                     .map_or(false, |value| value.is_true()),
                 Value::String { .. }
                 | Value::List { .. }
                 | Value::CellPath { .. }
                 | Value::CustomValue { .. } => term
-                    .r#in(span, &lower_value)
+                    .r#in(span, &lower_value, span)
                     .map_or(false, |value| value.is_true()),
                 Value::Record { vals, .. } => vals.iter().any(|val| {
                     if let Ok(span) = val.span() {
@@ -320,10 +320,11 @@ fn find_with_rest(
                             Span::test_data(),
                         );
 
-                        term.r#in(span, &lower_val)
+                        term.r#in(span, &lower_val, span)
                             .map_or(false, |value| value.is_true())
                     } else {
-                        term.r#in(span, val).map_or(false, |value| value.is_true())
+                        term.r#in(span, val, span)
+                            .map_or(false, |value| value.is_true())
                     }
                 }),
                 Value::Binary { .. } => false,

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -67,6 +67,7 @@ pub fn average(values: &[Value], head: &Span) -> Result<Value, ShellError> {
                 val: values.len() as i64,
                 span: *head,
             },
+            *head,
         ),
     }
 }

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -98,7 +98,7 @@ pub fn sum(data: Vec<Value>, head: Span) -> Result<Value, ShellError> {
             | Value::Float { .. }
             | Value::Filesize { .. }
             | Value::Duration { .. } => {
-                acc = acc.add(head, value)?;
+                acc = acc.add(head, value, head)?;
             }
             other => {
                 return Err(ShellError::UnsupportedInput(
@@ -129,7 +129,7 @@ pub fn product(data: Vec<Value>, head: Span) -> Result<Value, ShellError> {
     for value in &data {
         match value {
             Value::Int { .. } | Value::Float { .. } => {
-                acc = acc.mul(head, value)?;
+                acc = acc.mul(head, value, head)?;
             }
             other => {
                 return Err(ShellError::UnsupportedInput(

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -78,15 +78,15 @@ fn sum_of_squares(values: &[Value], span: &Span) -> Result<Value, ShellError> {
                     value.span().unwrap_or(*span),
                 ))
         }?;
-        let v_squared = &v.mul(*span, v)?;
-        sum_x2 = sum_x2.add(*span, v_squared)?;
-        sum_x = sum_x.add(*span, v)?;
+        let v_squared = &v.mul(*span, v, *span)?;
+        sum_x2 = sum_x2.add(*span, v_squared, *span)?;
+        sum_x = sum_x.add(*span, v, *span)?;
     }
 
-    let sum_x_squared = sum_x.mul(*span, &sum_x)?;
-    let sum_x_squared_div_n = sum_x_squared.div(*span, &n)?;
+    let sum_x_squared = sum_x.mul(*span, &sum_x, *span)?;
+    let sum_x_squared_div_n = sum_x_squared.div(*span, &n, *span)?;
 
-    let ss = sum_x2.sub(*span, &sum_x_squared_div_n)?;
+    let ss = sum_x2.sub(*span, &sum_x_squared_div_n, *span)?;
 
     Ok(ss)
 }
@@ -111,7 +111,7 @@ pub fn compute_variance(sample: bool) -> impl Fn(&[Value], &Span) -> Result<Valu
             val: n as i64,
             span: *span,
         };
-        ss.div(*span, &n)
+        ss.div(*span, &n, *span)
     }
 }
 

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
@@ -65,7 +65,7 @@ impl Command for KeybindingsList {
                 .collect()
         } else {
             call.named_iter()
-                .flat_map(|(argument, _)| get_records(argument.item.as_str(), &call.head))
+                .flat_map(|(argument, _, _)| get_records(argument.item.as_str(), &call.head))
                 .collect()
         };
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -32,7 +32,7 @@ pub fn eval_call(
 ) -> Result<PipelineData, ShellError> {
     let decl = engine_state.get_decl(call.decl_id);
 
-    if !decl.is_known_external() && call.named_iter().any(|(flag, _)| flag.item == "help") {
+    if !decl.is_known_external() && call.named_iter().any(|(flag, _, _)| flag.item == "help") {
         let mut signature = decl.signature();
         signature.usage = decl.usage().to_string();
         signature.extra_usage = decl.extra_usage().to_string();
@@ -103,7 +103,7 @@ pub fn eval_call(
                 let mut found = false;
                 for call_named in call.named_iter() {
                     if call_named.0.item == named.long {
-                        if let Some(arg) = &call_named.1 {
+                        if let Some(arg) = &call_named.2 {
                             let result = eval_expression(engine_state, caller_stack, arg)?;
 
                             callee_stack.add_var(var_id, result);
@@ -211,6 +211,7 @@ fn eval_external(
                 span: head.span,
             },
             None,
+            None,
         ))
     }
 
@@ -220,6 +221,7 @@ fn eval_external(
                 item: "redirect-stderr".into(),
                 span: head.span,
             },
+            None,
             None,
         ))
     }
@@ -343,7 +345,7 @@ pub fn eval_expression(
                         })
                     } else {
                         let rhs = eval_expression(engine_state, stack, rhs)?;
-                        lhs.and(op_span, &rhs)
+                        lhs.and(op_span, &rhs, expr.span)
                     }
                 }
                 Operator::Or => {
@@ -354,76 +356,76 @@ pub fn eval_expression(
                         })
                     } else {
                         let rhs = eval_expression(engine_state, stack, rhs)?;
-                        lhs.or(op_span, &rhs)
+                        lhs.or(op_span, &rhs, expr.span)
                     }
                 }
                 Operator::Plus => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.add(op_span, &rhs)
+                    lhs.add(op_span, &rhs, expr.span)
                 }
                 Operator::Minus => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.sub(op_span, &rhs)
+                    lhs.sub(op_span, &rhs, expr.span)
                 }
                 Operator::Multiply => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.mul(op_span, &rhs)
+                    lhs.mul(op_span, &rhs, expr.span)
                 }
                 Operator::Divide => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.div(op_span, &rhs)
+                    lhs.div(op_span, &rhs, expr.span)
                 }
                 Operator::LessThan => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.lt(op_span, &rhs)
+                    lhs.lt(op_span, &rhs, expr.span)
                 }
                 Operator::LessThanOrEqual => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.lte(op_span, &rhs)
+                    lhs.lte(op_span, &rhs, expr.span)
                 }
                 Operator::GreaterThan => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.gt(op_span, &rhs)
+                    lhs.gt(op_span, &rhs, expr.span)
                 }
                 Operator::GreaterThanOrEqual => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.gte(op_span, &rhs)
+                    lhs.gte(op_span, &rhs, expr.span)
                 }
                 Operator::Equal => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.eq(op_span, &rhs)
+                    lhs.eq(op_span, &rhs, expr.span)
                 }
                 Operator::NotEqual => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.ne(op_span, &rhs)
+                    lhs.ne(op_span, &rhs, expr.span)
                 }
                 Operator::In => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.r#in(op_span, &rhs)
+                    lhs.r#in(op_span, &rhs, expr.span)
                 }
                 Operator::NotIn => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.not_in(op_span, &rhs)
+                    lhs.not_in(op_span, &rhs, expr.span)
                 }
                 Operator::RegexMatch => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.regex_match(op_span, &rhs, false)
+                    lhs.regex_match(op_span, &rhs, false, expr.span)
                 }
                 Operator::NotRegexMatch => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.regex_match(op_span, &rhs, true)
+                    lhs.regex_match(op_span, &rhs, true, expr.span)
                 }
                 Operator::Modulo => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.modulo(op_span, &rhs)
+                    lhs.modulo(op_span, &rhs, expr.span)
                 }
                 Operator::Pow => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.pow(op_span, &rhs)
+                    lhs.pow(op_span, &rhs, expr.span)
                 }
                 Operator::StartsWith => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
-                    lhs.starts_with(op_span, &rhs)
+                    lhs.starts_with(op_span, &rhs, expr.span)
                 }
             }
         }

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -150,7 +150,7 @@ pub fn flatten_expression(
             }
             for named in call.named_iter() {
                 args.push((named.0.span, FlatShape::Flag));
-                if let Some(expr) = &named.1 {
+                if let Some(expr) = &named.2 {
                     args.extend(flatten_expression(working_set, expr));
                 }
             }

--- a/crates/nu-plugin/src/protocol/evaluated_call.rs
+++ b/crates/nu-plugin/src/protocol/evaluated_call.rs
@@ -29,7 +29,7 @@ impl EvaluatedCall {
             .collect::<Result<Vec<Value>, ShellError>>()?;
 
         let mut named = Vec::with_capacity(call.named_len());
-        for (string, expr) in call.named_iter() {
+        for (string, _, expr) in call.named_iter() {
             let value = match expr {
                 None => None,
                 Some(expr) => Some(eval_expression(engine_state, stack, expr)?),

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -6,7 +6,7 @@ use crate::{DeclId, Span, Spanned};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Argument {
     Positional(Expression),
-    Named((Spanned<String>, Option<Expression>)),
+    Named((Spanned<String>, Option<Spanned<String>>, Option<Expression>)),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -30,7 +30,9 @@ impl Call {
         }
     }
 
-    pub fn named_iter(&self) -> impl Iterator<Item = &(Spanned<String>, Option<Expression>)> {
+    pub fn named_iter(
+        &self,
+    ) -> impl Iterator<Item = &(Spanned<String>, Option<Spanned<String>>, Option<Expression>)> {
         self.arguments.iter().filter_map(|arg| match arg {
             Argument::Named(named) => Some(named),
             Argument::Positional(_) => None,
@@ -39,7 +41,8 @@ impl Call {
 
     pub fn named_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = &mut (Spanned<String>, Option<Expression>)> {
+    ) -> impl Iterator<Item = &mut (Spanned<String>, Option<Spanned<String>>, Option<Expression>)>
+    {
         self.arguments.iter_mut().filter_map(|arg| match arg {
             Argument::Named(named) => Some(named),
             Argument::Positional(_) => None,
@@ -50,7 +53,10 @@ impl Call {
         self.named_iter().count()
     }
 
-    pub fn add_named(&mut self, named: (Spanned<String>, Option<Expression>)) {
+    pub fn add_named(
+        &mut self,
+        named: (Spanned<String>, Option<Spanned<String>>, Option<Expression>),
+    ) {
         self.arguments.push(Argument::Named(named));
     }
 
@@ -93,7 +99,7 @@ impl Call {
     pub fn get_flag_expr(&self, flag_name: &str) -> Option<Expression> {
         for name in self.named_iter() {
             if flag_name == name.0.item {
-                return name.1.clone();
+                return name.2.clone();
             }
         }
 
@@ -119,7 +125,7 @@ impl Call {
             }
         }
 
-        for (named, val) in self.named_iter() {
+        for (named, _, val) in self.named_iter() {
             if named.span.end > span.end {
                 span.end = named.span.end;
             }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -139,7 +139,7 @@ impl Expression {
                     }
                 }
                 for named in call.named_iter() {
-                    if let Some(expr) = &named.1 {
+                    if let Some(expr) = &named.2 {
                         if expr.has_in_variable(working_set) {
                             return true;
                         }
@@ -306,7 +306,7 @@ impl Expression {
                     positional.replace_in_variable(working_set, new_var_id);
                 }
                 for named in call.named_iter_mut() {
-                    if let Some(expr) = &mut named.1 {
+                    if let Some(expr) = &mut named.2 {
                         expr.replace_in_variable(working_set, new_var_id)
                     }
                 }
@@ -453,7 +453,7 @@ impl Expression {
                     positional.replace_span(working_set, replaced, new_span);
                 }
                 for named in call.named_iter_mut() {
-                    if let Some(expr) = &mut named.1 {
+                    if let Some(expr) = &mut named.2 {
                         expr.replace_span(working_set, replaced, new_span)
                     }
                 }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::{cmp::Ordering, fmt::Debug};
 
 use crate::ast::{CellPath, PathMember};
-use crate::{did_you_mean, span, BlockId, Config, Span, Spanned, Type, VarId};
+use crate::{did_you_mean, BlockId, Config, Span, Spanned, Type, VarId};
 
 use crate::ast::Operator;
 pub use custom_value::CustomValue;
@@ -1413,9 +1413,7 @@ impl PartialEq for Value {
 }
 
 impl Value {
-    pub fn add(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn add(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_add(*rhs) {
@@ -1486,9 +1484,7 @@ impl Value {
             }),
         }
     }
-    pub fn sub(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn sub(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_sub(*rhs) {
@@ -1566,9 +1562,7 @@ impl Value {
             }),
         }
     }
-    pub fn mul(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn mul(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_mul(*rhs) {
@@ -1629,9 +1623,7 @@ impl Value {
             }),
         }
     }
-    pub fn div(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn div(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if *rhs != 0 {
@@ -1747,9 +1739,7 @@ impl Value {
             }),
         }
     }
-    pub fn lt(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn lt(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::LessThan, op, rhs);
         }
@@ -1775,9 +1765,7 @@ impl Value {
             }),
         }
     }
-    pub fn lte(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn lte(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::LessThanOrEqual, op, rhs);
         }
@@ -1803,9 +1791,7 @@ impl Value {
             }),
         }
     }
-    pub fn gt(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn gt(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::GreaterThan, op, rhs);
         }
@@ -1831,9 +1817,7 @@ impl Value {
             }),
         }
     }
-    pub fn gte(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn gte(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::GreaterThanOrEqual, op, rhs);
         }
@@ -1859,9 +1843,7 @@ impl Value {
             }),
         }
     }
-    pub fn eq(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn eq(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::Equal, op, rhs);
         }
@@ -1885,9 +1867,7 @@ impl Value {
             },
         }
     }
-    pub fn ne(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn ne(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         if let (Value::CustomValue { val: lhs, span }, rhs) = (self, rhs) {
             return lhs.operation(*span, Operator::NotEqual, op, rhs);
         }
@@ -1912,9 +1892,7 @@ impl Value {
         }
     }
 
-    pub fn r#in(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn r#in(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (lhs, Value::Range { val: rhs, .. }) => Ok(Value::Bool {
                 val: rhs.contains(lhs),
@@ -1971,9 +1949,7 @@ impl Value {
         }
     }
 
-    pub fn not_in(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn not_in(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (lhs, Value::Range { val: rhs, .. }) => Ok(Value::Bool {
                 val: !rhs.contains(lhs),
@@ -2030,9 +2006,13 @@ impl Value {
         }
     }
 
-    pub fn regex_match(&self, op: Span, rhs: &Value, invert: bool) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn regex_match(
+        &self,
+        op: Span,
+        rhs: &Value,
+        invert: bool,
+        span: Span,
+    ) -> Result<Value, ShellError> {
         match (self, rhs) {
             (
                 Value::String { val: lhs, .. },
@@ -2072,9 +2052,7 @@ impl Value {
         }
     }
 
-    pub fn starts_with(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn starts_with(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::String { val: lhs, .. }, Value::String { val: rhs, .. }) => Ok(Value::Bool {
                 val: lhs.starts_with(rhs),
@@ -2093,9 +2071,7 @@ impl Value {
         }
     }
 
-    pub fn modulo(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn modulo(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if *rhs != 0 {
@@ -2151,9 +2127,7 @@ impl Value {
         }
     }
 
-    pub fn and(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn and(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Bool { val: lhs, .. }, Value::Bool { val: rhs, .. }) => Ok(Value::Bool {
                 val: *lhs && *rhs,
@@ -2172,9 +2146,7 @@ impl Value {
         }
     }
 
-    pub fn or(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn or(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Bool { val: lhs, .. }, Value::Bool { val: rhs, .. }) => Ok(Value::Bool {
                 val: *lhs || *rhs,
@@ -2193,9 +2165,7 @@ impl Value {
         }
     }
 
-    pub fn pow(&self, op: Span, rhs: &Value) -> Result<Value, ShellError> {
-        let span = span(&[self.span()?, rhs.span()?]);
-
+    pub fn pow(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_pow(*rhs as u32) {

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -23,22 +23,22 @@ fn test_comparison_nothing() {
 
     for value in values {
         assert!(matches!(
-            value.eq(Span::test_data(), &nothing),
+            value.eq(Span::test_data(), &nothing, Span::test_data()),
             Ok(Value::Bool { val: false, .. })
         ));
 
         assert!(matches!(
-            value.ne(Span::test_data(), &nothing),
+            value.ne(Span::test_data(), &nothing, Span::test_data()),
             Ok(Value::Bool { val: true, .. })
         ));
 
         assert!(matches!(
-            nothing.eq(Span::test_data(), &value),
+            nothing.eq(Span::test_data(), &value, Span::test_data()),
             Ok(Value::Bool { val: false, .. })
         ));
 
         assert!(matches!(
-            nothing.ne(Span::test_data(), &value),
+            nothing.ne(Span::test_data(), &value, Span::test_data()),
             Ok(Value::Bool { val: true, .. })
         ));
     }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -366,3 +366,11 @@ fn reuseable_in() -> TestResult {
         "6",
     )
 }
+
+#[test]
+fn better_operator_spans() -> TestResult {
+    run_test(
+        r#"metadata ({foo: 10} | (20 - $in.foo)) | get span | $in.start < $in.end"#,
+        "true",
+    )
+}


### PR DESCRIPTION
# Description

fixes https://github.com/nushell/nushell/issues/4953

Also fixes some issues with the new unified arg system and known externals. 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
