### PR TITLE
Document out positional argument type in help message

### DIFF
--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -56,7 +56,7 @@ fn test_cd_html_color_flag_dark_false() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; <span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span><span style='color:#037979;'>~<span style='color:black;font-weight:normal;'><br><br>  Change to a directory via abbreviations<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>d/s/9<span style='color:black;font-weight:normal;'><br><br></body></html></span></span>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; <span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span><span style='color:#037979;'>~<span style='color:black;font-weight:normal;'><br><br>  Change to a directory via abbreviations<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>d/s/9<span style='color:black;font-weight:normal;'><br><br></body></html></span></span>"
     );
 }
 
@@ -71,6 +71,6 @@ fn test_no_color_flag() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br></body></html>"
     );
 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -87,19 +87,22 @@ fn get_documentation(
     {
         long_desc.push_str("\nParameters:\n");
         for positional in &sig.required_positional {
-            long_desc.push_str(&format!("  {}: {}\n", positional.name, positional.desc));
+            long_desc.push_str(&format!(
+                "  {} <{:?}>: {}\n",
+                positional.name, positional.shape, positional.desc
+            ));
         }
         for positional in &sig.optional_positional {
             long_desc.push_str(&format!(
-                "  (optional) {}: {}\n",
-                positional.name, positional.desc
+                "  (optional) {} <{:?}>: {}\n",
+                positional.name, positional.shape, positional.desc
             ));
         }
 
         if let Some(rest_positional) = &sig.rest_positional {
             long_desc.push_str(&format!(
-                "  ...{}: {}\n",
-                rest_positional.name, rest_positional.desc
+                "  ...{} <{:?}>: {}\n",
+                rest_positional.name, rest_positional.shape, rest_positional.desc
             ));
         }
     }


### PR DESCRIPTION
# Description

Document out `positional argument type`(just like what flag does) in help message

I think this can make help message more helpful.

Take the following script as exmple:
```nu
def greet [name: int, age: int, --aaa: int] {
    echo "hello" $name
}
```

Running `greet -h`

**Before**
```
Usage:
  > greet {flags} <name> <age>

Flags:
  -h, --help
      Display this help message
  --aaa <Int>


Parameters:
  name:
  age:
```

**After (Parameters session changed)**
```
Usage:
  > greet {flags} <name> <age>

Flags:
  -h, --help
      Display this help message
  --aaa <Int>


Parameters:
  name <Int>:
  age <Int>:
```

And it also affects builtin commands help message too.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
