### PR TITLE
Add Miette "fancy" feature to fix plugin builds

### DIFF
--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.61.1"
 
 [dependencies]
 thiserror = "1.0.29"
-miette = "4.5.0"
+miette = { version = "4.5.0", features = ["fancy"] }
 serde = {version = "1.0.130", features = ["derive"]}
 chrono = { version="0.4.19", features=["serde"] }
 indexmap = { version="1.7", features=["serde-1"] }


### PR DESCRIPTION
# Description

This PR is a short-term fix for a bug introduced in https://github.com/nushell/nushell/pull/5389 (my bad); after that change plugin builds were failing. Once the dust has settled, I'll think about longer term improvements:

- Have we ended up with the right solution for error printing? I'm not sure we have; maybe we'll end up moving this functionality to a crate other than `nu-protocol`
- We need to test plugin builds in CI, this should have been caught in CI

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
