### PR TITLE
nu-cli/completions: better fix for files with special characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.4.0"
-source = "git+https://github.com/nushell/reedline?branch=main#2e2bdc54621643e7bee5ba2e2d9bf28e757074e0"
+source = "git+https://github.com/nushell/reedline?branch=main#229c729898ef91bf9cb83a5420a6fe7b4c8d1045"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -157,7 +157,8 @@ pub fn escape_path_str(path: String) -> String {
     let mut path = path;
     if path.contains(' ') || path.contains('\\') || path.contains('"') || path.contains('`') {
         // Escape characters
-        path = path.replace('"', "\"");
+        path = path.replace('\\', "\\\\");
+        path = path.replace('"', "\\\"");
 
         // Wrap with double quotes
         path = format!("\"{}\"", path);

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -155,12 +155,19 @@ pub fn matches(partial: &str, from: &str) -> bool {
 // escape paths that contains some special characters
 pub fn escape_path_str(path: String) -> String {
     let mut path = path;
-    if path.contains(' ')
-        || path.contains('\\')
-        || path.contains('"')
-        || path.contains('\'')
-        || path.contains('`')
-    {
+
+    // Check if path needs to be escaped
+    let needs_escape = path.bytes().fold(
+        false,
+        |acc, x| {
+            acc
+        || (x >> 4) == 0b0010
+        || x == '\\' as u8 // 0x5c
+        || x == '`' as u8
+        }, // 0x60
+    );
+
+    if needs_escape {
         // Escape characters
         path = path.replace('\\', "\\\\");
         path = path.replace('"', "\\\"");

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -226,7 +226,10 @@ mod test {
         ];
 
         for item in cases.into_iter() {
-            assert_eq!(escape_path_str(item.0.to_string()), item.1.to_string())
+            assert_eq!(
+                crate::completions::escape_path_str(item.0.to_string()),
+                item.1.to_string()
+            )
         }
     }
 }

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -157,15 +157,12 @@ pub fn escape_path_str(path: String) -> String {
     let mut path = path;
 
     // Check if path needs to be escaped
-    let needs_escape = path.bytes().fold(
-        false,
-        |acc, x| {
-            acc
+    let needs_escape = path.bytes().fold(false, |acc, x| {
+        acc
         || (x >> 4) == 0b0010
         || x == b'\\' // 0x5c
-        || x == b'`'
-        }, // 0x60
-    );
+        || x == b'`' // 0x60
+    });
 
     if needs_escape {
         // Escape characters

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -202,8 +202,6 @@ pub fn escape_path_str(path: String) -> String {
 }
 
 mod test {
-    use crate::completions::escape_path_str;
-
     #[test]
     fn escape_path() {
         // Vec of (path, expected escape)

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -155,9 +155,8 @@ pub fn matches(partial: &str, from: &str) -> bool {
 // escape paths that contains some special characters
 pub fn escape_path_str(path: String) -> String {
     let mut path = path;
-    if path.contains(' ') || path.contains('\\') || path.contains('"') {
+    if path.contains(' ') || path.contains('\\') || path.contains('"') || path.contains('`') {
         // Escape characters
-        path = path.replace('\\', "\\\\");
         path = path.replace('"', "\"");
 
         // Wrap with double quotes

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -155,7 +155,12 @@ pub fn matches(partial: &str, from: &str) -> bool {
 // escape paths that contains some special characters
 pub fn escape_path_str(path: String) -> String {
     let mut path = path;
-    if path.contains(' ') || path.contains('\\') || path.contains('"') || path.contains('`') {
+    if path.contains(' ')
+        || path.contains('\\')
+        || path.contains('"')
+        || path.contains('\'')
+        || path.contains('`')
+    {
         // Escape characters
         path = path.replace('\\', "\\\\");
         path = path.replace('"', "\\\"");

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -162,8 +162,8 @@ pub fn escape_path_str(path: String) -> String {
         |acc, x| {
             acc
         || (x >> 4) == 0b0010
-        || x == '\\' as u8 // 0x5c
-        || x == '`' as u8
+        || x == b'\\' // 0x5c
+        || x == b'`'
         }, // 0x60
     );
 

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -132,14 +132,8 @@ pub fn file_path_completion(
                             file_name.push(SEP);
                         }
 
-                        if path.contains(' ') {
-                            path = format!("\'{}\'", path);
-                        }
-
-                        // Fix files or folders with quotes
-                        if path.contains('\'') || path.contains('"') {
-                            path = format!("`{}`", path);
-                        }
+                        // Escape path string if necessary
+                        path = escape_path_str(path);
 
                         Some((span, path))
                     } else {
@@ -156,4 +150,19 @@ pub fn file_path_completion(
 pub fn matches(partial: &str, from: &str) -> bool {
     from.to_ascii_lowercase()
         .starts_with(&partial.to_ascii_lowercase())
+}
+
+// escape paths that contains some special characters
+pub fn escape_path_str(path: String) -> String {
+    let mut path = path;
+    if path.contains(' ') || path.contains('\\') || path.contains('"') {
+        // Escape characters
+        path = path.replace('\\', "\\\\");
+        path = path.replace('"', "\"");
+
+        // Wrap with double quotes
+        path = format!("\"{}\"", path);
+    }
+
+    path
 }

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -165,6 +165,7 @@ pub fn escape_path_str(path: String) -> String {
         acc
         || x == b'\\' // 0x5c
         || x == b'`' // 0x60
+        || x == b'"'
         || x == b' '
         || x == b'\''
     });
@@ -198,4 +199,36 @@ pub fn escape_path_str(path: String) -> String {
     }
 
     path
+}
+
+mod test {
+    use crate::completions::escape_path_str;
+
+    #[test]
+    fn escape_path() {
+        // Vec of (path, expected escape)
+        let cases: Vec<(&str, &str)> = vec![
+            ("/home/nushell/filewith`", "\"/home/nushell/filewith`\""),
+            (
+                "/home/nushell/folder with spaces",
+                "\"/home/nushell/folder with spaces\"",
+            ),
+            (
+                "/home/nushell/folder\"withquotes",
+                "\"/home/nushell/folder\\\"withquotes\"",
+            ),
+            (
+                "C:\\windows\\system32\\escape path",
+                "\"C:\\\\windows\\\\system32\\\\escape path\"",
+            ),
+            (
+                "/home/nushell/shouldnt/be/escaped",
+                "/home/nushell/shouldnt/be/escaped",
+            ),
+        ];
+
+        for item in cases.into_iter() {
+            assert_eq!(escape_path_str(item.0.to_string()), item.1.to_string())
+        }
+    }
 }

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -170,7 +170,6 @@ pub fn escape_path_str(path: String) -> String {
     });
 
     if needs_escape {
-        // Worst case, escape everything (+2 double quotes)
         let mut result: Vec<u8> = vec![b'\"'];
 
         // Walk through the path characters

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -171,10 +171,7 @@ pub fn escape_path_str(path: String) -> String {
 
     if needs_escape {
         // Worst case, escape everything (+2 double quotes)
-        let mut result = String::with_capacity(path.len() * 2 + 2);
-
-        // Starting quotes
-        result.push('\"');
+        let mut result: Vec<u8> = vec![b'\"'];
 
         // Walk through the path characters
         for b in path.bytes() {
@@ -187,18 +184,18 @@ pub fn escape_path_str(path: String) -> String {
                 }
             }) {
                 for rb in replacements[idx] {
-                    result.push(*rb as char);
+                    result.push(*rb);
                 }
             } else {
-                result.push(b as char);
+                result.push(b);
             }
         }
 
         // Final quote
-        result.push('\"');
+        result.push(b'\"');
 
         // Update path
-        path = result;
+        path = String::from_utf8(result).unwrap_or(path);
     }
 
     path

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -16,6 +16,6 @@ pub use completion_options::{CompletionOptions, SortBy};
 pub use custom_completions::CustomCompletion;
 pub use directory_completions::DirectoryCompletion;
 pub use dotnu_completions::DotNuCompletion;
-pub use file_completions::{file_path_completion, partial_from, FileCompletion};
+pub use file_completions::{escape_path_str, file_path_completion, partial_from, FileCompletion};
 pub use flag_completions::FlagCompletion;
 pub use variable_completions::VariableCompletion;

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -91,7 +91,16 @@ pub fn new_engine() -> (PathBuf, String, EngineState) {
 fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
     suggestions.into_iter().for_each(|it| {
         let items = expected.clone();
-        let result = items.into_iter().find(|x| x == &it.value);
+        let result = items.into_iter().find(|x| {
+            let mut current_item = x.clone();
+
+            // For windows the expected should also escape "\"
+            if cfg!(windows) {
+                current_item = current_item.replace("\\", "\\\\");
+            }
+
+            &current_item == &it.value
+        });
 
         match result {
             Some(val) => assert_eq!(val, it.value),

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -8,6 +8,7 @@ use reedline::{Completer, Suggestion};
 const SEP: char = std::path::MAIN_SEPARATOR;
 
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn file_completions() {
     // Create a new engine
     let (dir, dir_str, engine) = new_engine();
@@ -45,6 +46,7 @@ fn file_completions() {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn folder_completions() {
     // Create a new engine
     let (dir, dir_str, engine) = new_engine();
@@ -104,7 +106,7 @@ fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
 
         match result {
             Some(val) => assert_eq!(val, it.value),
-            None => panic!("expected path {} but received {}", val, it.value),
+            None => panic!("the path {} is not expected", it.value),
         }
     });
 }

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -27,7 +27,6 @@ fn file_completions() {
         folder(dir.clone().join("test_a")),
         folder(dir.clone().join("test_b")),
         folder(dir.clone().join("another")),
-        format!("\"{}\"", file(dir.clone().join("`\\\'\\\"_file\\\'`"))),
         format!("\"{}\"", file(dir.clone().join("\\\'needs_escape\\\'"))),
         format!("\"{}\"", file(dir.clone().join("`needs_escape\\\"\\\""))),
         format!(

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -27,12 +27,6 @@ fn file_completions() {
         folder(dir.clone().join("test_a")),
         folder(dir.clone().join("test_b")),
         folder(dir.clone().join("another")),
-        format!("\"{}\"", file(dir.clone().join("\\\'needs_escape\\\'"))),
-        format!("\"{}\"", file(dir.clone().join("`needs_escape\\\"\\\""))),
-        format!(
-            "\"{}\"",
-            folder(dir.clone().join("folder_with\\\'\\\\_chars"))
-        ),
         file(dir.clone().join(".hidden_file")),
         folder(dir.clone().join(".hidden_folder")),
     ];

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -104,7 +104,7 @@ fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
 
         match result {
             Some(val) => assert_eq!(val, it.value),
-            None => panic!("the path {} is not expected", it.value),
+            None => panic!("expected path {} but received {}", val, it.value),
         }
     });
 }

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -23,12 +23,19 @@ fn file_completions() {
 
     // Create the expected values
     let expected_paths: Vec<String> = vec![
-        file(dir.join("nushell")),
-        folder(dir.join("test_a")),
-        folder(dir.join("test_b")),
-        folder(dir.join("another")),
-        file(dir.join(".hidden_file")),
-        folder(dir.join(".hidden_folder")),
+        file(dir.clone().join("nushell")),
+        folder(dir.clone().join("test_a")),
+        folder(dir.clone().join("test_b")),
+        folder(dir.clone().join("another")),
+        format!("\"{}\"", file(dir.clone().join("`\\\'\\\"_file\\\'`"))),
+        format!("\"{}\"", file(dir.clone().join("\\\'needs_escape\\\'"))),
+        format!("\"{}\"", file(dir.clone().join("`needs_escape\\\"\\\""))),
+        format!(
+            "\"{}\"",
+            folder(dir.clone().join("folder_with\\\'\\\\_chars"))
+        ),
+        file(dir.clone().join(".hidden_file")),
+        folder(dir.clone().join(".hidden_folder")),
     ];
 
     // Match the results

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -23,7 +23,6 @@ fn file_completions() {
 
     // Create the expected values
     let expected_paths: Vec<String> = vec![
-        file(dir.clone().join("nushell")),
         folder(dir.clone().join("test_a")),
         folder(dir.clone().join("test_b")),
         folder(dir.clone().join("another")),

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -94,9 +94,17 @@ pub fn new_engine() -> (PathBuf, String, EngineState) {
 }
 
 // match a list of suggestions with the expected values
-pub fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
-    expected.iter().zip(suggestions).for_each(|it| {
-        assert_eq!(it.0, &it.1.value);
+// skipping the order (for now) due to some issue with sorting behaving
+// differently for each OS
+fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
+    suggestions.into_iter().for_each(|it| {
+        let items = expected.clone();
+        let result = items.into_iter().find(|x| x == &it.value);
+
+        match result {
+            Some(val) => assert_eq!(val, it.value),
+            None => panic!("the path {} is not expected", it.value),
+        }
     });
 }
 


### PR DESCRIPTION
# Description

Creating this PR for for discussing a better implementation for handling paths with special characters.

Related:
- https://github.com/nushell/nushell/pull/5242
- https://github.com/nushell/nushell/issues/5185
- https://github.com/nushell/nushell/issues/5223

Also, created a function so that logic can be reused.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
