### PR TITLE
add case_sensitive_completions config option

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -37,7 +37,10 @@ impl NuCompleter {
     ) -> Vec<Suggestion> {
         let config = self.engine_state.get_config();
 
-        let mut options = CompletionOptions::default();
+        let mut options = CompletionOptions {
+            case_sensitive: config.case_sensitive_completions,
+            ..Default::default()
+        };
 
         if config.completion_algorithm == "fuzzy" {
             options.match_algorithm = MatchAlgorithm::Fuzzy;

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -75,6 +75,7 @@ pub struct Config {
     pub buffer_editor: String,
     pub disable_table_indexes: bool,
     pub cd_with_abbreviations: bool,
+    pub case_sensitive_completions: bool,
 }
 
 impl Default for Config {
@@ -105,6 +106,7 @@ impl Default for Config {
             buffer_editor: String::new(),
             disable_table_indexes: false,
             cd_with_abbreviations: false,
+            case_sensitive_completions: false,
         }
     }
 }
@@ -311,7 +313,14 @@ impl Value {
                         if let Ok(b) = value.as_bool() {
                             config.cd_with_abbreviations = b;
                         } else {
-                            eprintln!("$config.disable_table_indexes is not a bool")
+                            eprintln!("$config.cd_with_abbreviations is not a bool")
+                        }
+                    }
+                    "case_sensitive_completions" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.case_sensitive_completions = b;
+                        } else {
+                            eprintln!("$config.case_sensitive_completions is not a bool")
                         }
                     }
                     x => {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -199,6 +199,8 @@ let-env config = {
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
   disable_table_indexes: false # set to true to remove the index column from tables
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
+  case_sensitive_completions: false # set to true to enable case-sensitive completions
+
   hooks: {
     pre_prompt: [{
       $nothing  # replace with source code to run before the prompt is shown


### PR DESCRIPTION
# Description

This PR allows you to control whether the completions are case sensitive using a config point.
```
    case_sensitive_completions: true # true enabled case_sensitive completions, false disables it
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
