### PR TITLE
implement seq char command to generate single character sequence

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -353,6 +353,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             Cal,
             Seq,
             SeqDate,
+            SeqChar,
         };
 
         // Hash

--- a/crates/nu-command/src/generators/mod.rs
+++ b/crates/nu-command/src/generators/mod.rs
@@ -1,7 +1,9 @@
 mod cal;
 mod seq;
 mod seq_date;
+mod seq_char;
 
 pub use cal::Cal;
 pub use seq::Seq;
 pub use seq_date::SeqDate;
+pub use seq_char::SeqChar;

--- a/crates/nu-command/src/generators/mod.rs
+++ b/crates/nu-command/src/generators/mod.rs
@@ -1,9 +1,9 @@
 mod cal;
 mod seq;
-mod seq_date;
 mod seq_char;
+mod seq_date;
 
 pub use cal::Cal;
 pub use seq::Seq;
-pub use seq_date::SeqDate;
 pub use seq_char::SeqChar;
+pub use seq_date::SeqDate;

--- a/crates/nu-command/src/generators/seq_char.rs
+++ b/crates/nu-command/src/generators/seq_char.rs
@@ -1,5 +1,9 @@
+use nu_engine::CallExt;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Example, Signature, Span, Value, IntoPipelineData};
+use nu_protocol::{
+    ast::Call, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span,
+    Spanned, SyntaxShape, Value,
+};
 
 #[derive(Clone)]
 pub struct SeqChar;
