### PR TITLE
Fix doc building for vuepress-next, avoid using angle brackets

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -51,7 +51,7 @@ impl Command for Watch {
             .named(
                 "recursive",
                 SyntaxShape::Boolean,
-                "Watch all directories under `path` recursively. Will be ignored if `path` is a file (default: true)",
+                "Watch all directories under `<path>` recursively. Will be ignored if `<path>` is a file (default: true)",
                 Some('r'),
             )
             .switch("verbose", "Operate in verbose mode (default: false)", Some('v'))

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -51,7 +51,7 @@ impl Command for Watch {
             .named(
                 "recursive",
                 SyntaxShape::Boolean,
-                "Watch all directories under <path> recursively. Will be ignored if <path> is a file (default: true)",
+                "Watch all directories under `path` recursively. Will be ignored if `path` is a file (default: true)",
                 Some('r'),
             )
             .switch("verbose", "Operate in verbose mode (default: false)", Some('v'))


### PR DESCRIPTION
# Description

Fix doc building for vuepress-next, avoid using bare angle brackets in examples, if you have to use it please wrap it in backticks, or documents building will fail, see: https://github.com/nushell/nushell.github.io/runs/6704828867?check_suite_focus=true


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
