### PR TITLE
Completion for variables of type Record

### DIFF
--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -1,7 +1,7 @@
 use crate::completions::{Completer, CompletionOptions};
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
-    Span,
+    Span, Value,
 };
 use reedline::Suggestion;
 use std::sync::Arc;
@@ -10,15 +10,19 @@ use std::sync::Arc;
 pub struct VariableCompletion {
     engine_state: Arc<EngineState>,
     stack: Stack,
-    previous_expr: Vec<u8>,
+    var_context: (Vec<u8>, Vec<Vec<u8>>), // tuple with $var and the sublevels (.b.c.d)
 }
 
 impl VariableCompletion {
-    pub fn new(engine_state: Arc<EngineState>, stack: Stack, previous_expr: Vec<u8>) -> Self {
+    pub fn new(
+        engine_state: Arc<EngineState>,
+        stack: Stack,
+        var_context: (Vec<u8>, Vec<Vec<u8>>),
+    ) -> Self {
         Self {
             engine_state,
             stack,
-            previous_expr,
+            var_context,
         }
     }
 }
@@ -34,38 +38,83 @@ impl Completer for VariableCompletion {
     ) -> (Vec<Suggestion>, CompletionOptions) {
         let mut output = vec![];
         let builtins = ["$nu", "$in", "$config", "$env", "$nothing"];
-        let previous_expr_str = std::str::from_utf8(&self.previous_expr)
+        let var_str = std::str::from_utf8(&self.var_context.0)
             .unwrap_or("")
             .to_lowercase();
+        let var_id = working_set.find_variable(&self.var_context.0);
+        let current_span = reedline::Span {
+            start: span.start - offset,
+            end: span.end - offset,
+        };
 
-        // Completions for the given variable (e.g: $env.<tab> for completing $env.SOMETHING)
-        if !self.previous_expr.is_empty() && previous_expr_str.as_str() == "$env" {
-            for env_var in self.stack.get_env_vars(&self.engine_state) {
-                output.push(Suggestion {
-                    value: env_var.0,
-                    description: None,
-                    extra: None,
-                    span: reedline::Span {
-                        start: span.start - offset,
-                        end: span.end - offset,
-                    },
-                });
+        // Completions for the given variable
+        if !var_str.is_empty() {
+            // Completion for $env.<tab>
+            if var_str.as_str() == "$env" {
+                for env_var in self.stack.get_env_vars(&self.engine_state) {
+                    output.push(Suggestion {
+                        value: env_var.0,
+                        description: None,
+                        extra: None,
+                        span: current_span,
+                    });
+                }
+
+                return (output, CompletionOptions::default());
             }
 
-            return (output, CompletionOptions::default());
+            // Completion other variable types
+            if let Some(var_id) = var_id {
+                // Extract the variable value from the stack
+                let var = self.stack.get_var(
+                    var_id,
+                    Span {
+                        start: span.start,
+                        end: span.end,
+                    },
+                );
+
+                // If the value exists and it's of type Record
+                if let Ok(mut value) = var {
+                    // Find recursively the values for sublevels
+                    // if no sublevels are set it returns the current value
+                    value = recursive_value(value, self.var_context.1.clone());
+
+                    match value {
+                        Value::Record {
+                            cols,
+                            vals: _,
+                            span: _,
+                        } => {
+                            // Add all the columns as completion
+                            for item in cols {
+                                output.push(Suggestion {
+                                    value: item,
+                                    description: None,
+                                    extra: None,
+                                    span: current_span,
+                                });
+                            }
+
+                            return (output, CompletionOptions::default());
+                        }
+
+                        _ => {
+                            return (output, CompletionOptions::default());
+                        }
+                    }
+                }
+            }
         }
 
+        // Variable completion (e.g: $en<tab> to complete $env)
         for builtin in builtins {
-            // Variable completion (e.g: $en<tab> to complete $env)
             if builtin.as_bytes().starts_with(&prefix) {
                 output.push(Suggestion {
                     value: builtin.to_string(),
                     description: None,
                     extra: None,
-                    span: reedline::Span {
-                        start: span.start - offset,
-                        end: span.end - offset,
-                    },
+                    span: current_span,
                 });
             }
         }
@@ -78,10 +127,7 @@ impl Completer for VariableCompletion {
                         value: String::from_utf8_lossy(v.0).to_string(),
                         description: None,
                         extra: None,
-                        span: reedline::Span {
-                            start: span.start - offset,
-                            end: span.end - offset,
-                        },
+                        span: current_span,
                     });
                 }
             }
@@ -95,10 +141,7 @@ impl Completer for VariableCompletion {
                         value: String::from_utf8_lossy(v.0).to_string(),
                         description: None,
                         extra: None,
-                        span: reedline::Span {
-                            start: span.start - offset,
-                            end: span.end - offset,
-                        },
+                        span: current_span,
                     });
                 }
             }
@@ -108,4 +151,33 @@ impl Completer for VariableCompletion {
 
         (output, CompletionOptions::default())
     }
+}
+
+fn recursive_value(val: Value, sublevels: Vec<Vec<u8>>) -> Value {
+    // Go to next sublevel
+    if let Some(next_sublevel) = sublevels.clone().into_iter().next() {
+        match val {
+            Value::Record {
+                cols,
+                vals,
+                span: _,
+            } => {
+                for item in cols.into_iter().zip(vals.into_iter()) {
+                    // Check if index matches with sublevel
+                    if item.0.as_bytes().to_vec() == next_sublevel {
+                        // If matches try to fetch recursively the next
+                        return recursive_value(item.1, sublevels.into_iter().skip(1).collect());
+                    }
+                }
+
+                // Current sublevel value not found
+                return Value::Nothing {
+                    span: Span { start: 0, end: 0 },
+                };
+            }
+            _ => return val,
+        }
+    }
+
+    val
 }


### PR DESCRIPTION
# Description

This adds completion for variables of type `Record` going backwards until the first variable. Once we find that variable we fetch the results based on the **depth** of the sequence.

**Idea:**
```
$ let rec = {name: nushell, a: { b: { c: e, d: f} } }
$ echo $rec.a.b.<tab>
c            d
```


The idea is based on sublevels (which I'm calling depth here), once we fetch the value for the `Variable` ($rec in this case) we need to recursively be able to find all the sublevels `a` and `b` and return as suggestion the columns that the record `b` has.
```
[
  (Span { start: 22668, end: 22672 }, InternalCall),   # | |  echo
  (Span { start: 22673, end: 22677 }, Variable),       # | | a
  (Span { start: 22678, end: 22679 }, String),         # | | b
  (Span { start: 22682, end: 22684 }, String)          # <tab> completion
                                                        # \/ depth
]
```

We need to go all the way up to the first most left variable we find, if no variable is found the variable completion shouldn't be triggered. I'm doing some tricks to reverse the order of the `Vec` to correctly mount the sublevels.

In order to complete the recursive part I created the function `recursive_value` which is responsible for going all the depth for a given `Value` and the sublevels `Vec<Vec<u8>>`.

**Test cases:**
- [x] `echo $rec.<tab>` needs to return `[ a,  name ]`
- [x] `echo $rec.a.<tab>` needs to return `[ b ]`
- [x] `echo $rec.a.b.<tab>` needs to return `[ c, d ]`
- [x] `echo $rec.a.b.c.<tab>` needs to return `[  ]`

[![asciicast](https://asciinema.org/a/XaudNMDGaRmTiKCD0y9IPxGC1.svg)](https://asciinema.org/a/XaudNMDGaRmTiKCD0y9IPxGC1)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
