### PR TITLE
add os to $nu based on rust's understanding

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1249,6 +1249,10 @@ pub fn eval_variable(
             output_cols.push("pid".into());
             output_vals.push(Value::int(pid as i64, span));
 
+            let os = std::env::consts::OS;
+            output_cols.push("os".into());
+            output_vals.push(Value::string(os, span));
+
             Ok(Value::Record {
                 cols: output_cols,
                 vals: output_vals,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1249,9 +1249,17 @@ pub fn eval_variable(
             output_cols.push("pid".into());
             output_vals.push(Value::int(pid as i64, span));
 
-            let os = std::env::consts::OS;
-            output_cols.push("os".into());
-            output_vals.push(Value::string(os, span));
+            let os_record = Value::Record {
+                cols: vec!["os".into(), "arch".into(), "family".into()],
+                vals: vec![
+                    Value::string(std::env::consts::OS, span),
+                    Value::string(std::env::consts::ARCH, span),
+                    Value::string(std::env::consts::FAMILY, span),
+                ],
+                span,
+            };
+            output_cols.push("os-info".into());
+            output_vals.push(os_record);
 
             Ok(Value::Record {
                 cols: output_cols,


### PR DESCRIPTION
# Description

This PR adds a new `os` entry in the special `$nu` variable for operating system. It's based on what rust understands the system to be as documented [here](https://doc.rust-lang.org/std/env/consts/constant.OS.html). The hope is that this will be easier and faster than `(sys).host` on all platforms. I'm not sure what it does on a platform that is not supported. Good luck to us all. :)

This is from the source code
```rust
    /// A string describing the specific operating system in use.
    /// Example value is `linux`.
    ///
    /// Some possible values:
    ///
    /// - linux
    /// - macos
    /// - ios
    /// - freebsd
    /// - dragonfly
    /// - netbsd
    /// - openbsd
    /// - solaris
    /// - android
    /// - windows
```


This should close https://github.com/nushell/nushell/issues/5231

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
