### PR TITLE
Fix `to csv` and `to tsv` for simple list, close: #4780

### DIFF
--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -110,7 +110,7 @@ pub fn merge_descriptors(values: &[Value]) -> Vec<String> {
             _ => vec!["".to_string()],
         };
         for desc in data_descriptors {
-            if !seen.contains(&desc) {
+            if desc != "" && !seen.contains(&desc) {
                 seen.insert(desc.to_string());
                 ret.push(desc.to_string());
             }

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -110,7 +110,7 @@ pub fn merge_descriptors(values: &[Value]) -> Vec<String> {
             _ => vec!["".to_string()],
         };
         for desc in data_descriptors {
-            if desc != "" && !seen.contains(&desc) {
+            if !desc.is_empty() && !seen.contains(&desc) {
                 seen.insert(desc.to_string());
                 ret.push(desc.to_string());
             }


### PR DESCRIPTION
# Description

Fix `to csv` and `to tsv` for simple list, close: #4780

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
