### PR TITLE
Add `char -i` for chars from integers

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -164,6 +164,7 @@ impl Command for Char {
             .rest("rest", SyntaxShape::String, "multiple Unicode bytes")
             .switch("list", "List all supported character names", Some('l'))
             .switch("unicode", "Unicode string i.e. 1f378", Some('u'))
+            .switch("integer", "Create a codepoint from an integer", Some('i'))
             .category(Category::Strings)
     }
 
@@ -191,6 +192,11 @@ impl Command for Char {
                 description: "Output Unicode character",
                 example: r#"char -u 1f378"#,
                 result: Some(Value::test_string("\u{1f378}")),
+            },
+            Example {
+                description: "Create unicode from integer",
+                example: r#"char -i (0x60 + 1) (0x60 + 2)"#,
+                result: Some(Value::test_string("ab")),
             },
             Example {
                 description: "Output multi-byte Unicode character",
@@ -235,8 +241,25 @@ impl Command for Char {
                 .into_pipeline_data(engine_state.ctrlc.clone()));
         }
         // handle -u flag
-        let args: Vec<String> = call.rest(engine_state, stack, 0)?;
-        if call.has_flag("unicode") {
+        if call.has_flag("integer") {
+            let args: Vec<i64> = call.rest(engine_state, stack, 0)?;
+            if args.is_empty() {
+                return Err(ShellError::MissingParameter(
+                    "missing at least one unicode character".into(),
+                    call_span,
+                ));
+            }
+            let mut multi_byte = String::new();
+            for (i, &arg) in args.iter().enumerate() {
+                let span = call
+                    .positional_nth(i)
+                    .expect("Unexpected missing argument")
+                    .span;
+                multi_byte.push(integer_to_unicode_char(arg, &span)?)
+            }
+            Ok(Value::string(multi_byte, call_span).into_pipeline_data())
+        } else if call.has_flag("unicode") {
+            let args: Vec<String> = call.rest(engine_state, stack, 0)?;
             if args.is_empty() {
                 return Err(ShellError::MissingParameter(
                     "missing at least one unicode character".into(),
@@ -253,6 +276,7 @@ impl Command for Char {
             }
             Ok(Value::string(multi_byte, call_span).into_pipeline_data())
         } else {
+            let args: Vec<String> = call.rest(engine_state, stack, 0)?;
             if args.is_empty() {
                 return Err(ShellError::MissingParameter(
                     "missing name of the character".into(),
@@ -271,6 +295,19 @@ impl Command for Char {
                 ))
             }
         }
+    }
+}
+
+fn integer_to_unicode_char(value: i64, t: &Span) -> Result<char, ShellError> {
+    let decoded_char = value.try_into().ok().and_then(std::char::from_u32);
+
+    if let Some(ch) = decoded_char {
+        Ok(ch)
+    } else {
+        Err(ShellError::UnsupportedInput(
+            "not a valid Unicode codepoint".into(),
+            *t,
+        ))
     }
 }
 


### PR DESCRIPTION
# Description

A followup for #5174 since having `-u` accept both strings and ints provides bad UX.

Adds a new switch `-i` that takes integers exclusively.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
