### PR TITLE
Use better quoting for commandline args

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -22,7 +22,10 @@ pub fn evaluate_commands(
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        let (input, _) = if commands.item.starts_with('\'') || commands.item.starts_with('"') {
+        let (input, _) = if commands.item.starts_with('\'')
+            || commands.item.starts_with('"')
+            || commands.item.starts_with('`')
+        {
             (
                 trim_quotes(commands.item.as_bytes()),
                 commands.span.start + 1,

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -512,6 +512,7 @@ fn trim_enclosing_quotes(input: &str) -> String {
     match (chars.next(), chars.next_back()) {
         (Some('"'), Some('"')) => chars.collect(),
         (Some('\''), Some('\'')) => chars.collect(),
+        (Some('`'), Some('`')) => chars.collect(),
         _ => input.to_string(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,13 +83,13 @@ fn main() -> Result<()> {
     for arg in std::env::args().skip(1) {
         if !script_name.is_empty() {
             args_to_script.push(if arg.contains(' ') {
-                format!("'{}'", arg)
+                format!("`{}`", arg)
             } else {
                 arg
             });
         } else if collect_arg_nushell {
             args_to_nushell.push(if arg.contains(' ') {
-                format!("'{}'", arg)
+                format!("`{}`", arg)
             } else {
                 arg
             });

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -297,6 +297,15 @@ mod nu_commands {
 
         assert_eq!(actual.out, "foo");
     }
+
+    #[test]
+    fn better_arg_quoting() {
+        let actual = nu!(cwd: ".", r#"
+        nu -c "\# '"
+        "#);
+
+        assert_eq!(actual.out, "");
+    }
 }
 
 mod nu_script {


### PR DESCRIPTION
# Description

Fixes the re-quoting we use on commandline args to use backticks instead. Also touches up a few places in the code where raw strings weren't quote-trimmed correctly

fixes #5175 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
