### PR TITLE
nu-cli/completions: add filtering tests for variables completions

### DIFF
--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -42,6 +42,16 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
             },
         },
     );
+    stack.add_env_var(
+        "TEST".to_string(),
+        Value::String {
+            val: "NUSHELL".to_string(),
+            span: nu_protocol::Span {
+                start: 0,
+                end: dir_str.len(),
+            },
+        },
+    );
 
     // Merge delta
     let merge_result = engine_state.merge_delta(delta, Some(&mut stack), &dir);

--- a/crates/nu-cli/tests/variables_completions.rs
+++ b/crates/nu-cli/tests/variables_completions.rs
@@ -35,6 +35,16 @@ fn variables_completions() {
     // Match results
     match_suggestions(expected, suggestions);
 
+    // Test completions for $nu.h (filter)
+    let suggestions = completer.complete("$nu.h".into(), 5);
+
+    assert_eq!(2, suggestions.len());
+
+    let expected: Vec<String> = vec!["history-path".into(), "home-path".into()];
+
+    // Match results
+    match_suggestions(expected, suggestions);
+
     // Test completions for custom var
     let suggestions = completer.complete("$actor.".into(), 7);
 
@@ -45,12 +55,32 @@ fn variables_completions() {
     // Match results
     match_suggestions(expected, suggestions);
 
-    // Test completions for $env
-    let suggestions = completer.complete("$env.".into(), 5);
+    // Test completions for custom var (filtering)
+    let suggestions = completer.complete("$actor.n".into(), 7);
 
     assert_eq!(1, suggestions.len());
 
-    let expected: Vec<String> = vec!["PWD".into()];
+    let expected: Vec<String> = vec!["name".into()];
+
+    // Match results
+    match_suggestions(expected, suggestions);
+
+    // Test completions for $env
+    let suggestions = completer.complete("$env.".into(), 5);
+
+    assert_eq!(2, suggestions.len());
+
+    let expected: Vec<String> = vec!["PWD".into(), "TEST".into()];
+
+    // Match results
+    match_suggestions(expected, suggestions);
+
+    // Test completions for $env
+    let suggestions = completer.complete("$env.T".into(), 5);
+
+    assert_eq!(1, suggestions.len());
+
+    let expected: Vec<String> = vec!["TEST".into()];
 
     // Match results
     match_suggestions(expected, suggestions);


### PR DESCRIPTION
# Description

This PR adds tests for filtering variable completions.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
