### PR TITLE
Replace mpsc::sync_channel with mpsc::channel, to avoid timing bugs

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -17,7 +17,6 @@ use pathdiff::diff_paths;
 use regex::Regex;
 
 const OUTPUT_BUFFER_SIZE: usize = 1024;
-const OUTPUT_BUFFERS_IN_FLIGHT: usize = 3;
 
 #[derive(Clone)]
 pub struct External;
@@ -189,8 +188,8 @@ impl ExternalCommand {
                 let redirect_stderr = self.redirect_stderr;
                 let span = self.name.span;
                 let output_ctrlc = ctrlc.clone();
-                let (stdout_tx, stdout_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
-                let (stderr_tx, stderr_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
+                let (stdout_tx, stdout_rx) = mpsc::channel();
+                let (stderr_tx, stderr_rx) = mpsc::channel();
                 let (exit_code_tx, exit_code_rx) = mpsc::channel();
 
                 std::thread::spawn(move || {


### PR DESCRIPTION
# Description

Fixes #5156.

External commands have their output sent over a `mpsc::sync_channel` to a consumer. `sync_channel` has a static maximum queue size, and calls to a full channel block.

Seperately, within `crate/nu-command/src/system/complete.rs`, The entire stdout output is consumed, and then the entire stderr output is consumed.

The bug in #5156 arises when stderr's entire output does not fit into the stderr mpsc channel queue. The external command reads all of stdout before beginning to read stderr, but stdout will not close until the child process closes. The child process will not close until stderr can be completely written to the channel. Stderr cannot be written to the channel unless there is room in the channel's queue. The only way to have room in the channels queue is to consume the stderr stream, which loops all the way back around, and *tada*, deadlock.

Cheap fix is just to allow the queue to grow to arbitrary sizes. The other option to fix this is to actually create three threads, one for stdout, one for stderr, and one for joining those two, and handling exit codes. The three-thread option feels bloated and inefficient, but I understand that unbounded queue sizes is also a little scary.

Negative effects of this change is that the entirety of stderr is pushed into and out of memory, which could be problematic for large outputs.

# Tests

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
