### PR TITLE
Fuzzy completion matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2272,7 @@ name = "nu-cli"
 version = "0.61.1"
 dependencies = [
  "crossterm",
+ "fuzzy-matcher",
  "is_executable",
  "log",
  "miette 4.5.0",
@@ -4350,6 +4360,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -22,6 +22,7 @@ reedline = { git = "https://github.com/nushell/reedline", branch = "main", featu
 crossterm = "0.23.0"
 miette = { version = "4.5.0", features = ["fancy"] }
 thiserror = "1.0.29"
+fuzzy-matcher = "0.3.7"
 
 log = "0.4"
 is_executable = "1.0.1"

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1,6 +1,6 @@
 use crate::completions::{
     CommandCompletion, Completer, CompletionOptions, CustomCompletion, DirectoryCompletion,
-    DotNuCompletion, FileCompletion, FlagCompletion, VariableCompletion,
+    DotNuCompletion, FileCompletion, FlagCompletion, MatchAlgorithm, VariableCompletion,
 };
 use nu_parser::{flatten_expression, parse, FlatShape};
 use nu_protocol::{
@@ -35,7 +35,13 @@ impl NuCompleter {
         offset: usize,
         pos: usize,
     ) -> Vec<Suggestion> {
-        let options = CompletionOptions::default();
+        let config = self.engine_state.get_config();
+
+        let mut options = CompletionOptions::default();
+
+        if config.completion_algorithm == "fuzzy" {
+            options.match_algorithm = MatchAlgorithm::Fuzzy;
+        }
 
         // Fetch
         let mut suggestions =

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -1,4 +1,6 @@
-use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
+use std::fmt::Display;
+
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 
 #[derive(Copy, Clone)]
 pub enum SortBy {
@@ -8,7 +10,7 @@ pub enum SortBy {
 }
 
 /// Describes how suggestions should be matched.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum MatchAlgorithm {
     /// Only show suggestions which begin with the given input
     ///
@@ -31,7 +33,7 @@ impl MatchAlgorithm {
             MatchAlgorithm::Fuzzy => {
                 let matcher = SkimMatcherV2::default();
                 matcher.fuzzy_match(haystack, needle).is_some()
-            },
+            }
         }
     }
 
@@ -45,10 +47,37 @@ impl MatchAlgorithm {
 
                 let matcher = SkimMatcherV2::default();
                 matcher.fuzzy_match(&haystack_str, &needle_str).is_some()
-            },
+            }
         }
     }
 }
+
+impl TryFrom<String> for MatchAlgorithm {
+    type Error = InvalidMatchAlgorithm;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "prefix" => Ok(Self::Prefix),
+            "fuzzy" => Ok(Self::Fuzzy),
+            _ => Err(InvalidMatchAlgorithm::Unknown),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InvalidMatchAlgorithm {
+    Unknown,
+}
+
+impl Display for InvalidMatchAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            InvalidMatchAlgorithm::Unknown => write!(f, "unknown match algorithm"),
+        }
+    }
+}
+
+impl std::error::Error for InvalidMatchAlgorithm {}
 
 #[derive(Clone)]
 pub struct CompletionOptions {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     pub use_ansi_coloring: bool,
     pub quick_completions: bool,
     pub partial_completions: bool,
+    pub completion_algorithm: String,
     pub edit_mode: String,
     pub max_history_size: i64,
     pub sync_history_on_enter: bool,
@@ -63,6 +64,7 @@ impl Default for Config {
             use_ansi_coloring: true,
             quick_completions: true,
             partial_completions: true,
+            completion_algorithm: "prefix".into(),
             edit_mode: "emacs".into(),
             max_history_size: 1000,
             sync_history_on_enter: true,
@@ -180,6 +182,13 @@ impl Value {
                             config.partial_completions = b;
                         } else {
                             eprintln!("$config.partial_completions is not a bool")
+                        }
+                    }
+                    "completion_algorithm" => {
+                        if let Ok(v) = value.as_string() {
+                            config.completion_algorithm = v.to_lowercase();
+                        } else {
+                            eprintln!("$config.completion_algorithm is not a string")
                         }
                     }
                     "rm_always_trash" => {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -187,6 +187,7 @@ let-env config = {
   footer_mode: "25" # always, never, number_of_rows, auto
   quick_completions: true  # set this to false to prevent auto-selecting completions when only one remains
   partial_completions: true  # set this to false to prevent partial filling of the prompt
+  completion_algorithm: "prefix"  # prefix, fuzzy
   animate_prompt: false # redraw the prompt every second
   float_precision: 2
   use_ansi_coloring: true


### PR DESCRIPTION
# Description

This adds a new `MatchAlgorithm::Fuzzy` which uses the `fuzzy-completer` crate from skim (https://github.com/lotabout/fuzzy-matcher) to complete suggestions with a "fuzzy" search.

This is opt-in and can be enabled in the `config.nu` by setting the new `completion_algorithm` setting to `fuzzy` instead of the `prefix` default:

```
let-env config = {
  ...
  completion_algorithm: "fuzzy"
  ...
}
```

I developed and tested it on Windows so the fuzzy-matcher crate seems to support Windows even if skim itself does not.

Custom completions can still override completion options, although the `positional` and `case_sensitive` option has no effect at the moment if the `completion_algorithm` for this custom completion is `fuzzy`.

# Examples

```
> git out<tab>
> git checkout

> git checkout featcompl<tab>
> git checkout feature/new-completions

> echo $env.chome<tab>
> echo $env.CARGO_HOME
```

# Known Issues

* Completion may be slower than "prefix" completion
* `case_sensitive` option for custom commands does not work with fuzzy completion algorithm

# Future ideas

* Highlight matching chars
* Sort completions by matching score