### PR TITLE
Improve test coverage of command examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ debian/nu/
 # Helix configuration folder
 .helix/*
 .helix
+
+# Coverage tools
+lcov.info
+tarpaulin-report.html

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -27,7 +27,14 @@ impl Command for Columns {
             Example {
                 example: "[[name,age,grade]; [bill,20,a]] | columns",
                 description: "Get the columns from the table",
-                result: None,
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_string("name"),
+                        Value::test_string("age"),
+                        Value::test_string("grade"),
+                    ],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 example: "[[name,age,grade]; [bill,20,a]] | columns | first",

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -57,11 +57,18 @@ impl Command for DropColumn {
             description: "Remove the last column of a table",
             example: "echo [[lib, extension]; [nu-lib, rs] [nu-core, rb]] | drop column",
             result: Some(Value::List {
-                vals: vec![Value::Record {
-                    cols: vec!["lib".into()],
-                    vals: vec![Value::test_string("nu-lib"), Value::test_string("nu-core")],
-                    span: Span::test_data(),
-                }],
+                vals: vec![
+                    Value::Record {
+                        cols: vec!["lib".into()],
+                        vals: vec![Value::test_string("nu-lib")],
+                        span: Span::test_data(),
+                    },
+                    Value::Record {
+                        cols: vec!["lib".into()],
+                        vals: vec![Value::test_string("nu-core")],
+                        span: Span::test_data(),
+                    },
+                ],
                 span: Span::test_data(),
             }),
         }]
@@ -179,4 +186,14 @@ fn get_keep_columns(input: Vec<String>, mut num_of_columns_to_drop: i64) -> Vec<
 
     let num_of_columns_to_keep = (vlen - num_of_columns_to_drop) as usize;
     input[0..num_of_columns_to_keep].to_vec()
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::DropColumn;
+        use crate::test_examples;
+        test_examples(DropColumn {})
+    }
 }

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -205,3 +205,13 @@ fn reject_record_columns(cols: &mut Vec<String>, vals: &mut Vec<Value>, rejects:
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::Reject;
+        use crate::test_examples;
+        test_examples(Reject {})
+    }
+}

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -70,13 +70,35 @@ impl Command for Wrap {
             description: "Wrap a list into a table with a given column name",
             example: "echo [1 2 3] | wrap num",
             result: Some(Value::List {
-                vals: vec![Value::Record {
-                    cols: vec!["num".into()],
-                    vals: vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)],
-                    span: Span::test_data(),
-                }],
+                vals: vec![
+                    Value::Record {
+                        cols: vec!["num".into()],
+                        vals: vec![Value::test_int(1)],
+                        span: Span::test_data(),
+                    },
+                    Value::Record {
+                        cols: vec!["num".into()],
+                        vals: vec![Value::test_int(2)],
+                        span: Span::test_data(),
+                    },
+                    Value::Record {
+                        cols: vec!["num".into()],
+                        vals: vec![Value::test_int(3)],
+                        span: Span::test_data(),
+                    },
+                ],
                 span: Span::test_data(),
             }),
         }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::Wrap;
+        use crate::test_examples;
+        test_examples(Wrap {})
     }
 }

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -55,12 +55,12 @@ impl Command for FromOds {
         vec![
             Example {
                 description: "Convert binary .ods data to a table",
-                example: "open test.txt | from ods",
+                example: "open --raw test.ods | from ods",
                 result: None,
             },
             Example {
                 description: "Convert binary .ods data to a table, specifying the tables",
-                example: "open test.txt | from ods -s [Spreadsheet1]",
+                example: "open --raw test.ods | from ods -s [Spreadsheet1]",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -55,12 +55,12 @@ impl Command for FromXlsx {
         vec![
             Example {
                 description: "Convert binary .xlsx data to a table",
-                example: "open test.txt | from xlsx",
+                example: "open --raw test.xlsx | from xlsx",
                 result: None,
             },
             Example {
                 description: "Convert binary .xlsx data to a table, specifying the tables",
-                example: "open test.txt | from xlsx -s [Spreadsheet1]",
+                example: "open --raw test.xlsx | from xlsx -s [Spreadsheet1]",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -39,7 +39,7 @@ impl Command for ToNuon {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Outputs a nuon string representing the contents of this table",
+            description: "Outputs a nuon string representing the contents of this list",
             example: "[1 2 3] | to nuon",
             result: Some(Value::test_string("[1, 2, 3]")),
         }]
@@ -146,4 +146,14 @@ fn to_nuon(call: &Call, input: PipelineData) -> Result<String, ShellError> {
     let v = input.into_value(call.head);
 
     value_to_string(&v, call.head)
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::ToNuon;
+        use crate::test_examples;
+        test_examples(ToNuon {})
+    }
 }

--- a/crates/nu-command/src/hash/base64.rs
+++ b/crates/nu-command/src/hash/base64.rs
@@ -232,8 +232,14 @@ fn action(
 
 #[cfg(test)]
 mod tests {
-    use super::{action, ActionType, Base64Config};
+    use super::{action, ActionType, Base64, Base64Config};
     use nu_protocol::{Span, Value};
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+        test_examples(Base64 {})
+    }
 
     #[test]
     fn base64_encode_standard() {

--- a/crates/nu-command/src/path/parse.rs
+++ b/crates/nu-command/src/path/parse.rs
@@ -77,7 +77,21 @@ On Windows, an extra 'prefix' column is added."#
             Example {
                 description: "Parse a single path",
                 example: r"'C:\Users\viking\spam.txt' | path parse",
-                result: None,
+                result: Some(Value::Record {
+                    cols: vec![
+                        "prefix".into(),
+                        "parent".into(),
+                        "stem".into(),
+                        "extension".into(),
+                    ],
+                    vals: vec![
+                        Value::test_string("C:"),
+                        Value::test_string(r"C:\Users\viking"),
+                        Value::test_string("spam"),
+                        Value::test_string("txt"),
+                    ],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Replace a complex extension",
@@ -87,7 +101,21 @@ On Windows, an extra 'prefix' column is added."#
             Example {
                 description: "Ignore the extension",
                 example: r"'C:\Users\viking.d' | path parse -e ''",
-                result: None,
+                result: Some(Value::Record {
+                    cols: vec![
+                        "prefix".into(),
+                        "parent".into(),
+                        "stem".into(),
+                        "extension".into(),
+                    ],
+                    vals: vec![
+                        Value::test_string("C:"),
+                        Value::test_string(r"C:\Users"),
+                        Value::test_string("viking.d"),
+                        Value::test_string(""),
+                    ],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Parse all paths under the 'name' column",
@@ -103,7 +131,15 @@ On Windows, an extra 'prefix' column is added."#
             Example {
                 description: "Parse a path",
                 example: r"'/home/viking/spam.txt' | path parse",
-                result: None,
+                result: Some(Value::Record {
+                    cols: vec!["parent".into(), "stem".into(), "extension".into()],
+                    vals: vec![
+                        Value::test_string("/home/viking"),
+                        Value::test_string("spam"),
+                        Value::test_string("txt"),
+                    ],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Replace a complex extension",
@@ -113,7 +149,15 @@ On Windows, an extra 'prefix' column is added."#
             Example {
                 description: "Ignore the extension",
                 example: r"'/etc/conf.d' | path parse -e ''",
-                result: None,
+                result: Some(Value::Record {
+                    cols: vec!["parent".into(), "stem".into(), "extension".into()],
+                    vals: vec![
+                        Value::test_string("/etc"),
+                        Value::test_string("conf.d"),
+                        Value::test_string(""),
+                    ],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Parse all paths under the 'name' column",

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -139,7 +139,7 @@ prints out the list properly."#
                 description: "Render a simple list to a grid",
                 example: "[1 2 3 a b c] | grid",
                 result: Some(Value::String {
-                    val: "1 │ 2 │ 3 │ a │ b │ c".to_string(),
+                    val: "1 │ 2 │ 3 │ a │ b │ c\n".to_string(),
                     span: Span::test_data(),
                 }),
             },
@@ -147,7 +147,7 @@ prints out the list properly."#
                 description: "The above example is the same as:",
                 example: "[1 2 3 a b c] | wrap name | grid",
                 result: Some(Value::String {
-                    val: "1 │ 2 │ 3 │ a │ b │ c".to_string(),
+                    val: "1 │ 2 │ 3 │ a │ b │ c\n".to_string(),
                     span: Span::test_data(),
                 }),
             },
@@ -155,7 +155,7 @@ prints out the list properly."#
                 description: "Render a record to a grid",
                 example: "{name: 'foo', b: 1, c: 2} | grid",
                 result: Some(Value::String {
-                    val: "foo".to_string(),
+                    val: "foo\n".to_string(),
                     span: Span::test_data(),
                 }),
             },
@@ -163,7 +163,7 @@ prints out the list properly."#
                 description: "Render a list of records to a grid",
                 example: "[{name: 'A', v: 1} {name: 'B', v: 2} {name: 'C', v: 3}] | grid",
                 result: Some(Value::String {
-                    val: "A │ B │ C".to_string(),
+                    val: "A │ B │ C\n".to_string(),
                     span: Span::test_data(),
                 }),
             },
@@ -171,7 +171,7 @@ prints out the list properly."#
                 description: "Render a table with 'name' column in it to a grid",
                 example: "[[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid",
                 result: Some(Value::String {
-                    val: "0.1.0 │ 0.1.1 │ 0.2.0".to_string(),
+                    val: "0.1.0 │ 0.1.1 │ 0.2.0\n".to_string(),
                     span: Span::test_data(),
                 }),
             },
@@ -356,5 +356,15 @@ fn convert_to_list(
         Some(interleaved)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::Griddle;
+        use crate::test_examples;
+        test_examples(Griddle {})
     }
 }


### PR DESCRIPTION
# Description

Currently only a subset of the `Command::examples` gets tested.
This PR aims to improve the coverage of the examples to make sure they are up to date and also to increase the coverage of the implementation.


The runner `nu-command::example_test::test_example` only runs tests with an corresponding output. Three things limit that effort:

1. Undecidable output: examples like those using `ls` would produce different output without a mocking environment / test fixtures. But they are very useful as actual examples as users can relate to them
2. Commands that require interaction or may run for a long time. They should not be tested regularly and require different tests.
3. The `test_example` runner only uses a bare bones set of commands instead of full nu. This limits rather typical usecases to untestable examples at the moment.

# Coverage analysis

Done with 

```
cargo tarpaulin --all --out html lcov --ignore-tests -- --skip platform::sleep::tests::examples_work_as_expecte
```

Increase in coverage of ~0.6%

# Commits

## New tests

- Add expected result for `columns` example
- Add example test harness to `reject`
- Run `to nuon` examples
- Run `hash base64` examples
- Add example output to `path parse`

## Fixes to example output as a result

- Test and fix `wrap` example
- Test and fix `drop column` example
- Test and fix the `grid` examples

## Change to example source

- Update `from ods` examples
- Update `from xlsx` examples

## Other

- Ignore `cargo tarpaulin` output files

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
