### PR TITLE
Look up git commit hash ourselves, drop libgit2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4191,7 +4191,6 @@ checksum = "f47e98e36909e951f4da3908f4475f969bec92a41734dd92e883aaa11c10294b"
 dependencies = [
  "chrono",
  "const_format",
- "git2",
  "is_debug",
 ]
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -70,7 +70,8 @@ serde_ini = "0.2.0"
 serde_urlencoded = "0.7.0"
 serde_yaml = "0.8.16"
 sha2 = "0.10.0"
-shadow-rs = "0.11.0"
+# Disable default features b/c the default features build Git (very slow to compile)
+shadow-rs = { version = "0.11.0", default-features = false }
 strip-ansi-escapes = "0.1.1"
 sysinfo = "0.23.5"
 terminal_size = "0.1.17"
@@ -112,7 +113,7 @@ dataframe = ["polars", "num"]
 database = ["sqlparser", "rusqlite"]
 
 [build-dependencies]
-shadow-rs = "0.11.0"
+shadow-rs = { version = "0.11.0", default-features = false }
 
 [dev-dependencies]
 hamcrest2 = "0.3.0"

--- a/crates/nu-command/build.rs
+++ b/crates/nu-command/build.rs
@@ -1,3 +1,18 @@
+use std::process::Command;
+
 fn main() -> shadow_rs::SdResult<()> {
+    // Look up the current Git commit ourselves instead of relying on shadow_rs,
+    // because shadow_rs does it in a really slow-to-compile way (it builds libgit2)
+    let hash = get_git_hash().expect("failed to get latest git commit hash");
+    println!("cargo:rustc-env=NU_COMMIT_HASH={}", hash);
+
     shadow_rs::new()
+}
+
+fn get_git_hash() -> Result<String, std::io::Error> {
+    let out = Command::new("git").args(["rev-parse", "HEAD"]).output()?;
+    Ok(String::from_utf8(out.stdout)
+        .expect("could not convert stdout to string")
+        .trim()
+        .to_string())
 }

--- a/crates/nu-command/src/core_commands/version.rs
+++ b/crates/nu-command/src/core_commands/version.rs
@@ -63,33 +63,11 @@ pub fn version(
         span: call.head,
     });
 
-    cols.push("tag".to_string());
-    vals.push(Value::String {
-        val: shadow_rs::tag(),
-        span: call.head,
-    });
-
-    let short_commit: Option<&str> = Some(shadow::SHORT_COMMIT).filter(|x| !x.is_empty());
-    if let Some(short_commit) = short_commit {
-        cols.push("short_commit".to_string());
-        vals.push(Value::String {
-            val: short_commit.to_string(),
-            span: call.head,
-        });
-    }
-    let commit_hash: Option<&str> = Some(shadow::COMMIT_HASH).filter(|x| !x.is_empty());
+    let commit_hash: Option<&str> = option_env!("NU_COMMIT_HASH");
     if let Some(commit_hash) = commit_hash {
         cols.push("commit_hash".to_string());
         vals.push(Value::String {
             val: commit_hash.to_string(),
-            span: call.head,
-        });
-    }
-    let commit_date: Option<&str> = Some(shadow::COMMIT_DATE).filter(|x| !x.is_empty());
-    if let Some(commit_date) = commit_date {
-        cols.push("commit_date".to_string());
-        vals.push(Value::String {
-            val: commit_date.to_string(),
             span: call.head,
         });
     }


### PR DESCRIPTION
# Description

The `version` command uses [`shadow-rs`](https://github.com/baoyachi/shadow-rs) to look up Nu's Git commit hash at build time. This is useful for diagnosis, but it comes at a large cost because `shadow-rs` literally builds Git to do this. To speed up the build, we can just run `git rev-parse HEAD` ourselves at compile time.

# Impact

Our GitHub runners have 2 cores. To approximate this, I ran `cargo build -jobs 2` during testing. **On Windows on my Surface Pro 8, this change takes ~35s off the time for `cargo build`**. I expect that it will take longer off the build times in CI, since the GitHub runners are relatively slow.

This reduces Nu's crate count by 8, and the `target/debug` folder is ~100MB smaller after the change.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo build; cargo test --all --all-features` to check that all the tests pass
