### PR TITLE
Add hooks to cli/repl

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -214,8 +214,8 @@ pub fn evaluate_repl(
         // Right before we start our prompt and take input from the user,
         // fire the "pre_prompt" hook
         if let Some(hook) = &config.hooks.pre_prompt {
-            if let Err(err) = run_hook(engine_state, stack, &hook) {
-                let working_set = StateWorkingSet::new(&engine_state);
+            if let Err(err) = run_hook(engine_state, stack, hook) {
+                let working_set = StateWorkingSet::new(engine_state);
                 report_error(&working_set, &err);
             }
         }
@@ -228,8 +228,8 @@ pub fn evaluate_repl(
                 // Right before we start running the code the user gave us,
                 // fire the "pre_execution" hook
                 if let Some(hook) = &config.hooks.pre_execution {
-                    if let Err(err) = run_hook(engine_state, stack, &hook) {
-                        let working_set = StateWorkingSet::new(&engine_state);
+                    if let Err(err) = run_hook(engine_state, stack, hook) {
+                        let working_set = StateWorkingSet::new(engine_state);
                         report_error(&working_set, &err);
                     }
                 }

--- a/crates/nu-cli/tests/test_completions.rs
+++ b/crates/nu-cli/tests/test_completions.rs
@@ -18,7 +18,7 @@ fn flag_completions() {
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     // Test completions for the 'ls' flags
-    let suggestions = completer.complete("ls -".into(), 4);
+    let suggestions = completer.complete("ls -", 4);
 
     assert_eq!(12, suggestions.len());
 

--- a/crates/nu-command/src/filesystem/cd_query.rs
+++ b/crates/nu-command/src/filesystem/cd_query.rs
@@ -411,9 +411,9 @@ mod test {
 
     #[test]
     fn test_order_paths() {
-        fn sort<'a>(paths: &'a Vec<&'a str>, abbr: &str) -> Vec<&'a str> {
+        fn sort<'a>(paths: &'a [&'a str], abbr: &str) -> Vec<&'a str> {
             let abbr = Abbr::new_sanitized(abbr);
-            let mut paths = paths.clone();
+            let mut paths = paths.to_owned();
             paths.sort_by_key(|path| abbr.compare(path).unwrap());
 
             paths

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -966,7 +966,7 @@ mod test {
                 .and_then(|p| match p.components().next().unwrap() {
                     Component::Prefix(prefix_component) => {
                         let path = Path::new(prefix_component.as_os_str()).join("*");
-                        Some(path.to_path_buf())
+                        Some(path)
                     }
                     _ => panic!("no prefix in this path"),
                 })

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -40,6 +40,12 @@ impl Hooks {
     }
 }
 
+impl Default for Hooks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Config {
     pub filesize_metric: bool,

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -199,6 +199,14 @@ let-env config = {
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
   disable_table_indexes: false # set to true to remove the index column from tables
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
+  hooks: {
+    pre_prompt: {
+      $nothing  # replace with source code to run before the prompt is shown 
+    }
+    pre_execution: {
+      $nothing  # replace with source code to run before the repl input is run
+    }
+  }
   menus: [
       # Configuration for default nushell menus
       # Note the lack of souce parameter


### PR DESCRIPTION
# Description

This adds pre-prompt and pre-execution hooks to the repl that will fire and run a block that you configure it to run.

For example:
```
  ...
  hooks: {
    pre_prompt: {
      let-env FOOBAR = "BAZ"
      print "pre-prompt hook"
    }
    pre_execution: {
      print "pre-execution hook"
    }
  }
  ...
```

![image](https://user-images.githubusercontent.com/547158/167310537-22624fa2-2a14-4346-bd4e-f9f307a768fe.png)

Hooks are able to update the current stack, so the above also adds an environment variable in the `pre-prompt` hook.

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
