### PR TITLE
Clarify error message for `let` in pipeline

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -83,7 +83,7 @@ pub enum ParseError {
         code(nu::parser::unexpected_keyword),
         url(docsrs),
         help(
-            "Assigning '{0}' to '{1}' does not produce a value to be piped. If the pipeline is meant to apply to '{0}' by itself, use 'let {1} = ({0} | ...)'."
+            "Assigning '{0}' to '{1}' does not produce a value to be piped. If the pipeline result is meant to be assigned to '{1}', use 'let {1} = ({0} | ...)'."
         )
     )]
     LetInPipeline(String, String, #[label("let in pipeline")] Span),


### PR DESCRIPTION
# Description

Refer to the suggestion as an assignment

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
