### PR TITLE
Allow passing an integer to `char -u`

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -193,6 +193,11 @@ impl Command for Char {
                 result: Some(Value::test_string("\u{1f378}")),
             },
             Example {
+                description: "Output a character from an integer",
+                example: r#"char -u 0x61"#,
+                result: Some(Value::test_string("a")),
+            },
+            Example {
                 description: "Output multi-byte Unicode character",
                 example: r#"char -u 1F468 200D 1F466 200D 1F466"#,
                 result: Some(Value::test_string(
@@ -235,8 +240,8 @@ impl Command for Char {
                 .into_pipeline_data(engine_state.ctrlc.clone()));
         }
         // handle -u flag
-        let args: Vec<String> = call.rest(engine_state, stack, 0)?;
         if call.has_flag("unicode") {
+            let args: Vec<Value> = call.rest(engine_state, stack, 0)?;
             if args.is_empty() {
                 return Err(ShellError::MissingParameter(
                     "missing at least one unicode character".into(),
@@ -249,10 +254,11 @@ impl Command for Char {
                     .positional_nth(i)
                     .expect("Unexpected missing argument")
                     .span;
-                multi_byte.push(string_to_unicode_char(arg, &span)?)
+                multi_byte.push(value_to_unicode_char(arg, &span)?)
             }
             Ok(Value::string(multi_byte, call_span).into_pipeline_data())
         } else {
+            let args: Vec<String> = call.rest(engine_state, stack, 0)?;
             if args.is_empty() {
                 return Err(ShellError::MissingParameter(
                     "missing name of the character".into(),
@@ -274,10 +280,14 @@ impl Command for Char {
     }
 }
 
-fn string_to_unicode_char(s: &str, t: &Span) -> Result<char, ShellError> {
-    let decoded_char = u32::from_str_radix(s, 16)
-        .ok()
-        .and_then(std::char::from_u32);
+fn value_to_unicode_char(value: &Value, t: &Span) -> Result<char, ShellError> {
+    let decoded_char = match *value {
+        Value::String { ref val, .. } => u32::from_str_radix(val, 16)
+            .ok()
+            .and_then(std::char::from_u32),
+        Value::Int { val, .. } => val.try_into().ok().and_then(std::char::from_u32),
+        _ => return Err(ShellError::TypeMismatch("string or int".to_owned(), *t)),
+    };
 
     if let Some(ch) = decoded_char {
         Ok(ch)


### PR DESCRIPTION
# Description

Right now if you try to pass an integer to `char -u` you get a "can't convert int to string" type error like this:
![image](https://user-images.githubusercontent.com/1254344/163106155-638d3578-ff45-44fa-b371-9a597e7e7afe.png)

I'm fixing this by allowing an int to be passed. It might be slightly confusing because if you type in a number, it will be interpreted as decimal if it happens contains the digits 0-9 only, and hexadecimal otherwise. I'm not sure if there's any way to avoid that, but the syntax highlighting makes it clear when you've typed a number vs a string.

This makes it possible to procedurally create characters, like this:
```
> for $x in 0x61..0x7a { char -u $x } | str collect
abcdefghijklmnopqrstuvwxyz
```

The only way to do this before would have been to convert the integers to hexadecimal strings first, which I don't actually know how to do in nu.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass

Note: Some symlink-related tests failed, but these are unrelated to the change I'm making and appear to be because I'm on Windows.
```
failures:
    path::canonicalize::canonicalize_nested_symlink_relative_to
    path::canonicalize::canonicalize_nested_symlink_within_symlink_dir_relative_to
    path::canonicalize::canonicalize_symlink
    path::canonicalize::canonicalize_symlink_relative_to
```