@@ -14,27 +18,189 @@ impl Command for SeqChar {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("seq cha")
+        Signature::build("seq char")
+            .rest("rest", SyntaxShape::String, "sequence chars")
+            .named(
+                "separator",
+                SyntaxShape::String,
+                "separator character (defaults to \\n)",
+                Some('s'),
+            )
+            .named(
+                "terminator",
+                SyntaxShape::String,
+                "terminator character (defaults to \\n)",
+                Some('t'),
+            )
+            .category(Category::Generators)
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "aaa",
-            example: "seq char",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "sequence a to e with newline separator",
+                example: "seq char a e",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_string('a'),
+                        Value::test_string('b'),
+                        Value::test_string('c'),
+                        Value::test_string('d'),
+                        Value::test_string('e'),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "sequence a to e with pipe separator separator",
+                example: "seq char -s '|' a e",
+                result: Some(Value::test_string("a|b|c|d|e")),
+            },
+        ]
     }
 
     fn run(
         &self,
         engine_state: &EngineState,
         stack: &mut Stack,
-        call: &nu_protocol::ast::Call,
-        input: nu_protocol::PipelineData,
+        call: &Call,
+        _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        Ok(Value::Bool {
-            val: true,
-            span: Span::test_data(),
-        }.into_pipeline_data())
+        seq_char(engine_state, stack, call)
+    }
+}
+
+fn is_single_character(ch: &str) -> bool {
+    ch.is_ascii() && ch.len() == 1 && ch.chars().all(char::is_alphabetic)
+}
+
+fn seq_char(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+) -> Result<PipelineData, ShellError> {
+    // input check.
+    let separator: Option<Spanned<String>> = call.get_flag(engine_state, stack, "separator")?;
+    let terminator: Option<Spanned<String>> = call.get_flag(engine_state, stack, "terminator")?;
+    let rest_inputs: Vec<Spanned<String>> = call.rest(engine_state, stack, 0)?;
+
+    let (start_ch, end_ch) = if rest_inputs.len() != 2
+        || !is_single_character(&rest_inputs[0].item)
+        || !is_single_character(&rest_inputs[1].item)
+    {
+        return Err(ShellError::GenericError(
+            "seq char required two character parameters".into(),
+            "needs parameter".into(),
+            Some(call.head),
+            None,
+            Vec::new(),
+        ));
+    } else {
+        // unwrap here is ok, because we just check the length of `rest_inputs`.
+        (
+            rest_inputs[0]
+                .item
+                .chars()
+                .next()
+                .expect("seq char input must contains 2 inputs"),
+            rest_inputs[1]
+                .item
+                .chars()
+                .next()
+                .expect("seq char input must contains 2 inputs"),
+        )
+    };
+
+    let sep: String = match separator {
+        Some(s) => {
+            if s.item == r"\t" {
+                '\t'.to_string()
+            } else if s.item == r"\n" {
+                '\n'.to_string()
+            } else if s.item == r"\r" {
+                '\r'.to_string()
+            } else {
+                let vec_s: Vec<char> = s.item.chars().collect();
+                if vec_s.is_empty() {
+                    return Err(ShellError::GenericError(
+                        "Expected a single separator char from --separator".into(),
+                        "requires a single character string input".into(),
+                        Some(s.span),
+                        None,
+                        Vec::new(),
+                    ));
+                };
+                vec_s.iter().collect()
+            }
+        }
+        _ => '\n'.to_string(),
+    };
+
+    let terminator: String = match terminator {
+        Some(t) => {
+            if t.item == r"\t" {
+                '\t'.to_string()
+            } else if t.item == r"\n" {
+                '\n'.to_string()
+            } else if t.item == r"\r" {
+                '\r'.to_string()
+            } else {
+                let vec_t: Vec<char> = t.item.chars().collect();
+                if vec_t.is_empty() {
+                    return Err(ShellError::GenericError(
+                        "Expected a single terminator char from --terminator".into(),
+                        "requires a single character string input".into(),
+                        Some(t.span),
+                        None,
+                        Vec::new(),
+                    ));
+                };
+                vec_t.iter().collect()
+            }
+        }
+        _ => '\n'.to_string(),
+    };
+
+    let span = call.head;
+    run_seq_char(start_ch, end_ch, sep, terminator, span)
+}
+
+fn run_seq_char(
+    start_ch: char,
+    end_ch: char,
+    sep: String,
+    terminator: String,
+    span: Span,
+) -> Result<PipelineData, ShellError> {
+    let mut result_vec = vec![];
+    for current_ch in start_ch as u8..end_ch as u8 + 1 {
+        result_vec.push((current_ch as char).to_string())
+    }
+    let return_list = (sep == "\n" || sep == "\r") && (terminator == "\n" || terminator == "\r");
+    if return_list {
+        let result = result_vec
+            .into_iter()
+            .map(|x| Value::String { val: x, span })
+            .collect::<Vec<Value>>();
+        Ok(Value::List { vals: result, span }.into_pipeline_data())
+    } else {
+        let mut result = result_vec.join(&sep);
+        result.push_str(&terminator);
+        // doesn't output a list, if separator is '\n', it's better to eliminate them.
+        // and it matches `seq` behavior.
+        let result = result.lines().collect();
+        Ok(Value::String { val: result, span }.into_pipeline_data())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SeqChar {})
     }
 }

--- a/crates/nu-command/src/generators/seq_char.rs
+++ b/crates/nu-command/src/generators/seq_char.rs
@@ -1,0 +1,40 @@
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Example, Signature, Span, Value, IntoPipelineData};
+
+#[derive(Clone)]
+pub struct SeqChar;
+
+impl Command for SeqChar {
+    fn name(&self) -> &str {
+        "seq char"
+    }
+
+    fn usage(&self) -> &str {
+        "Print sequence of chars"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("seq cha")
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "aaa",
+            example: "seq char",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &nu_protocol::ast::Call,
+        input: nu_protocol::PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Ok(Value::Bool {
+            val: true,
+            span: Span::test_data(),
+        }.into_pipeline_data())
+    }
+}


### PR DESCRIPTION
# Description

Add `seq char` command to generate a table with data a to z, or a to e;  Handles:  #3951

Refer to more description in the issue
> even more like monday-sunday something real sequence in the world

I think the requirement is not clarified, so just leave it unimplemented.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
