### PR TITLE
added open editor event in config parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.4.0"
-source = "git+https://github.com/nushell/reedline?branch=main#29f30a8f7926ad5cded3be564b6c26679c10e1c5"
+source = "git+https://github.com/nushell/reedline?branch=main#33a91e53a25e7edcbdf93224497c1a1b55e74fae"
 dependencies = [
  "chrono",
  "crossterm",

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -837,6 +837,7 @@ fn event_from_record(
         "menuprevious" => ReedlineEvent::MenuPrevious,
         "menupagenext" => ReedlineEvent::MenuPageNext,
         "menupageprevious" => ReedlineEvent::MenuPagePrevious,
+        "openeditor" => ReedlineEvent::OpenEditor,
         "menu" => {
             let menu = extract_value("name", cols, vals, span)?;
             ReedlineEvent::Menu(menu.into_string("", config))


### PR DESCRIPTION
# Description

Adds open editor event in config parsing

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
