### PR TITLE
mute false import warning for nu-command test where_

### DIFF
--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -1,4 +1,5 @@
 use nu_test_support::nu;
+#[allow(unused)]
 use nu_test_support::pipeline;
 
 #[test]


### PR DESCRIPTION

when running the tests we were getting an import warning
for the nu-command test where_

even though the import was needed...

so this #[allow(unused)]
mutes the false warning...
