### PR TITLE
consolidate shell integration behind config setting

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -7,6 +7,9 @@ use {
     std::borrow::Cow,
 };
 
+const PROMPT_MARKER_BEFORE_PS1: &str = "\x1b]133;A\x1b\\"; // OSC 133;A ST
+const PROMPT_MARKER_BEFORE_PS2: &str = "\x1b]133;A;k=s\x1b\\"; // OSC 133;A;k=s ST
+
 /// Nushell prompt definition
 #[derive(Clone)]
 pub struct NushellPrompt {
@@ -95,7 +98,7 @@ impl Prompt for NushellPrompt {
         // Just before starting to draw the PS1 prompt send the escape code (see
         // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
         let mut prompt = if self.shell_integration {
-            String::from("\x1b]133;A\x1b\\")
+            String::from(PROMPT_MARKER_BEFORE_PS1)
         } else {
             String::new()
         };
@@ -155,7 +158,7 @@ impl Prompt for NushellPrompt {
         // Just before starting to draw the PS1 prompt send the escape code (see
         // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
         let mut prompt = if self.shell_integration {
-            String::from("\x1b]133;A;k=s\x1b\\")
+            String::from(PROMPT_MARKER_BEFORE_PS2)
         } else {
             String::new()
         };

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -147,7 +147,7 @@ pub(crate) fn update_prompt<'prompt>(
         (prompt_vi_insert_string, prompt_vi_normal_string),
     );
 
-    if config.use_ansi_coloring {
+    if config.shell_integration {
         nu_prompt.enable_shell_integration();
     }
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -18,6 +18,7 @@ use nu_protocol::{
     ShellError, Span, Value,
 };
 use reedline::{DefaultHinter, Emacs, Vi};
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::{sync::atomic::Ordering, time::Instant};
 
@@ -212,18 +213,7 @@ pub fn evaluate_repl(
         }
 
         let input = line_editor.read_line(prompt);
-
-        if config.shell_integration {
-            // Just before running a command/program, send the escape code (see
-            // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
-            let mut ansi_escapes = String::from(PROMPT_MARKER_BEFORE_CMD);
-            ansi_escapes.push_str(RESET_APPLICATION_MODE);
-            // if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
-            //     let path = cwd.as_string()?;
-            //     ansi_escapes.push_str(&format!("\x1b]2;{}\\a", path));
-            // }
-            print!("{}", ansi_escapes);
-        }
+        let use_shell_integration = config.shell_integration;
 
         match input {
             Ok(Signal::Success(s)) => {
@@ -313,6 +303,22 @@ pub fn evaluate_repl(
                     let path = cwd.as_string()?;
                     let _ = std::env::set_current_dir(path);
                     engine_state.env_vars.insert("PWD".into(), cwd);
+                }
+
+                if use_shell_integration {
+                    // Just before running a command/program, send the escape code (see
+                    // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
+                    let mut ansi_escapes = String::from(PROMPT_MARKER_BEFORE_CMD);
+                    ansi_escapes.push_str(RESET_APPLICATION_MODE);
+                    if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
+                        let path = cwd.as_string()?;
+                        ansi_escapes.push_str(&format!("\x1b]2;{}\x07", path));
+                    }
+                    // print!("{}", ansi_escapes);
+                    match io::stdout().write_all(ansi_escapes.as_bytes()) {
+                        Ok(it) => it,
+                        Err(err) => print!("error: {}", err),
+                    };
                 }
             }
             Ok(Signal::CtrlC) => {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -21,6 +21,9 @@ use reedline::{DefaultHinter, Emacs, Vi};
 use std::path::PathBuf;
 use std::{sync::atomic::Ordering, time::Instant};
 
+const PROMPT_MARKER_BEFORE_CMD: &str = "\x1b]133;C\x1b\\"; // OSC 133;C ST
+const RESET_APPLICATION_MODE: &str = "\x1b[?1l";
+
 pub fn evaluate_repl(
     engine_state: &mut EngineState,
     stack: &mut Stack,
@@ -210,10 +213,16 @@ pub fn evaluate_repl(
 
         let input = line_editor.read_line(prompt);
 
-        if config.use_ansi_coloring {
+        if config.shell_integration {
             // Just before running a command/program, send the escape code (see
             // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
-            print!("\x1b]133;C\x1b\\");
+            let mut ansi_escapes = String::from(PROMPT_MARKER_BEFORE_CMD);
+            ansi_escapes.push_str(RESET_APPLICATION_MODE);
+            // if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
+            //     let path = cwd.as_string()?;
+            //     ansi_escapes.push_str(&format!("\x1b]2;{}\\a", path));
+            // }
+            print!("{}", ansi_escapes);
         }
 
         match input {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -45,6 +45,7 @@ pub struct Config {
     pub keybindings: Vec<ParsedKeybinding>,
     pub menus: Vec<ParsedMenu>,
     pub rm_always_trash: bool,
+    pub shell_integration: bool,
 }
 
 impl Default for Config {
@@ -69,6 +70,7 @@ impl Default for Config {
             keybindings: Vec::new(),
             menus: Vec::new(),
             rm_always_trash: false,
+            shell_integration: false,
         }
     }
 }
@@ -236,6 +238,14 @@ impl Value {
                             eprintln!("{:?}", e);
                         }
                     },
+                    "shell_integration" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.shell_integration = b;
+                        } else {
+                            eprintln!("$config.shell_integration is not a bool")
+                        }
+                    }
+
                     x => {
                         eprintln!("$config.{} is an unknown config setting", x)
                     }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -194,6 +194,7 @@ let-env config = {
   edit_mode: emacs # emacs, vi
   max_history_size: 10000 # Session has to be reloaded for this to take effect
   sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
+  shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
   menus: [
       # Configuration for default nushell menus
       # Note the lack of souce parameter


### PR DESCRIPTION
# Description

This PR consolidates the shell_integration settings that nushell is passing with each prompt. They have to do with prompt marking and a work-around to ssh problems with arrow keys not working.

```rust
const PROMPT_MARKER_BEFORE_PS1: &str = "\x1b]133;A\x1b\\"; // OSC 133;A ST
const PROMPT_MARKER_BEFORE_PS2: &str = "\x1b]133;A;k=s\x1b\\"; // OSC 133;A;k=s ST
const PROMPT_MARKER_BEFORE_CMD: &str = "\x1b]133;C\x1b\\"; // OSC 133;C ST
const RESET_APPLICATION_MODE: &str = "\x1b[?1l"; // reset arrow keys
```

To use these features you need to set the new config flag `shell_integration` to `true` in your config.nu file.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
