### PR TITLE
Revert "Enable backtraces by default (#5562)"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,11 +38,6 @@ use std::{
 thread_local! { static IS_PERF: RefCell<bool> = RefCell::new(false) }
 
 fn main() -> Result<()> {
-    // Enable backtraces on panic to help diagnostics
-    if std::env::var("RUST_BACKTRACE").is_err() {
-        std::env::set_var("RUST_BACKTRACE", "1");
-    }
-
     // miette::set_panic_hook();
     let miette_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |x| {


### PR DESCRIPTION
# Description

Child processes were inheriting `RUST_BACKTRACE` from Nu, which might confuse Rust programmers using Nu. Reverting #5562 for now.

It's unfortunate that Rust leaves backtraces off by default and only offers an environment variable configuration point (I think). Not sure if there's a perfect way to solve this.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
