### PR TITLE
Add search terms for `all?`, `any?`, `length`, and `keybindings`

### DIFF
--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -27,6 +27,10 @@ impl Command for All {
         "Test if every element of the input matches a predicate."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["every"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -27,6 +27,10 @@ impl Command for Any {
         "Tests if any element of the input matches a predicate."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["some"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -24,6 +24,10 @@ impl Command for Length {
             .category(Category::Filters)
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["count", "len", "size"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/reedline_commands/keybindings.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings.rs
@@ -21,6 +21,10 @@ impl Command for Keybindings {
         "Keybindings related commands"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["shortcut", "hotkey"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,


### PR DESCRIPTION
# Description

Add search terms for the `all?`, `any?`, `length`, and `keybindings` commands.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
