### PR TITLE
Add known external tests

### DIFF
--- a/examples/test_hello.rs
+++ b/examples/test_hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("test-hello");
+}

--- a/examples/test_hello.rs
+++ b/examples/test_hello.rs
@@ -1,3 +1,6 @@
+/// This function is only meant to be used as part of the test suite
+/// as a simple, cross-platform executable with known output.
+
 fn main() {
     println!("test-hello");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,7 @@ mod test_engine;
 mod test_env;
 mod test_hiding;
 mod test_iteration;
+mod test_known_external;
 mod test_math;
 mod test_modules;
 mod test_parser;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,6 +43,10 @@ pub fn run_test(input: &str, expected: &str) -> TestResult {
 
     let mut cmd = Command::cargo_bin("nu")?;
     cmd.arg(name);
+    cmd.env(
+        "PWD",
+        std::env::current_dir().expect("Can't get current dir"),
+    );
 
     writeln!(file, "{}", input)?;
 

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -1,0 +1,33 @@
+use crate::tests::{fail_test, run_test, TestResult};
+
+#[test]
+fn known_external_runs() -> TestResult {
+    run_test(
+        r#"extern "cargo run" [-q, --example: string, ...args]; cargo run -q --example test_hello"#,
+        "test-hello",
+    )
+}
+
+#[test]
+fn known_external_unknown_flag() -> TestResult {
+    fail_test(
+        r#"extern "cargo run" [-q, --example: string, ...args]; cargo run -d"#,
+        "command doesn't have flag",
+    )
+}
+
+#[test]
+fn known_external_alias() -> TestResult {
+    run_test(
+        r#"extern "cargo run" [-q, --example: string, ...args]; alias cr = cargo run; cr -q --example test_hello"#,
+        "test-hello",
+    )
+}
+
+#[test]
+fn known_external_subcommand_alias() -> TestResult {
+    run_test(
+        r#"extern "cargo run" [-q, --example: string, ...args]; alias c = cargo; c run -q --example test_hello"#,
+        "test-hello",
+    )
+}

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -16,6 +16,7 @@ fn known_external_unknown_flag() -> TestResult {
     )
 }
 
+/// GitHub issues #5179, #4618
 #[test]
 fn known_external_alias() -> TestResult {
     run_test(
@@ -24,6 +25,7 @@ fn known_external_alias() -> TestResult {
     )
 }
 
+/// GitHub issues #5179, #4618
 #[test]
 fn known_external_subcommand_alias() -> TestResult {
     run_test(


### PR DESCRIPTION
# Description

There were no tests for known externals so far, this PR adds some.

`examples/test_hello.rs` just prints `test-hello` to stdout and is meant to be used as a simple cross-platform executable with known output. I don't particularly like that it's in the top-level crate, because it seems a bit misleading, but I also didn't find a more appropriate place to put it.

The tests themselves use `cargo run` as the known external, but run the example file to test for output. Currently, I think that the first invocation of `cargo run` compiles `test_hello.rs` while the tests are running. Subsequent tests reuse the already compiled binary. We could build the example as part of the build process prior to running the tests, but since it's just about the simplest program there is, I don't think that's necessarily worth it right now.

PR #5213 fixed the following issues, but this PR adds tests for them:
- #5179 
- #4618 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
