### PR TITLE
event ClearScrollback is working in reedline / update config.nu

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -383,5 +383,12 @@ let-env config = {
       mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: commands_with_description }
     }
+    {
+      name: clear_backbuffer
+      modifier: control
+      keycode: char_l
+      mode: emacs
+      event: { send: ClearScrollback }
+    }
   ]
 }


### PR DESCRIPTION
@sholderbach fixed the ClearScrollback issue in reedline...

https://github.com/nushell/reedline/pull/416

https://github.com/nushell/reedline/issues/120

update config.nu with @fdncred config fix...

I set the mode to this

```rust
      mode: emacs
```

Or should it be this

```rust
      mode: [emacs, vi_normal, vi_insert]
```