### PR TITLE
Update reedline: Support more bindings in vi mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.6.0"
-source = "git+https://github.com/nushell/reedline?branch=main#d8ff270f94c43ddec3ddfffdbc5b4154fe748440"
+source = "git+https://github.com/nushell/reedline?branch=main#fe795caabc5401d811006b93d5a6d4f220a049ff"
 dependencies = [
  "chrono",
  "crossterm",


### PR DESCRIPTION
# Changes to reedline since:

Now more bindings are shared between vi-mode and emacs mode.
E.g. Ctrl-D, Ctrl-C, Ctrl-L, Ctrl-O will work in all modes.

Also arrow navigation extra functions will behave consistent.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
