### PR TITLE
Openssl feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --all --features=extra
+          args: --release --all --features=extra,static-link-openssl
 
       # - name: Strip binaries (nu)
       #   run: strip target/release/nu
@@ -93,10 +93,6 @@ jobs:
           cp LICENSE output/LICENSE
           rm output/*.d
 
-      # Note: If OpenSSL changes, this path will need to be updated
-      - name: Copy OpenSSL to output
-        run: cp /usr/lib/x86_64-linux-gnu/libssl.so.1.1 output/
-
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
@@ -121,7 +117,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --all --features=extra
+          args: --release --all --features=extra,static-link-openssl
 
       # - name: Strip binaries (nu)
       #   run: strip target/release/nu
@@ -217,7 +213,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --all --features=extra
+          args: --release --all --features=extra,static-link-openssl
 
       # - name: Strip binaries (nu.exe)
       #   run: strip target/release/nu.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Copy files to output
         run: |
           cp target/release/nu target/release/nu_plugin_* output/
-          cp README.build.txt output/README.txt
+          cp README.release.txt output/README.txt
           cp LICENSE output/LICENSE
           rm output/*.d
 
@@ -179,7 +179,7 @@ jobs:
       - name: Copy files to output
         run: |
           cp target/release/nu target/release/nu_plugin_* output/
-          cp README.build.txt output/README.txt
+          cp README.release.txt output/README.txt
           cp LICENSE output/LICENSE
           rm output/*.d
 
@@ -284,7 +284,7 @@ jobs:
           cp LICENSE output\
           cp target\release\LICENSE-for-less.txt output\
           cp target\release\nu_plugin_*.exe output\
-          cp README.build.txt output\README.txt
+          cp README.release.txt output\README.txt
           cp target\release\less.exe output\
       # Note: If the version of `less.exe` needs to be changed, update this URL
       # Similarly, if `less.exe` is checked into the repo, copy from the local path here

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ nu-protocol = { path = "./crates/nu-protocol", version = "0.61.1"  }
 nu-system = { path = "./crates/nu-system", version = "0.61.1" }
 nu-table = { path = "./crates/nu-table", version = "0.61.1"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.61.1"  }
-openssl = { version = "0.10.38", features = ["vendored"] } # Force subdependencies to statically link OpenSSL
+openssl = { version = "0.10.38", features = ["vendored"], optional = true }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
@@ -76,6 +76,8 @@ default = ["plugin", "which-support", "trash-support"]
 stable = ["default"]
 extra = ["default", "dataframe", "database"]
 wasi = []
+# Enable to statically link OpenSSL; otherwise the system version will be used. Not enabled by default because it takes a while to build
+static-link-openssl = ["dep:openssl"]
 
 # Stable (Default)
 which-support = ["nu-command/which-support"]

--- a/README.release.txt
+++ b/README.release.txt
@@ -1,0 +1,3 @@
+To use Nu plugins, use the register command to tell Nu where to find the plugin. For example:
+
+> register -e json ./nu_plugin_query


### PR DESCRIPTION
# Description

[As requested](https://github.com/nushell/nushell/pull/5349#issuecomment-1111713557), moving the OpenSSL static linking from https://github.com/nushell/nushell/pull/5349 behind a feature (`static-link-openssl`).

I tested the release workflow as part of this and noticed that it was previously broken in https://github.com/nushell/nushell/pull/5272 (my bad - I didn't realize that `README.build.txt` was being included in releases). Fixed it up accordingly.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
