### PR TITLE
add `--table_mode` `-m` parameter

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -61,15 +61,18 @@ pub fn evaluate_file(
 }
 
 pub fn print_table_or_error(
-    engine_state: &EngineState,
+    engine_state: &mut EngineState,
     stack: &mut Stack,
     mut pipeline_data: PipelineData,
-    config: &Config,
+    config: &mut Config,
 ) {
     let exit_code = match &mut pipeline_data {
         PipelineData::ExternalStream { exit_code, .. } => exit_code.take(),
         _ => None,
     };
+
+    // Change the engine_state config to use the passed in configuration
+    engine_state.set_config(config);
 
     match engine_state.find_decl("table".as_bytes(), &[]) {
         Some(decl_id) => {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -44,6 +44,7 @@ impl Command for Table {
                 "row number to start viewing from",
                 Some('n'),
             )
+            .switch("list", "list available table modes/themes", Some('l'))
             .category(Category::Viewers)
     }
 
@@ -60,12 +61,34 @@ impl Command for Table {
         let color_hm = get_color_config(config);
         let start_num: Option<i64> = call.get_flag(engine_state, stack, "start-number")?;
         let row_offset = start_num.unwrap_or_default() as usize;
+        let list: bool = call.has_flag("list");
 
         let term_width = if let Some((Width(w), Height(_h))) = terminal_size::terminal_size() {
             (w - 1) as usize
         } else {
             80usize
         };
+
+        if list {
+            let table_modes = vec![
+                Value::string("basic", Span::test_data()),
+                Value::string("compact", Span::test_data()),
+                Value::string("compact_double", Span::test_data()),
+                Value::string("default", Span::test_data()),
+                Value::string("heavy", Span::test_data()),
+                Value::string("light", Span::test_data()),
+                Value::string("none", Span::test_data()),
+                Value::string("reinforced", Span::test_data()),
+                Value::string("rounded", Span::test_data()),
+                Value::string("thin", Span::test_data()),
+                Value::string("with_love", Span::test_data()),
+            ];
+            return Ok(Value::List {
+                vals: table_modes,
+                span: Span::test_data(),
+            }
+            .into_pipeline_data());
+        }
 
         // reset vt processing, aka ansi because illbehaved externals can break it
         #[cfg(windows)]

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -817,6 +817,10 @@ impl EngineState {
         &self.config
     }
 
+    pub fn set_config(&mut self, conf: &Config) {
+        self.config = conf.clone();
+    }
+
     pub fn get_var(&self, var_id: VarId) -> &Variable {
         self.vars
             .get(var_id)

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> Result<()> {
         } else if arg.starts_with('-') {
             // Cool, it's a flag
             let flag_value = match arg.as_ref() {
-                "--commands" | "-c" | "--table_mode" | "-m" => {
+                "--commands" | "-c" | "--table-mode" | "-m" => {
                     args.next().map(|a| escape_quote_string(&a))
                 }
                 "--config" | "--env-config" => args.next().map(|a| escape_quote_string(&a)),
@@ -325,7 +325,7 @@ fn parse_commandline_args(
             let log_level: Option<Expression> = call.get_flag_expr("log-level");
             let threads: Option<Value> = call.get_flag(engine_state, &mut stack, "threads")?;
             let table_mode: Option<Value> =
-                call.get_flag(engine_state, &mut stack, "table_mode")?;
+                call.get_flag(engine_state, &mut stack, "table-mode")?;
 
             fn extract_contents(
                 expression: Option<Expression>,
@@ -471,7 +471,7 @@ impl Command for Nu {
                 Some('t'),
             )
             .named(
-                "table_mode",
+                "table-mode",
                 SyntaxShape::String,
                 "the table mode to use. rounded is default.",
                 Some('m'),

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,9 @@ fn main() -> Result<()> {
         } else if arg.starts_with('-') {
             // Cool, it's a flag
             let flag_value = match arg.as_ref() {
-                "--commands" | "-c" => args.next().map(|a| escape_quote_string(&a)),
+                "--commands" | "-c" | "--table_mode" | "-m" => {
+                    args.next().map(|a| escape_quote_string(&a))
+                }
                 "--config" | "--env-config" => args.next().map(|a| escape_quote_string(&a)),
                 "--log-level" | "--testbin" | "--threads" | "-t" => args.next(),
                 _ => None,
@@ -200,11 +202,11 @@ fn main() -> Result<()> {
                     &mut stack,
                     input,
                     is_perf_true(),
+                    binary_args.table_mode,
                 );
                 if is_perf_true() {
                     info!("-c command execution {}:{}:{}", file!(), line!(), column!());
                 }
-
                 ret_val
             } else if !script_name.is_empty() && binary_args.interactive_shell.is_none() {
                 #[cfg(feature = "plugin")]
@@ -322,6 +324,8 @@ fn parse_commandline_args(
             let env_file: Option<Expression> = call.get_flag_expr("env-config");
             let log_level: Option<Expression> = call.get_flag_expr("log-level");
             let threads: Option<Value> = call.get_flag(engine_state, &mut stack, "threads")?;
+            let table_mode: Option<Value> =
+                call.get_flag(engine_state, &mut stack, "table_mode")?;
 
             fn extract_contents(
                 expression: Option<Expression>,
@@ -384,6 +388,7 @@ fn parse_commandline_args(
                 log_level,
                 perf,
                 threads,
+                table_mode,
             });
         }
     }
@@ -406,6 +411,7 @@ struct NushellCliArgs {
     log_level: Option<Spanned<String>>,
     perf: bool,
     threads: Option<Value>,
+    table_mode: Option<Value>,
 }
 
 #[derive(Clone)]
@@ -464,6 +470,12 @@ impl Command for Nu {
                 "threads to use for parallel commands",
                 Some('t'),
             )
+            .named(
+                "table_mode",
+                SyntaxShape::String,
+                "the table mode to use. rounded is default.",
+                Some('m'),
+            )
             .optional(
                 "script file",
                 SyntaxShape::Filepath,
@@ -514,11 +526,6 @@ impl Command for Nu {
 pub fn is_perf_true() -> bool {
     IS_PERF.with(|value| *value.borrow())
 }
-
-// #[allow(dead_code)]
-// fn is_perf_value() -> bool {
-//     IS_PERF.with(|value| *value.borrow())
-// }
 
 fn set_is_perf_value(value: bool) {
     IS_PERF.with(|new_value| {


### PR DESCRIPTION
# Description

This PR allows you to run a nushell command and pass a table mode parameter.
<img width="982" alt="Screen Shot 2022-05-11 at 11 04 48 AM" src="https://user-images.githubusercontent.com/343840/167896341-c6d631e8-2a99-4191-9572-3f9f9026740b.png">
<img width="1014" alt="Screen Shot 2022-05-11 at 11 05 27 AM" src="https://user-images.githubusercontent.com/343840/167896379-2c61b5ee-d523-4a87-8a8f-d0ce387731f7.png">


Also added a `table --list` parameter to show what modes are available.
```
> table -l 
╭────────────────╮
│ basic          │
│ compact        │
│ compact_double │
│ default        │
│ heavy          │
│ light          │
│ none           │
│ reinforced     │
│ rounded        │
│ thin           │
│ with_love      │
╰────────────────╯
```

closes #5278
# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
