### PR TITLE
Faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-            key: "1" # increment this to bust the cache if needed
+            key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
 
       - name: Rustfmt
         uses: actions-rs/cargo@v1
@@ -96,7 +96,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-            key: "1" # increment this to bust the cache if needed
+            key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
 
       - name: Rustfmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 name: continuous-integration
 
 jobs:
-  ci:
+  build-clippy:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,54 @@ jobs:
           command: clippy
           args: --workspace ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+        style: [all, default]
+        rust:
+          - stable
+        include:
+          - style: all
+            flags: '--all-features'
+          - style: default
+            flags: ''
+        exclude:
+          - platform: windows-latest
+            style: default
+          - platform: macos-latest
+            style: default
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+            key: "1" # increment this to bust the cache if needed
+
+      - name: Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
       - name: Tests
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace ${{ matrix.flags }}
-
 
   python-virtualenv:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
         with:
             key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
 
+      - uses: taiki-e/install-action@nextest
+
       - name: Rustfmt
         uses: actions-rs/cargo@v1
         with:
@@ -107,8 +109,8 @@ jobs:
       - name: Tests
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --workspace ${{ matrix.flags }}
+          command: nextest
+          args: run --all ${{ matrix.flags }}
 
   python-virtualenv:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,6 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
-      - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
       - name: Tests
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
# Description

3 changes to speed up CI some more:
- Use a more specific cache key, so the `default` and `all` runs aren't sharing a cache
- Split tests out into their own jobs. This allows for better parallelization (GitHub gives us up to 20 workers at once, might as well use them) and I think better caching too
- Use [`cargo nextest`](https://nexte.st/) to make running the tests faster