### PR TITLE
Database commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all ${{ matrix.flags }}
+          args: --all-features --all ${{ matrix.flags }}
 
 
   python-virtualenv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+          args: --all-features --all ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
       - name: Build Nushell
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+          args: --all-features --all -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
       - name: Build Nushell
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features --all ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+          args: --all ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
       - name: Build Nushell
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features --all -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+          args: --all ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
       - name: Build Nushell
         uses: actions-rs/cargo@v1
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --all ${{ matrix.flags }}
+          args: --all ${{ matrix.flags }}
 
 
   python-virtualenv:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ debian/nu/
 
 # VSCode's IDE items
 .vscode/*
+
+# Helix configuration folder
+.helix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.2",
  "shadow-rs",
+ "sqlparser",
  "strip-ansi-escapes",
  "sysinfo",
  "terminal_size",
@@ -4048,6 +4049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9a527b68048eb95495a1508f6c8395c8defcff5ecdbe8ad4106d08a2ef2a3c"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ trash-support = ["nu-command/trash-support"]
 # Dataframe feature for nushell
 dataframe = ["nu-command/dataframe"]
 
+# Database commands for nusellf
+database = ["nu-command/database"]
+
 [profile.release]
 opt-level = "s" # Optimize for size
 strip = "debuginfo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ trash-support = ["nu-command/trash-support"]
 # Dataframe feature for nushell
 dataframe = ["nu-command/dataframe"]
 
-# Database commands for nusellf
+# Database commands for nushell
 database = ["nu-command/database"]
 
 [profile.release]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -24,7 +24,6 @@ nu-term-grid = { path = "../nu-term-grid", version = "0.61.1"  }
 nu-test-support = { path = "../nu-test-support", version = "0.61.1"  }
 nu-utils = { path = "../nu-utils", version = "0.61.1" }
 nu-ansi-term = "0.45.1"
-rusqlite = { version = "0.27.0", features = ["bundled"] }
 
 # Potential dependencies for extras
 base64 = "0.13.0"
@@ -81,6 +80,8 @@ uuid = { version = "0.8.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
 reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 wax = { version =  "0.4.0", features = ["diagnostics"] }
+rusqlite = { version = "0.27.0", features = ["bundled"], optional = true }
+sqlparser = { version = "0.16.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 umask = "1.0.0"
@@ -105,6 +106,7 @@ trash-support = ["trash"]
 which-support = ["which"]
 plugin = ["nu-parser/plugin"]
 dataframe = ["polars", "num"]
+database = ["sqlparser", "rusqlite"]
 
 [build-dependencies]
 shadow-rs = "0.11.0"

--- a/crates/nu-command/src/database/commands/collect.rs
+++ b/crates/nu-command/src/database/commands/collect.rs
@@ -1,0 +1,49 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature,
+};
+
+use super::super::SQLiteDatabase;
+
+#[derive(Clone)]
+pub struct CollectDb;
+
+impl Command for CollectDb {
+    fn name(&self) -> &str {
+        "db collect"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Custom("database".into()))
+    }
+
+    fn usage(&self) -> &str {
+        "Query a database using SQL."
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Collect from a select query",
+            example: "open foo.db | db select a | db from table_1 | db collect",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["database", "collect"]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let db = SQLiteDatabase::try_from_pipeline(input, call.head)?;
+
+        db.collect(call.head)
+            .map(IntoPipelineData::into_pipeline_data)
+    }
+}

--- a/crates/nu-command/src/database/commands/command.rs
+++ b/crates/nu-command/src/database/commands/command.rs
@@ -1,0 +1,42 @@
+use nu_engine::get_full_help;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+};
+
+#[derive(Clone)]
+pub struct Database;
+
+impl Command for Database {
+    fn name(&self) -> &str {
+        "db"
+    }
+
+    fn usage(&self) -> &str {
+        "Database commands"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Custom("database".into()))
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(Value::String {
+            val: get_full_help(
+                &Database.signature(),
+                &Database.examples(),
+                engine_state,
+                stack,
+            ),
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+}

--- a/crates/nu-command/src/database/commands/describe.rs
+++ b/crates/nu-command/src/database/commands/describe.rs
@@ -1,0 +1,47 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature,
+};
+
+use super::super::SQLiteDatabase;
+
+#[derive(Clone)]
+pub struct DescribeDb;
+
+impl Command for DescribeDb {
+    fn name(&self) -> &str {
+        "db describe"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Custom("database".into()))
+    }
+
+    fn usage(&self) -> &str {
+        "Describes connection and query of the DB object"
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Describe SQLite database constructed query",
+            example: "db open foo.db | db select table_1 | db describe",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["database", "SQLite"]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let db = SQLiteDatabase::try_from_pipeline(input, call.head)?;
+        Ok(db.describe(call.head).into_pipeline_data())
+    }
+}

--- a/crates/nu-command/src/database/commands/from.rs
+++ b/crates/nu-command/src/database/commands/from.rs
@@ -1,0 +1,130 @@
+use super::super::SQLiteDatabase;
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape,
+};
+use sqlparser::ast::{Ident, ObjectName, Query, Select, SetExpr, TableFactor, TableWithJoins};
+
+#[derive(Clone)]
+pub struct FromDb;
+
+impl Command for FromDb {
+    fn name(&self) -> &str {
+        "db from"
+    }
+
+    fn usage(&self) -> &str {
+        "Select section from query statement for a DB"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "select",
+                SyntaxShape::String,
+                "Name of table to select from",
+            )
+            .category(Category::Custom("database".into()))
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["database", "from"]
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Selects table from database",
+            example: "db open db.mysql | db from table_a",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let table: String = call.req(engine_state, stack, 0)?;
+
+        let mut db = SQLiteDatabase::try_from_pipeline(input, call.head)?;
+        db.query = match db.query {
+            None => Some(create_query(table)),
+            Some(query) => Some(modify_query(query, table)),
+        };
+
+        Ok(db.into_value(call.head).into_pipeline_data())
+    }
+}
+
+fn create_query(table: String) -> Query {
+    Query {
+        with: None,
+        body: SetExpr::Select(Box::new(create_select(table))),
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+        fetch: None,
+        lock: None,
+    }
+}
+
+fn modify_query(mut query: Query, table: String) -> Query {
+    query.body = match query.body {
+        SetExpr::Select(select) => SetExpr::Select(Box::new(modify_select(select, table))),
+        _ => SetExpr::Select(Box::new(create_select(table))),
+    };
+
+    query
+}
+
+fn modify_select(select: Box<Select>, table: String) -> Select {
+    Select {
+        from: create_from(table),
+        ..select.as_ref().clone()
+    }
+}
+
+fn create_select(table: String) -> Select {
+    Select {
+        distinct: false,
+        top: None,
+        projection: Vec::new(),
+        into: None,
+        from: create_from(table),
+        lateral_views: Vec::new(),
+        selection: None,
+        group_by: Vec::new(),
+        cluster_by: Vec::new(),
+        distribute_by: Vec::new(),
+        sort_by: Vec::new(),
+        having: None,
+    }
+}
+
+// This function needs more work
+// It needs to define multi tables and joins
+// I assume we will need to define expressions for the columns instead of strings
+fn create_from(table: String) -> Vec<TableWithJoins> {
+    let ident = Ident {
+        value: table,
+        quote_style: None,
+    };
+
+    let table_factor = TableFactor::Table {
+        name: ObjectName(vec![ident]),
+        alias: None,
+        args: Vec::new(),
+        with_hints: Vec::new(),
+    };
+
+    let table = TableWithJoins {
+        relation: table_factor,
+        joins: Vec::new(),
+    };
+
+    vec![table]
+}

--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -1,0 +1,22 @@
+mod command;
+mod open;
+mod query;
+
+use command::Database;
+use nu_protocol::engine::StateWorkingSet;
+use open::OpenDb;
+use query::QueryDb;
+
+pub fn add_database_decls(working_set: &mut StateWorkingSet) {
+    macro_rules! bind_command {
+            ( $command:expr ) => {
+                working_set.add_decl(Box::new($command));
+            };
+            ( $( $command:expr ),* ) => {
+                $( working_set.add_decl(Box::new($command)); )*
+            };
+        }
+
+    // Series commands
+    bind_command!(Database, QueryDb, OpenDb);
+}

--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -1,11 +1,18 @@
+mod collect;
 mod command;
+mod from;
 mod open;
 mod query;
+mod select;
+mod utils;
 
+use collect::CollectDb;
 use command::Database;
+use from::FromDb;
 use nu_protocol::engine::StateWorkingSet;
 use open::OpenDb;
 use query::QueryDb;
+use select::SelectDb;
 
 pub fn add_database_decls(working_set: &mut StateWorkingSet) {
     macro_rules! bind_command {
@@ -18,5 +25,5 @@ pub fn add_database_decls(working_set: &mut StateWorkingSet) {
         }
 
     // Series commands
-    bind_command!(Database, QueryDb, OpenDb);
+    bind_command!(CollectDb, Database, FromDb, QueryDb, SelectDb, OpenDb);
 }

--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -1,5 +1,6 @@
 mod collect;
 mod command;
+mod describe;
 mod from;
 mod open;
 mod query;
@@ -8,6 +9,7 @@ mod utils;
 
 use collect::CollectDb;
 use command::Database;
+use describe::DescribeDb;
 use from::FromDb;
 use nu_protocol::engine::StateWorkingSet;
 use open::OpenDb;
@@ -25,5 +27,5 @@ pub fn add_database_decls(working_set: &mut StateWorkingSet) {
         }
 
     // Series commands
-    bind_command!(CollectDb, Database, FromDb, QueryDb, SelectDb, OpenDb);
+    bind_command!(CollectDb, Database, DescribeDb, FromDb, QueryDb, SelectDb, OpenDb);
 }

--- a/crates/nu-command/src/database/commands/open.rs
+++ b/crates/nu-command/src/database/commands/open.rs
@@ -1,0 +1,93 @@
+use std::{fs::File, io::Read, path::PathBuf};
+
+use super::super::SQLiteDatabase;
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
+    Value,
+};
+
+const SQLITE_MAGIC_BYTES: &[u8] = "SQLite format 3\0".as_bytes();
+
+#[derive(Clone)]
+pub struct OpenDb;
+
+impl Command for OpenDb {
+    fn name(&self) -> &str {
+        "db open"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required("query", SyntaxShape::Filepath, "SQLite file to be opened")
+            .category(Category::Custom("database".into()))
+    }
+
+    fn usage(&self) -> &str {
+        "Open a database"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["database", "open"]
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "",
+            example: r#"""#,
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let path: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
+
+        let mut file = File::open(&path.item).map_err(|e| {
+            ShellError::GenericError(
+                "Error opening file".into(),
+                e.to_string(),
+                Some(path.span),
+                None,
+                Vec::new(),
+            )
+        })?;
+
+        let mut buf: [u8; 16] = [0; 16];
+        file.read_exact(&mut buf)
+            .map_err(|e| {
+                ShellError::GenericError(
+                    "Error extracting data".into(),
+                    e.to_string(),
+                    Some(path.span),
+                    None,
+                    Vec::new(),
+                )
+            })
+            .and_then(|_| {
+                if buf == SQLITE_MAGIC_BYTES {
+                    let custom_val = Value::CustomValue {
+                        val: Box::new(SQLiteDatabase::new(path.item.as_path())),
+                        span: call.head,
+                    };
+
+                    Ok(custom_val.into_pipeline_data())
+                } else {
+                    Err(ShellError::GenericError(
+                        "Error reading SQLite file".into(),
+                        "Not a SQLite file".into(),
+                        Some(path.span),
+                        None,
+                        Vec::new(),
+                    ))
+                }
+            })
+    }
+}

--- a/crates/nu-command/src/database/commands/open.rs
+++ b/crates/nu-command/src/database/commands/open.rs
@@ -1,15 +1,11 @@
-use std::{fs::File, io::Read, path::PathBuf};
-
 use super::super::SQLiteDatabase;
 use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
-    Value,
 };
-
-const SQLITE_MAGIC_BYTES: &[u8] = "SQLite format 3\0".as_bytes();
+use std::path::PathBuf;
 
 #[derive(Clone)]
 pub struct OpenDb;
@@ -50,44 +46,7 @@ impl Command for OpenDb {
     ) -> Result<PipelineData, ShellError> {
         let path: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
 
-        let mut file = File::open(&path.item).map_err(|e| {
-            ShellError::GenericError(
-                "Error opening file".into(),
-                e.to_string(),
-                Some(path.span),
-                None,
-                Vec::new(),
-            )
-        })?;
-
-        let mut buf: [u8; 16] = [0; 16];
-        file.read_exact(&mut buf)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error reading file header".into(),
-                    e.to_string(),
-                    Some(path.span),
-                    None,
-                    Vec::new(),
-                )
-            })
-            .and_then(|_| {
-                if buf == SQLITE_MAGIC_BYTES {
-                    let custom_val = Value::CustomValue {
-                        val: Box::new(SQLiteDatabase::new(path.item.as_path())),
-                        span: call.head,
-                    };
-
-                    Ok(custom_val.into_pipeline_data())
-                } else {
-                    Err(ShellError::GenericError(
-                        "Error reading file".into(),
-                        "Not a SQLite file".into(),
-                        Some(path.span),
-                        None,
-                        Vec::new(),
-                    ))
-                }
-            })
+        SQLiteDatabase::try_from_path(path.item.as_path(), path.span)
+            .map(|db| db.into_value(call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/database/commands/open.rs
+++ b/crates/nu-command/src/database/commands/open.rs
@@ -47,7 +47,7 @@ impl Command for OpenDb {
         stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
-    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+    ) -> Result<PipelineData, ShellError> {
         let path: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
 
         let mut file = File::open(&path.item).map_err(|e| {
@@ -64,7 +64,7 @@ impl Command for OpenDb {
         file.read_exact(&mut buf)
             .map_err(|e| {
                 ShellError::GenericError(
-                    "Error extracting data".into(),
+                    "Error reading file header".into(),
                     e.to_string(),
                     Some(path.span),
                     None,
@@ -81,7 +81,7 @@ impl Command for OpenDb {
                     Ok(custom_val.into_pipeline_data())
                 } else {
                     Err(ShellError::GenericError(
-                        "Error reading SQLite file".into(),
+                        "Error reading file".into(),
                         "Not a SQLite file".into(),
                         Some(path.span),
                         None,

--- a/crates/nu-command/src/database/commands/query.rs
+++ b/crates/nu-command/src/database/commands/query.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
 };
 
 use super::super::SQLiteDatabase;
@@ -29,6 +29,14 @@ impl Command for QueryDb {
         "Query a database using SQL."
     }
 
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get 1 table out of a SQLite database",
+            example: r#"db open foo.db | db query "SELECT * FROM Bar""#,
+            result: None,
+        }]
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "SQLite"]
     }
@@ -39,58 +47,11 @@ impl Command for QueryDb {
         stack: &mut Stack,
         call: &Call,
         input: PipelineData,
-    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+    ) -> Result<PipelineData, ShellError> {
         let sql: Spanned<String> = call.req(engine_state, stack, 0)?;
-        let call_head = call.head;
 
-        input.map(
-            move |value| query_input(value, call_head, &sql),
-            engine_state.ctrlc.clone(),
-        )
-    }
-
-    fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Get 1 table out of a SQLite database",
-            example: r#"open foo.db | query db "SELECT * FROM Bar""#,
-            result: None,
-        }]
-    }
-}
-
-fn query_input(input: Value, call_span: Span, sql: &Spanned<String>) -> Value {
-    // this fn has slightly awkward error handling because it needs to jam errors into Value instead of returning a Result
-    if let Value::CustomValue {
-        val,
-        span: input_span,
-    } = input
-    {
-        let sqlite = val.as_any().downcast_ref::<SQLiteDatabase>();
-
-        if let Some(db) = sqlite {
-            return match db.query(sql, call_span) {
-                Ok(val) => val,
-                Err(error) => Value::Error { error },
-            };
-        }
-
-        return Value::Error {
-            error: ShellError::PipelineMismatch(
-                "a SQLite database".to_string(),
-                call_span,
-                input_span,
-            ),
-        };
-    }
-
-    match input.span() {
-        Ok(input_span) => Value::Error {
-            error: ShellError::PipelineMismatch(
-                "a SQLite database".to_string(),
-                call_span,
-                input_span,
-            ),
-        },
-        Err(err) => Value::Error { error: err },
+        let db = SQLiteDatabase::try_from_pipeline(input, call.head)?;
+        db.query(&sql, call.head)
+            .map(IntoPipelineData::into_pipeline_data)
     }
 }

--- a/crates/nu-command/src/database/commands/query.rs
+++ b/crates/nu-command/src/database/commands/query.rs
@@ -5,24 +5,24 @@ use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
 
-use crate::database::SQLiteDatabase;
+use super::super::SQLiteDatabase;
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct QueryDb;
 
-impl Command for SubCommand {
+impl Command for QueryDb {
     fn name(&self) -> &str {
-        "query db"
+        "db query"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("query db")
+        Signature::build(self.name())
             .required(
                 "query",
                 SyntaxShape::String,
                 "SQL to execute against the database",
             )
-            .category(Category::Date) // TODO: change category
+            .category(Category::Custom("database".into()))
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/database/commands/select.rs
+++ b/crates/nu-command/src/database/commands/select.rs
@@ -1,0 +1,131 @@
+use super::{super::SQLiteDatabase, utils::extract_strings};
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Value,
+};
+use sqlparser::ast::{Expr, Ident, Query, Select, SelectItem, SetExpr};
+
+#[derive(Clone)]
+pub struct SelectDb;
+
+impl Command for SelectDb {
+    fn name(&self) -> &str {
+        "db select"
+    }
+
+    fn usage(&self) -> &str {
+        "Creates a select statement for a DB"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "select",
+                SyntaxShape::Any,
+                "Select expression(s) on the table",
+            )
+            .category(Category::Custom("database".into()))
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["database", "select"]
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "selects a column from a database",
+                example: "db open db.mysql | db select a",
+                result: None,
+            },
+            Example {
+                description: "selects columns from a database",
+                example: "db open db.mysql | db select [a, b, c]",
+                result: None,
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let value: Value = call.req(engine_state, stack, 0)?;
+        let expressions = extract_strings(value)?;
+
+        let mut db = SQLiteDatabase::try_from_pipeline(input, call.head)?;
+        db.query = match db.query {
+            None => Some(create_query(expressions)),
+            Some(query) => Some(modify_query(query, expressions)),
+        };
+
+        Ok(db.into_value(call.head).into_pipeline_data())
+    }
+}
+
+fn create_query(expressions: Vec<String>) -> Query {
+    Query {
+        with: None,
+        body: SetExpr::Select(Box::new(create_select(expressions))),
+        order_by: Vec::new(),
+        limit: None,
+        offset: None,
+        fetch: None,
+        lock: None,
+    }
+}
+
+fn modify_query(mut query: Query, expressions: Vec<String>) -> Query {
+    query.body = match query.body {
+        SetExpr::Select(select) => SetExpr::Select(Box::new(modify_select(select, expressions))),
+        _ => SetExpr::Select(Box::new(create_select(expressions))),
+    };
+
+    query
+}
+
+fn modify_select(select: Box<Select>, expressions: Vec<String>) -> Select {
+    Select {
+        projection: create_projection(expressions),
+        ..select.as_ref().clone()
+    }
+}
+
+fn create_select(expressions: Vec<String>) -> Select {
+    Select {
+        distinct: false,
+        top: None,
+        projection: create_projection(expressions),
+        into: None,
+        from: Vec::new(),
+        lateral_views: Vec::new(),
+        selection: None,
+        group_by: Vec::new(),
+        cluster_by: Vec::new(),
+        distribute_by: Vec::new(),
+        sort_by: Vec::new(),
+        having: None,
+    }
+}
+
+// This function needs more work
+// It needs to define alias and functions in the columns
+// I assume we will need to define expressions for the columns instead of strings
+fn create_projection(expressions: Vec<String>) -> Vec<SelectItem> {
+    expressions
+        .into_iter()
+        .map(|expression| {
+            let expr = Expr::Identifier(Ident {
+                value: expression,
+                quote_style: None,
+            });
+
+            SelectItem::UnnamedExpr(expr)
+        })
+        .collect()
+}

--- a/crates/nu-command/src/database/commands/utils.rs
+++ b/crates/nu-command/src/database/commands/utils.rs
@@ -1,0 +1,15 @@
+use nu_protocol::{FromValue, ShellError, Value};
+
+pub fn extract_strings(value: Value) -> Result<Vec<String>, ShellError> {
+    match (
+        <String as FromValue>::from_value(&value),
+        <Vec<String> as FromValue>::from_value(&value),
+    ) {
+        (Ok(col), Err(_)) => Ok(vec![col]),
+        (Err(_), Ok(cols)) => Ok(cols),
+        _ => Err(ShellError::IncompatibleParametersSingle(
+            "Expected a string or list of strings".into(),
+            value.span()?,
+        )),
+    }
+}

--- a/crates/nu-command/src/database/mod.rs
+++ b/crates/nu-command/src/database/mod.rs
@@ -2,4 +2,4 @@ mod commands;
 mod values;
 
 pub use commands::add_database_decls;
-use values::SQLiteDatabase;
+pub(crate) use values::SQLiteDatabase;

--- a/crates/nu-command/src/database/mod.rs
+++ b/crates/nu-command/src/database/mod.rs
@@ -1,3 +1,5 @@
-mod sqlite;
+mod commands;
+mod values;
 
-pub use sqlite::SQLiteDatabase;
+pub use commands::add_database_decls;
+use values::SQLiteDatabase;

--- a/crates/nu-command/src/database/values/mod.rs
+++ b/crates/nu-command/src/database/values/mod.rs
@@ -1,0 +1,3 @@
+mod sqlite;
+
+pub(crate) use sqlite::SQLiteDatabase;

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -21,7 +21,7 @@ pub struct SQLiteDatabase {
     pub query: Option<Query>,
 }
 
-// Mocked serialization of the LazyFrame object
+// Mocked serialization of the object
 impl Serialize for SQLiteDatabase {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -31,7 +31,7 @@ impl Serialize for SQLiteDatabase {
     }
 }
 
-// Mocked deserialization of the LazyFrame object
+// Mocked deserialization of the object
 impl<'de> Deserialize<'de> for SQLiteDatabase {
     fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -25,6 +25,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
 
         // Database-related
         // Adds all related commands to query databases
+        #[cfg(feature = "database")]
         add_database_decls(&mut working_set);
 
         // Core

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -23,6 +23,10 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         #[cfg(feature = "dataframe")]
         add_dataframe_decls(&mut working_set);
 
+        // Database-related
+        // Adds all related commands to query databases
+        add_database_decls(&mut working_set);
+
         // Core
         bind_command! {
             Alias,
@@ -359,11 +363,6 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         // Experimental
         bind_command! {
             ViewSource,
-        };
-
-        // Database-related
-        bind_command! {
-            QueryDb
         };
 
         // Deprecated

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -1,4 +1,3 @@
-use crate::database::SQLiteDatabase;
 use crate::filesystem::util::BufferedReader;
 use nu_engine::{eval_block, get_full_help, CallExt};
 use nu_protocol::ast::Call;
@@ -8,6 +7,9 @@ use nu_protocol::{
     SyntaxShape, Value,
 };
 use std::io::BufReader;
+
+#[cfg(feature = "database")]
+use crate::database::SQLiteDatabase;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -16,7 +16,6 @@ mod math;
 mod network;
 mod path;
 mod platform;
-mod query;
 mod random;
 mod shells;
 mod strings;
@@ -25,7 +24,6 @@ mod viewers;
 
 pub use conversions::*;
 pub use core_commands::*;
-pub use database::*;
 pub use date::*;
 pub use default_context::*;
 pub use deprecated::*;
@@ -42,7 +40,6 @@ pub use math::*;
 pub use network::*;
 pub use path::*;
 pub use platform::*;
-pub use query::*;
 pub use random::*;
 pub use shells::*;
 pub use strings::*;
@@ -54,3 +51,6 @@ mod dataframe;
 
 #[cfg(feature = "dataframe")]
 pub use dataframe::*;
+
+// Database commands
+pub use database::*;

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -1,6 +1,5 @@
 mod conversions;
 mod core_commands;
-mod database;
 mod date;
 mod default_context;
 mod deprecated;
@@ -52,5 +51,8 @@ mod dataframe;
 #[cfg(feature = "dataframe")]
 pub use dataframe::*;
 
-// Database commands
+#[cfg(feature = "database")]
+mod database;
+
+#[cfg(feature = "database")]
 pub use database::*;

--- a/crates/nu-command/src/query/mod.rs
+++ b/crates/nu-command/src/query/mod.rs
@@ -1,3 +1,0 @@
-mod db;
-
-pub use db::SubCommand as QueryDb;

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -39,6 +39,7 @@ mod open;
 mod parse;
 mod path;
 mod prepend;
+#[cfg(feature = "database")]
 mod query;
 mod random;
 mod range;

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -108,8 +108,8 @@ fn parses_more_bson_complexity() {
 // │ 4 │      │
 // ╰───┴──────╯
 
+#[cfg(feature = "database")]
 #[test]
-
 fn parses_sqlite() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
@@ -123,6 +123,7 @@ fn parses_sqlite() {
     assert_eq!(actual.out, "3");
 }
 
+#[cfg(feature = "database")]
 #[test]
 fn parses_sqlite_get_column_name() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/query/db.rs
+++ b/crates/nu-command/tests/commands/query/db.rs
@@ -33,7 +33,7 @@ fn invalid_input_fails() {
     let actual = nu!(
     cwd: "tests/fixtures/formats", pipeline(
         r#"
-            "foo" | query db "select * from asdf"
+            "foo" | db query "select * from asdf"
         "#
     ));
 

--- a/crates/nu-command/tests/commands/query/db.rs
+++ b/crates/nu-command/tests/commands/query/db.rs
@@ -1,13 +1,12 @@
 use nu_test_support::{nu, pipeline};
 
 #[test]
-
 fn can_query_single_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             open sample.db
-            | query db "select * from strings"
+            | db query "select * from strings"
             | where x =~ ell
             | length
         "#
@@ -22,7 +21,7 @@ fn invalid_sql_fails() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             open sample.db
-            | query db "select *asdfasdf"
+            | db query "select *asdfasdf"
         "#
     ));
 
@@ -32,11 +31,11 @@ fn invalid_sql_fails() {
 #[test]
 fn invalid_input_fails() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    cwd: "tests/fixtures/formats", pipeline(
         r#"
             "foo" | query db "select * from asdf"
         "#
     ));
 
-    assert!(actual.err.contains("pipeline_mismatch"));
+    assert!(actual.err.contains("Invalid parameter"));
 }

--- a/crates/nu-command/tests/commands/query/db.rs
+++ b/crates/nu-command/tests/commands/query/db.rs
@@ -37,5 +37,5 @@ fn invalid_input_fails() {
         "#
     ));
 
-    assert!(actual.err.contains("Invalid parameter"));
+    assert!(actual.err.contains("can't convert string"));
 }

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -41,6 +41,7 @@ fn where_not_in_table() {
     assert_eq!(actual.out, "4");
 }
 
+#[cfg(feature = "database")]
 #[test]
 fn binary_operator_comparisons() {
     let actual = nu!(
@@ -109,6 +110,7 @@ fn binary_operator_comparisons() {
     assert_eq!(actual.out, "42");
 }
 
+#[cfg(feature = "database")]
 #[test]
 fn contains_operator() {
     let actual = nu!(


### PR DESCRIPTION
# Description

Beginning of db functionality. These new commands allow to connect to a sqlite database and query from it using nushell commands or a query string

This will help us expand into new db syntax and create a generic connector that can query any database

![image](https://user-images.githubusercontent.com/6942205/164959570-e870e175-b123-4fe1-8033-338b938bc858.png)

Note. The DB functionality is behind the `database` feature flag

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
