### PR TITLE
CI: enable rust-cache, remove minimal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+            key: "1" # increment this to bust the cache if needed
+
       - name: Rustfmt
         uses: actions-rs/cargo@v1
         with:
@@ -88,6 +92,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+            key: "1" # increment this to bust the cache if needed
 
       - name: Install Nushell
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        style: [all, default, minimal]
+        style: [all, default]
         rust:
           - stable
         include:
@@ -16,17 +16,11 @@ jobs:
             flags: '--all-features'
           - style: default
             flags: ''
-          - style: minimal
-            flags: '--no-default-features'
         exclude:
           - platform: windows-latest
             style: default
-          - platform: windows-latest
-            style: minimal
           - platform: macos-latest
             style: default
-          - platform: macos-latest
-            style: minimal
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
# Description

Start using [the `rust-cache` GitHub action](https://github.com/Swatinem/rust-cache) to speed up CI. Also, remove the `minimal` CI run; it was mostly useful for wasm and we're not planning to focus on that for v1.0.

# Details

GitHub gives us [10GB of cache space](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) to help speed up GitHub Actions. The `rust-cache` action is an easy way to use that for Rust; it essentially stores temporary files for our dependencies across CI runs.

I've tested this out on my fork. It's hard to get consistent performance measurements (GitHub Actions perf has very high variance), but I'm seeing total CI times of 10-15 min compared to 20-30 min before `rust-cache`.

GitHub doesn't currently have a way to clear the cache if something goes wrong; [there's an issue for it](https://github.com/actions/cache/issues/2) and they plan to add that feature later this year. For now, I've added a key that can be used to bust the cache if needed.

# Future work

I think I can speed up CI further by tweaking our Clippy+test setup. Will experiment with that next.