### PR TITLE
nu-cli/completions: add tests for flag completions

### DIFF
--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -8,6 +8,40 @@ use reedline::{Completer, Suggestion};
 const SEP: char = std::path::MAIN_SEPARATOR;
 
 #[test]
+fn flag_completions() {
+    // Create a new engine
+    let (_, _, engine) = new_engine();
+
+    let stack = Stack::new();
+
+    // Instatiate a new completer
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    // Test completions for the 'ls' flags
+    let suggestions = completer.complete("ls -".into(), 4);
+
+    assert_eq!(12, suggestions.len());
+
+    let expected: Vec<String> = vec![
+        "--all".into(),
+        "--du".into(),
+        "--full-paths".into(),
+        "--help".into(),
+        "--long".into(),
+        "--short-names".into(),
+        "-a".into(),
+        "-d".into(),
+        "-f".into(),
+        "-h".into(),
+        "-l".into(),
+        "-s".into(),
+    ];
+
+    // Match results
+    match_suggestions(expected, suggestions);
+}
+
+#[test]
 fn file_completions() {
     // Create a new engine
     let (dir, dir_str, engine) = new_engine();


### PR DESCRIPTION
# Description

Adding test for flag completions using the `ls` as example. Once it's a built-in command we can guarantee that those flags will always be there.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
