### PR TITLE
Support binary literals with binary format

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1074,26 +1074,40 @@ pub fn parse_binary(
     working_set: &mut StateWorkingSet,
     span: Span,
 ) -> (Expression, Option<ParseError>) {
-    pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
-        (0..s.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
-            .collect()
+    let (hex_value, err) = parse_binary_with_base(working_set, span, 16, 2, b"0x[", b"]");
+    if err.is_some() {
+        return parse_binary_with_base(working_set, span, 2, 8, b"0b[", b"]");
     }
+    (hex_value, err)
+}
 
+fn parse_binary_with_base(
+    working_set: &mut StateWorkingSet,
+    span: Span,
+    base: u32,
+    digits_per_byte: usize,
+    prefix: &[u8],
+    suffix: &[u8],
+) -> (Expression, Option<ParseError>) {
     let token = working_set.get_span_contents(span);
 
-    if let Some(token) = token.strip_prefix(b"0x[") {
-        if let Some(token) = token.strip_suffix(b"]") {
-            let (lexed, err) = lex(token, span.start + 3, &[b',', b'\r', b'\n'], &[], true);
+    if let Some(token) = token.strip_prefix(prefix) {
+        if let Some(token) = token.strip_suffix(suffix) {
+            let (lexed, err) = lex(
+                token,
+                span.start + prefix.len(),
+                &[b',', b'\r', b'\n'],
+                &[],
+                true,
+            );
 
-            let mut hex_value = vec![];
+            let mut binary_value = vec![];
             for token in lexed {
                 match token.contents {
                     TokenContents::Item => {
                         let contents = working_set.get_span_contents(token.span);
 
-                        hex_value.extend_from_slice(contents);
+                        binary_value.extend_from_slice(contents);
                     }
                     TokenContents::Pipe => {
                         return (
@@ -1105,20 +1119,20 @@ pub fn parse_binary(
                 }
             }
 
-            if hex_value.len() % 2 != 0 {
+            if binary_value.len() % digits_per_byte != 0 {
                 return (
                     garbage(span),
                     Some(ParseError::IncorrectValue(
                         "incomplete binary".into(),
                         span,
-                        "number of binary digits needs to be a multiple of 2".into(),
+                        "number of binary digits needs to form a whole number of bytes".into(),
                     )),
                 );
             }
 
-            let str = String::from_utf8_lossy(&hex_value).to_string();
+            let str = String::from_utf8_lossy(&binary_value).to_string();
 
-            match decode_hex(&str) {
+            match decode_with_base(&str, base, digits_per_byte) {
                 Ok(v) => {
                     return (
                         Expression {
@@ -1147,6 +1161,13 @@ pub fn parse_binary(
         garbage(span),
         Some(ParseError::Expected("binary".into(), span)),
     )
+}
+
+fn decode_with_base(s: &str, base: u32, digits_per_byte: usize) -> Result<Vec<u8>, ParseIntError> {
+    (0..s.len())
+        .step_by(digits_per_byte)
+        .map(|i| u8::from_str_radix(&s[i..i + digits_per_byte], base))
+        .collect()
 }
 
 pub fn parse_int(token: &[u8], span: Span) -> (Expression, Option<ParseError>) {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -62,6 +62,34 @@ pub fn parse_int() {
 }
 
 #[test]
+pub fn parse_binary_with_hex_format() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let (block, err) = parse(&mut working_set, None, b"0x[13]", true, &[]);
+
+    assert!(err.is_none());
+    assert!(block.len() == 1);
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert_eq!(expressions[0].expr, Expr::Binary(vec![0x13]))
+}
+
+#[test]
+pub fn parse_binary_with_binary_format() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let (block, err) = parse(&mut working_set, None, b"0b[1010 1000]", true, &[]);
+
+    assert!(err.is_none());
+    assert!(block.len() == 1);
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert_eq!(expressions[0].expr, Expr::Binary(vec![0b10101000]))
+}
+
+#[test]
 pub fn parse_call() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -76,6 +76,20 @@ pub fn parse_binary_with_hex_format() {
 }
 
 #[test]
+pub fn parse_binary_with_incomplete_hex_format() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let (block, err) = parse(&mut working_set, None, b"0x[3]", true, &[]);
+
+    assert!(err.is_none());
+    assert!(block.len() == 1);
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert_eq!(expressions[0].expr, Expr::Binary(vec![0x03]))
+}
+
+#[test]
 pub fn parse_binary_with_binary_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
@@ -87,6 +101,20 @@ pub fn parse_binary_with_binary_format() {
     let expressions = &block[0];
     assert!(expressions.len() == 1);
     assert_eq!(expressions[0].expr, Expr::Binary(vec![0b10101000]))
+}
+
+#[test]
+pub fn parse_binary_with_incomplete_binary_format() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let (block, err) = parse(&mut working_set, None, b"0b[10]", true, &[]);
+
+    assert!(err.is_none());
+    assert!(block.len() == 1);
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert_eq!(expressions[0].expr, Expr::Binary(vec![0b00000010]))
 }
 
 #[test]


### PR DESCRIPTION
# Description

This PR lets users specify binary literals in binary format, e.g. `0b[1010 0001]` (before it was only implemented for hex format).
Also, automatic left padding with zeros is enabled, that is `0b[1]` is equivalent to `0b[0000 0001]`.

Relevant documentation update: https://github.com/nushell/nushell.github.io/pull/390

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style ~-> fails even on main branch at nu-protocol>config.rs:302,339 (config parameter is only used in recursion; clippy 0.1.61 (8f36334 2022-04-06); no complains in my code though)~ works with clippy 0.1.60
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
