### PR TITLE
CI: make Clippy reuse build artifacts, other cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,23 +45,23 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
-
       - name: Build Nushell
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: ${{ matrix.flags }}
+          args: --workspace ${{ matrix.flags }}
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
       - name: Tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all ${{ matrix.flags }}
+          args: --workspace ${{ matrix.flags }}
 
 
   python-virtualenv:


### PR DESCRIPTION
# Description

Our CI wastes a lot of time when it builds Nu for Clippy then rebuilds Nu for `cargo build`. I did some experimenting, and if we just move Clippy after `cargo build` it will reuse the artifacts from `cargo build`. This can shave a lot of time off a CI run, and Clippy ends up finishing around the same time as it did before.

Also did some other CI cleanup while I was in the area:
- Replace `--all` flags with `--workspace` because `--all` is a deprecated alias for `--workspace`
- Don't bother installing `rustfmt` and Clippy for the virtualenv tests, they're not used

# Notes

I also experimented with `cargo nextest` but it didn't really move the needle; we spend a lot more time compiling tests than running them.

`cargo test` rebuilds a lot of crates and I'm not certain why. Maybe they have `#[cfg(test)]` annotations that require a rebuild in test mode?