### PR TITLE
nu-cli/completions: fix filter for variable completions

### DIFF
--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -70,7 +70,18 @@ impl Completer for VariableCompletion {
                         self.var_context.1.clone().into_iter().skip(1).collect();
 
                     if let Some(val) = env_vars.get(&target_var_str) {
-                        return nested_suggestions(val.clone(), nested_levels, current_span);
+                        for suggestion in
+                            nested_suggestions(val.clone(), nested_levels, current_span)
+                        {
+                            if options
+                                .match_algorithm
+                                .matches_u8(suggestion.value.as_bytes(), &prefix)
+                            {
+                                output.push(suggestion);
+                            }
+                        }
+
+                        return output;
                     }
                 } else {
                     // No nesting provided, return all env vars
@@ -105,7 +116,18 @@ impl Completer for VariableCompletion {
                         end: current_span.end,
                     },
                 ) {
-                    return nested_suggestions(nuval, self.var_context.1.clone(), current_span);
+                    for suggestion in
+                        nested_suggestions(nuval, self.var_context.1.clone(), current_span)
+                    {
+                        if options
+                            .match_algorithm
+                            .matches_u8(suggestion.value.as_bytes(), &prefix)
+                        {
+                            output.push(suggestion);
+                        }
+                    }
+
+                    return output;
                 }
             }
 
@@ -122,7 +144,18 @@ impl Completer for VariableCompletion {
 
                 // If the value exists and it's of type Record
                 if let Ok(value) = var {
-                    return nested_suggestions(value, self.var_context.1.clone(), current_span);
+                    for suggestion in
+                        nested_suggestions(value, self.var_context.1.clone(), current_span)
+                    {
+                        if options
+                            .match_algorithm
+                            .matches_u8(suggestion.value.as_bytes(), &prefix)
+                        {
+                            output.push(suggestion);
+                        }
+                    }
+
+                    return output;
                 }
             }
         }


### PR DESCRIPTION
# Description

This adds the filtering for variable completions, should fix https://github.com/nushell/nushell/issues/5623.

[![asciicast](https://asciinema.org/a/wCm2bHaFT0sAwE9wqMtq3VOto.svg)](https://asciinema.org/a/wCm2bHaFT0sAwE9wqMtq3VOto)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
