### PR TITLE
Add watch command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -243,7 +243,7 @@ checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.4.4",
  "object",
@@ -416,6 +416,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -431,7 +437,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -508,7 +514,7 @@ dependencies = [
  "regex",
  "terminal_size",
  "unicode-width",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -574,7 +580,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -583,7 +589,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -593,7 +599,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -605,7 +611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -618,7 +624,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -631,12 +637,12 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.2",
  "parking_lot 0.12.0",
  "serde",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -645,7 +651,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -740,7 +746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
  "nix",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -820,7 +826,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -832,7 +838,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -843,7 +849,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -932,7 +938,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -975,7 +981,7 @@ checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1037,7 +1043,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e245f4c8ec30c6415c56cb132c07e69e74f1942f6b4a4061da748b49f486ca"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "rustix",
  "windows-sys 0.30.0",
 ]
@@ -1048,7 +1054,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1057,10 +1063,10 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1069,7 +1075,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "miniz_oxide 0.5.1",
@@ -1113,10 +1119,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futf"
@@ -1278,7 +1319,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1289,7 +1330,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
@@ -1622,12 +1663,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1657,6 +1718,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,7 +1750,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1729,10 +1799,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical"
@@ -1912,7 +1998,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2109,16 +2195,59 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -2127,7 +2256,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2169,6 +2298,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,7 +2322,7 @@ checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset",
 ]
@@ -2233,12 +2373,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2286,7 +2444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7bca0d33a384280d1563b97f49cb95303df9fa22588739a04b7d8015c1ccd50"
 dependencies = [
  "overload",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2355,6 +2513,7 @@ dependencies = [
  "md-5",
  "meval",
  "mime",
+ "notify",
  "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
@@ -2511,7 +2670,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "procfs",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2776,7 +2935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2817,7 +2976,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2859,12 +3018,12 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2873,7 +3032,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -3381,7 +3540,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3589,7 +3748,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3649,7 +3808,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -3743,7 +3902,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3774,7 +3933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3981,7 +4140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -3993,7 +4152,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.3",
 ]
@@ -4027,7 +4186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.2",
  "signal-hook",
 ]
 
@@ -4083,7 +4242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4292,7 +4451,7 @@ dependencies = [
  "cstr_core",
  "libc",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4301,13 +4460,13 @@ version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eea2ed6847da2e0c7289f72cb4f285f0bd704694ca067d32be811b2a45ea858"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4326,12 +4485,12 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4361,7 +4520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4424,7 +4583,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4461,11 +4620,11 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.2",
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4513,7 +4672,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4796,7 +4955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -4834,7 +4993,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -4859,7 +5018,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4937,6 +5096,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -4944,6 +5109,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -4957,7 +5128,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5088,7 +5259,17 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -53,6 +53,7 @@ lscolors = { version = "0.9.0", features = ["crossterm"]}
 md5 = { package = "md-5", version = "0.10.0" }
 meval = "0.2.0"
 mime = "0.3.16"
+notify = "4.0.17"
 num = { version = "0.4.0", optional = true }
 pathdiff = "0.2.1"
 quick-xml = "0.22"

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -199,6 +199,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             Save,
             Touch,
             Glob,
+            Watch,
         };
 
         // Platform

--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -9,6 +9,7 @@ mod rm;
 mod save;
 mod touch;
 mod util;
+mod watch;
 
 pub use cd::Cd;
 pub use cp::Cp;
@@ -21,3 +22,4 @@ pub use rm::Rm;
 pub use save::Save;
 pub use touch::Touch;
 pub use util::BufferedReader;
