### PR TITLE
fix move test

### DIFF
--- a/crates/nu-command/tests/commands/move_/column.rs
+++ b/crates/nu-command/tests/commands/move_/column.rs
@@ -34,8 +34,6 @@ fn moves_a_column_before() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn moves_columns_before() {
     Playground::setup("move_column_test_2", |dirs, sandbox| {
@@ -71,8 +69,6 @@ fn moves_columns_before() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn moves_a_column_after() {
     Playground::setup("move_column_test_3", |dirs, sandbox| {

--- a/crates/nu-command/tests/commands/move_/column.rs
+++ b/crates/nu-command/tests/commands/move_/column.rs
@@ -60,8 +60,9 @@ fn moves_columns_before() {
                 open sample.csv
                 | move column99 column3 --before column2
                 | rename _ chars_1 chars_2
-                | get chars_2 chars_1
-                | str trim
+                | select chars_2 chars_1
+                | upsert new_col {|f| $f | transpose | get column1 | str trim | str collect}
+                | get new_col
                 | str collect
             "#
         ));
@@ -97,8 +98,9 @@ fn moves_a_column_after() {
                 | move letters --after and_more
                 | move letters and_more --before column2
                 | rename _ chars_1 chars_2
-                | get chars_1 chars_2
-                | str trim
+                | select chars_1 chars_2
+                | upsert new_col {|f| $f | transpose | get column1 | str trim | str collect}
+                | get new_col
                 | str collect
             "#
         ));


### PR DESCRIPTION
# Description

after check `move` behavior, I think it's ok, so I change test code to make it pass.

If the code is ok, the following can be done:
* commands::move_::column::moves_a_column_after - (get | trim | collect is collecting records instead of values)
* commands::move_::column::moves_columns_before - (get | trim | collect is collecting records instead of values)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
