### PR TITLE
Fix #3899, make `mv` and `rm` to be quiet by default

### DIFF
--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -45,7 +45,11 @@ impl Command for Mv {
                 SyntaxShape::Filepath,
                 "the location to move files/directories to",
             )
-            .switch("quiet", "suppress output showing files moved", Some('q'))
+            .switch(
+                "verbose",
+                "make mv to be verbose, showing files been moved.",
+                Some('v'),
+            )
             // .switch("interactive", "ask user to confirm action", Some('i'))
             // .switch("force", "suppress error when no file", Some('f'))
             .category(Category::FileSystem)
@@ -61,7 +65,7 @@ impl Command for Mv {
         // TODO: handle invalid directory or insufficient permissions when moving
         let spanned_source: Spanned<String> = call.req(engine_state, stack, 0)?;
         let spanned_destination: Spanned<String> = call.req(engine_state, stack, 1)?;
-        let quiet = call.has_flag("quiet");
+        let verbose = call.has_flag("verbose");
         // let interactive = call.has_flag("interactive");
         // let force = call.has_flag("force");
 
@@ -148,15 +152,15 @@ impl Command for Mv {
                 );
                 if let Err(error) = result {
                     Some(Value::Error { error })
-                } else if quiet {
-                    None
-                } else {
+                } else if verbose {
                     let val = format!(
                         "moved {:} to {:}",
                         entry.to_string_lossy(),
                         destination.to_string_lossy()
                     );
                     Some(Value::String { val, span })
+                } else {
+                    None
                 }
             })
             .into_pipeline_data(ctrlc))

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -62,7 +62,11 @@ impl Command for Rm {
             );
         sig.switch("recursive", "delete subdirectories recursively", Some('r'))
             .switch("force", "suppress error when no file", Some('f'))
-            .switch("quiet", "suppress output showing files deleted", Some('q'))
+            .switch(
+                "verbose",
+                "make rm to be verbose, showing files been deleted",
+                Some('v'),
+            )
             // .switch("interactive", "ask user to confirm action", Some('i'))
             .rest(
                 "rest",
@@ -129,7 +133,7 @@ fn rm(
     let permanent = call.has_flag("permanent");
     let recursive = call.has_flag("recursive");
     let force = call.has_flag("force");
-    let quiet = call.has_flag("quiet");
+    let verbose = call.has_flag("verbose");
     // let interactive = call.has_flag("interactive");
 
     let ctrlc = engine_state.ctrlc.clone();
@@ -327,11 +331,11 @@ fn rm(
                                 Vec::new(),
                             ),
                         }
-                    } else if quiet {
-                        Value::Nothing { span }
-                    } else {
+                    } else if verbose {
                         let val = format!("deleted {:}", f.to_string_lossy());
                         Value::String { val, span }
+                    } else {
+                        Value::Nothing { span }
                     }
                 } else {
                     let msg = format!("Cannot remove {:}. try --recursive", f.to_string_lossy());


### PR DESCRIPTION
# Description

Fix #3899, make `mv` and `rm` to be quiet by default

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
