### PR TITLE
fix argument type

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -72,19 +72,13 @@ impl Command for External {
         let mut spanned_args = vec![];
         for one_arg in args {
             match one_arg {
-                Value::List { vals, span } => {
+                Value::List { vals, .. } => {
                     // turn all the strings in the array into params.
                     // Example: one_arg may be something like ["ls" "-a"]
-                    // convert it to "ls -a"
-                    let mut sub_args = vec![];
+                    // convert it to "ls" "-a"
                     for v in vals {
-                        sub_args.push(v.as_string()?)
+                        spanned_args.push(value_as_spanned(v)?)
                     }
-                    let arg_as_string = sub_args.join(" ");
-                    spanned_args.push(Spanned {
-                        item: arg_as_string,
-                        span,
-                    })
                 }
                 val => spanned_args.push(value_as_spanned(val)?),
             }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -69,20 +69,30 @@ impl Command for External {
                 })
         }
 
-        let args = args
-            .into_iter()
-            .flat_map(|arg| match arg {
-                Value::List { vals, .. } => vals
-                    .into_iter()
-                    .map(value_as_spanned)
-                    .collect::<Vec<Result<Spanned<String>, ShellError>>>(),
-                val => vec![value_as_spanned(val)],
-            })
-            .collect::<Result<Vec<Spanned<String>>, ShellError>>()?;
+        let mut spanned_args = vec![];
+        for one_arg in args {
+            match one_arg {
+                Value::List { vals, span } => {
+                    // turn all the strings in the array into params.
+                    // Example: one_arg may be something like ["ls" "-a"]
+                    // convert it to "ls -a"
+                    let mut sub_args = vec![];
+                    for v in vals {
+                        sub_args.push(v.as_string()?)
+                    }
+                    let arg_as_string = sub_args.join(" ");
+                    spanned_args.push(Spanned {
+                        item: arg_as_string,
+                        span,
+                    })
+                }
+                val => spanned_args.push(value_as_spanned(val)?),
+            }
+        }
 
         let command = ExternalCommand {
             name,
-            args,
+            args: spanned_args,
             redirect_stdout,
             redirect_stderr,
             env_vars: env_vars_str,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -290,8 +290,13 @@ pub fn parse_external_call(
     for span in &spans[1..] {
         let contents = working_set.get_span_contents(*span);
 
-        if contents.starts_with(b"$") || contents.starts_with(b"(") {
+        if contents.starts_with(b"$") {
             let (arg, err) = parse_dollar_expr(working_set, *span, expand_aliases_denylist);
+            error = error.or(err);
+            args.push(arg);
+        } else if contents.starts_with(b"(") {
+            let (arg, err) =
+                parse_full_cell_path(working_set, None, *span, expand_aliases_denylist);
             error = error.or(err);
             args.push(arg);
         } else if contents.starts_with(b"[") {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -295,8 +295,12 @@ pub fn parse_external_call(
             error = error.or(err);
             args.push(arg);
         } else if contents.starts_with(b"[") {
-            let (arg, err) =
-                parse_full_cell_path(working_set, None, *span, expand_aliases_denylist);
+            let (arg, err) = parse_list_expression(
+                working_set,
+                *span,
+                &SyntaxShape::Any,
+                expand_aliases_denylist,
+            );
             error = error.or(err);
             args.push(arg);
         } else {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -290,13 +290,8 @@ pub fn parse_external_call(
     for span in &spans[1..] {
         let contents = working_set.get_span_contents(*span);
 
-        if contents.starts_with(b"$") {
+        if contents.starts_with(b"$") || contents.starts_with(b"(") {
             let (arg, err) = parse_dollar_expr(working_set, *span, expand_aliases_denylist);
-            error = error.or(err);
-            args.push(arg);
-        } else if contents.starts_with(b"(") {
-            let (arg, err) =
-                parse_full_cell_path(working_set, None, *span, expand_aliases_denylist);
             error = error.or(err);
             args.push(arg);
         } else if contents.starts_with(b"[") {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -294,7 +294,7 @@ pub fn parse_external_call(
             let (arg, err) = parse_dollar_expr(working_set, *span, expand_aliases_denylist);
             error = error.or(err);
             args.push(arg);
-        } else if contents.starts_with(b"(") {
+        } else if contents.starts_with(b"[") {
             let (arg, err) =
                 parse_full_cell_path(working_set, None, *span, expand_aliases_denylist);
             error = error.or(err);

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -306,6 +306,30 @@ mod nu_commands {
 
         assert_eq!(actual.out, "");
     }
+
+    #[test]
+    fn command_list_arg_test() {
+        let actual = nu!(cwd: ".", r#"
+        nu ['-c' 'version']
+        "#);
+
+        assert!(actual.out.contains("version"));
+        assert!(actual.out.contains("rust_version"));
+        assert!(actual.out.contains("rust_channel"));
+        assert!(actual.out.contains("pkg_version"));
+    }
+
+    #[test]
+    fn command_cell_path_arg_test() {
+        let actual = nu!(cwd: ".", r#"
+        nu ([ '-c' 'version' ])
+        "#);
+
+        assert!(actual.out.contains("version"));
+        assert!(actual.out.contains("rust_version"));
+        assert!(actual.out.contains("rust_channel"));
+        assert!(actual.out.contains("pkg_version"));
+    }
 }
 
 mod nu_script {


### PR DESCRIPTION
# Description

Fixes: #5056 

Contains two part:
1. while parsing input args, if we get `list`, parse it to `Value::List` rather than `Value::String`.
2. Inside `run_external`, convert from `Value::List` to ~String~ `Vec<Spanned<String>>` to pass right arguments to external commands

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
