### PR TITLE
Use correct ParseError

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1109,8 +1109,8 @@ pub fn parse_module_block(
                     }
                     _ => (
                         garbage_pipeline(&pipeline.commands[0].parts),
-                        Some(ParseError::UnexpectedKeyword(
-                            "expected def or export keyword".into(),
+                        Some(ParseError::ExpectedKeyword(
+                            "def or export keyword".into(),
                             pipeline.commands[0].parts[0],
                         )),
                     ),


### PR DESCRIPTION
# Description
Issue: [#5275](https://github.com/nushell/nushell/issues/5275)

Currently, the user receives a confusing error messages reading `unexpected expected def or export keyword`, when it should just read `expected def or export keyword`. This can be fixed by using `ParseError::ExpectedKeyword` and removing the word "expected" in the error message.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
