### PR TITLE
Feature/refactor completion options

### DIFF
--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -14,36 +14,6 @@ pub trait Completer {
         pos: usize,
     ) -> (Vec<Suggestion>, CompletionOptions);
 
-    // Filter results using the completion options
-    fn filter(
-        &self,
-        prefix: Vec<u8>,
-        items: Vec<Suggestion>,
-        options: CompletionOptions,
-    ) -> Vec<Suggestion> {
-        items
-            .into_iter()
-            .filter(|it| {
-                // Minimise clones for new functionality
-                match (options.case_sensitive, options.positional) {
-                    (true, true) => it.value.as_bytes().starts_with(&prefix),
-                    (true, false) => it
-                        .value
-                        .contains(std::str::from_utf8(&prefix).unwrap_or("")),
-                    (false, positional) => {
-                        let value = it.value.to_lowercase();
-                        let prefix = std::str::from_utf8(&prefix).unwrap_or("").to_lowercase();
-                        if positional {
-                            value.starts_with(&prefix)
-                        } else {
-                            value.contains(&prefix)
-                        }
-                    }
-                }
-            })
-            .collect()
-    }
-
     // Sort results using the completion options
     fn sort(
         &self,

--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -1,4 +1,4 @@
-use crate::completions::{CompletionOptions, SortBy};
+use crate::completions::SortBy;
 use nu_protocol::{engine::StateWorkingSet, levenshtein_distance, Span};
 use reedline::Suggestion;
 
@@ -12,19 +12,13 @@ pub trait Completer {
         span: Span,
         offset: usize,
         pos: usize,
-    ) -> (Vec<Suggestion>, CompletionOptions);
+    ) -> Vec<Suggestion>;
 
     fn get_sort_by(&self) -> SortBy {
         SortBy::Ascending
     }
 
