### PR TITLE
Change history menu keybinding from ctrl+x to ctrl+r

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -501,6 +501,27 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         ReedlineEvent::MenuPrevious,
     );
 
+    keybindings.add_binding(
+        KeyModifiers::CONTROL,
+        KeyCode::Char('r'),
+        ReedlineEvent::Menu("history_menu".to_string()),
+    );
+
+    keybindings.add_binding(
+        KeyModifiers::CONTROL,
+        KeyCode::Char('x'),
+        ReedlineEvent::MenuPageNext,
+    );
+
+    keybindings.add_binding(
+        KeyModifiers::CONTROL,
+        KeyCode::Char('z'),
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::MenuPagePrevious,
+            ReedlineEvent::Edit(vec![EditCommand::Undo]),
+        ]),
+    );
+
     // Help menu keybinding
     keybindings.add_binding(
         KeyModifiers::CONTROL,

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -504,7 +504,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
     // History menu keybinding
     keybindings.add_binding(
         KeyModifiers::CONTROL,
-        KeyCode::Char('x'),
+        KeyCode::Char('r'),
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("history_menu".to_string()),
             ReedlineEvent::MenuPageNext,

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -501,25 +501,6 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         ReedlineEvent::MenuPrevious,
     );
 
-    // History menu keybinding
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('r'),
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Menu("history_menu".to_string()),
-            ReedlineEvent::MenuPageNext,
-        ]),
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('z'),
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::MenuPagePrevious,
-            ReedlineEvent::Edit(vec![EditCommand::Undo]),
-        ]),
-    );
-
     // Help menu keybinding
     keybindings.add_binding(
         KeyModifiers::CONTROL,

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -354,11 +354,23 @@ let-env config = {
       event: { send: menu name: history_menu }
     }
     {
-      name: undo
+      name: next_page
+      modifier: control
+      keycode: char_x
+      mode: emacs
+      event: { send: menupagenext }
+    }
+    {
+      name: undo_or_previous_page
       modifier: control
       keycode: char_z
       mode: emacs
-      event: { edit: undo }
+      event: {
+        until: [
+          { send: menupageprevious }
+          { edit: undo }
+        ]
+       }
     }
     # Keybindings used to trigger the user defined menus
     {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -349,7 +349,7 @@ let-env config = {
     {
       name: history_menu
       modifier: control
-      keycode: char_x
+      keycode: char_r
       mode: emacs
       event: {
         until: [

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -201,7 +201,7 @@ let-env config = {
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   hooks: {
     pre_prompt: [{
-      $nothing  # replace with source code to run before the prompt is shown 
+      $nothing  # replace with source code to run before the prompt is shown
     }]
     pre_execution: [{
       $nothing  # replace with source code to run before the repl input is run

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -351,24 +351,14 @@ let-env config = {
       modifier: control
       keycode: char_r
       mode: emacs
-      event: {
-        until: [
-          { send: menu name: history_menu }
-          { send: menupagenext }
-        ]
-      }
+      event: { send: menu name: history_menu }
     }
     {
-      name: history_previous
+      name: undo
       modifier: control
       keycode: char_z
       mode: emacs
-      event: {
-        until: [
-          { send: menupageprevious }
-          { edit: undo }
-        ]
-      }
+      event: { edit: undo }
     }
     # Keybindings used to trigger the user defined menus
     {


### PR DESCRIPTION
# Description

~This is a draft PR for now; let's discuss before merging it.~

This PR changes the default history menu keybinding to `ctrl+r` from `ctrl+x`. I think `ctrl+r` is a better, more discoverable keybinding for Nu's most polished history search feature; it's probably the first keybinding users of Bash, Powershell, and fzf will try. I might be missing good reasons to keep the current keybinding, let me know if I am!

This does hide the simple reverse-i-search functionality that Reedline binds to `ctrl+r` by default; I'm personally OK with that, I think reverse-i-search is quite limited compared to the history menu.

# Tests

I did some manual testing and confirmed that this works, both with a fresh install of Nu and with an old default config file. If using the old config file, you'll end up with history search bound to both `ctrl+r` and `ctrl+x`.

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
