### PR TITLE
Bump reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.4.0"
-source = "git+https://github.com/nushell/reedline?branch=main#23cbd8a74b889e2aa483128c82ce335b102816eb"
+source = "git+https://github.com/nushell/reedline?branch=main#2947a94fefac63e8fba2076327bae373f8d09b9d"
 dependencies = [
  "chrono",
  "crossterm",


### PR DESCRIPTION
# Changes since the last reedline pull

- Fix to the `ClearScrollback` command
- Fix of vi mode `x` so it adds the character to the clipboard
- Vi mode shorthands `s` and `S`

