### PR TITLE
fix: remove `println!()` from `exec` builtin

### DIFF
--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -90,7 +90,6 @@ fn exec(
     let mut command = external_command.spawn_simple_command(&cwd.to_string_lossy().to_string())?;
     command.current_dir(current_dir);
 
-    println!("{:#?}", command);
     let err = command.exec(); // this replaces our process, should not return
 
     Err(ShellError::GenericError(


### PR DESCRIPTION
# Description

- currently, the `exec` built-in prints the provided command/arguments to stdout
- this is different behaviour to other shells where the `exec` built-in is silent
- this PR is a 1-line change to make it so that `exec` is silent like other shells
- I did check for related issues, it doesn't seem like this has been discussed (at least on GitHub)
- I understand this could be controversial (theoretically the output could be useful for debugging, especially #2675, etc), so please disregard/decline if you feel the current behaviour is more in keeping with the goals of this project

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
