### PR TITLE
Shorten the links of parser keywords help msgs

### DIFF
--- a/crates/nu-command/src/core_commands/alias.rs
+++ b/crates/nu-command/src/core_commands/alias.rs
@@ -26,8 +26,8 @@ impl Command for Alias {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/def.rs
+++ b/crates/nu-command/src/core_commands/def.rs
@@ -27,8 +27,8 @@ impl Command for Def {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/def_env.rs
+++ b/crates/nu-command/src/core_commands/def_env.rs
@@ -27,8 +27,8 @@ impl Command for DefEnv {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export.rs
+++ b/crates/nu-command/src/core_commands/export.rs
@@ -22,8 +22,8 @@ impl Command for ExportCommand {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_alias.rs
+++ b/crates/nu-command/src/core_commands/export_alias.rs
@@ -26,8 +26,8 @@ impl Command for ExportAlias {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_def.rs
+++ b/crates/nu-command/src/core_commands/export_def.rs
@@ -27,8 +27,8 @@ impl Command for ExportDef {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -27,8 +27,8 @@ impl Command for ExportDefEnv {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_env.rs
+++ b/crates/nu-command/src/core_commands/export_env.rs
@@ -30,8 +30,8 @@ impl Command for ExportEnv {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_extern.rs
+++ b/crates/nu-command/src/core_commands/export_extern.rs
@@ -22,8 +22,8 @@ impl Command for ExportExtern {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/extern_.rs
+++ b/crates/nu-command/src/core_commands/extern_.rs
@@ -22,8 +22,8 @@ impl Command for Extern {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -45,8 +45,8 @@ impl Command for For {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -25,9 +25,8 @@ impl Command for Hide {
     fn extra_usage(&self) -> &str {
         r#"Symbols are hidden by priority: First aliases, then custom commands, then environment variables.
 
-This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages
-            "#
+This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -34,8 +34,8 @@ impl Command for If {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -27,8 +27,8 @@ impl Command for Let {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/module.rs
+++ b/crates/nu-command/src/core_commands/module.rs
@@ -26,8 +26,8 @@ impl Command for Module {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/overlay/add.rs
+++ b/crates/nu-command/src/core_commands/overlay/add.rs
@@ -34,8 +34,8 @@ impl Command for OverlayAdd {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/overlay/command.rs
+++ b/crates/nu-command/src/core_commands/overlay/command.rs
@@ -22,8 +22,8 @@ impl Command for Overlay {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/overlay/remove.rs
+++ b/crates/nu-command/src/core_commands/overlay/remove.rs
@@ -29,8 +29,8 @@ impl Command for OverlayRemove {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/register.rs
+++ b/crates/nu-command/src/core_commands/register.rs
@@ -42,8 +42,8 @@ impl Command for Register {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/source.rs
+++ b/crates/nu-command/src/core_commands/source.rs
@@ -27,8 +27,8 @@ impl Command for Source {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -24,8 +24,8 @@ impl Command for Use {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check
-https://www.nushell.sh/book/thinking_in_nushell.html#parsing-and-evaluation-are-different-stages"#
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nushell.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {


### PR DESCRIPTION
# Description

Shortens the links so they're not so wide.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
