### PR TITLE
Move uses of trim_quotes to unescape for filenames

### DIFF
--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -8,7 +8,7 @@ fn copies_a_file() {
     Playground::setup("cp_test_1", |dirs, _| {
         nu!(
             cwd: dirs.root(),
-            "cp \"{}\" cp_test_1/sample.ini",
+            "cp `{}` cp_test_1/sample.ini",
             dirs.formats().join("sample.ini")
         );
 
@@ -171,13 +171,13 @@ fn copies_same_file_twice() {
     Playground::setup("cp_test_8", |dirs, _| {
         nu!(
             cwd: dirs.root(),
-            "cp \"{}\" cp_test_8/sample.ini",
+            "cp `{}` cp_test_8/sample.ini",
             dirs.formats().join("sample.ini")
         );
 
         nu!(
             cwd: dirs.root(),
-            "cp \"{}\" cp_test_8/sample.ini",
+            "cp `{}` cp_test_8/sample.ini",
             dirs.formats().join("sample.ini")
         );
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -23,7 +23,7 @@ use crate::{
         parse_internal_call, parse_multispan_value, parse_signature, parse_string,
         parse_var_with_opt_type, trim_quotes,
     },
-    ParseError,
+    unescape_unquote_string, ParseError,
 };
 
 pub fn parse_def_predecl(
@@ -1312,9 +1312,10 @@ pub fn parse_use(
         } else {
             // TODO: Do not close over when loading module from file
             // It could be a file
-            if let Ok(module_filename) =
-                String::from_utf8(trim_quotes(&import_pattern.head.name).to_vec())
-            {
+
+            let (module_filename, err) =
+                unescape_unquote_string(&import_pattern.head.name, import_pattern.head.span);
+            if err.is_none() {
                 if let Some(module_path) =
                     find_in_dirs(&module_filename, working_set, &cwd, LIB_DIRS_ENV)
                 {
@@ -1816,8 +1817,8 @@ pub fn parse_source(
             // Command and one file name
             if spans.len() >= 2 {
                 let name_expr = working_set.get_span_contents(spans[1]);
-                let name_expr = trim_quotes(name_expr);
-                if let Ok(filename) = String::from_utf8(name_expr.to_vec()) {
+                let (filename, err) = unescape_unquote_string(name_expr, spans[1]);
+                if err.is_none() {
                     if let Some(path) = find_in_dirs(&filename, working_set, &cwd, LIB_DIRS_ENV) {
                         if let Ok(contents) = std::fs::read(&path) {
                             // This will load the defs from the file into the
@@ -1967,26 +1968,27 @@ pub fn parse_register(
         .map(|expr| {
             let name_expr = working_set.get_span_contents(expr.span);
 
-            let name_expr = trim_quotes(name_expr);
-            String::from_utf8(name_expr.to_vec())
-                .map_err(|_| ParseError::NonUtf8(expr.span))
-                .and_then(|name| {
-                    if let Some(p) = find_in_dirs(&name, working_set, &cwd, PLUGIN_DIRS_ENV) {
-                        Ok(p)
-                    } else {
-                        Err(ParseError::RegisteredFileNotFound(name, expr.span))
-                    }
-                })
-                .and_then(|path| {
-                    if path.exists() & path.is_file() {
-                        Ok(path)
-                    } else {
-                        Err(ParseError::RegisteredFileNotFound(
-                            format!("{:?}", path),
-                            expr.span,
-                        ))
-                    }
-                })
+            let (name, err) = unescape_unquote_string(name_expr, expr.span);
+
+            if let Some(err) = err {
+                Err(err)
+            } else {
+                let path = if let Some(p) = find_in_dirs(&name, working_set, &cwd, PLUGIN_DIRS_ENV)
+                {
+                    p
+                } else {
+                    return Err(ParseError::RegisteredFileNotFound(name, expr.span));
+                };
+
+                if path.exists() & path.is_file() {
+                    Ok(path)
+                } else {
+                    Err(ParseError::RegisteredFileNotFound(
+                        format!("{:?}", path),
+                        expr.span,
+                    ))
+                }
+            }
         })
         .expect("required positional has being checked")
         .and_then(|path| {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1928,10 +1928,10 @@ pub fn parse_directory(
     span: Span,
 ) -> (Expression, Option<ParseError>) {
     let bytes = working_set.get_span_contents(span);
-    let bytes = trim_quotes(bytes);
+    let (token, err) = unescape_unquote_string(bytes, span);
     trace!("parsing: directory");
 
-    if let Ok(token) = String::from_utf8(bytes.into()) {
+    if err.is_none() {
         trace!("-- found {}", token);
         (
             Expression {
@@ -1955,10 +1955,10 @@ pub fn parse_filepath(
     span: Span,
 ) -> (Expression, Option<ParseError>) {
     let bytes = working_set.get_span_contents(span);
-    let bytes = trim_quotes(bytes);
+    let (token, err) = unescape_unquote_string(bytes, span);
     trace!("parsing: filepath");
 
-    if let Ok(token) = String::from_utf8(bytes.into()) {
+    if err.is_none() {
         trace!("-- found {}", token);
         (
             Expression {
@@ -2267,12 +2267,11 @@ pub fn parse_glob_pattern(
     working_set: &mut StateWorkingSet,
     span: Span,
 ) -> (Expression, Option<ParseError>) {
+    let bytes = working_set.get_span_contents(span);
+    let (token, err) = unescape_unquote_string(bytes, span);
     trace!("parsing: glob pattern");
 
-    let bytes = working_set.get_span_contents(span);
-    let bytes = trim_quotes(bytes);
-
-    if let Ok(token) = String::from_utf8(bytes.into()) {
+    if err.is_none() {
         trace!("-- found {}", token);
         (
             Expression {


### PR DESCRIPTION
# Description

This tries to use unescaping wherever we're reading in a filename from the user. This should hopefully fix some of the jankiness around escaping we're seeing on Windows.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
