### PR TITLE
Clean REPL code, hide Hints without ANSI coloring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.3.1"
-source = "git+https://github.com/nushell/reedline?branch=main#7ce8b674e060a120c2b110d367aff623c792abcd"
+source = "git+https://github.com/nushell/reedline?branch=main#e906c008c12c7e89a5a07df2d3b020e9936ad5b7"
 dependencies = [
  "chrono",
  "crossterm",


### PR DESCRIPTION
# Description

- With a change to reedline hints can now be hidden. This is useful when
no ANSI coloring is available as hints become indistinguishable from the
actual buffer
- remove commented out code
- order the logging calls according to the implementation

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
