### PR TITLE
Allowing for flags with '=' in them to register as flags.

### DIFF
--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -94,7 +94,7 @@ pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
                         }
                     }
                 }
-                if word.contains(input) {
+                if word.contains(input) || {let s: Vec<&str> = input.split('=').collect(); word.contains(s[0])} {
                     return input.to_string();
                 }
             }


### PR DESCRIPTION
# Description

While this fixes #5532, I don't think this is sustainable in the long run. Per the discussion in #5492, hopefully a more sustainable long-term solution can be found in the near future.

```
/home/gabriel/CodingProjects/nushell〉cat b.nu                                05/18/2022 11:54:57 PM
# b.nu
def main [kernel: string, --version: string] {
    echo $kernel;
    echo $version
}
/home/gabriel/CodingProjects/nushell〉target/debug/nu b.nu linux --version=v5.2
linux
v5.2
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
