### PR TITLE
Remove 'empty' block support reminders, for now.

### DIFF
--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -56,6 +56,7 @@ impl Command for Empty {
                 }),
             },
             Example {
+                // TODO: revisit empty cell path semantics for a record.
                 description: "Check if more than one column are empty",
                 example: "[[meal size]; [arepa small] [taco '']] | empty? meal size",
                 result: Some(Value::Bool {
@@ -125,27 +126,12 @@ fn empty(
                 span: head,
             }
             .into_pipeline_data()),
-            PipelineData::Value(value, ..) => {
-                let answer = is_empty(value);
-
-                Ok(Value::Bool {
-                    val: answer,
-                    span: head,
-                }
-                .into_pipeline_data())
+            PipelineData::Value(value, ..) => Ok(Value::Bool {
+                val: value.is_empty(),
+                span: head,
             }
+            .into_pipeline_data()),
         }
-    }
-}
-
-pub fn is_empty(value: Value) -> bool {
-    match value {
-        Value::List { vals, .. } => vals.is_empty(),
-        Value::String { val, .. } => val.is_empty(),
-        Value::Binary { val, .. } => val.is_empty(),
-        Value::Nothing { .. } => true,
-        Value::Record { cols, .. } => cols.is_empty(),
-        _ => false,
     }
 }
 

--- a/crates/nu-command/tests/commands/empty.rs
+++ b/crates/nu-command/tests/commands/empty.rs
@@ -1,7 +1,5 @@
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn reports_emptiness() {
     let actual = nu!(
@@ -10,85 +8,14 @@ fn reports_emptiness() {
             echo [[are_empty];
                      [([[check]; [[]]      ])]
                      [([[check]; [""]      ])]
-                     [([[check]; [(wrap)] ])]
+                     [([[check]; [{}] ])]
             ]
             | get are_empty
-            | empty? check
-            | where check
-            | length
+            | all? {
+              empty? check
+            }
         "#
     ));
 
-    assert_eq!(actual.out, "3");
-}
-
-// FIXME: jt: needs more work
-#[ignore]
-#[test]
-fn sets_block_run_value_for_an_empty_column() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            echo [
-                     [  first_name, last_name,   rusty_at, likes  ];
-                     [      Andrés,  Robalino, 10/11/2013,   1    ]
-                     [    Jonathan,    Turner, 10/12/2013,   1    ]
-                     [       Jason,     Gedge, 10/11/2013,   1    ]
-                     [      Yehuda,      Katz, 10/11/2013,  ''    ]
-            ]
-            | empty? likes -b {|_| 1 }
-            | get likes
-            | math sum
-        "#
-    ));
-
-    assert_eq!(actual.out, "4");
-}
-
-// FIXME: jt: needs more work
-#[ignore]
-#[test]
-fn sets_block_run_value_for_many_empty_columns() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            echo [
-                     [  boost   check   ];
-                     [     1,    []     ]
-                     [     1,    ""     ]
-                     [     1,  (wrap)  ]
-            ]
-            | empty? boost check -b { 1 }
-            | get boost check
-            | math sum
-        "#
-    ));
-
-    assert_eq!(actual.out, "6");
-}
-
-// FIXME: jt: needs more work
-#[ignore]
-#[test]
-fn passing_a_block_will_set_contents_on_empty_cells_and_leave_non_empty_ones_untouched() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            echo [
-                     [      NAME, LVL,   HP ];
-                     [    Andrés,  30, 3000 ]
-                     [  Alistair,  29, 2900 ]
-                     [    Arepas,  "",   "" ]
-                     [     Jorge,  30, 3000 ]
-            ]
-            | empty? LVL -b { 9 }
-            | empty? HP -b {
-                $it.LVL * 1000
-              }
-            | math sum
-            | get HP
-        "#
-    ));
-
-    assert_eq!(actual.out, "17900");
+    assert_eq!(actual.out, "true");
 }

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -31,6 +31,10 @@ impl Span {
         Span { start, end }
     }
 
