### PR TITLE
Use search terms in the help menu search

### DIFF
--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -20,6 +20,10 @@ impl NuHelpCompleter {
                 sig.name.to_lowercase().contains(&line.to_lowercase())
                     || sig.usage.to_lowercase().contains(&line.to_lowercase())
                     || sig
+                        .search_terms
+                        .iter()
+                        .any(|term| term.to_lowercase().contains(&line.to_lowercase()))
+                    || sig
                         .extra_usage
                         .to_lowercase()
                         .contains(&line.to_lowercase())


### PR DESCRIPTION
# Description

Currently only `help --find` was using the search terms
With this change they will also be used by the `F1` help menu

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
