### PR TITLE
nu-cli/completions: complete external args as filepath

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -175,7 +175,9 @@ impl NuCompleter {
                                     pos,
                                 );
                             }
-                            FlatShape::Filepath | FlatShape::GlobPattern => {
+                            FlatShape::Filepath
+                            | FlatShape::GlobPattern
+                            | FlatShape::ExternalArg => {
                                 let mut completer = FileCompletion::new(self.engine_state.clone());
 
                                 return self.process_completion(


### PR DESCRIPTION
# Description

Handles `ExternalArgs` as Filepath completions. Fixes https://github.com/nushell/nushell/issues/5367

[![asciicast](https://asciinema.org/a/Xeuj4XWLmCQUDn4rTKvtg4hE7.svg)](https://asciinema.org/a/Xeuj4XWLmCQUDn4rTKvtg4hE7)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
