### PR TITLE
fix  typo for `version` command

### DIFF
--- a/crates/nu-command/src/core_commands/version.rs
+++ b/crates/nu-command/src/core_commands/version.rs
@@ -83,7 +83,7 @@ pub fn version(
 
     let build_target: Option<&str> = Some(shadow::BUILD_TARGET).filter(|x| !x.is_empty());
     if let Some(build_target) = build_target {
-        cols.push("build_os".to_string());
+        cols.push("build_target".to_string());
         vals.push(Value::String {
             val: build_target.to_string(),
             span: call.head,


### PR DESCRIPTION
# Description

fix typo for `version` command

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
