### PR TITLE
Bump to the 0.62.1 dev version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "crossterm",
  "fuzzy-matcher",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "nu-ansi-term",
  "nu-json",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "Inflector",
  "alphanumeric-sort",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "chrono",
  "nu-glob",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "doc-comment",
  "tempdir",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "nu-json"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "lazy_static",
  "linked-hash-map",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "chrono",
  "log",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "dirs-next",
  "dunce",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "capnp",
  "nu-engine",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "heapless 0.7.10",
  "nu-ansi-term",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "chrono",
  "errno",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "ansi-str",
  "atty",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "strip-ansi-escapes",
  "unicode-width",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "getset",
  "hamcrest2",
@@ -2717,14 +2717,14 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "crossterm_winapi",
 ]
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "git2",
  "nu-engine",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "gjson",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "nu"
 readme = "README.md"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.62.0"
+version = "0.62.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -38,19 +38,19 @@ ctrlc = "3.2.1"
 log = "0.4"
 miette = "4.5.0"
 nu-ansi-term = "0.45.1"
-nu-cli = { path="./crates/nu-cli", version = "0.62.0"  }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.62.0"  }
-nu-command = { path="./crates/nu-command", version = "0.62.0"  }
-nu-engine = { path="./crates/nu-engine", version = "0.62.0"  }
-nu-json = { path="./crates/nu-json", version = "0.62.0"  }
-nu-parser = { path="./crates/nu-parser", version = "0.62.0"  }
-nu-path = { path="./crates/nu-path", version = "0.62.0"  }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.62.0"  }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.62.0"  }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.62.0"  }
-nu-system = { path = "./crates/nu-system", version = "0.62.0" }
-nu-table = { path = "./crates/nu-table", version = "0.62.0"  }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.62.0"  }
+nu-cli = { path="./crates/nu-cli", version = "0.62.1"  }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.62.1"  }
+nu-command = { path="./crates/nu-command", version = "0.62.1"  }
+nu-engine = { path="./crates/nu-engine", version = "0.62.1"  }
+nu-json = { path="./crates/nu-json", version = "0.62.1"  }
+nu-parser = { path="./crates/nu-parser", version = "0.62.1"  }
+nu-path = { path="./crates/nu-path", version = "0.62.1"  }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.62.1"  }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.62.1"  }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.62.1"  }
+nu-system = { path = "./crates/nu-system", version = "0.62.1" }
+nu-table = { path = "./crates/nu-table", version = "0.62.1"  }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.62.1"  }
 openssl = { version = "0.10.38", features = ["vendored"], optional = true }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
@@ -58,7 +58,7 @@ reedline = { version = "0.5.0", features = ["bashisms"]}
 is_executable = "1.0.1"
 
 [dev-dependencies]
-nu-test-support = { path="./crates/nu-test-support", version = "0.62.0"  }
+nu-test-support = { path="./crates/nu-test-support", version = "0.62.1"  }
 tempfile = "3.2.0"
 assert_cmd = "2.0.2"
 pretty_assertions = "1.0.0"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -4,20 +4,20 @@ description = "CLI-related functionality for Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.62.0"
+version = "0.62.1"
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.62.0"  }
-nu-command = { path = "../nu-command", version = "0.62.0" }
+nu-test-support = { path="../nu-test-support", version = "0.62.1"  }
+nu-command = { path = "../nu-command", version = "0.62.1" }
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.62.0"  }
-nu-path = { path = "../nu-path", version = "0.62.0"  }
-nu-parser = { path = "../nu-parser", version = "0.62.0"  }
-nu-protocol = { path = "../nu-protocol", version = "0.62.0"  }
-nu-utils = { path = "../nu-utils", version = "0.62.0"  }
+nu-engine = { path = "../nu-engine", version = "0.62.1"  }
+nu-path = { path = "../nu-path", version = "0.62.1"  }
+nu-parser = { path = "../nu-parser", version = "0.62.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.62.1"  }
+nu-utils = { path = "../nu-utils", version = "0.62.1"  }
 nu-ansi-term = "0.45.1"
