### PR TITLE
Temporarily disable rust-cache in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,11 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ matrix.style }}v3 # increment this to bust the cache if needed
+      # Temporarily disabled; the cache was getting huge (2.6GB compressed) on Windows and causing issues.
+      # TODO: investigate why the cache was so big
+      # - uses: Swatinem/rust-cache@v1
+      #   with:
+      #     key: ${{ matrix.style }}v3 # increment this to bust the cache if needed
 
       - name: Tests
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
# Description

We've been seeing CI failures on Windows where we run out of disk space. I've noticed that the `rust-cache` cache size for tests has been creeping up lately (it's now 2.6GB on Windows) which might be related. Temporarily disabling `rust-cache` in tests while we sort out the larger issue.