### PR TITLE
Add 'overlay new' command

### DIFF
--- a/crates/nu-command/src/core_commands/overlay/mod.rs
+++ b/crates/nu-command/src/core_commands/overlay/mod.rs
@@ -1,9 +1,11 @@
 mod add;
 mod command;
 mod list;
+mod new;
 mod remove;
 
 pub use add::OverlayAdd;
 pub use command::Overlay;
 pub use list::OverlayList;
+pub use new::OverlayNew;
 pub use remove::OverlayRemove;

--- a/crates/nu-command/src/core_commands/overlay/new.rs
+++ b/crates/nu-command/src/core_commands/overlay/new.rs
@@ -1,0 +1,74 @@
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape};
+
+#[derive(Clone)]
+pub struct OverlayNew;
+
+impl Command for OverlayNew {
+    fn name(&self) -> &str {
+        "overlay new"
+    }
+
+    fn usage(&self) -> &str {
+        "Create an empty overlay"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("overlay new")
+            .required("name", SyntaxShape::String, "Name of the overlay")
+            // TODO:
+            // .switch(
+            //     "prefix",
+            //     "Prepend module name to the imported symbols",
+            //     Some('p'),
+            // )
+            .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"The command will first create an empty module, then add it as an overlay.
+
+This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let name_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
+
+        stack.add_overlay(name_arg.item);
+
+        Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Create an empty overlay",
+            example: r#"overlay new spam"#,
+            result: None,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(OverlayNew {})
+    }
+}

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -55,6 +55,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             Overlay,
             OverlayAdd,
             OverlayList,
+            OverlayNew,
             OverlayRemove,
             Let,
             Metadata,

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -496,3 +496,14 @@ fn reset_overrides() {
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
 }
+
+#[test]
+fn overlay_new() {
+    let inp = &[r#"overlay new spam"#, r#"overlay list | last"#];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert_eq!(actual.out, "spam");
+    assert_eq!(actual_repl.out, "spam");
+}


### PR DESCRIPTION
# Description

Adds a new `overlay new` command as a shorthand for `module spam { }; overlay add spam`

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
