### PR TITLE
Allow hooks to be lists of blocks

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -200,12 +200,12 @@ let-env config = {
   disable_table_indexes: false # set to true to remove the index column from tables
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   hooks: {
-    pre_prompt: {
+    pre_prompt: [{
       $nothing  # replace with source code to run before the prompt is shown 
-    }
-    pre_execution: {
+    }]
+    pre_execution: [{
       $nothing  # replace with source code to run before the repl input is run
-    }
+    }]
   }
   menus: [
       # Configuration for default nushell menus


### PR DESCRIPTION
# Description

This allows the configured hooks to also be lists of blocks

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
