### PR TITLE
nu-cli/completions: fix file completions with quotes

### DIFF
--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -149,10 +149,8 @@ pub fn file_path_completion(
                         }
 
                         // Fix files or folders with quotes
-                        if path.contains('\'') {
-                            path = format!(r#""{}""#, path);
-                        } else if path.contains('"') {
-                            path = format!(r#"'{}'"#, path);
+                        if path.contains('\'') || path.contains('"') {
+                            path = format!("`{}`", path);
                         }
 
                         Some((span, path))

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -148,6 +148,13 @@ pub fn file_path_completion(
                             path = format!("\'{}\'", path);
                         }
 
+                        // Fix files or folders with quotes
+                        if path.contains('\'') {
+                            path = format!(r#""{}""#, path);
+                        } else if path.contains('"') {
+                            path = format!(r#"'{}'"#, path);
+                        }
+
                         Some((span, path))
                     } else {
                         None


### PR DESCRIPTION
# Description

This fixes the issue https://github.com/nushell/nushell/issues/5223 . I'm just checking if the path has single/double quotes, and wrapping the path with quotes.

- single quotes -> wrap with double quotes
- double quotes -> wrap with single quotes

To be honest I'm not 100% sure that this is the correct way of doing it, perhaps there are more special characters we need to check. Any suggestion is welcome.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
