### PR TITLE
Add MatchAlgorithm for completion suggestions

### DIFF
--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -1,4 +1,4 @@
-use crate::completions::SortBy;
+use crate::completions::{CompletionOptions, SortBy};
 use nu_protocol::{engine::StateWorkingSet, levenshtein_distance, Span};
 use reedline::Suggestion;
 
@@ -12,6 +12,7 @@ pub trait Completer {
         span: Span,
         offset: usize,
         pos: usize,
+        options: &CompletionOptions,
     ) -> Vec<Suggestion>;
 
     fn get_sort_by(&self) -> SortBy {

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1,6 +1,6 @@
 use crate::completions::{
-    CommandCompletion, Completer, CustomCompletion, DirectoryCompletion, DotNuCompletion,
-    FileCompletion, FlagCompletion, VariableCompletion,
+    CommandCompletion, Completer, CompletionOptions, CustomCompletion, DirectoryCompletion,
+    DotNuCompletion, FileCompletion, FlagCompletion, VariableCompletion,
 };
 use nu_parser::{flatten_expression, parse, FlatShape};
 use nu_protocol::{
@@ -35,8 +35,11 @@ impl NuCompleter {
         offset: usize,
         pos: usize,
     ) -> Vec<Suggestion> {
+        let options = CompletionOptions::default();
+
         // Fetch
-        let mut suggestions = completer.fetch(working_set, prefix.clone(), new_span, offset, pos);
+        let mut suggestions =
+            completer.fetch(working_set, prefix.clone(), new_span, offset, pos, &options);
 
         // Sort
         suggestions = completer.sort(suggestions, prefix);

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -5,18 +5,25 @@ pub enum SortBy {
     None,
 }
 
+/// Describes how suggestions should be matched.
 #[derive(Copy, Clone)]
 pub enum MatchAlgorithm {
+    /// Only show suggestions which begin with the given input
+    ///
+    /// Example:
+    /// "git switch" is matched by "git sw"
     Prefix,
 }
 
 impl MatchAlgorithm {
+    /// Returns whether the `needle` search text matches the given `haystack`.
     pub fn matches_str(&self, haystack: &str, needle: &str) -> bool {
         match *self {
             MatchAlgorithm::Prefix => haystack.starts_with(needle),
         }
     }
 
+    /// Returns whether the `needle` search text matches the given `haystack`.
     pub fn matches_u8(&self, haystack: &[u8], needle: &[u8]) -> bool {
         match *self {
             MatchAlgorithm::Prefix => haystack.starts_with(needle),
@@ -40,5 +47,23 @@ impl Default for CompletionOptions {
             sort_by: SortBy::Ascending,
             match_algorithm: MatchAlgorithm::Prefix,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::MatchAlgorithm;
+
+    #[test]
+    fn match_algorithm_prefix() {
+        let algorithm = MatchAlgorithm::Prefix;
+
+        assert!(algorithm.matches_str("example text", ""));
+        assert!(algorithm.matches_str("example text", "examp"));
+        assert!(!algorithm.matches_str("example text", "text"));
+
+        assert!(algorithm.matches_u8(&[1, 2, 3], &[]));
+        assert!(algorithm.matches_u8(&[1, 2, 3], &[1, 2]));
+        assert!(!algorithm.matches_u8(&[1, 2, 3], &[2, 3]));
     }
 }

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -5,11 +5,31 @@ pub enum SortBy {
     None,
 }
 
+#[derive(Copy, Clone)]
+pub enum MatchAlgorithm {
+    Prefix,
+}
+
+impl MatchAlgorithm {
+    pub fn matches_str(&self, haystack: &str, needle: &str) -> bool {
+        match *self {
+            MatchAlgorithm::Prefix => haystack.starts_with(needle),
+        }
+    }
+
+    pub fn matches_u8(&self, haystack: &[u8], needle: &[u8]) -> bool {
+        match *self {
+            MatchAlgorithm::Prefix => haystack.starts_with(needle),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct CompletionOptions {
     pub case_sensitive: bool,
     pub positional: bool,
     pub sort_by: SortBy,
+    pub match_algorithm: MatchAlgorithm,
 }
 
 impl Default for CompletionOptions {
@@ -18,6 +38,7 @@ impl Default for CompletionOptions {
             case_sensitive: true,
             positional: true,
             sort_by: SortBy::Ascending,
+            match_algorithm: MatchAlgorithm::Prefix,
         }
     }
 }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::{Completer, CompletionOptions, SortBy};
+use crate::completions::{Completer, CompletionOptions, MatchAlgorithm, SortBy};
 use nu_engine::eval_call;
 use nu_protocol::{
     ast::{Argument, Call, Expr, Expression},
@@ -170,6 +170,7 @@ impl Completer for CustomCompletion {
                                 } else {
                                     SortBy::None
                                 },
+                                match_algorithm: MatchAlgorithm::Prefix,
                             }
                         } else {
                             CompletionOptions::default()

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -97,6 +97,7 @@ impl Completer for CustomCompletion {
         span: Span,
         offset: usize,
         pos: usize,
+        _options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         // Line position
         let line_pos = pos - offset;

--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::{file_path_completion, Completer};
+use crate::completions::{file_path_completion, Completer, CompletionOptions};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
@@ -28,6 +28,7 @@ impl Completer for DirectoryCompletion {
         span: Span,
         offset: usize,
         _: usize,
+        options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         let cwd = if let Some(d) = self.engine_state.env_vars.get("PWD") {
             match d.as_string() {
@@ -37,10 +38,10 @@ impl Completer for DirectoryCompletion {
         } else {
             "".to_string()
         };
-        let prefix = String::from_utf8_lossy(&prefix).to_string();
+        let partial = String::from_utf8_lossy(&prefix).to_string();
 
         // Filter only the folders
-        let output: Vec<_> = file_path_completion(span, &prefix, &cwd)
+        let output: Vec<_> = file_path_completion(span, &partial, &cwd, options.match_algorithm)
             .into_iter()
             .filter_map(move |x| {
                 if x.1.ends_with(SEP) {

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -28,7 +28,7 @@ impl Completer for DotNuCompletion {
         span: Span,
         offset: usize,
         _: usize,
-        _options: &CompletionOptions,
+        options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         let prefix_str = String::from_utf8_lossy(&prefix).to_string();
         let mut search_dirs: Vec<String> = vec![];
@@ -91,7 +91,7 @@ impl Completer for DotNuCompletion {
         let output: Vec<Suggestion> = search_dirs
             .into_iter()
             .flat_map(|it| {
-                file_path_completion(span, &partial, &it)
+                file_path_completion(span, &partial, &it, options.match_algorithm)
                     .into_iter()
                     .filter(|it| {
                         // Different base dir, so we list the .nu files or folders

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -1,4 +1,6 @@
-use crate::completions::{file_path_completion, partial_from, Completer, SortBy};
+use crate::completions::{
+    file_path_completion, partial_from, Completer, CompletionOptions, SortBy,
+};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     Span,
@@ -26,6 +28,7 @@ impl Completer for DotNuCompletion {
         span: Span,
         offset: usize,
         _: usize,
+        _options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         let prefix_str = String::from_utf8_lossy(&prefix).to_string();
         let mut search_dirs: Vec<String> = vec![];

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::Completer;
+use crate::completions::{Completer, CompletionOptions};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
@@ -28,6 +28,7 @@ impl Completer for FileCompletion {
         span: Span,
         offset: usize,
         _: usize,
+        _options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         let cwd = if let Some(d) = self.engine_state.env_vars.get("PWD") {
             match d.as_string() {

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -26,7 +26,7 @@ impl Completer for FlagCompletion {
         span: Span,
         offset: usize,
         _: usize,
-        _options: &CompletionOptions,
+        options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         // Check if it's a flag
         if let Expr::Call(call) = &self.expression.expr {
@@ -41,7 +41,8 @@ impl Completer for FlagCompletion {
                     let mut named = vec![0; short.len_utf8()];
                     short.encode_utf8(&mut named);
                     named.insert(0, b'-');
-                    if named.starts_with(&prefix) {
+
+                    if options.match_algorithm.matches_u8(&named, &prefix) {
                         output.push(Suggestion {
                             value: String::from_utf8_lossy(&named).to_string(),
                             description: Some(flag_desc.to_string()),
@@ -61,7 +62,8 @@ impl Completer for FlagCompletion {
                 let mut named = named.long.as_bytes().to_vec();
                 named.insert(0, b'-');
                 named.insert(0, b'-');
-                if named.starts_with(&prefix) {
+
+                if options.match_algorithm.matches_u8(&named, &prefix) {
                     output.push(Suggestion {
                         value: String::from_utf8_lossy(&named).to_string(),
                         description: Some(flag_desc.to_string()),

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::Completer;
+use crate::completions::{Completer, CompletionOptions};
 use nu_protocol::{
     ast::{Expr, Expression},
     engine::StateWorkingSet,
@@ -26,6 +26,7 @@ impl Completer for FlagCompletion {
         span: Span,
         offset: usize,
         _: usize,
+        _options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         // Check if it's a flag
         if let Expr::Call(call) = &self.expression.expr {

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -12,7 +12,7 @@ mod variable_completions;
 pub use base::Completer;
 pub use command_completions::CommandCompletion;
 pub use completer::NuCompleter;
-pub use completion_options::{CompletionOptions, SortBy};
+pub use completion_options::{CompletionOptions, MatchMode, SortBy};
 pub use custom_completions::CustomCompletion;
 pub use directory_completions::DirectoryCompletion;
 pub use dotnu_completions::DotNuCompletion;

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -12,7 +12,7 @@ mod variable_completions;
 pub use base::Completer;
 pub use command_completions::CommandCompletion;
 pub use completer::NuCompleter;
-pub use completion_options::{CompletionOptions, MatchMode, SortBy};
+pub use completion_options::{CompletionOptions, MatchAlgorithm, SortBy};
 pub use custom_completions::CustomCompletion;
 pub use directory_completions::DirectoryCompletion;
 pub use dotnu_completions::DotNuCompletion;

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -37,7 +37,7 @@ impl Completer for VariableCompletion {
         span: Span,
         offset: usize,
         _: usize,
-        _options: &CompletionOptions,
+        options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         let mut output = vec![];
         let builtins = ["$nu", "$in", "$config", "$env", "$nothing"];
@@ -55,7 +55,10 @@ impl Completer for VariableCompletion {
             // Completion for $env.<tab>
             if var_str.as_str() == "$env" {
                 for env_var in self.stack.get_env_vars(&self.engine_state) {
-                    if env_var.0.as_bytes().starts_with(&prefix) {
+                    if options
+                        .match_algorithm
+                        .matches_u8(env_var.0.as_bytes(), &prefix)
+                    {
                         output.push(Suggestion {
                             value: env_var.0,
                             description: None,
@@ -156,7 +159,10 @@ impl Completer for VariableCompletion {
 
         // Variable completion (e.g: $en<tab> to complete $env)
         for builtin in builtins {
-            if builtin.as_bytes().starts_with(&prefix) {
+            if options
+                .match_algorithm
+                .matches_u8(builtin.as_bytes(), &prefix)
+            {
                 output.push(Suggestion {
                     value: builtin.to_string(),
                     description: None,
@@ -169,7 +175,7 @@ impl Completer for VariableCompletion {
         // Working set scope vars
         for scope in &working_set.delta.scope {
             for v in &scope.vars {
-                if v.0.starts_with(&prefix) {
+                if options.match_algorithm.matches_u8(v.0, &prefix) {
                     output.push(Suggestion {
                         value: String::from_utf8_lossy(v.0).to_string(),
                         description: None,
@@ -183,7 +189,7 @@ impl Completer for VariableCompletion {
         // Permanent state vars
         for scope in &self.engine_state.scope {
             for v in &scope.vars {
-                if v.0.starts_with(&prefix) {
+                if options.match_algorithm.matches_u8(v.0, &prefix) {
                     output.push(Suggestion {
                         value: String::from_utf8_lossy(v.0).to_string(),
                         description: None,

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::Completer;
+use crate::completions::{Completer, CompletionOptions};
 use nu_engine::eval_variable;
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
@@ -37,6 +37,7 @@ impl Completer for VariableCompletion {
         span: Span,
         offset: usize,
         _: usize,
+        _options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         let mut output = vec![];
         let builtins = ["$nu", "$in", "$config", "$env", "$nothing"];

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -444,12 +444,15 @@ impl EngineState {
         None
     }
 
-    pub fn find_commands_by_prefix(&self, name: &[u8]) -> Vec<(Vec<u8>, Option<String>)> {
+    pub fn find_commands_by_predicate(
+        &self,
+        predicate: impl Fn(&[u8]) -> bool,
+    ) -> Vec<(Vec<u8>, Option<String>)> {
         let mut output = vec![];
 
         for scope in self.scope.iter().rev() {
             for decl in &scope.decls {
-                if decl.0.starts_with(name) {
+                if predicate(decl.0) {
                     let command = self.get_decl(*decl.1);
                     output.push((decl.0.clone(), Some(command.usage().to_string())));
                 }
@@ -459,12 +462,12 @@ impl EngineState {
         output
     }
 
-    pub fn find_aliases_by_prefix(&self, name: &[u8]) -> Vec<Vec<u8>> {
+    pub fn find_aliases_by_predicate(&self, predicate: impl Fn(&[u8]) -> bool) -> Vec<Vec<u8>> {
         self.scope
             .iter()
             .rev()
             .flat_map(|scope| &scope.aliases)
-            .filter(|decl| decl.0.starts_with(name))
+            .filter(|decl| predicate(decl.0))
             .map(|decl| decl.0.clone())
             .collect()
     }
@@ -1315,34 +1318,40 @@ impl<'a> StateWorkingSet<'a> {
         }
     }
 
-    pub fn find_commands_by_prefix(&self, name: &[u8]) -> Vec<(Vec<u8>, Option<String>)> {
+    pub fn find_commands_by_predicate(
+        &self,
+        predicate: impl Fn(&[u8]) -> bool,
+    ) -> Vec<(Vec<u8>, Option<String>)> {
         let mut output = vec![];
 
         for scope in self.delta.scope.iter().rev() {
             for decl in &scope.decls {
-                if decl.0.starts_with(name) {
+                if predicate(decl.0) {
                     let command = self.get_decl(*decl.1);
                     output.push((decl.0.clone(), Some(command.usage().to_string())));
                 }
             }
         }
 
-        let mut permanent = self.permanent_state.find_commands_by_prefix(name);
+        let mut permanent = self.permanent_state.find_commands_by_predicate(predicate);
 
         output.append(&mut permanent);
 
         output
     }
 
-    pub fn find_aliases_by_prefix(&self, name: &[u8]) -> Vec<Vec<u8>> {
+    pub fn find_aliases_by_predicate(
+        &self,
+        predicate: impl Fn(&[u8]) -> bool + Copy,
+    ) -> Vec<Vec<u8>> {
         self.delta
             .scope
             .iter()
             .rev()
             .flat_map(|scope| &scope.aliases)
-            .filter(|decl| decl.0.starts_with(name))
+            .filter(|decl| predicate(decl.0))
             .map(|decl| decl.0.clone())
-            .chain(self.permanent_state.find_aliases_by_prefix(name))
+            .chain(self.permanent_state.find_aliases_by_predicate(predicate))
             .collect()
     }
 


### PR DESCRIPTION
# Description

This PR tackles two topics:

1) Pass options to `Completer::fetch()` to allow customization of the completer
2) Move suggestion filtering to `MatchAlgorithm` so it is easy to add more advanced suggestion matching (e.g. fuzzy matching)

# Implementation

Pass `CompletionOptions` to each `fetch()` call for each `Completer` and add `MatchAlgorithm` to `CompletionOptions` which specifes how completers should match possible suggestions. The current default would be "prefix", ~this PR will add some kind of substring matching~ (Edit: this PR adds just the basic implementation with a prefix matcher). Future PRs can add more match algorithms, (e.g. fuzzy matching or substring matching). The check if a completion matches the input is also moved to the `MatchAlgorithm` so that the actual comparison happens only at one place and is not duplicated in every completer.

This PR is not intended to change the current completion behaviour (which is prefix based).

# TODOs
- [x] Pass `CompletionOptions` to every completer
- [x] Handle matching logic in `MatchAlgorithm` (instead of in every single completer)
- [x] Add basic unit test for `MatchAlgorithm::Prefix`