### PR TITLE
CI: remove rust-cache from virtualenv tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-            key: "1" # increment this to bust the cache if needed
-
       - name: Install Nushell
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
We're seeing fewer cache hits than I'd like with `rust-cache`. Let's disable `rust-cache` for the Python virtualenv tests; they're not the bottleneck for CI and they're consuming cache space that can be better used by the all-feature CI jobs.