### PR TITLE
Overlay keep

### DIFF
--- a/crates/nu-command/src/core_commands/overlay/add.rs
+++ b/crates/nu-command/src/core_commands/overlay/add.rs
@@ -56,16 +56,10 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
             .is_some()
         {
             Some(name_arg.item.clone())
+        } else if let Some(os_str) = Path::new(&name_arg.item).file_stem() {
+            os_str.to_str().map(|name| name.to_string())
         } else {
-            if let Some(os_str) = Path::new(&name_arg.item).file_stem() {
-                if let Some(name) = os_str.to_str() {
-                    Some(name.to_string())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
+            None
         };
 
         if let Some(overlay_name) = maybe_overlay_name {

--- a/crates/nu-command/src/core_commands/overlay/remove.rs
+++ b/crates/nu-command/src/core_commands/overlay/remove.rs
@@ -19,7 +19,7 @@ impl Command for OverlayRemove {
         Signature::build("overlay remove")
             .optional("name", SyntaxShape::String, "Overlay to remove")
             .switch(
-                "keep",
+                "keep-custom",
                 "Keep newly added symbols within the next activated overlay",
                 Some('k'),
             )
@@ -51,7 +51,7 @@ https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-
             }
         };
 
-        let env_vars_to_keep = if call.has_flag("keep") {
+        let env_vars_to_keep = if call.has_flag("keep-custom") {
             if let Some(id) = engine_state.find_active_overlay(module_name.item.as_bytes()) {
                 let overlay_frame = engine_state.get_overlay(id);
                 let orig_module = engine_state.get_module(overlay_frame.origin);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2063,6 +2063,8 @@ pub fn parse_overlay_remove(
         )
     };
 
+    let keep_custom = call.has_flag("keep-custom");
+
     let pipeline = Pipeline::from_vec(vec![Expression {
         expr: Expr::Call(call),
         span: span(spans),
@@ -2097,16 +2099,7 @@ pub fn parse_overlay_remove(
         );
     }
 
-    // let original_module = if call.has_flag("discard") {
-    //     None
-    // } else if let Some(module_id) = working_set.find_module(overlay_name.as_bytes()) {
-    //     // TODO: Remove clone
-    //     Some(working_set.get_module(module_id).clone())
-    // } else {
-    //     Some(Module::new())
-    // };
-
-    working_set.remove_overlay(overlay_name.as_bytes());
+    working_set.remove_overlay(overlay_name.as_bytes(), keep_custom);
 
     (pipeline, None)
 }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1780,23 +1780,23 @@ impl<'a> StateWorkingSet<'a> {
     pub fn remove_overlay(&mut self, name: &[u8], keep_custom: bool) {
         let last_scope_frame = self.delta.last_scope_frame_mut();
 
-        let removed_overlay = if let Some(overlay_id) = last_scope_frame.find_overlay(name) {
+        let removed_overlay_origin = if let Some(overlay_id) = last_scope_frame.find_overlay(name) {
             last_scope_frame
                 .active_overlays
                 .retain(|id| id != &overlay_id);
 
-            Some(last_scope_frame.get_overlay(overlay_id).clone())
+            Some(last_scope_frame.get_overlay(overlay_id).origin)
         } else {
             self.permanent_state
                 .find_overlay(name)
-                .map(|id| self.permanent_state.get_overlay(id).clone())
+                .map(|id| self.permanent_state.get_overlay(id).origin)
         };
 
-        if let Some(overlay_frame) = removed_overlay {
+        if let Some(module_id) = removed_overlay_origin {
             last_scope_frame.removed_overlays.push(name.to_owned());
 
             if keep_custom {
-                let origin_module = self.get_module(overlay_frame.origin);
+                let origin_module = self.get_module(module_id);
 
                 let decls = self
                     .decls_of_overlay(name)

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1712,7 +1712,7 @@ impl<'a> StateWorkingSet<'a> {
         } else {
             last_scope_frame
                 .overlays
-                .push((name, OverlayFrame::from(origin)));
+                .push((name, OverlayFrame::from_origin(origin)));
             last_scope_frame.overlays.len() - 1
         };
 

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -101,7 +101,7 @@ impl ScopeFrame {
 
     pub fn with_empty_overlay(name: Vec<u8>, origin: ModuleId) -> Self {
         Self {
-            overlays: vec![(name, OverlayFrame::from(origin))],
+            overlays: vec![(name, OverlayFrame::from_origin(origin))],
             active_overlays: vec![0],
             removed_overlays: vec![],
             predecls: HashMap::new(),
@@ -209,7 +209,7 @@ pub struct OverlayFrame {
 }
 
 impl OverlayFrame {
-    pub fn from(origin: ModuleId) -> Self {
+    pub fn from_origin(origin: ModuleId) -> Self {
         Self {
             vars: HashMap::new(),
             predecls: HashMap::new(),

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use crate::{AliasId, DeclId, ModuleId, OverlayId, VarId};
 
+use super::StateWorkingSet;
+
 pub static DEFAULT_OVERLAY_NAME: &str = "zero";
 
 /// Tells whether a decl or alias is visible or not
@@ -195,7 +197,7 @@ impl ScopeFrame {
     }
 }
 
-// type OverlayDiff = (Vec<(Vec<u8>, DeclId)>, Vec<(Vec<u8>, AliasId)>);
+type OverlayDiff = (Vec<(Vec<u8>, DeclId)>, Vec<(Vec<u8>, AliasId)>);
 
 #[derive(Debug, Clone)]
 pub struct OverlayFrame {
@@ -221,44 +223,44 @@ impl OverlayFrame {
         }
     }
 
-    // Find out which definitions are custom compared to the origin module
-    // pub fn diff(&self, engine_state: &EngineState) -> OverlayDiff {
-    //     let module = engine_state.get_module(self.origin);
+    /// Find out which definitions are newly added compared to the origin module
+    pub fn diff(&self, working_set: &StateWorkingSet) -> OverlayDiff {
+        let module = working_set.get_module(self.origin);
 
-    //     let decls = self
-    //         .decls
-    //         .iter()
-    //         .filter(|(name, decl_id)| {
-    //             if self.visibility.is_decl_id_visible(decl_id) {
-    //                 if let Some(original_id) = module.get_decl_id(name) {
-    //                     &original_id != *decl_id
-    //                 } else {
-    //                     true
-    //                 }
-    //             } else {
-    //                 false
-    //             }
-    //         })
-    //         .map(|(name, decl_id)| (name.to_owned(), *decl_id))
-    //         .collect();
+        let decls = self
+            .decls
+            .iter()
+            .filter(|(name, decl_id)| {
+                if self.visibility.is_decl_id_visible(decl_id) {
+                    if module.has_decl(name) {
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+            })
+            .map(|(name, decl_id)| (name.to_owned(), *decl_id))
+            .collect();
 
-    //     let aliases = self
-    //         .aliases
-    //         .iter()
-    //         .filter(|(name, alias_id)| {
-    //             if self.visibility.is_alias_id_visible(alias_id) {
-    //                 if let Some(original_id) = module.get_alias_id(name) {
-    //                     &original_id != *alias_id
-    //                 } else {
-    //                     true
-    //                 }
-    //             } else {
-    //                 false
-    //             }
-    //         })
-    //         .map(|(name, alias_id)| (name.to_owned(), *alias_id))
-    //         .collect();
+        let aliases = self
+            .aliases
+            .iter()
+            .filter(|(name, alias_id)| {
+                if self.visibility.is_alias_id_visible(alias_id) {
+                    if module.has_alias(name) {
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+            })
+            .map(|(name, alias_id)| (name.to_owned(), *alias_id))
+            .collect();
 
-    //     (decls, aliases)
-    // }
+        (decls, aliases)
+    }
 }

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 
 use crate::{AliasId, DeclId, ModuleId, OverlayId, VarId};
 
-use super::StateWorkingSet;
-
 pub static DEFAULT_OVERLAY_NAME: &str = "zero";
 
 /// Tells whether a decl or alias is visible or not
@@ -197,8 +195,6 @@ impl ScopeFrame {
     }
 }
 
-type OverlayDiff = (Vec<(Vec<u8>, DeclId)>, Vec<(Vec<u8>, AliasId)>);
-
 #[derive(Debug, Clone)]
 pub struct OverlayFrame {
     pub vars: HashMap<Vec<u8>, VarId>,
@@ -221,46 +217,5 @@ impl OverlayFrame {
             visibility: Visibility::new(),
             origin,
         }
-    }
-
-    /// Find out which definitions are newly added compared to the origin module
-    pub fn diff(&self, working_set: &StateWorkingSet) -> OverlayDiff {
-        let module = working_set.get_module(self.origin);
-
-        let decls = self
-            .decls
-            .iter()
-            .filter(|(name, decl_id)| {
-                if self.visibility.is_decl_id_visible(decl_id) {
-                    if module.has_decl(name) {
-                        false
-                    } else {
-                        true
-                    }
-                } else {
-                    false
-                }
-            })
-            .map(|(name, decl_id)| (name.to_owned(), *decl_id))
-            .collect();
-
-        let aliases = self
-            .aliases
-            .iter()
-            .filter(|(name, alias_id)| {
-                if self.visibility.is_alias_id_visible(alias_id) {
-                    if module.has_alias(name) {
-                        false
-                    } else {
-                        true
-                    }
-                } else {
-                    false
-                }
-            })
-            .map(|(name, alias_id)| (name.to_owned(), *alias_id))
-            .collect();
-
-        (decls, aliases)
     }
 }

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -178,12 +178,60 @@ impl Stack {
         result
     }
 
+    /// Flatten the env var scope frames into one frame, only from one overlay
+    pub fn get_overlay_env_vars(
+        &self,
+        engine_state: &EngineState,
+        overlay_name: &str,
+    ) -> HashMap<String, Value> {
+        let mut result = HashMap::new();
+
+        // for active_overlay in self.active_overlays.iter() {
+        if let Some(active_overlay) = self.active_overlays.iter().find(|n| n == &overlay_name) {
+            if let Some(env_vars) = engine_state.env_vars.get(active_overlay) {
+                result.extend(
+                    env_vars
+                        .iter()
+                        .filter(|(k, _)| {
+                            if let Some(env_hidden) = self.env_hidden.get(active_overlay) {
+                                !env_hidden.contains(*k)
+                            } else {
+                                // nothing has been hidden in this overlay
+                                true
+                            }
+                        })
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect::<HashMap<String, Value>>(),
+                );
+            }
+        }
+
+        result.extend(self.get_stack_overlay_env_vars(overlay_name));
+
+        result
+    }
+
     /// Get flattened environment variables only from the stack
     pub fn get_stack_env_vars(&self) -> HashMap<String, Value> {
         let mut result = HashMap::new();
 
         for scope in &self.env_vars {
             for active_overlay in self.active_overlays.iter() {
+                if let Some(env_vars) = scope.get(active_overlay) {
+                    result.extend(env_vars.clone());
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Get flattened environment variables only from the stack and one overlay
+    pub fn get_stack_overlay_env_vars(&self, overlay_name: &str) -> HashMap<String, Value> {
+        let mut result = HashMap::new();
+
+        for scope in &self.env_vars {
+            if let Some(active_overlay) = self.active_overlays.iter().find(|n| n == &overlay_name) {
                 if let Some(env_vars) = scope.get(active_overlay) {
                     result.extend(env_vars.clone());
                 }

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -374,6 +374,10 @@ impl Stack {
         engine_state.env_vars.contains_key(name)
     }
 
+    pub fn is_overlay_active(&self, name: &String) -> bool {
+        self.active_overlays.contains(name)
+    }
+
     pub fn add_overlay(&mut self, name: String) {
         self.env_hidden.remove(&name);
 
@@ -381,14 +385,8 @@ impl Stack {
         self.active_overlays.push(name);
     }
 
-    pub fn remove_overlay(&mut self, name: &String, span: &Span) -> Result<(), ShellError> {
-        if !self.active_overlays.contains(name) {
-            return Err(ShellError::OverlayNotFoundAtRuntime(name.into(), *span));
-        }
-
+    pub fn remove_overlay(&mut self, name: &String) {
         self.active_overlays.retain(|o| o != name);
-
-        Ok(())
     }
 }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -234,7 +234,7 @@ pub enum ShellError {
     ///
     /// Check the module name. Did you typo it? Did you forget to declare it? Is the casing right?
     #[error("Module or overlay'{0}' not found")]
-    #[diagnostic(code(nu::shell::module_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::module_or_overlay_not_found), url(docsrs))]
     ModuleOrOverlayNotFoundAtRuntime(String, #[label = "not a module or overlay"] Span),
 
     /// A referenced overlay was not found at runtime.

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -308,11 +308,27 @@ fn remove_overlay_discard_env() {
 }
 
 #[test]
+fn remove_overlay_keep_env() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"let-env BAGR = "bagr""#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"$env.BAGR"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.out.contains("bagr"));
+    assert!(actual_repl.out.contains("bagr"));
+}
+
+#[test]
 fn remove_overlay_keep_discard_overwritten_env() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"let-env BAZ = "bagr""#,
-        r#"overlay remove --keep spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"$env.BAZ"#,
     ];
 
@@ -324,11 +340,13 @@ fn remove_overlay_keep_discard_overwritten_env() {
 }
 
 #[test]
-fn remove_overlay_keep_env() {
+fn remove_overlay_keep_env_in_latest_overlay() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"let-env BAGR = "bagr""#,
-        r#"overlay remove --keep spam"#,
+        r#"module eggs { }"#,
+        r#"overlay add eggs"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"$env.BAGR"#,
     ];
 

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -324,6 +324,38 @@ fn remove_overlay_keep_env() {
 }
 
 #[test]
+fn remove_overlay_keep_decl() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"def bagr [] { "bagr" }"#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"bagr"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.out.contains("bagr"));
+    assert!(actual_repl.out.contains("bagr"));
+}
+
+#[test]
+fn remove_overlay_keep_alias() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"alias bagr = "bagr""#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"bagr"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.out.contains("bagr"));
+    assert!(actual_repl.out.contains("bagr"));
+}
+
+#[test]
 fn remove_overlay_keep_discard_overwritten_env() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -308,22 +308,6 @@ fn remove_overlay_discard_env() {
 }
 
 #[test]
-fn remove_overlay_keep_env() {
-    let inp = &[
-        r#"overlay add samples/spam.nu"#,
-        r#"let-env BAGR = "bagr""#,
-        r#"overlay remove --keep-custom spam"#,
-        r#"$env.BAGR"#,
-    ];
-
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu_repl("tests/overlays", inp);
-
-    assert!(actual.out.contains("bagr"));
-    assert!(actual_repl.out.contains("bagr"));
-}
-
-#[test]
 fn remove_overlay_keep_decl() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
@@ -356,6 +340,60 @@ fn remove_overlay_keep_alias() {
 }
 
 #[test]
+fn remove_overlay_keep_env() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"let-env BAGR = "bagr""#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"$env.BAGR"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.out.contains("bagr"));
+    assert!(actual_repl.out.contains("bagr"));
+}
+
+#[test]
+fn remove_overlay_keep_discard_overwritten_decl() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"def foo [] { 'bar' }"#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"foo"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(!actual.err.is_empty());
+    #[cfg(windows)]
+    assert!(actual_repl.out != "bagr");
+    #[cfg(not(windows))]
+    assert!(!actual_repl.err.is_empty());
+}
+
+#[test]
+fn remove_overlay_keep_discard_overwritten_alias() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"alias bar = 'baz'"#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"bar"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(!actual.err.is_empty());
+    #[cfg(windows)]
+    assert!(actual_repl.out != "bagr");
+    #[cfg(not(windows))]
+    assert!(!actual_repl.err.is_empty());
+}
+
+#[test]
 fn remove_overlay_keep_discard_overwritten_env() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
@@ -369,6 +407,42 @@ fn remove_overlay_keep_discard_overwritten_env() {
 
     assert!(actual.err.contains("did you mean"));
     assert!(actual_repl.err.contains("DidYouMean"));
+}
+
+#[test]
+fn remove_overlay_keep_decl_in_latest_overlay() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"def bagr [] { 'bagr' }"#,
+        r#"module eggs { }"#,
+        r#"overlay add eggs"#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"bagr"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.out.contains("bagr"));
+    assert!(actual_repl.out.contains("bagr"));
+}
+
+#[test]
+fn remove_overlay_keep_alias_in_latest_overlay() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"alias bagr = 'bagr'"#,
+        r#"module eggs { }"#,
+        r#"overlay add eggs"#,
+        r#"overlay remove --keep-custom spam"#,
+        r#"bagr"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.out.contains("bagr"));
+    assert!(actual_repl.out.contains("bagr"));
 }
 
 #[test]

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -308,6 +308,38 @@ fn remove_overlay_discard_env() {
 }
 
 #[test]
+fn remove_overlay_keep_discard_overwritten_env() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"let-env BAZ = "bagr""#,
+        r#"overlay remove --keep spam"#,
+        r#"$env.BAZ"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.err.contains("did you mean"));
+    assert!(actual_repl.err.contains("DidYouMean"));
+}
+
+#[test]
+fn remove_overlay_keep_env() {
+    let inp = &[
+        r#"overlay add samples/spam.nu"#,
+        r#"let-env BAGR = "bagr""#,
+        r#"overlay remove --keep spam"#,
+        r#"$env.BAGR"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert!(actual.out.contains("bagr"));
+    assert!(actual_repl.out.contains("bagr"));
+}
+
+#[test]
 fn preserve_overrides() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,


### PR DESCRIPTION
# Description

This PR adds a new option to preserve newly defined symbols when removing overlay.
If there are some commands/aliases/environment variables defined in an overlay but not present in the original overlay's module, they can be copied into the last active overlay after the removal.

# Example no.1

```
(zero) > module spam { export env BAZ = "baz" }
(zero) > overlay add spam
(spam) > let-env BAGR = "bagr"
(spam) > overlay remove --keep-custom spam
(zero) > $env.BAGR
```

# Example no.2

The extra definitions from the removed overlay are removed to the last active overlay (not the one "below" the removed overlay):

```
(zero) > module spam { export env BAZ = "baz" }
(zero) > overlay add spam
(spam) > let-env BAGR = "bagr"
(spam) > module eggs { }
(spam) > overlay add eggs
(eggs) > overlay remove --keep-custom spam
(eggs) > $env.BAGR
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
