### PR TITLE
Fix `ls` for Windows system files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,6 +2618,7 @@ dependencies = [
  "uuid",
  "wax",
  "which",
+ "windows",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -107,6 +107,15 @@ features = [
 	"dynamic_groupby"
 ]
 
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.37.0"
+features = [
+    "alloc",
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+	"Win32_System_SystemServices",
+]
+
 [features]
 trash-support = ["trash"]
 which-support = ["which"]

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -13,9 +13,11 @@ use nu_protocol::{
 };
 use pathdiff::diff_paths;
 
+#[cfg(windows)]
 use std::mem::MaybeUninit;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(windows)]
 use std::os::windows::prelude::OsStrExt;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -12,11 +12,24 @@ use nu_protocol::{
     PipelineMetadata, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
 use pathdiff::diff_paths;
+
+use std::mem::MaybeUninit;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::os::windows::prelude::OsStrExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(windows)]
+use windows::Win32::Foundation::FILETIME;
+#[cfg(windows)]
+use windows::Win32::Storage::FileSystem::{
+    FindFirstFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_READONLY,
+    FILE_ATTRIBUTE_REPARSE_POINT, WIN32_FIND_DATAW,
+};
+#[cfg(windows)]
+use windows::Win32::System::SystemServices::{IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_SYMLINK};
 
 #[derive(Clone)]
 pub struct Ls;
