### PR TITLE
a little database cleanup

### DIFF
--- a/crates/nu-command/src/database/mod.rs
+++ b/crates/nu-command/src/database/mod.rs
@@ -6,8 +6,8 @@ pub use commands::add_commands_decls;
 pub use expressions::add_expression_decls;
 use nu_protocol::engine::StateWorkingSet;
 pub use values::{
-    convert_sqlite_row_to_nu_value, convert_sqlite_value_to_nu_value, open_and_read_sqlite_db,
-    open_connection_in_memory, read_sqlite_db, SQLiteDatabase,
+    convert_sqlite_row_to_nu_value, convert_sqlite_value_to_nu_value, open_connection_in_memory,
+    SQLiteDatabase,
 };
 
 pub fn add_database_decls(working_set: &mut StateWorkingSet) {

--- a/crates/nu-command/src/database/values/mod.rs
+++ b/crates/nu-command/src/database/values/mod.rs
@@ -3,6 +3,6 @@ pub mod dsl;
 pub mod sqlite;
 
 pub use sqlite::{
-    convert_sqlite_row_to_nu_value, convert_sqlite_value_to_nu_value, open_and_read_sqlite_db,
-    open_connection_in_memory, read_sqlite_db, SQLiteDatabase,
+    convert_sqlite_row_to_nu_value, convert_sqlite_value_to_nu_value, open_connection_in_memory,
+    SQLiteDatabase,
 };


### PR DESCRIPTION
# Description

Remove some duplicate functions. Move cleanup is needed to homogenize the database api.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
