### PR TITLE
remove ctrl-l from config.nu as a way to clear scrollback

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -383,12 +383,5 @@ let-env config = {
       mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: commands_with_description }
     }
-    {
-      name: clear_backbuffer
-      modifier: control
-      keycode: char_l
-      mode: emacs
-      event: { send: ClearScrollback }
-    }
   ]
 }


### PR DESCRIPTION
We will search for another way to get the job done

on the default mac terminal
of simulating what the CMD-K key sequence does which is
to clear the screen and the scroll back buffer...

The solution I put in there is not ideal...

Because it breaks the default way of clearing the screen
without clearing the scroll back.
