### PR TITLE
Add meta command for the config subcommands

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -317,6 +317,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             WithEnv,
             ConfigNu,
             ConfigEnv,
+            ConfigMeta,
         };
 
         // Math

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -1,0 +1,46 @@
+use nu_engine::get_full_help;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, IntoPipelineData, PipelineData, Signature, Value,
+};
+
+#[derive(Clone)]
+pub struct ConfigMeta;
+
+impl Command for ConfigMeta {
+    fn name(&self) -> &str {
+        "config"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name()).category(Category::Env)
+    }
+
+    fn usage(&self) -> &str {
+        "Edit nushell configuration files"
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Ok(Value::String {
+            val: get_full_help(
+                &ConfigMeta.signature(),
+                &ConfigMeta.examples(),
+                engine_state,
+                stack,
+            ),
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["options", "setup"]
+    }
+}

--- a/crates/nu-command/src/env/config/mod.rs
+++ b/crates/nu-command/src/env/config/mod.rs
@@ -1,5 +1,7 @@
+mod config_;
 mod config_env;
 mod config_nu;
 mod utils;
+pub use config_::ConfigMeta;
 pub use config_env::ConfigEnv;
 pub use config_nu::ConfigNu;

--- a/crates/nu-command/src/env/mod.rs
+++ b/crates/nu-command/src/env/mod.rs
@@ -5,6 +5,7 @@ mod load_env;
 mod with_env;
 
 pub use config::ConfigEnv;
+pub use config::ConfigMeta;
 pub use config::ConfigNu;
 pub use env_command::Env;
 pub use let_env::LetEnv;


### PR DESCRIPTION
# Description

When using `config` without the `config nu` or `config env` subcommands
introduced by #5607 display basic usage like `str`.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
