### PR TITLE
Feature: add '|&' to redirect stderr

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -69,8 +69,8 @@ impl NuCompleter {
         );
 
         for pipeline in output.pipelines.into_iter() {
-            for expr in pipeline.expressions {
-                let flattened: Vec<_> = flatten_expression(&working_set, &expr);
+            for item in pipeline.items {
+                let flattened: Vec<_> = flatten_expression(&working_set, &item.expression);
 
                 for (flat_idx, flat) in flattened.iter().enumerate() {
                     if pos >= flat.0.start && pos < flat.0.end {
@@ -132,7 +132,7 @@ impl NuCompleter {
 
                         // Flags completion
                         if prefix.starts_with(b"-") {
-                            let mut completer = FlagCompletion::new(expr);
+                            let mut completer = FlagCompletion::new(item.expression);
 
                             return self.process_completion(
                                 &mut completer,

--- a/crates/nu-command/src/core_commands/do_.rs
+++ b/crates/nu-command/src/core_commands/do_.rs
@@ -90,7 +90,22 @@ impl Command for Do {
 
         if ignore_errors {
             match result {
-                Ok(x) => Ok(x),
+                Ok(x) => match x {
+                    PipelineData::ExternalStream {
+                        stdout,
+                        exit_code,
+                        span,
+                        metadata,
+                        ..
+                    } => Ok(PipelineData::ExternalStream {
+                        stdout,
+                        stderr: None,
+                        exit_code,
+                        span,
+                        metadata,
+                    }),
+                    _ => Ok(x),
+                },
                 Err(_) => Ok(PipelineData::new(call.head)),
             }
         } else {

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -94,7 +94,7 @@ impl Command for FromNuon {
         error = error.or(err);
 
         if let Some(pipeline) = block.pipelines.get(1) {
-            if let Some(expr) = pipeline.expressions.get(0) {
+            if let Some(expr) = pipeline.get_expr(0) {
                 return Err(ShellError::GenericError(
                     "error when loading nuon text".into(),
                     "could not load nuon text".into(),
@@ -134,7 +134,7 @@ impl Command for FromNuon {
         } else {
             let mut pipeline = block.pipelines.remove(0);
 
-            if let Some(expr) = pipeline.expressions.get(1) {
+            if let Some(expr) = pipeline.get_expr(1) {
                 return Err(ShellError::GenericError(
                     "error when loading nuon text".into(),
                     "could not load nuon text".into(),
@@ -149,7 +149,7 @@ impl Command for FromNuon {
                 ));
             }
 
-            if pipeline.expressions.is_empty() {
+            if pipeline.items.is_empty() {
                 Expression {
                     expr: Expr::Nothing,
                     span: head,
@@ -157,7 +157,7 @@ impl Command for FromNuon {
                     ty: Type::Nothing,
                 }
             } else {
-                pipeline.expressions.remove(0)
+                pipeline.items.remove(0).expression
             }
         };
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -310,11 +310,15 @@ impl ExternalCommand {
                     } else {
                         None
                     },
-                    stderr: Some(RawStream::new(
-                        Box::new(stderr_receiver),
-                        output_ctrlc.clone(),
-                        head,
-                    )),
+                    stderr: if redirect_stderr {
+                        Some(RawStream::new(
+                            Box::new(stderr_receiver),
+                            output_ctrlc.clone(),
+                            head,
+                        ))
+                    } else {
+                        None
+                    },
                     exit_code: Some(ListStream::from_stream(
                         Box::new(exit_code_receiver),
                         output_ctrlc,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -643,7 +643,7 @@ pub fn eval_block(
                 elem,
                 input,
                 redirect_stdout || (i != pipeline.expressions.len() - 1),
-                redirect_stderr,
+                redirect_stderr || (i != pipeline.expressions.len() - 1),
             )?
         }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -637,13 +637,14 @@ pub fn eval_block(
     let num_pipelines = block.len();
     for (pipeline_idx, pipeline) in block.pipelines.iter().enumerate() {
         for (i, elem) in pipeline.expressions.iter().enumerate() {
+            let not_last = i != pipeline.expressions.len() - 1;
             input = eval_expression_with_input(
                 engine_state,
                 stack,
                 elem,
                 input,
-                redirect_stdout || (i != pipeline.expressions.len() - 1),
-                redirect_stderr || (i != pipeline.expressions.len() - 1),
+                redirect_stdout || not_last,
+                redirect_stderr || not_last,
             )?
         }
 

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -494,8 +494,8 @@ pub fn flatten_pipeline(
     pipeline: &Pipeline,
 ) -> Vec<(Span, FlatShape)> {
     let mut output = vec![];
-    for expr in &pipeline.expressions {
-        output.extend(flatten_expression(working_set, expr))
+    for item in &pipeline.items {
+        output.extend(flatten_expression(working_set, &item.expression))
     }
     output
 }

--- a/crates/nu-parser/tests/test_lite_parser.rs
+++ b/crates/nu-parser/tests/test_lite_parser.rs
@@ -25,12 +25,12 @@ fn comment_before() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 1);
-    assert_eq!(lite_block.block[0].commands.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].comments.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].parts.len(), 3);
+    assert_eq!(lite_block.block[0].items.len(), 1);
+    assert_eq!(lite_block.block[0].items[0].command.comments.len(), 1);
+    assert_eq!(lite_block.block[0].items[0].command.parts.len(), 3);
 
     assert_eq!(
-        lite_block.block[0].commands[0].comments[0],
+        lite_block.block[0].items[0].command.comments[0],
         Span { start: 0, end: 19 }
     );
 
@@ -46,12 +46,12 @@ fn comment_beside() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 1);
-    assert_eq!(lite_block.block[0].commands.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].comments.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].parts.len(), 3);
+    assert_eq!(lite_block.block[0].items.len(), 1);
+    assert_eq!(lite_block.block[0].items[0].command.comments.len(), 1);
+    assert_eq!(lite_block.block[0].items[0].command.parts.len(), 3);
 
     assert_eq!(
-        lite_block.block[0].commands[0].comments[0],
+        lite_block.block[0].items[0].command.comments[0],
         Span { start: 12, end: 31 }
     );
 
@@ -69,16 +69,16 @@ fn comments_stack() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].comments.len(), 2);
-    assert_eq!(lite_block.block[0].commands[0].parts.len(), 3);
+    assert_eq!(lite_block.block[0].items[0].command.comments.len(), 2);
+    assert_eq!(lite_block.block[0].items[0].command.parts.len(), 3);
 
     assert_eq!(
-        lite_block.block[0].commands[0].comments[0],
+        lite_block.block[0].items[0].command.comments[0],
         Span { start: 0, end: 19 }
     );
 
     assert_eq!(
-        lite_block.block[0].commands[0].comments[1],
+        lite_block.block[0].items[0].command.comments[1],
         Span { start: 20, end: 37 }
     );
 
@@ -97,11 +97,11 @@ fn separated_comments_dont_stack() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].comments.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].parts.len(), 3);
+    assert_eq!(lite_block.block[0].items[0].command.comments.len(), 1);
+    assert_eq!(lite_block.block[0].items[0].command.parts.len(), 3);
 
     assert_eq!(
-        lite_block.block[0].commands[0].comments[0],
+        lite_block.block[0].items[0].command.comments[0],
         Span { start: 21, end: 38 }
     );
 
@@ -121,17 +121,17 @@ fn multiple_pipelines() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 2);
-    assert_eq!(lite_block.block[0].commands[0].comments.len(), 1);
-    assert_eq!(lite_block.block[0].commands[0].parts.len(), 4);
+    assert_eq!(lite_block.block[0].items[0].command.comments.len(), 1);
+    assert_eq!(lite_block.block[0].items[0].command.parts.len(), 4);
     assert_eq!(
-        lite_block.block[0].commands[0].comments[0],
+        lite_block.block[0].items[0].command.comments[0],
         Span { start: 0, end: 10 }
     );
 
-    assert_eq!(lite_block.block[1].commands[0].comments.len(), 1);
-    assert_eq!(lite_block.block[1].commands[0].parts.len(), 4);
+    assert_eq!(lite_block.block[1].items[0].command.comments.len(), 1);
+    assert_eq!(lite_block.block[1].items[0].command.parts.len(), 4);
     assert_eq!(
-        lite_block.block[1].commands[0].comments[0],
+        lite_block.block[1].items[0].command.comments[0],
         Span { start: 52, end: 61 }
     );
 
@@ -149,11 +149,11 @@ fn multiple_commands() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 2);
-    assert_eq!(lite_block.block[0].commands.len(), 2);
-    assert_eq!(lite_block.block[1].commands.len(), 1);
+    assert_eq!(lite_block.block[0].items.len(), 2);
+    assert_eq!(lite_block.block[1].items.len(), 1);
 
     assert_eq!(
-        lite_block.block[1].commands[0].comments[0],
+        lite_block.block[1].items[0].command.comments[0],
         Span { start: 41, end: 50 }
     );
 
@@ -173,11 +173,11 @@ fn multiple_commands_with_comment() -> Result<(), ParseError> {
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 2);
-    assert_eq!(lite_block.block[0].commands.len(), 2);
-    assert_eq!(lite_block.block[1].commands.len(), 1);
+    assert_eq!(lite_block.block[0].items.len(), 2);
+    assert_eq!(lite_block.block[1].items.len(), 1);
 
     assert_eq!(
-        lite_block.block[0].commands[1].comments[0],
+        lite_block.block[0].items[1].command.comments[0],
         Span { start: 29, end: 38 }
     );
 
@@ -208,11 +208,11 @@ let b = 0
     let lite_block = lite_parse_helper(input)?;
 
     assert_eq!(lite_block.block.len(), 2);
-    assert_eq!(lite_block.block[0].commands[0].comments.len(), 3);
-    assert_eq!(lite_block.block[0].commands[0].parts.len(), 4);
+    assert_eq!(lite_block.block[0].items[0].command.comments.len(), 3);
+    assert_eq!(lite_block.block[0].items[0].command.parts.len(), 4);
 
     assert_eq!(
-        lite_block.block[0].commands[0].parts[3],
+        lite_block.block[0].items[0].command.parts[3],
         Span {
             start: 32,
             end: 107
@@ -220,18 +220,18 @@ let b = 0
     );
 
     assert_eq!(
-        lite_block.block[0].commands[0].comments[2],
+        lite_block.block[0].items[0].command.comments[2],
         Span {
             start: 108,
             end: 123
         }
     );
 
-    assert_eq!(lite_block.block[1].commands[0].comments.len(), 1);
-    assert_eq!(lite_block.block[1].commands[0].parts.len(), 4);
+    assert_eq!(lite_block.block[1].items[0].command.comments.len(), 1);
+    assert_eq!(lite_block.block[1].items[0].command.parts.len(), 4);
 
     assert_eq!(
-        lite_block.block[1].commands[0].comments[0],
+        lite_block.block[1].items[0].command.comments[0],
         Span {
             start: 124,
             end: 135

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -123,8 +123,8 @@ impl Expression {
                 }
 
                 if let Some(pipeline) = block.pipelines.get(0) {
-                    match pipeline.expressions.get(0) {
-                        Some(expr) => expr.has_in_variable(working_set),
+                    match pipeline.items.get(0) {
+                        Some(item) => item.expression.has_in_variable(working_set),
                         None => false,
                     }
                 } else {
@@ -228,8 +228,8 @@ impl Expression {
                 let block = working_set.get_block(*block_id);
 
                 if let Some(pipeline) = block.pipelines.get(0) {
-                    if let Some(expr) = pipeline.expressions.get(0) {
-                        expr.has_in_variable(working_set)
+                    if let Some(item) = pipeline.items.get(0) {
+                        item.expression.has_in_variable(working_set)
                     } else {
                         false
                     }
@@ -274,8 +274,8 @@ impl Expression {
                 let block = working_set.get_block(*block_id);
 
                 let new_expr = if let Some(pipeline) = block.pipelines.get(0) {
-                    if let Some(expr) = pipeline.expressions.get(0) {
-                        let mut new_expr = expr.clone();
+                    if let Some(item) = pipeline.items.get(0) {
+                        let mut new_expr = item.expression.clone();
                         new_expr.replace_in_variable(working_set, new_var_id);
                         Some(new_expr)
                     } else {
@@ -289,8 +289,8 @@ impl Expression {
 
                 if let Some(new_expr) = new_expr {
                     if let Some(pipeline) = block.pipelines.get_mut(0) {
-                        if let Some(expr) = pipeline.expressions.get_mut(0) {
-                            *expr = new_expr
+                        if let Some(item) = pipeline.items.get_mut(0) {
+                            item.expression = new_expr;
                         }
                     }
                 }
@@ -369,8 +369,8 @@ impl Expression {
                 let block = working_set.get_block(*block_id);
 
                 let new_expr = if let Some(pipeline) = block.pipelines.get(0) {
-                    if let Some(expr) = pipeline.expressions.get(0) {
-                        let mut new_expr = expr.clone();
+                    if let Some(item) = pipeline.items.get(0) {
+                        let mut new_expr = item.expression.clone();
                         new_expr.replace_in_variable(working_set, new_var_id);
                         Some(new_expr)
                     } else {
@@ -384,8 +384,8 @@ impl Expression {
 
                 if let Some(new_expr) = new_expr {
                     if let Some(pipeline) = block.pipelines.get_mut(0) {
-                        if let Some(expr) = pipeline.expressions.get_mut(0) {
-                            *expr = new_expr
+                        if let Some(item) = pipeline.items.get_mut(0) {
+                            item.expression = new_expr;
                         }
                     }
                 }
@@ -439,8 +439,9 @@ impl Expression {
                 let mut block = working_set.get_block(*block_id).clone();
 
                 for pipeline in block.pipelines.iter_mut() {
-                    for expr in pipeline.expressions.iter_mut() {
-                        expr.replace_span(working_set, replaced, new_span)
+                    for item in pipeline.items.iter_mut() {
+                        item.expression
+                            .replace_span(working_set, replaced, new_span)
                     }
                 }
 
@@ -517,8 +518,9 @@ impl Expression {
                 let mut block = working_set.get_block(*block_id).clone();
 
                 for pipeline in block.pipelines.iter_mut() {
-                    for expr in pipeline.expressions.iter_mut() {
-                        expr.replace_span(working_set, replaced, new_span)
+                    for item in pipeline.items.iter_mut() {
+                        item.expression
+                            .replace_span(working_set, replaced, new_span)
                     }
                 }
 

--- a/crates/nu-protocol/src/ast/pipeline.rs
+++ b/crates/nu-protocol/src/ast/pipeline.rs
@@ -3,8 +3,44 @@ use std::ops::{Index, IndexMut};
 use crate::ast::Expression;
 
 #[derive(Debug, Clone)]
+pub struct Pipe {
+    pub redirect_stdout: bool,
+    pub redirect_stderr: bool,
+}
+
+impl Default for Pipe {
+    fn default() -> Self {
+        Self::new(true, false)
+    }
+}
+
+impl Pipe {
+    pub fn new(redirect_stdout: bool, redirect_stderr: bool) -> Self {
+        Self {
+            redirect_stdout,
+            redirect_stderr,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineItem {
+    pub expression: Expression,
+    pub pipe: Option<Pipe>,
+}
+
+impl PipelineItem {
+    pub fn from_expr(expression: Expression) -> Self {
+        Self {
+            expression,
+            pipe: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Pipeline {
-    pub expressions: Vec<Expression>,
+    pub items: Vec<PipelineItem>,
 }
 
 impl Default for Pipeline {
@@ -15,21 +51,36 @@ impl Default for Pipeline {
 
 impl Pipeline {
     pub fn new() -> Self {
-        Self {
-            expressions: vec![],
+        Self { items: vec![] }
+    }
+
+    pub fn from_expr_vec(expressions: Vec<Expression>) -> Pipeline {
+        let mut items = Vec::new();
+        for (i, expr) in expressions.iter().enumerate() {
+            let mut item = PipelineItem::from_expr(expr.clone());
+            if i != expressions.len() - 1 {
+                item.pipe = Some(Pipe::default());
+            }
+
+            items.push(item);
+        }
+        Self { items }
+    }
+
+    pub fn get_expr(&self, i: usize) -> Option<&Expression> {
+        if i >= self.items.len() {
+            None
+        } else {
+            Some(&self.items[i].expression)
         }
     }
 
-    pub fn from_vec(expressions: Vec<Expression>) -> Pipeline {
-        Self { expressions }
-    }
-
     pub fn len(&self) -> usize {
-        self.expressions.len()
+        self.items.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.expressions.is_empty()
+        self.items.is_empty()
     }
 }
 
@@ -37,12 +88,12 @@ impl Index<usize> for Pipeline {
     type Output = Expression;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.expressions[index]
+        &self.items[index].expression
     }
 }
 
 impl IndexMut<usize> for Pipeline {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.expressions[index]
+        &mut self.items[index].expression
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,7 +351,7 @@ fn parse_commandline_args(
         if let Some(Expression {
             expr: Expr::Call(call),
             ..
-        }) = pipeline.expressions.get(0)
+        }) = pipeline.get_expr(0)
         {
             let redirect_stdin = call.get_named_arg("stdin");
             let login_shell = call.get_named_arg("login");


### PR DESCRIPTION
# Description

Related to #5519.

I found that `stderr` is not being redirected correctly where expression is not the last one, so the `complete` command cannot read the information in `stderr`.

Just like other shells, `|` only redirects stdout to pipe, `|&` can redirect stdout and stderr to pipe. Currently nushell doesn't support `|&`, so I refactored the pipeline related code to support this feature.

Now, we can use:

```shell
git push abc main |& complete
```
to get output like below:

```
stdout                                                                                                  
stderr           fatal: 'abc' does not appear to be a git repository        
                     fatal: Could not read from remote repository.                
                     Please make sure you have the correct access rights. 
                     and the repository exists.                                                 
exit_code    128                                                                                      
```

It also supports redirecting `stderr` to `stdin` for external commands. 
Similar with other shells, it can be used like this:

```shell
git push abc main |& grep abc
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass