### PR TITLE
Simplify known external tests

### DIFF
--- a/examples/test_hello.rs
+++ b/examples/test_hello.rs
@@ -1,6 +1,0 @@
-/// This function is only meant to be used as part of the test suite
-/// as a simple, cross-platform executable with known output.
-
-fn main() {
-    println!("test-hello");
-}

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -5,10 +5,7 @@ use crate::tests::{fail_test, run_test_contains, TestResult};
 
 #[test]
 fn known_external_runs() -> TestResult {
-    run_test_contains(
-        r#"extern "cargo version" []; cargo version"#,
-        "cargo",
-    )
+    run_test_contains(r#"extern "cargo version" []; cargo version"#, "cargo")
 }
 
 #[test]

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -1,17 +1,20 @@
-use crate::tests::{fail_test, run_test, TestResult};
+use crate::tests::{fail_test, run_test_contains, TestResult};
+
+// cargo version prints a string of the form:
+// cargo 1.60.0 (d1fd9fe2c 2022-03-01)
 
 #[test]
 fn known_external_runs() -> TestResult {
-    run_test(
-        r#"extern "cargo run" [-q, --example: string, ...args]; cargo run -q --example test_hello"#,
-        "test-hello",
+    run_test_contains(
+        r#"extern "cargo version" []; cargo version"#,
+        "cargo",
     )
 }
 
 #[test]
 fn known_external_unknown_flag() -> TestResult {
     fail_test(
-        r#"extern "cargo run" [-q, --example: string, ...args]; cargo run -d"#,
+        r#"extern "cargo version" []; cargo version --no-such-flag"#,
         "command doesn't have flag",
     )
 }
@@ -19,17 +22,17 @@ fn known_external_unknown_flag() -> TestResult {
 /// GitHub issues #5179, #4618
 #[test]
 fn known_external_alias() -> TestResult {
-    run_test(
-        r#"extern "cargo run" [-q, --example: string, ...args]; alias cr = cargo run; cr -q --example test_hello"#,
-        "test-hello",
+    run_test_contains(
+        r#"extern "cargo version" []; alias cv = cargo version; cv"#,
+        "cargo",
     )
 }
 
 /// GitHub issues #5179, #4618
 #[test]
 fn known_external_subcommand_alias() -> TestResult {
-    run_test(
-        r#"extern "cargo run" [-q, --example: string, ...args]; alias c = cargo; c run -q --example test_hello"#,
-        "test-hello",
+    run_test_contains(
+        r#"extern "cargo version" []; alias c = cargo; c version"#,
+        "cargo",
     )
 }


### PR DESCRIPTION
# Description

This is a follow-up of #5216. I realized the former ran slowly because for some configuration in the CI we ended up recompiling a lot to get the example running.

In this PR, we instead just use `cargo version`.

An alternative to this PR would be to use the `testbin` binaries from nu, but we can't test subcommands for those and we would additionally need to use the `nu!` macro, which isn't used in this suite of tests, so I wouldn't want to include it specifically for known externals.

An alternative command we could use is:

```
cargo metadata --format-version 1 | from json | get version
```

which should always print `"1"`. That would allow us to test the entire output, but it's slower and the invocation is long enough that it kinda obscures the more interesting part of the test.

If you would prefer that, I'll change it.


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
