### PR TITLE
Clean up tests and unused documentation code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,6 @@ name = "nu-engine"
 version = "0.61.1"
 dependencies = [
  "chrono",
- "itertools",
  "nu-glob",
  "nu-path",
  "nu-protocol",

--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -55,11 +55,6 @@ impl Command for Help {
                 result: None,
             },
             Example {
-                description: "generate documentation",
-                example: "help generate_docs",
-                result: None,
-            },
-            Example {
                 description: "show help for single command",
                 example: "help match",
                 result: None,

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -14,20 +14,3 @@ fn help_commands_length() {
     let is_positive = output_int.is_positive();
     assert!(is_positive);
 }
-
-// FIXME: jt: needs more work
-#[ignore]
-#[test]
-fn help_generate_docs_length() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        help generate_docs | flatten | length
-        "#
-    ));
-
-    let output = actual.out;
-    let output_int: i32 = output.parse().unwrap();
-    let is_positive = output_int.is_positive();
-    assert!(is_positive);
-}

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -66,10 +66,8 @@ fn complex_nested_columns() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
-fn allows_if_given_unknown_column_name_is_missing() {
+fn fails_if_given_unknown_column_name() {
     let actual = nu!(cwd: ".", pipeline(
         r#"
             echo [
@@ -84,7 +82,7 @@ fn allows_if_given_unknown_column_name_is_missing() {
         "#
     ));
 
-    assert_eq!(actual.out, "3");
+    assert!(actual.err.contains("nu::shell::name_not_found"));
 }
 
 #[test]

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -11,7 +11,6 @@ nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.61.
 nu-path = { path = "../nu-path", version = "0.61.1"  }
 nu-glob = { path = "../nu-glob", version = "0.61.1" }
 
-itertools = "0.10.1"
 chrono = { version="0.4.19", features=["serde"] }
 
 [features]

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -1,17 +1,26 @@
-use itertools::Itertools;
 use nu_protocol::{
     ast::Call,
     engine::{EngineState, Stack},
     Example, IntoPipelineData, Signature, Span, Value,
 };
 
-use std::borrow::Borrow;
-use std::collections::HashMap;
-
-const COMMANDS_DOCS_DIR: &str = "docs/commands";
+pub fn get_full_help(
+    sig: &Signature,
+    examples: &[Example],
+    engine_state: &EngineState,
+    stack: &mut Stack,
+) -> String {
+    get_documentation(
+        sig,
+        examples,
+        engine_state,
+        stack,
+        &DocumentationConfig::default(),
+    )
+}
 
 #[derive(Default)]
-pub struct DocumentationConfig {
+struct DocumentationConfig {
     no_subcommands: bool,
     //FIXME: add back in color support
     #[allow(dead_code)]
@@ -19,137 +28,8 @@ pub struct DocumentationConfig {
     brief: bool,
 }
 
-fn generate_doc(
-    name: &str,
-    engine_state: &EngineState,
-    stack: &mut Stack,
-    head: Span,
-) -> (Vec<String>, Vec<Value>) {
-    let mut cols = vec![];
-    let mut vals = vec![];
-
-    let command = engine_state
-        .find_decl(name.as_bytes())
-        .map(|decl_id| engine_state.get_decl(decl_id))
-        .unwrap_or_else(|| panic!("Expected command '{}' from names to be in registry", name));
-
-    cols.push("name".to_string());
-    vals.push(Value::String {
-        val: name.into(),
-        span: head,
-    });
-
-    cols.push("usage".to_string());
-    vals.push(Value::String {
-        val: command.usage().to_owned(),
-        span: head,
-    });
-
-    if let Some(link) = retrieve_doc_link(name) {
-        cols.push("doc_link".into());
-        vals.push(Value::String {
-            val: link,
-            span: head,
-        });
-    }
-
-    let signature = command.signature().update_from_command(command.borrow());
-
-    cols.push("documentation".to_owned());
-    vals.push(Value::String {
-        val: get_documentation(
-            &signature,
-            &command.examples(),
-            engine_state,
-            stack,
-            &DocumentationConfig {
-                no_subcommands: true,
-                no_color: true,
-                brief: false,
-            },
-        ),
-        span: head,
-    });
-
-    (cols, vals)
-}
-
-// generate_docs gets the documentation from each command and returns a Table as output
-pub fn generate_docs(engine_state: &EngineState, stack: &mut Stack, head: Span) -> Value {
-    let signatures = engine_state.get_signatures(true);
-
-    // cmap will map parent commands to it's subcommands e.g. to -> [to csv, to yaml, to bson]
-    let mut cmap: HashMap<String, Vec<String>> = HashMap::new();
-    for sig in &signatures {
-        if sig.name.contains(' ') {
-            let mut split_name = sig.name.split_whitespace();
-            let parent_name = split_name.next().expect("Expected a parent command name");
-            if cmap.contains_key(parent_name) {
-                let sub_names = cmap
-                    .get_mut(parent_name)
-                    .expect("Expected an entry for parent");
-                sub_names.push(sig.name.to_owned());
-            }
-        } else {
-            cmap.insert(sig.name.to_owned(), Vec::new());
-        };
-    }
-    // Return documentation for each command
-    // Sub-commands are nested under their respective parent commands
-    let mut table = Vec::new();
-    for sig in &signatures {
-        // Must be a sub-command, skip since it's being handled underneath when we hit the parent command
-        if !cmap.contains_key(&sig.name) {
-            continue;
-        }
-        let mut row_entries = generate_doc(&sig.name, engine_state, stack, head);
-        // Iterate over all the subcommands of the parent command
-        let mut sub_table = Vec::new();
-        for sub_name in cmap.get(&sig.name).unwrap_or(&Vec::new()) {
-            let (cols, vals) = generate_doc(sub_name, engine_state, stack, head);
-            sub_table.push(Value::Record {
-                cols,
-                vals,
-                span: head,
-            });
-        }
-
-        if !sub_table.is_empty() {
-            row_entries.0.push("subcommands".into());
-            row_entries.1.push(Value::List {
-                vals: sub_table,
-                span: head,
-            });
-        }
-        table.push(Value::Record {
-            cols: row_entries.0,
-            vals: row_entries.1,
-            span: head,
-        });
-    }
-    Value::List {
-        vals: table,
-        span: head,
-    }
-}
-
-fn retrieve_doc_link(name: &str) -> Option<String> {
-    let doc_name = name.split_whitespace().join("_"); // Because .replace(" ", "_") didn't work
-    let mut entries =
-        std::fs::read_dir(COMMANDS_DOCS_DIR).expect("Directory for command docs are missing!");
-    entries.find_map(|r| {
-        r.map_or(None, |de| {
-            if de.file_name().to_string_lossy() == format!("{}.{}", &doc_name, "md") {
-                Some(format!("/commands/{}.{}", &doc_name, "html"))
-            } else {
-                None
-            }
-        })
-    })
-}
-
 #[allow(clippy::cognitive_complexity)]
-pub fn get_documentation(
+fn get_documentation(
     sig: &Signature,
     examples: &[Example],
     engine_state: &EngineState,
@@ -347,38 +227,4 @@ pub fn get_flags_section(signature: &Signature) -> String {
         long_desc.push_str(&msg);
     }
     long_desc
-}
-
-pub fn get_brief_help(
-    sig: &Signature,
-    examples: &[Example],
-    engine_state: &EngineState,
-    stack: &mut Stack,
-) -> String {
-    get_documentation(
-        sig,
-        examples,
-        engine_state,
-        stack,
-        &DocumentationConfig {
-            no_subcommands: false,
-            no_color: false,
-            brief: true,
-        },
-    )
-}
-
-pub fn get_full_help(
-    sig: &Signature,
-    examples: &[Example],
-    engine_state: &EngineState,
-    stack: &mut Stack,
-) -> String {
-    get_documentation(
-        sig,
-        examples,
-        engine_state,
-        stack,
-        &DocumentationConfig::default(),
-    )
 }

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -7,7 +7,7 @@ mod glob_from;
 
 pub use call_ext::CallExt;
 pub use column::get_columns;
-pub use documentation::{generate_docs, get_brief_help, get_documentation, get_full_help};
+pub use documentation::get_full_help;
 pub use env::*;
 pub use eval::{
     eval_block, eval_call, eval_expression, eval_expression_with_input, eval_operator,


### PR DESCRIPTION
# Description

Pushed #4314 forward a bit:

- Updated `commands::select::allows_if_given_unknown_column_name_is_missing` to account for the new behavior of `select`
- Started trying to fix `commands::help::help_generate_docs_length`, but concluded that it's no longer necessary - and neither is a bunch of related code
  - A Discord search indicated that the `generate_docs` functionality never really went anywhere: "we had aspirations of generating help automagically when someone contributed generate_docs, and using it for the website somehow but, as I recall, it was like half implemented."
  - Pretty sure we can just get rid of all this now that we generate website docs with a Nu script

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
