### PR TITLE
nu-cli/completions: verify case for matching dir, .nu, file and command

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -236,7 +236,7 @@ impl Completer for CommandCompletion {
         // let prefix = working_set.get_span_contents(flat.0);
         let prefix = String::from_utf8_lossy(&prefix).to_string();
 
-        file_path_completion(span, &prefix, &cwd, options.match_algorithm)
+        file_path_completion(span, &prefix, &cwd, options)
             .into_iter()
             .map(move |x| {
                 if self.flat_idx == 0 {

--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use super::{partial_from, prepend_base_dir, MatchAlgorithm};
+use super::{partial_from, prepend_base_dir};
 
 const SEP: char = std::path::MAIN_SEPARATOR;
 
@@ -44,7 +44,7 @@ impl Completer for DirectoryCompletion {
         let partial = String::from_utf8_lossy(&prefix).to_string();
 
         // Filter only the folders
-        let output: Vec<_> = directory_completion(span, &partial, &cwd, options.match_algorithm)
+        let output: Vec<_> = directory_completion(span, &partial, &cwd, options)
             .into_iter()
             .map(move |x| Suggestion {
                 value: x.1,
@@ -103,7 +103,7 @@ pub fn directory_completion(
     span: nu_protocol::Span,
     partial: &str,
     cwd: &str,
-    match_algorithm: MatchAlgorithm,
+    options: &CompletionOptions,
 ) -> Vec<(nu_protocol::Span, String)> {
     let original_input = partial;
 
@@ -124,7 +124,7 @@ pub fn directory_completion(
                     if let Ok(metadata) = fs::metadata(entry.path()) {
                         if metadata.is_dir() {
                             let mut file_name = entry.file_name().to_string_lossy().into_owned();
-                            if matches(&partial, &file_name, match_algorithm) {
+                            if matches(&partial, &file_name, options) {
                                 let mut path = if prepend_base_dir(original_input, &base_dir_name) {
                                     format!("{}{}", base_dir_name, file_name)
                                 } else {

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -91,7 +91,7 @@ impl Completer for DotNuCompletion {
         let output: Vec<Suggestion> = search_dirs
             .into_iter()
             .flat_map(|it| {
-                file_path_completion(span, &partial, &it, options.match_algorithm)
+                file_path_completion(span, &partial, &it, options)
                     .into_iter()
                     .filter(|it| {
                         // Different base dir, so we list the .nu files or folders

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -1,4 +1,4 @@
-use crate::completions::{Completer, CompletionOptions, MatchAlgorithm};
+use crate::completions::{Completer, CompletionOptions};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
@@ -39,7 +39,7 @@ impl Completer for FileCompletion {
             "".to_string()
         };
         let prefix = String::from_utf8_lossy(&prefix).to_string();
-        let output: Vec<_> = file_path_completion(span, &prefix, &cwd, options.match_algorithm)
+        let output: Vec<_> = file_path_completion(span, &prefix, &cwd, options)
             .into_iter()
             .map(move |x| Suggestion {
                 value: x.1,
@@ -112,7 +112,7 @@ pub fn file_path_completion(
     span: nu_protocol::Span,
     partial: &str,
     cwd: &str,
-    match_algorithm: MatchAlgorithm,
+    options: &CompletionOptions,
 ) -> Vec<(nu_protocol::Span, String)> {
     let original_input = partial;
     let (base_dir_name, partial) = partial_from(partial);
@@ -129,7 +129,7 @@ pub fn file_path_completion(
             .filter_map(|entry| {
                 entry.ok().and_then(|entry| {
                     let mut file_name = entry.file_name().to_string_lossy().into_owned();
-                    if matches(&partial, &file_name, match_algorithm) {
+                    if matches(&partial, &file_name, options) {
                         let mut path = if prepend_base_dir(original_input, &base_dir_name) {
                             format!("{}{}", base_dir_name, file_name)
                         } else {
@@ -158,8 +158,18 @@ pub fn file_path_completion(
     Vec::new()
 }
 
-pub fn matches(partial: &str, from: &str, match_algorithm: MatchAlgorithm) -> bool {
-    match_algorithm.matches_str(&from.to_ascii_lowercase(), &partial.to_ascii_lowercase())
+pub fn matches(partial: &str, from: &str, options: &CompletionOptions) -> bool {
+    // Create new values to not mutate the original ones
+    let mut haystack = from.to_string();
+    let mut needle = partial.to_string();
+
+    // Check for case sensitive
+    if !options.case_sensitive {
+        haystack = haystack.to_ascii_lowercase();
+        needle = needle.to_ascii_lowercase();
+    }
+
+    options.match_algorithm.matches_str(&haystack, &needle)
 }
 
 /// Returns whether the base_dir should be prepended to the file path

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -159,17 +159,14 @@ pub fn file_path_completion(
 }
 
 pub fn matches(partial: &str, from: &str, options: &CompletionOptions) -> bool {
-    // Create new values to not mutate the original ones
-    let mut haystack = from.to_string();
-    let mut needle = partial.to_string();
-
     // Check for case sensitive
     if !options.case_sensitive {
-        haystack = haystack.to_ascii_lowercase();
-        needle = needle.to_ascii_lowercase();
+        return options
+            .match_algorithm
+            .matches_str(&from.to_ascii_lowercase(), &partial.to_ascii_lowercase());
     }
 
-    options.match_algorithm.matches_str(&haystack, &needle)
+    options.match_algorithm.matches_str(&from, &partial)
 }
 
 /// Returns whether the base_dir should be prepended to the file path

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -166,7 +166,7 @@ pub fn matches(partial: &str, from: &str, options: &CompletionOptions) -> bool {
             .matches_str(&from.to_ascii_lowercase(), &partial.to_ascii_lowercase());
     }
 
-    options.match_algorithm.matches_str(&from, &partial)
+    options.match_algorithm.matches_str(from, partial)
 }
 
 /// Returns whether the base_dir should be prepended to the file path


### PR DESCRIPTION
# Description

This PR adds back the check for `CompletionOptions.case_sensitive` when doing the completion match for directory, dot nu, file and command completions.
Probably fixes https://github.com/nushell/nushell/issues/5438, but I couldn't test correctly because none of the 3 OSes I use have a case sensitive filesystem.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
