### PR TITLE
activates optional trim in 'from csv' and 'from tsv'

### DIFF
--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -1,8 +1,9 @@
-use super::delimited::from_delimited_data;
+use super::delimited::{from_delimited_data, trim_from_str};
 
+use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Config, Example, PipelineData, ShellError, Signature};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
 
 #[derive(Clone)]
 pub struct FromTsv;
@@ -19,6 +20,12 @@ impl Command for FromTsv {
                 "don't treat the first row as column names",
                 Some('n'),
             )
+            .named(
+                "trim",
+                SyntaxShape::String,
+                "drop leading and trailing whitespaces around headers names and/or field values",
+                Some('t'),
+            )
             .category(Category::Formats)
     }
 
@@ -29,12 +36,11 @@ impl Command for FromTsv {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
-        let config = engine_state.get_config();
-        from_tsv(call, input, config)
+        from_tsv(engine_state, stack, call, input)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -49,16 +55,45 @@ impl Command for FromTsv {
                 example: r#"echo $'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv -n"#,
                 result: None,
             },
+            Example {
+                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces",
+                example: r#"echo $'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv --trim all"#,
+                result: None,
+            },
+            Example {
+                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces in the header names",
+                example: r#"echo $'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv --trim headers"#,
+                result: None,
+            },
+            Example {
+                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces in the field values",
+                example: r#"echo $'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv --trim fields"#,
+                result: None,
+            },
         ]
     }
 }
 
-fn from_tsv(call: &Call, input: PipelineData, config: &Config) -> Result<PipelineData, ShellError> {
+fn from_tsv(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+) -> Result<PipelineData, ShellError> {
     let name = call.head;
 
     let noheaders = call.has_flag("noheaders");
+    let trim: Option<Value> = call.get_flag(engine_state, stack, "trim")?;
+    let trim = trim_from_str(trim)?;
 
-    from_delimited_data(noheaders, '\t', input, name, config)
+    from_delimited_data(
+        noheaders,
+        '\t',
+        trim,
+        input,
+        name,
+        engine_state.get_config(),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

I often find myself willing to process files that are basically csv *but* formatted so as to have a nice vertical alignment (these are research results, and I like to have the ability to monitor and make sense of them, as the experiment is running).
Before the present PR, it was a bit of a pain to process these files with nushell combinators as the vertical alignment would cause the occurrence of whitespaces in header name and field values. 

In order to fix this, I propose (current PR) to expose a "--trim" flag in the "from csv" and "from tsv" commands (the from tsv case is merely for uniformity purposes). These are basically shim around the `csv::ReaderBuilder` which readily exposes the 'trim' flag. This PR simply adds the missing bits to provide users with a possibility to trim both headers and field values `--trim all`, only header names `--trim headers` or just the field values `--trim fields`. By default, no trimming is done, so it remains user-compatible with previous version.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
