### PR TITLE
load config when requried

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,25 @@ fn main() -> Result<()> {
                     NUSHELL_FOLDER,
                     is_perf_true(),
                 );
+                // only want to load config and env if relative argument is provided.
+                if binary_args.config_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.config_file,
+                        is_perf_true(),
+                        false,
+                    );
+                }
+                if binary_args.env_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.env_file,
+                        is_perf_true(),
+                        true,
+                    );
+                }
 
                 let ret_val = evaluate_commands(
                     commands,
@@ -217,6 +236,25 @@ fn main() -> Result<()> {
                     NUSHELL_FOLDER,
                     is_perf_true(),
                 );
+                // only want to load config and env if relative argument is provided.
+                if binary_args.config_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.config_file,
+                        is_perf_true(),
+                        false,
+                    );
+                }
+                if binary_args.env_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.env_file,
+                        is_perf_true(),
+                        true,
+                    );
+                }
 
                 let ret_val = evaluate_file(
                     script_name,


### PR DESCRIPTION
# Description

Hope that I get the idea mentioned in the issue #5544 
Also related: #5053 

For now, we can use `nu script.nu --config-file xxx` to load config file while execute nu script or nu command.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
