### PR TITLE
Make if else more lazy

### DIFF
--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -1,9 +1,8 @@
-use nu_engine::{eval_block, eval_expression, CallExt};
+use nu_engine::{eval_block, eval_expression, eval_expression_with_input, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, FromValue, IntoPipelineData, PipelineData, ShellError, Signature,
-    SyntaxShape, Value,
+    Category, Example, FromValue, PipelineData, ShellError, Signature, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -85,12 +84,24 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
                                 call.redirect_stderr,
                             )
                         } else {
-                            eval_expression(engine_state, stack, else_expr)
-                                .map(|x| x.into_pipeline_data())
+                            eval_expression_with_input(
+                                engine_state,
+                                stack,
+                                else_expr,
+                                input,
+                                call.redirect_stdout,
+                                call.redirect_stderr,
+                            )
                         }
                     } else {
-                        eval_expression(engine_state, stack, else_case)
-                            .map(|x| x.into_pipeline_data())
+                        eval_expression_with_input(
+                            engine_state,
+                            stack,
+                            else_case,
+                            input,
+                            call.redirect_stdout,
+                            call.redirect_stderr,
+                        )
                     }
                 } else {
                     Ok(PipelineData::new(call.head))

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -44,6 +44,14 @@ fn in_variable_6() -> TestResult {
 }
 
 #[test]
+fn in_and_if_else() -> TestResult {
+    run_test(
+        r#"[1, 2, 3] | if false {} else if true { $in | length }"#,
+        "3",
+    )
+}
+
+#[test]
 fn help_works_with_missing_requirements() -> TestResult {
     run_test(r#"each --help | lines | length"#, "29")
 }


### PR DESCRIPTION
# Description

This makes the `else` part of `if` evaluate more lazily (aka more "pipeline"-like and less "eager expression"-like)

This should help with a few subtle bugs:

* `if else` not getting to see the input
* `if else` forcing a command to finish before you can see the output (which may help #5363)

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
