### PR TITLE
fix bug in shell_integration

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -311,12 +311,19 @@ pub fn evaluate_repl(
                     ansi_escapes.push_str(PROMPT_MARKER_BEFORE_CMD);
                     if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
                         let path = cwd.as_string()?;
+                        // Try to abbreviate string for windows title
                         let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
                             path.replace(&p.as_path().display().to_string(), "~")
                         } else {
                             path
                         };
-                        ansi_escapes.push_str(&format!("\x1b]1;{}\x07", maybe_abbrev_path));
+
+                        // Set window title too
+                        // https://tldp.org/HOWTO/Xterm-Title-3.html
+                        // ESC]0;stringBEL -- Set icon name and window title to string
+                        // ESC]1;stringBEL -- Set icon name to string
+                        // ESC]2;stringBEL -- Set window title to string
+                        ansi_escapes.push_str(&format!("\x1b]2;{}\x07", maybe_abbrev_path));
                     }
                     match io::stdout().write_all(ansi_escapes.as_bytes()) {
                         Ok(it) => it,


### PR DESCRIPTION
# Description

There was a problem with shell integration. We were using io::stdout().write_all() but not flushing so, some writes weren't getting through.

should close #5449

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
