### PR TITLE
Error printing changes for `watch`

### DIFF
--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -1,7 +1,6 @@
 mod commands;
 mod completions;
 mod config_files;
-mod errors;
 mod eval_file;
 mod menus;
 mod nu_highlight;
@@ -17,7 +16,6 @@ mod validation;
 pub use commands::evaluate_commands;
 pub use completions::{FileCompletion, NuCompleter};
 pub use config_files::eval_config_contents;
-pub use errors::CliError;
 pub use eval_file::evaluate_file;
 pub use menus::{DescriptionMenu, NuHelpCompleter};
 pub use nu_highlight::NuHighlight;

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -1,8 +1,8 @@
-use crate::CliError;
 use log::trace;
 use nu_engine::eval_block;
 use nu_parser::{lex, parse, unescape_unquote_string, Token, TokenContents};
 use nu_protocol::engine::StateWorkingSet;
+use nu_protocol::CliError;
 use nu_protocol::{
     engine::{EngineState, Stack},
     PipelineData, ShellError, Span, Value,

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -6,10 +6,10 @@ use std::time::Duration;
 use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 use nu_engine::{current_dir, eval_block, CallExt};
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
+use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
-    Value,
+    format_error, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature,
+    Spanned, SyntaxShape, Value,
 };
 
 // durations chosen mostly arbitrarily
@@ -219,9 +219,8 @@ impl Command for Watch {
                             val.print(engine_state, stack)?;
                         }
                         Err(err) => {
-                            // TODO: this isn't as nice as the Miette errors. Find a way to print those.
-                            // Unfortunately can't just wrap err in PipelineData, PipelineData.print() doesn't work that way
-                            eprintln!("{err:?}");
+                            let working_set = StateWorkingSet::new(engine_state);
+                            eprintln!("{}", format_error(&working_set, &err));
                         }
                     }
                 }

--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -1,5 +1,5 @@
+use crate::engine::StateWorkingSet;
 use miette::{LabeledSpan, MietteHandler, ReportHandler, Severity, SourceCode};
-use nu_protocol::engine::StateWorkingSet;
 use thiserror::Error;
 
 /// This error exists so that we can defer SourceCode handling. It simply
@@ -10,6 +10,13 @@ pub struct CliError<'src>(
     pub &'src (dyn miette::Diagnostic + Send + Sync + 'static),
     pub &'src StateWorkingSet<'src>,
 );
+
+pub fn format_error(
+    working_set: &StateWorkingSet,
+    error: &(dyn miette::Diagnostic + Send + Sync + 'static),
+) -> String {
+    return format!("Error: {:?}", CliError(error, working_set));
+}
 
 impl std::fmt::Debug for CliError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ast;
+mod cli_error;
 mod config;
 pub mod engine;
 mod example;
@@ -14,6 +15,7 @@ mod ty;
 mod value;
 mod variable;
 
+pub use cli_error::*;
 pub use config::*;
 pub use engine::{ENV_VARIABLE_ID, IN_VARIABLE_ID, NU_VARIABLE_ID};
 pub use example::*;

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -455,11 +455,6 @@ impl PipelineData {
 
                 for item in table {
                     let stdout = std::io::stdout();
-
-                    if let Value::Error { error } = item {
-                        return Err(error);
-                    }
-
                     let mut out = item.into_string("\n", config);
                     out.push('\n');
 
@@ -472,11 +467,6 @@ impl PipelineData {
             None => {
                 for item in self {
                     let stdout = std::io::stdout();
-
-                    if let Value::Error { error } = item {
-                        return Err(error);
-                    }
-
                     let mut out = item.into_string("\n", config);
                     out.push('\n');
 


### PR DESCRIPTION
This PR makes a few changes in the area of error printing, motivated by some needs in the `watch` command:

### Change code that prints `PipelineData` to print error values instead of failing

The `watch` command runs a block and gets a `PipelineData` that it needs to print. `PipelineData` contains values, and one possible value type is `Value::Error`. But the usual code for printing `PipelineData` can't print a `Value::Error`; when it sees one it gives up and returns an error! 

This behavior doesn't work for `watch`, which needs to print whatever it gets - even errors. I also think it's unusual behavior; I think that _returning_ an error should be reserved for situations where the data could not be printed. I've changed some printing code accordingly.

### Move some Miette error printing code from `nu-cli` to `nu-protocol`

I ran into a practical issue with the above change: to print errors nicely with Miette, Nu code uses `CliError` - and that lives in `nu-cli`. It's not the first time I've run into this issue; there's another place where `watch` wants to print an error with nice Miette formatting, but can't because `nu-command` knows nothing about the `nu-cli` crate.

`CliError` doesn't actually use anything CLI-specific, so I moved it to `nu-protocol` where it can be used from more code. The `CliError` name now feels a little out of place; I'm open to other suggestions.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
