### PR TITLE
CI: build virtualenv tests in dev profile for speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --path=. --no-default-features
+          args: --path=. --no-default-features --debug
 
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
# Description

The virtualenv tests run `cargo install`, which defaults to release builds. We can shave a few minutes off many CI runs just by opting in to dev/debug builds.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
