### PR TITLE
Fix flatten behavior

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -127,7 +127,7 @@ enum TableInside<'a> {
     Entries(&'a str, &'a Span, Vec<&'a Value>),
     // handle for a column which contains a table, we can flatten the inner column to outer level
     // `columns` means that for the given row, it contains `len(columns)` nested rows, and each nested row contains a list of column name.
-    // at the same, `values` means that for the given row, it contains `len(values)` nested rows, and each nested row contains a list of values.
+    // Likely, `values` means that for the given row, it contains `len(values)` nested rows, and each nested row contains a list of values.
     //
     // `parent_column_name` is handled for conflicting column name, the nested table may contains columns which has the same name
     // to outer level, for that case, the output column name should be f"{parent_column_name}_{inner_column_name}".

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -178,9 +178,16 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value>
                         cols,
                         vals,
                         span: _,
-                    } => cols.iter().enumerate().for_each(|(idx, column)| {
-                        out.insert(column.to_string(), vals[idx].clone());
-                    }),
+                    } => {
+                        if column_requested.is_none() && !columns.is_empty() {
+                            out.insert(column.to_string(), value.clone());
+                        } else {
+                            cols.iter().enumerate().for_each(|(idx, column)| {
+                                out.insert(column.to_string(), vals[idx].clone());
+                            })
+                        }
+                    }
+                    /*
                     Value::List { vals, span: _ } if vals.iter().all(|f| f.as_record().is_ok()) => {
                         let mut cs = vec![];
                         let mut vs = vec![];
@@ -212,6 +219,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value>
                             }
                         }
                     }
+                    */
                     Value::List {
                         vals: values,
                         span: _,

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -307,7 +307,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value>
                         };
                         expanded.push(record);
                     }
-                },
+                }
                 Some(TableInside::FlatternedRows {
                     columns,
                     _span,
@@ -330,7 +330,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value>
                         };
                         expanded.push(record);
                     }
-                },
+                }
                 None => {
                     let record = Value::Record {
                         cols: out.keys().map(|f| f.to_string()).collect::<Vec<_>>(),

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -180,10 +180,21 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span) -> Vec<Value>
                         span: _,
                     } => {
                         if column_requested.is_none() && !columns.is_empty() {
-                            out.insert(column.to_string(), value.clone());
+                            if out.contains_key(column) {
+                                out.insert(format!("{}_{}", column, column), value.clone());
+                            } else {
+                                out.insert(column.to_string(), value.clone());
+                            }
                         } else {
-                            cols.iter().enumerate().for_each(|(idx, column)| {
-                                out.insert(column.to_string(), vals[idx].clone());
+                            cols.iter().enumerate().for_each(|(idx, inner_record_col)| {
+                                if out.contains_key(inner_record_col) {
+                                    out.insert(
+                                        format!("{}_{}", column, inner_record_col),
+                                        vals[idx].clone(),
+                                    );
+                                } else {
+                                    out.insert(inner_record_col.to_string(), vals[idx].clone());
+                                }
                             })
                         }
                     }

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -123,7 +123,7 @@ fn flatten(
 }
 
 enum TableInside<'a> {
-    // handle for a column which contains a single list.
+    // handle for a column which contains a single list(but not list of records).
     Entries(&'a str, &'a Span, Vec<&'a Value>),
     // handle for a column which contains a table, we can flatten the inner column to outer level
     // `columns` means that for the given row, it contains `len(columns)` nested rows, and each nested row contains a list of column name.

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -78,8 +78,6 @@ fn flatten_row_column_explicitly() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn flatten_row_columns_having_same_column_names_flats_separately() {
     Playground::setup("flatten_test_2", |dirs, sandbox| {
@@ -114,8 +112,6 @@ fn flatten_row_columns_having_same_column_names_flats_separately() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn flatten_table_columns_explicitly() {
     Playground::setup("flatten_test_3", |dirs, sandbox| {


### PR DESCRIPTION
# Description

Push #4314 about flatten command, also relative: #5443

Compared to `0.44` implementation, the main issue is caused by:
1. when we do `flat_value` for a record, it doesn't check `columns` input, if we want to flatten inner columns.
2. when we do `flat_value` for a table(a list of records), it still needs to expand out values, because a table may contains many rows.

@onthebridgetonowhere I'm sorry for taking this from your side, I just want to help on tests but found that #5443 may also be solved....

## Tasks can be done
If the code is ok, the following task can be done:
* commands::flatten::flatten_row_columns_having_same_column_names_flats_separately - (don't think flatten is working right here)
* commands::flatten::flatten_table_columns_explicitly - (flatten is working differently here too)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
