### PR TITLE
make print flush

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -37,7 +37,6 @@ impl Command for Print {
     ) -> Result<PipelineData, ShellError> {
         let args: Vec<Value> = call.rest(engine_state, stack, 0)?;
         let no_newline = call.has_flag("no_newline");
-
         let head = call.head;
 
         for arg in args {

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -437,6 +437,7 @@ impl PipelineData {
             if let Some(stream) = stream {
                 for s in stream {
                     let _ = stdout.lock().write_all(s?.as_binary()?);
+                    let _ = stdout.lock().flush()?;
                 }
             }
 
@@ -475,7 +476,9 @@ impl PipelineData {
                     }
 
                     match stdout.lock().write_all(out.as_bytes()) {
-                        Ok(_) => (),
+                        Ok(_) => {
+                            let _ = stdout.lock().flush()?;
+                        }
                         Err(err) => eprintln!("{}", err),
                     };
                 }
@@ -498,7 +501,9 @@ impl PipelineData {
                     }
 
                     match stdout.lock().write_all(out.as_bytes()) {
-                        Ok(_) => (),
+                        Ok(_) => {
+                            let _ = stdout.lock().flush()?;
+                        }
                         Err(err) => eprintln!("{}", err),
                     };
                 }


### PR DESCRIPTION
# Description

This fixes a bug where `print` doesn't flush the output

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
