### PR TITLE
update miette and switch to GenericErrors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,13 +2026,13 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a097de91d72c13382f60213ed9f7f7a26afd8bee0ea320b47f886a9a67ca5a1"
+checksum = "01ff8e2f24552a78cbf93f2b197f6a788192200c7200648514647cce438714bf"
 dependencies = [
  "atty",
  "backtrace",
- "miette-derive 4.4.0",
+ "miette-derive 4.5.0",
  "once_cell",
  "owo-colors",
  "supports-color",
@@ -2057,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a95a48d0bc28f9af628286e8a4da09f96f34a97744a2e9a5a4db9814ad527d"
+checksum = "7119608a3ee194199d537849bb7b600f9e04bb1c91b98fb2620b9a867f17ef20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2244,7 +2244,7 @@ dependencies = [
  "is_executable",
  "itertools",
  "log",
- "miette 4.4.0",
+ "miette 4.5.0",
  "nu-ansi-term",
  "nu-cli",
  "nu-color-config",
@@ -2286,7 +2286,7 @@ dependencies = [
  "crossterm",
  "is_executable",
  "log",
- "miette 4.4.0",
+ "miette 4.5.0",
  "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
@@ -2431,7 +2431,7 @@ version = "0.61.1"
 dependencies = [
  "chrono",
  "log",
- "miette 4.4.0",
+ "miette 4.5.0",
  "nu-path",
  "nu-plugin",
  "nu-protocol",
@@ -2475,7 +2475,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "indexmap",
- "miette 4.4.0",
+ "miette 4.5.0",
  "nu-json",
  "num-format",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.19"
 crossterm = "0.23.0"
 ctrlc = "3.2.1"
 log = "0.4"
-miette = "4.1.0"
+miette = "4.5.0"
 nu-ansi-term = "0.45.1"
 nu-cli = { path="./crates/nu-cli", version = "0.61.1"  }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.61.1"  }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -16,7 +16,7 @@ nu-ansi-term = "0.45.1"
 nu-color-config = { path = "../nu-color-config", version = "0.61.1"  }
 
 crossterm = "0.23.0"
-miette = { version = "4.4.0", features = ["fancy"] }
+miette = { version = "4.5.0", features = ["fancy"] }
 thiserror = "1.0.29"
 reedline = { version = "0.4.0", features = ["bashisms"]}
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -262,7 +262,7 @@ pub fn evaluate_repl(
 
                             report_error(
                                 &working_set,
-                                &ShellError::DirectoryNotFound(tokens.0[0].span),
+                                &ShellError::DirectoryNotFound(tokens.0[0].span, None),
                             );
                         }
 

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -106,9 +106,12 @@ fn gather_env_vars(vars: impl Iterator<Item = (String, String)>, engine_state: &
         let working_set = StateWorkingSet::new(engine_state);
         report_error(
             &working_set,
-            &ShellError::LabeledError(
+            &ShellError::GenericError(
                 format!("Environment variable was not captured: {}", env_str),
-                msg.into(),
+                "".to_string(),
+                None,
+                Some(msg.into()),
+                Vec::new(),
             ),
         );
     }
@@ -152,9 +155,12 @@ fn gather_env_vars(vars: impl Iterator<Item = (String, String)>, engine_state: &
                 let working_set = StateWorkingSet::new(engine_state);
                 report_error(
                     &working_set,
-                    &ShellError::LabeledError(
+                    &ShellError::GenericError(
                         "Current directory not found".to_string(),
-                        format!("Retrieving current directory failed: {:?}", e),
+                        "".to_string(),
+                        None,
+                        Some(format!("Retrieving current directory failed: {:?}", e)),
+                        Vec::new(),
                     ),
                 );
             }

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -136,11 +136,14 @@ fn string_to_boolean(s: &str, span: Span) -> Result<bool, ShellError> {
             let val = o.parse::<f64>();
             match val {
                 Ok(f) => Ok(f.abs() >= f64::EPSILON),
-                Err(_) => Err(ShellError::CantConvertWithHelp(
+                Err(_) => Err(ShellError::CantConvert(
                     "boolean".to_string(),
                     "string".to_string(),
                     span,
-                    r#"the strings "true" and "false" can be converted into a bool"#.to_string(),
+                    Some(
+                        r#"the strings "true" and "false" can be converted into a bool"#
+                            .to_string(),
+                    ),
                 )),
             }
         }

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -260,11 +260,11 @@ fn action(
                     Ok(d) => Value::Date { val: d, span: head },
                     Err(reason) => {
                         return Value::Error {
-                            error: ShellError::CantConvertWithHelp(
+                            error: ShellError::CantConvert(
                                 format!("could not parse as datetime using format '{}'", dt.0),
                                 reason.to_string(),
                                 head,
-                                "you can use `into datetime` without a format string to enable flexible parsing".to_string()
+                                Some("you can use `into datetime` without a format string to enable flexible parsing".to_string())
                             ),
                         }
                     }

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -101,7 +101,12 @@ fn action(input: &Value, head: Span) -> Value {
             match other.parse::<f64>() {
                 Ok(x) => Value::Float { val: x, span: head },
                 Err(reason) => Value::Error {
-                    error: ShellError::CantConvert("float".to_string(), reason.to_string(), *span),
+                    error: ShellError::CantConvert(
+                        "float".to_string(),
+                        reason.to_string(),
+                        *span,
+                        None,
+                    ),
                 },
             }
         }

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -151,11 +151,11 @@ fn string_to_duration(s: &str, span: Span) -> Result<i64, ShellError> {
         }
     }
 
-    Err(ShellError::CantConvertWithHelp(
+    Err(ShellError::CantConvert(
         "duration".to_string(),
         "string".to_string(),
         span,
-        "supported units are ns, us, ms, sec, min, hr, day, and wk".to_string(),
+        Some("supported units are ns, us, ms, sec, min, hr, day, and wk".to_string()),
     ))
 }
 

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -148,7 +148,12 @@ pub fn action(input: &Value, span: Span) -> Value {
 fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     match a_string.trim().parse::<bytesize::ByteSize>() {
         Ok(n) => Ok(n.0 as i64),
-        Err(_) => Err(ShellError::CantConvert("int".into(), "string".into(), span)),
+        Err(_) => Err(ShellError::CantConvert(
+            "int".into(),
+            "string".into(),
+            span,
+            None,
+        )),
     }
 }
 

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -207,7 +207,7 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
     match i64::from_str_radix(&i, radix) {
         Ok(n) => Value::Int { val: n, span: head },
         Err(_reason) => Value::Error {
-            error: ShellError::CantConvert("int".to_string(), "string".to_string(), head),
+            error: ShellError::CantConvert("int".to_string(), "string".to_string(), head, None),
         },
     }
 }
@@ -219,29 +219,30 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
             let num = match i64::from_str_radix(b.trim_start_matches("0b"), 2) {
                 Ok(n) => n,
                 Err(_reason) => {
-                    return Err(ShellError::CantConvertWithHelp(
+                    return Err(ShellError::CantConvert(
                         "int".to_string(),
                         "string".to_string(),
                         span,
-                        r#"digits following "0b" can only be 0 or 1"#.to_string(),
+                        Some(r#"digits following "0b" can only be 0 or 1"#.to_string()),
                     ))
                 }
             };
             Ok(num)
         }
         h if h.starts_with("0x") => {
-            let num = match i64::from_str_radix(h.trim_start_matches("0x"), 16) {
-                Ok(n) => n,
-                Err(_reason) => {
-                    return Err(ShellError::CantConvertWithHelp(
+            let num =
+                match i64::from_str_radix(h.trim_start_matches("0x"), 16) {
+                    Ok(n) => n,
+                    Err(_reason) => return Err(ShellError::CantConvert(
                         "int".to_string(),
                         "string".to_string(),
                         span,
-                        r#"hexadecimal digits following "0x" should be in 0-9, a-f, or A-F"#
-                            .to_string(),
-                    ))
-                }
-            };
+                        Some(
+                            r#"hexadecimal digits following "0x" should be in 0-9, a-f, or A-F"#
+                                .to_string(),
+                        ),
+                    )),
+                };
             Ok(num)
         }
         _ => match a_string.parse::<i64>() {
@@ -252,6 +253,7 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
                     "int".to_string(),
                     "string".to_string(),
                     span,
+                    None,
                 )),
             },
         },

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -258,15 +258,20 @@ pub fn action(
             ),
         },
         Value::Binary { .. } => Value::Error {
-            error: ShellError::CantConvertWithHelp(
+            error: ShellError::CantConvert(
                 "string".into(),
                 "binary".into(),
                 span,
-                "try using the `decode` command".into(),
+                Some("try using the `decode` command".into()),
             ),
         },
         x => Value::Error {
-            error: ShellError::CantConvert(String::from("string"), x.get_type().to_string(), span),
+            error: ShellError::CantConvert(
+                String::from("string"),
+                x.get_type().to_string(),
+                span,
+                None,
+            ),
         },
     }
 }

--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -39,10 +39,12 @@ impl Command for ErrorMake {
             Ok(make_error(&arg)
                 .map(|err| Value::Error { error: err })
                 .unwrap_or_else(|| Value::Error {
-                    error: ShellError::SpannedLabeledError(
+                    error: ShellError::GenericError(
                         "Creating error value not supported.".into(),
                         "unsupported error format".into(),
-                        span,
+                        Some(span),
+                        None,
+                        Vec::new(),
                     ),
                 })
                 .into_pipeline_data())
@@ -52,10 +54,12 @@ impl Command for ErrorMake {
                     make_error(&value)
                         .map(|err| Value::Error { error: err })
                         .unwrap_or_else(|| Value::Error {
-                            error: ShellError::SpannedLabeledError(
+                            error: ShellError::GenericError(
                                 "Creating error value not supported.".into(),
                                 "unsupported error format".into(),
-                                span,
+                                Some(span),
+                                None,
+                                Vec::new(),
                             ),
                         })
                 },
@@ -103,20 +107,26 @@ fn make_error(value: &Value) -> Option<ShellError> {
                         Some(Value::String {
                             val: label_text, ..
                         }),
-                    ) => Some(ShellError::SpannedLabeledError(
+                    ) => Some(ShellError::GenericError(
                         message,
                         label_text,
-                        Span {
+                        Some(Span {
                             start: start as usize,
                             end: end as usize,
-                        },
+                        }),
+                        None,
+                        Vec::new(),
                     )),
                     _ => None,
                 }
             }
-            (Some(Value::String { val: message, .. }), None) => {
-                Some(ShellError::UnlabeledError(message))
-            }
+            (Some(Value::String { val: message, .. }), None) => Some(ShellError::GenericError(
+                message,
+                "".to_string(),
+                None,
+                None,
+                Vec::new(),
+            )),
             _ => None,
         }
     } else {

--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -48,10 +48,12 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         {
             pat
         } else {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Unexpected import".into(),
                 "import pattern not supported".into(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             ));
         };
 

--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -100,6 +100,7 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
                 "bool".into(),
                 x.get_type().to_string(),
                 result.span()?,
+                None,
             )),
         }
     }

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -46,10 +46,12 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         {
             pat
         } else {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Unexpected import".into(),
                 "import pattern not supported".into(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             ));
         };
 
@@ -120,13 +122,15 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
         } else {
             // TODO: This is a workaround since call.positional[0].span points at 0 for some reason
             // when this error is triggered
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 format!(
                     "Could not import from '{}'",
                     String::from_utf8_lossy(&import_pattern.head.name)
                 ),
                 "module does not exist".to_string(),
-                import_pattern.head.span,
+                Some(import_pattern.head.span),
+                None,
+                Vec::new(),
             ));
         }
 

--- a/crates/nu-command/src/dataframe/eager/column.rs
+++ b/crates/nu-command/src/dataframe/eager/column.rs
@@ -62,7 +62,13 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let res = df.as_ref().column(&column.item).map_err(|e| {
-        ShellError::SpannedLabeledError("Error selecting column".into(), e.to_string(), column.span)
+        ShellError::GenericError(
+            "Error selecting column".into(),
+            e.to_string(),
+            Some(column.span),
+            None,
+            Vec::new(),
+        )
     })?;
 
     NuDataFrame::try_from_series(vec![res.clone()], call.head)

