### PR TITLE
Adds fix for when multiple flags are in one line.

### DIFF
--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -94,8 +94,8 @@ pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
                         }
                     }
                 }
-                if word == input {
-                    return word;
+                if word.contains(input) {
+                    return input.to_string();
                 }
             }
             let mut final_word = String::new();


### PR DESCRIPTION
# Description

As per the still-active #5445, defining multiple flags in one line caused issues. This was because the function checked if the flag was in the line, not factoring in the possibility of there being multiple flags; as such, it would check if "--flag1--flag2" was equal to "--flag1", which it would clearly not be. By checking now if "--flag1--flag2" _contains_ "--flag1", the issue is resolved.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
