### PR TITLE
Fix quoting for command line args

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -1,7 +1,7 @@
 use crate::CliError;
 use log::trace;
 use nu_engine::eval_block;
-use nu_parser::{lex, parse, unescape_unquote_string, Token, TokenContents};
+use nu_parser::{escape_quote_string, lex, parse, unescape_unquote_string, Token, TokenContents};
 use nu_protocol::engine::StateWorkingSet;
 use nu_protocol::{
     engine::{EngineState, Stack},
@@ -36,20 +36,9 @@ fn gather_env_vars(vars: impl Iterator<Item = (String, String)>, engine_state: &
     }
 
     fn put_env_to_fake_file(name: &str, val: &str, fake_env_file: &mut String) {
-        fn push_string_literal(s: &str, fake_env_file: &mut String) {
-            fake_env_file.push('"');
-            for c in s.chars() {
-                if c == '\\' || c == '"' {
-                    fake_env_file.push('\\');
-                }
-                fake_env_file.push(c);
-            }
-            fake_env_file.push('"');
-        }
-
-        push_string_literal(name, fake_env_file);
+        fake_env_file.push_str(&escape_quote_string(name));
         fake_env_file.push('=');
-        push_string_literal(val, fake_env_file);
+        fake_env_file.push_str(&escape_quote_string(val));
         fake_env_file.push('\n');
     }
 

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -1,5 +1,6 @@
 use core::fmt::Write;
 use nu_engine::get_columns;
+use nu_parser::escape_quote_string;
 use nu_protocol::ast::{Call, RangeInclusion};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -137,13 +138,8 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
             }
             Ok(format!("{{{}}}", collection.join(", ")))
         }
-        Value::String { val, .. } => Ok(format!("\"{}\"", escape(val))),
+        Value::String { val, .. } => Ok(escape_quote_string(val)),
     }
-}
-
-fn escape(input: &str) -> String {
-    let output = input.replace('\\', "\\\\");
-    output.replace('"', "\\\"")
 }
 
 fn to_nuon(call: &Call, input: PipelineData) -> Result<String, ShellError> {

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,0 +1,14 @@
+pub fn escape_quote_string(input: &str) -> String {
+    let mut output = String::with_capacity(input.len() + 2);
+    output.push('"');
+
+    for c in input.chars() {
+        if c == '"' || c == '\\' {
+            output.push('\\');
+        }
+        output.push(c);
+    }
+
+    output.push('"');
+    output
+}

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -1,3 +1,4 @@
+mod deparse;
 mod errors;
 mod flatten;
 mod known_external;
@@ -7,6 +8,7 @@ mod parse_keywords;
 mod parser;
 mod type_check;
 
+pub use deparse::escape_quote_string;
 pub use errors::ParseError;
 pub use flatten::{flatten_block, flatten_expression, flatten_pipeline, FlatShape};
 pub use known_external::KnownExternal;

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,9 +86,12 @@ fn main() -> Result<()> {
         } else if arg.starts_with('-') {
             // Cool, it's a flag
             let flag_value = match arg.as_ref() {
-                "--commands" | "-c" | "--config" | "--env-config" => {
-                    args.next().map(|a| escape_quote_string(&a))
+                "--commands" | "-c" => {
+                    // FIXME: Use proper quoting. `escape_quote_string()` can't be used for now due to https://github.com/nushell/nushell/issues/5383.
+
+                    args.next().map(|a| format!("`{}`", a))
                 }
+                "--config" | "--env-config" => args.next().map(|a| escape_quote_string(&a)),
                 "--log-level" | "--testbin" | "--threads" | "-t" => args.next(),
                 _ => None,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use nu_cli::{
 };
 use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
-use nu_parser::parse;
+use nu_parser::{escape_quote_string, parse};
 use nu_protocol::{
     ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},
@@ -79,36 +79,25 @@ fn main() -> Result<()> {
     // Would be nice if we had a way to parse this. The first flags we see will be going to nushell
     // then it'll be the script name
     // then the args to the script
-    let mut collect_arg_nushell = false;
-    for arg in std::env::args().skip(1) {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
         if !script_name.is_empty() {
-            args_to_script.push(if arg.contains(' ') {
-                format!("`{}`", arg)
-            } else {
-                arg
-            });
-        } else if collect_arg_nushell {
-            args_to_nushell.push(if arg.contains(' ') {
-                format!("`{}`", arg)
-            } else {
-                arg
-            });
-            collect_arg_nushell = false;
+            args_to_script.push(escape_quote_string(&arg));
         } else if arg.starts_with('-') {
             // Cool, it's a flag
-            if arg == "-c"
-                || arg == "--commands"
-                || arg == "--testbin"
-                || arg == "--log-level"
-                || arg == "--config"
-                || arg == "--env-config"
-                || arg == "--threads"
-                || arg == "-t"
-            {
-                collect_arg_nushell = true;
-            }
+            let flag_value = match arg.as_ref() {
+                "--commands" | "-c" | "--config" | "--env-config" => {
+                    args.next().map(|a| escape_quote_string(&a))
+                }
+                "--log-level" | "--testbin" | "--threads" | "-t" => args.next(),
+                _ => None,
+            };
 
             args_to_nushell.push(arg);
+
+            if let Some(flag_value) = flag_value {
+                args_to_nushell.push(flag_value);
+            }
         } else {
             // Our script file
             script_name = arg;


### PR DESCRIPTION
# Description

Fixes https://github.com/nushell/nushell/issues/5370
Fixes https://github.com/nushell/nushell/issues/5371

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
