### PR TITLE
Allow for test_iteration_errors to work when run as root

### DIFF
--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -936,16 +936,18 @@ mod test {
         use std::io;
         let mut iter = glob("/root/*").unwrap();
 
-        // GlobErrors shouldn't halt iteration
-        let next = iter.next();
-        assert!(next.is_some());
+        if std::fs::read_dir("/root/").is_err() {
+            // GlobErrors shouldn't halt iteration
+            let next = iter.next();
+            assert!(next.is_some());
 
-        let err = next.unwrap();
-        assert!(err.is_err());
+            let err = next.unwrap();
+            assert!(err.is_err());
 
-        let err = err.err().unwrap();
-        assert!(err.path() == Path::new("/root"));
-        assert!(err.error().kind() == io::ErrorKind::PermissionDenied);
+            let err = err.err().unwrap();
+            assert!(err.path() == Path::new("/root"));
+            assert!(err.error().kind() == io::ErrorKind::PermissionDenied);
+        }
     }
 
     #[test]

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -936,6 +936,7 @@ mod test {
         use std::io;
         let mut iter = glob("/root/*").unwrap();
 
+        // Skip test if running with permissions to read /root
         if std::fs::read_dir("/root/").is_err() {
             // GlobErrors shouldn't halt iteration
             let next = iter.next();


### PR DESCRIPTION
# Description

As per #5565 (part 2), `test_iteration_errors` was also failing when run as root. Adding a simple check that it cannot be accessed fixes this issue.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
