### PR TITLE
Fix coloring when string has spaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,15 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi-cut"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe8d2994390ae20a3eb52a909f9518a89f8fd7e6990f3d25d38e51021b2c8ce"
-dependencies = [
- "ansi-parser",
-]
-
-[[package]]
 name = "ansi-parser"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +70,15 @@ checksum = "bcb2392079bf27198570d6af79ecbd9ec7d8f16d3ec6b60933922fdb66287127"
 dependencies = [
  "heapless 0.5.6",
  "nom 4.2.3",
+]
+
+[[package]]
+name = "ansi-str"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb0ceb8c444d026166795e474e9dfe54b443bdc07cc21bd6c5073f5e637482"
+dependencies = [
+ "ansi-parser",
 ]
 
 [[package]]
@@ -2678,7 +2678,7 @@ dependencies = [
 name = "nu-table"
 version = "0.61.1"
 dependencies = [
- "ansi-cut",
+ "ansi-str",
  "atty",
  "nu-ansi-term",
  "nu-protocol",

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -17,5 +17,5 @@ nu-protocol = { path = "../nu-protocol", version = "0.61.1" }
 regex = "1.4"
 unicode-width = "0.1.8"
 strip-ansi-escapes = "0.1.1"
-ansi-cut = "0.2.0"
+ansi-str = "0.1.1"
 atty = "0.2.14"

--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -92,9 +92,9 @@ fn strip_ansi(string: &str) -> Cow<str> {
 
 pub fn split_sublines(input: &str) -> Vec<Vec<Subline>> {
     input
-        .split_terminator('\n')
+        .ansi_split("\n")
         .map(|line| {
-            line.split_terminator(' ')
+            line.ansi_split(" ")
                 .map(|x| Subline {
                     subline: x.to_string(),
                     width: {
@@ -109,7 +109,7 @@ pub fn split_sublines(input: &str) -> Vec<Vec<Subline>> {
                         // let c = strip_ansi(x).chars().count();
                         // let u = special_width(x);
                         // std::cmp::max(c, u)
-                        let stripped = strip_ansi(x);
+                        let stripped = strip_ansi(&x);
 
                         let c = stripped.chars().count();
                         let u = stripped.width();

--- a/crates/nu-table/src/wrap.rs
+++ b/crates/nu-table/src/wrap.rs
@@ -1,5 +1,5 @@
 use crate::table::TextStyle;
-use ansi_cut::AnsiCut;
+use ansi_str::AnsiStr;
 use nu_ansi_term::Style;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -159,7 +159,7 @@ fn split_word(cell_width: usize, word: &str) -> Vec<Subline> {
             end_index = c.0;
             if current_width + width > cell_width {
                 output.push(Subline {
-                    subline: word.cut(start_index..end_index),
+                    subline: word.ansi_cut(start_index..end_index),
                     width: current_width,
                 });
 
@@ -173,7 +173,7 @@ fn split_word(cell_width: usize, word: &str) -> Vec<Subline> {
 
     if start_index != word_no_ansi.len() {
         output.push(Subline {
-            subline: word.cut(start_index..),
+            subline: word.ansi_cut(start_index..),
             width: current_width,
         });
     }


### PR DESCRIPTION
The issue is here https://github.com/nushell/nushell/blob/e36649f74b37ee183a2b2999b5b3ee4762cb921a/crates/nu-table/src/wrap.rs#L93

When you split the lines you split ansi sequences.

I'd like to note that apparently now we don't handle this trailing space?

By the way why you need `Subline`s exactly?

close #5412 
