### PR TITLE
fix select tests

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -126,7 +126,7 @@ fn select(
                         //FIXME: improve implementation to not clone
                         let fetcher = input_val.clone().follow_cell_path(&path.members)?;
 
-                        cols.push(path.into_string());
+                        cols.push(path.into_string().replace('.', "_"));
                         vals.push(fetcher);
                     }
 
@@ -150,11 +150,11 @@ fn select(
                         //FIXME: improve implementation to not clone
                         match x.clone().follow_cell_path(&path.members) {
                             Ok(value) => {
-                                cols.push(path.into_string());
+                                cols.push(path.into_string().replace('.', "_"));
                                 vals.push(value);
                             }
                             Err(_) => {
-                                cols.push(path.into_string());
+                                cols.push(path.into_string().replace('.', "_"));
                                 vals.push(Value::Nothing { span });
                             }
                         }
@@ -175,7 +175,7 @@ fn select(
                     // FIXME: remove clone
                     let result = v.clone().follow_cell_path(&cell_path.members)?;
 
-                    cols.push(cell_path.into_string());
+                    cols.push(cell_path.into_string().replace('.', "_"));
                     vals.push(result);
                 }
 

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -22,8 +22,6 @@ fn regular_columns() {
     assert_eq!(actual.out, "Robalino");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn complex_nested_columns() {
     Playground::setup("select_test_2", |dirs, sandbox| {
@@ -57,8 +55,9 @@ fn complex_nested_columns() {
             r#"
                 open los_tres_caballeros.json
                 | select nu."0xATYKARNU" nu.committers.name nu.releases.version
-                | where nu_releases_version > "0.8"
                 | get nu_releases_version
+                | where $it > "0.8"
+                | get 0
             "#
         ));
 


### PR DESCRIPTION
# Description

Change little of `select` command, and push #4314 .   Sadly I have to change test script to make it pass, due to the behavior of open changed.

In the test case, I think select something like `nu.releases.version` return a record without auto flatten is expected behavior, because it keeps the structure unchanged, so maybe it's ok to change?


If the code is ok, the following tasks can be done:
* commands::select::complex_nested_columns - (commands working different + duplication bug)

By the way, this can be done too:
* commands::select::allows_if_given_unknown_column_name_is_missing - ( select doesn't insert a column if missing, just errors)

From #5273, the test code is no longer valid, it's replaced by `fails_if_given_unknown_column_name`

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
