### PR TITLE
Remove "./" prefix for file path completions

### DIFF
--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -128,7 +128,11 @@ pub fn file_path_completion(
                 entry.ok().and_then(|entry| {
                     let mut file_name = entry.file_name().to_string_lossy().into_owned();
                     if matches(&partial, &file_name, match_algorithm) {
-                        let mut path = format!("{}{}", base_dir_name, file_name);
+                        let mut path = if is_current_dir(&base_dir_name) {
+                            file_name.to_string()
+                        } else {
+                            format!("{}{}", base_dir_name, file_name)
+                        };
                         if entry.path().is_dir() {
                             path.push(SEP);
                             file_name.push(SEP);
@@ -157,4 +161,8 @@ pub fn file_path_completion(
 
 pub fn matches(partial: &str, from: &str, match_algorithm: MatchAlgorithm) -> bool {
     match_algorithm.matches_str(&from.to_ascii_lowercase(), &partial.to_ascii_lowercase())
+}
+
+fn is_current_dir(base_dir: &str) -> bool {
+    base_dir == format!(".{}", SEP)
 }


### PR DESCRIPTION
# Description

Removes automatic prefix insertion of `./` (or `.\` on Windows) for local paths. There are two reasons for it:

1) Preparation for fuzzy matching
There is currently a problem with fuzzy matching (see https://github.com/nushell/nushell/pull/5320#issuecomment-1110255908). To fix this another PR will be created for reedline which only extends the entered input with suggestions. Because file completions currently always prepend `./` the partial completion won't complete anything as long as `./` is not entered manually. This problem does not happen when the `./` prefix is not automatically inserted.

2) History completion remembers `./`. When navigating around the file system I often change into the same directories. Usually entering `cd c` already suggests the folder path I want to switch into. When prefixing the path path with `./` the history completion remembers `cd ./code/long/path/to/project` instead of `cd code/long/path/to/project`. This means that I have to enter `cd ./c` to get the same behaviour.