### PR TITLE
feat: add search terms to random & typo fix

### DIFF
--- a/crates/nu-command/src/random/random_.rs
+++ b/crates/nu-command/src/random/random_.rs
@@ -18,7 +18,11 @@ impl Command for RandomCommand {
     }
 
     fn usage(&self) -> &str {
-        "Generate a random values."
+        "Generate a random value."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["generate", "generator"]
     }
 
     fn run(


### PR DESCRIPTION
# Description

added search terms to the "random" command and fixed a typo

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
