### PR TITLE
Improve <table> output of 'to html',

### DIFF
--- a/crates/nu-command/src/formats/to/html.rs
+++ b/crates/nu-command/src/formats/to/html.rs
@@ -118,21 +118,21 @@ impl Command for ToHtml {
                 description: "Outputs an  HTML string representing the contents of this table",
                 example: "[[foo bar]; [1 2]] | to html",
                 result: Some(Value::test_string(
-                    r#"<html><style>body { background-color:white;color:black; }</style><body><table><tr><th>foo</th><th>bar</th></tr><tr><td>1</td><td>2</td></tr></table></body></html>"#,
+                    r#"<html><style>body { background-color:white;color:black; }</style><body><table><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table></body></html>"#,
                 )),
             },
             Example {
                 description: "Optionally, only output the html for the content itself",
                 example: "[[foo bar]; [1 2]] | to html --partial",
                 result: Some(Value::test_string(
-                    r#"<div style="background-color:white;color:black;"><table><tr><th>foo</th><th>bar</th></tr><tr><td>1</td><td>2</td></tr></table></div>"#,
+                    r#"<div style="background-color:white;color:black;"><table><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table></div>"#,
                 )),
             },
             Example {
                 description: "Optionally, output the string with a dark background",
                 example: "[[foo bar]; [1 2]] | to html --dark",
                 result: Some(Value::test_string(
-                    r#"<html><style>body { background-color:black;color:white; }</style><body><table><tr><th>foo</th><th>bar</th></tr><tr><td>1</td><td>2</td></tr></table></body></html>"#,
+                    r#"<html><style>body { background-color:black;color:white; }</style><body><table><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table></body></html>"#,
                 )),
             },
         ]

--- a/crates/nu-command/src/formats/to/html.rs
+++ b/crates/nu-command/src/formats/to/html.rs
@@ -360,13 +360,13 @@ fn html_table(table: Vec<Value>, headers: Vec<String>, config: &Config) -> Strin
 
     output_string.push_str("<table>");
 
-    output_string.push_str("<tr>");
+    output_string.push_str("<thead><tr>");
     for header in &headers {
         output_string.push_str("<th>");
         output_string.push_str(&htmlescape::encode_minimal(header));
         output_string.push_str("</th>");
     }
-    output_string.push_str("</tr>");
+    output_string.push_str("</tr></thead><tbody>");
 
     for row in table {
         if let Value::Record { span, .. } = row {
@@ -383,7 +383,7 @@ fn html_table(table: Vec<Value>, headers: Vec<String>, config: &Config) -> Strin
             output_string.push_str("</tr>");
         }
     }
-    output_string.push_str("</table>");
+    output_string.push_str("</tbody></table>");
 
     output_string
 }

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -41,7 +41,7 @@ fn out_html_table() {
 
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body><table><tr><th>name</th></tr><tr><td>darren</td></tr></table></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body><table><thead><tr><th>name</th></tr></thead><tbody><tr><td>darren</td></tr></tbody></table></body></html>"
     );
 }
 


### PR DESCRIPTION
Specifically, add `<thead>` and `<tbody>` elements. That allows for better styling and (future) some neat JavaScr

I've run `cargo fmt` and `cargo test`.  I haven't run `cargo clippy` - clippy seems to be missing in my setup.