### PR TITLE
don't join paths to cwd ever in calls to external functions

### DIFF
--- a/crates/nu-path/src/expansions.rs
+++ b/crates/nu-path/src/expansions.rs
@@ -73,3 +73,16 @@ where
 
     expand_path(path)
 }
+
+/// Resolve similarly to other shells - tilde is expanded, and ndot path components are expanded.
+///
+/// This function will take a leading tilde path component, and expand it to the user's home directory;
+/// it will also expand any path elements consisting of only dots into the correct number of `..` path elements.
+/// It does not touch the system at all, except for getting the home directory of the current user.
+pub fn expand_path_for_external_programs<P>(path: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    let path = expand_tilde(path);
+    expand_ndots(path)
+}

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -4,7 +4,7 @@ mod helpers;
 mod tilde;
 mod util;
 
-pub use expansions::{canonicalize_with, expand_path_with};
+pub use expansions::{canonicalize_with, expand_path_for_external_programs, expand_path_with};
 pub use helpers::{config_dir, home_dir};
 pub use tilde::expand_tilde;
 pub use util::trim_trailing_slash;


### PR DESCRIPTION
This is a follow-up to #5131, since I don't personally like the way it worked.

# Description

Instead of attempting to normalize paths by pasting cwd on the front, this skips all path normalization except for tilde and `...+`. This is more in line with other shells, like bash:

```sh
$ cat test.c
int main(int argc, char** argv) {
  int printf(char const*, ...);
  printf("called as: '%s' '%s'\n", argv[0], argv[1]);
}
$ ./a.exe ~/foo
called as: './a.exe' 'C:\Users\nimazzuc/foo'
$ ./a.exe ../foo
called as: './a.exe' '../foo'
$ ./a.exe .../foo
called as './a.exe' '../../foo'
$ ./a.exe ./foo
called as './a.exe' './foo'
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass (the only tests that didn't pass were related to symlinks, since I don't have perms to create them)
