### PR TITLE
nu-glob: add fs::symlink_metadata to detect broken symlinks

### DIFF
--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -969,8 +969,7 @@ mod test {
                 .ok()
                 .and_then(|p| match p.components().next().unwrap() {
                     Component::Prefix(prefix_component) => {
-                        let path = Path::new(prefix_component.as_os_str());
-                        path.join("*");
+                        let path = Path::new(prefix_component.as_os_str()).join("*");
                         Some(path.to_path_buf())
                     }
                     _ => panic!("no prefix in this path"),

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -782,7 +782,11 @@ fn fill_todo(
             } else {
                 path.join(&s)
             };
-            if (special && is_dir) || (!special && fs::metadata(&next_path).is_ok()) {
+            if (special && is_dir)
+                || (!special
+                    && (fs::metadata(&next_path).is_ok()
+                        || fs::symlink_metadata(&next_path).is_ok()))
+            {
                 add(todo, next_path);
             }
         }
@@ -965,8 +969,9 @@ mod test {
                 .ok()
                 .and_then(|p| match p.components().next().unwrap() {
                     Component::Prefix(prefix_component) => {
-                        let path = Path::new(prefix_component.as_os_str()).join("*");
-                        Some(path)
+                        let path = Path::new(prefix_component.as_os_str());
+                        path.join("*");
+                        Some(path.to_path_buf())
                     }
                     _ => panic!("no prefix in this path"),
                 })


### PR DESCRIPTION
# Description

Fixes https://github.com/nushell/nushell/issues/3977 (also related to https://github.com/rust-lang-nursery/glob/pull/105)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
