### PR TITLE
Fix help menu panic.

### DIFF
--- a/crates/nu-cli/src/menus/description_menu.rs
+++ b/crates/nu-cli/src/menus/description_menu.rs
@@ -586,7 +586,7 @@ impl Menu for DescriptionMenu {
                         } else {
                             self.example_index = Some(self.examples.len().saturating_sub(1));
                         }
-                    } else {
+                    } else if !self.examples.is_empty() {
                         self.example_index = Some(0);
                     }
                 }
@@ -598,7 +598,7 @@ impl Menu for DescriptionMenu {
                         } else {
                             self.example_index = Some(0);
                         }
-                    } else {
+                    } else if !self.examples.is_empty() {
                         self.example_index = Some(0);
                     }
                 }


### PR DESCRIPTION
# Description

Fixes issue #5580: panic in `help_menu` for commands with no examples. 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
