### PR TITLE
Added search terms to math commands

### DIFF
--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -18,6 +18,10 @@ impl Command for SubCommand {
         "Returns absolute values of a list of numbers"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["absolute", "modulus", "positive", "distance"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
         "Finds the average of a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["average", "mean"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -18,6 +18,10 @@ impl Command for SubCommand {
         "Applies the ceil function to a list of numbers"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["ceiling"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/math/eval.rs
+++ b/crates/nu-command/src/math/eval.rs
@@ -17,6 +17,10 @@ impl Command for SubCommand {
         "Evaluate a math expression into a number"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["evaluation", "solve", "equation", "expression"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build("math eval")
             .optional(

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
         "Finds the maximum within a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["maximum", "largest"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -22,6 +22,10 @@ impl Command for SubCommand {
         "Gets the median of a list of numbers"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["middle", "average"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
         "Finds the minimum within a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["minimum", "smallest"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -43,6 +43,10 @@ impl Command for SubCommand {
         "Gets the most frequent element(s) from a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["common", "often", "average"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
         "Finds the product of a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["times", "multiply", "x", "*"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -28,6 +28,10 @@ impl Command for SubCommand {
         "Applies the round function to a list of numbers"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["approx", "rough"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -18,6 +18,10 @@ impl Command for SubCommand {
         "Applies the square root function to a list of numbers"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["square", "root"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -22,6 +22,10 @@ impl Command for SubCommand {
         "Finds the stddev of a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["SD", "standard", "deviation", "dispersion", "variation"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
         "Finds the sum of a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["plus", "add", "+"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,


### PR DESCRIPTION
# Description

I added search terms to math commands. I hope I got the format right.

Relevant issue: https://github.com/nushell/nushell/issues/5093

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
