### PR TITLE
Add completions for nu

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -121,6 +121,22 @@ module completions {
     --verbose(-v)                                   # be more verbose
     --help                                          # Display this help message
   ]
+  # Completions for nu itself
+  export extern "nu" [
+    --help(-h)                # Display this help message
+    --stdin                   # redirect the stdin
+    --login(-l)               # start as a login shell
+    --interactive(-i)         # start as an interactive shell
+    --version(-v)             # print the version
+    --perf(-p)                # start and print performance metrics during startup
+    --testbin:string          # run internal test binary
+    --commands(-c):string     # run the given commands and then exit
+    --config:string           # start with an alternate config file
+    --env-config:string       # start with an alternate environment config file
+    --log-level:string        # log level for performance logs
+    --threads:int             # threads to use for parallel commands
+    --table-mode(-m):string   # the table mode to use. rounded is default.
+]
 }
 
 # Get just the extern definitions without the custom completion commands


### PR DESCRIPTION
Come to think of it it's kinda weird nu doesn't have autocompletions for its own binary

# Description

(description of your pull request here)

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
