### PR TITLE
make `to text` work more intuitively

### DIFF
--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -1,7 +1,9 @@
-use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack};
+use chrono_humanize::HumanTime;
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    format_duration, format_filesize_from_conf, Category, Config, Example, IntoPipelineData,
+    PipelineData, ShellError, Signature, Value,
 };
 
 #[derive(Clone)]
@@ -36,7 +38,8 @@ impl Command for ToText {
             "\n"
         };
 
-        let collected_input = input.collect_string(line_ending, config)?;
+        let collected_input = local_into_string(input.into_value(span), line_ending, config);
+
         Ok(Value::String {
             val: collected_input,
             span,
@@ -66,6 +69,44 @@ impl Command for ToText {
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["text", "convert"]
+    }
+}
+
+fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
+    match value {
+        Value::Bool { val, .. } => val.to_string(),
+        Value::Int { val, .. } => val.to_string(),
+        Value::Float { val, .. } => val.to_string(),
+        Value::Filesize { val, .. } => format_filesize_from_conf(val, config),
+        Value::Duration { val, .. } => format_duration(val),
+        Value::Date { val, .. } => {
+            format!("{} ({})", val.to_rfc2822(), HumanTime::from(val))
+        }
+        Value::Range { val, .. } => {
+            format!(
+                "{}..{}",
+                local_into_string(val.from, ", ", config),
+                local_into_string(val.to, ", ", config)
+            )
+        }
+        Value::String { val, .. } => val,
+        Value::List { vals: val, .. } => val
+            .iter()
+            .map(|x| local_into_string(x.clone(), ", ", config))
+            .collect::<Vec<_>>()
+            .join(separator),
+        Value::Record { cols, vals, .. } => cols
+            .iter()
+            .zip(vals.iter())
+            .map(|(x, y)| format!("{}: {}", x, local_into_string(y.clone(), ", ", config)))
+            .collect::<Vec<_>>()
+            .join(separator),
+        Value::Block { val, .. } => format!("<Block {}>", val),
+        Value::Nothing { .. } => String::new(),
+        Value::Error { error } => format!("{:?}", error),
+        Value::Binary { val, .. } => format!("{:?}", val),
+        Value::CellPath { val, .. } => val.into_string(),
+        Value::CustomValue { val, .. } => val.value_string(),
     }
 }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2361,7 +2361,7 @@ pub fn format_duration(duration: i64) -> String {
     )
 }
 
-fn format_filesize_from_conf(num_bytes: i64, config: &Config) -> String {
+pub fn format_filesize_from_conf(num_bytes: i64, config: &Config) -> String {
     // We need to take into account config.filesize_metric so, if someone asks for KB
     // filesize_metric is true, return KiB
     format_filesize(


### PR DESCRIPTION
# Description

In this PR I changed the way `to text` works so that it has it's own version of converting to strings called `local_into_string`. It was stolen from other parts of the code base but having it in here allows us to tweak each value type's output as we see fit without affecting other areas of code.

Things like `ls | get name | to text` work better now and `ls | get modified | to text`. I'm not sure about `ls | get size | to text`, we may just want to spit out normal bytes here instead of formatted byte representations.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