-    // Sort results using the completion options
-    fn sort(
-        &self,
-        items: Vec<Suggestion>,
-        prefix: Vec<u8>,
-        options: CompletionOptions,
-    ) -> Vec<Suggestion> {
+    fn sort(&self, items: Vec<Suggestion>, prefix: Vec<u8>) -> Vec<Suggestion> {
         let prefix_str = String::from_utf8_lossy(&prefix).to_string();
         let mut filtered_items = items;
 

--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -14,6 +14,10 @@ pub trait Completer {
         pos: usize,
     ) -> (Vec<Suggestion>, CompletionOptions);
 
+    fn get_sort_by(&self) -> SortBy {
+        SortBy::Ascending
+    }
+
     // Sort results using the completion options
     fn sort(
         &self,
@@ -25,7 +29,7 @@ pub trait Completer {
         let mut filtered_items = items;
 
         // Sort items
-        match options.sort_by {
+        match self.get_sort_by() {
             SortBy::LevenshteinDistance => {
                 filtered_items.sort_by(|a, b| {
                     let a_distance = levenshtein_distance(&prefix_str, &a.value);

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -266,9 +266,4 @@ impl Completer for CommandCompletion {
 
         (output, options)
     }
-
-    // Replace base filter with no filter once all the results are already based in the current path
-    fn filter(&self, _: Vec<u8>, items: Vec<Suggestion>, _: CompletionOptions) -> Vec<Suggestion> {
-        items
-    }
 }

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -266,4 +266,8 @@ impl Completer for CommandCompletion {
 
         (output, options)
     }
+
+    fn get_sort_by(&self) -> SortBy {
+        SortBy::LevenshteinDistance
+    }
 }

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -220,7 +220,8 @@ impl Completer for CommandCompletion {
         };
         // let prefix = working_set.get_span_contents(flat.0);
         let prefix = String::from_utf8_lossy(&prefix).to_string();
-        let output = file_path_completion(span, &prefix, &cwd)
+
+        file_path_completion(span, &prefix, &cwd)
             .into_iter()
             .map(move |x| {
                 if self.flat_idx == 0 {
@@ -257,9 +258,7 @@ impl Completer for CommandCompletion {
             })
             .chain(subcommands.into_iter())
             .chain(commands.into_iter())
-            .collect::<Vec<_>>();
-
-        output
+            .collect::<Vec<_>>()
     }
 
     fn get_sort_by(&self) -> SortBy {

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -1,6 +1,4 @@
-use crate::completions::{
-    file_completions::file_path_completion, Completer, CompletionOptions, SortBy,
-};
+use crate::completions::{file_completions::file_path_completion, Completer, SortBy};
 use nu_parser::{trim_quotes, FlatShape};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
@@ -154,7 +152,7 @@ impl Completer for CommandCompletion {
         span: Span,
         offset: usize,
         pos: usize,
-    ) -> (Vec<Suggestion>, CompletionOptions) {
+    ) -> Vec<Suggestion> {
         let last = self
             .flattened
             .iter()
@@ -172,9 +170,6 @@ impl Completer for CommandCompletion {
             })
             .last();
 
-        // Options
-        let options = CompletionOptions::new(true, true, SortBy::LevenshteinDistance);
-
         // The last item here would be the earliest shape that could possible by part of this subcommand
         let subcommands = if let Some(last) = last {
             self.complete_commands(
@@ -191,7 +186,7 @@ impl Completer for CommandCompletion {
         };
 
         if !subcommands.is_empty() {
-            return (subcommands, options);
+            return subcommands;
         }
 
         let commands = if matches!(self.flat_shape, nu_parser::FlatShape::External)
@@ -264,7 +259,7 @@ impl Completer for CommandCompletion {
             .chain(commands.into_iter())
             .collect::<Vec<_>>();
 
-        (output, options)
+        output
     }
 
     fn get_sort_by(&self) -> SortBy {

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -39,9 +39,6 @@ impl NuCompleter {
         let (mut suggestions, options) =
             completer.fetch(working_set, prefix.clone(), new_span, offset, pos);
 
-        // Filter
-        suggestions = completer.filter(prefix.clone(), suggestions, options.clone());
-
         // Sort
         suggestions = completer.sort(suggestions, prefix, options);
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -36,11 +36,10 @@ impl NuCompleter {
         pos: usize,
     ) -> Vec<Suggestion> {
         // Fetch
-        let (mut suggestions, options) =
-            completer.fetch(working_set, prefix.clone(), new_span, offset, pos);
+        let mut suggestions = completer.fetch(working_set, prefix.clone(), new_span, offset, pos);
 
         // Sort
-        suggestions = completer.sort(suggestions, prefix, options);
+        suggestions = completer.sort(suggestions, prefix);
 
         suggestions
     }

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -12,16 +12,6 @@ pub struct CompletionOptions {
     pub sort_by: SortBy,
 }
 
-impl CompletionOptions {
-    pub fn new(case_sensitive: bool, positional: bool, sort_by: SortBy) -> Self {
-        Self {
-            case_sensitive,
-            positional,
-            sort_by,
-        }
-    }
-}
-
 impl Default for CompletionOptions {
     fn default() -> Self {
         Self {

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub enum SortBy {
     LevenshteinDistance,
     Ascending,

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -61,7 +61,7 @@ impl Completer for CustomCompletion {
         span: Span,
         offset: usize,
         pos: usize,
-    ) -> (Vec<Suggestion>, CompletionOptions) {
+    ) -> Vec<Suggestion> {
         // Line position
         let line_pos = pos - offset;
 
@@ -150,7 +150,7 @@ impl Completer for CustomCompletion {
             _ => (vec![], CompletionOptions::default()),
         };
 
-        (filter(&prefix, suggestions, options.clone()), options)
+        filter(&prefix, suggestions, options)
     }
 
     fn get_sort_by(&self) -> SortBy {

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -13,6 +13,7 @@ pub struct CustomCompletion {
     stack: Stack,
     decl_id: usize,
     line: String,
+    sort_by: SortBy,
 }
 
 impl CustomCompletion {
@@ -22,6 +23,7 @@ impl CustomCompletion {
             stack,
             decl_id,
             line,
+            sort_by: SortBy::None,
         }
     }
 
@@ -113,6 +115,10 @@ impl Completer for CustomCompletion {
                                 .and_then(|val| val.as_bool().ok())
                                 .unwrap_or(false);
 
+                            if should_sort {
+                                self.sort_by = SortBy::Ascending;
+                            }
+
                             CompletionOptions {
                                 case_sensitive: options
                                     .get_data_by_key("case_sensitive")
@@ -145,6 +151,10 @@ impl Completer for CustomCompletion {
         };
 
         (filter(&prefix, suggestions, options.clone()), options)
+    }
+
+    fn get_sort_by(&self) -> SortBy {
+        self.sort_by
     }
 }
 

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -164,13 +164,11 @@ fn filter(prefix: &[u8], items: Vec<Suggestion>, options: CompletionOptions) -> 
         .filter(|it| {
             // Minimise clones for new functionality
             match (options.case_sensitive, options.positional) {
-                (true, true) => it.value.as_bytes().starts_with(&prefix),
-                (true, false) => it
-                    .value
-                    .contains(std::str::from_utf8(&prefix).unwrap_or("")),
+                (true, true) => it.value.as_bytes().starts_with(prefix),
+                (true, false) => it.value.contains(std::str::from_utf8(prefix).unwrap_or("")),
                 (false, positional) => {
                     let value = it.value.to_lowercase();
-                    let prefix = std::str::from_utf8(&prefix).unwrap_or("").to_lowercase();
+                    let prefix = std::str::from_utf8(prefix).unwrap_or("").to_lowercase();
                     if positional {
                         value.starts_with(&prefix)
                     } else {

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -1,6 +1,4 @@
-use crate::completions::{
-    file_path_completion, partial_from, Completer, CompletionOptions, SortBy,
-};
+use crate::completions::{file_path_completion, partial_from, Completer, SortBy};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     Span,
@@ -21,11 +19,6 @@ impl DotNuCompletion {
 }
 
 impl Completer for DotNuCompletion {
-    // Replace base filter with no filter once all the results are already filtered
-    fn filter(&self, _: Vec<u8>, items: Vec<Suggestion>, _: CompletionOptions) -> Vec<Suggestion> {
-        items
-    }
-
     fn fetch(
         &mut self,
         _: &StateWorkingSet,
@@ -33,7 +26,7 @@ impl Completer for DotNuCompletion {
         span: Span,
         offset: usize,
         _: usize,
-    ) -> (Vec<Suggestion>, CompletionOptions) {
+    ) -> Vec<Suggestion> {
         let prefix_str = String::from_utf8_lossy(&prefix).to_string();
         let mut search_dirs: Vec<String> = vec![];
         let (base_dir, mut partial) = partial_from(&prefix_str);
@@ -118,9 +111,10 @@ impl Completer for DotNuCompletion {
             })
             .collect();
 
-        // Options
-        let options = CompletionOptions::new(false, true, SortBy::LevenshteinDistance);
+        output
+    }
 
-        (output, options)
+    fn get_sort_by(&self) -> SortBy {
+        SortBy::LevenshteinDistance
     }
 }

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::{Completer, CompletionOptions};
+use crate::completions::Completer;
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
@@ -28,7 +28,7 @@ impl Completer for FileCompletion {
         span: Span,
         offset: usize,
         _: usize,
-    ) -> (Vec<Suggestion>, CompletionOptions) {
+    ) -> Vec<Suggestion> {
         let cwd = if let Some(d) = self.engine_state.env_vars.get("PWD") {
             match d.as_string() {
                 Ok(s) => s,
@@ -51,19 +51,11 @@ impl Completer for FileCompletion {
             })
             .collect();
 
-        // Options
-        let options = CompletionOptions::default();
-
-        (output, options)
+        output
     }
 
     // Sort results prioritizing the non hidden folders
-    fn sort(
-        &self,
-        items: Vec<Suggestion>,
-        prefix: Vec<u8>,
-        _: CompletionOptions, // Ignore the given options, once it's a custom sorting
-    ) -> Vec<Suggestion> {
+    fn sort(&self, items: Vec<Suggestion>, prefix: Vec<u8>) -> Vec<Suggestion> {
         let prefix_str = String::from_utf8_lossy(&prefix).to_string();
 
         // Sort items

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -97,11 +97,6 @@ impl Completer for FileCompletion {
 
         non_hidden
     }
-
-    // Replace base filter with no filter once all the results are already based in the current path
-    fn filter(&self, _: Vec<u8>, items: Vec<Suggestion>, _: CompletionOptions) -> Vec<Suggestion> {
-        items
-    }
 }
 
 pub fn partial_from(input: &str) -> (String, String) {

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::{Completer, CompletionOptions};
+use crate::completions::Completer;
 use nu_protocol::{
     ast::{Expr, Expression},
     engine::StateWorkingSet,
@@ -26,7 +26,7 @@ impl Completer for FlagCompletion {
         span: Span,
         offset: usize,
         _: usize,
-    ) -> (Vec<Suggestion>, CompletionOptions) {
+    ) -> Vec<Suggestion> {
         // Check if it's a flag
         if let Expr::Call(call) = &self.expression.expr {
             let decl = working_set.get_decl(call.decl_id);
@@ -73,9 +73,9 @@ impl Completer for FlagCompletion {
                 }
             }
 
-            return (output, CompletionOptions::default());
+            return output;
         }
 
-        (vec![], CompletionOptions::default())
+        vec![]
     }
 }

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::{Completer, CompletionOptions};
+use crate::completions::Completer;
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
     Span, Value,
@@ -35,7 +35,7 @@ impl Completer for VariableCompletion {
         span: Span,
         offset: usize,
         _: usize,
-    ) -> (Vec<Suggestion>, CompletionOptions) {
+    ) -> Vec<Suggestion> {
         let mut output = vec![];
         let builtins = ["$nu", "$in", "$config", "$env", "$nothing"];
         let var_str = std::str::from_utf8(&self.var_context.0)
@@ -62,7 +62,7 @@ impl Completer for VariableCompletion {
                     }
                 }
 
-                return (output, CompletionOptions::default());
+                return output;
             }
 
             // Completion other variable types
@@ -98,11 +98,11 @@ impl Completer for VariableCompletion {
                                 });
                             }
 
-                            return (output, CompletionOptions::default());
+                            return output;
                         }
 
                         _ => {
-                            return (output, CompletionOptions::default());
+                            return output;
                         }
                     }
                 }
@@ -151,7 +151,7 @@ impl Completer for VariableCompletion {
 
         output.dedup();
 
-        (output, CompletionOptions::default())
+        output
     }
 }
 

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -52,12 +52,14 @@ impl Completer for VariableCompletion {
             // Completion for $env.<tab>
             if var_str.as_str() == "$env" {
                 for env_var in self.stack.get_env_vars(&self.engine_state) {
-                    output.push(Suggestion {
-                        value: env_var.0,
-                        description: None,
-                        extra: None,
-                        span: current_span,
-                    });
+                    if env_var.0.as_bytes().starts_with(&prefix) {
+                        output.push(Suggestion {
+                            value: env_var.0,
+                            description: None,
+                            extra: None,
+                            span: current_span,
+                        });
+                    }
                 }
 
                 return (output, CompletionOptions::default());


### PR DESCRIPTION
# Description

Currently `NuCompleter::process_completion()` works the following way:

* Fetch suggestions *and `CompletionOptions`* from the specific completer
* Filter suggestions based on the returned `CompletionOptions`
* Sort suggestions based on the returned `CompletionOptions`

In my opinion it's a bit confusing that the call to `fetch()` returns `CompletionOptions`. As far as I can tell the only reason this is necessary is because `CustomCompletion` has an undocumented feature where a custom command can return a record instead of a list of suggestions. This record allows to specify `CompletionOptions` specifically for this command.

The goal of this PR is to stop returning the `CompletionOptions` from the `Completer::fetch()` function. Each `Completer` should still behave like before. In a future PR I'd like to pass extended `CompletionOptions` into the `fetch()` function to enable customizing the `Completer` a bit more (e.g. specify how it matches suggestions: fuzzy or prefix, or substring, etc.).

To allow removing the `CompletionOptions` the following changes were made:

* Remove `Completer::filter()` from trait
  * Most completers filter inside the `fetch()` function anyway (which probably makes sense to avoid unnecessary memory allocations)
* Remove `CompletionOptions` from `Completer::fetch()` return values

## Detailed explanation

### Reasoning for removal of `Completer::filter()`

* `CommandCompletion`
  * `filter()` is overriden and just returns the input list (so no filtering happens)
* `FileCompletion`
  * `filter()` is overriden and just returns the input list (so no filtering happens)
* `FlagCompletion`
  * Returns default options and only returns suggestions which start with the prefix
  * Default options lead to filtering by `starts_with` anyway, so the filtering should be redundant
* `VariableCompletion`
  * Returns default options and with this PR only returns suggestions which start with the prefix
  * Default options lead to filtering by `starts_with` anyway, so the filtering should be redundant
* `CustomCompletion`
  * May read `CompletionOptions` from a custom completion function
  * The `filter()` function was moved into the `CustomCompleter` type
  * Therefore filtering happens now when fetching the suggestions (just like all other completers)

### Sorting changes

The `sort` function also takes `CompletionOptions` as argument because `SortBy` is specified there. A new function is added to the `Completer` trait which returns the sorting for the given completer.