### PR TITLE
Improve internal documentation of `save` command

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -20,7 +20,16 @@ impl Command for Save {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["save", "write", "write_file"]
+        vec![
+            "write",
+            "write_file",
+            "append",
+            "redirection",
+            "file",
+            "io",
+            ">",
+            ">>",
+        ]
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -214,12 +223,17 @@ impl Command for Save {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Save a string to foo.txt in current directory",
+                description: "Save a string to foo.txt in the current directory",
                 example: r#"echo 'save me' | save foo.txt"#,
                 result: None,
             },
             Example {
-                description: "Save a record to foo.json in current directory",
+                description: "Append a string to the end of foo.txt",
+                example: r#"echo 'append me' | save --append foo.txt"#,
+                result: None,
+            },
+            Example {
+                description: "Save a record to foo.json in the current directory",
                 example: r#"echo { a: 1, b: 2 } | save foo.json"#,
                 result: None,
             },


### PR DESCRIPTION
# Description

- Example for `--append` mode.
- Search terms for redirection

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
