### PR TITLE
Add search term to str substring command.

### DIFF
--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -48,6 +48,10 @@ impl Command for SubCommand {
         "Get part of a string"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["slice"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,


### PR DESCRIPTION
# Description

Add "slice" search term to str substring command. Relevant to #5093 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
