### PR TITLE
complete some commands tests

### DIFF
--- a/crates/nu-command/tests/commands/hash_/mod.rs
+++ b/crates/nu-command/tests/commands/hash_/mod.rs
@@ -26,8 +26,6 @@ fn base64_encode_characterset_binhex() {
     assert_eq!(actual.out, "F@0NEPjJD97kE\'&bEhFZEP3");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn error_when_invalid_character_set_given() {
     let actual = nu!(
@@ -43,8 +41,6 @@ fn error_when_invalid_character_set_given() {
         .contains("this is invalid is not a valid character-set"));
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn base64_decode_characterset_binhex() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/source.rs
+++ b/crates/nu-command/tests/commands/source.rs
@@ -123,8 +123,6 @@ fn sources_unicode_file_in_unicode_dir_without_spaces_2() {
     try_source_foo_without_quotes_in(":fire_engine:", "source_test_9");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn sources_unicode_file_in_unicode_dir_with_spaces_1() {
     // this one fails
@@ -133,8 +131,6 @@ fn sources_unicode_file_in_unicode_dir_with_spaces_1() {
     try_source_foo_with_double_quotes_in("e-$ èрт🚒♞中片-j", "source_test_9");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[cfg(not(windows))] // ':' is not allowed in Windows paths
 #[test]
 fn sources_unicode_file_in_unicode_dir_with_spaces_2() {


### PR DESCRIPTION
# Description

Trying to push #4314, and find out some tests can just pass without modifying :-)

And the following can be done:
* commands::hash_::base64_decode_characterset_binhex - (single quote inside of double quote problem)
* commands::hash_::error_when_invalid_character_set_given - (nu!() doesn't appear to be capturing the actual.err)
* commands::source::sources_unicode_file_in_unicode_dir_with_spaces_1 - (seems like unicode is throwing it off but the below tests passed)
* commands::source::sources_unicode_file_in_unicode_dir_with_spaces_2 - (seems like unicode is throwing it off but the below tests passed)
# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
