### PR TITLE
Enable backtraces by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,11 @@ use std::{
 thread_local! { static IS_PERF: RefCell<bool> = RefCell::new(false) }
 
 fn main() -> Result<()> {
+    // Enable backtraces on panic to help diagnostics
+    if std::env::var("RUST_BACKTRACE").is_err() {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
+
     // miette::set_panic_hook();
     let miette_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |x| {


### PR DESCRIPTION
# Description

This change enables stack traces/backtraces by default, so we get more actionable information from panics.

I looked into _why_ backtraces are disabled by default in Rust, and found [this comment](https://www.reddit.com/r/rust/comments/bnqina/why_does_not_rust_give_a_backtrace_by_default/enc29sj/). tl;dr: seems like a historical accident, I can't find any good reason for Nu to leave backtraces off.

**Before:**

```
thread 'main' panicked at 'explicit panic', crates/nu-command/src/filesystem/ls.rs:77:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
**After:**
```
thread 'main' panicked at 'explicit panic', crates/nu-command/src/filesystem/ls.rs:77:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
   2: core::panicking::panic
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:48:5
   3: <nu_command::filesystem::ls::Ls as nu_protocol::engine::command::Command>::run
             at ./crates/nu-command/src/filesystem/ls.rs:77:9
   4: nu_engine::eval::eval_call
             at ./crates/nu-engine/src/eval.rs:182:9
   5: nu_engine::eval::eval_expression_with_input
             at ./crates/nu-engine/src/eval.rs:591:25
   6: nu_engine::eval::eval_block
             at ./crates/nu-engine/src/eval.rs:640:21
   7: nu_cli::util::eval_source
             at ./crates/nu-cli/src/util.rs:228:11
   8: nu_cli::repl::evaluate_repl
             at ./crates/nu-cli/src/repl.rs:325:21
   9: nu::main
             at ./src/main.rs:249:21
  10: core::ops::function::FnOnce::call_once
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I considered setting `RUST_BACKTRACE=full` but IMO it's unnecessarily verbose for our needs.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
