### PR TITLE
Upgrade trash dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4730,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "2.0.4"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2ed4369f59214865022230fb397ad71353101fe87bfef0f0cf887c43eaa094"
+checksum = "115b3303b13438787fbe4e813a3b16bb4f2928840aa41d80a593c347d0425192"
 dependencies = [
  "chrono",
  "libc",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -92,7 +92,7 @@ umask = "2.0.0"
 users = "0.11.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
-version = "2.0.2"
+version = "2.1.3"
 optional = true
 
 [dependencies.polars]
@@ -100,7 +100,7 @@ version = "0.21.1"
 # path = "../../../../polars/polars"
 optional = true
 features = [
-	"default", "to_dummies", "parquet", "json", "serde", "serde-lazy", 
+	"default", "to_dummies", "parquet", "json", "serde", "serde-lazy",
 	"object", "checked_arithmetic", "strings", "cum_agg", "is_in",
 	"rolling_window", "strings", "rows", "random",
   "dtype-datetime", "dtype-struct", "lazy", "cross_join",


### PR DESCRIPTION
I noticed that Nu was building the `windows` crate on Mac+Linux because it's a dependency of `trash-rs`. [I fixed this upstream](https://github.com/Byron/trash-rs/pull/50) and the author has already published a new version.

Note: the `trash-rs` author mentioned that they're looking for some help with Windows stuff, maybe take a look if you have time? https://github.com/Byron/trash-rs/pull/49

### Impact

This means we build 4 fewer crates on Linux. It saves 5s on my desktop (Linux, 12900K, mold linker, `cargo build -j 2`) and it should save a lot more on the slower GitHub runners.