### PR TITLE
Fix #5469, making $nothing or null convert to filesize of 0B

### DIFF
--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -133,6 +133,10 @@ pub fn action(input: &Value, span: Span) -> Value {
                 },
                 Err(error) => Value::Error { error },
             },
+            Value::Nothing { .. } => Value::Filesize {
+                val: 0,
+                span: value_span,
+            },
             _ => Value::Error {
                 error: ShellError::UnsupportedInput(
                     "'into filesize' for unsupported type".into(),


### PR DESCRIPTION
# Description

Fix #5469, making $nothing or null convert to filesize of 0B

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
