### PR TITLE
feat: add `tutor list` support, remove tutor `engine-q`, fix: #4950

### DIFF
--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -143,7 +143,8 @@ Welcome to the Nushell tutorial!
 With the `tutor` command, you'll be able to learn a lot about how Nushell
 works along with many fun tips and tricks to speed up everyday tasks.
 
-To get started, you can use `tutor begin`.
+To get started, you can use `tutor begin`, and to see all the available
+tutorials just run `tutor list`.
 
 "#
 }

--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -113,7 +113,8 @@ fn tutor(
             }
         }
 
-        let message = format!("You can find '{find}' in the following topics:\n\n{}\n\n{notes}",
+        let message = format!(
+            "You can find '{find}' in the following topics:\n\n{}\n\n{notes}",
             results.into_iter().map(|x| format!("- {}", x)).join("\n")
         );
 
@@ -121,7 +122,8 @@ fn tutor(
     } else if let Some(search) = search {
         if search == "list" {
             let results = search_space.map(|s| s.0[0].to_string());
-            let message = format!("This tutorial contains the following topics:\n\n{}\n\n{notes}",
+            let message = format!(
+                "This tutorial contains the following topics:\n\n{}\n\n{notes}",
                 results.map(|x| format!("- {}", x)).join("\n")
             );
             return Ok(display(&message, engine_state, stack, span));

--- a/crates/nu-command/src/core_commands/tutor.rs
+++ b/crates/nu-command/src/core_commands/tutor.rs
@@ -74,6 +74,7 @@ fn tutor(
 
     let search: Option<String> = call.opt(engine_state, stack, 0).unwrap_or(None);
     let find: Option<String> = call.get_flag(engine_state, stack, "find")?;
+    let notes = "You can learn about a topic using `tutor` followed by the name of the topic.\nFor example: `tutor table` to open the table topic.\n\n";
 
     let search_space = [
         (vec!["begin"], begin_tutor()),
@@ -100,7 +101,6 @@ fn tutor(
             vec!["var", "vars", "variable", "variables"],
             variable_tutor(),
         ),
-        (vec!["engine-q", "e-q"], engineq_tutor()),
         (vec!["block", "blocks"], block_tutor()),
         (vec!["shorthand", "shorthands"], shorthand_tutor()),
     ];
@@ -113,13 +113,20 @@ fn tutor(
             }
         }
 
-        let message = format!("You can find '{}' in the following topics:\n{}\n\nYou can learn about a topic using `tutor` followed by the name of the topic.\nFor example: `tutor table` to open the table topic.\n\n",
-            find,
+        let message = format!("You can find '{find}' in the following topics:\n\n{}\n\n{notes}",
             results.into_iter().map(|x| format!("- {}", x)).join("\n")
         );
 
         return Ok(display(&message, engine_state, stack, span));
     } else if let Some(search) = search {
+        if search == "list" {
+            let results = search_space.map(|s| s.0[0].to_string());
+            let message = format!("This tutorial contains the following topics:\n\n{}\n\n{notes}",
+                results.map(|x| format!("- {}", x)).join("\n")
+            );
+            return Ok(display(&message, engine_state, stack, span));
+        }
+
         for search_group in search_space {
             if search_group.0.contains(&search.as_str()) {
                 return Ok(display(search_group.1, engine_state, stack, span));
@@ -387,29 +394,6 @@ same value using:
 ```
 (ls).4.name
 ```
-"#
-}
-
-fn engineq_tutor() -> &'static str {
-    r#"
-Engine-q is the upcoming engine for Nushell. Build for speed and correctness,
-it also comes with a set of changes from Nushell versions prior to 0.60. To
-get ready for engine-q look for some of these changes that might impact your
-current scripts:
-
-* Engine-q now uses a few new data structures, including a record syntax
-  that allows you to model key-value pairs similar to JSON objects.
-* Environment variables can now contain more than just strings. Structured
-  values are converted to strings for external commands using converters.
-* `if` will now use an `else` keyword before the else block.
-* We're moving from "config.toml" to "config.nu". This means startup will
-  now be a script file.
-* `config` and its subcommands are being replaced by a record that you can
-  update in the shell which contains all the settings under the variable
-  `$config`.
-* bigint/bigdecimal values are now machine i64 and f64 values
-* And more, you can read more about upcoming changes in the up-to-date list
-  at: https://github.com/nushell/engine-q/issues/522
 "#
 }
 


### PR DESCRIPTION
# Description

feat: add `tutor list` support, remove tutor `engine-q`, fix: #4950

![Screen Shot 2022-05-11 at 20 42 34](https://user-images.githubusercontent.com/1161607/167852501-c8b2ac07-6aaa-4b2f-a2b2-7dd546a05ba4.png)


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
