### PR TITLE
Don't report error when cwd is not exists.

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -220,10 +220,7 @@ pub fn eval_source(
         }
     };
 
-    if let Err(err) = engine_state.merge_delta(delta, Some(stack), &cwd) {
-        let working_set = StateWorkingSet::new(engine_state);
-        report_error(&working_set, &err);
-    }
+    let _ = engine_state.merge_delta(delta, Some(stack), &cwd);
 
     match eval_block(engine_state, stack, &block, input, false, false) {
         Ok(mut pipeline_data) => {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -339,8 +339,7 @@ impl ExternalCommand {
                 self.create_command(d)?
             };
 
-            // not trying to set current directory if cwd is not exists
-            // or else it will cause process running failed.
+            // do not try to set current directory if cwd does not exist
             if Path::new(&d).exists() {
                 process.current_dir(d);
             }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command as CommandSys, Stdio};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
@@ -339,7 +339,11 @@ impl ExternalCommand {
                 self.create_command(d)?
             };
 
-            process.current_dir(d);
+            // not trying to set current directory if cwd is not exists
+            // or else it will cause process running failed.
+            if Path::new(&d).exists() {
+                process.current_dir(d);
+            }
             process
         } else {
             return Err(ShellError::GenericError(


### PR DESCRIPTION
# Description

Fixes: #5515

The main issue is because:
If child process is running on not exists `cwd`, the process will run failed.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
