### PR TITLE
opt: improve ls by call get_file_type only one time

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -451,7 +451,6 @@ pub(crate) fn dir_entry_dict(
 
     cols.push("size".to_string());
     if let Some(md) = metadata {
-        #[cfg(unix)]
         let zero_sized =
             file_type == "socket" || file_type == "block device" || file_type == "char device";
 

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -353,6 +353,7 @@ pub(crate) fn dir_entry_dict(
 ) -> Result<Value, ShellError> {
     let mut cols = vec![];
     let mut vals = vec![];
+    let mut file_type = "unknown";
 
     cols.push("name".into());
     vals.push(Value::String {
@@ -361,9 +362,10 @@ pub(crate) fn dir_entry_dict(
     });
 
     if let Some(md) = metadata {
+        file_type = get_file_type(md);
         cols.push("type".into());
         vals.push(Value::String {
-            val: get_file_type(md).to_string(),
+            val: file_type.to_string(),
             span,
         });
     } else {
@@ -450,9 +452,9 @@ pub(crate) fn dir_entry_dict(
     cols.push("size".to_string());
     if let Some(md) = metadata {
         #[cfg(unix)]
-        let zero_sized = md.file_type().is_socket()
-            || md.file_type().is_char_device()
-            || md.file_type().is_block_device();
+        let zero_sized = file_type == "socket"
+            || file_type == "block device"
+            || file_type == "char device";
 
         if md.is_dir() {
             if du {
@@ -486,9 +488,6 @@ pub(crate) fn dir_entry_dict(
                 vals.push(Value::nothing(span));
             }
         } else {
-            #[cfg(not(unix))]
-            let value = Value::nothing(span);
-            #[cfg(unix)]
             let value = if zero_sized {
                 Value::Filesize { val: 0, span }
             } else {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -452,9 +452,8 @@ pub(crate) fn dir_entry_dict(
     cols.push("size".to_string());
     if let Some(md) = metadata {
         #[cfg(unix)]
-        let zero_sized = file_type == "socket"
-            || file_type == "block device"
-            || file_type == "char device";
+        let zero_sized =
+            file_type == "socket" || file_type == "block device" || file_type == "char device";
 
         if md.is_dir() {
             if du {


### PR DESCRIPTION
# Description

opt: improve ls by call get_file_type only one time

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
