### PR TITLE
Update Nu crate descriptions

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "CLI-related functionality for Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "Color configuration code used by Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "Nushell's built-in commands"
 edition = "2021"
 license = "MIT"
 name = "nu-command"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "Nushell's evaluation engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "Nushell's parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "Functionality for building Nushell plugins"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "Nushell's internal protocols, including its abstract syntax tree"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "A set of query commands for Nushell"
+description = "A Nushell plugin to query JSON, XML, and various web data"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"


### PR DESCRIPTION
# Description

I noticed that a lot of Nu crates have the same inaccurate description on crates.io:

<img width="234" alt="image" src="https://user-images.githubusercontent.com/26268125/162793542-e2c44704-d69a-46c5-aa5c-c25b333f7200.png">

Guessing this was just a copy-paste oversight, I went through and added more accurate/specific crate descriptions.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
