### PR TITLE
Make flatten works better and predictable

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -197,13 +197,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                         vals,
                         span: _,
                     } => {
-                        if !need_flatten {
-                            if out.contains_key(column) {
-                                out.insert(format!("{}_{}", column, column), value.clone());
-                            } else {
-                                out.insert(column.to_string(), value.clone());
-                            }
-                        } else {
+                        if need_flatten {
                             cols.iter().enumerate().for_each(|(idx, inner_record_col)| {
                                 if out.contains_key(inner_record_col) {
                                     out.insert(
@@ -214,6 +208,10 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                                     out.insert(inner_record_col.to_string(), vals[idx].clone());
                                 }
                             })
+                        } else if out.contains_key(column) {
+                            out.insert(format!("{}_{}", column, column), value.clone());
+                        } else {
+                            out.insert(column.to_string(), value.clone());
                         }
                     }
                     Value::List { vals, span: _ }
@@ -237,13 +235,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                             }
                         }
 
-                        if !need_flatten {
-                            if out.contains_key(column) {
-                                out.insert(format!("{}_{}", column, column), value.clone());
-                            } else {
-                                out.insert(column.to_string(), value.clone());
-                            }
-                        } else {
+                        if need_flatten {
                             let cols = cs.into_iter().map(|f| f.to_vec());
                             let vals = vs.into_iter().map(|f| f.to_vec());
 
@@ -254,6 +246,10 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                                 parent_column_name: column,
                                 parent_column_index: column_index,
                             });
