### PR TITLE
fix: normalize some parameter names

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -17,7 +17,7 @@ impl Command for Print {
         Signature::build("print")
             .rest("rest", SyntaxShape::Any, "the values to print")
             .switch(
-                "no_newline",
+                "no-newline",
                 "print without inserting a newline for the line ending",
                 Some('n'),
             )
@@ -40,7 +40,7 @@ impl Command for Print {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let args: Vec<Value> = call.rest(engine_state, stack, 0)?;
-        let no_newline = call.has_flag("no_newline");
+        let no_newline = call.has_flag("no-newline");
         let head = call.head;
 
         for arg in args {

--- a/crates/nu-command/src/database/commands/order_by.rs
+++ b/crates/nu-command/src/database/commands/order_by.rs
@@ -24,7 +24,7 @@ impl Command for OrderByDb {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .switch("ascending", "Order by ascending values", Some('a'))
-            .switch("nulls_first", "Show nulls first in order", Some('n'))
+            .switch("nulls-first", "Show nulls first in order", Some('n'))
             .rest(
                 "select",
                 SyntaxShape::Any,
@@ -40,10 +40,10 @@ impl Command for OrderByDb {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "orders query by a column",
-            example: r#"db open db.mysql 
-    | db from table_a 
-    | db select a 
-    | db order-by a 
+            example: r#"db open db.mysql
+    | db from table_a
+    | db select a
+    | db order-by a
     | db describe"#,
             result: None,
         }]
@@ -57,7 +57,7 @@ impl Command for OrderByDb {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let asc = call.has_flag("ascending");
-        let nulls_first = call.has_flag("nulls_first");
+        let nulls_first = call.has_flag("nulls-first");
         let expressions: Vec<Value> = call.rest(engine_state, stack, 0)?;
         let expressions = Value::List {
             vals: expressions,


### PR DESCRIPTION
# Description

fix: normalize some parameter names

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