-nu-color-config = { path = "../nu-color-config", version = "0.62.0"  }
+nu-color-config = { path = "../nu-color-config", version = "0.62.1"  }
 reedline = { version = "0.5.0", features = ["bashisms"]}
 crossterm = "0.23.0"
 miette = { version = "4.5.0", features = ["fancy"] }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -4,11 +4,11 @@ description = "Color configuration code used by Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.62.0"
+version = "0.62.1"
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.62.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.62.1"  }
 nu-ansi-term = "0.45.1"
-nu-json = { path = "../nu-json", version = "0.62.0"  }
-nu-table = { path = "../nu-table", version = "0.62.0"  }
+nu-json = { path = "../nu-json", version = "0.62.1"  }
+nu-table = { path = "../nu-table", version = "0.62.1"  }
 serde = { version="1.0.123", features=["derive"] }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -4,25 +4,25 @@ description = "Nushell's built-in commands"
 edition = "2021"
 license = "MIT"
 name = "nu-command"
-version = "0.62.0"
+version = "0.62.1"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-color-config = { path = "../nu-color-config", version = "0.62.0"  }
-nu-engine = { path = "../nu-engine", version = "0.62.0"  }
-nu-glob = { path = "../nu-glob", version = "0.62.0" }
-nu-json = { path = "../nu-json", version = "0.62.0"  }
-nu-parser = { path = "../nu-parser", version = "0.62.0"  }
-nu-path = { path = "../nu-path", version = "0.62.0"  }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.62.0"  }
-nu-protocol = { path = "../nu-protocol", version = "0.62.0"  }
-nu-system = { path = "../nu-system", version = "0.62.0"  }
-nu-table = { path = "../nu-table", version = "0.62.0"  }
-nu-term-grid = { path = "../nu-term-grid", version = "0.62.0"  }
-nu-test-support = { path = "../nu-test-support", version = "0.62.0"  }
-nu-utils = { path = "../nu-utils", version = "0.62.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.62.1"  }
+nu-engine = { path = "../nu-engine", version = "0.62.1"  }
+nu-glob = { path = "../nu-glob", version = "0.62.1" }
+nu-json = { path = "../nu-json", version = "0.62.1"  }
+nu-parser = { path = "../nu-parser", version = "0.62.1"  }
+nu-path = { path = "../nu-path", version = "0.62.1"  }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.62.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.62.1"  }
+nu-system = { path = "../nu-system", version = "0.62.1"  }
+nu-table = { path = "../nu-table", version = "0.62.1"  }
+nu-term-grid = { path = "../nu-term-grid", version = "0.62.1"  }
+nu-test-support = { path = "../nu-test-support", version = "0.62.1"  }
+nu-utils = { path = "../nu-utils", version = "0.62.1" }
 nu-ansi-term = "0.45.1"
 
 # Potential dependencies for extras

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -4,12 +4,12 @@ description = "Nushell's evaluation engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.62.0"
+version = "0.62.1"
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.62.0"  }
-nu-path = { path = "../nu-path", version = "0.62.0"  }
-nu-glob = { path = "../nu-glob", version = "0.62.0" }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.62.1"  }
+nu-path = { path = "../nu-path", version = "0.62.1"  }
+nu-glob = { path = "../nu-glob", version = "0.62.1" }
 
 chrono = { version="0.4.19", features=["serde"] }
 sysinfo = "0.23.10"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.62.0"
+version = "0.62.1"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -4,7 +4,7 @@ description = "Fork of serde-hjson"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.62.0"
+version = "0.62.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,5 +20,5 @@ lazy_static = "1"
 linked-hash-map = { version="0.5", optional=true }
 
 [dev-dependencies]
-nu-path = { path="../nu-path", version = "0.62.0" }
+nu-path = { path="../nu-path", version = "0.62.1" }
 serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -4,16 +4,16 @@ description = "Nushell's parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.62.0"
+version = "0.62.1"
 
 [dependencies]
 chrono = "0.4.19"
 miette = "4.5.0"
 thiserror = "1.0.29"
 serde_json = "1.0"
