### PR TITLE
Make $nothing | into string == ""

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -248,7 +248,7 @@ pub fn action(
             span,
         },
         Value::Nothing { .. } => Value::String {
-            val: "nothing".to_string(),
+            val: "".to_string(),
             span,
         },
         Value::Record {

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -157,3 +157,15 @@ fn from_table() {
     assert!(actual.out.contains("32.38"));
     assert!(actual.out.contains("15.20"));
 }
+
+#[test]
+fn from_nothing() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        $nothing | into string
+        "#
+    ));
+
+    assert_eq!(actual.out, "");
+}

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -1,12 +1,13 @@
-use nu_test_support::playground::{Dirs, Playground};
+use nu_test_support::playground::{Playground};
 use nu_test_support::{nu, pipeline};
+use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 
 #[test]
 fn from_range() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1..5 | into string | to json
+        echo 1..5 | into string | to json -r
         "#
         )
     );
@@ -79,7 +80,7 @@ fn from_filename() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "ls sample.toml | get name | into string"
+            "ls sample.toml | get name | into string | get 0"
         );
 
         assert_eq!(actual.out, "sample.toml");
@@ -99,7 +100,7 @@ fn from_filesize() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "ls sample.toml | get size | into string"
+            "ls sample.toml | get size | into string | get 0"
         );
 
         assert_eq!(actual.out, "25 B");
@@ -111,7 +112,7 @@ fn from_decimal_correct_trailing_zeros() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        = 1.23000 | into string -d 3
+        1.23000 | into string -d 3
         "#
     ));
 
@@ -123,7 +124,7 @@ fn from_int_decimal_correct_trailing_zeros() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        = 1.00000 | into string -d 3
+        1.00000 | into string -d 3
         "#
     ));
 
@@ -135,7 +136,7 @@ fn from_int_decimal_trim_trailing_zeros() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        = 1.00000 | into string | format "{$it} flat"
+        1.00000 | into string | $"($in) flat"
         "#
     ));
 

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -1,6 +1,6 @@
-use nu_test_support::playground::{Playground};
-use nu_test_support::{nu, pipeline};
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
 
 #[test]
 fn from_range() {

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -103,7 +103,9 @@ fn from_filesize() {
             "ls sample.toml | get size | into string | get 0"
         );
 
-        assert_eq!(actual.out, "25 B");
+        let expected = if cfg!(windows) { "27 B" } else { "25 B" };
+
+        assert_eq!(actual.out, expected);
     })
 }
 

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -1,4 +1,5 @@
 mod collect;
+mod into_string;
 
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;


### PR DESCRIPTION
# Description

Makes `$nothing | into string` yield empty string per discussion on [the original PR](https://github.com/nushell/nushell/pull/3969)

# Tests

Not sure about adding a test to cover this, I saw some tests in `crates/nu-command/tests/commands/str_/into_string.rs` but got test & compilation failures when I enabled the tests there..