### PR TITLE
Allowed for view-source to include entire custom command definition

### DIFF
--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -3,7 +3,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
-    Value
+    Value,
 };
 
 #[derive(Clone)]
@@ -70,8 +70,7 @@ impl Command for ViewSource {
                             }
                             final_contents.push_str("] ");
                             final_contents.push_str(&String::from_utf8_lossy(contents));
-                            Ok(Value::string(final_contents, call.head)
-                                .into_pipeline_data())
+                            Ok(Value::string(final_contents, call.head).into_pipeline_data())
                         } else {
                             Err(ShellError::GenericError(
                                 "Cannot view value".to_string(),

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -47,7 +47,7 @@ impl Command for ViewSource {
                 }
             }
             Value::String { val, .. } => {
-                if let Some(decl_id) = engine_state.find_decl(&val.as_bytes()) {
+                if let Some(decl_id) = engine_state.find_decl(val.as_bytes()) {
                     // arg is a command
                     let decl = engine_state.get_decl(decl_id);
                     let sig = decl.signature();


### PR DESCRIPTION
# Description

As per #5373 , `view-source` previously did NOT show the parameters list. Now, it does.

```
/home/gabriel/CodingProjects/nushell〉view-source foo                                                                           05/04/2022 02:29:30 PM
def foo [ sth:string ] {echo $sth}
```
(Previously, the command would have returned something like `{echo $sth}`. I get the arguments from the struct and cobble them together to get the appropriate format.)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
