### PR TITLE
add -n flag to print to print without a newline

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -16,6 +16,11 @@ impl Command for Print {
     fn signature(&self) -> Signature {
         Signature::build("print")
             .rest("rest", SyntaxShape::Any, "the values to print")
+            .switch(
+                "no_newline",
+                "print without inserting a newline for the line ending",
+                Some('n'),
+            )
             .category(Category::Strings)
     }
 
@@ -31,10 +36,13 @@ impl Command for Print {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let args: Vec<Value> = call.rest(engine_state, stack, 0)?;
+        let no_newline = call.has_flag("no_newline");
+
         let head = call.head;
 
         for arg in args {
-            arg.into_pipeline_data().print(engine_state, stack)?;
+            arg.into_pipeline_data()
+                .print(engine_state, stack, no_newline)?;
         }
 
         Ok(PipelineData::new(head))

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -237,7 +237,7 @@ pub fn eval_source(
                 set_last_exit_code(stack, 0);
             }
 
-            if let Err(err) = pipeline_data.print(engine_state, stack) {
+            if let Err(err) = pipeline_data.print(engine_state, stack, false) {
                 let working_set = StateWorkingSet::new(engine_state);
 
                 report_error(&working_set, &err);

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -216,7 +216,7 @@ impl Command for Watch {
 
                     match eval_result {
                         Ok(val) => {
-                            val.print(engine_state, stack)?;
+                            val.print(engine_state, stack, false)?;
                         }
                         Err(err) => {
                             let working_set = StateWorkingSet::new(engine_state);

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -464,12 +464,10 @@ impl PipelineData {
                         let working_set = StateWorkingSet::new(engine_state);
 
                         format_error(&working_set, &error)
+                    } else if no_newline {
+                        item.into_string("", config)
                     } else {
-                        if no_newline {
-                            item.into_string("", config)
-                        } else {
-                            item.into_string("\n", config)
-                        }
+                        item.into_string("\n", config)
                     };
 
                     if !no_newline {
@@ -489,12 +487,10 @@ impl PipelineData {
                         let working_set = StateWorkingSet::new(engine_state);
 
                         format_error(&working_set, &error)
+                    } else if no_newline {
+                        item.into_string("", config)
                     } else {
-                        if no_newline {
-                            item.into_string("", config)
-                        } else {
-                            item.into_string("\n", config)
-                        }
+                        item.into_string("\n", config)
                     };
 
                     if !no_newline {

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -416,12 +416,16 @@ impl PipelineData {
         }
     }
 
-    pub fn print(self, engine_state: &EngineState, stack: &mut Stack) -> Result<(), ShellError> {
+    pub fn print(
+        self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        no_newline: bool,
+    ) -> Result<(), ShellError> {
         // If the table function is in the declarations, then we can use it
         // to create the table value that will be printed in the terminal
 
         let config = engine_state.get_config();
-
         let stdout = std::io::stdout();
 
         if let PipelineData::ExternalStream {
@@ -461,10 +465,16 @@ impl PipelineData {
 
                         format_error(&working_set, &error)
                     } else {
-                        item.into_string("\n", config)
+                        if no_newline {
+                            item.into_string("", config)
+                        } else {
+                            item.into_string("\n", config)
+                        }
                     };
 
-                    out.push('\n');
+                    if !no_newline {
+                        out.push('\n');
+                    }
 
                     match stdout.lock().write_all(out.as_bytes()) {
                         Ok(_) => (),
@@ -480,9 +490,16 @@ impl PipelineData {
 
                         format_error(&working_set, &error)
                     } else {
-                        item.into_string("\n", config)
+                        if no_newline {
+                            item.into_string("", config)
+                        } else {
+                            item.into_string("\n", config)
+                        }
                     };
-                    out.push('\n');
+
+                    if !no_newline {
+                        out.push('\n');
+                    }
 
                     match stdout.lock().write_all(out.as_bytes()) {
                         Ok(_) => (),


### PR DESCRIPTION
# Description

This PR enables you to use the `print` command without printing a newline.
![image](https://user-images.githubusercontent.com/343840/167205973-f8148dd2-d005-43bc-bcbd-1d9c73852f8e.png)


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
