### PR TITLE
Add 'and' and 'or' operators

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4000,8 +4000,8 @@ pub fn parse_operator(
         b"in" => Operator::In,
         b"not-in" => Operator::NotIn,
         b"mod" => Operator::Modulo,
-        b"&&" => Operator::And,
-        b"||" => Operator::Or,
+        b"&&" | b"and" => Operator::And,
+        b"||" | b"or" => Operator::Or,
         b"**" => Operator::Pow,
         _ => {
             return (

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -409,3 +409,8 @@ fn unary_not_6() -> TestResult {
 fn date_literal() -> TestResult {
     run_test(r#"2022-09-10 | date to-record | get day"#, "10")
 }
+
+#[test]
+fn and_and_or() -> TestResult {
+    run_test(r#"true and false or true"#, "true")
+}


### PR DESCRIPTION
# Description

Add the `and` and `or` operators as synonyms of `&&` and `||`. Can sometimes help with readability.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
