### PR TITLE
Adds flags and optional arguments to view-source

### DIFF
--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -52,6 +52,8 @@ impl Command for ViewSource {
                     let decl = engine_state.get_decl(decl_id);
                     let sig = decl.signature();
                     let vec_of_required = &sig.required_positional;
+                    let vec_of_optional = &sig.optional_positional;
+                    let vec_of_flags = &sig.named;
                     // gets vector of positionals.
                     if let Some(block_id) = decl.get_block_id() {
                         let block = engine_state.get_block(block_id);
@@ -66,6 +68,33 @@ impl Command for ViewSource {
                                 // name of positional arg
                                 final_contents.push(':');
                                 final_contents.push_str(&n.shape.to_string());
+                                final_contents.push(' ');
+                            }
+                            for n in vec_of_optional {
+                                if vec_of_required.contains(n) {
+                                    break;
+                                    // this check is necessary because optional returns mandatory
+                                    // args as well.
+                                }
+                                final_contents.push_str(&n.name);
+                                // name of positional arg
+                                final_contents.push_str("?:");
+                                final_contents.push_str(&n.shape.to_string());
+                                final_contents.push(' ');
+                            }
+                            for n in vec_of_flags {
+                                final_contents.push_str("--");
+                                final_contents.push_str(&n.long);
+                                final_contents.push(' ');
+                                if n.short.is_some() {
+                                    final_contents.push_str("(-");
+                                    final_contents.push(n.short.unwrap());
+                                    final_contents.push(')');
+                                }
+                                if n.arg.is_some() {
+                                    final_contents.push_str(": ");
+                                    final_contents.push_str(&n.arg.as_ref().unwrap().to_string());
+                                }
                                 final_contents.push(' ');
                             }
                             final_contents.push_str("] ");

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -71,11 +71,6 @@ impl Command for ViewSource {
                                 final_contents.push(' ');
                             }
                             for n in vec_of_optional {
-                                if vec_of_required.contains(n) {
-                                    break;
-                                    // this check is necessary because optional returns mandatory
-                                    // args as well.
-                                }
                                 final_contents.push_str(&n.name);
                                 // name of positional arg
                                 final_contents.push_str("?:");

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -88,7 +88,9 @@ impl Command for ViewSource {
                                 }
                                 if n.arg.is_some() {
                                     final_contents.push_str(": ");
-                                    final_contents.push_str(&n.arg.as_ref().expect("this cannot trigger.").to_string());
+                                    final_contents.push_str(
+                                        &n.arg.as_ref().expect("this cannot trigger.").to_string(),
+                                    );
                                 }
                                 final_contents.push(' ');
                             }

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -83,12 +83,12 @@ impl Command for ViewSource {
                                 final_contents.push(' ');
                                 if n.short.is_some() {
                                     final_contents.push_str("(-");
-                                    final_contents.push(n.short.unwrap());
+                                    final_contents.push(n.short.expect("this cannot trigger."));
                                     final_contents.push(')');
                                 }
                                 if n.arg.is_some() {
                                     final_contents.push_str(": ");
-                                    final_contents.push_str(&n.arg.as_ref().unwrap().to_string());
+                                    final_contents.push_str(&n.arg.as_ref().expect("this cannot trigger.").to_string());
                                 }
                                 final_contents.push(' ');
                             }


### PR DESCRIPTION
# Description

Title. Previously, view-source would only return mandatory arguments, and completely ignore flags and optional args. Now it takes both into account.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
