### PR TITLE
Attempts to add a command that checks if nushell is running with admin priveleges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "is-root"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a4202a60e86f1c9702706bb42270dadd333f2db7810157563c86f17af3c873"
+dependencies = [
+ "users 0.10.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2570,7 @@ dependencies = [
  "htmlescape",
  "ical",
  "indexmap",
+ "is-root",
  "itertools",
  "lazy_static",
  "log",
@@ -2614,7 +2625,7 @@ dependencies = [
  "umask",
  "unicode-segmentation",
  "url",
- "users",
+ "users 0.11.0",
  "uuid",
  "wax",
  "which",
@@ -4971,6 +4982,16 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "users"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -47,6 +47,7 @@ htmlescape = "0.3.1"
 ical = "0.7.0"
 indexmap = { version="1.7", features=["serde-1"] }
 Inflector = "0.11"
+is-root = "0.1.2"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -382,6 +382,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         // Experimental
         bind_command! {
             ViewSource,
+            IsAdmin,
         };
 
         // Deprecated

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -1,10 +1,7 @@
 use is_root::is_root;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, Signature, Span,
-    Value,
-};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Span, Value};
 
 #[derive(Clone)]
 pub struct IsAdmin;

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -1,11 +1,10 @@
-use nu_engine::CallExt;
+use is_root::is_root;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span,
     Value,
 };
-use is_root::is_root;
 
 #[derive(Clone)]
 pub struct IsAdmin;
@@ -20,8 +19,7 @@ impl Command for IsAdmin {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("is-admin")
-            .category(Category::Core)
+        Signature::build("is-admin").category(Category::Core)
     }
 
     fn run(

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -12,7 +12,7 @@ impl Command for IsAdmin {
     }
 
     fn usage(&self) -> &str {
-        "Check if nushell is running with administrator priveleges"
+        "Check if nushell is running with administrator or root priviliges"
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -36,7 +36,7 @@ impl Command for IsAdmin {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Echo 'iamroot' if nushell is running with admin priveleges, and 'iamnotroot' if not.",
+                description: "Echo 'iamroot' if nushell is running with admin/root privileges, and 'iamnotroot' if not.",
                 example: r#"if is_admin { echo "iamroot" } else { echo "iamnotroot" }"#,
                 result: Some(Value::String {
                     val: "iamnotroot".to_string(),

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -1,0 +1,53 @@
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Value,
+};
+use is_root::is_root;
+
+#[derive(Clone)]
+pub struct IsAdmin;
+
+impl Command for IsAdmin {
+    fn name(&self) -> &str {
+        "is-admin"
+    }
+
+    fn usage(&self) -> &str {
+        "Check if nushell is running with administrator priveleges"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("is-admin")
+            .category(Category::Core)
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Ok(Value::Bool {
+            val: is_root(),
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Echo 'iamroot' if nushell is running with admin priveleges, and 'iamnotroot' if not.",
+                example: r#"if is_admin { echo "iamroot" } else { echo "iamnotroot" }"#,
+                result: Some(Value::String {
+                    val: "iamnotroot".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -37,7 +37,7 @@ impl Command for IsAdmin {
         vec![
             Example {
                 description: "Echo 'iamroot' if nushell is running with admin/root privileges, and 'iamnotroot' if not.",
-                example: r#"if is_admin { echo "iamroot" } else { echo "iamnotroot" }"#,
+                example: r#"if is-admin { echo "iamroot" } else { echo "iamnotroot" }"#,
                 result: Some(Value::String {
                     val: "iamnotroot".to_string(),
                     span: Span::test_data(),

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -12,7 +12,7 @@ impl Command for IsAdmin {
     }
 
     fn usage(&self) -> &str {
-        "Check if nushell is running with administrator or root priviliges"
+        "Check if nushell is running with administrator or root privileges"
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/experimental/mod.rs
+++ b/crates/nu-command/src/experimental/mod.rs
@@ -1,5 +1,5 @@
-mod view_source;
 mod is_admin;
+mod view_source;
 
-pub use view_source::ViewSource;
 pub use is_admin::IsAdmin;
+pub use view_source::ViewSource;

--- a/crates/nu-command/src/experimental/mod.rs
+++ b/crates/nu-command/src/experimental/mod.rs
@@ -1,3 +1,5 @@
 mod view_source;
+mod is_admin;
 
 pub use view_source::ViewSource;
+pub use is_admin::IsAdmin;


### PR DESCRIPTION
# Description

Title. Fixes #5689.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
