### PR TITLE
Fix completions for `git push` and `git checkout` close: #5021 and #4599

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -14,59 +14,61 @@ module completions {
     ^git remote | lines | each { |line| $line | str trim }
   }
 
+  # Check out git branches and files
   export extern "git checkout" [
-    branch?: string@"nu-complete git branches" # name of the branch to checkout
-    -b: string                                 # create and checkout a new branch
-    -B: string                                 # create/reset and checkout a branch
-    -l                                         # create reflog for new branch
-    --guess                                    # second guess 'git checkout <no-such-branch>' (default)
-    --overlay                                  # use overlay mode (default)
-    --quiet(-q)                                # suppress progress reporting
-    --recurse-submodules: string               # control recursive updating of submodules
-    --progress                                 # force progress reporting
-    --merge(-m)                                # perform a 3-way merge with the new branch
-    --conflict: string                         # conflict style (merge or diff3)
-    --detach(-d)                               # detach HEAD at named commit
-    --track(-t)                                # set upstream info for new branch
-    --force(-f)                                # force checkout (throw away local modifications)
-    --orphan: string                           # new unparented branch
-    --overwrite-ignore                         # update ignored files (default)
-    --ignore-other-worktrees                   # do not check if another worktree is holding the given ref
-    --ours(-2)                                 # checkout our version for unmerged files
-    --theirs(-3)                               # checkout their version for unmerged files
-    --patch(-p)                                # select hunks interactively
-    --ignore-skip-worktree-bits                # do not limit pathspecs to sparse entries only
-    --pathspec-from-file: string               # read pathspec from file
+    ...targets: string@"nu-complete git branches"   # name of the branch or files to checkout
+    --conflict: string                              # conflict style (merge or diff3)
+    --detach(-d)                                    # detach HEAD at named commit
+    --force(-f)                                     # force checkout (throw away local modifications)
+    --guess                                         # second guess 'git checkout <no-such-branch>' (default)
+    --ignore-other-worktrees                        # do not check if another worktree is holding the given ref
+    --ignore-skip-worktree-bits                     # do not limit pathspecs to sparse entries only
+    --merge(-m)                                     # perform a 3-way merge with the new branch
+    --orphan: string                                # new unparented branch
+    --ours(-2)                                      # checkout our version for unmerged files
+    --overlay                                       # use overlay mode (default)
+    --overwrite-ignore                              # update ignored files (default)
+    --patch(-p)                                     # select hunks interactively
+    --pathspec-from-file: string                    # read pathspec from file
+    --progress                                      # force progress reporting
+    --quiet(-q)                                     # suppress progress reporting
+    --recurse-submodules: string                    # control recursive updating of submodules
+    --theirs(-3)                                    # checkout their version for unmerged files
+    --track(-t)                                     # set upstream info for new branch
+    -b: string                                      # create and checkout a new branch
+    -B: string                                      # create/reset and checkout a branch
+    -l                                              # create reflog for new branch
   ]
 
+  # Push changes
   export extern "git push" [
-    remote?: string@"nu-complete git remotes", # the name of the remote
-    refspec?: string@"nu-complete git branches"# the branch / refspec
-    --verbose(-v)                              # be more verbose
-    --quiet(-q)                                # be more quiet
-    --repo: string                             # repository
-    --all                                      # push all refs
-    --mirror                                   # mirror all refs
-    --delete(-d)                               # delete refs
-    --tags                                     # push tags (can't be used with --all or --mirror)
-    --dry-run(-n)                              # dry run
-    --porcelain                                # machine-readable output
-    --force(-f)                                # force updates
-    --force-with-lease: string                 # require old value of ref to be at this value
-    --recurse-submodules: string               # control recursive pushing of submodules
-    --thin                                     # use thin pack
-    --receive-pack: string                     # receive pack program
-    --exec: string                             # receive pack program
-    --set-upstream(-u)                         # set upstream for git pull/status
-    --progress                                 # force progress reporting
-    --prune                                    # prune locally removed refs
-    --no-verify                                # bypass pre-push hook
-    --follow-tags                              # push missing but relevant tags
-    --signed: string                           # GPG sign the push
-    --atomic                                   # request atomic transaction on remote side
-    --push-option(-o): string                  # option to transmit
-    --ipv4(-4)                                 # use IPv4 addresses only
-    --ipv6(-6)                                 # use IPv6 addresses only
+    remote?: string@"nu-complete git remotes",      # the name of the remote
+    ...refs: string@"nu-complete git branches"      # the branch / refspec
+    --all                                           # push all refs
+    --atomic                                        # request atomic transaction on remote side
+    --delete(-d)                                    # delete refs
+    --dry-run(-n)                                   # dry run
+    --exec: string                                  # receive pack program
+    --follow-tags                                   # push missing but relevant tags
+    --force-with-lease: string                      # require old value of ref to be at this value
+    --force(-f)                                     # force updates
+    --ipv4(-4)                                      # use IPv4 addresses only
+    --ipv6(-6)                                      # use IPv6 addresses only
+    --mirror                                        # mirror all refs
+    --no-verify                                     # bypass pre-push hook
+    --porcelain                                     # machine-readable output
+    --progress                                      # force progress reporting
+    --prune                                         # prune locally removed refs
+    --push-option(-o): string                       # option to transmit
+    --quiet(-q)                                     # be more quiet
+    --receive-pack: string                          # receive pack program
+    --recurse-submodules: string                    # control recursive pushing of submodules
+    --repo: string                                  # repository
+    --set-upstream(-u)                              # set upstream for git pull/status
+    --signed: string                                # GPG sign the push
+    --tags                                          # push tags (can't be used with --all or --mirror)
+    --thin                                          # use thin pack
+    --verbose(-v)                                   # be more verbose
   ]
 }
 


### PR DESCRIPTION
# Description

Fix completions for `git push` and `git checkout` close: #5021 and #4599
Sort flags in ascending order

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
