### PR TITLE
make cd recornize symblic link

### DIFF
--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -4,6 +4,7 @@ use nu_protocol::{
     levenshtein_distance, Span,
 };
 use reedline::Suggestion;
+use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -120,7 +121,7 @@ pub fn directory_completion(
         return result
             .filter_map(|entry| {
                 entry.ok().and_then(|entry| {
-                    if let Ok(metadata) = entry.metadata() {
+                    if let Ok(metadata) = fs::metadata(entry.path()) {
                         if metadata.is_dir() {
                             let mut file_name = entry.file_name().to_string_lossy().into_owned();
                             if matches(&partial, &file_name, match_algorithm) {


### PR DESCRIPTION
# Description

According to [metadata method in DirEntry](https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.metadata), it doesn't traverse symlinks if this entry points at a symlink.  And we can use [fs::metadata](https://doc.rust-lang.org/std/fs/fn.metadata.html) instead.

Fixes #5451

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
