### PR TITLE
Add config command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -314,6 +314,8 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             LetEnv,
             LoadEnv,
             WithEnv,
+            ConfigNu,
+            ConfigEnv,
         };
 
         // Math

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -1,0 +1,80 @@
+use nu_engine::env_to_strings;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned,
+};
+
+use crate::ExternalCommand;
+
+use super::utils::get_editor;
+
+#[derive(Clone)]
+pub struct ConfigEnv;
+
+impl Command for ConfigEnv {
+    fn name(&self) -> &str {
+        "config env"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Env)
+    }
+
+    fn usage(&self) -> &str {
+        "Edit nu environment configurations"
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "allow user to open and update nu env",
+            example: "config env",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        _call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let env_vars_str = env_to_strings(engine_state, stack)?;
+        let mut config_path = match nu_path::config_dir() {
+            Some(path) => path,
+            None => {
+                return Err(ShellError::GenericError(
+                    "Could not find nu env path".to_string(),
+                    "Could not find nu env path".to_string(),
+                    None,
+                    None,
+                    Vec::new(),
+                ));
+            }
+        };
+        config_path.push("nushell");
+        let mut nu_config = config_path.clone();
+        nu_config.push("env.nu");
+
+        let name = Spanned {
+            item: get_editor(engine_state, stack),
+            span: Span { start: 0, end: 0 },
+        };
+
+        let args = vec![Spanned {
+            item: nu_config.to_string_lossy().to_string(),
+            span: Span { start: 0, end: 0 },
+        }];
+
+        let command = ExternalCommand {
+            name,
+            args,
+            redirect_stdout: false,
+            redirect_stderr: false,
+            env_vars: env_vars_str,
+        };
+
+        command.run_with_input(engine_state, stack, input)
+    }
+}

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -1,0 +1,80 @@
+use nu_engine::env_to_strings;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned,
+};
+
+use crate::ExternalCommand;
+
+use super::utils::get_editor;
+
+#[derive(Clone)]
+pub struct ConfigNu;
+
+impl Command for ConfigNu {
+    fn name(&self) -> &str {
+        "config nu"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Env)
+    }
+
+    fn usage(&self) -> &str {
+        "Edit nu configurations"
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "allow user to open and update nu config",
+            example: "config nu",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        _call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let env_vars_str = env_to_strings(engine_state, stack)?;
+        let mut config_path = match nu_path::config_dir() {
+            Some(path) => path,
+            None => {
+                return Err(ShellError::GenericError(
+                    "Could not find nu config path".to_string(),
+                    "Could not find nu config path".to_string(),
+                    None,
+                    None,
+                    Vec::new(),
+                ));
+            }
+        };
+        config_path.push("nushell");
+        let mut nu_config = config_path.clone();
+        nu_config.push("config.nu");
+
+        let name = Spanned {
+            item: get_editor(engine_state, stack),
+            span: Span { start: 0, end: 0 },
+        };
+
+        let args = vec![Spanned {
+            item: nu_config.to_string_lossy().to_string(),
+            span: Span { start: 0, end: 0 },
+        }];
+
+        let command = ExternalCommand {
+            name,
+            args,
+            redirect_stdout: false,
+            redirect_stderr: false,
+            env_vars: env_vars_str,
+        };
+
+        command.run_with_input(engine_state, stack, input)
+    }
+}

--- a/crates/nu-command/src/env/config/mod.rs
+++ b/crates/nu-command/src/env/config/mod.rs
@@ -1,0 +1,5 @@
+mod config_env;
+mod config_nu;
+mod utils;
+pub use config_env::ConfigEnv;
+pub use config_nu::ConfigNu;

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -5,9 +5,9 @@ pub(crate) fn get_editor(engine_state: &EngineState, stack: &mut Stack) -> Strin
     let env_vars = stack.get_env_vars(engine_state);
     if !config.buffer_editor.is_empty() {
         config.buffer_editor.clone()
-    } else if let Some(value) = env_vars.get("EDITOR"){
+    } else if let Some(value) = env_vars.get("EDITOR") {
         value.as_string().expect("Unknown type")
-    } else if let Some(value) = env_vars.get("VISUAL"){
+    } else if let Some(value) = env_vars.get("VISUAL") {
         value.as_string().expect("Unknown type")
     } else if cfg!(target_os = "windows") {
         "notepad".to_string()

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -1,0 +1,17 @@
+use nu_protocol::engine::{EngineState, Stack};
+
+pub(crate) fn get_editor(engine_state: &EngineState, stack: &mut Stack) -> String {
+    let config = engine_state.get_config();
+    let env_vars = stack.get_env_vars(engine_state);
+    if !config.buffer_editor.is_empty() {
+        config.buffer_editor.clone()
+    } else if let Some(value) = env_vars.get("EDITOR"){
+        value.as_string().expect("Unknown type")
+    } else if let Some(value) = env_vars.get("VISUAL"){
+        value.as_string().expect("Unknown type")
+    } else if cfg!(target_os = "windows") {
+        "notepad".to_string()
+    } else {
+        "nano".to_string()
+    }
+}

--- a/crates/nu-command/src/env/mod.rs
+++ b/crates/nu-command/src/env/mod.rs
@@ -1,8 +1,11 @@
+mod config;
 mod env_command;
 mod let_env;
 mod load_env;
 mod with_env;
 
+pub use config::ConfigEnv;
+pub use config::ConfigNu;
 pub use env_command::Env;
 pub use let_env::LetEnv;
 pub use load_env::LoadEnv;


### PR DESCRIPTION
# Description

By adding 2 commands `config env` and `config nu`, user is able to easily update nu configuration. this PR will address part of [Issue 5436](https://github.com/nushell/nushell/issues/5436)

config tries to locate the text editor by following orders:

- Check nu `buffer_editor`
- Check `$env.EDITOR`
- Check `$env.VISUAL`
- If windows -> `notepad`
- Else -> `nano`

`config env`
![env](https://user-images.githubusercontent.com/85712372/169676219-44e36b7d-5443-420f-9ecc-901d34f33ec8.gif)

`config nu`
![nu](https://user-images.githubusercontent.com/85712372/169676289-80211004-d093-455e-8c65-b415964f4b80.gif)


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
