### PR TITLE
Try to do less work during capture discovery

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4924,15 +4924,18 @@ pub fn discover_captures_in_expr(
             output.extend(&result);
         }
         Expr::Block(block_id) => {
-            let block = working_set.get_block(*block_id);
-            let results = {
-                let mut seen = vec![];
-                discover_captures_in_block(working_set, block, &mut seen, seen_blocks)
-            };
-            seen_blocks.insert(*block_id, results.clone());
-            for var_id in results.into_iter() {
-                if !seen.contains(&var_id) {
-                    output.push(var_id)
+            if !seen_blocks.contains_key(block_id) {
+                let block = working_set.get_block(*block_id);
+                seen_blocks.insert(*block_id, vec![]);
+                let results = {
+                    let mut seen = vec![];
+                    discover_captures_in_block(working_set, block, &mut seen, seen_blocks)
+                };
+                seen_blocks.insert(*block_id, results.clone());
+                for var_id in results.into_iter() {
+                    if !seen.contains(&var_id) {
+                        output.push(var_id)
+                    }
                 }
             }
         }
@@ -5073,15 +5076,18 @@ pub fn discover_captures_in_expr(
             }
         }
         Expr::RowCondition(block_id) | Expr::Subexpression(block_id) => {
-            let block = working_set.get_block(*block_id);
-            let results = {
-                let mut seen = vec![];
-                discover_captures_in_block(working_set, block, &mut seen, seen_blocks)
-            };
-            seen_blocks.insert(*block_id, results.clone());
-            for var_id in results.into_iter() {
-                if !seen.contains(&var_id) {
-                    output.push(var_id)
+            if !seen_blocks.contains_key(block_id) {
+                let block = working_set.get_block(*block_id);
+                seen_blocks.insert(*block_id, vec![]);
+                let results = {
+                    let mut seen = vec![];
+                    discover_captures_in_block(working_set, block, &mut seen, seen_blocks)
+                };
+                seen_blocks.insert(*block_id, results.clone());
+                for var_id in results.into_iter() {
+                    if !seen.contains(&var_id) {
+                        output.push(var_id)
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

We try to guard against doing capture discovery on blocks we've already seen. With luck, this will help improve parse times for larger files.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
