### PR TITLE
Fix Value::Record compare logic, and pass uniq tests.

### DIFF
--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -61,8 +61,6 @@ fn uniq_values() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn nested_json_structures() {
     Playground::setup("uniq_test_3", |dirs, sandbox| {
@@ -127,8 +125,6 @@ fn nested_json_structures() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn uniq_when_keys_out_of_order() {
     let actual = nu!(

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1289,6 +1289,8 @@ impl PartialOrd for Value {
                     ..
                 } => {
                     // reorder cols and vals to make more logically compare.
+                    // more genral, if two record have same col and values,
+                    // the order of cols shouldn't affect the equal property.
                     let (lhs_cols_ordered, lhs_vals_ordered) =
                         reorder_record_inner(lhs_cols, lhs_vals);
                     let (rhs_cols_ordered, rhs_vals_ordered) =


### PR DESCRIPTION
# Description

Fix record compare logic, to make the following expression true:

```nu
[{"a": "a", "b": [1,2,3]}] == [{"b": [1,2,3], "a": "a"}]
```

And it can also push #4314 

If the code is ok, the following can be done:
*  commands::uniq::nested_json_structures - (uniq doesn't appear to work on structures any longer)
* commands::uniq::uniq_when_keys_out_of_order - (uniq doesn't appear to work on structures any longer)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
