### PR TITLE
make cp can copy folders contains dangling symbolic link

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -56,8 +56,8 @@ impl Command for Cp {
             // .switch("force", "suppress error when no file", Some('f'))
             .switch("interactive", "ask user to confirm action", Some('i'))
             .switch(
-                "no-follow-symlink",
-                "don't follow symbolic link file while copy directory, it's only useful when copy directory with '-r' flag",
+                "no-dereference",
+                "If the -r option is specified, no symbolic links are followed.",
                 Some('p'),
             )
             .category(Category::FileSystem)
@@ -194,7 +194,7 @@ impl Command for Cp {
                     )
                 })?;
 
-                let not_follow_symlink = call.has_flag("no-follow-symlink");
+                let not_follow_symlink = call.has_flag("no-dereference");
                 let sources = sources.paths_applying_with(|(source_file, depth_level)| {
                     let mut dest = destination.clone();
 

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -288,7 +288,7 @@ fn copy_dir_contains_symlink() {
             "rm tmp_dir/good_bye; cp -r -p tmp_dir tmp_dir_2",
         );
 
-        // check hello_there exists inside `tmp_dir_2`, and `dangle_symlink` don't exists inside `tmp_dir_2`.
+        // check hello_there exists inside `tmp_dir_2`, and `dangle_symlink` also exists inside `tmp_dir_2`.
         let expected = sandbox.cwd().join("tmp_dir_2");
         assert!(files_exist_at(vec!["hello_there"], expected.clone()));
         let path = expected.join("dangle_symlink");

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -1,3 +1,4 @@
+use nu_test_support::fs::file_contents;
 use nu_test_support::fs::{files_exist_at, AbsoluteFile, Stub::EmptyFile};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
@@ -293,5 +294,27 @@ fn copy_dir_contains_symlink() {
         assert!(files_exist_at(vec!["hello_there"], expected.clone()));
         let path = expected.join("dangle_symlink");
         assert!(path.is_symlink());
+    });
+}
+
+#[test]
+fn copy_dir_symlink_file_body_not_changed() {
+    Playground::setup("cp_test_14", |_dirs, sandbox| {
+        sandbox
+            .within("tmp_dir")
+            .with_files(vec![EmptyFile("hello_there"), EmptyFile("good_bye")])
+            .within("tmp_dir")
+            .symlink("good_bye", "dangle_symlink");
+
+        // make symbolic link and copy.
+        nu!(
+            cwd: sandbox.cwd(),
+            "rm tmp_dir/good_bye; cp -r -p tmp_dir tmp_dir_2; rm -r tmp_dir; cp -r -p tmp_dir_2 tmp_dir; echo hello_data | save tmp_dir/good_bye",
+        );
+
+        // check dangle_symlink in tmp_dir is no longer dangling.
+        let expected_file = sandbox.cwd().join("tmp_dir").join("dangle_symlink");
+        let actual = file_contents(expected_file);
+        assert!(actual.contains("hello_data"));
     });
 }

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -249,3 +249,26 @@ fn copy_to_non_existing_dir() {
         assert!(actual.err.contains("destination directory does not exist"));
     });
 }
+
+#[test]
+fn copy_dir_contains_symlink() {
+    Playground::setup("cp_test_12", |_dirs, sandbox| {
+        sandbox
+            .within("tmp_dir")
+            .with_files(vec![EmptyFile("hello_there"), EmptyFile("good_bye")])
+            .within("tmp_dir")
+            .symlink("good_bye", "dangle_symlink");
+
+        // make symbolic link and copy.
+        nu!(
+            cwd: sandbox.cwd(),
+            "rm tmp_dir/good_bye; cp -r tmp_dir tmp_dir_2",
+        );
+
+        // check hello_there exists inside `tmp_dir_2`, and `dangle_symlink` don't exists inside `tmp_dir_2`.
+        let expected = sandbox.cwd().join("tmp_dir_2");
+        assert!(files_exist_at(vec!["hello_there"], expected.clone()));
+        let path = expected.join("dangle_symlink");
+        assert!(!path.exists());
+    });
+}

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -228,7 +228,9 @@ impl<'a> Playground<'a> {
 
     pub fn within(&mut self, directory: &str) -> &mut Self {
         self.cwd.push(directory);
-        std::fs::create_dir(&self.cwd).expect("can not create directory");
+        if !(self.cwd.exists() && self.cwd.is_dir()) {
+            std::fs::create_dir(&self.cwd).expect("can not create directory");
+        }
         self
     }
 


### PR DESCRIPTION
# Description

Relative: #5526

New behavior:
1. By default: if there are dangling symbolic link inside a folder, the symbolic link will not be copied.
2. Add `-p` argument, which will copy dangling symbolic link inside a folder.

Maybe there are more cases needs to be handle in `cp` command.  But for now, I think it's suited for #5526 usage.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