+pub use watch::Watch;

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -1,0 +1,295 @@
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc::{channel, RecvTimeoutError};
+use std::time::Duration;
+
+use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use nu_engine::{current_dir, eval_block, CallExt};
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
+    Value,
+};
+
+// durations chosen mostly arbitrarily
+const CHECK_CTRL_C_FREQUENCY: Duration = Duration::from_millis(100);
+const DEFAULT_WATCH_DEBOUNCE_DURATION: Duration = Duration::from_millis(100);
+
+#[derive(Clone)]
+pub struct Watch;
+
+impl Command for Watch {
+    fn name(&self) -> &str {
+        "watch"
+    }
+
+    fn usage(&self) -> &str {
+        "Watch for file changes and execute Nu code when they happen."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["watcher", "reload", "filesystem"]
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("watch")
+            .required("path", SyntaxShape::Filepath, "the path to watch. Can be a file or directory")
+            .required("block", SyntaxShape::Block(None), "A Nu block of code to run whenever a file changes. The block will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order")
+            .named(
+                "debounce-ms",
+                SyntaxShape::Int,
+                "Debounce changes for this many milliseconds (default: 100). Adjust if you find that single writes are reported as multiple events",
+                Some('d'),
+            )
+            .named(
+                "glob",
+                SyntaxShape::String, // SyntaxShape::GlobPattern gets interpreted relative to cwd, so use String instead
+                "Only report changes for files that match this glob pattern (default: all files)",
+                Some('g'),
+            )
+            .named(
+                "recursive",
+                SyntaxShape::Boolean,
+                "Watch all directories under <path> recursively. Will be ignored if <path> is a file (default: true)",
+                Some('r'),
+            )
+            .switch("verbose", "Operate in verbose mode (default: false)", Some('v'))
+            .category(Category::FileSystem)
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let cwd = current_dir(engine_state, stack)?;
+        let path_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
+
+        let path_no_whitespace = &path_arg
+            .item
+            .trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
+
+        let path = match nu_path::canonicalize_with(path_no_whitespace, &cwd) {
+            Ok(p) => p,
+            Err(e) => {
+                return Err(ShellError::DirectoryNotFound(
+                    path_arg.span,
+                    Some(format!("IO Error: {:?}", e)),
+                ))
+            }
+        };
+
+        let capture_block: CaptureBlock = call.req(engine_state, stack, 1)?;
+        let block = engine_state
+            .clone()
+            .get_block(capture_block.block_id)
+            .clone();
+
+        let verbose = call.has_flag("verbose");
+
+        let debounce_duration_flag: Option<Spanned<i64>> =
+            call.get_flag(engine_state, stack, "debounce-ms")?;
+        let debounce_duration = match debounce_duration_flag {
+            Some(val) => match u64::try_from(val.item) {
+                Ok(val) => Duration::from_millis(val),
+                Err(_) => {
+                    return Err(ShellError::UnsupportedInput(
+                        "Input out of range".to_string(),
+                        val.span,
+                    ))
+                }
+            },
+            None => DEFAULT_WATCH_DEBOUNCE_DURATION,
+        };
+
+        let glob_flag: Option<Spanned<String>> = call.get_flag(engine_state, stack, "glob")?;
+        let glob_pattern = match glob_flag {
+            Some(glob) => {
+                let absolute_path = path.join(glob.item);
+                if verbose {
+                    eprintln!("Absolute glob path: {absolute_path:?}");
+                }
+
+                match nu_glob::Pattern::new(&absolute_path.to_string_lossy()) {
+                    Ok(pattern) => Some(pattern),
+                    Err(_) => return Err(ShellError::UnsupportedInput("".to_string(), glob.span)),
+                }
+            }
+            None => None,
+        };
+
+        let recursive_flag: Option<Spanned<bool>> =
+            call.get_flag(engine_state, stack, "recursive")?;
+        let recursive_mode = match recursive_flag {
+            Some(recursive) => {
+                if recursive.item {
+                    RecursiveMode::Recursive
+                } else {
+                    RecursiveMode::NonRecursive
+                }
+            }
+            None => RecursiveMode::Recursive,
+        };
+
+        let ctrlc_ref = &engine_state.ctrlc.clone();
+        let (tx, rx) = channel();
+
+        let mut watcher: RecommendedWatcher = match Watcher::new(tx, debounce_duration) {
+            Ok(w) => w,
+            Err(e) => {
+                return Err(ShellError::IOError(format!(
+                    "Failed to create watcher: {e}"
+                )))
+            }
+        };
+
+        if let Err(e) = watcher.watch(path.clone(), recursive_mode) {
+            return Err(ShellError::IOError(format!("Failed to start watcher: {e}")));
+        }
+
+        eprintln!("Now watching files at {path:?}. Press ctrl+c to abort.");
+
+        let event_handler =
+            |operation: &str, path: PathBuf, new_path: Option<PathBuf>| -> Result<(), ShellError> {
+                let glob_pattern = glob_pattern.clone();
+                let matches_glob = match glob_pattern.clone() {
+                    Some(glob) => glob.matches_path(&path),
+                    None => true,
+                };
+                if verbose && glob_pattern.is_some() {
+                    eprintln!("Matches glob: {matches_glob}");
+                }
+
+                if matches_glob {
+                    let stack = &mut stack.clone();
+
+                    if let Some(position) = block.signature.get_positional(0) {
+                        if let Some(position_id) = &position.var_id {
+                            stack.add_var(
+                                *position_id,
+                                Value::String {
+                                    val: operation.to_string(),
+                                    span: call.span(),
+                                },
+                            );
+                        }
+                    }
+
+                    if let Some(position) = block.signature.get_positional(1) {
+                        if let Some(position_id) = &position.var_id {
+                            stack.add_var(
+                                *position_id,
+                                Value::String {
+                                    val: path.to_string_lossy().to_string(),
+                                    span: call.span(),
+                                },
+                            );
+                        }
+                    }
+
+                    if let Some(position) = block.signature.get_positional(2) {
+                        if let Some(position_id) = &position.var_id {
+                            stack.add_var(
+                                *position_id,
+                                Value::String {
+                                    val: new_path
+                                        .unwrap_or_else(|| "".into())
+                                        .to_string_lossy()
+                                        .to_string(),
+                                    span: call.span(),
+                                },
+                            );
+                        }
+                    }
+
+                    let eval_result = eval_block(
+                        engine_state,
+                        stack,
+                        &block,
+                        Value::Nothing { span: call.span() }.into_pipeline_data(),
+                        call.redirect_stdout,
+                        call.redirect_stderr,
+                    );
+
+                    match eval_result {
+                        Ok(val) => {
+                            val.print(engine_state, stack)?;
+                        }
+                        Err(err) => {
+                            // TODO: this isn't as nice as the Miette errors. Find a way to print those.
+                            // Unfortunately can't just wrap err in PipelineData, PipelineData.print() doesn't work that way
+                            eprintln!("{err:?}");
+                        }
+                    }
+                }
+
+                Ok(())
+            };
+
+        loop {
+            match rx.recv_timeout(CHECK_CTRL_C_FREQUENCY) {
+                Ok(event) => {
+                    if verbose {
+                        eprintln!("{:?}", event);
+                    }
+                    let handler_result = match event {
+                        DebouncedEvent::Create(path) => event_handler("Create", path, None),
+                        DebouncedEvent::Write(path) => event_handler("Write", path, None),
+                        DebouncedEvent::Remove(path) => event_handler("Remove", path, None),
+                        DebouncedEvent::Rename(path, new_path) => {
+                            event_handler("Rename", path, Some(new_path))
+                        }
+                        DebouncedEvent::Error(err, path) => match path {
+                            Some(path) => Err(ShellError::IOError(format!(
+                                "Error detected for {path:?}: {err:?}"
+                            ))),
+                            None => Err(ShellError::IOError(format!("Error detected: {err:?}"))),
+                        },
+                        // These are less likely to be interesting events
+                        DebouncedEvent::Chmod(_)
+                        | DebouncedEvent::NoticeRemove(_)
+                        | DebouncedEvent::NoticeWrite(_)
+                        | DebouncedEvent::Rescan => Ok(()),
+                    };
+                    handler_result?;
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(ShellError::IOError(
+                        "Unexpected disconnect from file watcher".into(),
+                    ));
+                }
+                Err(RecvTimeoutError::Timeout) => {}
+            }
+            if let Some(ctrlc) = ctrlc_ref {
+                if ctrlc.load(Ordering::SeqCst) {
+                    break;
+                }
+            }
+        }
+
+        Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Run `cargo test` whenever a Rust file changes",
+                example: r#"watch . --glob=**/*.rs { cargo test }"#,
+                result: None,
+            },
+            Example {
+                description: "Watch all changes in the current directory",
+                example: r#"watch . { |op, path, new_path| $"($op) ($path) ($new_path)"}"#,
+                result: None,
+            },
+            Example {
+                description: "Log all changes in a directory",
+                example: r#"watch /foo/bar { |op, path| $"($op) - ($path)(char nl)" | save --append changes_in_bar.log }"#,
+                result: None,
+            },
+        ]
+    }
+}