--- a/crates/nu-command/src/dataframe/eager/describe.rs
+++ b/crates/nu-command/src/dataframe/eager/describe.rs
@@ -121,18 +121,22 @@ fn command(
                     if (&0.0..=&1.0).contains(&val) {
                         Ok(*val)
                     } else {
-                        Err(ShellError::SpannedLabeledError(
+                        Err(ShellError::GenericError(
                             "Incorrect value for quantile".to_string(),
                             "value should be between 0 and 1".to_string(),
-                            *span,
+                            Some(*span),
+                            None,
+                            Vec::new(),
                         ))
                     }
                 }
                 _ => match value.span() {
-                    Ok(span) => Err(ShellError::SpannedLabeledError(
+                    Ok(span) => Err(ShellError::GenericError(
                         "Incorrect value for quantile".to_string(),
                         "value should be a float".to_string(),
-                        span,
+                        Some(span),
+                        None,
+                        Vec::new(),
                     )),
                     Err(e) => Err(e),
                 },
@@ -242,7 +246,13 @@ fn command(
 
     DataFrame::new(res)
         .map_err(|e| {
-            ShellError::SpannedLabeledError("Dataframe Error".into(), e.to_string(), call.head)
+            ShellError::GenericError(
+                "Dataframe Error".into(),
+                e.to_string(),
+                Some(call.head),
+                None,
+                Vec::new(),
+            )
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-command/src/dataframe/eager/drop.rs
+++ b/crates/nu-command/src/dataframe/eager/drop.rs
@@ -66,18 +66,22 @@ fn command(
     let new_df = col_string
         .get(0)
         .ok_or_else(|| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Empty names list".into(),
                 "No column names where found".into(),
-                col_span,
+                Some(col_span),
+                None,
+                Vec::new(),
             )
         })
         .and_then(|col| {
             df.as_ref().drop(&col.item).map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error dropping column".into(),
                     e.to_string(),
-                    col.span,
+                    Some(col.span),
+                    None,
+                    Vec::new(),
                 )
             })
         })?;
@@ -89,10 +93,12 @@ fn command(
         .skip(1)
         .try_fold(new_df, |new_df, col| {
             new_df.drop(&col.item).map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error dropping column".into(),
                     e.to_string(),
-                    col.span,
+                    Some(col.span),
+                    None,
+                    Vec::new(),
                 )
             })
         })

--- a/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
@@ -97,10 +97,12 @@ fn command(
     df.as_ref()
         .distinct(subset_slice, keep_strategy)
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error dropping duplicates".into(),
                 e.to_string(),
-                col_span,
+                Some(col_span),
+                None,
+                Vec::new(),
             )
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -112,7 +112,13 @@ fn command(
     df.as_ref()
         .drop_nulls(subset_slice)
         .map_err(|e| {
-            ShellError::SpannedLabeledError("Error dropping nulls".into(), e.to_string(), col_span)
+            ShellError::GenericError(
+                "Error dropping nulls".into(),
+                e.to_string(),
+                Some(col_span),
+                None,
+                Vec::new(),
+            )
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -115,11 +115,12 @@ fn command(
     df.as_ref()
         .to_dummies()
         .map_err(|e| {
-            ShellError::SpannedLabeledErrorHelp(
+            ShellError::GenericError(
                 "Error calculating dummies".into(),
                 e.to_string(),
-                call.head,
-                "The only allowed column types for dummies are String or Int".into(),
+                Some(call.head),
+                Some("The only allowed column types for dummies are String or Int".into()),
+                Vec::new(),
             )
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -63,11 +63,12 @@ fn command(
     let mask_span = mask_value.span()?;
     let mask = NuDataFrame::try_from_value(mask_value)?.as_series(mask_span)?;
     let mask = mask.bool().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error casting to bool".into(),
             e.to_string(),
-            mask_span,
-            "Perhaps you want to use a series with booleans as mask".into(),
+            Some(mask_span),
+            Some("Perhaps you want to use a series with booleans as mask".into()),
+            Vec::new(),
         )
     })?;
 
@@ -76,11 +77,12 @@ fn command(
     df.as_ref()
         .filter(mask)
         .map_err(|e| {
-            ShellError::SpannedLabeledErrorHelp(
+            ShellError::GenericError(
                 "Error calculating dummies".into(),
                 e.to_string(),
-                call.head,
-                "The only allowed column types for dummies are String or Int".into(),
+                Some(call.head),
+                Some("The only allowed column types for dummies are String or Int".into()),
+                Vec::new(),
             )
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -67,10 +67,12 @@ fn command(
     df.as_ref()
         .select(&col_string)
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error selecting columns".into(),
                 e.to_string(),
-                col_span,
+                Some(col_span),
+                None,
+                Vec::new(),
             )
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/eager/groupby.rs
+++ b/crates/nu-command/src/dataframe/eager/groupby.rs
@@ -61,7 +61,13 @@ fn command(
     // dataframe. Once it has been done these values can be stored
     // in a NuGroupBy
     let groupby = df.as_ref().groupby(&col_string).map_err(|e| {
-        ShellError::SpannedLabeledError("Error creating groupby".into(), e.to_string(), col_span)
+        ShellError::GenericError(
+            "Error creating groupby".into(),
+            e.to_string(),
+            Some(col_span),
+            None,
+            Vec::new(),
+        )
     })?;
 
     let groups = groupby.get_groups();

--- a/crates/nu-command/src/dataframe/eager/melt.rs
+++ b/crates/nu-command/src/dataframe/eager/melt.rs
@@ -148,29 +148,35 @@ fn command(
         .as_ref()
         .melt(&id_col_string, &val_col_string)
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error calculating melt".into(),
                 e.to_string(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )
         })?;
 
     if let Some(name) = &variable_name {
         res.rename("variable", &name.item).map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error renaming column".into(),
                 e.to_string(),
-                name.span,
+                Some(name.span),
+                None,
+                Vec::new(),
             )
         })?;
     }
 
     if let Some(name) = &value_name {
         res.rename("value", &name.item).map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error renaming column".into(),
                 e.to_string(),
-                name.span,
+                Some(name.span),
+                None,
+                Vec::new(),
             )
         })?;
     }
@@ -187,10 +193,12 @@ fn check_column_datatypes<T: AsRef<str>>(
     col_span: Span,
 ) -> Result<(), ShellError> {
     if cols.is_empty() {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "Merge error".into(),
             "empty column list".into(),
-            col_span,
+            Some(col_span),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -198,31 +206,36 @@ fn check_column_datatypes<T: AsRef<str>>(
     if cols.len() > 1 {
         for w in cols.windows(2) {
             let l_series = df.column(w[0].as_ref()).map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error selecting columns".into(),
                     e.to_string(),
-                    col_span,
+                    Some(col_span),
+                    None,
+                    Vec::new(),
                 )
             })?;
 
             let r_series = df.column(w[1].as_ref()).map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error selecting columns".into(),
                     e.to_string(),
-                    col_span,
+                    Some(col_span),
+                    None,
+                    Vec::new(),
                 )
             })?;
 
             if l_series.dtype() != r_series.dtype() {
-                return Err(ShellError::SpannedLabeledErrorHelp(
+                return Err(ShellError::GenericError(
                     "Merge error".into(),
                     "found different column types in list".into(),
-                    col_span,
-                    format!(
+                    Some(col_span),
+                    Some(format!(
                         "datatypes {} and {} are incompatible",
                         l_series.dtype(),
                         r_series.dtype()
-                    ),
+                    )),
+                    Vec::new(),
                 ));
             }
         }

--- a/crates/nu-command/src/dataframe/eager/pivot.rs
+++ b/crates/nu-command/src/dataframe/eager/pivot.rs
@@ -28,11 +28,12 @@ impl Operation {
             "max" => Ok(Operation::Max),
             "mean" => Ok(Operation::Mean),
             "median" => Ok(Operation::Median),
-            _ => Err(ShellError::SpannedLabeledErrorHelp(
+            _ => Err(ShellError::GenericError(
                 "Operation not fount".into(),
                 "Operation does not exist for pivot".into(),
-                name.span,
-                "Options: first, sum, min, max, mean, median".into(),
+                Some(name.span),
+                Some("Options: first, sum, min, max, mean, median".into()),
+                Vec::new(),
             )),
         }
     }
@@ -116,7 +117,13 @@ fn command(
         Operation::Median => pivot.median(),
     }
     .map_err(|e| {
-        ShellError::SpannedLabeledError("Error creating pivot".into(), e.to_string(), call.head)
+        ShellError::GenericError(
+            "Error creating pivot".into(),
+            e.to_string(),
+            Some(call.head),
+            None,
+            Vec::new(),
+        )
     })
     .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }
@@ -126,7 +133,13 @@ fn check_pivot_column(
     col: &Spanned<String>,
 ) -> Result<(), ShellError> {
     let series = df.column(&col.item).map_err(|e| {
-        ShellError::SpannedLabeledError("Column not found".into(), e.to_string(), col.span)
+        ShellError::GenericError(
+            "Column not found".into(),
+            e.to_string(),
+            Some(col.span),
+            None,
+            Vec::new(),
+        )
     })?;
 
     match series.dtype() {
@@ -139,10 +152,12 @@ fn check_pivot_column(
         | DataType::Int32
         | DataType::Int64
         | DataType::Utf8 => Ok(()),
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Pivot error".into(),
             format!("Unsupported datatype {}", series.dtype()),
-            col.span,
+            Some(col.span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -152,7 +167,13 @@ fn check_value_column(
     col: &Spanned<String>,
 ) -> Result<(), ShellError> {
     let series = df.column(&col.item).map_err(|e| {
-        ShellError::SpannedLabeledError("Column not found".into(), e.to_string(), col.span)
+        ShellError::GenericError(
+            "Column not found".into(),
+            e.to_string(),
+            Some(col.span),
+            None,
+            Vec::new(),
+        )
     })?;
 
     match series.dtype() {
@@ -166,10 +187,12 @@ fn check_value_column(
         | DataType::Int64
         | DataType::Float32
         | DataType::Float64 => Ok(()),
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Pivot error".into(),
             format!("Unsupported datatype {}", series.dtype()),
-            col.span,
+            Some(col.span),
+            None,
+            Vec::new(),
         )),
     }
 }

--- a/crates/nu-command/src/dataframe/eager/rename.rs
+++ b/crates/nu-command/src/dataframe/eager/rename.rs
@@ -72,7 +72,13 @@ fn command(
     df.as_mut()
         .rename(&from, &to)
         .map_err(|e| {
-            ShellError::SpannedLabeledError("Error renaming".into(), e.to_string(), call.head)
+            ShellError::GenericError(
+                "Error renaming".into(),
+                e.to_string(),
+                Some(call.head),
+                None,
+                Vec::new(),
+            )
         })
         .map(|df| {
             PipelineData::Value(

--- a/crates/nu-command/src/dataframe/eager/sample.rs
+++ b/crates/nu-command/src/dataframe/eager/sample.rs
@@ -77,29 +77,36 @@ fn command(
 
     match (rows, fraction) {
         (Some(rows), None) => df.as_ref().sample_n(rows.item, replace, 0).map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error creating sample".into(),
                 e.to_string(),
-                rows.span,
+                Some(rows.span),
+                None,
+                Vec::new(),
             )
         }),
         (None, Some(frac)) => df.as_ref().sample_frac(frac.item, replace, 0).map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error creating sample".into(),
                 e.to_string(),
-                frac.span,
+                Some(frac.span),
+                None,
+                Vec::new(),
             )
         }),
-        (Some(_), Some(_)) => Err(ShellError::SpannedLabeledError(
+        (Some(_), Some(_)) => Err(ShellError::GenericError(
             "Incompatible flags".into(),
             "Only one selection criterion allowed".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )),
-        (None, None) => Err(ShellError::SpannedLabeledErrorHelp(
+        (None, None) => Err(ShellError::GenericError(
             "No selection".into(),
             "No selection criterion was found".into(),
-            call.head,
-            "Perhaps you want to use the flag -n or -f".into(),
+            Some(call.head),
+            Some("Perhaps you want to use the flag -n or -f".into()),
+            Vec::new(),
         )),
     }
     .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/eager/sort.rs
+++ b/crates/nu-command/src/dataframe/eager/sort.rs
@@ -95,10 +95,12 @@ fn command(
         df.as_ref()
             .sort(columns, reverse)
             .map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error sorting dataframe".into(),
                     e.to_string(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 )
             })
             .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
@@ -111,20 +113,24 @@ fn command(
             df.as_ref()
                 .sort(&col_string, reverse)
                 .map_err(|e| {
-                    ShellError::SpannedLabeledError(
+                    ShellError::GenericError(
                         "Error sorting dataframe".into(),
                         e.to_string(),
-                        col_span,
+                        Some(col_span),
+                        None,
+                        Vec::new(),
                     )
                 })
                 .map(|df| {
                     PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None)
                 })
         } else {
-            Err(ShellError::SpannedLabeledError(
+            Err(ShellError::GenericError(
                 "Missing columns".into(),
                 "missing column name to perform sort".into(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             ))
         }
     }

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -95,26 +95,31 @@ fn command(
     let casted = match index.dtype() {
         DataType::UInt32 | DataType::UInt64 | DataType::Int32 | DataType::Int64 => {
             index.cast(&DataType::UInt32).map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error casting index list".into(),
                     e.to_string(),
-                    index_span,
+                    Some(index_span),
+                    None,
+                    Vec::new(),
                 )
             })
         }
-        _ => Err(ShellError::SpannedLabeledErrorHelp(
+        _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             "Series with incorrect type".into(),
-            call.head,
-            "Consider using a Series with type int type".into(),
+            Some(call.head),
+            Some("Consider using a Series with type int type".into()),
+            Vec::new(),
         )),
     }?;
 
     let indices = casted.u32().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting index list".into(),
             e.to_string(),
-            index_span,
+            Some(index_span),
+            None,
+            Vec::new(),
         )
     })?;
 
@@ -122,10 +127,12 @@ fn command(
         df.as_ref()
             .take(indices)
             .map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error taking values".into(),
                     e.to_string(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 )
             })
             .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-command/src/dataframe/eager/to_csv.rs
@@ -74,10 +74,12 @@ fn command(
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let mut file = File::create(&file_name.item).map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error with file name".into(),
             e.to_string(),
-            file_name.span,
+            Some(file_name.span),
+            None,
+            Vec::new(),
         )
     })?;
 
@@ -93,10 +95,12 @@ fn command(
         None => writer,
         Some(d) => {
             if d.item.len() != 1 {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Incorrect delimiter".into(),
                     "Delimiter has to be one char".into(),
-                    d.span,
+                    Some(d.span),
+                    None,
+                    Vec::new(),
                 ));
             } else {
                 let delimiter = match d.item.chars().next() {
@@ -110,10 +114,12 @@ fn command(
     };
 
     writer.finish(df.as_mut()).map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error writing to file".into(),
             e.to_string(),
-            file_name.span,
+            Some(file_name.span),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-command/src/dataframe/eager/to_parquet.rs
@@ -58,15 +58,23 @@ fn command(
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let file = File::create(&file_name.item).map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error with file name".into(),
             e.to_string(),
-            file_name.span,
+            Some(file_name.span),
+            None,
+            Vec::new(),
         )
     })?;
 
     ParquetWriter::new(file).finish(df.as_mut()).map_err(|e| {
-        ShellError::SpannedLabeledError("Error saving file".into(), e.to_string(), file_name.span)
+        ShellError::GenericError(
+            "Error saving file".into(),
+            e.to_string(),
+            Some(file_name.span),
+            None,
+            Vec::new(),
+        )
     })?;
 
     let file_value = Value::String {

--- a/crates/nu-command/src/dataframe/eager/with_column.rs
+++ b/crates/nu-command/src/dataframe/eager/with_column.rs
@@ -83,10 +83,12 @@ fn command(
     df.as_mut()
         .with_column(series)
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error adding column to dataframe".into(),
                 e.to_string(),
-                other_span,
+                Some(other_span),
+                None,
+                Vec::new(),
             )
         })
         .map(|df| {

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -74,10 +74,12 @@ fn command(
 
     let series = df.as_series(call.head)?;
     let bool = series.bool().map_err(|_| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error converting to bool".into(),
             "all-false only works with series of type bool".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -74,10 +74,12 @@ fn command(
 
     let series = df.as_series(call.head)?;
     let bool = series.bool().map_err(|_| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error converting to bool".into(),
             "all-false only works with series of type bool".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/cumulative.rs
+++ b/crates/nu-command/src/dataframe/series/cumulative.rs
@@ -20,11 +20,12 @@ impl CumType {
             "min" => Ok(Self::Min),
             "max" => Ok(Self::Max),
             "sum" => Ok(Self::Sum),
-            _ => Err(ShellError::SpannedLabeledErrorHelp(
+            _ => Err(ShellError::GenericError(
                 "Wrong operation".into(),
                 "Operation not valid for cumulative".into(),
-                span,
-                "Allowed values: max, min, sum".into(),
+                Some(span),
+                Some("Allowed values: max, min, sum".into()),
+                Vec::new(),
             )),
         }
     }
@@ -102,10 +103,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     if let DataType::Object(_) = series.dtype() {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "Found object series".into(),
             "Series of type object cannot be used for cumulative operation".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         ));
     }
 

--- a/crates/nu-command/src/dataframe/series/date/as_date.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_date.rs
@@ -65,7 +65,13 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
     let casted = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledError("Error casting to string".into(), e.to_string(), call.head)
+        ShellError::GenericError(
+            "Error casting to string".into(),
+            e.to_string(),
+            Some(call.head),
+            None,
+            Vec::new(),
+        )
     })?;
 
     let res = if not_exact {
@@ -76,10 +82,12 @@ fn command(
 
     let mut res = res
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error creating datetime".into(),
                 e.to_string(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )
         })?
         .into_series();

--- a/crates/nu-command/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_datetime.rs
@@ -98,7 +98,13 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
     let casted = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledError("Error casting to string".into(), e.to_string(), call.head)
+        ShellError::GenericError(
+            "Error casting to string".into(),
+            e.to_string(),
+            Some(call.head),
+            None,
+            Vec::new(),
+        )
     })?;
 
     let res = if not_exact {
@@ -109,10 +115,12 @@ fn command(
 
     let mut res = res
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error creating datetime".into(),
                 e.to_string(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )
         })?
         .into_series();

--- a/crates/nu-command/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_day.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_hour.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_minute.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_month.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_second.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_week.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_weekday.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_year.rs
@@ -61,10 +61,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error casting to datetime type".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -59,10 +59,12 @@ fn command(
 
     let series = df.as_series(call.head)?;
     let bool = series.bool().map_err(|_| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error converting to bool".into(),
             "all-false only works with series of type bool".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -61,10 +61,12 @@ fn command(
         .as_series(call.head)?
         .arg_unique()
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error extracting unique values".into(),
                 e.to_string(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )
         })?
         .into_series();

--- a/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
@@ -69,10 +69,12 @@ fn command(
         .as_series(call.head)?
         .is_duplicated()
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error finding duplicates".into(),
                 e.to_string(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )
         })?
         .into_series();

--- a/crates/nu-command/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_in.rs
@@ -78,10 +78,12 @@ fn command(
         .as_series(call.head)?
         .is_in(&other)
         .map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error finding in other".into(),
                 e.to_string(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )
         })?
         .into_series();

--- a/crates/nu-command/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_unique.rs
@@ -66,10 +66,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let mut res = df.as_series(call.head)?.is_unique().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error finding unique values".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
     res.rename("is_unique");

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -65,7 +65,13 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let bool = series.bool().map_err(|e| {
-        ShellError::SpannedLabeledError("Error inverting mask".into(), e.to_string(), call.head)
+        ShellError::GenericError(
+            "Error inverting mask".into(),
+            e.to_string(),
+            Some(call.head),
+            None,
+            Vec::new(),
+        )
     })?;
 
     let res = bool.not();

--- a/crates/nu-command/src/dataframe/series/masks/set.rs
+++ b/crates/nu-command/src/dataframe/series/masks/set.rs
@@ -82,16 +82,20 @@ fn command(
 
     let bool_mask = match mask.dtype() {
         DataType::Boolean => mask.bool().map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error casting to bool".into(),
                 e.to_string(),
-                mask_span,
+                Some(mask_span),
+                None,
+                Vec::new(),
             )
         }),
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             "can only use bool series as mask".into(),
-            mask_span,
+            Some(mask_span),
+            None,
+            Vec::new(),
         )),
     }?;
 
