### PR TITLE
[ls, path relative-to] Fix use of `ls ~ | path relative-to ~`

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -3,13 +3,13 @@ use crate::DirInfo;
 use chrono::{DateTime, Local};
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
+use nu_path::expand_to_real_path;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, DataSource, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     PipelineMetadata, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
-use nu_path::expand_to_real_path;
 use pathdiff::diff_paths;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -9,6 +9,7 @@ use nu_protocol::{
     Category, DataSource, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     PipelineMetadata, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
+use nu_path::expand_to_real_path;
 use pathdiff::diff_paths;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -76,7 +77,7 @@ impl Command for Ls {
         let (path, p_tag, absolute_path) = match pattern_arg {
             Some(p) => {
                 let p_tag = p.span;
-                let mut p = PathBuf::from(p.item);
+                let mut p = expand_to_real_path(p.item);
 
                 let expanded = nu_path::expand_path_with(&p, &cwd);
                 if expanded.is_dir() {
@@ -224,6 +225,11 @@ impl Command for Ls {
                 result: None,
             },
             Example {
+                description: "List all files with full path in the parent directory",
+                example: "ls -f ..",
+                result: None,
+            },
+            Example {
                 description: "List all rust files",
                 example: "ls *.rs",
                 result: None,
@@ -234,8 +240,8 @@ impl Command for Ls {
                 result: None,
             },
             Example {
-                description: "List all dirs with full path name in your home directory",
-                example: "ls -f ~ | where type == dir",
+                description: "List all dirs in your home directory",
+                example: "ls ~ | where type == dir",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -4,6 +4,7 @@ use nu_engine::CallExt;
 use nu_protocol::{
     engine::Command, Example, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
+use nu_path::expand_to_real_path;
 
 use super::PathSubcommandArguments;
 
@@ -114,7 +115,9 @@ path."#
 }
 
 fn relative_to(path: &Path, span: Span, args: &Arguments) -> Value {
-    match path.strip_prefix(Path::new(&args.path.item)) {
+    let lhs = expand_to_real_path(path);
+    let rhs = expand_to_real_path(&args.path.item);
+    match lhs.strip_prefix(&rhs) {
         Ok(p) => Value::string(p.to_string_lossy(), span),
         Err(e) => Value::Error {
             error: ShellError::CantConvert(e.to_string(), "string".into(), span),

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
 use nu_engine::CallExt;
+use nu_path::expand_to_real_path;
 use nu_protocol::{
     engine::Command, Example, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
-use nu_path::expand_to_real_path;
 
 use super::PathSubcommandArguments;
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -398,7 +398,7 @@ impl ExternalCommand {
     /// Spawn a command without shelling out to an external shell
     pub fn spawn_simple_command(&self, cwd: &str) -> Result<std::process::Command, ShellError> {
         let head = trim_enclosing_quotes(&self.name.item);
-        let head = nu_path::expand_path_for_external_programs(head)
+        let head = nu_path::expand_to_real_path(head)
             .to_string_lossy()
             .to_string();
 
@@ -409,7 +409,7 @@ impl ExternalCommand {
                 item: trim_enclosing_quotes(&arg.item),
                 span: arg.span,
             };
-            arg.item = nu_path::expand_path_for_external_programs(arg.item)
+            arg.item = nu_path::expand_to_real_path(arg.item)
                 .to_string_lossy()
                 .to_string();
 

--- a/crates/nu-path/src/expansions.rs
+++ b/crates/nu-path/src/expansions.rs
@@ -50,8 +50,7 @@ where
 }
 
 fn expand_path(path: impl AsRef<Path>) -> PathBuf {
-    let path = expand_tilde(path);
-    let path = expand_ndots(path);
+    let path = expand_to_real_path(path);
     expand_dots(path)
 }
 
@@ -74,12 +73,13 @@ where
     expand_path(path)
 }
 
-/// Resolve similarly to other shells - tilde is expanded, and ndot path components are expanded.
+/// Resolve to a path that is accepted by the system and no further - tilde is expanded, and ndot path components are expanded.
 ///
 /// This function will take a leading tilde path component, and expand it to the user's home directory;
 /// it will also expand any path elements consisting of only dots into the correct number of `..` path elements.
-/// It does not touch the system at all, except for getting the home directory of the current user.
-pub fn expand_path_for_external_programs<P>(path: P) -> PathBuf
+/// It does not do any normalization except to what will be accepted by Path::open,
+/// and it does not touch the system at all, except for getting the home directory of the current user.
+pub fn expand_to_real_path<P>(path: P) -> PathBuf
 where
     P: AsRef<Path>,
 {

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -4,7 +4,7 @@ mod helpers;
 mod tilde;
 mod util;
 
-pub use expansions::{canonicalize_with, expand_path_for_external_programs, expand_path_with};
+pub use expansions::{canonicalize_with, expand_to_real_path, expand_path_with};
 pub use helpers::{config_dir, home_dir};
 pub use tilde::expand_tilde;
 pub use util::trim_trailing_slash;

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -4,7 +4,7 @@ mod helpers;
 mod tilde;
 mod util;
 
-pub use expansions::{canonicalize_with, expand_to_real_path, expand_path_with};
+pub use expansions::{canonicalize_with, expand_path_with, expand_to_real_path};
 pub use helpers::{config_dir, home_dir};
 pub use tilde::expand_tilde;
 pub use util::trim_trailing_slash;


### PR DESCRIPTION
# Description

Fixes #5202 

It makes two changes:

* `ls ~` expands the tilde
* `path relative-to` expands both the lhs and rhs, so that `'~' | path relative-to HOMEDIR` is correct, and `'HOMEDIR' | path relative-to ~` is correct; it additionally fixes `...` paths

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
