### PR TITLE
adjust where prompt markers go

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -131,30 +131,6 @@ impl Prompt for NushellPrompt {
     }
 
     fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
-        match edit_mode {
-            PromptEditMode::Default => match &self.default_prompt_indicator {
-                Some(indicator) => indicator.as_str().into(),
-                None => "〉".into(),
-            },
-            PromptEditMode::Emacs => match &self.default_prompt_indicator {
-                Some(indicator) => indicator.as_str().into(),
-                None => "〉".into(),
-            },
-            PromptEditMode::Vi(vi_mode) => match vi_mode {
-                PromptViMode::Normal => match &self.default_vi_normal_prompt_indicator {
-                    Some(indicator) => indicator.as_str().into(),
-                    None => ": ".into(),
-                },
-                PromptViMode::Insert => match &self.default_vi_insert_prompt_indicator {
-                    Some(indicator) => indicator.as_str().into(),
-                    None => "〉".into(),
-                },
-            },
-            PromptEditMode::Custom(str) => self.default_wrapped_custom_string(str).into(),
-        }
-    }
-
-    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
         // Just before starting to draw the PS1 prompt send the escape code (see
         // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
         let mut prompt = if self.shell_integration {
@@ -163,13 +139,45 @@ impl Prompt for NushellPrompt {
             String::new()
         };
 
-        prompt.push_str(
-            self.default_multiline_indicator
-                .as_ref()
-                .unwrap_or(&String::from("::: ")),
-        );
+        match edit_mode {
+            PromptEditMode::Default | PromptEditMode::Emacs => {
+                prompt.push_str(
+                    self.default_prompt_indicator
+                        .as_ref()
+                        .unwrap_or(&String::from("〉")),
+                );
+                prompt.into()
+            }
+            PromptEditMode::Vi(vi_mode) => match vi_mode {
+                PromptViMode::Normal => {
+                    prompt.push_str(
+                        self.default_vi_normal_prompt_indicator
+                            .as_ref()
+                            .unwrap_or(&String::from(": ")),
+                    );
+                    prompt.into()
+                }
+                PromptViMode::Insert => {
+                    prompt.push_str(
+                        self.default_vi_insert_prompt_indicator
+                            .as_ref()
+                            .unwrap_or(&String::from("〉")),
+                    );
+                    prompt.into()
+                }
+            },
+            PromptEditMode::Custom(str) => {
+                prompt.push_str(&self.default_wrapped_custom_string(str));
+                prompt.into()
+            }
+        }
+    }
 
-        prompt.into()
+    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+        match &self.default_multiline_indicator {
+            Some(indicator) => indicator.as_str().into(),
+            None => "::: ".into(),
+        }
     }
 
     fn render_prompt_history_search_indicator(

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -147,10 +147,6 @@ pub(crate) fn update_prompt<'prompt>(
         (prompt_vi_insert_string, prompt_vi_normal_string),
     );
 
-    if config.shell_integration {
-        nu_prompt.enable_shell_integration();
-    }
-
     let ret_val = nu_prompt as &dyn Prompt;
     if is_perf_true {
         info!("update_prompt {}:{}:{}", file!(), line!(), column!());

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -234,6 +234,42 @@ pub fn evaluate_repl(
                     }
                 }
 
+                if use_shell_integration {
+                    // Just before running a command/program, send the escape code (see
+                    // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
+                    let mut ansi_escapes = String::from(RESET_APPLICATION_MODE);
+                    ansi_escapes.push_str(PROMPT_MARKER_BEFORE_CMD);
+                    if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
+                        let path = cwd.as_string()?;
+                        // Try to abbreviate string for windows title
+                        let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
+                            path.replace(&p.as_path().display().to_string(), "~")
+                        } else {
+                            path
+                        };
+
+                        // Set window title too
+                        // https://tldp.org/HOWTO/Xterm-Title-3.html
+                        // ESC]0;stringBEL -- Set icon name and window title to string
+                        // ESC]1;stringBEL -- Set icon name to string
+                        // ESC]2;stringBEL -- Set window title to string
+                        ansi_escapes.push_str(&format!("\x1b]2;{}\x07", maybe_abbrev_path));
+                    }
+                    match io::stdout().write_all(ansi_escapes.as_bytes()) {
+                        Ok(it) => it,
+                        Err(err) => println!("error: {}", err),
+                    };
+                    let _ = io::stdout().flush().map_err(|e| {
+                        ShellError::GenericError(
+                            "Error flushing stdio".into(),
+                            e.to_string(),
+                            Some(Span { start: 0, end: 0 }),
+                            None,
+                            Vec::new(),
+                        )
+                    });
+                }
+
                 let start_time = Instant::now();
                 let tokens = lex(s.as_bytes(), 0, &[], &[], false);
                 // Check if this is a single call to a directory, if so auto-cd
