### PR TITLE
enable `ls` to output datetime in local time vs utc

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -1,6 +1,6 @@
 use crate::DirBuilder;
 use crate::DirInfo;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -477,9 +477,9 @@ pub(crate) fn dir_entry_dict(
         if long {
             cols.push("created".to_string());
             if let Ok(c) = md.created() {
-                let utc: DateTime<Utc> = c.into();
+                let utc: DateTime<Local> = c.into();
                 vals.push(Value::Date {
-                    val: utc.into(),
+                    val: utc.with_timezone(utc.offset()).into(),
                     span,
                 });
             } else {
@@ -488,9 +488,9 @@ pub(crate) fn dir_entry_dict(
 
             cols.push("accessed".to_string());
             if let Ok(a) = md.accessed() {
-                let utc: DateTime<Utc> = a.into();
+                let utc: DateTime<Local> = a.into();
                 vals.push(Value::Date {
-                    val: utc.into(),
+                    val: utc.with_timezone(utc.offset()).into(),
                     span,
                 });
             } else {
@@ -500,9 +500,9 @@ pub(crate) fn dir_entry_dict(
 
         cols.push("modified".to_string());
         if let Ok(m) = md.modified() {
-            let utc: DateTime<Utc> = m.into();
+            let utc: DateTime<Local> = m.into();
             vals.push(Value::Date {
-                val: utc.into(),
+                val: utc.with_timezone(utc.offset()).into(),
                 span,
             });
         } else {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -1,6 +1,6 @@
 use crate::DirBuilder;
 use crate::DirInfo;
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Local};
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -479,7 +479,7 @@ pub(crate) fn dir_entry_dict(
             if let Ok(c) = md.created() {
                 let utc: DateTime<Local> = c.into();
                 vals.push(Value::Date {
-                    val: utc.with_timezone(utc.offset()).into(),
+                    val: utc.with_timezone(utc.offset()),
                     span,
                 });
             } else {
@@ -490,7 +490,7 @@ pub(crate) fn dir_entry_dict(
             if let Ok(a) = md.accessed() {
                 let utc: DateTime<Local> = a.into();
                 vals.push(Value::Date {
-                    val: utc.with_timezone(utc.offset()).into(),
+                    val: utc.with_timezone(utc.offset()),
                     span,
                 });
             } else {
@@ -502,7 +502,7 @@ pub(crate) fn dir_entry_dict(
         if let Ok(m) = md.modified() {
             let utc: DateTime<Local> = m.into();
             vals.push(Value::Date {
-                val: utc.with_timezone(utc.offset()).into(),
+                val: utc.with_timezone(utc.offset()),
                 span,
             });
         } else {


### PR DESCRIPTION
# Description

This PR changes `ls` so that it outputs the date time in `Local` instead of `Utc`

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
