### PR TITLE
feat[table]: Allow specific table width with `-w`, like command `grid`.

### DIFF
--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -491,13 +491,19 @@ pub fn draw_table(
     config: &Config,
 ) -> String {
     // Remove the edges, if used
-    let termwidth = if table.theme.print_left_border && table.theme.print_right_border {
-        termwidth - 3
+    let edges_width = if table.theme.print_left_border && table.theme.print_right_border {
+        3
     } else if table.theme.print_left_border || table.theme.print_right_border {
-        termwidth - 1
+        1
     } else {
-        termwidth
+        0
     };
+
+    if termwidth < edges_width {
+        return format!("Couldn't fit table into {} columns!", termwidth);
+    }
+
+    let termwidth = termwidth - edges_width;
 
     let mut processed_table = process_table(table);
 


### PR DESCRIPTION
# Description

Add `-w` flag of `table`, like command `grid -w` do.

This allow us specific table width, when using nushell in pipes.  
Instead of using default hard coded terminal width `80usize`.

close #5624

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
