### PR TITLE
Statically link the CRT on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
-# increase the default windows stack size
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "link-args=-stack:10000000"]
+# increase the default windows stack size
+# statically link the CRT so users don't have to install it
+rustflags = ["-C", "link-args=-stack:10000000", "-C", "target-feature=+crt-static"]
 
 # keeping this but commentting out in case we need them in the future
 


### PR DESCRIPTION
# Description

Statically link the C runtime on Windows so users don't have to install it. Prior this change, if you run Nu on a clean Windows install (or in Windows Sandbox) you get this error message:

![image](https://user-images.githubusercontent.com/26268125/172070285-07faad76-a5c6-49b6-ba5d-3cd01cc7bca2.png)

We do mention the dependency on the Nu homepage ("Windows users may also need to install the latest Microsoft Visual C++ Redistributable."), but ideally we wouldn't have to.

I asked in one of my Windows developer communities and nobody was aware of a compelling reason to not do this. The cost is negligible; it makes nu.exe about 200kb larger in release mode, and I measured several times but wasn't able to notice any impact on build time.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
