### PR TITLE
Add '-o'/`--output` flag to `fetch` to download to file

### DIFF
--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -1,4 +1,5 @@
 use crate::BufferedReader;
+use std::io::{BufWriter, Write};
 
 use base64::encode;
 use nu_engine::CallExt;
@@ -15,7 +16,7 @@ use std::collections::HashMap;
 use std::io::BufReader;
 
 use reqwest::StatusCode;
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -63,6 +64,22 @@ impl Command for SubCommand {
                 "fetch contents as text rather than a table",
                 Some('r'),
             )
+            .named(
+                "output",
+                SyntaxShape::Filepath,
+                "save contents into a file",
+                Some('o'),
+            )
+            .switch(
+                "bin",
+                "if saving into a file, save as raw binary",
+                Some('b'),
+            )
+            .switch(
+                "append",
+                "if saving into a file, append to end of file",
+                Some('a'),
+            )
             .filter()
             .category(Category::Network)
     }
@@ -88,7 +105,187 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        run_fetch(engine_state, stack, call, input)
+        let output = call.has_flag("output");
+        if !output {
+            run_fetch(engine_state, stack, call, input)
+        }
+        else {
+            match run_fetch(engine_state, stack, call, input) {
+                Err(err) => Err(err),
+                Ok(value) => {
+                    let path:Value = call.get_flag(engine_state, stack, "output").expect("there should be a value").expect("value should be unwrappable");
+                    let bin = call.has_flag("bin");
+                    let append = call.has_flag("append");
+                    let span = call.head;
+                    let path = &path.as_string().expect("path should be a string");
+                    let path = Path::new(path);
+
+        let file = match (append, path.exists()) {
+            (true, true) => std::fs::OpenOptions::new()
+                .write(true)
+                .append(true)
+                .open(path),
+            _ => std::fs::File::create(path),
+        };
+
+        let mut file = match file {
+            Ok(file) => file,
+            Err(err) => {
+                let arg_span = call.get_named_arg("output").expect("arg should exist").span;
+                return Ok(PipelineData::Value(
+                    Value::Error {
+                        error: ShellError::GenericError(
+                            "Permission denied".into(),
+                            err.to_string(),
+                            Some(arg_span),
+                            None,
+                            Vec::new(),
+                        ),
+                    },
+                    None,
+                ));
+            }
+        };
+
+        let ext = if bin {
+            None
+        } else {
+            path.extension()
+                .map(|name| name.to_string_lossy().to_string())
+        };
+
+        if let Some(ext) = ext {
+            let output = match engine_state.find_decl(format!("to {}", ext).as_bytes(), &[]) {
+                Some(converter_id) => {
+                    let output = engine_state.get_decl(converter_id).run(
+                        engine_state,
+                        stack,
+                        &Call::new(span),
+                        value,
+                    )?;
+
+                    output.into_value(span)
+                }
+                None => value.into_value(span),
+            };
+
+            match output {
+                Value::String { val, .. } => {
+                    if let Err(err) = file.write_all(val.as_bytes()) {
+                        return Err(ShellError::IOError(err.to_string()));
+                    } else {
+                        file.flush()?
+                    }
+
+                    Ok(PipelineData::new(span))
+                }
+                Value::Binary { val, .. } => {
+                    if let Err(err) = file.write_all(&val) {
+                        return Err(ShellError::IOError(err.to_string()));
+                    } else {
+                        file.flush()?
+                    }
+
+                    Ok(PipelineData::new(span))
+                }
+                Value::List { vals, .. } => {
+                    let val = vals
+                        .into_iter()
+                        .map(|it| it.as_string())
+                        .collect::<Result<Vec<String>, ShellError>>()?
+                        .join("\n")
+                        + "\n";
+
+                    if let Err(err) = file.write_all(val.as_bytes()) {
+                        return Err(ShellError::IOError(err.to_string()));
+                    } else {
+                        file.flush()?
+                    }
+
+                    Ok(PipelineData::new(span))
+                }
+                v => Err(ShellError::UnsupportedInput(
+                    format!("{:?} not supported", v.get_type()),
+                    span,
+                )),
+            }
+        } else {
+            match value {
+                PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(span)),
+                PipelineData::ExternalStream {
+                    stdout: Some(mut stream),
+                    ..
+                } => {
+                    let mut writer = BufWriter::new(file);
+
+                    stream
+                        .try_for_each(move |result| {
+                            let buf = match result {
+                                Ok(v) => match v {
+                                    Value::String { val, .. } => val.into_bytes(),
+                                    Value::Binary { val, .. } => val,
+                                    _ => {
+                                        return Err(ShellError::UnsupportedInput(
+                                            format!("{:?} not supported", v.get_type()),
+                                            v.span()?,
+                                        ));
+                                    }
+                                },
+                                Err(err) => return Err(err),
+                            };
+
+                            if let Err(err) = writer.write(&buf) {
+                                return Err(ShellError::IOError(err.to_string()));
+                            }
+                            Ok(())
+                        })
+                        .map(|_| PipelineData::new(span))
+                }
+                value => match value.into_value(span) {
+                    Value::String { val, .. } => {
+                        if let Err(err) = file.write_all(val.as_bytes()) {
+                            return Err(ShellError::IOError(err.to_string()));
+                        } else {
+                            file.flush()?
+                        }
+
+                        Ok(PipelineData::new(span))
+                    }
+                    Value::Binary { val, .. } => {
+                        if let Err(err) = file.write_all(&val) {
+                            return Err(ShellError::IOError(err.to_string()));
+                        } else {
+                            file.flush()?
+                        }
+
+                        Ok(PipelineData::new(span))
+                    }
+                    Value::List { vals, .. } => {
+                        let val = vals
+                            .into_iter()
+                            .map(|it| it.as_string())
+                            .collect::<Result<Vec<String>, ShellError>>()?
+                            .join("\n")
+                            + "\n";
+
+                        if let Err(err) = file.write_all(val.as_bytes()) {
+                            return Err(ShellError::IOError(err.to_string()));
+                        } else {
+                            file.flush()?
+                        }
+
+                        Ok(PipelineData::new(span))
+                    }
+                    v => Err(ShellError::UnsupportedInput(
+                        format!("{:?} not supported", v.get_type()),
+                        span,
+                    )),
+                },
+            }
+        }
+                },
+            }
+        }
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -65,10 +65,10 @@ impl Command for SubCommand {
                 Some('r'),
             )
             .named(
-                "file",
+                "output",
                 SyntaxShape::Filepath,
                 "save contents into a file",
-                Some('f'),
+                Some('o'),
             )
             .switch(
                 "bin",
@@ -105,15 +105,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let file = call.has_flag("file");
-        if !file {
+        let output = call.has_flag("output");
+        if !output {
             run_fetch(engine_state, stack, call, input)
         } else {
             match run_fetch(engine_state, stack, call, input) {
                 Err(err) => Err(err),
                 Ok(value) => {
                     let path: Value = call
-                        .get_flag(engine_state, stack, "file")
+                        .get_flag(engine_state, stack, "output")
                         .expect("there should be a value")
                         .expect("value should be unwrappable");
                     let bin = call.has_flag("bin");
@@ -134,7 +134,7 @@ impl Command for SubCommand {
                         Ok(file) => file,
                         Err(err) => {
                             let arg_span =
-                                call.get_named_arg("file").expect("arg should exist").span;
+                                call.get_named_arg("output").expect("arg should exist").span;
                             return Ok(PipelineData::Value(
                                 Value::Error {
                                     error: ShellError::GenericError(

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::io::BufReader;
 
 use reqwest::StatusCode;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -108,182 +108,188 @@ impl Command for SubCommand {
         let output = call.has_flag("output");
         if !output {
             run_fetch(engine_state, stack, call, input)
-        }
-        else {
+        } else {
             match run_fetch(engine_state, stack, call, input) {
                 Err(err) => Err(err),
                 Ok(value) => {
-                    let path:Value = call.get_flag(engine_state, stack, "output").expect("there should be a value").expect("value should be unwrappable");
+                    let path: Value = call
+                        .get_flag(engine_state, stack, "output")
+                        .expect("there should be a value")
+                        .expect("value should be unwrappable");
                     let bin = call.has_flag("bin");
                     let append = call.has_flag("append");
                     let span = call.head;
                     let path = &path.as_string().expect("path should be a string");
                     let path = Path::new(path);
 
-        let file = match (append, path.exists()) {
-            (true, true) => std::fs::OpenOptions::new()
-                .write(true)
-                .append(true)
-                .open(path),
-            _ => std::fs::File::create(path),
-        };
+                    let file = match (append, path.exists()) {
+                        (true, true) => std::fs::OpenOptions::new()
+                            .write(true)
+                            .append(true)
+                            .open(path),
+                        _ => std::fs::File::create(path),
+                    };
 
-        let mut file = match file {
-            Ok(file) => file,
-            Err(err) => {
-                let arg_span = call.get_named_arg("output").expect("arg should exist").span;
-                return Ok(PipelineData::Value(
-                    Value::Error {
-                        error: ShellError::GenericError(
-                            "Permission denied".into(),
-                            err.to_string(),
-                            Some(arg_span),
-                            None,
-                            Vec::new(),
-                        ),
-                    },
-                    None,
-                ));
-            }
-        };
-
-        let ext = if bin {
-            None
-        } else {
-            path.extension()
-                .map(|name| name.to_string_lossy().to_string())
-        };
-
-        if let Some(ext) = ext {
-            let output = match engine_state.find_decl(format!("to {}", ext).as_bytes(), &[]) {
-                Some(converter_id) => {
-                    let output = engine_state.get_decl(converter_id).run(
-                        engine_state,
-                        stack,
-                        &Call::new(span),
-                        value,
-                    )?;
-
-                    output.into_value(span)
-                }
-                None => value.into_value(span),
-            };
-
-            match output {
-                Value::String { val, .. } => {
-                    if let Err(err) = file.write_all(val.as_bytes()) {
-                        return Err(ShellError::IOError(err.to_string()));
-                    } else {
-                        file.flush()?
-                    }
-
-                    Ok(PipelineData::new(span))
-                }
-                Value::Binary { val, .. } => {
-                    if let Err(err) = file.write_all(&val) {
-                        return Err(ShellError::IOError(err.to_string()));
-                    } else {
-                        file.flush()?
-                    }
-
-                    Ok(PipelineData::new(span))
-                }
-                Value::List { vals, .. } => {
-                    let val = vals
-                        .into_iter()
-                        .map(|it| it.as_string())
-                        .collect::<Result<Vec<String>, ShellError>>()?
-                        .join("\n")
-                        + "\n";
-
-                    if let Err(err) = file.write_all(val.as_bytes()) {
-                        return Err(ShellError::IOError(err.to_string()));
-                    } else {
-                        file.flush()?
-                    }
-
-                    Ok(PipelineData::new(span))
-                }
-                v => Err(ShellError::UnsupportedInput(
-                    format!("{:?} not supported", v.get_type()),
-                    span,
-                )),
-            }
-        } else {
-            match value {
-                PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(span)),
-                PipelineData::ExternalStream {
-                    stdout: Some(mut stream),
-                    ..
-                } => {
-                    let mut writer = BufWriter::new(file);
-
-                    stream
-                        .try_for_each(move |result| {
-                            let buf = match result {
-                                Ok(v) => match v {
-                                    Value::String { val, .. } => val.into_bytes(),
-                                    Value::Binary { val, .. } => val,
-                                    _ => {
-                                        return Err(ShellError::UnsupportedInput(
-                                            format!("{:?} not supported", v.get_type()),
-                                            v.span()?,
-                                        ));
-                                    }
+                    let mut file = match file {
+                        Ok(file) => file,
+                        Err(err) => {
+                            let arg_span =
+                                call.get_named_arg("output").expect("arg should exist").span;
+                            return Ok(PipelineData::Value(
+                                Value::Error {
+                                    error: ShellError::GenericError(
+                                        "Permission denied".into(),
+                                        err.to_string(),
+                                        Some(arg_span),
+                                        None,
+                                        Vec::new(),
+                                    ),
                                 },
-                                Err(err) => return Err(err),
+                                None,
+                            ));
+                        }
+                    };
+
+                    let ext = if bin {
+                        None
+                    } else {
+                        path.extension()
+                            .map(|name| name.to_string_lossy().to_string())
+                    };
+
+                    if let Some(ext) = ext {
+                        let output =
+                            match engine_state.find_decl(format!("to {}", ext).as_bytes(), &[]) {
+                                Some(converter_id) => {
+                                    let output = engine_state.get_decl(converter_id).run(
+                                        engine_state,
+                                        stack,
+                                        &Call::new(span),
+                                        value,
+                                    )?;
+
+                                    output.into_value(span)
+                                }
+                                None => value.into_value(span),
                             };
 
-                            if let Err(err) = writer.write(&buf) {
-                                return Err(ShellError::IOError(err.to_string()));
+                        match output {
+                            Value::String { val, .. } => {
+                                if let Err(err) = file.write_all(val.as_bytes()) {
+                                    return Err(ShellError::IOError(err.to_string()));
+                                } else {
+                                    file.flush()?
+                                }
+
+                                Ok(PipelineData::new(span))
                             }
-                            Ok(())
-                        })
-                        .map(|_| PipelineData::new(span))
+                            Value::Binary { val, .. } => {
+                                if let Err(err) = file.write_all(&val) {
+                                    return Err(ShellError::IOError(err.to_string()));
+                                } else {
+                                    file.flush()?
+                                }
+
+                                Ok(PipelineData::new(span))
+                            }
+                            Value::List { vals, .. } => {
+                                let val = vals
+                                    .into_iter()
+                                    .map(|it| it.as_string())
+                                    .collect::<Result<Vec<String>, ShellError>>()?
+                                    .join("\n")
+                                    + "\n";
+
+                                if let Err(err) = file.write_all(val.as_bytes()) {
+                                    return Err(ShellError::IOError(err.to_string()));
+                                } else {
+                                    file.flush()?
+                                }
+
+                                Ok(PipelineData::new(span))
+                            }
+                            v => Err(ShellError::UnsupportedInput(
+                                format!("{:?} not supported", v.get_type()),
+                                span,
+                            )),
+                        }
+                    } else {
+                        match value {
+                            PipelineData::ExternalStream { stdout: None, .. } => {
+                                Ok(PipelineData::new(span))
+                            }
+                            PipelineData::ExternalStream {
+                                stdout: Some(mut stream),
+                                ..
+                            } => {
+                                let mut writer = BufWriter::new(file);
+
+                                stream
+                                    .try_for_each(move |result| {
+                                        let buf = match result {
+                                            Ok(v) => match v {
+                                                Value::String { val, .. } => val.into_bytes(),
+                                                Value::Binary { val, .. } => val,
+                                                _ => {
+                                                    return Err(ShellError::UnsupportedInput(
+                                                        format!("{:?} not supported", v.get_type()),
+                                                        v.span()?,
+                                                    ));
+                                                }
+                                            },
+                                            Err(err) => return Err(err),
+                                        };
+
+                                        if let Err(err) = writer.write(&buf) {
+                                            return Err(ShellError::IOError(err.to_string()));
+                                        }
+                                        Ok(())
+                                    })
+                                    .map(|_| PipelineData::new(span))
+                            }
+                            value => match value.into_value(span) {
+                                Value::String { val, .. } => {
+                                    if let Err(err) = file.write_all(val.as_bytes()) {
+                                        return Err(ShellError::IOError(err.to_string()));
+                                    } else {
+                                        file.flush()?
+                                    }
+
+                                    Ok(PipelineData::new(span))
+                                }
+                                Value::Binary { val, .. } => {
+                                    if let Err(err) = file.write_all(&val) {
+                                        return Err(ShellError::IOError(err.to_string()));
+                                    } else {
+                                        file.flush()?
+                                    }
+
+                                    Ok(PipelineData::new(span))
+                                }
+                                Value::List { vals, .. } => {
+                                    let val = vals
+                                        .into_iter()
+                                        .map(|it| it.as_string())
+                                        .collect::<Result<Vec<String>, ShellError>>()?
+                                        .join("\n")
+                                        + "\n";
+
+                                    if let Err(err) = file.write_all(val.as_bytes()) {
+                                        return Err(ShellError::IOError(err.to_string()));
+                                    } else {
+                                        file.flush()?
+                                    }
+
+                                    Ok(PipelineData::new(span))
+                                }
+                                v => Err(ShellError::UnsupportedInput(
+                                    format!("{:?} not supported", v.get_type()),
+                                    span,
+                                )),
+                            },
+                        }
+                    }
                 }
-                value => match value.into_value(span) {
-                    Value::String { val, .. } => {
-                        if let Err(err) = file.write_all(val.as_bytes()) {
-                            return Err(ShellError::IOError(err.to_string()));
-                        } else {
-                            file.flush()?
-                        }
-
-                        Ok(PipelineData::new(span))
-                    }
-                    Value::Binary { val, .. } => {
-                        if let Err(err) = file.write_all(&val) {
-                            return Err(ShellError::IOError(err.to_string()));
-                        } else {
-                            file.flush()?
-                        }
-
-                        Ok(PipelineData::new(span))
-                    }
-                    Value::List { vals, .. } => {
-                        let val = vals
-                            .into_iter()
-                            .map(|it| it.as_string())
-                            .collect::<Result<Vec<String>, ShellError>>()?
-                            .join("\n")
-                            + "\n";
-
-                        if let Err(err) = file.write_all(val.as_bytes()) {
-                            return Err(ShellError::IOError(err.to_string()));
-                        } else {
-                            file.flush()?
-                        }
-
-                        Ok(PipelineData::new(span))
-                    }
-                    v => Err(ShellError::UnsupportedInput(
-                        format!("{:?} not supported", v.get_type()),
-                        span,
-                    )),
-                },
-            }
-        }
-                },
             }
         }
     }

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -65,10 +65,10 @@ impl Command for SubCommand {
                 Some('r'),
             )
             .named(
-                "output",
+                "file",
                 SyntaxShape::Filepath,
                 "save contents into a file",
-                Some('o'),
+                Some('f'),
             )
             .switch(
                 "bin",
@@ -105,15 +105,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let output = call.has_flag("output");
-        if !output {
+        let file = call.has_flag("file");
+        if !file {
             run_fetch(engine_state, stack, call, input)
         } else {
             match run_fetch(engine_state, stack, call, input) {
                 Err(err) => Err(err),
                 Ok(value) => {
                     let path: Value = call
-                        .get_flag(engine_state, stack, "output")
+                        .get_flag(engine_state, stack, "file")
                         .expect("there should be a value")
                         .expect("value should be unwrappable");
                     let bin = call.has_flag("bin");
@@ -134,7 +134,7 @@ impl Command for SubCommand {
                         Ok(file) => file,
                         Err(err) => {
                             let arg_span =
-                                call.get_named_arg("output").expect("arg should exist").span;
+                                call.get_named_arg("file").expect("arg should exist").span;
                             return Ok(PipelineData::Value(
                                 Value::Error {
                                     error: ShellError::GenericError(


### PR DESCRIPTION
# Description

As per the request in issue #5670. 

```
/home/gabriel/CodingProjects/nushell〉fetch https://raw.githubusercontent.com/merelymyself/merelymyself.github.io/main/README.md -o test.md                              05/29/2022 05:10:15 PM
/home/gabriel/CodingProjects/nushell〉cat test.md                                                                                                                        05/29/2022 05:10:19 PM
# merelymyself.github.io

Well, hopefully I can deposit my lousy HTML sites here.

/home/gabriel/CodingProjects/nushell〉fetch https://raw.githubusercontent.com/merelymyself/merelymyself.github.io/main/README.md -o test.md -a                           05/29/2022 05:10:21 PM
/home/gabriel/CodingProjects/nushell〉cat test.md                                                                                                                        05/29/2022 05:10:28 PM
# merelymyself.github.io

Well, hopefully I can deposit my lousy HTML sites here.

# merelymyself.github.io

Well, hopefully I can deposit my lousy HTML sites here.
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
