### PR TITLE
Fix #5578, assume pipe file be zero-sized

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -452,7 +452,7 @@ pub(crate) fn dir_entry_dict(
     cols.push("size".to_string());
     if let Some(md) = metadata {
         let zero_sized =
-            file_type == "socket" || file_type == "block device" || file_type == "char device";
+            file_type == "socket" || file_type == "block device" || file_type == "char device" || file_type == "pipe";
 
         if md.is_dir() {
             if du {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -451,8 +451,10 @@ pub(crate) fn dir_entry_dict(
 
     cols.push("size".to_string());
     if let Some(md) = metadata {
-        let zero_sized =
-            file_type == "socket" || file_type == "block device" || file_type == "char device" || file_type == "pipe";
+        let zero_sized = file_type == "pipe"
+            || file_type == "socket"
+            || file_type == "char device"
+            || file_type == "block device";
 
         if md.is_dir() {
             if du {


### PR DESCRIPTION
# Description

Fix #5578, assume pipe file be zero-sized

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
