### PR TITLE
add rename

### DIFF
--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -112,6 +112,7 @@ fn rename(
     let columns: Vec<String> = call.rest(engine_state, stack, 0)?;
     let metadata = input.metadata();
 
+    let head_span = call.head;
     input
         .map(
             move |item| match item {
@@ -151,7 +152,13 @@ fn rename(
 
                     Value::Record { cols, vals, span }
                 }
-                x => x,
+                x => Value::Error {
+                    error: ShellError::UnsupportedInput(
+                        "can't rename: input is not table, so no column names available for rename"
+                            .to_string(),
+                        x.span().unwrap_or(head_span),
+                    ),
+                },
             },
             engine_state.ctrlc.clone(),
         )

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -61,8 +61,6 @@ fn keeps_remaining_original_names_given_less_new_names_than_total_original_names
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn errors_if_no_columns_present() {
     Playground::setup("rename_test_3", |dirs, sandbox| {


### PR DESCRIPTION
# Description

little change for handling invalid pipeline input on `rename` command, pushing #4314

If the code is ok, following can be done:
* commands::rename::errors_if_no_columns_present - (silent failure with renaming a column that doesn't exist)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
