### PR TITLE
Move help menu to canonical `F1` binding

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -522,8 +522,8 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
 
     // Help menu keybinding
     keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('q'),
+        KeyModifiers::NONE,
+        KeyCode::F(1),
         ReedlineEvent::Menu("help_menu".to_string()),
     );
 }


### PR DESCRIPTION
# Description

Currently the fully fledged help menu is bound to `Ctrl-Q`.
Help is widely associated with `F1`.

Before merging check that it is passed through on all platforms and
terminal emulators

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
