### PR TITLE
More escaping/unescaping fixes

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -2,7 +2,7 @@ use crate::util::report_error;
 use log::info;
 use miette::Result;
 use nu_engine::{convert_env_values, eval_block};
-use nu_parser::{parse, trim_quotes};
+use nu_parser::parse;
 use nu_protocol::engine::Stack;
 use nu_protocol::{
     engine::{EngineState, StateDelta, StateWorkingSet},
@@ -22,19 +22,7 @@ pub fn evaluate_commands(
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        let (input, _) = if commands.item.starts_with('\'')
-            || commands.item.starts_with('"')
-            || commands.item.starts_with('`')
-        {
-            (
-                trim_quotes(commands.item.as_bytes()),
-                commands.span.start + 1,
-            )
-        } else {
-            (commands.item.as_bytes(), commands.span.start)
-        };
-
-        let (output, err) = parse(&mut working_set, None, input, false, &[]);
+        let (output, err) = parse(&mut working_set, None, commands.item.as_bytes(), false, &[]);
         if let Some(err) = err {
             report_error(&working_set, &err);
 

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -21,6 +21,21 @@ macro_rules! nu {
         pub use std::process::{Command, Stdio};
         pub use $crate::NATIVE_PATH_ENV_VAR;
 
+        pub fn escape_quote_string(input: String) -> String {
+            let mut output = String::with_capacity(input.len() + 2);
+            output.push('"');
+
+            for c in input.chars() {
+                if c == '"' || c == '\\' {
+                    output.push('\\');
+                }
+                output.push(c);
+            }
+
+            output.push('"');
+            output
+        }
+
         // let commands = &*format!(
         //     "
         //                     {}
@@ -58,7 +73,7 @@ macro_rules! nu {
             // .arg("--no-history")
             // .arg("--config-file")
             // .arg($crate::fs::DisplayPath::display_path(&$crate::fs::fixtures().join("playground/config/default.toml")))
-            .arg(format!("-c '{}'", $crate::fs::DisplayPath::display_path(&path)))
+            .arg(format!("-c {}", escape_quote_string($crate::fs::DisplayPath::display_path(&path))))
             .stdout(Stdio::piped())
             // .stdin(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
# Description

Found a few more places where the escaping needs to happen and where we were throwing away work from the parser that did unescaping

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
