### PR TITLE
prevent panic with `let` alone in pipeline

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4376,7 +4376,7 @@ pub fn parse_expression(
                         1 | 2 | 3 => b"value",
                         _ => working_set.get_span_contents(spans[3]),
                     })
-                        .to_string(),
+                    .to_string(),
                     String::from_utf8_lossy(match spans.len() {
                         1 => b"variable",
                         _ => working_set.get_span_contents(spans[1]),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4372,9 +4372,16 @@ pub fn parse_expression(
                 )
                 .0,
                 Some(ParseError::LetInPipeline(
-                    String::from_utf8_lossy(working_set.get_span_contents(spans[spans.len() - 1]))
+                    String::from_utf8_lossy(match spans.len() {
+                        1 | 2 | 3 => b"value",
+                        _ => working_set.get_span_contents(spans[3]),
+                    })
                         .to_string(),
-                    String::from_utf8_lossy(working_set.get_span_contents(spans[1])).to_string(),
+                    String::from_utf8_lossy(match spans.len() {
+                        1 => b"variable",
+                        _ => working_set.get_span_contents(spans[1]),
+                    })
+                    .to_string(),
                     spans[0],
                 )),
             ),


### PR DESCRIPTION
# Description

Fixes #5675. Sorry for the sloppy code, @sholderbach. 
Also takes the opportunity to make the error much better when the span is something like 'let a' or 'let a ='.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
