### PR TITLE
fixes an issue with an empty selector panic

### DIFF
--- a/crates/nu_plugin_query/src/query_web.rs
+++ b/crates/nu_plugin_query/src/query_web.rs
@@ -307,7 +307,13 @@ mod tests {
 
     #[test]
     fn test_first_child() {
-        let item = execute_selector_query(SIMPLE_LIST, "li:first-child", false, Span::test_data());
+        let item = execute_selector_query(
+            SIMPLE_LIST,
+            "li:first-child",
+            false,
+            false,
+            Span::test_data(),
+        );
         let config = nu_protocol::Config::default();
         let out = item.into_string("\n", &config);
         assert_eq!("[Coffee]".to_string(), out)

--- a/crates/nu_plugin_query/src/query_web.rs
+++ b/crates/nu_plugin_query/src/query_web.rs
@@ -87,12 +87,14 @@ fn begin_selector_query(input_html: String, selector: Selector, span: Span) -> V
                 input_html.as_str(),
                 selector.query.as_str(),
                 selector.as_html,
+                selector.inspect,
                 span,
             ),
             false => execute_selector_query_with_attribute(
                 input_html.as_str(),
                 selector.query.as_str(),
                 selector.attribute.as_str(),
+                selector.inspect,
                 span,
             ),
         }
@@ -132,10 +134,7 @@ pub fn retrieve_tables(
 
     if tables.len() == 1 {
         return retrieve_table(
-            tables
-                .into_iter()
-                .next()
-                .expect("This should never trigger"),
+            tables.into_iter().next().expect("Error retrieving table"),
             columns,
             span,
         );
@@ -227,12 +226,13 @@ fn execute_selector_query_with_attribute(
     input_string: &str,
     query_string: &str,
     attribute: &str,
+    inspect: bool,
     span: Span,
 ) -> Value {
     let doc = Html::parse_fragment(input_string);
 
     let vals: Vec<Value> = doc
-        .select(&css(query_string))
+        .select(&css(query_string, inspect))
         .map(|selection| {
             Value::string(
                 selection.value().attr(attribute).unwrap_or("").to_string(),
@@ -247,17 +247,18 @@ fn execute_selector_query(
     input_string: &str,
     query_string: &str,
     as_html: bool,
+    inspect: bool,
     span: Span,
 ) -> Value {
     let doc = Html::parse_fragment(input_string);
 
     let vals: Vec<Value> = match as_html {
         true => doc
-            .select(&css(query_string))
+            .select(&css(query_string, inspect))
             .map(|selection| Value::string(selection.html(), span))
             .collect(),
         false => doc
-            .select(&css(query_string))
+            .select(&css(query_string, inspect))
             .map(|selection| {
                 Value::string(
                     selection
@@ -272,8 +273,12 @@ fn execute_selector_query(
     Value::List { vals, span }
 }
 
-pub fn css(selector: &str) -> ScraperSelector {
-    ScraperSelector::parse(selector).expect("this should never trigger")
+pub fn css(selector: &str, inspect: bool) -> ScraperSelector {
+    if inspect {
+        ScraperSelector::parse("html").expect("Error unwrapping the default scraperselector")
+    } else {
+        ScraperSelector::parse(selector).expect("Error unwrapping scraperselector::parse")
+    }
 }
 
 #[cfg(test)]
@@ -290,10 +295,14 @@ mod tests {
 
     #[test]
     fn test_first_child_is_not_empty() {
-        assert!(
-            !execute_selector_query(SIMPLE_LIST, "li:first-child", false, Span::test_data())
-                .is_empty()
+        assert!(!execute_selector_query(
+            SIMPLE_LIST,
+            "li:first-child",
+            false,
+            false,
+            Span::test_data()
         )
+        .is_empty())
     }
 
     #[test]

--- a/crates/nu_plugin_query/src/web_tables.rs
+++ b/crates/nu_plugin_query/src/web_tables.rs
@@ -14,12 +14,15 @@ impl WebTable {
     /// Finds the first table in `html`.
     pub fn find_first(html: &str) -> Option<WebTable> {
         let html = Html::parse_fragment(html);
-        html.select(&css("table")).next().map(WebTable::new)
+        html.select(&css("table", false)).next().map(WebTable::new)
     }
 
     pub fn find_all_tables(html: &str) -> Option<Vec<WebTable>> {
         let html = Html::parse_fragment(html);
-        let iter: Vec<WebTable> = html.select(&css("table")).map(WebTable::new).collect();
+        let iter: Vec<WebTable> = html
+            .select(&css("table", false))
+            .map(WebTable::new)
+            .collect();
         if iter.is_empty() {
             return None;
         }
@@ -51,9 +54,9 @@ impl WebTable {
             return WebTable::find_all_tables(html);
         }
 
-        let sel_table = css("table");
-        let sel_tr = css("tr");
-        let sel_th = css("th");
+        let sel_table = css("table", false);
+        let sel_tr = css("tr", false);
+        let sel_th = css("th", false);
 
         let html = Html::parse_fragment(html);
         let mut tables = html
@@ -98,9 +101,9 @@ impl WebTable {
     }
 
     // fn new(element: ElementRef) -> Table {
-    //     let sel_tr = css("tr");
-    //     let sel_th = css("th");
-    //     let sel_td = css("td");
+    //     let sel_tr = css("tr", false);
+    //     let sel_th = css("th", false);
+    //     let sel_td = css("td", false);
 
     //     let mut headers = HashMap::new();
     //     let mut rows = element.select(&sel_tr).peekable();
@@ -117,9 +120,9 @@ impl WebTable {
     // }
 
     fn new(element: ElementRef) -> WebTable {
-        let sel_tr = css("tr");
-        let sel_th = css("th");
-        let sel_td = css("td");
+        let sel_tr = css("tr", false);
+        let sel_th = css("th", false);
+        let sel_td = css("td", false);
 
         let mut headers = HashMap::new();
         let mut rows = element.select(&sel_tr).peekable();


### PR DESCRIPTION
# Description

This fixes an issue where using the inspect flag with an empty selector would panic.

closes #5319

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
