### PR TITLE
use reverse iter on value search

### DIFF
--- a/crates/nu-command/tests/commands/merge.rs
+++ b/crates/nu-command/tests/commands/merge.rs
@@ -2,8 +2,6 @@ use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn row() {
     Playground::setup("merge_test_1", |dirs, sandbox| {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -660,8 +660,12 @@ impl Value {
                         let cols = cols.clone();
                         let span = *span;
 
-                        if let Some(found) =
-                            cols.iter().zip(vals.iter()).find(|x| x.0 == column_name)
+                        // Make reverse iterate to avoid duplicate column leads to first value, actuall last value is expected.
+                        if let Some(found) = cols
+                            .iter()
+                            .zip(vals.iter())
+                            .rev()
+                            .find(|x| x.0 == column_name)
                         {
                             current = found.1.clone();
                         } else if let Some(suggestion) = did_you_mean(&cols, column_name) {


### PR DESCRIPTION
# Description
Push #4314 on `merge` command

It also makes table representation more constitent with `0.44`.

Take the following expression as example:
```
[[a, b, c, c, b]; [1, 2, 3, 5, 10]]
```

In 0.44, it leads to:
```
───┬───┬────┬───
 # │ a │ b  │ c
───┼───┼────┼───
 0 │ 1 │ 10 │ 5
───┴───┴────┴───
```

In current main, it leads to (I think it's incorrect, new value should be shown rather than old value for the column b and c):
```
╭───┬───┬───┬───╮
│ # │ a │ b │ c │
├───┼───┼───┼───┤
│ 0 │ 1 │ 2 │ 3 │
╰───┴───┴───┴───╯
```

If the code is ok, the following task can be done:
* commands::merge::row - (merge doesn't appear to work this way any longer)

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
