### PR TITLE
print warning message if meet non utf-8 path

### DIFF
--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -422,7 +422,10 @@ impl Iterator for Paths {
                         // FIXME (#9639): How do we handle non-utf8 filenames?
                         // Ignore them for now; ideally we'd still match them
                         // against a *
-                        None => continue,
+                        None => {
+                            println!("warning: get non-utf8 filename {path:?}, ignored.");
+                            continue;
+                        }
                         Some(x) => x,
                     }
                 },


### PR DESCRIPTION
# Description

Fixes: #2987

Currently it's fixed by throwing out warning message


Refer to the relative issue: https://github.com/rust-lang-nursery/glob/issues/23, and the pr: https://github.com/rust-lang/rust/pull/11972, it's hard to make it right.  So for a better work around, I would consider using [globset](https://github.com/BurntSushi/ripgrep/tree/master/crates/globset) instead of [glob](https://github.com/rust-lang-nursery/glob), but I need more time to investigate it.

What do you think about this?

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
