### PR TITLE
Simplify known external name recovery

### DIFF
--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -1,4 +1,4 @@
-use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
+use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::{
     ast::{Argument, Call, Expr, Expression},
     engine::Command,
@@ -47,10 +47,7 @@ impl Command for KnownExternal {
 
         let mut extern_call = Call::new(head_span);
 
-        let working_state = StateWorkingSet::new(engine_state);
-        let extern_name = working_state.get_span_contents(call.head);
-        let extern_name = String::from_utf8(extern_name.to_vec())
-            .expect("this was already parsed as a command name");
+        let extern_name = engine_state.get_decl(call.decl_id).name();
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
 


### PR DESCRIPTION
# Description

Prior to this change we would recover the names for known
externals by looking up the span in the engine state. This would fail
when using an alias for two reasons:

1. In cases where we don't have a subcommand, like this:

```
>>> extern bat [filename: string]
>>> alias b = bat
>>> bat some_file
'b' is not recognized as an internal or external command,
operable program or batch file.
```

The problem is that after alias expansion, we replace the span of the
expanded name with the original alias (this is done to alleviate
non-related issues). The span contents we look up therefore contain `b`,
the alias, instead of the expanded command name.

2. In cases where there's a subcommand:
```
>>> alias g = git
>>> g push
thread 'main' panicked at 'internal error: span missing in file contents cache', crates\nu-protocol\src\engine\engine_state.rs:474:9
note: run with `RUST_BACKTRACE=1` environment variable to display a
backtrace
```

In this case, the span in call starts where the expansion for the `g`
alias is defined and end after `push` on the last command entered. This
is not a proper span and causes a panic when we try to look it up. Note
that this is the case for all expanded aliases that involve a
subcommand, but we never actually try to retrieve the contents for that
span in other cases.

Anyway, the new way of looking up the name is arguably cleaner
regardless of the issues mentioned above. But it's nice that it fixes
them too.


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
