### PR TITLE
feat: add search terms to category of strings

### DIFF
--- a/crates/nu-cli/src/nu_highlight.rs
+++ b/crates/nu-cli/src/nu_highlight.rs
@@ -19,6 +19,10 @@ impl Command for NuHighlight {
         "Syntax highlight the input string."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["syntax", "color", "convert"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -28,6 +28,10 @@ impl Command for Print {
         "Prints the values given"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["display"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/decode.rs
+++ b/crates/nu-command/src/strings/decode.rs
@@ -19,6 +19,10 @@ impl Command for Decode {
         "Decode bytes as a string."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["text", "encoding", "decoding"]
+    }
+
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("decode")
             .required("encoding", SyntaxShape::String, "the text encoding to use")

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -35,6 +35,10 @@ impl Command for DetectColumns {
         "Attempt to automatically split text into multiple columns"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["split"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -34,6 +34,10 @@ impl Command for FileSize {
         "Converts a column of filesizes to some specified format"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "display", "pattern", "file", "size"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -19,6 +19,10 @@ impl Command for Parse {
         "Parse columns from string data using a simple pattern."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["pattern", "match"]
+    }
+
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("parse")
             .required(

--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -24,6 +24,10 @@ impl Command for Size {
         "Gather word count statistics on the text."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["count", "word", "character", "unicode"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/split/chars.rs
+++ b/crates/nu-command/src/strings/split/chars.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
         "Split a string's characters into separate rows"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["character", "separate", "divide"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Split the string's characters into separate rows",

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -33,6 +33,10 @@ impl Command for SubCommand {
         "Split a string into multiple columns using a separator"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["column", "separate", "divide"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -33,6 +33,10 @@ impl Command for SubCommand {
         "Split a string into multiple rows using a separator"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["row", "separate", "divide"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -29,6 +29,10 @@ impl Command for SubCommand {
         "Convert a string to camelCase"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "style", "caps", "convention"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -27,6 +27,10 @@ impl Command for SubCommand {
         "Capitalize first letter of text"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "style", "caps", "upper"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -29,6 +29,10 @@ impl Command for SubCommand {
         "Convert a string to kebab-case"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "style", "hyphens", "convention"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -29,6 +29,10 @@ impl Command for SubCommand {
         "Convert a string to PascalCase"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "style", "caps", "upper", "convention"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -28,6 +28,10 @@ impl Command for SubCommand {
         "Convert a string to SCREAMING_SNAKE_CASE"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "style", "snake", "underscore", "convention"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -23,8 +23,20 @@ impl Command for SubCommand {
             )
             .category(Category::Strings)
     }
+
     fn usage(&self) -> &str {
         "Convert a string to snake_case"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec![
+            "convert",
+            "style",
+            "snake",
+            "underscore",
+            "lower",
+            "convention",
+        ]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -29,6 +29,10 @@ impl Command for SubCommand {
         "Convert a string to Title Case"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "style", "title", "convention"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -32,6 +32,10 @@ impl Command for SubCommand {
         "Checks if string contains pattern"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["pattern", "match", "find", "search"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -29,6 +29,10 @@ impl Command for SubCommand {
         "Check if a string ends with a pattern"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["pattern", "match", "find", "search"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -51,6 +51,10 @@ impl Command for SubCommand {
         "Returns start index of first occurrence of pattern in string, or -1 if no match"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["pattern", "match", "find", "search", "index"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -27,6 +27,10 @@ impl Command for SubCommand {
         "Output the length of any strings in the pipeline"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["len", "size", "count"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/lpad.rs
+++ b/crates/nu-command/src/strings/str_/lpad.rs
@@ -41,6 +41,10 @@ impl Command for SubCommand {
         "Left-pad a string to a specific length"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["append", "truncate", "padding"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -51,6 +51,10 @@ impl Command for SubCommand {
         "Find and replace text"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["search", "shift", "switch"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -27,6 +27,10 @@ impl Command for SubCommand {
         "Reverse every string in the pipeline"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "inverse"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/rpad.rs
+++ b/crates/nu-command/src/strings/str_/rpad.rs
@@ -41,6 +41,10 @@ impl Command for SubCommand {
         "Right-pad a string to a specific length"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["append", "truncate", "padding"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -36,6 +36,10 @@ impl Command for SubCommand {
         "Check if string starts with a pattern"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["pattern", "match", "find", "search"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,


### PR DESCRIPTION
# Description
#5093 

Add search term to all commands in strings category.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