@@ -360,6 +373,11 @@ pub(crate) fn dir_entry_dict(
     du: bool,
     ctrl_c: Option<Arc<AtomicBool>>,
 ) -> Result<Value, ShellError> {
+    #[cfg(windows)]
+    if metadata.is_none() {
+        return dir_entry_dict_windows_fallback(filename, display_name, span, long);
+    }
+
     let mut cols = vec![];
     let mut vals = vec![];
     let mut file_type = "unknown";
@@ -568,6 +586,180 @@ pub(crate) fn dir_entry_dict(
     Ok(Value::Record { cols, vals, span })
 }
 
+#[cfg(windows)]
+/// A secondary way to get file info on Windows, for when std::fs::symlink_metadata() fails.
+/// dir_entry_dict depends on metadata, but that can't be retrieved for some Windows system files:
+/// https://github.com/rust-lang/rust/issues/96980
+fn dir_entry_dict_windows_fallback(
+    filename: &Path,
+    display_name: &str,
+    span: Span,
+    long: bool,
+) -> Result<Value, ShellError> {
+    let mut cols = vec![];
+    let mut vals = vec![];
+
+    cols.push("name".into());
+    vals.push(Value::String {
+        val: display_name.to_string(),
+        span,
+    });
+
+    let find_data = find_first_file(filename, span)?;
+
+    cols.push("type".into());
+    vals.push(Value::String {
+        val: get_file_type_windows_fallback(&find_data),
+        span,
+    });
+
+    if long {
+        cols.push("target".into());
+        if is_symlink(&find_data) {
+            if let Ok(path_to_link) = filename.read_link() {
+                vals.push(Value::String {
+                    val: path_to_link.to_string_lossy().to_string(),
+                    span,
+                });
+            } else {
+                vals.push(Value::String {
+                    val: "Could not obtain target file's path".to_string(),
+                    span,
+                });
+            }
+        } else {
+            vals.push(Value::nothing(span));
+        }
+
+        cols.push("readonly".into());
+        vals.push(Value::Bool {
+            val: (find_data.dwFileAttributes & FILE_ATTRIBUTE_READONLY.0 != 0),
+            span,
+        });
+    }
+
+    cols.push("size".to_string());
+    let file_size = (find_data.nFileSizeHigh as u64) << 32 | find_data.nFileSizeLow as u64;
+    vals.push(Value::Filesize {
+        val: file_size as i64,
+        span,
+    });
+
+    if long {
+        cols.push("created".to_string());
+        {
+            let mut val = Value::nothing(span);
+            let seconds_since_unix_epoch = unix_time_from_filetime(&find_data.ftCreationTime);
+            if let Some(local) = unix_time_to_local_date_time(seconds_since_unix_epoch) {
+                val = Value::Date {
+                    val: local.with_timezone(local.offset()),
+                    span,
+                };
+            }
+            vals.push(val);
+        }
+
+        cols.push("accessed".to_string());
+        {
+            let mut val = Value::nothing(span);
+            let seconds_since_unix_epoch = unix_time_from_filetime(&find_data.ftLastAccessTime);
+            if let Some(local) = unix_time_to_local_date_time(seconds_since_unix_epoch) {
+                val = Value::Date {
+                    val: local.with_timezone(local.offset()),
+                    span,
+                };
+            }
+            vals.push(val);
+        }
+    }
+
+    cols.push("modified".to_string());
+    {
+        let mut val = Value::nothing(span);
+        let seconds_since_unix_epoch = unix_time_from_filetime(&find_data.ftLastWriteTime);
+        if let Some(local) = unix_time_to_local_date_time(seconds_since_unix_epoch) {
+            val = Value::Date {
+                val: local.with_timezone(local.offset()),
+                span,
+            };
+        }
+        vals.push(val);
+    }
+
+    Ok(Value::Record { cols, vals, span })
+}
+
+#[cfg(windows)]
+fn unix_time_from_filetime(ft: &FILETIME) -> i64 {
+    /// January 1, 1970 as Windows file time
+    const EPOCH_AS_FILETIME: u64 = 116444736000000000;
+    const HUNDREDS_OF_NANOSECONDS: u64 = 10000000;
+
+    let time_u64 = ((ft.dwHighDateTime as u64) << 32) | (ft.dwLowDateTime as u64);
+    let rel_to_linux_epoch = time_u64 - EPOCH_AS_FILETIME;
+    let seconds_since_unix_epoch = rel_to_linux_epoch / HUNDREDS_OF_NANOSECONDS;
+
+    seconds_since_unix_epoch as i64
+}
+
+#[cfg(windows)]
+// wrapper around the FindFirstFileW Win32 API
+fn find_first_file(filename: &Path, span: Span) -> Result<WIN32_FIND_DATAW, ShellError> {
+    unsafe {
+        let mut find_data = MaybeUninit::<WIN32_FIND_DATAW>::uninit();
+        // The windows crate really needs a nicer way to do string conversions
+        let filename_wide: Vec<u16> = filename
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        if FindFirstFileW(
+            windows::core::PCWSTR(filename_wide.as_ptr()),
+            find_data.as_mut_ptr(),
+        )
+        .is_err()
+        {
+            return Err(ShellError::ReadingFile(
+                "Could not read file metadata".to_string(),
+                span,
+            ));
+        }
+
+        let find_data = find_data.assume_init();
+        Ok(find_data)
+    }
+}
+
+#[cfg(windows)]
+fn get_file_type_windows_fallback(find_data: &WIN32_FIND_DATAW) -> String {
+    if find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY.0 != 0 {
+        return "dir".to_string();
+    }
+
+    if is_symlink(find_data) {
+        return "symlink".to_string();
+    }
+
+    "file".to_string()
+}
+
+#[cfg(windows)]
+fn is_symlink(find_data: &WIN32_FIND_DATAW) -> bool {
+    if find_data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0 {
+        // Follow Golang's lead in treating mount points as symlinks.
+        // https://github.com/golang/go/blob/016d7552138077741a9c3fdadc73c0179f5d3ff7/src/os/types_windows.go#L104-L105
+        if find_data.dwReserved0 == IO_REPARSE_TAG_SYMLINK
+            || find_data.dwReserved0 == IO_REPARSE_TAG_MOUNT_POINT
+        {
+            return true;
+        }
+    }
+    false
+}
+
+// TODO: can we get away from local times in `ls`? internals might be cleaner if we worked in UTC
+// and left the conversion to local time to the display layer
 fn try_convert_to_local_date_time(t: SystemTime) -> Option<DateTime<Local>> {
     // Adapted from https://github.com/chronotope/chrono/blob/v0.4.19/src/datetime.rs#L755-L767.
     let (sec, nsec) = match t.duration_since(UNIX_EPOCH) {
@@ -585,6 +777,13 @@ fn try_convert_to_local_date_time(t: SystemTime) -> Option<DateTime<Local>> {
     };
 
     match Utc.timestamp_opt(sec, nsec) {
+        LocalResult::Single(t) => Some(t.with_timezone(&Local)),
+        _ => None,
+    }
+}
+
+fn unix_time_to_local_date_time(secs: i64) -> Option<DateTime<Local>> {
+    match Utc.timestamp_opt(secs, 0) {
         LocalResult::Single(t) => Some(t.with_timezone(&Local)),
         _ => None,
     }

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -784,6 +784,8 @@ fn try_convert_to_local_date_time(t: SystemTime) -> Option<DateTime<Local>> {
     }
 }
 
+// #[cfg(windows)] is just to make Clippy happy, remove if you ever want to use this on other platforms
+#[cfg(windows)]
 fn unix_time_to_local_date_time(secs: i64) -> Option<DateTime<Local>> {
     match Utc.timestamp_opt(secs, 0) {
         LocalResult::Single(t) => Some(t.with_timezone(&Local)),

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -391,3 +391,40 @@ fn list_all_columns() {
         );
     });
 }
+
+/// Rust's fs::metadata function is unable to read info for certain system files on Windows,
+/// like  `C:\pagefile.sys`: https://github.com/rust-lang/rust/issues/96980
+/// This test confirms that Nu can work around this successfully.
+#[test]
+#[cfg(windows)]
+fn can_list_pagefile() {
+    let file_type = nu!(
+        cwd: "C:\\", pipeline(
+        r#"ls | where name =~ "pagefile.sys" | get type.0"#
+    ));
+    assert_eq!(file_type.out, "file");
+
+    let file_size = nu!(
+        cwd: "C:\\", pipeline(
+        r#"ls | where name =~ "pagefile.sys" | get size.0"#
+    ));
+    assert!(file_size.out.trim() != "");
+
+    let file_modified = nu!(
+        cwd: "C:\\", pipeline(
+        r#"ls | where name =~ "pagefile.sys" | get modified.0"#
+    ));
+    assert!(file_modified.out.trim() != "");
+
+    let file_accessed = nu!(
+        cwd: "C:\\", pipeline(
+        r#"ls -l | where name =~ "pagefile.sys" | get accessed.0"#
+    ));
+    assert!(file_accessed.out.trim() != "");
+
+    let file_created = nu!(
+        cwd: "C:\\", pipeline(
+        r#"ls -l | where name =~ "pagefile.sys" | get created.0"#
+    ));
+    assert!(file_created.out.trim() != "");
+}


### PR DESCRIPTION
# Description

Fixes #4975 on Windows only (does not fix the related issue on MacOS that @hustcer [noted here](https://github.com/nushell/nushell/issues/4975#issuecomment-1079646262)).

In a nushell, some Win32 APIs are unable to return useful information about Windows system files - [including APIs used by the Rust stdlib](https://github.com/rust-lang/rust/issues/96980). The way the .NET runtime solves this is by falling back on [FindFirstFile](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilew) if their initial attempt to get file metadata fails ([comment](https://github.com/dotnet/runtime/issues/26216#issuecomment-390269346), [code](https://github.com/dotnet/runtime/blob/6de7147b9266d7730b0d73ba67632b0c198cb11e/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs#L69-L80)). This PR does the same for Nushell.

### Before
<img width="515" alt="image" src="https://user-images.githubusercontent.com/26268125/171784194-08710914-602f-4cf2-9ede-36c027633871.png">

### After
<img width="531" alt="image" src="https://user-images.githubusercontent.com/26268125/171784338-b8b501bd-a624-447f-bff3-264e655ea77d.png">

# Notes

I'm using [Microsoft's `windows` crate](https://github.com/microsoft/windows-rs) for this. It shouldn't add much to build times because our `trash-rs` dependency also uses `windows`.

`windows` is a somewhat underdocumented crate, but once you get some practice it's not too bad; just let me know if you have any questions about how I've used it here.