### PR TITLE
Allow bare words to interpolate

### DIFF
--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -326,23 +326,33 @@ pub fn flatten_expression(
             output
         }
         Expr::StringInterpolation(exprs) => {
-            let mut output = vec![(
-                Span {
-                    start: expr.span.start,
-                    end: expr.span.start + 2,
-                },
-                FlatShape::StringInterpolation,
-            )];
+            let mut output = vec![];
             for expr in exprs {
                 output.extend(flatten_expression(working_set, expr));
             }
-            output.push((
-                Span {
-                    start: expr.span.end - 1,
-                    end: expr.span.end,
-                },
-                FlatShape::StringInterpolation,
-            ));
+
+            if let Some(first) = output.first() {
+                if first.0.start != expr.span.start {
+                    // If we aren't a bare word interpolation, also highlight the outer quotes
+                    output.insert(
+                        0,
+                        (
+                            Span {
+                                start: expr.span.start,
+                                end: expr.span.start + 2,
+                            },
+                            FlatShape::StringInterpolation,
+                        ),
+                    );
+                    output.push((
+                        Span {
+                            start: expr.span.end - 1,
+                            end: expr.span.end,
+                        },
+                        FlatShape::StringInterpolation,
+                    ));
+                }
+            }
             output
         }
         Expr::Record(list) => {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -41,7 +41,7 @@ pub fn parse_def_predecl(
     };
 
     if (name == b"def" || name == b"def-env") && spans.len() >= 4 {
-        let (name_expr, ..) = parse_string(working_set, spans[1]);
+        let (name_expr, ..) = parse_string(working_set, spans[1], expand_aliases_denylist);
         let name = name_expr.as_string();
 
         working_set.enter_scope();
@@ -64,7 +64,7 @@ pub fn parse_def_predecl(
             }
         }
     } else if name == b"extern" && spans.len() == 3 {
-        let (name_expr, ..) = parse_string(working_set, spans[1]);
+        let (name_expr, ..) = parse_string(working_set, spans[1], expand_aliases_denylist);
         let name = name_expr.as_string();
 
         working_set.enter_scope();
@@ -892,7 +892,8 @@ pub fn parse_export(
                 call.head = span(&spans[0..=1]);
 
                 if let Some(name_span) = spans.get(2) {
-                    let (name_expr, err) = parse_string(working_set, *name_span);
+                    let (name_expr, err) =
+                        parse_string(working_set, *name_span, expand_aliases_denylist);
                     error = error.or(err);
                     call.add_positional(name_expr);
 
@@ -1132,7 +1133,7 @@ pub fn parse_module(
     let bytes = working_set.get_span_contents(spans[0]);
 
     if bytes == b"module" && spans.len() >= 3 {
-        let (module_name_expr, err) = parse_string(working_set, spans[1]);
+        let (module_name_expr, err) = parse_string(working_set, spans[1], expand_aliases_denylist);
         error = error.or(err);
 
         let module_name = module_name_expr
@@ -1524,7 +1525,7 @@ pub fn parse_hide(
 
     if bytes == b"hide" && spans.len() >= 2 {
         for span in spans[1..].iter() {
-            let (_, err) = parse_string(working_set, *span);
+            let (_, err) = parse_string(working_set, *span, expand_aliases_denylist);
             error = error.or(err);
         }
 


### PR DESCRIPTION
# Description

This allows bare words to interpolate. For it, you need to wrap the expression in parens, like you do with other string interpolation:

```
> let foo = "Downloads"
> ls ~/($foo)
```

The `(` can't start a bare word, and the same is true here. The subexpression must occur inside of the bare word and not at the beginning.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
