### PR TITLE
feat(errors): more explicit module_or_overlay_not_found_error help me…

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -98,7 +98,7 @@ pub enum ParseError {
     #[diagnostic(
         code(nu::parser::module_not_found),
         url(docsrs),
-        help("module files need to be available before your script is run")
+        help("module files and their paths must be available before your script is run as parsing occurs before anything is evaluated")
     )]
     ModuleNotFound(#[label = "module not found"] Span),
 


### PR DESCRIPTION
# Description

module or overlay not found error could occur when trying to use a module with a non-hardcoded path e.g.

```
echo "export def a [] { echo aaaaaaa }" | save a.nu
use $"($env.HOME)/a.nu" *  # fails
Error: nu::parser::module_not_found (https://docs.rs/nu-parser/0.61.0/nu_parser/enum.ParseError.html#variant.ModuleNotFound)

  × Module not found.
   ╭─[entry #2:1:1]
 1 │ use $"($env.HOME)/a.nu" *
   ·     ─────────┬─────────
   ·              ╰── module not found
   ╰────
  help: module files need to be available before your script is run
use a.nu *  # works
```

In this case, the file **is** available before the script is run so the error can be a bit confusing. Hence the new message proposal that includes this probably common issue and provides pointer as to why it happens.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
