### PR TITLE
allow default color shortcut names

### DIFF
--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -161,7 +161,7 @@ pub fn lookup_ansi_color_style(s: &str) -> Style {
             "dgrbl" | "dark_gray_blink" => Color::DarkGray.blink(),
             "dgrst" | "dark_gray_strike" => Color::DarkGray.strikethrough(),
 
-            "def" | "default" => Color::Default,
+            "def" | "default" => Color::Default.normal(),
             "defb" | "default_bold" => Color::Default.bold(),
             "defu" | "default_underline" => Color::Default.underline(),
             "defi" | "default_italic" => Color::Default.italic(),

--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -161,6 +161,13 @@ pub fn lookup_ansi_color_style(s: &str) -> Style {
             "dgrbl" | "dark_gray_blink" => Color::DarkGray.blink(),
             "dgrst" | "dark_gray_strike" => Color::DarkGray.strikethrough(),
 
+            "def" | "default" => Color::Default,
+            "defb" | "default_bold" => Color::Default.bold(),
+            "defu" | "default_underline" => Color::Default.underline(),
+            "defi" | "default_italic" => Color::Default.italic(),
+            "defd" | "default_dimmed" => Color::Default.dimmed(),
+            "defr" | "default_reverse" => Color::Default.reverse(),
+
             _ => Color::White.normal(),
         }
     }

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -130,12 +130,12 @@ lazy_static! {
     AnsiCode{ short_name: Some("dgrd"), long_name: "dark_gray_dimmed", code: Color::DarkGray.dimmed().prefix().to_string()},
     AnsiCode{ short_name: Some("dgrr"), long_name: "dark_gray_reverse", code: Color::DarkGray.reverse().prefix().to_string()},
 
-    AnsiCode{ short_name: Some("der"), long_name: "default", code: Color::Default.prefix().to_string()},
-    AnsiCode{ short_name: Some("deb"), long_name: "default_bold", code: Color::Default.bold().prefix().to_string()},
-    AnsiCode{ short_name: Some("deu"), long_name: "default_underline", code: Color::Default.underline().prefix().to_string()},
-    AnsiCode{ short_name: Some("dei"), long_name: "default_italic", code: Color::Default.italic().prefix().to_string()},
-    AnsiCode{ short_name: Some("ded"), long_name: "default_dimmed", code: Color::Default.dimmed().prefix().to_string()},
-    AnsiCode{ short_name: Some("der"), long_name: "default_reverse", code: Color::Default.reverse().prefix().to_string()},
+    AnsiCode{ short_name: Some("def"), long_name: "default", code: Color::Default.prefix().to_string()},
+    AnsiCode{ short_name: Some("defb"), long_name: "default_bold", code: Color::Default.bold().prefix().to_string()},
+    AnsiCode{ short_name: Some("defu"), long_name: "default_underline", code: Color::Default.underline().prefix().to_string()},
+    AnsiCode{ short_name: Some("defi"), long_name: "default_italic", code: Color::Default.italic().prefix().to_string()},
+    AnsiCode{ short_name: Some("defd"), long_name: "default_dimmed", code: Color::Default.dimmed().prefix().to_string()},
+    AnsiCode{ short_name: Some("defr"), long_name: "default_reverse", code: Color::Default.reverse().prefix().to_string()},
 
     AnsiCode{ short_name: None, long_name: "reset", code: "\x1b[0m".to_owned()},
     // Reference for ansi codes https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797


### PR DESCRIPTION
# Description

This PR should allow the `default` color to be used more easily in the config.

closes #5173 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