@@ -322,41 +358,41 @@ pub fn evaluate_repl(
                     engine_state.add_env_var("PWD".into(), cwd);
                 }
 
-                if use_shell_integration {
-                    // Just before running a command/program, send the escape code (see
-                    // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
-                    let mut ansi_escapes = String::from(RESET_APPLICATION_MODE);
-                    ansi_escapes.push_str(PROMPT_MARKER_BEFORE_CMD);
-                    if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
-                        let path = cwd.as_string()?;
-                        // Try to abbreviate string for windows title
-                        let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
-                            path.replace(&p.as_path().display().to_string(), "~")
-                        } else {
-                            path
-                        };
+                // if use_shell_integration {
+                //     // Just before running a command/program, send the escape code (see
+                //     // https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers)
+                //     let mut ansi_escapes = String::from(RESET_APPLICATION_MODE);
+                //     ansi_escapes.push_str(PROMPT_MARKER_BEFORE_CMD);
+                //     if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
+                //         let path = cwd.as_string()?;
+                //         // Try to abbreviate string for windows title
+                //         let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
+                //             path.replace(&p.as_path().display().to_string(), "~")
+                //         } else {
+                //             path
+                //         };
 
-                        // Set window title too
-                        // https://tldp.org/HOWTO/Xterm-Title-3.html
-                        // ESC]0;stringBEL -- Set icon name and window title to string
-                        // ESC]1;stringBEL -- Set icon name to string
-                        // ESC]2;stringBEL -- Set window title to string
-                        ansi_escapes.push_str(&format!("\x1b]2;{}\x07", maybe_abbrev_path));
-                    }
-                    match io::stdout().write_all(ansi_escapes.as_bytes()) {
-                        Ok(it) => it,
-                        Err(err) => println!("error: {}", err),
-                    };
-                    let _ = io::stdout().flush().map_err(|e| {
-                        ShellError::GenericError(
-                            "Error flushing stdio".into(),
-                            e.to_string(),
-                            Some(Span { start: 0, end: 0 }),
-                            None,
-                            Vec::new(),
-                        )
-                    });
-                }
+                //         // Set window title too
+                //         // https://tldp.org/HOWTO/Xterm-Title-3.html
+                //         // ESC]0;stringBEL -- Set icon name and window title to string
+                //         // ESC]1;stringBEL -- Set icon name to string
+                //         // ESC]2;stringBEL -- Set window title to string
+                //         ansi_escapes.push_str(&format!("\x1b]2;{}\x07", maybe_abbrev_path));
+                //     }
+                //     match io::stdout().write_all(ansi_escapes.as_bytes()) {
+                //         Ok(it) => it,
+                //         Err(err) => println!("error: {}", err),
+                //     };
+                //     let _ = io::stdout().flush().map_err(|e| {
+                //         ShellError::GenericError(
+                //             "Error flushing stdio".into(),
+                //             e.to_string(),
+                //             Some(Span { start: 0, end: 0 }),
+                //             None,
+                //             Vec::new(),
+                //         )
+                //     });
+                // }
             }
             Ok(Signal::CtrlC) => {
                 // `Reedline` clears the line content. New prompt is shown


### PR DESCRIPTION
# Description

The prompt markers were being placed at the wrong spot. 

Hopefully this fixes #5449 once and for all.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
