### PR TITLE
Shell Integration

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -147,6 +147,10 @@ pub(crate) fn update_prompt<'prompt>(
         (prompt_vi_insert_string, prompt_vi_normal_string),
     );
 
+    if config.use_ansi_coloring {
+        nu_prompt.enable_shell_integration();
+    }
+
     let ret_val = nu_prompt as &dyn Prompt;
     if is_perf_true {
         info!("update_prompt {}:{}:{}", file!(), line!(), column!());

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -231,6 +231,13 @@ pub fn evaluate_repl(
         }
 
         let input = line_editor.read_line(prompt);
+
+        if config.use_ansi_coloring {
+            // Just before running a command/program, send the escape code (see
+            // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
+            print!("\x1b]133;C\x1b\\");
+        }
+
         match input {
             Ok(Signal::Success(s)) => {
                 let start_time = Instant::now();


### PR DESCRIPTION
# Description

This PR renders ANSI chars in order to provide shell integrations such Kitty's opening feature that captures the output of the last command in a pager such as less.

Fixes #5138

I was thinking about the Shell integrations independently from #5138 and I created the code without noticing this issue. So, I did not had issue's discussion as an inspiration. :wink: Surely, I'm willing to finalize it so that Nushell integrates nicely with modern shells.

The suggested changes work with Nushell commands but external commands do not work yet. For example, the output of `cargo run` won't be captured by Kitty's output capturing. Here I would appreciate any guidance.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
