### PR TITLE
nu-command/filesystem: fix rm .sock file

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -301,7 +301,7 @@ fn rm(
                             trash::delete(&f).map_err(|e: trash::Error| {
                                 Error::new(ErrorKind::Other, format!("{:?}", e))
                             })
-                        } else if metadata.is_file() {
+                        } else if metadata.is_file() || is_socket || is_fifo {
                             std::fs::remove_file(&f)
                         } else {
                             std::fs::remove_dir_all(&f)


### PR DESCRIPTION
# Description

Adds back the check if it's the target is a file, fifo or sock.

Fixes https://github.com/nushell/nushell/issues/5522

[![asciicast](https://asciinema.org/a/zy67AbcEbYB7rcjbEJOiz5T0H.svg)](https://asciinema.org/a/zy67AbcEbYB7rcjbEJOiz5T0H)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
