### PR TITLE
Fix cd -

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -531,13 +531,20 @@ pub fn eval_expression(
             })
         }
         Expr::Directory(s) => {
-            let cwd = current_dir_str(engine_state, stack)?;
-            let path = expand_path_with(s, cwd);
+            if s == "-" {
+                Ok(Value::String {
+                    val: "-".to_string(),
+                    span: expr.span,
+                })
+            } else {
+                let cwd = current_dir_str(engine_state, stack)?;
+                let path = expand_path_with(s, cwd);
 
-            Ok(Value::String {
-                val: path.to_string_lossy().to_string(),
-                span: expr.span,
-            })
+                Ok(Value::String {
+                    val: path.to_string_lossy().to_string(),
+                    span: expr.span,
+                })
+            }
         }
         Expr::GlobPattern(s) => {
             let cwd = current_dir_str(engine_state, stack)?;


### PR DESCRIPTION
# Description

Changes `cd -` to also work if the `-` is passed in as the result of an expression/variable/subexpression.

Closes #4769

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
