### PR TITLE
Set to reedline main branch for development cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,8 +3524,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01487ee6361e894f914d59f4310deea779222357637ac576f34741a18dd02ed2"
+source = "git+https://github.com/nushell/reedline?branch=main#2e2bdc54621643e7bee5ba2e2d9bf28e757074e0"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ nu-table = { path = "./crates/nu-table", version = "0.61.1"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.61.1"  }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
-reedline = { version = "0.4.0", features = ["bashisms"]}
+reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 is_executable = "1.0.1"
 
 [dev-dependencies]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -18,11 +18,10 @@ nu-protocol = { path = "../nu-protocol", version = "0.61.1"  }
 nu-utils = { path = "../nu-utils", version = "0.61.1"  }
 nu-ansi-term = "0.45.1"
 nu-color-config = { path = "../nu-color-config", version = "0.61.1"  }
-
+reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 crossterm = "0.23.0"
 miette = { version = "4.5.0", features = ["fancy"] }
 thiserror = "1.0.29"
-reedline = { version = "0.4.0", features = ["bashisms"]}
 
 log = "0.4"
 is_executable = "1.0.1"

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -814,6 +814,7 @@ fn event_from_record(
         "none" => ReedlineEvent::None,
         "actionhandler" => ReedlineEvent::ActionHandler,
         "clearscreen" => ReedlineEvent::ClearScreen,
+        "clearscrollback" => ReedlineEvent::ClearScrollback,
         "historyhintcomplete" => ReedlineEvent::HistoryHintComplete,
         "historyhintwordcomplete" => ReedlineEvent::HistoryHintWordComplete,
         "ctrld" => ReedlineEvent::CtrlD,
@@ -881,6 +882,7 @@ fn edit_from_record(
             let value = extract_value("value", cols, vals, span)?;
             EditCommand::InsertString(value.into_string("", config))
         }
+        "insertnewline" => EditCommand::InsertNewline,
         "backspace" => EditCommand::Backspace,
         "delete" => EditCommand::Delete,
         "backspaceword" => EditCommand::BackspaceWord,

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -314,9 +314,6 @@ pub fn evaluate_repl(
                 println!();
                 break;
             }
-            Ok(Signal::CtrlL) => {
-                line_editor.clear_screen().into_diagnostic()?;
-            }
             Err(err) => {
                 let message = err.to_string();
                 if !message.contains("duration") {

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -79,7 +79,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-reedline =  { version = "0.4.0", features = ["bashisms"]}
+reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 wax = { version =  "0.4.0", features = ["diagnostics"] }
 zip = { version="0.5.9", optional = true }
 


### PR DESCRIPTION
# Changes to reedline since `v0.4.0`:

- vi normal mode `I` for inserting at line beginning
- `InsertNewline` edit command that can be bound to `Alt-Enter` if
desired to have line breaks without relying on the `Validator`
- `ClearScreen` will directly clear the visible screen. `Signal::CtrlL` has been
removed.
- `ClearScrollback` will clear the screen and scrollback. Can be used to
mimic macOS `Cmd-K` screen clearing. Helps with #5089


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