### PR DESCRIPTION
This PR creates an experimental `watch` command:

```
〉help watch
Watch for file changes and execute Nu code when they happen.

Search terms: watcher, reload, filesystem

Usage:
  > watch {flags} <path> <block> 

Flags:
  -h, --help
      Display this help message
  -d, --debounce-ms <Int>
      Debounce changes for this many milliseconds (default: 100). Adjust if you find that single writes are reported as multiple events
  -g, --glob <String>
      Only report changes for files that match this glob pattern (default: all files)
  -r, --recursive <Boolean>
      Watch all directories under <path> recursively. Will be ignored if <path> is a file (default: true)
  -v, --verbose
      Operate in verbose mode (default: false)

Parameters:
  path: the path to watch. Can be a file or directory
  block: A Nu block of code to run whenever a file changes. The block will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order

Examples:
  Run `cargo test` whenever a Rust file changes
  > watch . --glob=**/*.rs { cargo test }

  Watch all changes in the current directory
  > watch . { |op, path, new_path| $"($op) ($path) ($new_path)"}

  Log all changes in a directory
  > watch /foo/bar { |op, path| $"($op) - ($path)(char nl)" | save --append changes_in_bar.log }
```

![image](https://user-images.githubusercontent.com/26268125/165224711-e5c52527-a041-43c8-9ec3-79047b5579cc.png)

It uses [the popular `notify` crate](https://crates.io/crates/notify/4.0.17) to watch for file changes, and it runs in the foreground until the user presses `ctrl+c`.

## Motivation

I find myself using file watcher tools to automate tasks quite often; for example I'll want to run tests when my code changes, watch what a program is doing inside a directory, etc.

It's currently possible to use a tool like [`watchexec`](https://github.com/watchexec/watchexec) to launch a _new_ instance of Nu in response to file changes. But I think it might be more powerful and ergonomic to be able to respond to events without leaving Nu.

## Future work

- Currently this just queues up changes and runs the block in serial for each one. Might need to revisit that (maybe we'll want to batch changes if many arrive in a short period of time, or do some more work around cancellation?)
- I wasn't able to find a good way to display errors from the block with nice Miette formatting

## Build measurements
**Before PR:**  493 crates, 35.37s, 15.8 MiB
**After PR:** 502 crates, 36.42s, 16.0MiB

(`cargo build --release` on Linux w/ 12900K CPU, mold linker)

## Tests

I have tested manually on Linux and Windows.

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
