### PR TITLE
Statically link OpenSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,6 +2270,7 @@ dependencies = [
  "nu-table",
  "nu-term-grid",
  "nu-test-support",
+ "openssl",
  "pretty_assertions",
  "pretty_env_logger",
  "rayon",
@@ -2790,6 +2791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,6 +2808,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ nu-protocol = { path = "./crates/nu-protocol", version = "0.61.1"  }
 nu-system = { path = "./crates/nu-system", version = "0.61.1" }
 nu-table = { path = "./crates/nu-table", version = "0.61.1"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.61.1"  }
+openssl = { version = "0.10.38", features = ["vendored"] } # Force subdependencies to statically link OpenSSL
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}


### PR DESCRIPTION
# Description

This PR statically links OpenSSL using [a feature of the `openssl` crate](https://docs.rs/openssl/latest/openssl/). The hope is that this will address many of the support issues we see originating from dynamically linked OpenSSL.

Release build size goes up a bit from 15.8 MB to 18.1MB (Linux x64). I have manually tested the `nu` binary on Linux (and used `ldd` to confirm that it no longer uses OpenSSL shared libraries), and the builds+tests pass on all OSs.

Note: I needed to install the FindBin Perl tool (`dnf info perl-FindBin`) to get this to build on Fedora 36. Didn't need to tweak the GitHub CI config though.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
