### PR TITLE
Add a dockerfile example based on debian bullseye-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 # Other tags: nushell/debian-nu.0.61, nushell
 FROM debian:bullseye-slim
 
-LABEL maintainer=hustcer<hustcer@outlook.com>
+LABEL maintainer=nushell
 
 RUN apt update \
     && apt upgrade -y \
@@ -21,11 +21,11 @@ RUN apt update \
     && mkdir -p /root/.config/nushell && cd /root/.config/nushell \
     && aria2c https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_env.nu -o env.nu \
     && aria2c https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_config.nu -o config.nu \
-    # Cleanup nu source and cargo caches, etc.
+    # Do some cleanup work
     && cd /lib; rm -rf nu_0* nu-latest.tar.gz \
     && rm -rf /var/lib/apt/lists/* && apt autoremove -y \
     && echo '/usr/local/bin/nu' >> /etc/shells \
-    # Add and nushell user and create home dir
-    && useradd -m -s /user/local/bin/nu nushell
+    # Add an nushell user and create home dir
+    && useradd -m -s /usr/local/bin/nu nushell
 
 CMD [ "nu" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,17 +10,17 @@ LABEL maintainer=hustcer<hustcer@outlook.com>
 RUN apt update \
     && apt upgrade -y \
     # Need ca-certificates to make `curl -s` work
-    && apt install -y --no-install-recommends --no-install-suggests ca-certificates wget curl git unzip \
+    && apt install -y --no-install-recommends --no-install-suggests ca-certificates aria2 curl git unzip \
     # Make /bin/sh symlink to bash instead of dash:
     && echo "dash dash/sh boolean false" | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash \
-    && cd /lib; curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep linux | wget -i - -O nu-latest.tar.gz \
-    && tar xvf nu-latest.tar.gz \
+    && cd /lib; curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep linux | aria2c -i - \
+    && tar xvf nu_0*.tar.gz \
     && cd nu_0* && cp -aR nushell*/** /usr/local/bin/ \
     # Setup default config file for nushell
     && mkdir -p /root/.config/nushell && cd /root/.config/nushell \
-    && wget https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_env.nu -O env.nu \
-    && wget https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_config.nu -O config.nu \
+    && aria2c https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_env.nu -o env.nu \
+    && aria2c https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_config.nu -o config.nu \
     # Cleanup nu source and cargo caches, etc.
     && cd /lib; rm -rf nu_0* nu-latest.tar.gz \
     && rm -rf /var/lib/apt/lists/* && apt autoremove -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+# Git: git version 2.30.2
+# /etc/os-release: Debian: Debian GNU/Linux 11 (bullseye)
+# Kernel: Linux ec73d87a5aab 5.10.104-linuxkit #1 SMP Wed Mar 9 19:05:23 UTC 2022 x86_64 GNU/Linux
+# Build cmd: docker build --no-cache . -t nushell-0.61
+# Other tags: nushell/debian-nu.0.61, nushell
+FROM debian:bullseye-slim
+
+LABEL maintainer=hustcer<hustcer@outlook.com>
+
+RUN apt update \
+    && apt upgrade -y \
+    # Need ca-certificates to make `curl -s` work
+    && apt install -y --no-install-recommends --no-install-suggests ca-certificates wget curl git unzip \
+    # Make /bin/sh symlink to bash instead of dash:
+    && echo "dash dash/sh boolean false" | debconf-set-selections \
+    && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash \
+    && cd /lib; curl -s https://api.github.com/repos/nushell/nushell/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep linux | wget -i - -O nu-latest.tar.gz \
+    && tar xvf nu-latest.tar.gz \
+    && cd nu_0* && cp -aR nushell*/** /usr/local/bin/ \
+    # Setup default config file for nushell
+    && mkdir -p /root/.config/nushell && cd /root/.config/nushell \
+    && wget https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_env.nu -O env.nu \
+    && wget https://raw.githubusercontent.com/nushell/nushell/main/docs/sample_config/default_config.nu -O config.nu \
+    # Cleanup nu source and cargo caches, etc.
+    && cd /lib; rm -rf nu_0* nu-latest.tar.gz \
+    && rm -rf /var/lib/apt/lists/* && apt autoremove -y \
+    && echo '/usr/local/bin/nu' >> /etc/shells \
+    # Add and nushell user and create home dir
+    && useradd -m -s /user/local/bin/nu nushell
+
+CMD [ "nu" ]


### PR DESCRIPTION
# Description

Add a dockerfile example based on debian bullseye slim, I think we need this. don't we ?
Okay, Actually, I need a docker image, and create a PR by the way.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
