### PR TITLE
Ensures `where` works like `each` and `reduce`

### DIFF
--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -19,7 +19,11 @@ impl Command for Where {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("where")
-            .required("cond", SyntaxShape::RowCondition, "condition")
+            .required(
+                "block",
+                SyntaxShape::Block(Some(vec![SyntaxShape::Any])),
+                "the block to run",
+            )
             .category(Category::Filters)
     }
 


### PR DESCRIPTION
# Description

As per issue #5547, `where` did not work properly when passed in a variable containing a block. That was an issue with the signature requirements. This PR fixes it.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
