### PR TITLE
Improve #4975 of filtering `ls` output by size issue

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -449,6 +449,11 @@ pub(crate) fn dir_entry_dict(
 
     cols.push("size".to_string());
     if let Some(md) = metadata {
+        #[cfg(unix)]
+        let zero_sized = md.file_type().is_socket()
+            || md.file_type().is_char_device()
+            || md.file_type().is_block_device();
+
         if md.is_dir() {
             if du {
                 let params = DirBuilder::new(Span { start: 0, end: 2 }, None, false, None, false);
@@ -481,7 +486,11 @@ pub(crate) fn dir_entry_dict(
                 vals.push(Value::nothing(span));
             }
         } else {
-            vals.push(Value::nothing(span));
+            #[cfg(not(unix))]
+            let value = Value::nothing(span);
+            #[cfg(unix)]
+            let value = if zero_sized { Value::Filesize { val: 0, span } } else { Value::nothing(span) };
+            vals.push(value);
         }
     } else {
         vals.push(Value::nothing(span));

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -489,7 +489,11 @@ pub(crate) fn dir_entry_dict(
             #[cfg(not(unix))]
             let value = Value::nothing(span);
             #[cfg(unix)]
-            let value = if zero_sized { Value::Filesize { val: 0, span } } else { Value::nothing(span) };
+            let value = if zero_sized {
+                Value::Filesize { val: 0, span }
+            } else {
+                Value::nothing(span)
+            };
             vals.push(value);
         }
     } else {


### PR DESCRIPTION
# Description

Improve #4975 of filtering `ls` output by size issue
You can try the following commands on macOS:
```nu
ls -l /dev | where size > 2B
ls -l /private/tmp/| where size > 2B
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
