### PR TITLE
nu-cli/completions: add custom completion test

### DIFF
--- a/crates/nu-cli/tests/custom_completions.rs
+++ b/crates/nu-cli/tests/custom_completions.rs
@@ -1,0 +1,29 @@
+pub mod support;
+
+use nu_cli::NuCompleter;
+use reedline::Completer;
+use support::{match_suggestions, new_engine};
+
+#[test]
+fn variables_completions() {
+    // Create a new engine
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Add record value as example
+    let record = r#"def animals [] { ["cat", "dog", "eel" ] }
+    def my-command [animal: string@animals] { print $animal }"#;
+    assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
+
+    // Instatiate a new completer
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    // Test completions for $nu
+    let suggestions = completer.complete("my-command ".into(), 11);
+
+    assert_eq!(3, suggestions.len());
+
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+
+    // Match results
+    match_suggestions(expected, suggestions);
+}

--- a/crates/nu-cli/tests/dotnu_completions.rs
+++ b/crates/nu-cli/tests/dotnu_completions.rs
@@ -1,4 +1,4 @@
-mod support;
+pub mod support;
 
 use nu_cli::NuCompleter;
 use reedline::Completer;
@@ -17,12 +17,12 @@ fn dotnu_completions() {
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
     assert_eq!(1, suggestions.len());
-    assert_eq!("test_dotnu.nu", suggestions.get(0).unwrap().value);
+    assert_eq!("custom_completion.nu", suggestions.get(0).unwrap().value);
 
     // Test use completion
     let completion_str = "use ".to_string();
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
     assert_eq!(1, suggestions.len());
-    assert_eq!("test_dotnu.nu", suggestions.get(0).unwrap().value);
+    assert_eq!("custom_completion.nu", suggestions.get(0).unwrap().value);
 }

--- a/crates/nu-cli/tests/file_completions.rs
+++ b/crates/nu-cli/tests/file_completions.rs
@@ -1,4 +1,4 @@
-mod support;
+pub mod support;
 
 use nu_cli::NuCompleter;
 use reedline::Completer;
@@ -22,7 +22,7 @@ fn file_completions() {
         folder(dir.join("test_a")),
         folder(dir.join("test_b")),
         folder(dir.join("another")),
-        file(dir.join("test_dotnu.nu")),
+        file(dir.join("custom_completion.nu")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
     ];

--- a/crates/nu-cli/tests/flag_completions.rs
+++ b/crates/nu-cli/tests/flag_completions.rs
@@ -1,4 +1,4 @@
-mod support;
+pub mod support;
 
 use nu_cli::NuCompleter;
 use reedline::Completer;

--- a/crates/nu-cli/tests/folder_completions.rs
+++ b/crates/nu-cli/tests/folder_completions.rs
@@ -1,4 +1,4 @@
-mod support;
+pub mod support;
 
 use nu_cli::NuCompleter;
 use reedline::Completer;

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -5,13 +5,12 @@ use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
     engine::{EngineState, Stack, StateDelta, StateWorkingSet},
-    PipelineData, Span, Value,
+    PipelineData, ShellError, Span, Value,
 };
 use nu_test_support::fs;
 use reedline::Suggestion;
 const SEP: char = std::path::MAIN_SEPARATOR;
 
-#[allow(dead_code)]
 // creates a new engine with the current path into the completions fixtures folder
 pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
     // Target folder inside assets
@@ -48,12 +47,41 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
     let merge_result = engine_state.merge_delta(delta, Some(&mut stack), &dir);
     assert!(merge_result.is_ok());
 
-    // Add record value as example
-    let record = "let actor = { name: 'Tom Hardy', age: 44 }";
+    (dir, dir_str, engine_state, stack)
+}
+
+// match a list of suggestions with the expected values
+pub fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
+    expected.iter().zip(suggestions).for_each(|it| {
+        assert_eq!(it.0, &it.1.value);
+    });
+}
+
+// append the separator to the converted path
+pub fn folder(path: PathBuf) -> String {
+    let mut converted_path = file(path);
+    converted_path.push(SEP);
+
+    converted_path
+}
+
+// convert a given path to string
+pub fn file(path: PathBuf) -> String {
+    path.into_os_string().into_string().unwrap_or_default()
+}
+
+// merge_input executes the given input into the engine
+// and merges the state
+pub fn merge_input(
+    input: &[u8],
+    engine_state: &mut EngineState,
+    stack: &mut Stack,
+    dir: PathBuf,
+) -> Result<(), ShellError> {
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let (block, err) = parse(&mut working_set, None, record.as_bytes(), false, &[]);
+        let (block, err) = parse(&mut working_set, None, input, false, &[]);
 
         assert!(err.is_none());
 
@@ -61,7 +89,7 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
     };
     assert!(eval_block(
         &engine_state,
-        &mut stack,
+        stack,
         &block,
         PipelineData::Value(
             Value::Nothing {
@@ -75,31 +103,5 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
     .is_ok());
 
     // Merge delta
-    let merge_result = engine_state.merge_delta(delta, Some(&mut stack), &dir);
-    assert!(merge_result.is_ok());
-
-    (dir.clone(), dir_str, engine_state, stack)
-}
-
-#[allow(dead_code)]
-// match a list of suggestions with the expected values
-pub fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
-    expected.iter().zip(suggestions).for_each(|it| {
-        assert_eq!(it.0, &it.1.value);
-    });
-}
-
-#[allow(dead_code)]
-// append the separator to the converted path
-pub fn folder(path: PathBuf) -> String {
-    let mut converted_path = file(path);
-    converted_path.push(SEP);
-
-    converted_path
-}
-
-#[allow(dead_code)]
-// convert a given path to string
-pub fn file(path: PathBuf) -> String {
-    path.into_os_string().into_string().unwrap_or_default()
+    engine_state.merge_delta(delta, Some(stack), &dir)
 }

--- a/crates/nu-cli/tests/support/mod.rs
+++ b/crates/nu-cli/tests/support/mod.rs
@@ -1,3 +1,3 @@
 pub mod completions_helpers;
 
-pub use completions_helpers::{file, folder, match_suggestions, new_engine};
+pub use completions_helpers::{file, folder, match_suggestions, merge_input, new_engine};

--- a/crates/nu-cli/tests/variables_completions.rs
+++ b/crates/nu-cli/tests/variables_completions.rs
@@ -1,4 +1,4 @@
-mod support;
+pub mod support;
 
 use nu_cli::NuCompleter;
 use reedline::Completer;
@@ -7,7 +7,11 @@ use support::{match_suggestions, new_engine};
 #[test]
 fn variables_completions() {
     // Create a new engine
-    let (_, _, engine, stack) = new_engine();
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Add record value as example
+    let record = "let actor = { name: 'Tom Hardy', age: 44 }";
+    assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     // Instatiate a new completer
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);

--- a/tests/fixtures/completions/custom_completion.nu
+++ b/tests/fixtures/completions/custom_completion.nu
@@ -1,0 +1,2 @@
+def animals [] { ["cat", "dog", "eel" ] }
+def my-command [animal: string@animals] { print $animal }

--- a/tests/fixtures/completions/test_dotnu.nu
+++ b/tests/fixtures/completions/test_dotnu.nu
@@ -1,3 +1,0 @@
-def test[] {
-    Just a test
-}


### PR DESCRIPTION
# Description

* Refactor part of the `new_engine` function into `merge_input` to make it easier to be used with other tests.
* Add a simple custom completion test

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo build; cargo test --all --all-features` to check that all the tests pass
