### PR TITLE
base64 command more friendly

### DIFF
--- a/crates/nu-command/src/hash/base64.rs
+++ b/crates/nu-command/src/hash/base64.rs
@@ -170,31 +170,24 @@ fn action(
     command_span: &Span,
 ) -> Result<Value, ShellError> {
     let config_character_set = &base64_config.character_set;
-    let base64_config_enum: base64::Config = if &config_character_set.item == "standard" {
-        base64::STANDARD
-    } else if &config_character_set.item == "standard-no-padding" {
-        base64::STANDARD_NO_PAD
-    } else if &config_character_set.item == "url-safe" {
-        base64::URL_SAFE
-    } else if &config_character_set.item == "url-safe-no-padding" {
-        base64::URL_SAFE_NO_PAD
-    } else if &config_character_set.item == "binhex" {
-        base64::BINHEX
-    } else if &config_character_set.item == "bcrypt" {
-        base64::BCRYPT
-    } else if &config_character_set.item == "crypt" {
-        base64::CRYPT
-    } else {
-        return Err(ShellError::GenericError(
+    let base64_config_enum: base64::Config = match config_character_set.item.as_str() {
+        "standard" => base64::STANDARD,
+        "standard-no-padding" => base64::STANDARD_NO_PAD,
+        "url-safe" => base64::URL_SAFE,
+        "url-safe-no-padding" => base64::URL_SAFE_NO_PAD,
+        "binhex" => base64::BINHEX,
+        "bcrypt" => base64::BCRYPT,
+        "crypt" => base64::CRYPT,
+        not_valid => return Err(ShellError::GenericError(
             "value is not an accepted character set".to_string(),
             format!(
                 "{} is not a valid character-set.\nPlease use `help hash base64` to see a list of valid character sets.",
-                config_character_set.item
+                not_valid
             ),
             Some(config_character_set.span),
             None,
             Vec::new(),
-        ));
+        ))
     };
     match input {
         Value::Binary { val, .. } => match base64_config.action_type {

--- a/crates/nu-command/src/hash/base64.rs
+++ b/crates/nu-command/src/hash/base64.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
 
 #[derive(Clone)]
 pub struct Base64Config {
-    pub character_set: String,
+    pub character_set: Spanned<String>,
     pub action_type: ActionType,
 }
 
@@ -120,8 +120,11 @@ fn operate(
 
     // Default the character set to standard if the argument is not specified.
     let character_set = match character_set {
-        Some(inner_tag) => inner_tag.item,
-        None => "standard".to_string(),
+        Some(inner_tag) => inner_tag,
+        None => Spanned {
+            item: "standard".to_string(),
+            span: head, // actually this span is always useless, because default character_set is always valid.
+        },
     };
 
     let encoding_config = Base64Config {
@@ -166,35 +169,45 @@ fn action(
     base64_config: &Base64Config,
     command_span: &Span,
 ) -> Result<Value, ShellError> {
+    let config_character_set = &base64_config.character_set;
+    let base64_config_enum: base64::Config = if &config_character_set.item == "standard" {
+        base64::STANDARD
+    } else if &config_character_set.item == "standard-no-padding" {
+        base64::STANDARD_NO_PAD
+    } else if &config_character_set.item == "url-safe" {
+        base64::URL_SAFE
+    } else if &config_character_set.item == "url-safe-no-padding" {
+        base64::URL_SAFE_NO_PAD
+    } else if &config_character_set.item == "binhex" {
+        base64::BINHEX
+    } else if &config_character_set.item == "bcrypt" {
+        base64::BCRYPT
+    } else if &config_character_set.item == "crypt" {
+        base64::CRYPT
+    } else {
+        return Err(ShellError::GenericError(
+            "value is not an accepted character set".to_string(),
+            format!(
+                "{} is not a valid character-set.\nPlease use `help hash base64` to see a list of valid character sets.",
+                config_character_set.item
+            ),
+            Some(config_character_set.span),
+            None,
+            Vec::new(),
+        ));
+    };
     match input {
-        Value::String { val, span } => {
-            let base64_config_enum: base64::Config = if &base64_config.character_set == "standard" {
-                base64::STANDARD
-            } else if &base64_config.character_set == "standard-no-padding" {
-                base64::STANDARD_NO_PAD
-            } else if &base64_config.character_set == "url-safe" {
-                base64::URL_SAFE
-            } else if &base64_config.character_set == "url-safe-no-padding" {
-                base64::URL_SAFE_NO_PAD
-            } else if &base64_config.character_set == "binhex" {
-                base64::BINHEX
-            } else if &base64_config.character_set == "bcrypt" {
-                base64::BCRYPT
-            } else if &base64_config.character_set == "crypt" {
-                base64::CRYPT
-            } else {
-                return Err(ShellError::GenericError(
-                    "value is not an accepted character set".to_string(),
-                    format!(
-                        "{} is not a valid character-set.\nPlease use `help hash base64` to see a list of valid character sets.",
-                        &base64_config.character_set
-                    ),
-                    Some(*span),
-                    None,
-                    Vec::new(),
-                ));
-            };
-
+        Value::Binary { val, .. } => match base64_config.action_type {
+            ActionType::Encode => Ok(Value::string(
+                encode_config(&val, base64_config_enum),
+                *command_span,
+            )),
+            ActionType::Decode => Err(ShellError::UnsupportedInput(
+                "Binary data can only support encoding".to_string(),
+                *command_span,
+            )),
+        },
+        Value::String { val, .. } => {
             match base64_config.action_type {
                 ActionType::Encode => Ok(Value::string(
                     encode_config(&val, base64_config_enum),
@@ -202,6 +215,9 @@ fn action(
                 )),
 
                 ActionType::Decode => {
+                    // for decode, input val may contains invalid new line character, which is ok to omitted them by default.
+                    let val = val.clone();
+                    let val = val.replace("\r\n", "").replace('\n', "");
                     let decode_result = decode_config(&val, base64_config_enum);
 
                     match decode_result {
@@ -213,7 +229,7 @@ fn action(
                             "value could not be base64 decoded".to_string(),
                             format!(
                                 "invalid base64 input for character set {}",
-                                &base64_config.character_set
+                                &config_character_set.item
                             ),
                             Some(*command_span),
                             None,
@@ -233,7 +249,7 @@ fn action(
 #[cfg(test)]
 mod tests {
     use super::{action, ActionType, Base64, Base64Config};
-    use nu_protocol::{Span, Value};
+    use nu_protocol::{Span, Spanned, Value};
 
     #[test]
     fn test_examples() {
@@ -249,7 +265,10 @@ mod tests {
         let actual = action(
             &word,
             &Base64Config {
-                character_set: "standard".to_string(),
+                character_set: Spanned {
+                    item: "standard".to_string(),
+                    span: Span::test_data(),
+                },
                 action_type: ActionType::Encode,
             },
             &Span::test_data(),
@@ -266,7 +285,10 @@ mod tests {
         let actual = action(
             &word,
             &Base64Config {
-                character_set: "standard-no-padding".to_string(),
+                character_set: Spanned {
+                    item: "standard-no-padding".to_string(),
+                    span: Span::test_data(),
+                },
                 action_type: ActionType::Encode,
             },
             &Span::test_data(),
@@ -283,7 +305,10 @@ mod tests {
         let actual = action(
             &word,
             &Base64Config {
-                character_set: "url-safe".to_string(),
+                character_set: Spanned {
+                    item: "url-safe".to_string(),
+                    span: Span::test_data(),
+                },
                 action_type: ActionType::Encode,
             },
             &Span::test_data(),
@@ -300,12 +325,79 @@ mod tests {
         let actual = action(
             &word,
             &Base64Config {
-                character_set: "binhex".to_string(),
+                character_set: Spanned {
+                    item: "binhex".to_string(),
+                    span: Span::test_data(),
+                },
                 action_type: ActionType::Decode,
             },
             &Span::test_data(),
         )
         .unwrap();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn base64_decode_binhex_with_new_line_input() {
+        let word = Value::string("A5\"KC9jRB\n@IIF'8bF!", Span::test_data());
+        let expected = Value::string("a binhex test", Span::test_data());
+
+        let actual = action(
+            &word,
+            &Base64Config {
+                character_set: Spanned {
+                    item: "binhex".to_string(),
+                    span: Span::test_data(),
+                },
+                action_type: ActionType::Decode,
+            },
+            &Span::test_data(),
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn base64_encode_binary() {
+        let word = Value::Binary {
+            val: vec![77, 97, 110],
+            span: Span::test_data(),
+        };
+        let expected = Value::string("TWFu", Span::test_data());
+
+        let actual = action(
+            &word,
+            &Base64Config {
+                character_set: Spanned {
+                    item: "standard".to_string(),
+                    span: Span::test_data(),
+                },
+                action_type: ActionType::Encode,
+            },
+            &Span::test_data(),
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn base64_decode_binary_expect_error() {
+        let word = Value::Binary {
+            val: vec![77, 97, 110],
+            span: Span::test_data(),
+        };
+
+        let actual = action(
+            &word,
+            &Base64Config {
+                character_set: Spanned {
+                    item: "standard".to_string(),
+                    span: Span::test_data(),
+                },
+                action_type: ActionType::Decode,
+            },
+            &Span::test_data(),
+        );
+        assert!(actual.is_err())
     }
 }


### PR DESCRIPTION
# Description

Fixes: #5664 , and make `hash base64` support binary input, so we can type something like

`open -r xxx.png | hash base64`

In addition, make more friendly error message for invalid `--character-set` input.
Before:
![Screen Shot 2022-05-30 at 11 37 55](https://user-images.githubusercontent.com/22256154/170912875-c5ca5e28-f0b9-4732-878f-08a4b803a696.png)
After:
![Screen Shot 2022-05-30 at 11 30 56](https://user-images.githubusercontent.com/22256154/170912883-39f9295a-edf3-4ebd-b7ca-fcdba17b516c.png)

Which is more straightforward

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
