### PR TITLE
rust-cache fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [pull_request]
+on:
+  pull_request:
+  push: # Run CI on the main branch after every merge. This is important to fill the GitHub Actions cache in a way that pull requests can see it
+    branches:
+      - main
 
 name: continuous-integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+            key: "1" # increment this to bust the cache if needed
+
       - name: Install Nushell
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
# Description

This PR should address the issues we're seeing with `rust-cache` not finding anything in the cache. I missed an important aspect of the caching isolation model; cache data created in a pull-request-triggered CI run can't be seen by other PRs.

To address this, we can automatically run CI after every merge to `main`; cache data saved during that run _will_ be visible to PRs. I've tested+confirmed this on my fork.

Related info:
- https://stackoverflow.com/a/66632107/854694
- https://github.com/paritytech/smoldot/blob/44745db0c80cab80657d856d46e2c8d7a5a83410/.github/workflows/ci.yml#L24