### PR TITLE
Add unescaping to external command parsing

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -264,8 +264,11 @@ pub fn parse_external_call(
         error = error.or(err);
         Box::new(arg)
     } else {
+        let (contents, err) = unescape_unquote_string(&head_contents, head_span);
+        error = error.or(err);
+
         Box::new(Expression {
-            expr: Expr::String(String::from_utf8_lossy(&head_contents).to_string()),
+            expr: Expr::String(contents),
             span: head_span,
             ty: Type::String,
             custom_completion: None,
@@ -285,8 +288,11 @@ pub fn parse_external_call(
             error = error.or(err);
             args.push(arg);
         } else {
+            let (contents, err) = unescape_unquote_string(contents, *span);
+            error = error.or(err);
+
             args.push(Expression {
-                expr: Expr::String(String::from_utf8_lossy(contents).to_string()),
+                expr: Expr::String(contents),
                 span: *span,
                 ty: Type::String,
                 custom_completion: None,


### PR DESCRIPTION
# Description

This adds unescaping logic to both the external command and external arguments.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
