### PR TITLE
Line buffer editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.4.0"
-source = "git+https://github.com/nushell/reedline?branch=main#2e2bdc54621643e7bee5ba2e2d9bf28e757074e0"
+source = "git+https://github.com/nushell/reedline?branch=main#39c70136bb95b50104a57767fbfdde50d7654421"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -160,7 +160,7 @@ pub fn evaluate_repl(
                 Reedline::create()
             }
         };
-        
+
         line_editor = line_editor.with_buffer_editor(config.buffer_editor.clone(), "nu".into());
 
         if config.sync_history_on_enter {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -160,6 +160,8 @@ pub fn evaluate_repl(
                 Reedline::create()
             }
         };
+        
+        line_editor = line_editor.with_buffer_editor(config.buffer_editor.clone(), "nu".into());
 
         if config.sync_history_on_enter {
             if is_perf_true {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub menus: Vec<ParsedMenu>,
     pub rm_always_trash: bool,
     pub shell_integration: bool,
+    pub buffer_editor: String,
 }
 
 impl Default for Config {
@@ -73,6 +74,7 @@ impl Default for Config {
             menus: Vec::new(),
             rm_always_trash: false,
             shell_integration: false,
+            buffer_editor: String::new(),
         }
     }
 }
@@ -252,6 +254,13 @@ impl Value {
                             config.shell_integration = b;
                         } else {
                             eprintln!("$config.shell_integration is not a bool")
+                        }
+                    }
+                    "buffer_editor" => {
+                        if let Ok(v) = value.as_string() {
+                            config.buffer_editor = v.to_lowercase();
+                        } else {
+                            eprintln!("$config.buffer_editor is not a string")
                         }
                     }
 

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -190,6 +190,7 @@ let-env config = {
   completion_algorithm: "prefix"  # prefix, fuzzy
   animate_prompt: false # redraw the prompt every second
   float_precision: 2
+  buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctr+e
   use_ansi_coloring: true
   filesize_format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
   edit_mode: emacs # emacs, vi


### PR DESCRIPTION
# Description

Introduces a new keybinding (ctr+e) that opens an editor to modify the current line buffer. The default line editor in the config file is `emacs`. It should be changed in the user's config file

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