@@ -101,37 +105,69 @@ fn command(
     let res = match value {
         Value::Int { val, span } => {
             let chunked = series.i64().map_err(|e| {
-                ShellError::SpannedLabeledError("Error casting to i64".into(), e.to_string(), span)
+                ShellError::GenericError(
+                    "Error casting to i64".into(),
+                    e.to_string(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )
             })?;
 
             let res = chunked.set(bool_mask, Some(val)).map_err(|e| {
-                ShellError::SpannedLabeledError("Error setting value".into(), e.to_string(), span)
+                ShellError::GenericError(
+                    "Error setting value".into(),
+                    e.to_string(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )
             })?;
 
             NuDataFrame::try_from_series(vec![res.into_series()], call.head)
         }
         Value::Float { val, span } => {
             let chunked = series.as_ref().f64().map_err(|e| {
-                ShellError::SpannedLabeledError("Error casting to f64".into(), e.to_string(), span)
+                ShellError::GenericError(
+                    "Error casting to f64".into(),
+                    e.to_string(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )
             })?;
 
             let res = chunked.set(bool_mask, Some(val)).map_err(|e| {
-                ShellError::SpannedLabeledError("Error setting value".into(), e.to_string(), span)
+                ShellError::GenericError(
+                    "Error setting value".into(),
+                    e.to_string(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )
             })?;
 
             NuDataFrame::try_from_series(vec![res.into_series()], call.head)
         }
         Value::String { val, span } => {
             let chunked = series.as_ref().utf8().map_err(|e| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error casting to string".into(),
                     e.to_string(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )
             })?;
 
             let res = chunked.set(bool_mask, Some(val.as_ref())).map_err(|e| {
-                ShellError::SpannedLabeledError("Error setting value".into(), e.to_string(), span)
+                ShellError::GenericError(
+                    "Error setting value".into(),
+                    e.to_string(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )
             })?;
 
             let mut res = res.into_series();
@@ -139,13 +175,15 @@ fn command(
 
             NuDataFrame::try_from_series(vec![res.into_series()], call.head)
         }
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Incorrect value type".into(),
             format!(
                 "this value cannot be set in a series of type '{}'",
                 series.dtype()
             ),
-            value.span()?,
+            Some(value.span()?),
+            None,
+            Vec::new(),
         )),
     };
 

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -57,10 +57,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let res = df.as_series(call.head)?.n_unique().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error counting unique values".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/rolling.rs
+++ b/crates/nu-command/src/dataframe/series/rolling.rs
@@ -22,11 +22,12 @@ impl RollType {
             "max" => Ok(Self::Max),
             "sum" => Ok(Self::Sum),
             "mean" => Ok(Self::Mean),
-            _ => Err(ShellError::SpannedLabeledErrorHelp(
+            _ => Err(ShellError::GenericError(
                 "Wrong operation".into(),
                 "Operation not valid for cumulative".into(),
-                span,
-                "Allowed values: min, max, sum, mean".into(),
+                Some(span),
+                Some("Allowed values: min, max, sum, mean".into()),
+                Vec::new(),
             )),
         }
     }
@@ -123,10 +124,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     if let DataType::Object(_) = series.dtype() {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "Found object series".into(),
             "Series of type object cannot be used for rolling operation".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -146,10 +149,12 @@ fn command(
     };
 
     let mut res = res.map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error calculating rolling values".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-command/src/dataframe/series/string/concatenate.rs
@@ -75,19 +75,23 @@ fn command(
 
     let other_series = other_df.as_series(other_span)?;
     let other_chunked = other_series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "The concatenate only with string columns".into(),
             e.to_string(),
-            other_span,
+            Some(other_span),
+            None,
+            Vec::new(),
         )
     })?;
 
     let series = df.as_series(call.head)?;
     let chunked = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "The concatenate only with string columns".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/contains.rs
+++ b/crates/nu-command/src/dataframe/series/string/contains.rs
@@ -71,18 +71,22 @@ fn command(
 
     let series = df.as_series(call.head)?;
     let chunked = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "The contains command only with string columns".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 
     let res = chunked.contains(&pattern).map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error searching in series".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/replace.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace.rs
@@ -83,18 +83,22 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
     let chunked = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error convertion to string".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 
     let mut res = chunked.replace(&pattern, &replace).map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error finding pattern other".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace_all.rs
@@ -83,18 +83,22 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
     let chunked = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error convertion to string".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 
     let mut res = chunked.replace_all(&pattern, &replace).map_err(|e| {
-        ShellError::SpannedLabeledError(
+        ShellError::GenericError(
             "Error finding pattern other".into(),
             e.to_string(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_lengths.rs
@@ -59,11 +59,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let chunked = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error casting to string".into(),
             e.to_string(),
-            call.head,
-            "The str-lengths command can only be used with string columns".into(),
+            Some(call.head),
+            Some("The str-lengths command can only be used with string columns".into()),
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_slice.rs
@@ -72,16 +72,23 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let chunked = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error casting to string".into(),
             e.to_string(),
-            call.head,
-            "The str-slice command can only be used with string columns".into(),
+            Some(call.head),
+            Some("The str-slice command can only be used with string columns".into()),
+            Vec::new(),
         )
     })?;
 
     let mut res = chunked.str_slice(start, length).map_err(|e| {
-        ShellError::SpannedLabeledError("Error slicing series".into(), e.to_string(), call.head)
+        ShellError::GenericError(
+            "Error slicing series".into(),
+            e.to_string(),
+            Some(call.head),
+            None,
+            Vec::new(),
+        )
     })?;
     res.rename(series.name());
 

--- a/crates/nu-command/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-command/src/dataframe/series/string/strftime.rs
@@ -69,11 +69,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error casting to date".into(),
             e.to_string(),
-            call.head,
-            "The str-slice command can only be used with string columns".into(),
+            Some(call.head),
+            Some("The str-slice command can only be used with string columns".into()),
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
@@ -63,11 +63,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error casting to string".into(),
             e.to_string(),
-            call.head,
-            "The str-slice command can only be used with string columns".into(),
+            Some(call.head),
+            Some("The str-slice command can only be used with string columns".into()),
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
@@ -63,11 +63,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let casted = series.utf8().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error casting to string".into(),
             e.to_string(),
-            call.head,
-            "The str-slice command can only be used with string columns".into(),
+            Some(call.head),
+            Some("The str-slice command can only be used with string columns".into()),
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/unique.rs
+++ b/crates/nu-command/src/dataframe/series/unique.rs
@@ -59,11 +59,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let res = series.unique().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error calculating unique values".into(),
             e.to_string(),
-            call.head,
-            "The str-slice command can only be used with string columns".into(),
+            Some(call.head),
+            Some("The str-slice command can only be used with string columns".into()),
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/series/value_counts.rs
+++ b/crates/nu-command/src/dataframe/series/value_counts.rs
@@ -64,11 +64,12 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let res = series.value_counts().map_err(|e| {
-        ShellError::SpannedLabeledErrorHelp(
+        ShellError::GenericError(
             "Error calculating value counts values".into(),
             e.to_string(),
-            call.head,
-            "The str-slice command can only be used with string columns".into(),
+            Some(call.head),
+            Some("The str-slice command can only be used with string columns".into()),
+            Vec::new(),
         )
     })?;
 

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/between_values.rs
@@ -66,10 +66,12 @@ pub(super) fn compute_between_series(
                     res.rename(&name);
                     NuDataFrame::series_to_value(res, operation_span)
                 }
-                Err(e) => Err(ShellError::SpannedLabeledError(
+                Err(e) => Err(ShellError::GenericError(
                     "Division error".into(),
                     e.to_string(),
-                    right.span()?,
+                    Some(right.span()?),
+                    None,
+                    Vec::new(),
                 )),
             }
         }
@@ -121,10 +123,12 @@ pub(super) fn compute_between_series(
                         res.rename(&name);
                         NuDataFrame::series_to_value(res, operation_span)
                     }
-                    _ => Err(ShellError::SpannedLabeledError(
+                    _ => Err(ShellError::GenericError(
                         "Incompatible types".into(),
                         "unable to cast to boolean".into(),
-                        right.span()?,
+                        Some(right.span()?),
+                        None,
+                        Vec::new(),
                     )),
                 }
             }
@@ -148,10 +152,12 @@ pub(super) fn compute_between_series(
                         res.rename(&name);
                         NuDataFrame::series_to_value(res, operation_span)
                     }
-                    _ => Err(ShellError::SpannedLabeledError(
+                    _ => Err(ShellError::GenericError(
                         "Incompatible types".into(),
                         "unable to cast to boolean".into(),
-                        right.span()?,
+                        Some(right.span()?),
+                        None,
+                        Vec::new(),
                     )),
                 }
             }
@@ -413,10 +419,12 @@ where
                     let casted = series.i64();
                     compute_casted_i64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::SpannedLabeledError(
+                Err(e) => Err(ShellError::GenericError(
                     "Unable to cast to i64".into(),
                     e.to_string(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )),
             }
         }
@@ -424,13 +432,15 @@ where
             let casted = series.i64();
             compute_casted_i64(casted, val, f, span)
         }
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             format!(
                 "Series of type {} can not be used for operations with an i64 value",
                 series.dtype()
             ),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -450,10 +460,12 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::SpannedLabeledError(
+        Err(e) => Err(ShellError::GenericError(
             "Unable to cast to i64".into(),
             e.to_string(),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -476,10 +488,12 @@ where
                     let casted = series.f64();
                     compute_casted_f64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::SpannedLabeledError(
+                Err(e) => Err(ShellError::GenericError(
                     "Unable to cast to f64".into(),
                     e.to_string(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )),
             }
         }
@@ -487,13 +501,15 @@ where
             let casted = series.f64();
             compute_casted_f64(casted, val, f, span)
         }
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             format!(
                 "Series of type {} can not be used for operations with a decimal value",
                 series.dtype()
             ),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -513,10 +529,12 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::SpannedLabeledError(
+        Err(e) => Err(ShellError::GenericError(
             "Unable to cast to f64".into(),
             e.to_string(),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -537,10 +555,12 @@ where
                     let casted = series.i64();
                     compare_casted_i64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::SpannedLabeledError(
+                Err(e) => Err(ShellError::GenericError(
                     "Unable to cast to f64".into(),
                     e.to_string(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )),
             }
         }
@@ -556,10 +576,12 @@ where
                         .expect("already checked for casting");
                     compare_casted_i64(Ok(&casted), val, f, span)
                 }
-                Err(e) => Err(ShellError::SpannedLabeledError(
+                Err(e) => Err(ShellError::GenericError(
                     "Unable to cast to f64".into(),
                     e.to_string(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )),
             }
         }
@@ -567,13 +589,15 @@ where
             let casted = series.i64();
             compare_casted_i64(casted, val, f, span)
         }
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             format!(
                 "Series of type {} can not be used for operations with an i64 value",
                 series.dtype()
             ),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -593,10 +617,12 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::SpannedLabeledError(
+        Err(e) => Err(ShellError::GenericError(
             "Unable to cast to i64".into(),
             e.to_string(),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -619,10 +645,12 @@ where
                     let casted = series.f64();
                     compare_casted_f64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::SpannedLabeledError(
+                Err(e) => Err(ShellError::GenericError(
                     "Unable to cast to i64".into(),
                     e.to_string(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )),
             }
         }
@@ -630,13 +658,15 @@ where
             let casted = series.f64();
             compare_casted_f64(casted, val, f, span)
         }
-        _ => Err(ShellError::SpannedLabeledError(
+        _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             format!(
                 "Series of type {} can not be used for operations with a decimal value",
                 series.dtype()
             ),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -656,10 +686,12 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::SpannedLabeledError(
+        Err(e) => Err(ShellError::GenericError(
             "Unable to cast to f64".into(),
             e.to_string(),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -675,17 +707,21 @@ fn contains_series_pat(series: &Series, pat: &str, span: Span) -> Result<Value, 
                     let res = res.into_series();
                     NuDataFrame::series_to_value(res, span)
                 }
-                Err(e) => Err(ShellError::SpannedLabeledError(
+                Err(e) => Err(ShellError::GenericError(
                     "Error using contains".into(),
                     e.to_string(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )),
             }
         }
-        Err(e) => Err(ShellError::SpannedLabeledError(
+        Err(e) => Err(ShellError::GenericError(
             "Unable to cast to string".into(),
             e.to_string(),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )),
     }
 }

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
@@ -122,7 +122,13 @@ pub fn create_column(
         }
         DataType::UInt8 => {
             let casted = series.u8().map_err(|e| {
-                ShellError::LabeledError("Error casting column to u8".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to u8".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -141,7 +147,13 @@ pub fn create_column(
         }
         DataType::UInt16 => {
             let casted = series.u16().map_err(|e| {
-                ShellError::LabeledError("Error casting column to u16".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to u16".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -160,7 +172,13 @@ pub fn create_column(
         }
         DataType::UInt32 => {
             let casted = series.u32().map_err(|e| {
-                ShellError::LabeledError("Error casting column to u32".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to u32".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -179,7 +197,13 @@ pub fn create_column(
         }
         DataType::UInt64 => {
             let casted = series.u64().map_err(|e| {
-                ShellError::LabeledError("Error casting column to u64".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to u64".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -198,7 +222,13 @@ pub fn create_column(
         }
         DataType::Int8 => {
             let casted = series.i8().map_err(|e| {
-                ShellError::LabeledError("Error casting column to i8".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to i8".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -217,7 +247,13 @@ pub fn create_column(
         }
         DataType::Int16 => {
             let casted = series.i16().map_err(|e| {
-                ShellError::LabeledError("Error casting column to i16".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to i16".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -236,7 +272,13 @@ pub fn create_column(
         }
         DataType::Int32 => {
             let casted = series.i32().map_err(|e| {
-                ShellError::LabeledError("Error casting column to i32".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to i32".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -255,7 +297,13 @@ pub fn create_column(
         }
         DataType::Int64 => {
             let casted = series.i64().map_err(|e| {
-                ShellError::LabeledError("Error casting column to i64".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to i64".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -274,7 +322,13 @@ pub fn create_column(
         }
         DataType::Float32 => {
             let casted = series.f32().map_err(|e| {
-                ShellError::LabeledError("Error casting column to f32".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to f32".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -293,7 +347,13 @@ pub fn create_column(
         }
         DataType::Float64 => {
             let casted = series.f64().map_err(|e| {
-                ShellError::LabeledError("Error casting column to f64".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to f64".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
             let values = casted
                 .into_iter()
@@ -309,7 +369,13 @@ pub fn create_column(
         }
         DataType::Boolean => {
             let casted = series.bool().map_err(|e| {
-                ShellError::LabeledError("Error casting column to bool".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to bool".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
 
             let values = casted
@@ -326,7 +392,13 @@ pub fn create_column(
         }
         DataType::Utf8 => {
             let casted = series.utf8().map_err(|e| {
-                ShellError::LabeledError("Error casting column to string".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to string".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
 
             let values = casted
@@ -350,9 +422,12 @@ pub fn create_column(
                 .downcast_ref::<ChunkedArray<ObjectType<DataFrameValue>>>();
 
             match casted {
-                None => Err(ShellError::LabeledError(
+                None => Err(ShellError::GenericError(
                     "Error casting object from series".into(),
-                    format!("Object not supported for conversion: {}", x),
+                    "".to_string(),
+                    None,
+                    Some(format!("Object not supported for conversion: {}", x)),
+                    Vec::new(),
                 )),
                 Some(ca) => {
                     let values = ca
@@ -371,7 +446,13 @@ pub fn create_column(
         }
         DataType::Date => {
             let casted = series.date().map_err(|e| {
-                ShellError::LabeledError("Error casting column to date".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to date".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
 
             let values = casted
@@ -401,7 +482,13 @@ pub fn create_column(
         }
         DataType::Datetime(_, _) => {
             let casted = series.datetime().map_err(|e| {
-                ShellError::LabeledError("Error casting column to datetime".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to datetime".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
 
             let values = casted
@@ -431,7 +518,13 @@ pub fn create_column(
         }
         DataType::Time => {
             let casted = series.timestamp(TimeUnit::Nanoseconds).map_err(|e| {
-                ShellError::LabeledError("Error casting column to time".into(), e.to_string())
+                ShellError::GenericError(
+                    "Error casting column to time".into(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
+                )
             })?;
 
             let values = casted
@@ -449,9 +542,12 @@ pub fn create_column(
 
             Ok(Column::new(casted.name().into(), values))
         }
-        e => Err(ShellError::LabeledError(
+        e => Err(ShellError::GenericError(
             "Error creating Dataframe".into(),
-            format!("Value not supported in nushell: {}", e),
+            "".to_string(),
+            None,
+            Some(format!("Value not supported in nushell: {}", e)),
+            Vec::new(),
         )),
     }
 }
@@ -620,5 +716,13 @@ pub fn from_parsed_columns(column_values: ColumnMap) -> Result<NuDataFrame, Shel
 
     DataFrame::new(df_series)
         .map(NuDataFrame::new)
-        .map_err(|e| ShellError::LabeledError("Error creating dataframe".into(), e.to_string()))
+        .map_err(|e| {
+            ShellError::GenericError(
+                "Error creating dataframe".into(),
+                "".to_string(),
+                None,
+                Some(e.to_string()),
+                Vec::new(),
+            )
+        })
 }

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/mod.rs
@@ -111,10 +111,12 @@ impl NuDataFrame {
     pub fn series_to_value(series: Series, span: Span) -> Result<Value, ShellError> {
         match DataFrame::new(vec![series]) {
             Ok(dataframe) => Ok(NuDataFrame::dataframe_into_value(dataframe, span)),
-            Err(e) => Err(ShellError::SpannedLabeledError(
+            Err(e) => Err(ShellError::GenericError(
                 "Error creating dataframe".into(),
                 e.to_string(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )),
         }
     }
@@ -152,10 +154,12 @@ impl NuDataFrame {
 
     pub fn try_from_series(columns: Vec<Series>, span: Span) -> Result<Self, ShellError> {
         let dataframe = DataFrame::new(columns).map_err(|e| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Error creating dataframe".into(),
                 format!("Unable to create DataFrame: {}", e),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )
         })?;
 
@@ -183,12 +187,14 @@ impl NuDataFrame {
                     "dataframe".into(),
                     "non-dataframe".into(),
                     span,
+                    None,
                 )),
             },
             x => Err(ShellError::CantConvert(
                 "dataframe".into(),
                 x.get_type().to_string(),
                 x.span()?,
+                None,
             )),
         }
     }
@@ -212,7 +218,13 @@ impl NuDataFrame {
         })?;
 
         let dataframe = DataFrame::new(vec![s.clone()]).map_err(|e| {
-            ShellError::SpannedLabeledError("Error creating dataframe".into(), e.to_string(), span)
+            ShellError::GenericError(
+                "Error creating dataframe".into(),
+                e.to_string(),
+                Some(span),
+                None,
+                Vec::new(),
+            )
         })?;
 
         Ok(Self(dataframe))
@@ -224,10 +236,12 @@ impl NuDataFrame {
 
     pub fn as_series(&self, span: Span) -> Result<Series, ShellError> {
         if !self.is_series() {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Error using as series".into(),
                 "dataframe has more than one column".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             ));
         }
 

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/operations.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/operations.rs
@@ -138,10 +138,12 @@ impl NuDataFrame {
                     .collect::<Vec<Series>>();
 
                 let df_new = DataFrame::new(new_cols).map_err(|e| {
-                    ShellError::SpannedLabeledError(
+                    ShellError::GenericError(
                         "Error creating dataframe".into(),
                         e.to_string(),
-                        span,
+                        Some(span),
+                        None,
+                        Vec::new(),
                     )
                 })?;
 
@@ -183,10 +185,12 @@ impl NuDataFrame {
                         match res {
                             Ok(s) => Ok(s.clone()),
                             Err(e) => Err({
-                                ShellError::SpannedLabeledError(
+                                ShellError::GenericError(
                                     "Error appending dataframe".into(),
                                     format!("Unable to append: {}", e),
-                                    span,
+                                    Some(span),
+                                    None,
+                                    Vec::new(),
                                 )
                             }),
                         }
@@ -194,10 +198,12 @@ impl NuDataFrame {
                     .collect::<Result<Vec<Series>, ShellError>>()?;
 
                 let df_new = DataFrame::new(new_cols).map_err(|e| {
-                    ShellError::SpannedLabeledError(
+                    ShellError::GenericError(
                         "Error appending dataframe".into(),
                         format!("Unable to append dataframes: {}", e),
-                        span,
+                        Some(span),
+                        None,
+                        Vec::new(),
                     )
                 })?;
 

--- a/crates/nu-command/src/dataframe/values/nu_groupby/mod.rs
+++ b/crates/nu-command/src/dataframe/values/nu_groupby/mod.rs
@@ -78,12 +78,14 @@ impl NuGroupBy {
                     "groupby".into(),
                     "non-dataframe".into(),
                     span,
+                    None,
                 )),
             },
             x => Err(ShellError::CantConvert(
                 "groupby".into(),
                 x.get_type().to_string(),
                 x.span()?,
+                None,
             )),
         }
     }
@@ -95,7 +97,13 @@ impl NuGroupBy {
 
     pub fn to_groupby(&self) -> Result<GroupBy, ShellError> {
         let by = self.dataframe.select_series(&self.by).map_err(|e| {
-            ShellError::LabeledError("Error creating groupby".into(), e.to_string())
+            ShellError::GenericError(
+                "Error creating groupby".into(),
+                "".to_string(),
+                None,
+                Some(e.to_string()),
+                Vec::new(),
+            )
         })?;
 
         Ok(GroupBy::new(

--- a/crates/nu-command/src/dataframe/values/utils.rs
+++ b/crates/nu-command/src/dataframe/values/utils.rs
@@ -13,10 +13,12 @@ pub(crate) fn convert_columns(
     let mut col_span = columns
         .get(0)
         .ok_or_else(|| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Empty column list".into(),
                 "Empty list found for command".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )
         })
         .and_then(|v| v.span())?;
@@ -28,10 +30,12 @@ pub(crate) fn convert_columns(
                 col_span = span_join(&[col_span, span]);
                 Ok(Spanned { item: val, span })
             }
-            _ => Err(ShellError::SpannedLabeledError(
+            _ => Err(ShellError::GenericError(
                 "Incorrect column format".into(),
                 "Only string as column name".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )),
         })
         .collect::<Result<Vec<Spanned<String>>, _>>()?;
@@ -49,10 +53,12 @@ pub(crate) fn convert_columns_string(
     let mut col_span = columns
         .get(0)
         .ok_or_else(|| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Empty column list".into(),
                 "Empty list found for command".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )
         })
         .and_then(|v| v.span())?;
@@ -64,10 +70,12 @@ pub(crate) fn convert_columns_string(
                 col_span = span_join(&[col_span, span]);
                 Ok(val)
             }
-            _ => Err(ShellError::SpannedLabeledError(
+            _ => Err(ShellError::GenericError(
                 "Incorrect column format".into(),
                 "Only string as column name".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )),
         })
         .collect::<Result<Vec<String>, _>>()?;

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -102,6 +102,7 @@ fn with_env(
                             call.positional_nth(1)
                                 .expect("already checked through .req")
                                 .span,
+                            None,
                         ));
                     }
                 }
@@ -128,6 +129,7 @@ fn with_env(
                 call.positional_nth(1)
                     .expect("already checked through .req")
                     .span,
+                None,
             ));
         }
     };

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -57,17 +57,21 @@ impl Command for ViewSource {
                             Ok(Value::string(String::from_utf8_lossy(contents), call.head)
                                 .into_pipeline_data())
                         } else {
-                            Err(ShellError::SpannedLabeledError(
+                            Err(ShellError::GenericError(
                                 "Cannot view value".to_string(),
                                 "the command does not have a viewable block".to_string(),
-                                arg_span,
+                                Some(arg_span),
+                                None,
+                                Vec::new(),
                             ))
                         }
                     } else {
-                        Err(ShellError::SpannedLabeledError(
+                        Err(ShellError::GenericError(
                             "Cannot view value".to_string(),
                             "the command does not have a viewable block".to_string(),
-                            arg_span,
+                            Some(arg_span),
+                            None,
+                            Vec::new(),
                         ))
                     }
                 } else if let Some(overlay_id) = engine_state.find_overlay(val.as_bytes()) {
@@ -78,24 +82,30 @@ impl Command for ViewSource {
                         Ok(Value::string(String::from_utf8_lossy(contents), call.head)
                             .into_pipeline_data())
                     } else {
-                        Err(ShellError::SpannedLabeledError(
+                        Err(ShellError::GenericError(
                             "Cannot view value".to_string(),
                             "the module does not have a viewable block".to_string(),
-                            arg_span,
+                            Some(arg_span),
+                            None,
+                            Vec::new(),
                         ))
                     }
                 } else {
-                    Err(ShellError::SpannedLabeledError(
+                    Err(ShellError::GenericError(
                         "Cannot view value".to_string(),
                         "this name does not correspond to a viewable value".to_string(),
-                        arg_span,
+                        Some(arg_span),
+                        None,
+                        Vec::new(),
                     ))
                 }
             }
-            _ => Err(ShellError::SpannedLabeledError(
+            _ => Err(ShellError::GenericError(
                 "Cannot view value".to_string(),
                 "this value cannot be viewed".to_string(),
-                arg_span,
+                Some(arg_span),
+                None,
+                Vec::new(),
             )),
         }
     }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -46,9 +46,9 @@ impl Command for Cd {
                         let path = match nu_path::canonicalize_with(path, &cwd) {
                             Ok(p) => p,
                             Err(e) => {
-                                return Err(ShellError::DirectoryNotFoundHelp(
+                                return Err(ShellError::DirectoryNotFound(
                                     *span,
-                                    format!("IO Error: {:?}", e),
+                                    Some(format!("IO Error: {:?}", e)),
                                 ))
                             }
                         };
@@ -69,9 +69,9 @@ impl Command for Cd {
                             }
 
                             Err(e) => {
-                                return Err(ShellError::DirectoryNotFoundHelp(
+                                return Err(ShellError::DirectoryNotFound(
                                     v.span()?,
-                                    format!("IO Error: {:?}", e),
+                                    Some(format!("IO Error: {:?}", e)),
                                 ))
                             }
                         };

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -104,9 +104,12 @@ impl Command for Glob {
         let glob = match WaxGlob::new(&glob_pattern.item) {
             Ok(p) => p,
             Err(e) => {
-                return Err(ShellError::LabeledError(
+                return Err(ShellError::GenericError(
                     "error with glob pattern".to_string(),
-                    format!("{}", e),
+                    "".to_string(),
+                    None,
+                    Some(format!("{}", e)),
+                    Vec::new(),
                 ))
             }
         };

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -96,10 +96,12 @@ impl Command for Ls {
                         );
                         #[cfg(not(unix))]
                         let error_msg = String::from("Permission denied");
-                        return Err(ShellError::SpannedLabeledError(
+                        return Err(ShellError::GenericError(
                             "Permission denied".to_string(),
                             error_msg,
-                            p_tag,
+                            Some(p_tag),
+                            None,
+                            Vec::new(),
                         ));
                     }
                     if is_empty_dir(&expanded) {
@@ -129,9 +131,12 @@ impl Command for Ls {
 
         let mut paths_peek = paths.peekable();
         if paths_peek.peek().is_none() {
-            return Err(ShellError::LabeledError(
+            return Err(ShellError::GenericError(
                 format!("No matches found for {}", &path.display().to_string()),
-                "no matches found".to_string(),
+                "".to_string(),
+                None,
+                Some("no matches found".to_string()),
+                Vec::new(),
             ));
         }
 
@@ -176,10 +181,12 @@ impl Command for Ls {
                         Some(path.to_string_lossy().to_string())
                     }
                     .ok_or_else(|| {
-                        ShellError::SpannedLabeledError(
+                        ShellError::GenericError(
                             format!("Invalid file name: {:}", path.to_string_lossy()),
                             "invalid file name".into(),
-                            call_span,
+                            Some(call_span),
+                            None,
+                            Vec::new(),
                         )
                     });
 

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -94,19 +94,23 @@ impl Command for Open {
             );
             #[cfg(not(unix))]
             let error_msg = String::from("Permission denied");
-            Err(ShellError::SpannedLabeledError(
+            Err(ShellError::GenericError(
                 "Permission denied".into(),
                 error_msg,
-                arg_span,
+                Some(arg_span),
+                None,
+                Vec::new(),
             ))
         } else {
             let mut file = match std::fs::File::open(path) {
                 Ok(file) => file,
                 Err(err) => {
-                    return Err(ShellError::SpannedLabeledError(
+                    return Err(ShellError::GenericError(
                         "Permission denied".into(),
                         err.to_string(),
-                        arg_span,
+                        Some(arg_span),
+                        None,
+                        Vec::new(),
                     ));
                 }
             };
@@ -198,16 +202,20 @@ fn open_and_read_sqlite_db(path: &Path, call_span: Span) -> Result<Value, nu_pro
     match Connection::open(path) {
         Ok(conn) => match read_sqlite_db(conn, call_span) {
             Ok(data) => Ok(data),
-            Err(err) => Err(ShellError::SpannedLabeledError(
+            Err(err) => Err(ShellError::GenericError(
                 "Failed to read from SQLite database".into(),
                 err.to_string(),
-                call_span,
+                Some(call_span),
+                None,
+                Vec::new(),
             )),
         },
-        Err(err) => Err(ShellError::SpannedLabeledError(
+        Err(err) => Err(ShellError::GenericError(
             "Failed to open SQLite database".into(),
             err.to_string(),
-            call_span,
+            Some(call_span),
+            None,
+            Vec::new(),
         )),
     }
 }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -144,32 +144,38 @@ fn rm(
     ))]
     {
         if rm_always_trash {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Cannot execute `rm`; the current configuration specifies \
                     `rm_always_trash = true`, but the current nu executable was not \
                     built with feature `trash_support` or trash is not supported on \
                     your platform."
                     .into(),
                 "trash required to be true but not supported".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             ));
         } else if trash {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Cannot execute `rm` with option `--trash`; feature `trash-support` not \
                     enabled or trash is not supported on your platform"
                     .into(),
                 "this option is only available if nu is built with the `trash-support` feature"
                     .into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             ));
         }
     }
 
     if targets.is_empty() {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "rm requires target paths".into(),
             "needs parameter".into(),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -184,10 +190,12 @@ fn rm(
                 std::path::MAIN_SEPARATOR
             ))
         {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Cannot remove any parent directory".into(),
                 "cannot remove any parent directory".into(),
-                target.span,
+                Some(target.span),
+                None,
+                Vec::new(),
             ));
         }
 
@@ -214,30 +222,36 @@ fn rm(
                             all_targets.entry(f.clone()).or_insert_with(|| target.span);
                         }
                         Err(e) => {
-                            return Err(ShellError::SpannedLabeledError(
+                            return Err(ShellError::GenericError(
                                 format!("Could not remove {:}", path.to_string_lossy()),
                                 e.to_string(),
-                                target.span,
+                                Some(target.span),
+                                None,
+                                Vec::new(),
                             ));
                         }
                     }
                 }
             }
             Err(e) => {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     e.to_string(),
                     e.to_string(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 ))
             }
         };
     }
 
     if all_targets.is_empty() && !force {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "No valid paths".into(),
             "no valid paths".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -301,7 +315,13 @@ fn rm(
                     if let Err(e) = result {
                         let msg = format!("Could not delete because: {:}\nTry '--trash' flag", e);
                         Value::Error {
-                            error: ShellError::SpannedLabeledError(msg, e.to_string(), span),
+                            error: ShellError::GenericError(
+                                msg,
+                                e.to_string(),
+                                Some(span),
+                                None,
+                                Vec::new(),
+                            ),
                         }
                     } else if quiet {
                         Value::Nothing { span }
@@ -312,20 +332,24 @@ fn rm(
                 } else {
                     let msg = format!("Cannot remove {:}. try --recursive", f.to_string_lossy());
                     Value::Error {
-                        error: ShellError::SpannedLabeledError(
+                        error: ShellError::GenericError(
                             msg,
                             "cannot remove non-empty directory".into(),
-                            span,
+                            Some(span),
+                            None,
+                            Vec::new(),
                         ),
                     }
                 }
             } else {
                 let msg = format!("no such file or directory: {:}", f.to_string_lossy());
                 Value::Error {
-                    error: ShellError::SpannedLabeledError(
+                    error: ShellError::GenericError(
                         msg,
                         "no such file or directory".into(),
-                        span,
+                        Some(span),
+                        None,
+                        Vec::new(),
                     ),
                 }
             }

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -57,10 +57,12 @@ impl Command for Save {
             Err(err) => {
                 return Ok(PipelineData::Value(
                     Value::Error {
-                        error: ShellError::SpannedLabeledError(
+                        error: ShellError::GenericError(
                             "Permission denied".into(),
                             err.to_string(),
-                            arg_span,
+                            Some(arg_span),
+                            None,
+                            Vec::new(),
                         ),
                     },
                     None,

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -78,10 +78,12 @@ fn first_helper(
         match input_peek
             .peek()
             .ok_or_else(|| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Error in first".into(),
                     "unable to pick on next value".into(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 )
             })?
             .get_type()

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -96,10 +96,12 @@ pub fn group_by(
     let mut group_strategy = Grouper::ByColumn(None);
 
     if values.is_empty() {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "expected table from pipeline".into(),
             "requires a table input".into(),
-            name,
+            Some(name),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -133,10 +135,12 @@ pub fn group_by(
                             let collection: Vec<Value> = s.into_iter().collect();
 
                             if collection.len() > 1 {
-                                return Err(ShellError::SpannedLabeledError(
+                                return Err(ShellError::GenericError(
                                     "expected one value from the block".into(),
                                     "requires a table with one value for grouping".into(),
-                                    name,
+                                    Some(name),
+                                    None,
+                                    Vec::new(),
                                 ));
                             }
 

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -131,10 +131,12 @@ fn extract_headers(value: &Value, config: &Config) -> Result<Vec<String>, ShellE
             .map(|value| extract_headers(value, config))
             .next()
             .ok_or_else(|| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Found empty list".to_string(),
                     "unable to extract headers".to_string(),
-                    *span,
+                    Some(*span),
+                    None,
+                    Vec::new(),
                 )
             })?,
         _ => Err(ShellError::TypeMismatch(

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -120,17 +120,21 @@ impl Command for Move {
                 span: v.span()?,
             },
             (Some(_), Some(_)) => {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Cannot move columns".to_string(),
                     "Use either --after, or --before, not both".to_string(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 ))
             }
             (None, None) => {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Cannot move columns".to_string(),
                     "Missing --after or --before flag".to_string(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 ))
             }
         };
@@ -199,19 +203,23 @@ fn move_record_columns(
     match &before_or_after.item {
         BeforeOrAfter::After(after) => {
             if !inp_cols.contains(after) {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Cannot move columns".to_string(),
                     "column does not exist".to_string(),
-                    before_or_after.span,
+                    Some(before_or_after.span),
+                    None,
+                    Vec::new(),
                 ));
             }
         }
         BeforeOrAfter::Before(before) => {
             if !inp_cols.contains(before) {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Cannot move columns".to_string(),
                     "column does not exist".to_string(),
-                    before_or_after.span,
+                    Some(before_or_after.span),
+                    None,
+                    Vec::new(),
                 ));
             }
         }
@@ -224,10 +232,12 @@ fn move_record_columns(
         if let Some(idx) = inp_cols.iter().position(|inp_col| &column_str == inp_col) {
             column_idx.push(idx);
         } else {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Cannot move columns".to_string(),
                 "column does not exist".to_string(),
-                column.span()?,
+                Some(column.span()?),
+                None,
+                Vec::new(),
             ));
         }
     }

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -120,10 +120,12 @@ impl Command for Reduce {
         } else if let Some(val) = input_iter.next() {
             (1, val)
         } else {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "Expected input".to_string(),
                 "needs input".to_string(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             ));
         };
 

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -73,10 +73,12 @@ fn select(
         match members.get(0) {
             Some(PathMember::Int { val, span }) => {
                 if members.len() > 1 {
-                    return Err(ShellError::SpannedLabeledError(
+                    return Err(ShellError::GenericError(
                         "Select only allows row numbers for rows".into(),
                         "extra after row number".into(),
-                        *span,
+                        Some(*span),
+                        None,
+                        Vec::new(),
                     ));
                 }
 

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -128,9 +128,12 @@ impl Command for Sort {
 
 pub fn sort(vec: &mut [Value], span: Span, insensitive: bool) -> Result<(), ShellError> {
     if vec.is_empty() {
-        return Err(ShellError::LabeledError(
+        return Err(ShellError::GenericError(
             "no values to work with".to_string(),
-            "no values to work with".to_string(),
+            "".to_string(),
+            None,
+            Some("no values to work with".to_string()),
+            Vec::new(),
         ));
     }
 

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -157,9 +157,12 @@ pub fn sort(
     insensitive: bool,
 ) -> Result<(), ShellError> {
     if vec.is_empty() {
-        return Err(ShellError::LabeledError(
+        return Err(ShellError::GenericError(
             "no values to work with".to_string(),
-            "no values to work with".to_string(),
+            "".to_string(),
+            None,
+            Some("no values to work with".to_string()),
+            Vec::new(),
         ));
     }
 

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -140,10 +140,12 @@ pub fn split_by(
             });
             Ok(split(&splitter, input, name)?)
         }
-        None => Err(ShellError::SpannedLabeledError(
+        None => Err(ShellError::GenericError(
             "expected name".into(),
             "requires a column name for splitting".into(),
-            name,
+            Some(name),
+            None,
+            Vec::new(),
         )),
     }
 }
@@ -225,10 +227,12 @@ pub fn data_split(
             }
         }
         _ => {
-            return Err(ShellError::SpannedLabeledError(
+            return Err(ShellError::GenericError(
                 "unsupported input".into(),
                 "requires a table with one row for splitting".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             ))
         }
     }

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -146,10 +146,12 @@ pub fn transpose(
     let mut headers: Vec<String> = vec![];
 
     if !args.rest.is_empty() && args.header_row {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "Can not provide header names and use header row".into(),
             "using header row".into(),
-            name,
+            Some(name),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -161,26 +163,32 @@ pub fn transpose(
                         if let Ok(s) = x.as_string() {
                             headers.push(s.to_string());
                         } else {
-                            return Err(ShellError::SpannedLabeledError(
+                            return Err(ShellError::GenericError(
                                 "Header row needs string headers".into(),
                                 "used non-string headers".into(),
-                                name,
+                                Some(name),
+                                None,
+                                Vec::new(),
                             ));
                         }
                     }
                     _ => {
-                        return Err(ShellError::SpannedLabeledError(
+                        return Err(ShellError::GenericError(
                             "Header row is incomplete and can't be used".into(),
                             "using incomplete header row".into(),
-                            name,
+                            Some(name),
+                            None,
+                            Vec::new(),
                         ));
                     }
                 }
             } else {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Header row is incomplete and can't be used".into(),
                     "using incomplete header row".into(),
-                    name,
+                    Some(name),
+                    None,
+                    Vec::new(),
                 ));
             }
         }

--- a/crates/nu-command/src/formats/from/eml.rs
+++ b/crates/nu-command/src/formats/from/eml.rs
@@ -193,7 +193,7 @@ fn from_eml(
         .with_body_preview(body_preview)
         .parse()
         .map_err(|_| {
-            ShellError::CantConvert("structured eml data".into(), "string".into(), head)
+            ShellError::CantConvert("structured eml data".into(), "string".into(), head, None)
         })?;
 
     let mut collected = IndexMap::new();

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -137,6 +137,7 @@ fn convert_nujson_to_value(value: &nu_json::Value, span: Span) -> Value {
                         "i64 sized integer".into(),
                         "value larger than i64".into(),
                         span,
+                        None,
                     ),
                 }
             } else {
@@ -188,10 +189,11 @@ fn convert_string_to_value(string_input: String, span: Span) -> Result<Value, Sh
             nu_json::Error::Syntax(_, row, col) => {
                 let label = x.to_string();
                 let label_span = convert_row_column_to_span(row, col, &string_input);
-                Err(ShellError::SpannedLabeledErrorRelated(
+                Err(ShellError::GenericError(
                     "Error while parsing JSON text".into(),
                     "error parsing JSON text".into(),
-                    span,
+                    Some(span),
+                    None,
                     vec![ShellError::OutsideSpannedLabeledError(
                         string_input,
                         "Error while parsing JSON text".into(),
@@ -204,6 +206,7 @@ fn convert_string_to_value(string_input: String, span: Span) -> Result<Value, Sh
                 format!("structured json data ({})", x),
                 "string".into(),
                 span,
+                None,
             )),
         },
     }

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -95,10 +95,11 @@ impl Command for FromNuon {
 
         if let Some(pipeline) = block.pipelines.get(1) {
             if let Some(expr) = pipeline.expressions.get(0) {
-                return Err(ShellError::SpannedLabeledErrorRelated(
+                return Err(ShellError::GenericError(
                     "error when loading nuon text".into(),
                     "could not load nuon text".into(),
-                    head,
+                    Some(head),
+                    None,
                     vec![ShellError::OutsideSpannedLabeledError(
                         string_input,
                         "error when loading".into(),
@@ -107,14 +108,17 @@ impl Command for FromNuon {
                     )],
                 ));
             } else {
-                return Err(ShellError::SpannedLabeledErrorRelated(
+                return Err(ShellError::GenericError(
                     "error when loading nuon text".into(),
                     "could not load nuon text".into(),
-                    head,
-                    vec![ShellError::SpannedLabeledError(
+                    Some(head),
+                    None,
+                    vec![ShellError::GenericError(
                         "error when loading".into(),
                         "excess values when loading".into(),
-                        head,
+                        Some(head),
+                        None,
+                        Vec::new(),
                     )],
                 ));
             }
@@ -131,10 +135,11 @@ impl Command for FromNuon {
             let mut pipeline = block.pipelines.remove(0);
 
             if let Some(expr) = pipeline.expressions.get(1) {
-                return Err(ShellError::SpannedLabeledErrorRelated(
+                return Err(ShellError::GenericError(
                     "error when loading nuon text".into(),
                     "could not load nuon text".into(),
-                    head,
+                    Some(head),
+                    None,
                     vec![ShellError::OutsideSpannedLabeledError(
                         string_input,
                         "error when loading".into(),
@@ -157,10 +162,11 @@ impl Command for FromNuon {
         };
 
         if let Some(err) = error {
-            return Err(ShellError::SpannedLabeledErrorRelated(
+            return Err(ShellError::GenericError(
                 "error when parsing nuon text".into(),
                 "could not parse nuon text".into(),
-                head,
+                Some(head),
+                None,
                 vec![ShellError::OutsideSpannedLabeledError(
                     string_input,
                     "error when parsing".into(),
@@ -174,10 +180,11 @@ impl Command for FromNuon {
 
         match result {
             Ok(result) => Ok(result.into_pipeline_data()),
-            Err(err) => Err(ShellError::SpannedLabeledErrorRelated(
+            Err(err) => Err(ShellError::GenericError(
                 "error when loading nuon text".into(),
                 "could not load nuon text".into(),
-                head,
+                Some(head),
+                None,
                 vec![err],
             )),
         }

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -124,6 +124,7 @@ pub fn convert_string_to_value(string_input: String, span: Span) -> Result<Value
             "structured toml data".into(),
             "string".into(),
             span,
+            None,
         )),
     }
 }

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -142,6 +142,7 @@ pub fn to_delimited_data(
             format_name.into(),
             value.get_type().to_string(),
             value.span().unwrap_or(span),
+            None,
         )),
     }?;
     Ok(Value::string(output, span).into_pipeline_data())

--- a/crates/nu-command/src/formats/to/html.rs
+++ b/crates/nu-command/src/formats/to/html.rs
@@ -325,10 +325,12 @@ fn to_html(
         let color_hm = match color_hm {
             Ok(c) => c,
             _ => {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Error finding theme name".to_string(),
                     "Error finding theme name".to_string(),
-                    theme_span,
+                    Some(theme_span),
+                    None,
+                    Vec::new(),
                 ))
             }
         };

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -66,7 +66,12 @@ impl Command for ToJson {
             }
             .into_pipeline_data()),
             _ => Ok(Value::Error {
-                error: ShellError::CantConvert("JSON".into(), value.get_type().to_string(), span),
+                error: ShellError::CantConvert(
+                    "JSON".into(),
+                    value.get_type().to_string(),
+                    span,
+                    None,
+                ),
             }
             .into_pipeline_data()),
         }

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -107,7 +107,7 @@ fn toml_into_pipeline_data(
         }
         .into_pipeline_data()),
         _ => Ok(Value::Error {
-            error: ShellError::CantConvert("TOML".into(), value_type.to_string(), span),
+            error: ShellError::CantConvert("TOML".into(), value_type.to_string(), span, None),
         }
         .into_pipeline_data()),
     }

--- a/crates/nu-command/src/formats/to/url.rs
+++ b/crates/nu-command/src/formats/to/url.rs
@@ -68,6 +68,7 @@ fn to_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
                         "URL".into(),
                         value.get_type().to_string(),
                         head,
+                        None,
                     )),
                 }
             }

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -118,10 +118,12 @@ pub fn write_xml_events<W: Write>(
             for (k, v) in cols.iter().zip(vals.iter()) {
                 let mut e = BytesStart::owned(k.as_bytes(), k.len());
                 if !is_xml_row(v) {
-                    return Err(ShellError::SpannedLabeledError(
+                    return Err(ShellError::GenericError(
                         "Expected a row with 'children' and 'attributes' columns".to_string(),
                         "missing 'children' and 'attributes' columns ".to_string(),
-                        span,
+                        Some(span),
+                        None,
+                        Vec::new(),
                     ));
                 }
                 let a = get_attributes(v, config);
@@ -185,6 +187,7 @@ fn to_xml(
             "XML".into(),
             value_type.to_string(),
             head,
+            None,
         )),
     }
 }

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -103,7 +103,7 @@ fn to_yaml(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> 
         }
         .into_pipeline_data()),
         _ => Ok(Value::Error {
-            error: ShellError::CantConvert("YAML".into(), value.get_type().to_string(), head),
+            error: ShellError::CantConvert("YAML".into(), value.get_type().to_string(), head, None),
         }
         .into_pipeline_data()),
     }

--- a/crates/nu-command/src/generators/seq.rs
+++ b/crates/nu-command/src/generators/seq.rs
@@ -124,10 +124,12 @@ fn seq(
     let widths = call.has_flag("widths");
 
     if rest_nums.is_empty() {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "seq requires some parameters".into(),
             "needs parameter".into(),
-            call.head,
+            Some(call.head),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -142,10 +144,12 @@ fn seq(
             } else {
                 let vec_s: Vec<char> = s.item.chars().collect();
                 if vec_s.is_empty() {
-                    return Err(ShellError::SpannedLabeledError(
+                    return Err(ShellError::GenericError(
                         "Expected a single separator char from --separator".into(),
                         "requires a single character string input".into(),
-                        s.span,
+                        Some(s.span),
+                        None,
+                        Vec::new(),
                     ));
                 };
                 vec_s.iter().collect()
@@ -165,10 +169,12 @@ fn seq(
             } else {
                 let vec_t: Vec<char> = t.item.chars().collect();
                 if vec_t.is_empty() {
-                    return Err(ShellError::SpannedLabeledError(
+                    return Err(ShellError::GenericError(
                         "Expected a single terminator char from --terminator".into(),
                         "requires a single character string input".into(),
-                        t.span,
+                        Some(t.span),
+                        None,
+                        Vec::new(),
                     ));
                 };
                 vec_t.iter().collect()
@@ -228,7 +234,15 @@ pub fn run_seq(
         padding = dec;
         match parse_float(slice) {
             Ok(n) => n,
-            Err(s) => return Err(ShellError::LabeledError(s, "error parsing float".into())),
+            Err(s) => {
+                return Err(ShellError::GenericError(
+                    s,
+                    "".to_string(),
+                    None,
+                    Some("error parsing float".into()),
+                    Vec::new(),
+                ))
+            }
         }
     } else {
         1.0
@@ -241,7 +255,15 @@ pub fn run_seq(
         padding = cmp::max(padding, dec);
         match parse_float(slice) {
             Ok(n) => n,
-            Err(s) => return Err(ShellError::LabeledError(s, "error parsing float".into())),
+            Err(s) => {
+                return Err(ShellError::GenericError(
+                    s,
+                    "".to_string(),
+                    None,
+                    Some("error parsing float".into()),
+                    Vec::new(),
+                ))
+            }
         }
     } else {
         1.0
@@ -252,7 +274,13 @@ pub fn run_seq(
         match parse_float(slice) {
             Ok(n) => n,
             Err(s) => {
-                return Err(ShellError::LabeledError(s, "error parsing float".into()));
+                return Err(ShellError::GenericError(
+                    s,
+                    "".to_string(),
+                    None,
+                    Some("error parsing float".into()),
+                    Vec::new(),
+                ));
             }
         }
     };

--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -155,10 +155,12 @@ impl Command for SeqDate {
                 } else {
                     let vec_s: Vec<char> = s.item.chars().collect();
                     if vec_s.is_empty() {
-                        return Err(ShellError::SpannedLabeledError(
+                        return Err(ShellError::GenericError(
                             "Expected a single separator char from --separator".to_string(),
                             "requires a single character string input".to_string(),
-                            s.span,
+                            Some(s.span),
+                            None,
+                            Vec::new(),
                         ));
                     };
                     vec_s.iter().collect()
@@ -231,10 +233,12 @@ pub fn run_seq_dates(
         .expect("unable to change increment to i64");
 
     if step_size == 0 {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "increment cannot be 0".to_string(),
             "increment cannot be 0".to_string(),
-            increment.span()?,
+            Some(increment.span()?),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -242,9 +246,12 @@ pub fn run_seq_dates(
         Some(i) => match i.as_string() {
             Ok(v) => v,
             Err(e) => {
-                return Err(ShellError::LabeledError(
+                return Err(ShellError::GenericError(
                     e.to_string(),
-                    "error with input_format as_string".to_string(),
+                    "".to_string(),
+                    None,
+                    Some("error with input_format as_string".to_string()),
+                    Vec::new(),
                 ));
             }
         },
@@ -255,9 +262,12 @@ pub fn run_seq_dates(
         Some(i) => match i.as_string() {
             Ok(v) => v,
             Err(e) => {
-                return Err(ShellError::LabeledError(
+                return Err(ShellError::GenericError(
                     e.to_string(),
-                    "error with output_format as_string".to_string(),
+                    "".to_string(),
+                    None,
+                    Some("error with output_format as_string".to_string()),
+                    Vec::new(),
                 ));
             }
         },
@@ -268,10 +278,12 @@ pub fn run_seq_dates(
         Some(d) => match parse_date_string(&d, &in_format) {
             Ok(nd) => nd,
             Err(e) => {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     e.to_string(),
                     "Failed to parse date".to_string(),
-                    Span::test_data(),
+                    Some(Span::test_data()),
+                    None,
+                    Vec::new(),
                 ))
             }
         },
@@ -282,10 +294,12 @@ pub fn run_seq_dates(
         Some(d) => match parse_date_string(&d, &in_format) {
             Ok(nd) => nd,
             Err(e) => {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     e.to_string(),
                     "Failed to parse date".to_string(),
-                    Span::test_data(),
+                    Some(Span::test_data()),
+                    None,
+                    Vec::new(),
                 ))
             }
         },
@@ -307,10 +321,12 @@ pub fn run_seq_dates(
         end_date = match start_date.checked_add_signed(Duration::days(days_to_output)) {
             Some(date) => date,
             None => {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "integer value too large".to_string(),
                     "integer value too large".to_string(),
-                    Span::test_data(),
+                    Some(Span::test_data()),
+                    None,
+                    Vec::new(),
                 ));
             }
         }
@@ -327,10 +343,12 @@ pub fn run_seq_dates(
 
     let mut next = start_date;
     if is_out_of_range(next) {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "date is out of range".to_string(),
             "date is out of range".to_string(),
-            Span::test_data(),
+            Some(Span::test_data()),
+            None,
+            Vec::new(),
         ));
     }
 

--- a/crates/nu-command/src/hash/base64.rs
+++ b/crates/nu-command/src/hash/base64.rs
@@ -102,10 +102,12 @@ fn operate(
     let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
 
     if encode && decode {
-        return Err(ShellError::SpannedLabeledError(
+        return Err(ShellError::GenericError(
             "only one of --decode and --encode flags can be used".to_string(),
             "conflicting flags".to_string(),
-            head,
+            Some(head),
+            None,
+            Vec::new(),
         ));
     }
 
@@ -181,13 +183,15 @@ fn action(
             } else if &base64_config.character_set == "crypt" {
                 base64::CRYPT
             } else {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "value is not an accepted character set".to_string(),
                     format!(
                         "{} is not a valid character-set.\nPlease use `help hash base64` to see a list of valid character sets.",
                         &base64_config.character_set
                     ),
-                    *span,
+                    Some(*span),
+                    None,
+                    Vec::new(),
                 ));
             };
 
@@ -205,13 +209,15 @@ fn action(
                             std::string::String::from_utf8_lossy(&decoded_value),
                             *command_span,
                         )),
-                        Err(_) => Err(ShellError::SpannedLabeledError(
+                        Err(_) => Err(ShellError::GenericError(
                             "value could not be base64 decoded".to_string(),
                             format!(
                                 "invalid base64 input for character set {}",
                                 &base64_config.character_set
                             ),
-                            *command_span,
+                            Some(*command_span),
+                            None,
+                            Vec::new(),
                         )),
                     }
                 }

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -210,6 +210,7 @@ fn helper(
                                 "string list or single row".into(),
                                 x.get_type().to_string(),
                                 headers.span().unwrap_or_else(|_| Span::new(0, 0)),
+                                None,
                             ));
                         }
                     }
@@ -228,6 +229,7 @@ fn helper(
                     "string list or single row".into(),
                     x.get_type().to_string(),
                     headers.span().unwrap_or_else(|_| Span::new(0, 0)),
+                    None,
                 ));
             }
         };
@@ -243,21 +245,33 @@ fn helper(
         Ok(resp) => match resp.headers().get("content-type") {
             Some(content_type) => {
                 let content_type = content_type.to_str().map_err(|e| {
-                    ShellError::LabeledError(e.to_string(), "MIME type were invalid".to_string())
+                    ShellError::GenericError(
+                        e.to_string(),
+                        "".to_string(),
+                        None,
+                        Some("MIME type were invalid".to_string()),
+                        Vec::new(),
+                    )
                 })?;
                 let content_type = mime::Mime::from_str(content_type).map_err(|_| {
-                    ShellError::LabeledError(
+                    ShellError::GenericError(
                         format!("MIME type unknown: {}", content_type),
-                        "given unknown MIME type".to_string(),
+                        "".to_string(),
+                        None,
+                        Some("given unknown MIME type".to_string()),
+                        Vec::new(),
                     )
                 })?;
                 let ext = match (content_type.type_(), content_type.subtype()) {
                     (mime::TEXT, mime::PLAIN) => {
                         let path_extension = url::Url::parse(&requested_url)
                             .map_err(|_| {
-                                ShellError::LabeledError(
+                                ShellError::GenericError(
                                     format!("Cannot parse URL: {}", requested_url),
-                                    "cannot parse".to_string(),
+                                    "".to_string(),
+                                    None,
+                                    Some("cannot parse".to_string()),
+                                    Vec::new(),
                                 )
                             })?
                             .path_segments()

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -269,6 +269,7 @@ fn helper(
                                 "string list or single row".into(),
                                 x.get_type().to_string(),
                                 headers.span().unwrap_or_else(|_| Span::new(0, 0)),
+                                None,
                             ));
                         }
                     }
@@ -287,6 +288,7 @@ fn helper(
                     "string list or single row".into(),
                     x.get_type().to_string(),
                     headers.span().unwrap_or_else(|_| Span::new(0, 0)),
+                    None,
                 ));
             }
         };
@@ -302,21 +304,33 @@ fn helper(
         Ok(resp) => match resp.headers().get("content-type") {
             Some(content_type) => {
                 let content_type = content_type.to_str().map_err(|e| {
-                    ShellError::LabeledError(e.to_string(), "MIME type were invalid".to_string())
+                    ShellError::GenericError(
+                        e.to_string(),
+                        "".to_string(),
+                        None,
+                        Some("MIME type were invalid".to_string()),
+                        Vec::new(),
+                    )
                 })?;
                 let content_type = mime::Mime::from_str(content_type).map_err(|_| {
-                    ShellError::LabeledError(
+                    ShellError::GenericError(
                         format!("MIME type unknown: {}", content_type),
-                        "given unknown MIME type".to_string(),
+                        "".to_string(),
+                        None,
+                        Some("given unknown MIME type".to_string()),
+                        Vec::new(),
                     )
                 })?;
                 let ext = match (content_type.type_(), content_type.subtype()) {
                     (mime::TEXT, mime::PLAIN) => {
                         let path_extension = url::Url::parse(&requested_url)
                             .map_err(|_| {
-                                ShellError::LabeledError(
+                                ShellError::GenericError(
                                     format!("Cannot parse URL: {}", requested_url),
-                                    "cannot parse".to_string(),
+                                    "".to_string(),
+                                    None,
+                                    Some("cannot parse".to_string()),
+                                    Vec::new(),
                                 )
                             })?
                             .path_segments()

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -114,12 +114,14 @@ fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
         Value::string(p.to_string_lossy(), span)
     } else if args.strict {
         Value::Error {
-            error: ShellError::SpannedLabeledError(
+            error: ShellError::GenericError(
                 "Could not expand path".into(),
                 "could not be expanded (path might not exist, non-final \
                     component is not a directory, or other cause)"
                     .into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             ),
         }
     } else {

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -120,7 +120,7 @@ fn relative_to(path: &Path, span: Span, args: &Arguments) -> Value {
     match lhs.strip_prefix(&rhs) {
         Ok(p) => Value::string(p.to_string_lossy(), span),
         Err(e) => Value::Error {
-            error: ShellError::CantConvert(e.to_string(), "string".into(), span),
+            error: ShellError::CantConvert(e.to_string(), "string".into(), span, None),
         },
     }
 }

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -383,10 +383,12 @@ Format: #
                         None => Color::White.prefix().to_string(),
                     },
                     Err(err) => {
-                        return Err(ShellError::SpannedLabeledError(
+                        return Err(ShellError::GenericError(
                             "error parsing hex color".to_string(),
                             format!("{}", err),
-                            code.span()?,
+                            Some(code.span()?),
+                            None,
+                            Vec::new(),
                         ));
                     }
                 }

--- a/crates/nu-command/src/platform/du.rs
+++ b/crates/nu-command/src/platform/du.rs
@@ -95,7 +95,13 @@ impl Command for Du {
 
         let exclude = args.exclude.map_or(Ok(None), move |x| {
             Pattern::new(&x.item).map(Some).map_err(|e| {
-                ShellError::SpannedLabeledError(e.msg.to_string(), "glob error".to_string(), x.span)
+                ShellError::GenericError(
+                    e.msg.to_string(),
+                    "glob error".to_string(),
+                    Some(x.span),
+                    None,
+                    Vec::new(),
+                )
             })
         })?;
 
@@ -108,7 +114,13 @@ impl Command for Du {
             None => nu_glob::glob_with("*", GLOB_PARAMS),
         }
         .map_err(|e| {
-            ShellError::SpannedLabeledError(e.msg.to_string(), "glob error".to_string(), tag)
+            ShellError::GenericError(
+                e.msg.to_string(),
+                "glob error".to_string(),
+                Some(tag),
+                None,
+                Vec::new(),
+            )
         })?
         .filter(move |p| {
             if include_files {

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -87,10 +87,12 @@ impl Command for Kill {
                         left_span: call
                             .get_named_arg("force")
                             .ok_or_else(|| {
-                                ShellError::SpannedLabeledError(
+                                ShellError::GenericError(
                                     "Flag error".into(),
                                     "flag force not found".into(),
-                                    call.head,
+                                    Some(call.head),
+                                    None,
+                                    Vec::new(),
                                 )
                             })?
                             .span,
@@ -98,10 +100,12 @@ impl Command for Kill {
                         right_span: span(&[
                             call.get_named_arg("signal")
                                 .ok_or_else(|| {
-                                    ShellError::SpannedLabeledError(
+                                    ShellError::GenericError(
                                         "Flag error".into(),
                                         "flag signal not found".into(),
-                                        call.head,
+                                        Some(call.head),
+                                        None,
+                                        Vec::new(),
                                     )
                                 })?
                                 .span,

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_listen.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_listen.rs
@@ -36,9 +36,12 @@ impl Command for KeybindingsListen {
             Ok(v) => Ok(v.into_pipeline_data()),
             Err(e) => {
                 terminal::disable_raw_mode()?;
-                Err(ShellError::LabeledError(
+                Err(ShellError::GenericError(
                     "Error with input".to_string(),
-                    e.to_string(),
+                    "".to_string(),
+                    None,
+                    Some(e.to_string()),
+                    Vec::new(),
                 ))
             }
         }

--- a/crates/nu-command/src/shells/enter.rs
+++ b/crates/nu-command/src/shells/enter.rs
@@ -42,7 +42,7 @@ impl Command for Enter {
         let new_path = nu_path::canonicalize_with(new_path, &cwd)?;
 
         if !new_path.exists() {
-            return Err(ShellError::DirectoryNotFound(path_span));
+            return Err(ShellError::DirectoryNotFound(path_span, None));
         }
 
         if !new_path.is_dir() {

--- a/crates/nu-command/src/strings/decode.rs
+++ b/crates/nu-command/src/strings/decode.rs
@@ -60,13 +60,15 @@ documentation link at https://docs.rs/encoding_rs/0.8.28/encoding_rs/#statics"#
                 let bytes: Vec<u8> = stream.into_bytes()?.item;
 
                 let encoding = match Encoding::for_label(encoding.item.as_bytes()) {
-                    None => Err(ShellError::SpannedLabeledError(
+                    None => Err(ShellError::GenericError(
                         format!(
                             r#"{} is not a valid encoding, refer to https://docs.rs/encoding_rs/0.8.23/encoding_rs/#statics for a valid list of encodings"#,
                             encoding.item
                         ),
                         "invalid encoding".into(),
-                        encoding.span,
+                        Some(encoding.span),
+                        None,
+                        Vec::new(),
                     )),
                     Some(encoding) => Ok(encoding),
                 }?;
@@ -81,13 +83,15 @@ documentation link at https://docs.rs/encoding_rs/0.8.28/encoding_rs/#statics"#
             }
             PipelineData::Value(Value::Binary { val: bytes, .. }, ..) => {
                 let encoding = match Encoding::for_label(encoding.item.as_bytes()) {
-                    None => Err(ShellError::SpannedLabeledError(
+                    None => Err(ShellError::GenericError(
                         format!(
                             r#"{} is not a valid encoding, refer to https://docs.rs/encoding_rs/0.8.23/encoding_rs/#statics for a valid list of encodings"#,
                             encoding.item
                         ),
                         "invalid encoding".into(),
-                        encoding.span,
+                        Some(encoding.span),
+                        None,
+                        Vec::new(),
                     )),
                     Some(encoding) => Ok(encoding),
                 }?;

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -149,10 +149,12 @@ where
     let to_trim = match options.character.as_ref() {
         Some(v) => {
             if v.item.chars().count() > 1 {
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Trim only works with single character".into(),
                     "needs single character".into(),
-                    v.span,
+                    Some(v.span),
+                    None,
+                    Vec::new(),
                 ));
             }
             v.item.chars().next()

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -85,10 +85,12 @@ impl Command for Complete {
                 }
                 .into_pipeline_data())
             }
-            _ => Err(ShellError::SpannedLabeledError(
+            _ => Err(ShellError::GenericError(
                 "Complete only works with external streams".to_string(),
                 "complete only works on external streams".to_string(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )),
         }
     }

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -93,10 +93,12 @@ fn exec(
     println!("{:#?}", command);
     let err = command.exec(); // this replaces our process, should not return
 
-    Err(ShellError::SpannedLabeledError(
+    Err(ShellError::GenericError(
         "Error on exec".to_string(),
         err.to_string(),
-        name_span,
+        Some(name_span),
+        None,
+        Vec::new(),
     ))
 }
 
@@ -106,9 +108,11 @@ fn exec(
     _stack: &mut Stack,
     call: &Call,
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-    Err(ShellError::SpannedLabeledError(
+    Err(ShellError::GenericError(
         "Error on exec".to_string(),
         "exec is not supported on your platform".to_string(),
-        call.head,
+        Some(call.head),
+        None,
+        Vec::new(),
     ))
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -345,14 +345,15 @@ impl ExternalCommand {
             process.current_dir(d);
             process
         } else {
-            return Err(ShellError::SpannedLabeledErrorHelp(
+            return Err(ShellError::GenericError(
                 "Current directory not found".to_string(),
                 "did not find PWD environment variable".to_string(),
-                span,
-                concat!(
+                Some(span),
+                Some(concat!(
                     "The environment variable 'PWD' was not found. ",
                     "It is required to define the current directory when running an external command."
-                ).to_string(),
+                ).to_string()),
+                Vec::new(),
             ));
         };
 

--- a/crates/nu-command/src/viewers/icons.rs
+++ b/crates/nu-command/src/viewers/icons.rs
@@ -140,18 +140,22 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
         let str = file_path
             .file_name()
             .ok_or_else(|| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "File name error".into(),
                     "Unable to get file name".into(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )
             })?
             .to_str()
             .ok_or_else(|| {
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     "Unable to get str error".into(),
                     "Unable to convert to str file name".into(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 )
             })?;
         Ok(match str {
@@ -164,10 +168,12 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
         Ok(icon)
     } else if let Some(ext) = file_path.extension().as_ref() {
         let str = ext.to_str().ok_or_else(|| {
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 "Unable to get str error".into(),
                 "Unable to convert to str file name".into(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )
         })?;
         Ok(match str {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -417,9 +417,12 @@ fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellEr
     let val_float = match val.trim().parse::<f64>() {
         Ok(f) => f,
         Err(e) => {
-            return Err(ShellError::LabeledError(
+            return Err(ShellError::GenericError(
                 format!("error converting string [{}] to f64", &val),
-                e.to_string(),
+                "".to_string(),
+                None,
+                Some(e.to_string()),
+                Vec::new(),
             ));
         }
     };

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -148,19 +148,24 @@ pub fn current_dir_str(engine_state: &EngineState, stack: &Stack) -> Result<Stri
                 if Path::new(&cwd).is_absolute() {
                     Ok(cwd)
                 } else {
-                    Err(ShellError::SpannedLabeledError(
+                    Err(ShellError::GenericError(
                             "Invalid current directory".to_string(),
                             format!("The 'PWD' environment variable must be set to an absolute path. Found: '{}'", cwd),
-                            pwd.span()?
+                            Some(pwd.span()?),
+                            None,
+                            Vec::new()
                     ))
                 }
             }
             Err(e) => Err(e),
         }
     } else {
-        Err(ShellError::LabeledError(
+        Err(ShellError::GenericError(
                 "Current directory not found".to_string(),
-                "The environment variable 'PWD' was not found. It is required to define the current directory.".to_string(),
+                "".to_string(),
+                None,
+                Some("The environment variable 'PWD' was not found. It is required to define the current directory.".to_string()),
+                Vec::new(),
         ))
     }
 }
@@ -295,10 +300,12 @@ fn ensure_path(scope: &mut HashMap<String, Value>, env_path_name: &str) -> Optio
             // Must be a list of strings
             if !vals.iter().all(|v| matches!(v, Value::String { .. })) {
                 error = error.or_else(|| {
-                    Some(ShellError::SpannedLabeledError(
+                    Some(ShellError::GenericError(
                         format!("Wrong {} environment variable value", env_path_name),
                         format!("{} must be a list of strings", env_path_name),
-                        *span,
+                        Some(*span),
+                        None,
+                        Vec::new(),
                     ))
                 });
             }
@@ -314,10 +321,12 @@ fn ensure_path(scope: &mut HashMap<String, Value>, env_path_name: &str) -> Optio
             };
 
             error = error.or_else(|| {
-                Some(ShellError::SpannedLabeledError(
+                Some(ShellError::GenericError(
                     format!("Wrong {} environment variable value", env_path_name),
                     format!("{} must be a list of strings", env_path_name),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 ))
             });
         }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -257,6 +257,7 @@ pub fn eval_expression(
                 "unit value".into(),
                 x.get_type().to_string(),
                 e.span,
+                None,
             )),
         },
         Expr::Range(from, next, to, operator) => {
@@ -1319,20 +1320,24 @@ fn compute(size: i64, unit: Unit, span: Span) -> Value {
         Unit::Day => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24) {
             Some(val) => Value::Duration { val, span },
             None => Value::Error {
-                error: ShellError::SpannedLabeledError(
+                error: ShellError::GenericError(
                     "duration too large".into(),
                     "duration too large".into(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 ),
             },
         },
         Unit::Week => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 7) {
             Some(val) => Value::Duration { val, span },
             None => Value::Error {
-                error: ShellError::SpannedLabeledError(
+                error: ShellError::GenericError(
                     "duration too large".into(),
                     "duration too large".into(),
-                    span,
+                    Some(span),
+                    None,
+                    Vec::new(),
                 ),
             },
         },

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -44,7 +44,7 @@ pub fn glob_from(
         let path = if let Ok(p) = canonicalize_with(path, &cwd) {
             p
         } else {
-            return Err(ShellError::DirectoryNotFound(pattern.span));
+            return Err(ShellError::DirectoryNotFound(pattern.span, None));
         };
 
         if path.is_dir() {
@@ -62,10 +62,12 @@ pub fn glob_from(
                 #[cfg(not(unix))]
                 let error_msg = String::from("Permission denied");
 
-                return Err(ShellError::SpannedLabeledError(
+                return Err(ShellError::GenericError(
                     "Permission denied".into(),
                     error_msg,
-                    pattern.span,
+                    Some(pattern.span),
+                    None,
+                    Vec::new(),
                 ));
             }
 
@@ -82,10 +84,12 @@ pub fn glob_from(
     let pattern = pattern.to_string_lossy().to_string();
 
     let glob = nu_glob::glob(&pattern).map_err(|err| {
-        nu_protocol::ShellError::SpannedLabeledError(
+        nu_protocol::ShellError::GenericError(
             "Error extracting glob pattern".into(),
             err.to_string(),
-            span,
+            Some(span),
+            None,
+            Vec::new(),
         )
     })?;
 
@@ -93,10 +97,12 @@ pub fn glob_from(
         prefix,
         Box::new(glob.map(move |x| match x {
             Ok(v) => Ok(v),
-            Err(err) => Err(nu_protocol::ShellError::SpannedLabeledError(
+            Err(err) => Err(nu_protocol::ShellError::GenericError(
                 "Error extracting glob pattern".into(),
                 err.to_string(),
-                span,
+                Some(span),
+                None,
+                Vec::new(),
             )),
         })),
     ))

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.61.1"
 
 [dependencies]
 chrono = "0.4.19"
-miette = "4.4.0"
+miette = "4.5.0"
 thiserror = "1.0.29"
 serde_json = "1.0"
 nu-path = {path = "../nu-path", version = "0.61.1" }

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -63,10 +63,12 @@ impl Command for PluginDeclaration {
 
         let mut child = plugin_cmd.spawn().map_err(|err| {
             let decl = engine_state.get_decl(call.decl_id);
-            ShellError::SpannedLabeledError(
+            ShellError::GenericError(
                 format!("Unable to spawn plugin for {}", decl.name()),
                 format!("{}", err),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             )
         })?;
 
@@ -94,10 +96,12 @@ impl Command for PluginDeclaration {
 
             let response = self.encoding.decode_response(&mut buf_read).map_err(|err| {
                 let decl = engine_state.get_decl(call.decl_id);
-                ShellError::SpannedLabeledError(
+                ShellError::GenericError(
                     format!("Unable to decode call for {}", decl.name()),
                     err.to_string(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 )
             });
 
@@ -106,18 +110,22 @@ impl Command for PluginDeclaration {
                     Ok(PipelineData::Value(value.as_ref().clone(), None))
                 }
                 Ok(PluginResponse::Error(err)) => Err(err.into()),
-                Ok(PluginResponse::Signature(..)) => Err(ShellError::SpannedLabeledError(
+                Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError(
                     "Plugin missing value".into(),
                     "Received a signature from plugin instead of value".into(),
-                    call.head,
+                    Some(call.head),
+                    None,
+                    Vec::new(),
                 )),
                 Err(err) => Err(err),
             }
         } else {
-            Err(ShellError::SpannedLabeledError(
+            Err(ShellError::GenericError(
                 "Error with stdout reader".into(),
                 "no stdout reader".into(),
-                call.head,
+                Some(call.head),
+                None,
+                Vec::new(),
             ))
         };
 

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -28,8 +28,16 @@ pub struct LabeledError {
 impl From<LabeledError> for ShellError {
     fn from(error: LabeledError) -> Self {
         match error.span {
-            Some(span) => ShellError::SpannedLabeledError(error.label, error.msg, span),
-            None => ShellError::LabeledError(error.label, error.msg),
+            Some(span) => {
+                ShellError::GenericError(error.label, error.msg, Some(span), None, Vec::new())
+            }
+            None => ShellError::GenericError(
+                error.label,
+                "".to_string(),
+                None,
+                Some(error.msg),
+                Vec::new(),
+            ),
         }
     }
 }
@@ -37,18 +45,10 @@ impl From<LabeledError> for ShellError {
 impl From<ShellError> for LabeledError {
     fn from(error: ShellError) -> Self {
         match error {
-            ShellError::SpannedLabeledError(label, msg, span) => LabeledError {
-                label,
-                msg,
-                span: Some(span),
-            },
-            ShellError::LabeledError(label, msg) => LabeledError {
-                label,
-                msg,
-                span: None,
-            },
-            ShellError::CantConvert(expected, input, span)
-            | ShellError::CantConvertWithHelp(expected, input, span, _) => LabeledError {
+            ShellError::GenericError(label, msg, span, _help, _related) => {
+                LabeledError { label, msg, span }
+            }
+            ShellError::CantConvert(expected, input, span, _help) => LabeledError {
                 label: format!("Can't convert to {}", expected),
                 msg: format!("can't convert {} to {}", expected, input),
                 span: Some(span),

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.61.1"
 
 [dependencies]
 thiserror = "1.0.29"
-miette = "4.4.0"
+miette = "4.5.0"
 serde = {version = "1.0.130", features = ["derive"]}
 chrono = { version="0.4.19", features=["serde"] }
 indexmap = { version="1.7", features=["serde-1"] }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -215,21 +215,11 @@ pub enum ShellError {
     /// Not all values can be coerced this way. Check the supported type(s) and try again.
     #[error("Can't convert to {0}.")]
     #[diagnostic(code(nu::shell::cant_convert), url(docsrs))]
-    CantConvert(String, String, #[label("can't convert {1} to {0}")] Span),
-
-    /// Failed to convert a value of one type into a different type.
-    ///
-    /// ## Resolution
-    ///
-    /// Not all values can be coerced this way. Check the supported type(s) and try again, referring to the help text in the specific error message.
-    #[error("Can't convert to {0}.")]
-    #[diagnostic(code(nu::shell::cant_convert), url(docsrs), help("{3}"))]
-    // Identical to above, but with help
-    CantConvertWithHelp(
+    CantConvert(
         String,
         String,
         #[label("can't convert {1} to {0}")] Span,
-        String,
+        #[help] Option<String>,
     ),
 
     /// An environment variable cannot be represented as a string.
@@ -473,7 +463,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
     #[diagnostic(code(nu::shell::directory_not_found), url(docsrs))]
-    DirectoryNotFound(#[label("directory not found")] Span),
+    DirectoryNotFound(#[label("directory not found")] Span, #[help] Option<String>),
 
     /// Attempted to perform an operation on a directory that doesn't exist.
     ///
@@ -483,15 +473,6 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("Directory not found")]
     #[diagnostic(code(nu::shell::directory_not_found_custom), url(docsrs))]
     DirectoryNotFoundCustom(String, #[label("{0}")] Span),
-
-    /// Attempted to perform an operation on a directory that doesn't exist.
-    ///
-    /// ## Resolution
-    ///
-    /// Make sure the directory in the error message actually exists before trying again.
-    #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found_help), url(docsrs), help("{1}"))]
-    DirectoryNotFoundHelp(#[label("directory not found")] Span, String),
 
     /// The requested move operation cannot be completed. This is typically because both paths exist,
     /// but are of different types. For example, you might be trying to overwrite an existing file with
@@ -621,31 +602,13 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     /// This is a generic error type used for different situations.
     #[error("{0}")]
     #[diagnostic()]
-    SpannedLabeledError(String, String, #[label("{1}")] Span),
-
-    /// This is a generic error type used for different situations.
-    #[error("{0}")]
-    #[diagnostic(help("{3}"))]
-    SpannedLabeledErrorHelp(String, String, #[label("{1}")] Span, String),
-
-    /// This is a generic error type used for different situations.
-    #[error("{0}")]
-    #[diagnostic()]
-    SpannedLabeledErrorRelated(
+    GenericError(
         String,
         String,
-        #[label("{1}")] Span,
+        #[label("{1}")] Option<Span>,
+        #[help] Option<String>,
         #[related] Vec<ShellError>,
     ),
-
-    /// This is a generic error type used for different situations.
-    #[error("{0}")]
-    #[diagnostic(help("{1}"))]
-    LabeledError(String, String),
-
-    /// This is a generic error type used for different situations.
-    #[error("{0}")]
-    UnlabeledError(String),
 
     /// This is a generic error type used for different situations.
     #[error("{1}")]

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -549,8 +549,12 @@ impl Command for BlockCommand {
         _call: &Call,
         _input: PipelineData,
     ) -> Result<crate::PipelineData, crate::ShellError> {
-        Err(ShellError::UnlabeledError(
+        Err(ShellError::GenericError(
             "Internal error: can't run custom command with 'run', use block_id".to_string(),
+            "".to_string(),
+            None,
+            None,
+            Vec::new(),
         ))
     }
 

--- a/crates/nu-protocol/src/value/from.rs
+++ b/crates/nu-protocol/src/value/from.rs
@@ -8,6 +8,7 @@ impl Value {
                 "f64".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -19,6 +20,7 @@ impl Value {
                 "i64".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -37,6 +37,7 @@ impl FromValue for Spanned<i64> {
                 "integer".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -53,6 +54,7 @@ impl FromValue for i64 {
                 "integer".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -74,6 +76,7 @@ impl FromValue for Spanned<f64> {
                 "float".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -88,6 +91,7 @@ impl FromValue for f64 {
                 "float".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -131,6 +135,7 @@ impl FromValue for Spanned<usize> {
                 "non-negative integer".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -165,6 +170,7 @@ impl FromValue for usize {
                 "non-negative integer".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -180,6 +186,7 @@ impl FromValue for String {
                 "string".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -196,6 +203,7 @@ impl FromValue for Spanned<String> {
                         "string".into(),
                         v.get_type().to_string(),
                         v.span()?,
+                        None,
                     ))
                 }
             },
@@ -216,6 +224,7 @@ impl FromValue for Vec<String> {
                         "string".into(),
                         c.get_type().to_string(),
                         c.span()?,
+                        None,
                     )),
                 })
                 .collect::<Result<Vec<String>, ShellError>>(),
@@ -223,6 +232,7 @@ impl FromValue for Vec<String> {
                 "string".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -255,6 +265,7 @@ impl FromValue for CellPath {
                 "cell path".into(),
                 x.get_type().to_string(),
                 span,
+                None,
             )),
         }
     }
@@ -268,6 +279,7 @@ impl FromValue for bool {
                 "bool".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -284,6 +296,7 @@ impl FromValue for Spanned<bool> {
                 "bool".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -297,6 +310,7 @@ impl FromValue for DateTime<FixedOffset> {
                 "date".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -313,6 +327,7 @@ impl FromValue for Spanned<DateTime<FixedOffset>> {
                 "date".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -326,6 +341,7 @@ impl FromValue for Range {
                 "range".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -342,6 +358,7 @@ impl FromValue for Spanned<Range> {
                 "range".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -356,6 +373,7 @@ impl FromValue for Vec<u8> {
                 "binary data".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -373,6 +391,7 @@ impl FromValue for Spanned<PathBuf> {
                 "range".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -387,6 +406,7 @@ impl FromValue for Vec<Value> {
                 "Vector of values".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -401,6 +421,7 @@ impl FromValue for (Vec<String>, Vec<Value>) {
                 "Record".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -417,6 +438,7 @@ impl FromValue for CaptureBlock {
                 "Block".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }
@@ -440,6 +462,7 @@ impl FromValue for Spanned<CaptureBlock> {
                 "Block".into(),
                 v.get_type().to_string(),
                 v.span()?,
+                None,
             )),
         }
     }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -188,6 +188,7 @@ impl Value {
                         "string".into(),
                         "binary".into(),
                         self.span()?,
+                        None,
                     ));
                 }
             }),
@@ -195,6 +196,7 @@ impl Value {
                 "string".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -215,6 +217,7 @@ impl Value {
                         "string".into(),
                         "binary".into(),
                         self.span()?,
+                        None,
                     ))
                 }
             }),
@@ -222,6 +225,7 @@ impl Value {
                 "string".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -233,6 +237,7 @@ impl Value {
                 "path".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -244,6 +249,7 @@ impl Value {
                 "block".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -256,6 +262,7 @@ impl Value {
                 "binary".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -267,6 +274,7 @@ impl Value {
                 "record".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -278,6 +286,7 @@ impl Value {
                 "list".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -289,6 +298,7 @@ impl Value {
                 "boolean".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -301,6 +311,7 @@ impl Value {
                 "float".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }
@@ -312,6 +323,7 @@ impl Value {
                 "integer".into(),
                 x.get_type().to_string(),
                 self.span()?,
+                None,
             )),
         }
     }


### PR DESCRIPTION
# Description

v4.5.0 of miette added support for optional labels and help text to the derive macro. This PR takes advantage of that and coalesces all the various generic error types into a single GenericError type that we can start whittling away at over time.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
