### PR TITLE
add custom_completion field to `$nu.scope.commands` command

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -7,7 +7,7 @@ use nu_protocol::ast::{Block, Call, Expr, Expression, Operator};
 use nu_protocol::engine::{EngineState, Stack, Visibility};
 use nu_protocol::{
     IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Range, ShellError, Span,
-    Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
+    Spanned, SyntaxShape, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
 
 use crate::{current_dir_str, get_full_help};
@@ -759,6 +759,17 @@ pub fn eval_subexpression(
     Ok(input)
 }
 
+fn extract_custom_completion_from_arg(engine_state: &EngineState, shape: &SyntaxShape) -> String {
+    return match shape {
+        SyntaxShape::Custom(_, custom_completion_decl_id) => {
+            let custom_completion_command = engine_state.get_decl(*custom_completion_decl_id);
+            let custom_completion_command_name: &str = &*custom_completion_command.name();
+            custom_completion_command_name.to_string()
+        }
+        _ => "".to_string(),
+    };
+}
+
 pub fn create_scope(
     engine_state: &EngineState,
     stack: &Stack,
@@ -851,6 +862,7 @@ pub fn create_scope(
                     "is_optional".to_string(),
                     "short_flag".to_string(),
                     "description".to_string(),
+                    "custom_completion".to_string(),
                 ];
 
                 // required_positional
@@ -863,6 +875,10 @@ pub fn create_scope(
                         Value::boolean(false, span),
                         Value::nothing(span),
                         Value::string(req.desc, span),
+                        Value::string(
+                            extract_custom_completion_from_arg(engine_state, &req.shape),
+                            span,
+                        ),
                     ];
 
                     sig_records.push(Value::Record {
@@ -882,6 +898,10 @@ pub fn create_scope(
                         Value::boolean(true, span),
                         Value::nothing(span),
                         Value::string(opt.desc, span),
+                        Value::string(
+                            extract_custom_completion_from_arg(engine_state, &opt.shape),
+                            span,
+                        ),
                     ];
 
                     sig_records.push(Value::Record {
@@ -902,6 +922,10 @@ pub fn create_scope(
                             Value::boolean(true, span),
                             Value::nothing(span),
                             Value::string(rest.desc, span),
+                            Value::string(
+                                extract_custom_completion_from_arg(engine_state, &rest.shape),
+                                span,
+                            ),
                         ];
 
                         sig_records.push(Value::Record {
@@ -921,8 +945,11 @@ pub fn create_scope(
                         continue;
                     }
 
+                    let mut custom_completion_command_name: String = "".to_string();
                     let shape = if let Some(arg) = named.arg {
                         flag_type = Value::string("named", span);
+                        custom_completion_command_name =
+                            extract_custom_completion_from_arg(engine_state, &arg);
                         Value::string(arg.to_string(), span)
                     } else {
                         flag_type = Value::string("switch", span);
@@ -943,6 +970,7 @@ pub fn create_scope(
                         Value::boolean(!named.required, span),
                         short_flag,
                         Value::string(named.desc, span),
+                        Value::string(custom_completion_command_name, span),
                     ];
 
                     sig_records.push(Value::Record {


### PR DESCRIPTION
# Description

This PR aims to add reflection capabilities on the newly added feature "custom completions".
Whenever a command argument uses a function in order to give the user some completions, this function name will appear into the `custom_completion` field of the `signature` table returned by the `$nu.scope.commands` command.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
