### PR TITLE
Small typo fix in `signature.rs`

### DIFF
--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -208,7 +208,7 @@ impl Signature {
         self
     }
 
-    /// Add a required positional argument to the signature
+    /// Add an optional positional argument to the signature
     pub fn optional(
         mut self,
         name: impl Into<String>,


### PR DESCRIPTION
# Description

Just a very small, inconsequential typo fix (that affects the docs).

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
