### PR TITLE
nu-cli/completions: removed unnecessary bool

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -71,7 +71,6 @@ impl NuCompleter {
                 for (flat_idx, flat) in flattened.iter().enumerate() {
                     if pos >= flat.0.start && pos < flat.0.end {
                         // Context variables
-                        let mut is_variable_completion = false;
                         let most_left_var =
                             most_left_variable(flat_idx, &working_set, flattened.clone());
 
@@ -85,13 +84,8 @@ impl NuCompleter {
                         let mut prefix = working_set.get_span_contents(flat.0).to_vec();
                         prefix.remove(pos - flat.0.start);
 
-                        // Check if has most left variable
-                        if most_left_var.is_some() {
-                            is_variable_completion = true;
-                        }
-
                         // Variables completion
-                        if prefix.starts_with(b"$") || is_variable_completion {
+                        if prefix.starts_with(b"$") || most_left_var.is_some() {
                             let mut completer = VariableCompletion::new(
                                 self.engine_state.clone(),
                                 self.stack.clone(),


### PR DESCRIPTION
# Description

Just some cleanup removing one unnecessary boolean that was left behind.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
