### PR TITLE
Fix 'range' range exclusive

### DIFF
--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -1,6 +1,6 @@
 use nu_engine::CallExt;
 
-use nu_protocol::ast::Call;
+use nu_protocol::ast::{Call, RangeInclusion};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
@@ -69,7 +69,11 @@ impl Command for Range {
         let rows: nu_protocol::Range = call.req(engine_state, stack, 0)?;
 
         let rows_from = get_range_val(rows.from);
-        let rows_to = get_range_val(rows.to);
+        let rows_to = if rows.inclusion == RangeInclusion::RightExclusive {
+            get_range_val(rows.to) - 1
+        } else {
+            get_range_val(rows.to)
+        };
 
         // only collect the input if we have any negative indices
         if rows_from < 0 || rows_to < 0 {

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -347,3 +347,8 @@ fn better_operator_spans() -> TestResult {
         "true",
     )
 }
+
+#[test]
+fn range_right_exclusive() -> TestResult {
+    run_test(r#"[1, 4, 5, 8, 9] | range 1..<3 | math sum"#, "9")
+}


### PR DESCRIPTION
# Description

Right-exclusive ranges should now work a bit better: `[1, 4, 5, 8, 9] | range 1..<3`

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
