### PR TITLE
Pin reedline to v0.5.0 for the next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,8 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.4.0"
-source = "git+https://github.com/nushell/reedline?branch=main#29f30a8f7926ad5cded3be564b6c26679c10e1c5"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96c36021d0668f3b4f8c054fce3a9b9b0aa83fc60aa6c59df0e2165f9980763"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.61.1"  }
 openssl = { version = "0.10.38", features = ["vendored"], optional = true }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
-reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
+reedline = { version = "0.5.0", features = ["bashisms"]}
 is_executable = "1.0.1"
 
 [dev-dependencies]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -18,7 +18,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.61.1"  }
 nu-utils = { path = "../nu-utils", version = "0.61.1"  }
 nu-ansi-term = "0.45.1"
 nu-color-config = { path = "../nu-color-config", version = "0.61.1"  }
-reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
+reedline = { version = "0.5.0", features = ["bashisms"]}
 crossterm = "0.23.0"
 miette = { version = "4.5.0", features = ["fancy"] }
 thiserror = "1.0.29"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -79,7 +79,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
+reedline = { version = "0.5.0", features = ["bashisms"]}
 wax = { version =  "0.4.0", features = ["diagnostics"] }
 rusqlite = { version = "0.27.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.16.0", features = ["serde"], optional = true }


### PR DESCRIPTION
# Description

Release notes: https://github.com/nushell/reedline/releases/tag/v0.5.0

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
