### PR TITLE
expand env for path

### DIFF
--- a/docs/sample_config/default_env.nu
+++ b/docs/sample_config/default_env.nu
@@ -32,11 +32,11 @@ let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
 let-env ENV_CONVERSIONS = {
   "PATH": {
     from_string: { |s| $s | split row (char esep) }
-    to_string: { |v| $v | str collect (char esep) }
+    to_string: { |v| $v | path expand | str collect (char esep) }
   }
   "Path": {
     from_string: { |s| $s | split row (char esep) }
-    to_string: { |v| $v | str collect (char esep) }
+    to_string: { |v| $v | path expand | str collect (char esep) }
   }
 }
 


### PR DESCRIPTION
# Description

Fixes: #4855

After investigate, I found that `PATH` parsing logic lays inside `env.nu` file, maybe it's ok to change default env file, after user using new config file, the feature is gained.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
