### PR TITLE
Fix wrong `path` help message

### DIFF
--- a/crates/nu-command/src/path/path_.rs
+++ b/crates/nu-command/src/path/path_.rs
@@ -28,8 +28,8 @@ impl Command for PathCommand {
 * As a structured path: a table with 'parent', 'stem', and 'extension' (and
 * 'prefix' on Windows) columns. This format is produced by the 'path parse'
   subcommand.
-* As an inner list of path parts, e.g., '[[ / home viking spam.txt ]]'.
-  Splitting into parts is done by the `path split` command.
+* As a list of path parts, e.g., '[ / home viking spam.txt ]'. Splitting into
+  parts is done by the `path split` command.
 
 All subcommands accept all three variants as an input. Furthermore, the 'path
 join' subcommand can be used to join the structured path or path parts back into


### PR DESCRIPTION
# Description

We no longer have "inner list"

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