+                        } else if out.contains_key(column) {
+                            out.insert(format!("{}_{}", column, column), value.clone());
+                        } else {
+                            out.insert(column.to_string(), value.clone());
                         }
                     }
                     Value::List {

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -74,7 +74,7 @@ impl Command for Flatten {
             },
             Example {
                 description: "Flatten inner table",
-                example: "{ a: b, d: [ 1 2 3 4 ],  e: [ 4 3  ] } | flatten --all",
+                example: "{ a: b, d: [ 1 2 3 4 ],  e: [ 4 3  ] } | flatten d --all",
                 result: Some(Value::List{
                     vals: vec![
                         Value::Record{
@@ -125,19 +125,22 @@ fn flatten(
 }
 
 enum TableInside<'a> {
-    // handle for a column which contains a single list(but not list of records).
-    Entries(&'a str, &'a Span, Vec<&'a Value>),
+    // handle for a column which contains a single list(but not list of records)
+    // it contains (column, span, values in the column, column index).
+    Entries(&'a str, &'a Span, Vec<&'a Value>, usize),
     // handle for a column which contains a table, we can flatten the inner column to outer level
     // `columns` means that for the given row, it contains `len(columns)` nested rows, and each nested row contains a list of column name.
     // Likely, `values` means that for the given row, it contains `len(values)` nested rows, and each nested row contains a list of values.
     //
     // `parent_column_name` is handled for conflicting column name, the nested table may contains columns which has the same name
     // to outer level, for that case, the output column name should be f"{parent_column_name}_{inner_column_name}".
-    FlatternedRows {
+    // `parent_column_index` is the column index in original table.
+    FlattenedRows {
         columns: Vec<Vec<String>>,
         _span: &'a Span,
         values: Vec<Vec<Value>>,
         parent_column_name: &'a str,
+        parent_column_index: usize,
     },
 }
 
@@ -184,7 +187,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                 pairs
             };
 
-            for (column, value) in records_iterator {
+            for (column_index, (column, value)) in records_iterator.into_iter().enumerate() {
                 let column_requested = columns.iter().find(|c| c.into_string() == *column);
                 let need_flatten = { columns.is_empty() || column_requested.is_some() };
 
@@ -244,11 +247,12 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                             let cols = cs.into_iter().map(|f| f.to_vec());
                             let vals = vs.into_iter().map(|f| f.to_vec());
 
-                            inner_table = Some(TableInside::FlatternedRows {
+                            inner_table = Some(TableInside::FlattenedRows {
                                 columns: cols.collect(),
                                 _span: &s,
                                 values: vals.collect(),
                                 parent_column_name: column,
+                                parent_column_index: column_index,
                             });
                         }
                     }
@@ -276,6 +280,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                                     r,
                                     &s,
                                     values.iter().collect::<Vec<_>>(),
+                                    column_index,
                                 ));
                             } else {
                                 out.insert(column.to_string(), value.clone());
@@ -285,6 +290,7 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                                 column,
                                 &s,
                                 values.iter().collect::<Vec<_>>(),
+                                column_index,
                             ));
                         }
                     }
@@ -296,37 +302,80 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
 
             let mut expanded = vec![];
             match inner_table {
-                Some(TableInside::Entries(column, _, entries)) => {
+                Some(TableInside::Entries(column, _, entries, parent_column_index)) => {
                     for entry in entries {
-                        let mut base = out.clone();
-
-                        base.insert(column.to_string(), entry.clone());
+                        let base = out.clone();
+                        let (mut record_cols, mut record_vals) = (vec![], vec![]);
+                        let mut index = 0;
+                        for (col, val) in base.into_iter() {
+                            // meet the flattened column, push them to result record first
+                            // this can avoid output column order changed.
+                            if index == parent_column_index {
+                                record_cols.push(column.to_string());
+                                record_vals.push(entry.clone());
+                            }
+                            record_cols.push(col);
+                            record_vals.push(val);
+                            index += 1;
+                        }
+                        // the flattened column may be the last column in the original table.
+                        if index == parent_column_index {
+                            record_cols.push(column.to_string());
+                            record_vals.push(entry.clone());
+                        }
                         let record = Value::Record {
-                            cols: base.keys().map(|f| f.to_string()).collect::<Vec<_>>(),
-                            vals: base.values().cloned().collect(),
+                            cols: record_cols,
+                            vals: record_vals,
                             span: tag,
                         };
                         expanded.push(record);
                     }
                 }
-                Some(TableInside::FlatternedRows {
+                Some(TableInside::FlattenedRows {
                     columns,
                     _span,
                     values,
                     parent_column_name,
+                    parent_column_index,
                 }) => {
                     for (inner_cols, inner_vals) in columns.into_iter().zip(values) {
-                        let mut base = out.clone();
-                        for (col, val) in inner_cols.into_iter().zip(inner_vals) {
-                            if base.contains_key(&col) {
-                                base.insert(format!("{}_{}", parent_column_name, col), val);
-                            } else {
-                                base.insert(col, val);
+                        let base = out.clone();
+                        let (mut record_cols, mut record_vals) = (vec![], vec![]);
+                        let mut index = 0;
+
+                        for (base_col, base_val) in base.into_iter() {
+                            // meet the flattened column, push them to result record first
+                            // this can avoid output column order changed.
+                            if index == parent_column_index {
+                                for (col, val) in inner_cols.iter().zip(inner_vals.iter()) {
+                                    if record_cols.contains(col) {
+                                        record_cols.push(format!("{}_{}", parent_column_name, col));
+                                    } else {
+                                        record_cols.push(col.to_string());
+                                    }
+                                    record_vals.push(val.clone());
+                                }
+                            }
+
+                            record_cols.push(base_col);
+                            record_vals.push(base_val);
+                            index += 1;
+                        }
+
+                        // the flattened column may be the last column in the original table.
+                        if index == parent_column_index {
+                            for (col, val) in inner_cols.iter().zip(inner_vals.iter()) {
+                                if record_cols.contains(col) {
+                                    record_cols.push(format!("{}_{}", parent_column_name, col));
+                                } else {
+                                    record_cols.push(col.to_string());
+                                }
+                                record_vals.push(val.clone());
                             }
                         }
                         let record = Value::Record {
-                            cols: base.keys().map(|f| f.to_string()).collect::<Vec<_>>(),
-                            vals: base.values().cloned().collect(),
+                            cols: record_cols,
+                            vals: record_vals,
                             span: tag,
                         };
                         expanded.push(record);


### PR DESCRIPTION
# Description

Fix some issue mentioned in comment: https://github.com/nushell/nushell/pull/5606#issuecomment-1133645051

In detail:
1. The order of the columns shoudn't change.
2. To avoid flattened data size bursted, for the following case, (at least two column contains list)
```
> [{ a: b, d: [ 1 2 3 4 ],  e: [ 4 3  ] }]
╭───┬───┬────────────────┬────────────────╮
│ # │ a │       d        │       e        │
├───┼───┼────────────────┼────────────────┤
│ 0 │ b │ [list 4 items] │ [list 2 items] │
╰───┴───┴────────────────┴────────────────╯
```

`flatten` can only flatten a column at once, or else it will raise error.   Here is relative code in `0.44`: https://github.com/nushell/nushell/blob/0.44.0/crates/nu-command/src/commands/filters/flatten.rs#L121-L126

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
