### PR TITLE
CI: Add job to build plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,3 +155,50 @@ jobs:
       - name: Test Nushell in virtualenv
         run: cd virtualenv && tox -e ${{ matrix.py }} -- -k nushell
         shell: bash
+
+  plugins:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+        rust:
+          - stable
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      # This job does not use rust-cache because 1) we have limited cache space, 2) even 
+      # without caching, it's not the slowest job. Revisit if those facts change.
+
+      - name: Build nu_plugin_example
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_example
+
+      - name: Build nu_plugin_gstat
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_gstat
+
+      - name: Build nu_plugin_inc
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_inc
+
+      - name: Build nu_plugin_query
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_query


### PR DESCRIPTION
# Description

Add a job that builds every plugin on all 3 platforms (we weren't building plugins in CI before). Conveniently, we don't need to use any of our cache space for this; ~building the plugins from scratch is fast enough (7 min) that it doesn't slow down CI.~

Edit: of course, as soon as I say that the plugin build takes a bit longer than the other jobs. GitHub Actions performance is so inconsistent :sob:. I think this is probably still the best course of action; we can merge it and I'll experiment more with caching later if needed.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
