### PR TITLE
`db info` tweaks

### DIFF
--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -2,9 +2,9 @@ mod collect;
 mod command;
 mod describe;
 mod from;
-mod schema;
 mod open;
 mod query;
+mod schema;
 mod select;
 mod utils;
 
@@ -12,10 +12,10 @@ use collect::CollectDb;
 use command::Database;
 use describe::DescribeDb;
 use from::FromDb;
-use schema::SchemaDb;
 use nu_protocol::engine::StateWorkingSet;
 use open::OpenDb;
 use query::QueryDb;
+use schema::SchemaDb;
 use select::SelectDb;
 
 pub fn add_database_decls(working_set: &mut StateWorkingSet) {

--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -2,7 +2,7 @@ mod collect;
 mod command;
 mod describe;
 mod from;
-mod info;
+mod schema;
 mod open;
 mod query;
 mod select;
@@ -12,7 +12,7 @@ use collect::CollectDb;
 use command::Database;
 use describe::DescribeDb;
 use from::FromDb;
-use info::InfoDb;
+use schema::SchemaDb;
 use nu_protocol::engine::StateWorkingSet;
 use open::OpenDb;
 use query::QueryDb;
@@ -29,5 +29,5 @@ pub fn add_database_decls(working_set: &mut StateWorkingSet) {
         }
 
     // Series commands
-    bind_command!(CollectDb, Database, DescribeDb, FromDb, QueryDb, SelectDb, OpenDb, InfoDb);
+    bind_command!(CollectDb, Database, DescribeDb, FromDb, QueryDb, SelectDb, OpenDb, SchemaDb);
 }

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -1,12 +1,10 @@
 use super::super::SQLiteDatabase;
 use crate::database::values::db_row::DbRow;
-use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Value,
 };
-use std::path::PathBuf;
 
 #[derive(Clone)]
 pub struct SchemaDb;
@@ -17,40 +15,37 @@ impl Command for SchemaDb {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name())
-            .required("db", SyntaxShape::Filepath, "sqlite database file name")
-            .category(Category::Custom("database".into()))
+        Signature::build(self.name()).category(Category::Custom("database".into()))
     }
 
     fn usage(&self) -> &str {
-        "Show database information."
+        "Show database information, including its schema."
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Show information of a SQLite database",
-            example: r#"db info foo.db"#,
+            description: "Show the schema of a SQLite database",
+            example: r#"open foo.db | db schema"#,
             result: None,
         }]
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "info", "SQLite"]
+        vec!["database", "info", "SQLite", "schema"]
     }
 
     fn run(
         &self,
-        engine_state: &EngineState,
-        stack: &mut Stack,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let db_file: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
-        let span = db_file.span;
         let mut cols = vec![];
         let mut vals = vec![];
+        let span = call.head;
 
-        let sqlite_db = SQLiteDatabase::try_from_path(db_file.item.as_path(), db_file.span)?;
+        let sqlite_db = SQLiteDatabase::try_from_pipeline(input, span)?;
         let conn = sqlite_db.open_connection().map_err(|e| {
             ShellError::GenericError(
                 "Error opening file".into(),
@@ -73,7 +68,7 @@ impl Command for SchemaDb {
 
         cols.push("db_filename".into());
         vals.push(Value::String {
-            val: db_file.item.to_string_lossy().to_string(),
+            val: sqlite_db.path.to_string_lossy().to_string(),
             span,
         });
 

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -9,11 +9,11 @@ use nu_protocol::{
 use std::path::PathBuf;
 
 #[derive(Clone)]
-pub struct InfoDb;
+pub struct SchemaDb;
 
-impl Command for InfoDb {
+impl Command for SchemaDb {
     fn name(&self) -> &str {
-        "db info"
+        "db schema"
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -19,7 +19,7 @@ pub struct SQLiteDatabase {
     // I considered storing a SQLite connection here, but decided against it because
     // 1) YAGNI, 2) it's not obvious how cloning a connection could work, 3) state
     // management gets tricky quick. Revisit this approach if we find a compelling use case.
-    path: PathBuf,
+    pub path: PathBuf,
     pub query: Option<Query>,
 }
 


### PR DESCRIPTION
- Rename `db info` to `db schema` (makes it a little more obvious what it does IMO)
- Take the database from pipeline input instead of an argument (i.e. `open foo.db | db schema` instead of `db schema foo.db`), for consistency with other `db *` commands

# Tests

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
