### PR TITLE
bump miette to 4.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,13 +1996,13 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "4.2.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ea7314b2a8dd373c2f2d2322e866ddea5d62ffd3d6cd7f2bb8c1467e56529f"
+checksum = "0a097de91d72c13382f60213ed9f7f7a26afd8bee0ea320b47f886a9a67ca5a1"
 dependencies = [
  "atty",
  "backtrace",
- "miette-derive 4.2.1",
+ "miette-derive 4.4.0",
  "once_cell",
  "owo-colors",
  "supports-color",
@@ -2027,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "4.2.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c547b28d4f52cae473fb5a30ca087ed7fc5d1bac150bd6dfd9ec0a4562303aa3"
+checksum = "45a95a48d0bc28f9af628286e8a4da09f96f34a97744a2e9a5a4db9814ad527d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2218,7 +2218,7 @@ dependencies = [
  "is_executable",
  "itertools",
  "log",
- "miette 4.2.1",
+ "miette 4.4.0",
  "nu-ansi-term",
  "nu-cli",
  "nu-color-config",
@@ -2260,7 +2260,7 @@ dependencies = [
  "crossterm",
  "is_executable",
  "log",
- "miette 4.2.1",
+ "miette 4.4.0",
  "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
@@ -2404,7 +2404,7 @@ version = "0.61.0"
 dependencies = [
  "chrono",
  "log",
- "miette 4.2.1",
+ "miette 4.4.0",
  "nu-path",
  "nu-plugin",
  "nu-protocol",
@@ -2448,7 +2448,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "indexmap",
- "miette 4.2.1",
+ "miette 4.4.0",
  "nu-json",
  "num-format",
  "regex",
@@ -4287,9 +4287,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
  "smawk",
  "unicode-linebreak",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -16,7 +16,7 @@ nu-ansi-term = "0.45.1"
 nu-color-config = { path = "../nu-color-config", version = "0.61.0"  }
 
 crossterm = "0.23.0"
-miette = { version = "4.1.0", features = ["fancy"] }
+miette = { version = "4.4.0", features = ["fancy"] }
 thiserror = "1.0.29"
 reedline = { version = "0.4.0", features = ["bashisms"]}
 

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.61.0"
 
 [dependencies]
 chrono = "0.4.19"
-miette = "4.1.0"
+miette = "4.4.0"
 thiserror = "1.0.29"
 serde_json = "1.0"
 nu-path = {path = "../nu-path", version = "0.61.0" }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.61.0"
 
 [dependencies]
 thiserror = "1.0.29"
-miette = "4.1.0"
+miette = "4.4.0"
 serde = {version = "1.0.130", features = ["derive"]}
 chrono = { version="0.4.19", features=["serde"] }
 indexmap = { version="1.7", features=["serde-1"] }


### PR DESCRIPTION
# Description

This fixes an issue where docsrs error links were not working.

Ref: https://github.com/zkat/miette/issues/147

There are no other impactful changes from this version bump.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
