### PR TITLE
Add `$nu.scope.engine_state`

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1177,7 +1177,7 @@ pub fn create_scope(
     let engine_state_cols = vec![
         "source_bytes".to_string(),
         "num_vars".to_string(),
-        "num_decls".to_string(),
+        "num_commands".to_string(),
         "num_aliases".to_string(),
         "num_blocks".to_string(),
         "num_modules".to_string(),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1174,6 +1174,40 @@ pub fn create_scope(
         span,
     });
 
+    let engine_state_cols = vec![
+        "source_bytes".to_string(),
+        "num_vars".to_string(),
+        "num_decls".to_string(),
+        "num_aliases".to_string(),
+        "num_blocks".to_string(),
+        "num_modules".to_string(),
+        "num_env_vars".to_string(),
+    ];
+
+    let engine_state_vals = vec![
+        Value::int(engine_state.next_span_start() as i64, span),
+        Value::int(engine_state.num_vars() as i64, span),
+        Value::int(engine_state.num_decls() as i64, span),
+        Value::int(engine_state.num_aliases() as i64, span),
+        Value::int(engine_state.num_blocks() as i64, span),
+        Value::int(engine_state.num_modules() as i64, span),
+        Value::int(
+            engine_state
+                .env_vars
+                .values()
+                .map(|overlay| overlay.len() as i64)
+                .sum(),
+            span,
+        ),
+    ];
+
+    output_cols.push("engine_state".to_string());
+    output_vals.push(Value::Record {
+        cols: engine_state_cols,
+        vals: engine_state_vals,
+        span,
+    });
+
     Ok(Value::Record {
         cols: output_cols,
         vals: output_vals,


### PR DESCRIPTION
# Description

Adds a new `$nu.scope.engine_state` entry that includes the number of all inserted items in the engine state. It can be useful for tracking how the engine state grows over time.

Example output:
```
> $nu.scope.engine_state
  source_bytes   52951
  num_vars       421
  num_commands   339
  num_aliases    20
  num_blocks     371
  num_modules    9
  num_env_vars   220
```

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
