### PR TITLE
Update nu-ansi-term to remove `Deref` impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7bca0d33a384280d1563b97f49cb95303df9fa22588739a04b7d8015c1ccd50"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi 0.3.9",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.6.0"
-source = "git+https://github.com/nushell/reedline?branch=main#a3dbc6232b4f82af965ac361dc2eb05608c65258"
+source = "git+https://github.com/nushell/reedline?branch=main#09bbb24bfdcf4183914b671b0fc0b70d46c4b3fa"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ crossterm = "0.23.0"
 ctrlc = "3.2.1"
 log = "0.4"
 miette = "4.5.0"
-nu-ansi-term = "0.45.1"
+nu-ansi-term = "0.46.0"
 nu-cli = { path="./crates/nu-cli", version = "0.63.1"  }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.63.1"  }
 nu-command = { path="./crates/nu-command", version = "0.63.1"  }
@@ -118,3 +118,4 @@ debug = false
 [[bin]]
 name = "nu"
 path = "src/main.rs"
+

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -16,7 +16,7 @@ nu-path = { path = "../nu-path", version = "0.63.1"  }
 nu-parser = { path = "../nu-parser", version = "0.63.1"  }
 nu-protocol = { path = "../nu-protocol", version = "0.63.1"  }
 nu-utils = { path = "../nu-utils", version = "0.63.1"  }
-nu-ansi-term = "0.45.1"
+nu-ansi-term = "0.46.0"
 reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"]}
 nu-color-config = { path = "../nu-color-config", version = "0.63.1"  }
 crossterm = "0.23.0"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.63.1"
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.63.1"  }
-nu-ansi-term = "0.45.1"
+nu-ansi-term = "0.46.0"
 nu-json = { path = "../nu-json", version = "0.63.1"  }
 nu-table = { path = "../nu-table", version = "0.63.1"  }
 serde = { version="1.0.123", features=["derive"] }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -23,7 +23,7 @@ nu-table = { path = "../nu-table", version = "0.63.1"  }
 nu-term-grid = { path = "../nu-term-grid", version = "0.63.1"  }
 nu-test-support = { path = "../nu-test-support", version = "0.63.1"  }
 nu-utils = { path = "../nu-utils", version = "0.63.1" }
-nu-ansi-term = "0.45.1"
+nu-ansi-term = "0.46.0"
 
 # Potential dependencies for extras
 alphanumeric-sort = "1.4.4"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -16,7 +16,7 @@ name = "nu_pretty_hex"
 path = "src/main.rs"
 
 [dependencies]
-nu-ansi-term = "0.45.1"
+nu-ansi-term = "0.46.0"
 rand = "0.8.3"
 
 [dev-dependencies]

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -12,7 +12,7 @@ name = "table"
 path = "src/main.rs"
 
 [dependencies]
-nu-ansi-term = "0.45.1"
+nu-ansi-term = "0.46.0"
 nu-protocol = { path = "../nu-protocol", version = "0.63.1" }
 regex = "1.4"
 unicode-width = "0.1.8"


### PR DESCRIPTION
# Description

Resolves an unexpected issue due to `Deref` and `ToString` interacting

Details: https://github.com/nushell/nu-ansi-term/pull/5 and https://github.com/nushell/reedline/pull/435#issuecomment-1141348209

Also updates reedline: Includes a fix for a panic when the directory containing the history is deleted during a running reedline session. (nushell/reedline#436)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
