### PR TITLE
Address lints from clippy for beta/nightly

### DIFF
--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -1,6 +1,7 @@
 use nu_engine::documentation::get_flags_section;
 use nu_protocol::{engine::EngineState, levenshtein_distance};
 use reedline::{Completer, Suggestion};
+use std::fmt::Write;
 use std::sync::Arc;
 
 pub struct NuHelpCompleter(Arc<EngineState>);
@@ -53,7 +54,7 @@ impl NuHelpCompleter {
                     long_desc.push_str("\r\n\r\n");
                 }
 
-                long_desc.push_str(&format!("Usage:\r\n  > {}\r\n", sig.call_signature()));
+                let _ = write!(long_desc, "Usage:\r\n  > {}\r\n", sig.call_signature());
 
                 if !sig.named.is_empty() {
                     long_desc.push_str(&get_flags_section(sig))
@@ -65,21 +66,22 @@ impl NuHelpCompleter {
                 {
                     long_desc.push_str("\r\nParameters:\r\n");
                     for positional in &sig.required_positional {
-                        long_desc
-                            .push_str(&format!("  {}: {}\r\n", positional.name, positional.desc));
+                        let _ = write!(long_desc, "  {}: {}\r\n", positional.name, positional.desc);
                     }
                     for positional in &sig.optional_positional {
-                        long_desc.push_str(&format!(
+                        let _ = write!(
+                            long_desc,
                             "  (optional) {}: {}\r\n",
                             positional.name, positional.desc
-                        ));
+                        );
                     }
 
                     if let Some(rest_positional) = &sig.rest_positional {
-                        long_desc.push_str(&format!(
+                        let _ = write!(
+                            long_desc,
                             "  ...{}: {}\r\n",
                             rest_positional.name, rest_positional.desc
-                        ));
+                        );
                     }
                 }
 

--- a/crates/nu-cli/tests/custom_completions.rs
+++ b/crates/nu-cli/tests/custom_completions.rs
@@ -18,7 +18,7 @@ fn variables_completions() {
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     // Test completions for $nu
-    let suggestions = completer.complete("my-command ".into(), 11);
+    let suggestions = completer.complete("my-command ", 11);
 
     assert_eq!(3, suggestions.len());
 

--- a/crates/nu-cli/tests/flag_completions.rs
+++ b/crates/nu-cli/tests/flag_completions.rs
@@ -12,7 +12,7 @@ fn flag_completions() {
     // Instatiate a new completer
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
     // Test completions for the 'ls' flags
-    let suggestions = completer.complete("ls -".into(), 4);
+    let suggestions = completer.complete("ls -", 4);
 
     assert_eq!(12, suggestions.len());
 

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -89,7 +89,7 @@ pub fn merge_input(
     dir: PathBuf,
 ) -> Result<(), ShellError> {
     let (block, delta) = {
-        let mut working_set = StateWorkingSet::new(&engine_state);
+        let mut working_set = StateWorkingSet::new(engine_state);
 
         let (block, err) = parse(&mut working_set, None, input, false, &[]);
 
@@ -98,7 +98,7 @@ pub fn merge_input(
         (block, working_set.render())
     };
     assert!(eval_block(
-        &engine_state,
+        engine_state,
         stack,
         &block,
         PipelineData::Value(

--- a/crates/nu-cli/tests/variables_completions.rs
+++ b/crates/nu-cli/tests/variables_completions.rs
@@ -17,7 +17,7 @@ fn variables_completions() {
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     // Test completions for $nu
-    let suggestions = completer.complete("$nu.".into(), 4);
+    let suggestions = completer.complete("$nu.", 4);
 
     assert_eq!(8, suggestions.len());
 
@@ -36,7 +36,7 @@ fn variables_completions() {
     match_suggestions(expected, suggestions);
 
     // Test completions for $nu.h (filter)
-    let suggestions = completer.complete("$nu.h".into(), 5);
+    let suggestions = completer.complete("$nu.h", 5);
 
     assert_eq!(2, suggestions.len());
 
@@ -46,7 +46,7 @@ fn variables_completions() {
     match_suggestions(expected, suggestions);
 
     // Test completions for custom var
-    let suggestions = completer.complete("$actor.".into(), 7);
+    let suggestions = completer.complete("$actor.", 7);
 
     assert_eq!(2, suggestions.len());
 
@@ -56,7 +56,7 @@ fn variables_completions() {
     match_suggestions(expected, suggestions);
 
     // Test completions for custom var (filtering)
-    let suggestions = completer.complete("$actor.n".into(), 7);
+    let suggestions = completer.complete("$actor.n", 7);
 
     assert_eq!(1, suggestions.len());
 
@@ -66,7 +66,7 @@ fn variables_completions() {
     match_suggestions(expected, suggestions);
 
     // Test completions for $env
-    let suggestions = completer.complete("$env.".into(), 5);
+    let suggestions = completer.complete("$env.", 5);
 
     assert_eq!(2, suggestions.len());
 
@@ -76,7 +76,7 @@ fn variables_completions() {
     match_suggestions(expected, suggestions);
 
     // Test completions for $env
-    let suggestions = completer.complete("$env.T".into(), 5);
+    let suggestions = completer.complete("$env.T", 5);
 
     assert_eq!(1, suggestions.len());
 

--- a/crates/nu-color-config/src/nu_style.rs
+++ b/crates/nu-color-config/src/nu_style.rs
@@ -1,7 +1,7 @@
 use nu_ansi_term::{Color, Style};
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct NuStyle {
     pub fg: Option<String>,
     pub bg: Option<String>,

--- a/crates/nu-command/src/hash/base64.rs
+++ b/crates/nu-command/src/hash/base64.rs
@@ -12,7 +12,7 @@ pub struct Base64Config {
     pub action_type: ActionType,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ActionType {
     Encode,
     Decode,

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -87,7 +87,7 @@ fn exec(
         redirect_stderr: false,
     };
 
-    let mut command = external_command.spawn_simple_command(&cwd.to_string_lossy().to_string())?;
+    let mut command = external_command.spawn_simple_command(&cwd.to_string_lossy())?;
     command.current_dir(current_dir);
 
     let err = command.exec(); // this replaces our process, should not return

--- a/crates/nu-command/src/viewers/icons.rs
+++ b/crates/nu-command/src/viewers/icons.rs
@@ -428,7 +428,7 @@ pub fn extension_is_one_of(path: &Path, choices: &[&str]) -> bool {
 //     choices.contains(&&name[..])
 // }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct FileExtensions;
 
 // TODO: We may want to re-add these FileExtensions impl fns back. I have disabled

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -3,6 +3,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     Example, IntoPipelineData, Signature, Span, Value,
 };
+use std::fmt::Write;
 
 pub fn get_full_help(
     sig: &Signature,
@@ -62,13 +63,14 @@ fn get_documentation(
     }
 
     if !sig.search_terms.is_empty() {
-        long_desc.push_str(&format!(
+        let _ = write!(
+            long_desc,
             "Search terms: {}\n\n",
             sig.search_terms.join(", ")
-        ));
+        );
     }
 
-    long_desc.push_str(&format!("Usage:\n  > {}\n", sig.call_signature()));
+    let _ = write!(long_desc, "Usage:\n  > {}\n", sig.call_signature());
 
     if !subcommands.is_empty() {
         long_desc.push_str("\nSubcommands:\n");
@@ -87,23 +89,26 @@ fn get_documentation(
     {
         long_desc.push_str("\nParameters:\n");
         for positional in &sig.required_positional {
-            long_desc.push_str(&format!(
-                "  {} <{:?}>: {}\n",
+            let _ = writeln!(
+                long_desc,
+                "  {} <{:?}>: {}",
                 positional.name, positional.shape, positional.desc
-            ));
+            );
         }
         for positional in &sig.optional_positional {
-            long_desc.push_str(&format!(
-                "  (optional) {} <{:?}>: {}\n",
+            let _ = writeln!(
+                long_desc,
+                "  (optional) {} <{:?}>: {}",
                 positional.name, positional.shape, positional.desc
-            ));
+            );
         }
 
         if let Some(rest_positional) = &sig.rest_positional {
-            long_desc.push_str(&format!(
-                "  ...{} <{:?}>: {}\n",
+            let _ = writeln!(
+                long_desc,
+                "  ...{} <{:?}>: {}",
                 rest_positional.name, rest_positional.shape, rest_positional.desc
-            ));
+            );
         }
     }
 
@@ -117,7 +122,7 @@ fn get_documentation(
         long_desc.push_str(example.description);
 
         if config.no_color {
-            long_desc.push_str(&format!("\n  > {}\n", example.example));
+            let _ = write!(long_desc, "\n  > {}\n", example.example);
         } else if let Some(highlighter) = engine_state.find_decl(b"nu-highlight", &[]) {
             let decl = engine_state.get_decl(highlighter);
 
@@ -135,19 +140,19 @@ fn get_documentation(
                     let result = output.into_value(Span { start: 0, end: 0 });
                     match result.as_string() {
                         Ok(s) => {
-                            long_desc.push_str(&format!("\n  > {}\n", s));
+                            let _ = write!(long_desc, "\n  > {}\n", s);
                         }
                         _ => {
-                            long_desc.push_str(&format!("\n  > {}\n", example.example));
+                            let _ = write!(long_desc, "\n  > {}\n", example.example);
                         }
                     }
                 }
                 Err(_) => {
-                    long_desc.push_str(&format!("\n  > {}\n", example.example));
+                    let _ = write!(long_desc, "\n  > {}\n", example.example);
                 }
             }
         } else {
-            long_desc.push_str(&format!("\n  > {}\n", example.example));
+            let _ = write!(long_desc, "\n  > {}\n", example.example);
         }
     }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1108,7 +1108,7 @@ pub fn create_scope(
                 if !alias_text.is_empty() {
                     alias_text.push(' ');
                 }
-                alias_text.push_str(&String::from_utf8_lossy(contents).to_string());
+                alias_text.push_str(&String::from_utf8_lossy(contents));
             }
             aliases.push((
                 Value::String {

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -518,7 +518,7 @@ enum PatternToken {
 }
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum MatchResult {
     Match,
     SubPatternDoesntMatch,

--- a/crates/nu-json/src/error.rs
+++ b/crates/nu-json/src/error.rs
@@ -13,7 +13,7 @@ use serde::de;
 use serde::ser;
 
 /// The errors that can arise while parsing a JSON stream.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum ErrorCode {
     /// Catchall for syntax error messages
     Custom(String),

--- a/crates/nu-json/src/value.rs
+++ b/crates/nu-json/src/value.rs
@@ -974,7 +974,7 @@ struct VariantDeserializer {
     val: Option<Value>,
 }
 
-impl<'de, 'a> de::VariantAccess<'de> for VariantDeserializer {
+impl<'de> de::VariantAccess<'de> for VariantDeserializer {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {
@@ -1062,7 +1062,7 @@ struct MapDeserializer {
     value: Option<Value>,
 }
 
-impl<'de, 'a> de::MapAccess<'de> for MapDeserializer {
+impl<'de> de::MapAccess<'de> for MapDeserializer {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -156,10 +156,7 @@ pub fn parse_binary_with_invalid_octal_format() {
     assert!(block.len() == 1);
     let expressions = &block[0];
     assert!(expressions.len() == 1);
-    assert!(match &expressions[0].expr {
-        Expr::Binary(_) => false,
-        _ => true,
-    })
+    assert!(!matches!(&expressions[0].expr, Expr::Binary(_)))
 }
 
 #[test]

--- a/crates/nu-plugin/src/plugin_capnp.rs
+++ b/crates/nu-plugin/src/plugin_capnp.rs
@@ -2278,7 +2278,7 @@ pub mod signature {
 }
 
 #[repr(u16)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Category {
     Default = 0,
     Conversions = 1,
@@ -2841,7 +2841,7 @@ pub mod argument {
 }
 
 #[repr(u16)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Shape {
     None = 0,
     Any = 1,

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -18,7 +18,7 @@ pub enum PluginCall {
     CallInfo(Box<CallInfo>),
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct LabeledError {
     pub label: String,
     pub msg: String,

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -1,6 +1,7 @@
 use super::Expression;
 use crate::Span;
 use serde::{Deserialize, Serialize};
+use std::fmt::Write;
 
 #[derive(Debug, Clone, PartialOrd, Serialize, Deserialize)]
 pub enum PathMember {
@@ -32,7 +33,9 @@ impl CellPath {
                 output.push('.');
             }
             match elem {
-                PathMember::Int { val, .. } => output.push_str(&format!("{}", val)),
+                PathMember::Int { val, .. } => {
+                    let _ = write!(output, "{}", val);
+                }
                 PathMember::String { val, .. } => output.push_str(val),
             }
         }

--- a/crates/nu-protocol/src/ast/import_pattern.rs
+++ b/crates/nu-protocol/src/ast/import_pattern.rs
@@ -3,21 +3,21 @@ use serde::{Deserialize, Serialize};
 use crate::{span, ModuleId, Span};
 use std::collections::HashSet;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ImportPatternMember {
     Glob { span: Span },
     Name { name: Vec<u8>, span: Span },
     List { names: Vec<(Vec<u8>, Span)> },
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ImportPatternHead {
     pub name: Vec<u8>,
     pub id: Option<ModuleId>,
     pub span: Span,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ImportPattern {
     pub head: ImportPatternHead,
     pub members: Vec<ImportPatternMember>,

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -54,13 +54,13 @@ impl Display for Operator {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Serialize, Deserialize)]
 pub enum RangeInclusion {
     Inclusive,
     RightExclusive,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RangeOperator {
     pub inclusion: RangeInclusion,
     pub span: Span,

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -37,7 +37,7 @@ pub struct PositionalArg {
     pub default_value: Option<Expression>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Category {
     Default,
     Conversions,

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -11,6 +11,7 @@ use crate::PipelineData;
 use crate::ShellError;
 use crate::SyntaxShape;
 use crate::VarId;
+use std::fmt::Write;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Flag {
@@ -345,7 +346,7 @@ impl Signature {
         }
 
         if let Some(rest) = &self.rest_positional {
-            one_liner.push_str(&format!("...{}", get_positional_short_name(rest, false)));
+            let _ = write!(one_liner, "...{}", get_positional_short_name(rest, false));
         }
 
         // if !self.subcommands.is_empty() {

--- a/crates/nu-protocol/src/value/unit.rs
+++ b/crates/nu-protocol/src/value/unit.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Unit {
     // Filesize units: metric
     Byte,

--- a/crates/nu-term-grid/src/grid.rs
+++ b/crates/nu-term-grid/src/grid.rs
@@ -138,7 +138,7 @@ pub enum Alignment {
 /// The easiest way to create a Cell is just by using `string.into()`, which
 /// uses the **unicode width** of the string (see the `unicode_width` crate).
 /// However, the fields are public, if you wish to provide your own length.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Cell {
     /// The string to display when this cell gets rendered.
     pub contents: String,
@@ -171,7 +171,7 @@ impl<'a> From<&'a str> for Cell {
 }
 
 /// Direction cells should be written in — either across, or downwards.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum Direction {
     /// Starts at the top left and moves rightwards, going back to the first
     /// column for a new row, like a typewriter.
@@ -187,7 +187,7 @@ pub type Width = usize;
 
 /// The text to put in between each pair of columns.
 /// This does not include any spaces used when aligning cells.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Filling {
     /// A certain number of spaces should be used as the separator.
     Spaces(Width),
@@ -208,7 +208,7 @@ impl Filling {
 
 /// The user-assignable options for a grid view that should be passed to
 /// [`Grid::new()`](struct.Grid.html#method.new).
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct GridOptions {
     /// The direction that the cells should be written in — either
     /// across, or downwards.
@@ -218,7 +218,7 @@ pub struct GridOptions {
     pub filling: Filling,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 struct Dimensions {
     /// The number of lines in the grid.
     num_lines: Width,

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -121,7 +121,7 @@ macro_rules! nu_with_plugins {
         pub use std::error::Error;
         pub use std::io::prelude::*;
         pub use std::process::{Command, Stdio};
-        pub use crate::NATIVE_PATH_ENV_VAR;
+        pub use $crate::NATIVE_PATH_ENV_VAR;
 
         let commands = &*format!(
             "

--- a/crates/nu-test-support/src/playground/director.rs
+++ b/crates/nu-test-support/src/playground/director.rs
@@ -2,6 +2,7 @@ use super::nu_process::*;
 use super::EnvironmentVariable;
 use std::ffi::OsString;
 use std::fmt;
+use std::fmt::Write;
 
 #[derive(Default, Debug)]
 pub struct Director {
@@ -94,7 +95,7 @@ impl Executable for Director {
                         if !commands.is_empty() {
                             commands.push_str("| ");
                         }
-                        commands.push_str(&format!("{}\n", pipeline));
+                        let _ = writeln!(commands, "{}", pipeline);
                     }
                 }
 

--- a/crates/nu_plugin_query/src/query.rs
+++ b/crates/nu_plugin_query/src/query.rs
@@ -4,6 +4,7 @@ use crate::query_xml::execute_xpath_query;
 use nu_engine::documentation::get_flags_section;
 use nu_plugin::{EvaluatedCall, LabeledError, Plugin};
 use nu_protocol::{Signature, Spanned, Value};
+use std::fmt::Write;
 
 #[derive(Default)]
 pub struct Query;
@@ -59,15 +60,15 @@ impl Query {
 
 pub fn get_brief_subcommand_help(sigs: &[Signature]) -> String {
     let mut help = String::new();
-    help.push_str(&format!("{}\n\n", sigs[0].usage));
-    help.push_str(&format!("Usage:\n  > {}\n\n", sigs[0].name));
+    let _ = write!(help, "{}\n\n", sigs[0].usage);
+    let _ = write!(help, "Usage:\n  > {}\n\n", sigs[0].name);
     help.push_str("Subcommands:\n");
 
     for x in sigs.iter().enumerate() {
         if x.0 == 0 {
             continue;
         }
-        help.push_str(&format!("  {} - {}\n", x.1.name, x.1.usage));
+        let _ = writeln!(help, "  {} - {}", x.1.name, x.1.usage);
     }
 
     help.push_str(&get_flags_section(&sigs[0]));

--- a/crates/nu_plugin_query/src/web_tables.rs
+++ b/crates/nu_plugin_query/src/web_tables.rs
@@ -294,7 +294,7 @@ fn cell_content(element: ElementRef) -> String {
     let frag = Html::parse_fragment(&element);
     for node in frag.tree {
         if let scraper::node::Node::Text(text) = node {
-            dehtmlize.push_str(&text.text.to_string())
+            dehtmlize.push_str(&text.text)
         }
     }
 
@@ -314,7 +314,7 @@ fn contains_str(slice: &[String], item: &str) -> bool {
     let frag = Html::parse_fragment(item);
     for node in frag.tree {
         if let scraper::node::Node::Text(text) = node {
-            dehtmlized.push_str(&text.text.to_string());
+            dehtmlized.push_str(&text.text);
         }
     }
 


### PR DESCRIPTION
# Description

To prevent CI failures with the next rust release I ran clippy with both `+beta` and `+nightly` and preemptively fixed the issues.

We may exclude certain commits for now (e.g. the `format!` vs `write!` solution

## Uncontroversial

- Fix clippy lints in tests
- Fix macro crate relative import
- Remove unnnecessary `.to_string()` for Cow<str>
- Remove unused lifetime
- Derive `Eq` for `PartialEq` with `Eq` members


## May require a brief sanity check
- Remove `.to_string()` for `tendril::Tendril`

## Opinionated 
- Replace `format!` in `.push_str()` with `write!`


# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