-nu-path = {path = "../nu-path", version = "0.62.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.62.0" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.62.0"  }
+nu-path = {path = "../nu-path", version = "0.62.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.62.1" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.62.1"  }
 log = "0.4"
 
 [features]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -4,7 +4,7 @@ description = "Path handling library for Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.62.0"
+version = "0.62.1"
 
 [dependencies]
 dirs-next = "2.0.0"

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -4,11 +4,11 @@ description = "Functionality for building Nushell plugins"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.62.0"
+version = "0.62.1"
 
 [dependencies]
 capnp = "0.14.3"
-nu-protocol = { path = "../nu-protocol", version = "0.62.0"  }
-nu-engine = { path = "../nu-engine", version = "0.62.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.62.1"  }
+nu-engine = { path = "../nu-engine", version = "0.62.1"  }
 serde = {version = "1.0.130", features = ["derive"]}
 serde_json = { version = "1.0"}

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -4,7 +4,7 @@ description = "Pretty hex dump of bytes slice in the common style."
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -4,7 +4,7 @@ description = "Nushell's internal protocols, including its abstract syntax tree"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.62.0"
+version = "0.62.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,7 +17,7 @@ indexmap = { version="1.7", features=["serde-1"] }
 chrono-humanize = "0.2.1"
 byte-unit = "4.0.9"
 serde_json = { version = "1.0", optional = true }
-nu-json = { path = "../nu-json", version = "0.62.0"  }
+nu-json = { path = "../nu-json", version = "0.62.1"  }
 typetag = "0.1.8"
 num-format = "0.4.0"
 sys-locale = "0.2.0"

--- a/crates/nu-system/Cargo.lock
+++ b/crates/nu-system/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "errno",
  "libproc",

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 name = "nu-system"
-version = "0.62.0"
+version = "0.62.1"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -4,7 +4,7 @@ description = "Nushell table printing"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.62.0"
+version = "0.62.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 nu-ansi-term = "0.45.1"
-nu-protocol = { path = "../nu-protocol", version = "0.62.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.62.1" }
 regex = "1.4"
 unicode-width = "0.1.8"
 strip-ansi-escapes = "0.1.1"

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -4,7 +4,7 @@ description = "Nushell grid printing"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.62.0"
+version = "0.62.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -4,14 +4,14 @@ description = "Support for writing Nushell tests"
 edition = "2018"
 license = "MIT"
 name = "nu-test-support"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-path = { path="../nu-path", version = "0.62.0"  }
-nu-glob = { path = "../nu-glob", version = "0.62.0" }
+nu-path = { path="../nu-path", version = "0.62.1"  }
+nu-glob = { path = "../nu-glob", version = "0.62.1" }
 
 getset = "0.1.1"
 num-bigint = { version="0.4.3", features=["serde"] }

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -4,7 +4,7 @@ description = "Nushell utility functions"
 edition = "2021"
 license = "MIT"
 name = "nu-utils"
-version = "0.62.0"
+version = "0.62.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -4,8 +4,8 @@ description = "A version incrementer plugin for Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.62.0"
+version = "0.62.1"
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1", features = ["plugin"]}

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -4,14 +4,14 @@ description = "A git status plugin for Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-engine = { path="../nu-engine", version = "0.62.0" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-engine = { path="../nu-engine", version = "0.62.1" }
 
 git2 = "0.14.2"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -4,13 +4,13 @@ description = "A version incrementer plugin for Nushell"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1", features = ["plugin"]}
 
 semver = "0.11.0"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -4,15 +4,15 @@ description = "A Nushell plugin to query JSON, XML, and various web data"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-engine = { path="../nu-engine", version = "0.62.0" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-engine = { path="../nu-engine", version = "0.62.1" }
 gjson = "0.8.0"
 scraper = "0.12.0"
 sxd-document = "0.3.2"

--- a/crates/old/nu_plugin_chart/Cargo.toml
+++ b/crates/old/nu_plugin_chart/Cargo.toml
@@ -4,18 +4,18 @@ description = "A plugin to display charts"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_chart"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-data = { path="../nu-data", version = "0.62.0" }
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
-nu-value-ext = { path="../nu-value-ext", version = "0.62.0" }
+nu-data = { path="../nu-data", version = "0.62.1" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
+nu-value-ext = { path="../nu-value-ext", version = "0.62.1" }
 
 crossterm = "0.19.0"
 tui = { version="0.15.0", default-features=false, features=["crossterm"] }

--- a/crates/old/nu_plugin_from_bson/Cargo.toml
+++ b/crates/old/nu_plugin_from_bson/Cargo.toml
@@ -4,7 +4,7 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_bson"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
@@ -12,9 +12,9 @@ doctest = false
 [dependencies]
 bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
 
 [build-dependencies]

--- a/crates/old/nu_plugin_from_mp4/Cargo.toml
+++ b/crates/old/nu_plugin_from_mp4/Cargo.toml
@@ -4,16 +4,16 @@ description = "A converter plugin to the mp4 format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_mp4"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
 tempfile = "3.2.0"
 mp4 = "0.9.0"
 

--- a/crates/old/nu_plugin_from_sqlite/Cargo.toml
+++ b/crates/old/nu_plugin_from_sqlite/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_sqlite"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
 tempfile = "3.2.0"
 
 [dependencies.rusqlite]

--- a/crates/old/nu_plugin_s3/Cargo.toml
+++ b/crates/old/nu_plugin_s3/Cargo.toml
@@ -4,17 +4,17 @@ description = "An S3 plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_s3"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 futures = { version="0.3.12", features=["compat", "io-compat"] }
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
 s3handler = "0.7.5"
 
 [build-dependencies]

--- a/crates/old/nu_plugin_start/Cargo.toml
+++ b/crates/old/nu_plugin_start/Cargo.toml
@@ -4,17 +4,17 @@ description = "A plugin to open files/URLs directly from Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_start"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 glob = "0.3.0"
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
 url = "2.2.0"
 webbrowser = "0.5.5"
 
@@ -22,5 +22,5 @@ webbrowser = "0.5.5"
 open = "1.4.0"
 
 [build-dependencies]
-nu-errors = { version = "0.62.0", path="../nu-errors" }
-nu-source = { version = "0.62.0", path="../nu-source" }
+nu-errors = { version = "0.62.1", path="../nu-errors" }
+nu-source = { version = "0.62.1", path="../nu-source" }

--- a/crates/old/nu_plugin_to_bson/Cargo.toml
+++ b/crates/old/nu_plugin_to_bson/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_bson"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
 num-traits = "0.2.14"
 
 [features]

--- a/crates/old/nu_plugin_to_sqlite/Cargo.toml
+++ b/crates/old/nu_plugin_to_sqlite/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the SQLite format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_sqlite"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 hex = "0.4.2"
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
-nu-source = { path="../nu-source", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
+nu-source = { path="../nu-source", version = "0.62.1" }
 tempfile = "3.2.0"
 
 [dependencies.rusqlite]

--- a/crates/old/nu_plugin_tree/Cargo.toml
+++ b/crates/old/nu_plugin_tree/Cargo.toml
@@ -4,16 +4,16 @@ description = "Tree viewer plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_tree"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 derive-new = "0.5.8"
-nu-errors = { path="../nu-errors", version = "0.62.0" }
-nu-plugin = { path="../nu-plugin", version = "0.62.0" }
-nu-protocol = { path="../nu-protocol", version = "0.62.0" }
+nu-errors = { path="../nu-errors", version = "0.62.1" }
+nu-plugin = { path="../nu-plugin", version = "0.62.1" }
+nu-protocol = { path="../nu-protocol", version = "0.62.1" }
 ptree = { version = "0.4.0", default-features = false }
 
 

--- a/samples/wasm/Cargo.toml
+++ b/samples/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Nu authors"]
 edition = "2018"
 name = "wasm"
-version = "0.62.0"
+version = "0.62.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
# Description

Bump us to the dev version, so we know if people are using the version from main.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
