### PR TITLE
Allows the test `commands::ls::fails_with_ls_to_dir_without_permission` to work when run as root

### DIFF
--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -259,9 +259,20 @@ fn fails_with_ls_to_dir_without_permission() {
                 chmod 000 dir_a; ls dir_a
             "#
         ));
-        assert!(actual
-            .err
-            .contains("The permissions of 0 do not allow access for this user"));
+
+        let check_not_root = nu!(
+            cwd: dirs.test(), pipeline(
+                r#"
+                    id -u
+                "#
+        ));
+
+        assert!(
+            actual
+                .err
+                .contains("The permissions of 0 do not allow access for this user")
+                || check_not_root.out == "0"
+        );
     })
 }
 


### PR DESCRIPTION
# Description

As per #5565 , `commands::ls::fails_with_ls_to_dir_without_permission` does not work when run as root as root has access to the dir. I added a check to make sure user is not root, i.e. if `id -u` is 0, the test passes.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
