### PR TITLE
Added loginshell config file #4620

### DIFF
--- a/crates/nu-cli/tests/variables_completions.rs
+++ b/crates/nu-cli/tests/variables_completions.rs
@@ -19,13 +19,14 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(8, suggestions.len());
+    assert_eq!(9, suggestions.len());
 
     let expected: Vec<String> = vec![
         "config-path".into(),
         "env-path".into(),
         "history-path".into(),
         "home-path".into(),
+        "loginshell-path".into(),
         "os-info".into(),
         "pid".into(),
         "scope".into(),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1196,6 +1196,7 @@ pub fn eval_variable(
             if let Some(mut config_path) = nu_path::config_dir() {
                 config_path.push("nushell");
                 let mut env_config_path = config_path.clone();
+                let mut loginshell_path = config_path.clone();
 
                 let mut history_path = config_path.clone();
 
@@ -1220,6 +1221,14 @@ pub fn eval_variable(
                 output_cols.push("env-path".into());
                 output_vals.push(Value::String {
                     val: env_config_path.to_string_lossy().to_string(),
+                    span,
+                });
+
+                loginshell_path.push("login.nu");
+
+                output_cols.push("loginshell-path".into());
+                output_vals.push(Value::String {
+                    val: loginshell_path.to_string_lossy().to_string(),
                     span,
                 });
             }

--- a/docs/sample_config/sample_login.nu
+++ b/docs/sample_config/sample_login.nu
@@ -4,3 +4,6 @@
 
 # just as an example for overwriting of an environment variable of env.nu
 let-env PROMPT_INDICATOR = { "(LS)〉" }
+
+# Similar to env-path and config-path there is a variable containing the path to login.nu
+echo $nu.loginshell-path

--- a/docs/sample_config/sample_login.nu
+++ b/docs/sample_config/sample_login.nu
@@ -1,0 +1,6 @@
+# Example Nushell Loginshell Config File
+# - has to be as login.nu in the default config directory
+# - will be sourced after config.nu and env.nu in case of nushell started as login shell
+
+# just as an example for overwriting of an environment variable of env.nu
+let-env PROMPT_INDICATOR = { "(LS)〉" }

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 pub(crate) const NUSHELL_FOLDER: &str = "nushell";
 const CONFIG_FILE: &str = "config.nu";
 const ENV_FILE: &str = "env.nu";
+const LOGINSHELL_FILE: &str = "login.nu";
 const HISTORY_FILE: &str = "history.txt";
 
 pub(crate) fn read_config_file(
@@ -101,6 +102,26 @@ pub(crate) fn read_config_file(
 
     if is_perf_true {
         info!("read_config_file {}:{}:{}", file!(), line!(), column!());
+    }
+}
+
+pub(crate) fn read_loginshell_file(
+    engine_state: &mut EngineState,
+    stack: &mut Stack,
+    is_perf_true: bool,
+) {
+    // read and execute loginshell file if exists
+    if let Some(mut config_path) = nu_path::config_dir() {
+        config_path.push(NUSHELL_FOLDER);
+        config_path.push(LOGINSHELL_FILE);
+
+        if config_path.exists() {
+            eval_config_contents(config_path, engine_state, stack);
+        }
+    }
+
+    if is_perf_true {
+        info!("read_loginshell_file {}:{}:{}", file!(), line!(), column!());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,7 @@ fn main() -> Result<()> {
                     &mut stack,
                     binary_args.config_file,
                     binary_args.env_file,
+                    binary_args.login_shell.is_some(),
                 );
                 let history_path = config_files::create_history_path();
 
@@ -296,6 +297,7 @@ fn setup_config(
     stack: &mut Stack,
     config_file: Option<Spanned<String>>,
     env_file: Option<Spanned<String>>,
+    is_login_shell: bool,
 ) {
     #[cfg(feature = "plugin")]
     read_plugin_file(engine_state, stack, NUSHELL_FOLDER, is_perf_true());
@@ -306,6 +308,10 @@ fn setup_config(
 
     config_files::read_config_file(engine_state, stack, env_file, is_perf_true(), true);
     config_files::read_config_file(engine_state, stack, config_file, is_perf_true(), false);
+
+    if is_login_shell {
+        config_files::read_loginshell_file(engine_state, stack, is_perf_true());
+    }
 
     // Give a warning if we see `$config` for a few releases
     {


### PR DESCRIPTION
# Description

If nushell is used as login-shell (-l) and a login.nu file is present in the standard config directory, the file is run. The file is not created (or copied from a default) if it doen't exist unlike the other config files.
Fixes #4620

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
