### PR TITLE
feat: add disable field type inferencing for `from csv` and `from tsv`, fix: #3485 and #4217

### DIFF
--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -26,6 +26,7 @@ impl Command for FromCsv {
                 "don't treat the first row as column names",
                 Some('n'),
             )
+            .switch("no-infer", "no field type inferencing", None)
             .named(
                 "trim",
                 SyntaxShape::String,
@@ -98,6 +99,7 @@ fn from_csv(
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
 
+    let no_infer = call.has_flag("no-infer");
     let noheaders = call.has_flag("noheaders");
     let separator: Option<Value> = call.get_flag(engine_state, stack, "separator")?;
     let trim: Option<Value> = call.get_flag(engine_state, stack, "trim")?;
@@ -123,7 +125,7 @@ fn from_csv(
 
     let trim = trim_from_str(trim)?;
 
-    from_delimited_data(noheaders, sep, trim, input, name, config)
+    from_delimited_data(noheaders, no_infer, sep, trim, input, name, config)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -20,6 +20,7 @@ impl Command for FromTsv {
                 "don't treat the first row as column names",
                 Some('n'),
             )
+            .switch("no-infer", "no field type inferencing", None)
             .named(
                 "trim",
                 SyntaxShape::String,
@@ -82,12 +83,14 @@ fn from_tsv(
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
 
+    let no_infer = call.has_flag("no-infer");
     let noheaders = call.has_flag("noheaders");
     let trim: Option<Value> = call.get_flag(engine_state, stack, "trim")?;
     let trim = trim_from_str(trim)?;
 
     from_delimited_data(
         noheaders,
+        no_infer,
         '\t',
         trim,
         input,


### PR DESCRIPTION
add disable field type inferencing for `from csv` and `from tsv`

# Description

add disable field type inferencing for `from csv` and `from tsv`, fix: #3485 and #4217

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
