### PR TITLE
fix timestamp parsing on 32-bit platforms

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -124,7 +124,7 @@ impl Command for Touch {
                 let size = val.len();
 
                 // Each stamp is a 2 digit number and the whole stamp must not be less than 4 or greater than 7 pairs
-                if (size % 2 != 0 || !(8..=14).contains(&size)) || val.parse::<usize>().is_err() {
+                if (size % 2 != 0 || !(8..=14).contains(&size)) || val.parse::<u64>().is_err() {
                     return Err(ShellError::UnsupportedInput(
                         "input has an invalid timestamp".to_string(),
                         span,


### PR DESCRIPTION


# Description

Fixes #5191

Fix timestamp parsing on 32-bit platforms.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
