### PR TITLE
Change miette theme based on ANSI config

### DIFF
--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -181,7 +181,7 @@ fn errors_fetching_by_column_using_a_number() {
             .contains("Data cannot be accessed with a cell path"),);
         assert!(actual
             .err
-            .contains(" record<0: string> doesn't support cell paths"),);
+            .contains("record<0: string> doesn't support cell paths"),);
     })
 }
 

--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -1,5 +1,5 @@
 use crate::engine::StateWorkingSet;
-use miette::{LabeledSpan, MietteHandler, ReportHandler, Severity, SourceCode};
+use miette::{LabeledSpan, MietteHandlerOpts, ReportHandler, Severity, SourceCode};
 use thiserror::Error;
 
 /// This error exists so that we can defer SourceCode handling. It simply
@@ -20,7 +20,18 @@ pub fn format_error(
 
 impl std::fmt::Debug for CliError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        MietteHandler::default().debug(self, f)?;
+        let ansi_support = self.1.get_config().use_ansi_coloring;
+
+        let miette_handler = MietteHandlerOpts::new()
+            // For better support of terminal themes use the ANSI coloring
+            .rgb_colors(false)
+            .ansi_colors(true)
+            // If ansi support is disabled in the config disable the eye-candy
+            .color(ansi_support)
+            .unicode(ansi_support)
+            .terminal_links(ansi_support)
+            .build();
+        miette_handler.debug(self, f)?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Description

Use the base ansi colors to simplify the use of the terminal emulator
theming.
Turn of most eye-candy (including unicode) when using
`$config.use_ansi_coloring: false`

Addresses #5582

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
