### PR TITLE
allows for nushell to have tables without the index column

### DIFF
--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub menus: Vec<ParsedMenu>,
     pub rm_always_trash: bool,
     pub shell_integration: bool,
+    pub disable_table_indexes: bool,
 }
 
 impl Default for Config {
@@ -73,6 +74,7 @@ impl Default for Config {
             menus: Vec::new(),
             rm_always_trash: false,
             shell_integration: false,
+            disable_table_indexes: false,
         }
     }
 }
@@ -254,7 +256,13 @@ impl Value {
                             eprintln!("$config.shell_integration is not a bool")
                         }
                     }
-
+                    "disable_table_indexes" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.disable_table_indexes = b;
+                        } else {
+                            eprintln!("$config.disable_table_indexes is not a bool")
+                        }
+                    }
                     x => {
                         eprintln!("$config.{} is an unknown config setting", x)
                     }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -196,6 +196,7 @@ let-env config = {
   max_history_size: 10000 # Session has to be reloaded for this to take effect
   sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
+  disable_table_indexes: false # set to true to remove the index column from tables
   menus: [
       # Configuration for default nushell menus
       # Note the lack of souce parameter


### PR DESCRIPTION
# Description

This PR allows you to have tables without indexes if the `disable_table_indexes` is set to true

<img width="682" alt="Screen Shot 2022-04-30 at 8 49 56 AM" src="https://user-images.githubusercontent.com/343840/166108219-380bcaeb-8266-4a71-8ba6-0ec30d7a6c18.png">

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
