### PR TITLE
Fixed ctrl-c in recursion loop bug #5362

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -29,6 +29,11 @@ pub fn eval_call(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
+    if let Some(ctrlc) = &engine_state.ctrlc {
+        if ctrlc.load(core::sync::atomic::Ordering::SeqCst) {
+            return Ok(Value::Nothing { span: call.head }.into_pipeline_data());
+        }
+    }
     let decl = engine_state.get_decl(call.decl_id);
 
     if !decl.is_known_external() && call.named_iter().any(|(flag, _, _)| flag.item == "help") {


### PR DESCRIPTION
# Description

Fixed ctrl-c in recursion loop bug #5362

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
