### PR TITLE
Make `range` require its positional argument

### DIFF
--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -17,7 +17,7 @@ impl Command for Range {
 
     fn signature(&self) -> Signature {
         Signature::build("range")
-            .optional(
+            .required(
                 "rows",
                 SyntaxShape::Range,
                 "range of rows to return: Eg) 4..7 (=> from 4 to 7)",


### PR DESCRIPTION
# Description

Another small quibble. Currently, when `range` is passed without an argument, it has a very confusing error. Requiring the positional argument should make clear its usage.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
