### PR TITLE
fix zip test

### DIFF
--- a/crates/nu-command/tests/commands/zip.rs
+++ b/crates/nu-command/tests/commands/zip.rs
@@ -8,14 +8,12 @@ def expect [
     --to-eq,
     right
 ] {
-    $left | zip { $right } | all? {|row|
+    $left | zip $right | all? {|row|
         $row.name.0 == $row.name.1 && $row.commits.0 == $row.commits.1
     }
 }
 "#;
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn zips_two_tables() {
     Playground::setup("zip_test_1", |dirs, nu| {


### PR DESCRIPTION
# Description

Push #4314 for zip part.

It's a relative small change, after investigation, I think `zip` implementation is ok, the problem lays in the test util function.  Old `zip` can only accept `block` as input, but new zip doesn't.

If the code is ok, the following task can be done:
* commands::zips_two_tables - (zip appears to be creating a block in a table in error)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
