### PR TITLE
Display range values better

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -153,11 +153,15 @@ impl Command for Table {
                 let base_pipeline = val.to_base_value(span)?.into_pipeline_data();
                 self.run(engine_state, stack, call, base_pipeline)
             }
-            PipelineData::Value(x @ Value::Range { .. }, ..) => Ok(Value::String {
-                val: x.into_string("", config),
-                span: call.head,
-            }
-            .into_pipeline_data()),
+            PipelineData::Value(Value::Range { val, .. }, metadata) => handle_row_stream(
+                engine_state,
+                stack,
+                ListStream::from_stream(val.into_range_iter(ctrlc.clone())?, ctrlc.clone()),
+                call,
+                row_offset,
+                ctrlc,
+                metadata,
+            ),
             x => Ok(x),
         }
     }


### PR DESCRIPTION
# Description

Previously, ranges were not being expanded for display:
```
〉1..3
1..3
```

Now they are:

```
〉1..3
╭───┬───╮
│ 0 │ 1 │
│ 1 │ 2 │
│ 2 │ 3 │
╰───┴───╯
```

Closes #5042.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
