### PR TITLE
nu-command/filesystem: remove newline from cd path

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -54,7 +54,10 @@ impl Command for Cd {
                         (cwd.to_string_lossy().to_string(), v.span)
                     }
                 } else {
-                    let path = match nu_path::canonicalize_with(&v.item, &cwd) {
+                    let path_no_whitespace =
+                        &v.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
+
+                    let path = match nu_path::canonicalize_with(path_no_whitespace, &cwd) {
                         Ok(p) => {
                             if !p.is_dir() {
                                 return Err(ShellError::NotADirectory(v.span));

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -79,7 +79,8 @@ impl Command for Open {
             }
         };
         let arg_span = path.span;
-        let path = Path::new(&path.item);
+        let path_no_whitespace = &path.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
+        let path = Path::new(path_no_whitespace);
 
         if permission_denied(&path) {
             #[cfg(unix)]


### PR DESCRIPTION
# Description

This PR removes the new line `\n` from a path given to `cd` command. Once the paths can't have the newline it makes things hard when using external commands because they can return newline (e.g: `cd (^echo /)`). 
Removing all the new lines sounds like a good option because it prevents the user from doing `| str trim` all the time.

Fixes https://github.com/nushell/nushell/issues/2174

[![asciicast](https://asciinema.org/a/G3wmPyunv13UIQPvyywu05KdG.svg)](https://asciinema.org/a/G3wmPyunv13UIQPvyywu05KdG)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
