### PR TITLE
Avoid duplicating post headers

### DIFF
--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -205,6 +205,13 @@ fn helper(
     };
 
     let mut request = http_client(args.insecure.is_some()).post(location);
+
+    // set the content-type header before using e.g., request.json bc
+    //  that will vaoid duplicating the header value
+    if let Some(val) = args.content_type {
+        request = request.header("Content-Type", val);
+    }
+
     match body {
         Value::Binary { val, .. } => {
             request = request.body(val);
@@ -235,9 +242,6 @@ fn helper(
         }
     };
 
-    if let Some(val) = args.content_type {
-        request = request.header("Content-Type", val);
-    }
     if let Some(val) = args.content_length {
         request = request.header("Content-Length", val);
     }

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -206,8 +206,8 @@ fn helper(
 
     let mut request = http_client(args.insecure.is_some()).post(location);
 
-    // set the content-type header before using e.g., request.json bc
-    //  that will vaoid duplicating the header value
+    // set the content-type header before using e.g., request.json
+    // because that will avoid duplicating the header value
     if let Some(val) = args.content_type {
         request = request.header("Content-Type", val);
     }


### PR DESCRIPTION
This should fix #5194

# Description

It appears that reqwest handles not duplicating the content-type header when calling `request.json`, so setting the header before calling it should fix the problem.  I've tested it locally to ensure that the header isn't being duplicated.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
