### PR TITLE
feat: apply the `--numbered` option to acc in `reduce` command.

### DIFF
--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -51,7 +51,7 @@ impl Command for Reduce {
                 }),
             },
             Example {
-                example: "[ 1 2 3 ] | reduce -n {|it, acc| $acc + $it.item }",
+                example: "[ 1 2 3 ] | reduce -n {|it, acc| $acc.item + $it.item }",
                 description: "Sum values of a list (same as 'math sum')",
                 result: Some(Value::Int {
                     val: 6,
@@ -76,10 +76,10 @@ impl Command for Reduce {
             },
             Example {
                 example: r#"[ one longest three bar ] | reduce -n { |it, acc|
-                    if ($it.item | str length) > ($acc | str length) {
+                    if ($it.item | str length) > ($acc.item | str length) {
                         $it.item
                     } else {
-                        $acc
+                        $acc.item
                     }
                 }"#,
                 description: "Find the longest string and its index",
@@ -143,24 +143,27 @@ impl Command for Reduce {
             .enumerate()
             .map(|(idx, x)| {
                 if numbered {
-                    Value::Record {
-                        cols: vec!["index".to_string(), "item".to_string()],
-                        vals: vec![
-                            Value::Int {
-                                val: idx as i64 + off,
-                                span,
-                            },
-                            x,
-                        ],
-                        span,
-                    }
+                    (
+                        idx,
+                        Value::Record {
+                            cols: vec!["index".to_string(), "item".to_string()],
+                            vals: vec![
+                                Value::Int {
+                                    val: idx as i64 + off,
+                                    span,
+                                },
+                                x,
+                            ],
+                            span,
+                        },
+                    )
                 } else {
-                    x
+                    (idx, x)
                 }
             })
             .peekable();
 
-        while let Some(x) = input_iter.next() {
+        while let Some((idx, x)) = input_iter.next() {
             stack.with_env(&orig_env_vars, &orig_env_hidden);
 
             if let Some(var) = block.signature.get_positional(0) {
@@ -171,6 +174,26 @@ impl Command for Reduce {
 
             if let Some(var) = block.signature.get_positional(1) {
                 if let Some(var_id) = &var.var_id {
+                    acc = if numbered {
+                        if let Value::Record { .. } = &acc {
+                            acc
+                        } else {
+                            Value::Record {
+                                cols: vec!["index".to_string(), "item".to_string()],
+                                vals: vec![
+                                    Value::Int {
+                                        val: idx as i64 + off,
+                                        span,
+                                    },
+                                    acc,
+                                ],
+                                span,
+                            }
+                        }
+                    } else {
+                        acc
+                    };
+
                     stack.add_var(*var_id, acc);
                 }
             }

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -46,15 +46,13 @@ fn reduce_rows_example() {
     assert_eq!(actual.out, "14.8");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn reduce_numbered_example() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
         echo one longest three bar
-        | reduce -n { |it, acc| if ($it.item | str length) > ($acc | str length) {echo $it.item} else {echo $acc}}
+        | reduce -n { |it, acc| if ($it.item | str length) > ($acc.item | str length) {echo $it} else {echo $acc}}
         | get index
         "#
         )
@@ -69,7 +67,7 @@ fn reduce_numbered_integer_addition_example() {
         cwd: ".", pipeline(
         r#"
         echo [1 2 3 4]
-        | reduce -n { |it, acc| $acc + $it.item }
+        | reduce -n { |it, acc| $acc.item + $it.item }
         "#
         )
     );


### PR DESCRIPTION
# Description

The idea for this PR comes from the `commands::reduce::reduce_numbered_example` test in #4314.

I was curious about the `--numbered` option of `reduce` after seeing the following tests:
```rust
// FIXME: jt: needs more work
#[ignore]
#[test]
fn reduce_numbered_example() {
    let actual = nu!(
        cwd: ".", pipeline(
        r#"
        echo one longest three bar
        | reduce -n { |it, acc| if ($it.item | str length) > ($acc | str length) {echo $it.item} else {echo $acc}}
        | get index
        "#
        )
    );

    assert_eq!(actual.out, "1");
}
```

One of the reasons this test cannot work is that the types returned by `it` and `acc` are different.
Currently, the `-n` option converts only the `it` argument to a block containing an index.

This is why, in other examples, the `item` property is accessed only in the `it`.
It is a little bit different to the regular `reduce` provided in other languages.

So I modified the `-n` option to apply to both `acc` and `it`.

In this case, the test will get the result we expect if we change it like this:
```bash
> echo one longest three bar | reduce -n { |it, acc| if ($it.item | str length) > ($acc.item | str length) { echo $it } else { echo $acc } }
╭───────┬─────────╮
│ index │ 1       │
│ item  │ longest │
╰───────┴─────────╯
> 〉echo one longest three bar | reduce -n { |it, acc| if ($it.item | str length) > ($acc.item | str length) { echo $it } else { echo $acc } } | get index
1
```

Of course, this is a proposal. So, the related tests and examples have not been updated yet.
If we can come to an agreement on this, I will update the rest of the content, including the tests.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
