### PR TITLE
join and from derived tables

### DIFF
--- a/crates/nu-command/src/database/commands/alias.rs
+++ b/crates/nu-command/src/database/commands/alias.rs
@@ -29,26 +29,15 @@ impl Command for AliasExpr {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![
-            Example {
-                description: "Creates an alias for a column selection",
-                example: "db col name_a | db as new_a",
-                result: None,
-            },
-            Example {
-                description: "Creates an alias for a table",
-                example: r#"db open name 
-    | db select a 
-    | db from table_a 
-    | db as table_a_new 
-    | db describe"#,
-                result: None,
-            },
-        ]
+        vec![Example {
+            description: "Creates an alias for a column selection",
+            example: "db col name_a | db as new_a",
+            result: None,
+        }]
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "column", "expression"]
+        vec!["database", "alias", "column"]
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/conversions.rs
+++ b/crates/nu-command/src/database/commands/conversions.rs
@@ -1,0 +1,66 @@
+use crate::{database::values::definitions::ConnectionDb, SQLiteDatabase};
+use nu_protocol::{ShellError, Value};
+use sqlparser::ast::{ObjectName, Statement, TableAlias, TableFactor};
+
+pub fn value_into_table_factor(
+    table: Value,
+    connection: &ConnectionDb,
+    alias: Option<TableAlias>,
+) -> Result<TableFactor, ShellError> {
+    match table {
+        Value::String { val, .. } => {
+            let ident = sqlparser::ast::Ident {
+                value: val,
+                quote_style: None,
+            };
+
+            Ok(TableFactor::Table {
+                name: ObjectName(vec![ident]),
+                alias,
+                args: Vec::new(),
+                with_hints: Vec::new(),
+            })
+        }
+        Value::CustomValue { span, .. } => {
+            let db = SQLiteDatabase::try_from_value(table)?;
+
+            if &db.connection != connection {
+                return Err(ShellError::GenericError(
+                    "Incompatible connections".into(),
+                    "trying to join on table with different connection".into(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                ));
+            }
+
+            match db.statement {
+                Some(statement) => match statement {
+                    Statement::Query(query) => Ok(TableFactor::Derived {
+                        lateral: false,
+                        subquery: query,
+                        alias,
+                    }),
+                    s => Err(ShellError::GenericError(
+                        "Connection doesnt define a query".into(),
+                        format!("Expected a connection with query. Got {}", s),
+                        Some(span),
+                        None,
+                        Vec::new(),
+                    )),
+                },
+                None => Err(ShellError::GenericError(
+                    "Error creating derived table".into(),
+                    "there is no statement defined yet".into(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )),
+            }
+        }
+        _ => Err(ShellError::UnsupportedInput(
+            "String or connection".into(),
+            table.span()?,
+        )),
+    }
+}

--- a/crates/nu-command/src/database/commands/join.rs
+++ b/crates/nu-command/src/database/commands/join.rs
@@ -1,0 +1,178 @@
+use super::{super::SQLiteDatabase, conversions::value_into_table_factor};
+use crate::database::values::{definitions::ConnectionDb, dsl::ExprDb};
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Value,
+};
+use sqlparser::ast::{
+    Ident, Join, JoinConstraint, JoinOperator, Select, SetExpr, Statement, TableAlias,
+};
+
+#[derive(Clone)]
+pub struct JoinDb;
+
+impl Command for JoinDb {
+    fn name(&self) -> &str {
+        "db join"
+    }
+
+    fn usage(&self) -> &str {
+        "Joins with another table or derived table. Default join type is inner"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "table",
+                SyntaxShape::Any,
+                "table or derived table to join on",
+            )
+            .required("on", SyntaxShape::Any, "expression to join tables")
+            .named(
+                "as",
+                SyntaxShape::String,
+                "Alias for the selected join",
+                Some('a'),
+            )
+            .switch("left", "left outer join", Some('l'))
+            .switch("right", "right outer join", Some('r'))
+            .switch("outer", "full outer join", Some('o'))
+            .switch("cross", "cross join", Some('c'))
+            .category(Category::Custom("database".into()))
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["database", "join"]
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "",
+            example: "",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let mut db = SQLiteDatabase::try_from_pipeline(input, call.head)?;
+
+        db.statement = match db.statement {
+            Some(statement) => Some(modify_statement(
+                &db.connection,
+                statement,
+                engine_state,
+                stack,
+                call,
+            )?),
+            None => {
+                return Err(ShellError::GenericError(
+                    "Error creating join".into(),
+                    "there is no statement defined yet".into(),
+                    Some(call.head),
+                    None,
+                    Vec::new(),
+                ))
+            }
+        };
+
+        Ok(db.into_value(call.head).into_pipeline_data())
+    }
+}
+
+fn modify_statement(
+    connection: &ConnectionDb,
+    mut statement: Statement,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+) -> Result<Statement, ShellError> {
+    match statement {
+        Statement::Query(ref mut query) => {
+            match &mut query.body {
+                SetExpr::Select(ref mut select) => {
+                    modify_from(connection, select, engine_state, stack, call)?
+                }
+                s => {
+                    return Err(ShellError::GenericError(
+                        "Connection doesnt define a select".into(),
+                        format!("Expected a connection with select. Got {}", s),
+                        Some(call.head),
+                        None,
+                        Vec::new(),
+                    ))
+                }
+            };
+
+            Ok(statement)
+        }
+        s => Err(ShellError::GenericError(
+            "Connection doesnt define a query".into(),
+            format!("Expected a connection with query. Got {}", s),
+            Some(call.head),
+            None,
+            Vec::new(),
+        )),
+    }
+}
+
+fn modify_from(
+    connection: &ConnectionDb,
+    select: &mut Select,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+) -> Result<(), ShellError> {
+    match select.from.last_mut() {
+        Some(table) => {
+            let alias = call
+                .get_flag::<String>(engine_state, stack, "as")?
+                .map(|alias| TableAlias {
+                    name: Ident {
+                        value: alias,
+                        quote_style: None,
+                    },
+                    columns: Vec::new(),
+                });
+
+            let join_table: Value = call.req(engine_state, stack, 0)?;
+            let table_factor = value_into_table_factor(join_table, connection, alias)?;
+
+            let on_expr: Value = call.req(engine_state, stack, 1)?;
+            let on_expr = ExprDb::try_from_value(&on_expr)?;
+
+            let join_on = if call.has_flag("left") {
+                JoinOperator::LeftOuter(JoinConstraint::On(on_expr.into_native()))
+            } else if call.has_flag("right") {
+                JoinOperator::RightOuter(JoinConstraint::On(on_expr.into_native()))
+            } else if call.has_flag("outer") {
+                JoinOperator::FullOuter(JoinConstraint::On(on_expr.into_native()))
+            } else {
+                JoinOperator::Inner(JoinConstraint::On(on_expr.into_native()))
+            };
+
+            let join = Join {
+                relation: table_factor,
+                join_operator: join_on,
+            };
+
+            table.joins.push(join);
+
+            Ok(())
+        }
+        None => Err(ShellError::GenericError(
+            "Connection without table defined".into(),
+            "Expected a table defined".into(),
+            Some(call.head),
+            None,
+            Vec::new(),
+        )),
+    }
+}

