### PR TITLE
make sure no duplicate column exists during eval and merge

### DIFF
--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -81,3 +81,29 @@ fn ignores_duplicate_columns_rejected() {
 
     assert_eq!(actual.out, "last name");
 }
+
+#[test]
+fn reject_record_from_raw_eval() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+            {"a": 3, "a": 4} | reject a | describe
+            "#
+        )
+    );
+
+    assert!(actual.out.contains("record<>"));
+}
+
+#[test]
+fn reject_table_from_raw_eval() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+            [{"a": 3, "a": 4}] | reject a
+            "#
+        )
+    );
+
+    assert!(actual.out.contains("record 0 fields"));
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -472,8 +472,18 @@ pub fn eval_expression(
             let mut cols = vec![];
             let mut vals = vec![];
             for (col, val) in fields {
-                cols.push(eval_expression(engine_state, stack, col)?.as_string()?);
-                vals.push(eval_expression(engine_state, stack, val)?);
+                // avoid duplicate cols.
+                let col_name = eval_expression(engine_state, stack, col)?.as_string()?;
+                let pos = cols.iter().position(|c| c == &col_name);
+                match pos {
+                    Some(index) => {
+                        vals[index] = eval_expression(engine_state, stack, val)?;
+                    }
+                    None => {
+                        cols.push(col_name);
+                        vals.push(eval_expression(engine_state, stack, val)?);
+                    }
+                }
             }
 
             Ok(Value::Record {


### PR DESCRIPTION
# Description

Fixes: #5282

For now, while make merge:
```
❯ let res = ({foo: 42} | merge { {foo: 777} })
❯ $res
╭─────┬─────╮
│ foo │ 777 │
╰─────┴─────╯
❯ $res.foo
777
```

Relative `$res` information:
```
> $res | debug -r
Record {
    cols: [
        "foo",
    ],
    vals: [
        Int {
            val: 777,
            span: Span {
                start: 21816,
                end: 21819,
            },
        },
    ],
    span: Span {
        start: 21823,
        end: 21827,
    },
}
```
Relative to eval and reject:
```
> let data = [{foo: 1, foo: 2}]
> $data
╭───┬─────╮
│ # │ foo │
├───┼─────┤
│ 0 │   2 │
╰───┴─────╯
> $data | reject foo
╭───┬───────────────────╮
│ 0 │ {record 0 fields} │
╰───┴───────────────────╯
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
