### PR TITLE
Enable string interpolation for environment shorthand

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4287,13 +4287,16 @@ pub fn parse_expression(
                 },
             );
             let rhs = if spans[pos].start + point < spans[pos].end {
-                parse_string_strict(
-                    working_set,
-                    Span {
-                        start: spans[pos].start + point,
-                        end: spans[pos].end,
-                    },
-                )
+                let rhs_span = Span {
+                    start: spans[pos].start + point,
+                    end: spans[pos].end,
+                };
+
+                if working_set.get_span_contents(rhs_span).starts_with(b"$") {
+                    parse_dollar_expr(working_set, rhs_span, expand_aliases_denylist)
+                } else {
+                    parse_string_strict(working_set, rhs_span)
+                }
             } else {
                 (
                     Expression {

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -23,6 +23,15 @@ fn env_shorthand_with_equals() {
 }
 
 #[test]
+fn env_shorthand_with_interpolation() {
+    let actual = nu!(cwd: ".", r#"
+        let num = 123
+        FOO=$"($num) bar" echo $env.FOO
+        "#);
+    assert_eq!(actual.out, "123 bar");
+}
+
+#[test]
 fn env_shorthand_with_comma_equals() {
     let actual = nu!(cwd: ".", r#"
         RUST_LOG=info,my_module=info $env.RUST_LOG


### PR DESCRIPTION
# Description

This enables string interpolation for the [environment variable shorthand syntax](https://www.nushell.sh/book/environment.html#single-use-environment-variables).

For example, `FOO=$"(123)" $env.FOO` now interpolates the string and returns `123`. Before this change it returned `(123)`.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
