### PR TITLE
Makes a more helpful error for `let` in pipeline

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -78,6 +78,16 @@ pub enum ParseError {
     )]
     BuiltinCommandInPipeline(String, #[label("not allowed in pipeline")] Span),
 
+    #[error("Let statement used in pipeline.")]
+    #[diagnostic(
+        code(nu::parser::unexpected_keyword),
+        url(docsrs),
+        help(
+            "Assigning '{0}' to '{1}' does not produced a value to be piped. If the pipeline is meant to apply to '{0}' by itself, use '= ({0} | ...)'."
+        )
+    )]
+    LetInPipeline(String, String, #[label("let in pipeline")] Span),
+
     #[error("Incorrect value")]
     #[diagnostic(code(nu::parser::incorrect_value), url(docsrs), help("{2}"))]
     IncorrectValue(String, #[label("unexpected {0}")] Span, String),
@@ -300,6 +310,7 @@ impl ParseError {
             ParseError::ExpectedKeyword(_, s) => *s,
             ParseError::UnexpectedKeyword(_, s) => *s,
             ParseError::BuiltinCommandInPipeline(_, s) => *s,
+            ParseError::LetInPipeline(_, _, s) => *s,
             ParseError::IncorrectValue(_, s, _) => *s,
             ParseError::MultipleRestParams(s) => *s,
             ParseError::VariableNotFound(s) => *s,

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -83,7 +83,7 @@ pub enum ParseError {
         code(nu::parser::unexpected_keyword),
         url(docsrs),
         help(
-            "Assigning '{0}' to '{1}' does not produced a value to be piped. If the pipeline is meant to apply to '{0}' by itself, use 'let {1} = ({0} | ...)'."
+            "Assigning '{0}' to '{1}' does not produce a value to be piped. If the pipeline is meant to apply to '{0}' by itself, use 'let {1} = ({0} | ...)'."
         )
     )]
     LetInPipeline(String, String, #[label("let in pipeline")] Span),

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -83,7 +83,7 @@ pub enum ParseError {
         code(nu::parser::unexpected_keyword),
         url(docsrs),
         help(
-            "Assigning '{0}' to '{1}' does not produced a value to be piped. If the pipeline is meant to apply to '{0}' by itself, use '= ({0} | ...)'."
+            "Assigning '{0}' to '{1}' does not produced a value to be piped. If the pipeline is meant to apply to '{0}' by itself, use 'let {1} = ({0} | ...)'."
         )
     )]
     LetInPipeline(String, String, #[label("let in pipeline")] Span),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4371,7 +4371,7 @@ pub fn parse_expression(
                     expand_aliases_denylist,
                 )
                 .0,
-                Some(ParseError::BuiltinCommandInPipeline("let".into(), spans[0])),
+                Some(ParseError::LetInPipeline(String::from_utf8_lossy(working_set.get_span_contents(spans[spans.len()-1])).to_string(), String::from_utf8_lossy(working_set.get_span_contents(spans[1])).to_string(), spans[0])),
             ),
             b"alias" => (
                 parse_call(

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4371,7 +4371,12 @@ pub fn parse_expression(
                     expand_aliases_denylist,
                 )
                 .0,
-                Some(ParseError::LetInPipeline(String::from_utf8_lossy(working_set.get_span_contents(spans[spans.len()-1])).to_string(), String::from_utf8_lossy(working_set.get_span_contents(spans[1])).to_string(), spans[0])),
+                Some(ParseError::LetInPipeline(
+                    String::from_utf8_lossy(working_set.get_span_contents(spans[spans.len() - 1]))
+                        .to_string(),
+                    String::from_utf8_lossy(working_set.get_span_contents(spans[1])).to_string(),
+                    spans[0],
+                )),
             ),
             b"alias" => (
                 parse_call(


### PR DESCRIPTION
# Description

As per #5509 , the current error is unhelpful. This PR changes it to make it much clearer.

```
/home/gabriel/CodingProjects/nushell〉let test = "NuShell" | str snake-case     05/25/2022 12:04:53 PM
Error: nu::parser::unexpected_keyword (link)

  × Let statement used in pipeline.
   ╭─[entry #1:1:1]
 1 │ let test = "NuShell" | str snake-case
   · ─┬─
   ·  ╰── let in pipeline
   ╰────
  help: Assigning '"NuShell"' to 'test' does not produced a value to be piped. If the pipeline is
        meant to apply to '"NuShell"' by itself, use '= ("NuShell" | ...)'.
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
