### PR TITLE
Remove the im crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,15 +263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitpacking"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,20 +1577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check 0.9.4",
-]
-
-[[package]]
 name = "indent_write"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,7 +2447,6 @@ dependencies = [
  "byte-unit",
  "chrono",
  "chrono-humanize",
- "im",
  "indexmap",
  "miette 4.2.1",
  "nu-json",
@@ -3464,15 +3440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,16 +3986,6 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -16,7 +16,6 @@ chrono = { version="0.4.19", features=["serde"] }
 indexmap = { version="1.7", features=["serde-1"] }
 chrono-humanize = "0.2.1"
 byte-unit = "4.0.9"
-im = "15.0.0"
 serde_json = { version = "1.0", optional = true }
 nu-json = { path = "../nu-json", version = "0.60.1"  }
 typetag = "0.1.8"

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -166,16 +166,16 @@ impl Default for ScopeFrame {
 ///
 #[derive(Clone)]
 pub struct EngineState {
-    files: im::Vector<(String, usize, usize)>,
-    file_contents: im::Vector<(Vec<u8>, usize, usize)>,
-    vars: im::Vector<Variable>,
-    decls: im::Vector<Box<dyn Command + 'static>>,
-    aliases: im::Vector<Vec<Span>>,
-    blocks: im::Vector<Block>,
-    overlays: im::Vector<Overlay>,
-    pub scope: im::Vector<ScopeFrame>,
+    files: Vec<(String, usize, usize)>,
+    file_contents: Vec<(Vec<u8>, usize, usize)>,
+    vars: Vec<Variable>,
+    decls: Vec<Box<dyn Command + 'static>>,
+    aliases: Vec<Vec<Span>>,
+    blocks: Vec<Block>,
+    overlays: Vec<Overlay>,
+    pub scope: Vec<ScopeFrame>,
     pub ctrlc: Option<Arc<AtomicBool>>,
-    pub env_vars: im::HashMap<String, Value>,
+    pub env_vars: HashMap<String, Value>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
 }
@@ -189,22 +189,22 @@ pub const ENV_VARIABLE_ID: usize = 3;
 impl EngineState {
     pub fn new() -> Self {
         Self {
-            files: im::vector![],
-            file_contents: im::vector![],
-            vars: im::vector![
+            files: vec![],
+            file_contents: vec![],
+            vars: vec![
                 Variable::new(Span::new(0, 0), Type::Any),
                 Variable::new(Span::new(0, 0), Type::Any),
                 Variable::new(Span::new(0, 0), Type::Any),
                 Variable::new(Span::new(0, 0), Type::Any),
-                Variable::new(Span::new(0, 0), Type::Any)
+                Variable::new(Span::new(0, 0), Type::Any),
             ],
-            decls: im::vector![],
-            aliases: im::vector![],
-            blocks: im::vector![],
-            overlays: im::vector![],
-            scope: im::vector![ScopeFrame::new()],
+            decls: vec![],
+            aliases: vec![],
+            blocks: vec![],
+            overlays: vec![],
+            scope: vec![ScopeFrame::new()],
             ctrlc: None,
-            env_vars: im::HashMap::new(),
+            env_vars: HashMap::new(),
             #[cfg(feature = "plugin")]
             plugin_signatures: None,
         }
@@ -232,7 +232,7 @@ impl EngineState {
         self.blocks.extend(delta.blocks);
         self.overlays.extend(delta.overlays);
 
-        if let Some(last) = self.scope.back_mut() {
+        if let Some(last) = self.scope.last_mut() {
             let first = delta.scope.remove(0);
             for item in first.decls.into_iter() {
                 last.decls.insert(item.0, item.1);
@@ -610,10 +610,9 @@ impl EngineState {
         let next_span_end = next_span_start + contents.len();
 
         self.file_contents
-            .push_back((contents, next_span_start, next_span_end));
+            .push((contents, next_span_start, next_span_end));
 
-        self.files
-            .push_back((filename, next_span_start, next_span_end));
+        self.files.push((filename, next_span_start, next_span_end));
 
         self.num_files() - 1
     }


### PR DESCRIPTION
# Description

I tried running without `im` and couldn't notice a difference across a couple benchmarks (gradient [both par-each and each versions] and tight loop). Let's remove for now and watch to see if we see any other slowness.

fixes #5160 

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
