### PR TITLE
Use effectively unlimited history size if not set

### DIFF
--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -92,7 +92,7 @@ impl Default for Config {
             partial_completions: true,
             completion_algorithm: "prefix".into(),
             edit_mode: "emacs".into(),
-            max_history_size: 1000,
+            max_history_size: i64::MAX,
             sync_history_on_enter: true,
             log_level: String::new(),
             keybindings: Vec::new(),


### PR DESCRIPTION
Fixes #5586


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
