### PR TITLE
Fixing the flag issue

### DIFF
--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -11,9 +11,9 @@ fn looks_like_flag(input: &str) -> bool {
             // while it start with '-', it is not of the form '-x=y' or '-x y'
         } else {
             input.len() >= 2
-        } 
+        }
     } else {
-        input.len() > 2 
+        input.len() > 2
         // it is either a flag --x or a '--'
     }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,23 +1,22 @@
+fn parse_input(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for c in input.chars() {
+        if c == '"' || c == '\\' {
+            output.push('\\');
+        }
+        output.push(c);
+    }
+    output
+}
+
 pub fn escape_quote_string(input: &str) -> String {
     if input.starts_with('-') {
-        let mut output = String::new();
-        for c in input.chars() {
-            if c == '"' || c == '\\' {
-                output.push('\\');
-            }
-            output.push(c);
-        }
-        output
+        parse_input(input)
     } else {
         let mut output = String::with_capacity(input.len() + 2);
         output.push('"');
 
-        for c in input.chars() {
-            if c == '"' || c == '\\' {
-                output.push('\\');
-            }
-            output.push(c);
-        }
+        output.push_str(&parse_input(input));
 
         output.push('"');
         output

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,6 +1,13 @@
 pub fn escape_quote_string(input: &str) -> String {
     if input.starts_with('-') {
-        String::from(input)
+        let mut output = String::new();
+        for c in input.chars() {
+            if c == '"' || c == '\\' {
+                output.push('\\');
+            }
+            output.push(c);
+        }
+        output
     } else {
         let mut output = String::with_capacity(input.len() + 2);
         output.push('"');

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,24 +1,21 @@
-fn parse_input(input: &str) -> String {
+pub fn escape_quote_string(input: &str) -> String {
+    let mut output = String::with_capacity(input.len() + 2);
+    output.push('"');
     let mut output = String::with_capacity(input.len());
+    let is_flag = input.starts_with('-');
+    let mut flag_tripped = false;
     for c in input.chars() {
         if c == '"' || c == '\\' {
             output.push('\\');
         }
         output.push(c);
+        if (c == ' ' || c == '=') && is_flag && !flag_tripped {
+            output.push('"');
+            flag_tripped = true;
+        }
+    }
+    if is_flag {
+        output.push('"');
     }
     output
-}
-
-pub fn escape_quote_string(input: &str) -> String {
-    if input.starts_with('-') {
-        parse_input(input)
-    } else {
-        let mut output = String::with_capacity(input.len() + 2);
-        output.push('"');
-
-        output.push_str(&parse_input(input));
-
-        output.push('"');
-        output
-    }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,6 +1,21 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
+pub fn escape_quote_string(input: &str) -> String {
+    let mut output = String::with_capacity(input.len() + 2);
+    output.push('"');
+
+    for c in input.chars() {
+        if c == '"' || c == '\\' {
+            output.push('\\');
+        }
+        output.push(c);
+    }
+
+    output.push('"');
+    output
+}
+
 fn looks_like_flag(input: &str) -> bool {
     if !input.starts_with('-') {
         false
@@ -21,7 +36,7 @@ fn looks_like_flag(input: &str) -> bool {
     }
 }
 
-pub fn escape_quote_string(input: &str) -> String {
+fn escape_quote_string_new(input: &str) -> String {
     let mut output = String::new();
     if !looks_like_flag(input) {
         output.push('"');
@@ -37,6 +52,9 @@ pub fn escape_quote_string(input: &str) -> String {
         // this is a flag that requires delicate handling
         let mut flag_tripped = false;
         for c in input.chars() {
+            if c == '"' || c == '\\' {
+                output.push('\\');
+            }
             output.push(c);
             if (c == ' ' || c == '=') && !flag_tripped {
                 flag_tripped = true;
@@ -83,6 +101,6 @@ pub fn escape_quote_string_advanced(input: &str, file: &str) -> String {
             final_word.push('"');
             final_word
         }
-        _ => String::from(input),
+        _ => escape_quote_string_new(input),
     }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -17,5 +17,6 @@ pub fn escape_quote_string(input: &str) -> String {
     if is_flag {
         output.push('"');
     }
+    output.push('"');
     output
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
 fn looks_like_flag(input: &str) -> bool {
     if !input.starts_with('-') {
         false
@@ -45,5 +48,41 @@ pub fn escape_quote_string(input: &str) -> String {
     } else {
         // this is a normal flag, aka "--x"
         String::from(input)
+    }
+}
+
+pub fn escape_quote_string_advanced(input: &str, file: &str) -> String {
+    let file = File::open(file);
+    match file {
+        Ok(f) => {
+            let lines = BufReader::new(f).lines();
+            for line in lines {
+                let mut flag_start = false;
+                let mut word = String::new();
+                let line_or = line.unwrap_or(String::from(" "));
+                if line_or.contains('-') {
+                    for n in line_or.chars() {
+                        if n == '-' {
+                            flag_start = true;
+                        }
+                        if n == ' ' || n == ':' || n == ')' {
+                            flag_start = false;
+                        }
+                        if flag_start {
+                            word.push(n);
+                        }
+                    }
+                }
+                if &word == input {
+                    return word;              
+                }
+            }
+            let mut final_word = String::new();
+            final_word.push('"');
+            final_word.push_str(input);
+            final_word.push('"');
+            return final_word;
+        },
+        _ => return String::from(input), 
     }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -36,7 +36,9 @@ fn looks_like_flag(input: &str) -> bool {
     }
 }
 
-fn escape_quote_string_new(input: &str) -> String {
+fn escape_quote_string_when_flags_are_unclear(input: &str) -> String {
+    // internal use only. When reading the file for flags goes wrong, revert back to a manual check
+    // for flags.
     let mut output = String::new();
     if !looks_like_flag(input) {
         output.push('"');
@@ -69,7 +71,8 @@ fn escape_quote_string_new(input: &str) -> String {
     }
 }
 
-pub fn escape_quote_string_advanced(input: &str, file: &str) -> String {
+pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
+    // use when you want to cross-compare to a file to ensure flags are checked properly
     let file = File::open(file);
     match file {
         Ok(f) => {
@@ -101,6 +104,6 @@ pub fn escape_quote_string_advanced(input: &str, file: &str) -> String {
             final_word.push('"');
             final_word
         }
-        _ => escape_quote_string_new(input),
+        _ => escape_quote_string_when_flags_are_unclear(input),
     }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -59,7 +59,7 @@ pub fn escape_quote_string_advanced(input: &str, file: &str) -> String {
             for line in lines {
                 let mut flag_start = false;
                 let mut word = String::new();
-                let line_or = line.unwrap_or(String::from(" "));
+                let line_or = line.unwrap_or_else(|_| String::from(" "));
                 if line_or.contains('-') {
                     for n in line_or.chars() {
                         if n == '-' {
@@ -73,16 +73,16 @@ pub fn escape_quote_string_advanced(input: &str, file: &str) -> String {
                         }
                     }
                 }
-                if &word == input {
-                    return word;              
+                if word == input {
+                    return word;
                 }
             }
             let mut final_word = String::new();
             final_word.push('"');
             final_word.push_str(input);
             final_word.push('"');
-            return final_word;
-        },
-        _ => return String::from(input), 
+            final_word
+        }
+        _ => String::from(input),
     }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,22 +1,49 @@
+fn looks_like_flag(input: &str) -> bool {
+    if !input.starts_with('-') {
+        false
+        // it does not start with  '-'
+    } else if !input.starts_with("--") {
+        if input.len() > 2
+            && input.chars().nth(2).expect("this should never trigger") != '='
+            && input.chars().nth(2).expect("this should never trigger") != ' '
+        {
+            false
+            // while it start with '-', it is not of the form '-x=y' or '-x y'
+        } else {
+            input.len() >= 2
+        } 
+    } else {
+        input.len() > 2 
+        // it is either a flag --x or a '--'
+    }
+}
+
 pub fn escape_quote_string(input: &str) -> String {
-    let mut output = String::with_capacity(input.len() + 2);
-    output.push('"');
-    let mut output = String::with_capacity(input.len());
-    let is_flag = input.starts_with('-');
-    let mut flag_tripped = false;
-    for c in input.chars() {
-        if c == '"' || c == '\\' {
-            output.push('\\');
-        }
-        output.push(c);
-        if (c == ' ' || c == '=') && is_flag && !flag_tripped {
-            output.push('"');
-            flag_tripped = true;
-        }
-    }
-    if is_flag {
+    let mut output = String::new();
+    if !looks_like_flag(input) {
         output.push('"');
+        for c in input.chars() {
+            if c == '"' || c == '\\' {
+                output.push('\\');
+            }
+            output.push(c);
+        }
+        output.push('"');
+        output
+    } else if input.contains(' ') || input.contains('=') {
+        // this is a flag that requires delicate handling
+        let mut flag_tripped = false;
+        for c in input.chars() {
+            output.push(c);
+            if (c == ' ' || c == '=') && !flag_tripped {
+                flag_tripped = true;
+                output.push('"');
+            }
+        }
+        output.push('"');
+        output
+    } else {
+        // this is a normal flag, aka "--x"
+        String::from(input)
     }
-    output.push('"');
-    output
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,14 +1,18 @@
 pub fn escape_quote_string(input: &str) -> String {
-    let mut output = String::with_capacity(input.len() + 2);
-    output.push('"');
+    if input.starts_with('-') {
+        String::from(input)
+    } else {
+        let mut output = String::with_capacity(input.len() + 2);
+        output.push('"');
 
-    for c in input.chars() {
-        if c == '"' || c == '\\' {
-            output.push('\\');
+        for c in input.chars() {
+            if c == '"' || c == '\\' {
+                output.push('\\');
+            }
+            output.push(c);
         }
-        output.push(c);
-    }
 
-    output.push('"');
-    output
+        output.push('"');
+        output
+    }
 }

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -8,7 +8,7 @@ mod parse_keywords;
 mod parser;
 mod type_check;
 
-pub use deparse::{escape_quote_string, escape_quote_string_advanced};
+pub use deparse::{escape_quote_string, escape_quote_string_with_file};
 pub use errors::ParseError;
 pub use flatten::{flatten_block, flatten_expression, flatten_pipeline, FlatShape};
 pub use known_external::KnownExternal;

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -8,7 +8,7 @@ mod parse_keywords;
 mod parser;
 mod type_check;
 
-pub use deparse::escape_quote_string;
+pub use deparse::{escape_quote_string, escape_quote_string_advanced};
 pub use errors::ParseError;
 pub use flatten::{flatten_block, flatten_expression, flatten_pipeline, FlatShape};
 pub use known_external::KnownExternal;

--- a/script.nu
+++ b/script.nu
@@ -1,0 +1,4 @@
+def main [--foo: string, arg: string] {
+  echo $foo
+  echo $arg
+}

--- a/script.nu
+++ b/script.nu
@@ -1,4 +1,0 @@
-def main [--foo: string, arg: string] {
-  echo $foo
-  echo $arg
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use nu_cli::{
 };
 use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
-use nu_parser::{escape_quote_string, parse};
+use nu_parser::{escape_quote_string_advanced, escape_quote_string, parse};
 use nu_protocol::{
     ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},
@@ -82,7 +82,7 @@ fn main() -> Result<()> {
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         if !script_name.is_empty() {
-            args_to_script.push(escape_quote_string(&arg));
+            args_to_script.push(escape_quote_string_advanced(&arg, &script_name));
         } else if arg.starts_with('-') {
             // Cool, it's a flag
             let flag_value = match arg.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use nu_cli::{
 };
 use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
-use nu_parser::{escape_quote_string_advanced, escape_quote_string, parse};
+use nu_parser::{escape_quote_string, escape_quote_string_advanced, parse};
 use nu_protocol::{
     ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use nu_cli::{
 };
 use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
-use nu_parser::{escape_quote_string, escape_quote_string_advanced, parse};
+use nu_parser::{escape_quote_string, escape_quote_string_with_file, parse};
 use nu_protocol::{
     ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},
@@ -82,7 +82,7 @@ fn main() -> Result<()> {
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         if !script_name.is_empty() {
-            args_to_script.push(escape_quote_string_advanced(&arg, &script_name));
+            args_to_script.push(escape_quote_string_with_file(&arg, &script_name));
         } else if arg.starts_with('-') {
             // Cool, it's a flag
             let flag_value = match arg.as_ref() {


### PR DESCRIPTION
# Description

As per @uasi 's suggestions on #5445. This shouldn't affect anything other than flags, afaik - they're the only command line args that start with dashes, right?
```
def main [kernel: string, --version: string, --arch: string] {

} 
```
is working on my machine.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