+    pub fn unknown() -> Self {
+        Self::new(0, 0)
+    }
+
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors.
     pub fn test_data() -> Span {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -574,12 +574,9 @@ impl Value {
     pub fn is_empty(&self) -> bool {
         match self {
             Value::String { val, .. } => val.is_empty(),
-            Value::List { vals, .. } => {
-                vals.is_empty() && vals.iter().all(|v| v.clone().is_empty())
-            }
-            Value::Record { cols, vals, .. } => {
-                cols.iter().all(|v| v.is_empty()) && vals.iter().all(|v| v.clone().is_empty())
-            }
+            Value::List { vals, .. } => vals.is_empty(),
+            Value::Record { cols, .. } => cols.is_empty(),
+            Value::Binary { val, .. } => val.is_empty(),
             Value::Nothing { .. } => true,
             _ => false,
         }
@@ -2408,4 +2405,64 @@ fn get_config_filesize_format(config: &Config) -> (ByteUnit, &str) {
     };
 
     filesize_format
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{Span, Value};
+
+    mod is_empty {
+        use super::*;
+
+        #[test]
+        fn test_string() {
+            let value = Value::string("", Span::unknown());
+            assert!(value.is_empty());
+        }
+
+        #[test]
+        fn test_list() {
+            let list_with_no_values = Value::List {
+                vals: vec![],
+                span: Span::unknown(),
+            };
+            let list_with_one_empty_string = Value::List {
+                vals: vec![Value::string("", Span::unknown())],
+                span: Span::unknown(),
+            };
+
+            assert!(list_with_no_values.is_empty());
+            assert!(!list_with_one_empty_string.is_empty());
+        }
+
+        #[test]
+        fn test_record() {
+            let no_columns_nor_cell_values = Value::Record {
+                cols: vec![],
+                vals: vec![],
+                span: Span::unknown(),
+            };
+            let one_column_and_one_cell_value_with_empty_strings = Value::Record {
+                cols: vec![String::from("")],
+                vals: vec![Value::string("", Span::unknown())],
+                span: Span::unknown(),
+            };
+            let one_column_with_a_string_and_one_cell_value_with_empty_string = Value::Record {
+                cols: vec![String::from("column")],
+                vals: vec![Value::string("", Span::unknown())],
+                span: Span::unknown(),
+            };
+            let one_column_with_empty_string_and_one_value_with_a_string = Value::Record {
+                cols: vec![String::from("")],
+                vals: vec![Value::string("text", Span::unknown())],
+                span: Span::unknown(),
+            };
+
+            assert!(no_columns_nor_cell_values.is_empty());
+            assert!(!one_column_and_one_cell_value_with_empty_strings.is_empty());
+            assert!(!one_column_with_a_string_and_one_cell_value_with_empty_string.is_empty());
+            assert!(!one_column_with_empty_string_and_one_value_with_a_string.is_empty());
+        }
+    }
 }


### PR DESCRIPTION
# Description

Removing ignored tests. This is a good opportunity to step back and think `empty?` semantics when blocks are supported. I'm not completely sure whether block support should be here for the time being. The main reason is that, `empty?` at the moment looks like it's mostly for asking questions if something from the input is empty or not (we either want to know whether it's true or false).

The support for taking cell paths using `empty?` needs to be revisited as well. It looks like we currently use it now and assume `empty?` behaves as if we are asking "are any of these columns empty?, if so, return false" but this does not sound right (to answer a question like this one would use something like `... | any? { }` instead).

Block support we should definitively study it again. The original intent of blocks with `empty?` was, such that, it would run the block and its return value would be set against the input if it is empty. But I'm no longer sure (although quite powerful in practice) whether `empty?` should exclusively answer `true` or `false`, AND answer the result of a block if it's input is empty (doesn't feel right).

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
