### PR TITLE
handle SIGQUIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "reedline",
  "rstest",
  "serial_test",
+ "signal-hook",
  "tempfile",
  "winres",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ is_executable = "1.0.1"
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows
 openssl = { version = "0.10.38", features = ["vendored"], optional = true }
+signal-hook = { version = "0.3.14", default-features = false }
 
 [dev-dependencies]
 nu-test-support = { path="./crates/nu-test-support", version = "0.63.1"  }
@@ -118,4 +119,3 @@ debug = false
 [[bin]]
 name = "nu"
 path = "src/main.rs"
-

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -113,6 +113,10 @@ pub fn evaluate_repl(
         if let Some(ctrlc) = &mut engine_state.ctrlc {
             ctrlc.store(false, Ordering::SeqCst);
         }
+        // Reset the SIGQUIT handler
+        if let Some(sig_quit) = engine_state.get_sig_quit() {
+            sig_quit.store(false, Ordering::SeqCst);
+        }
 
         config = engine_state.get_config();
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -75,6 +75,8 @@ pub struct EngineState {
     pub config: Config,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
+    #[cfg(not(windows))]
+    sig_quit: Option<Arc<AtomicBool>>,
 }
 
 pub const NU_VARIABLE_ID: usize = 0;
@@ -106,6 +108,8 @@ impl EngineState {
             config: Config::default(),
             #[cfg(feature = "plugin")]
             plugin_signatures: None,
+            #[cfg(not(windows))]
+            sig_quit: None,
         }
     }
 
@@ -712,6 +716,21 @@ impl EngineState {
         self.files.push((filename, next_span_start, next_span_end));
 
         self.num_files() - 1
+    }
+
+    #[cfg(not(windows))]
+    pub fn get_sig_quit(&self) -> &Option<Arc<AtomicBool>> {
+        &self.sig_quit
+    }
+
+    #[cfg(windows)]
+    pub fn get_sig_quit(&self) -> &Option<Arc<AtomicBool>> {
+        None
+    }
+
+    #[cfg(not(windows))]
+    pub fn set_sig_quit(&mut self, sig_quit: Arc<AtomicBool>) {
+        self.sig_quit = Some(sig_quit)
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -725,7 +725,7 @@ impl EngineState {
 
     #[cfg(windows)]
     pub fn get_sig_quit(&self) -> &Option<Arc<AtomicBool>> {
-        None
+        &None
     }
 
     #[cfg(not(windows))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,16 @@ fn main() -> Result<()> {
     engine_state.ctrlc = Some(engine_state_ctrlc);
     // End ctrl-c protection section
 
+    // SIGQUIT protection section (only works for POSIX system)
+    #[cfg(not(windows))]
+    {
+        use signal_hook::consts::SIGQUIT;
+        let sig_quit = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(SIGQUIT, sig_quit.clone()).expect("Error setting SIGQUIT flag");
+        engine_state.set_sig_quit(sig_quit.clone());
+    }
+    // End SIGQUIT protection section
+
     let mut args_to_nushell = vec![];
     let mut script_name = String::new();
     let mut args_to_script = vec![];

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
         use signal_hook::consts::SIGQUIT;
         let sig_quit = Arc::new(AtomicBool::new(false));
         signal_hook::flag::register(SIGQUIT, sig_quit.clone()).expect("Error setting SIGQUIT flag");
-        engine_state.set_sig_quit(sig_quit.clone());
+        engine_state.set_sig_quit(sig_quit);
     }
     // End SIGQUIT protection section
 


### PR DESCRIPTION
# Description

Fixes: #5615

The problem is cause by `nu` doesn't handle for `SIGQUIT` signal(the signal is not availible on windows), to fix this, just handle that signal.

I think the next steps would be adding `SIGQUIT` handling for some inner `nu` commands(`sleep`, `input`as example)

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
