### PR TITLE
Enable converting dates to ints

### DIFF
--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -86,6 +86,11 @@ impl Command for SubCommand {
                 }),
             },
             Example {
+                description: "Convert date to integer (Unix timestamp)",
+                example: "2022-02-02 | into int",
+                result: Some(Value::test_int(1643760000)),
+            },
+            Example {
                 description: "Convert to integer from binary",
                 example: "'1101' | into int -r 2",
                 result: Some(Value::test_int(13)),
@@ -181,6 +186,10 @@ pub fn action(input: &Value, span: Span, radix: u32) -> Value {
                 Value::Int { val: 0, span }
             }
         }
+        Value::Date { val, .. } => Value::Int {
+            val: val.timestamp(),
+            span,
+        },
         _ => Value::Error {
             error: ShellError::UnsupportedInput("'into int' for unsupported type".into(), span),
         },


### PR DESCRIPTION
# Description

Previously `into int` would break when given a datetime. Now it converts the datetime to [a Unix timestamp](https://en.wikipedia.org/wiki/Unix_time).

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
