### PR TITLE
add quantile column in histogram 

### DIFF
--- a/crates/nu-command/tests/commands/histogram.rs
+++ b/crates/nu-command/tests/commands/histogram.rs
@@ -126,7 +126,7 @@ fn count() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            echo [[bit];  [1] [0] [0] [0] [0] [0] [0] [1]]
+            echo [[bit];  [1] [0] [0] [0] [0] [0] [0] [1] [1]]
             | histogram bit --percentage-type relative
             | sort-by count
             | reject frequency
@@ -134,7 +134,7 @@ fn count() {
         "#
     ));
 
-    let bit_json = r#"[  {    "bit": 1,    "count": 2,    "percentage": "33.33%"  },  {    "bit": 0,    "count": 6,    "percentage": "100.00%"  }]"#;
+    let bit_json = r#"[  {    "bit": 1,    "count": 3,    "quantile": 0.5,    "percentage": "50.00%"  },  {    "bit": 0,    "count": 6,    "quantile": 1,    "percentage": "100.00%"  }]"#;
 
     assert_eq!(actual.out, bit_json);
 }
@@ -152,7 +152,7 @@ fn count_with_normalize_percentage() {
         "#
     ));
 
-    let bit_json = r#"[  {    "bit": 1,    "count": 2,    "percentage": "25.00%"  },  {    "bit": 0,    "count": 6,    "percentage": "75.00%"  }]"#;
+    let bit_json = r#"[  {    "bit": 1,    "count": 2,    "quantile": 0.25,    "percentage": "25.00%"  },  {    "bit": 0,    "count": 6,    "quantile": 0.75,    "percentage": "75.00%"  }]"#;
 
     assert_eq!(actual.out, bit_json);
 }


### PR DESCRIPTION
# Description

add quantile column according to [this comment](https://github.com/nushell/nushell/pull/5518#issuecomment-1129639303)

I've check out https://stats.stackexchange.com/questions/156778/percentile-vs-quantile-vs-quartile, and think for representing decimal number, it should still be named `quantile`

Also adjust little about test code to avoid expect output like `0.3333333...`
# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
