### PR TITLE
Ensures that non-strings are not unnecessarily quoted

### DIFF
--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -99,12 +99,11 @@ pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
                 }
             }
 
-            if input.parse::<f64>().is_ok()
-                || (!input.contains(' ')
-                    && !input.contains('=')
-                    && !input.contains('"')
-                    && !input.contains('\\')
-                    && !input.contains('-'))
+            if !input.contains(' ')
+                && !input.contains('=')
+                && !input.contains('"')
+                && !input.contains('\\')
+                && !input.contains('-')
             {
                 return input.to_string();
             }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -99,7 +99,7 @@ pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
                 }
             }
 
-            if input.parse::<i32>().is_ok()
+            if input.parse::<f64>().is_ok()
                 || (!input.contains(' ')
                     && !input.contains('=')
                     && !input.contains('"')

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -105,7 +105,7 @@ pub fn escape_quote_string_with_file(input: &str, file: &str, count: usize) -> S
                             }
                             type_tripped = 0;
                         }
-                        if type_tripped != 0 {
+                        if type_tripped != 0 && n != ' ' {
                             word.push(n);
                         }
                     }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -73,6 +73,9 @@ fn escape_quote_string_when_flags_are_unclear(input: &str) -> String {
 
 pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
     // use when you want to cross-compare to a file to ensure flags are checked properly
+    if !input.contains(' ') && !input.contains('=') && !input.contains('"') && !input.contains("\\") {
+        return input.to_string();
+    }
     let file = File::open(file);
     match file {
         Ok(f) => {

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -73,9 +73,6 @@ fn escape_quote_string_when_flags_are_unclear(input: &str) -> String {
 
 pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
     // use when you want to cross-compare to a file to ensure flags are checked properly
-    if !input.contains(' ') && !input.contains('=') && !input.contains('"') && !input.contains("\\") {
-        return input.to_string();
-    }
     let file = File::open(file);
     match file {
         Ok(f) => {
@@ -101,9 +98,24 @@ pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
                     return word;
                 }
             }
+
+            if input.parse::<i32>().is_ok()
+                || (!input.contains(' ')
+                    && !input.contains('=')
+                    && !input.contains('"')
+                    && !input.contains('\\')
+                    && !input.contains('-'))
+            {
+                return input.to_string();
+            }
             let mut final_word = String::new();
             final_word.push('"');
-            final_word.push_str(input);
+            for c in input.chars() {
+                if c == '"' || c == '\\' {
+                    final_word.push('\\');
+                }
+                final_word.push(c);
+            }
             final_word.push('"');
             final_word
         }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -142,9 +142,9 @@ pub fn escape_quote_string_with_file(input: &str, file: &str, count: usize) -> S
                         || list_of_types[count] == "number"
                         || list_of_types[count] == "math"))
                     || (count >= list_of_types.len()
-                        && (list_of_optional_types[count - list_of_types.len()] == "int"
-                            || list_of_optional_types[count - list_of_types.len()] == "math"
-                            || list_of_optional_types[count - list_of_types.len()] == "number")))
+                        && (list_of_optional_types.contains(&String::from("int"))
+                            || list_of_optional_types.contains(&String::from("math"))
+                            || list_of_optional_types.contains(&String::from("number")))))
             {
                 // if the input is a negative number
                 let mut number_quoted = String::from('"');

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,11 @@ fn main() -> Result<()> {
     // then it'll be the script name
     // then the args to the script
     let mut args = std::env::args().skip(1);
+    let mut count = 0;
     while let Some(arg) = args.next() {
         if !script_name.is_empty() {
-            args_to_script.push(escape_quote_string_with_file(&arg, &script_name));
+            args_to_script.push(escape_quote_string_with_file(&arg, &script_name, count));
+            count += 1;
         } else if arg.starts_with('-') {
             // Cool, it's a flag
             let flag_value = match arg.as_ref() {


### PR DESCRIPTION
# Description

Intended to resolve issue #5472. By performing rigorous check that a string needs to be escaped. 

The primary issue comes with negative numbers.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
