### PR TITLE
Use bleeding edge reedline, with fix for #5593

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,8 +3737,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96c36021d0668f3b4f8c054fce3a9b9b0aa83fc60aa6c59df0e2165f9980763"
+source = "git+https://github.com/nushell/reedline?branch=main#85daf4e4fc7c18644077440009db3f70dcd8202c"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ nu-utils = { path = "./crates/nu-utils", version = "0.62.1"  }
 openssl = { version = "0.10.38", features = ["vendored"], optional = true }
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
-reedline = { version = "0.5.0", features = ["bashisms"]}
+reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 is_executable = "1.0.1"
 
 [dev-dependencies]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -18,7 +18,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.62.1"  }
 nu-utils = { path = "../nu-utils", version = "0.62.1"  }
 nu-ansi-term = "0.45.1"
 nu-color-config = { path = "../nu-color-config", version = "0.62.1"  }
-reedline = { version = "0.5.0", features = ["bashisms"]}
+reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 crossterm = "0.23.0"
 miette = { version = "4.5.0", features = ["fancy"] }
 thiserror = "1.0.29"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -82,7 +82,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-reedline = { version = "0.5.0", features = ["bashisms"]}
+reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 wax = { version =  "0.4.0", features = ["diagnostics"] }
 rusqlite = { version = "0.27.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.16.0", features = ["serde"], optional = true }


### PR DESCRIPTION
# Description

Fixes #5593

OOM introduced with #5587 when no config was present and an attempt was
made to allocate all memory in advance

Includes also other changes to reedline:
- Vi word definition fixed and `w` and `e` work as expected

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
