### PR TITLE
Fix env capture

### DIFF
--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -15,7 +15,7 @@ pub use lite_parse::{lite_parse, LiteBlock};
 
 pub use parser::{
     is_math_expression_like, parse, parse_block, parse_duration_bytes, parse_external_call,
-    trim_quotes, Import,
+    trim_quotes, unescape_unquote_string, Import,
 };
 
 #[cfg(feature = "plugin")]


### PR DESCRIPTION
# Description

Fixes #5185

Fix `put_env_to_fake_file()` to escape names and values correctly.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
