### PR TITLE
nu-cli/completions: add completion for $nu

### DIFF
--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -11,6 +11,6 @@ pub use documentation::get_full_help;
 pub use env::*;
 pub use eval::{
     eval_block, eval_call, eval_expression, eval_expression_with_input, eval_operator,
-    eval_subexpression,
+    eval_subexpression, eval_variable,
 };
 pub use glob_from::glob_from;


### PR DESCRIPTION
# Description

This PR adds the missing completion for $nu. Fixes https://github.com/nushell/nushell/issues/5215.

[![asciicast](https://asciinema.org/a/fbd69k6HLX6LdFbp2XmReb95W.svg)](https://asciinema.org/a/fbd69k6HLX6LdFbp2XmReb95W)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
