### PR TITLE
Refer to the span of `error make` if not given

### DIFF
--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -134,8 +134,8 @@ fn make_error(value: &Value, throw_span: Span) -> Option<ShellError> {
                 }
             }
             (Some(Value::String { val: message, .. }), None) => Some(ShellError::GenericError(
-                format!("Custom error: {}", message),
                 message,
+                "originates from here".to_string(),
                 Some(throw_span),
                 None,
                 Vec::new(),


### PR DESCRIPTION
# Description

Implements #5591

Currently the span of the "throwing" `error make`

Also allow to set `msg` and `label` without an additional span.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
