### PR TITLE
CI: bust caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
+          key: ${{ matrix.style }}v2 # increment this to bust the cache if needed
 
       # - uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: "v1" # increment this to bust the cache if needed
+          key: "v2" # increment this to bust the cache if needed
 
       - name: Rustfmt
         uses: actions-rs/cargo@v1
@@ -125,7 +125,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: "1" # increment this to bust the cache if needed
+          key: "2" # increment this to bust the cache if needed
 
       - name: Install Nushell
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Just trying something out with `rust-cache`; the cache got roughly twice as big after JT's change to disable debug symbols and I want to wipe out the cache to confirm that this is a temporary issue.