--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -1,3 +1,6 @@
+// Conversions between value and sqlparser objects
+pub mod conversions;
+
 mod alias;
 mod and;
 mod col;
@@ -7,6 +10,7 @@ mod describe;
 mod from;
 mod function;
 mod group_by;
+mod join;
 mod limit;
 mod open;
 mod or;
@@ -32,6 +36,7 @@ use describe::DescribeDb;
 use from::FromDb;
 use function::FunctionExpr;
 use group_by::GroupByDb;
+use join::JoinDb;
 use limit::LimitDb;
 use open::OpenDb;
 use or::OrDb;
@@ -56,20 +61,21 @@ pub fn add_database_decls(working_set: &mut StateWorkingSet) {
     bind_command!(
         AliasExpr,
         AndDb,
-        CollectDb,
         ColExpr,
+        CollectDb,
         Database,
         DescribeDb,
         FromDb,
         FunctionExpr,
         GroupByDb,
-        QueryDb,
+        JoinDb,
         LimitDb,
-        ProjectionDb,
         OpenDb,
         OrderByDb,
         OrDb,
         OverExpr,
+        QueryDb,
+        ProjectionDb,
         SchemaDb,
         TestingDb,
         WhereDb

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -68,7 +68,7 @@ impl Command for SchemaDb {
 
         cols.push("db_filename".into());
         vals.push(Value::String {
-            val: sqlite_db.path.to_string_lossy().to_string(),
+            val: sqlite_db.connection.to_string(),
             span,
         });
 

--- a/crates/nu-command/src/database/values/definitions/mod.rs
+++ b/crates/nu-command/src/database/values/definitions/mod.rs
@@ -1,3 +1,7 @@
+use nu_protocol::{ShellError, Span};
+use serde::{Deserialize, Serialize};
+use std::{fmt::Display, path::PathBuf};
+
 pub mod db;
 pub mod db_column;
 pub mod db_constraint;
@@ -6,3 +10,24 @@ pub mod db_index;
 pub mod db_row;
 pub mod db_schema;
 pub mod db_table;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum ConnectionDb {
+    Path(PathBuf),
+}
+
+impl Display for ConnectionDb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Path(path) => write!(f, "{}", path.to_str().unwrap_or("")),
+        }
+    }
+}
+
+impl ConnectionDb {
+    pub fn as_path(&self, _span: Span) -> Result<&PathBuf, ShellError> {
+        match self {
+            Self::Path(path) => Ok(path),
+        }
+    }
+}


### PR DESCRIPTION
# Description

More database commands to select and join from derived tables

![image](https://user-images.githubusercontent.com/6942205/167289844-ed44e655-8094-4a34-8d00-b17b11685c34.png)

when joining and selecting from derived tables the connection must be the same

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
