### PR TITLE
input and output types

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -4,6 +4,7 @@ use log::trace;
 use miette::{IntoDiagnostic, Result};
 use nu_engine::convert_env_values;
 use nu_parser::parse;
+use nu_protocol::Type;
 use nu_protocol::{
     ast::Call,
     engine::{EngineState, Stack, StateWorkingSet},
@@ -34,7 +35,7 @@ pub fn evaluate_file(
 
     let _ = parse(&mut working_set, Some(&path), &file, false, &[]);
 
-    if working_set.find_decl(b"main").is_some() {
+    if working_set.find_decl(b"main", &Type::Any).is_some() {
         let args = format!("main {}", args.join(" "));
 
         if !eval_source(

--- a/crates/nu-command/src/database/values/dsl/expression.rs
+++ b/crates/nu-command/src/database/values/dsl/expression.rs
@@ -91,7 +91,7 @@ impl CustomValue for ExprDb {
             Value::Bool { val, .. } => Ok(Expr::Value(sqlparser::ast::Value::Boolean(*val))),
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: Type::Custom,
+                lhs_ty: Type::Custom(self.typetag_name().into()),
                 lhs_span,
                 rhs_ty: right.get_type(),
                 rhs_span: right.span()?,

--- a/crates/nu-command/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu-command/src/dataframe/values/nu_expression/custom_value.rs
@@ -126,9 +126,9 @@ fn with_operator(
             .into_value(lhs_span)),
         _ => Err(ShellError::OperatorMismatch {
             op_span,
-            lhs_ty: Type::Custom,
+            lhs_ty: Type::Custom(left.typetag_name().into()),
             lhs_span,
-            rhs_ty: Type::Custom,
+            rhs_ty: Type::Custom(right.typetag_name().into()),
             rhs_span,
         }),
     }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -829,7 +829,7 @@ pub fn create_scope(
         })
     }
 
-    for (command_name, decl_id) in commands_map {
+    for ((command_name, _), decl_id) in commands_map {
         if visibility.is_decl_id_visible(decl_id) {
             let mut cols = vec![];
             let mut vals = vec![];

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -115,7 +115,7 @@ pub fn parse_for(
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(b"for") {
+    let (call, call_span) = match working_set.find_decl(b"for", &Type::Any) {
         None => {
             return (
                 garbage(spans[0]),
@@ -284,7 +284,7 @@ pub fn parse_def(
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(&def_call) {
+    let (call, call_span) = match working_set.find_decl(&def_call, &Type::Any) {
         None => {
             return (
                 garbage_pipeline(spans),
@@ -427,7 +427,7 @@ pub fn parse_extern(
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(&extern_call) {
+    let (call, call_span) = match working_set.find_decl(&extern_call, &Type::Any) {
         None => {
             return (
                 garbage_pipeline(spans),
@@ -520,7 +520,7 @@ pub fn parse_alias(
             return (Pipeline::from_vec(vec![garbage(*span)]), Some(err));
         }
 
-        if let Some(decl_id) = working_set.find_decl(b"alias") {
+        if let Some(decl_id) = working_set.find_decl(b"alias", &Type::Any) {
             let (call, _) = parse_internal_call(
                 working_set,
                 spans[0],
@@ -622,7 +622,7 @@ pub fn parse_export(
         );
     };
 
-    let export_decl_id = if let Some(id) = working_set.find_decl(b"export") {
+    let export_decl_id = if let Some(id) = working_set.find_decl(b"export", &Type::Any) {
         id
     } else {
         return (
@@ -655,18 +655,19 @@ pub fn parse_export(
                     parse_def(working_set, &lite_command, expand_aliases_denylist);
                 error = error.or(err);
 
-                let export_def_decl_id = if let Some(id) = working_set.find_decl(b"export def") {
-                    id
-                } else {
-                    return (
-                        garbage_pipeline(spans),
-                        None,
-                        Some(ParseError::InternalError(
-                            "missing 'export def' command".into(),
-                            export_span,
-                        )),
-                    );
-                };
+                let export_def_decl_id =
+                    if let Some(id) = working_set.find_decl(b"export def", &Type::Any) {
+                        id
+                    } else {
+                        return (
+                            garbage_pipeline(spans),
+                            None,
+                            Some(ParseError::InternalError(
+                                "missing 'export def' command".into(),
+                                export_span,
+                            )),
+                        );
+                    };
 
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(Expression {
@@ -690,7 +691,7 @@ pub fn parse_export(
                 if error.is_none() {
                     let decl_name = working_set.get_span_contents(spans[2]);
                     let decl_name = trim_quotes(decl_name);
-                    if let Some(decl_id) = working_set.find_decl(decl_name) {
+                    if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Any) {
                         Some(Exportable::Decl(decl_id))
                     } else {
                         error = error.or_else(|| {
@@ -714,19 +715,19 @@ pub fn parse_export(
                     parse_def(working_set, &lite_command, expand_aliases_denylist);
                 error = error.or(err);
 
-                let export_def_decl_id = if let Some(id) = working_set.find_decl(b"export def-env")
-                {
-                    id
-                } else {
-                    return (
-                        garbage_pipeline(spans),
-                        None,
-                        Some(ParseError::InternalError(
-                            "missing 'export def-env' command".into(),
-                            export_span,
-                        )),
-                    );
-                };
+                let export_def_decl_id =
+                    if let Some(id) = working_set.find_decl(b"export def-env", &Type::Any) {
+                        id
+                    } else {
+                        return (
+                            garbage_pipeline(spans),
+                            None,
+                            Some(ParseError::InternalError(
+                                "missing 'export def-env' command".into(),
+                                export_span,
+                            )),
+                        );
+                    };
 
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(Expression {
@@ -750,7 +751,7 @@ pub fn parse_export(
                 if error.is_none() {
                     let decl_name = working_set.get_span_contents(spans[2]);
                     let decl_name = trim_quotes(decl_name);
-                    if let Some(decl_id) = working_set.find_decl(decl_name) {
+                    if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Any) {
                         Some(Exportable::Decl(decl_id))
                     } else {
                         error = error.or_else(|| {
@@ -774,18 +775,19 @@ pub fn parse_export(
                     parse_extern(working_set, &lite_command, expand_aliases_denylist);
                 error = error.or(err);
 
-                let export_def_decl_id = if let Some(id) = working_set.find_decl(b"export extern") {
-                    id
-                } else {
-                    return (
-                        garbage_pipeline(spans),
-                        None,
-                        Some(ParseError::InternalError(
-                            "missing 'export extern' command".into(),
-                            export_span,
-                        )),
-                    );
-                };
+                let export_def_decl_id =
+                    if let Some(id) = working_set.find_decl(b"export extern", &Type::Any) {
+                        id
+                    } else {
+                        return (
+                            garbage_pipeline(spans),
+                            None,
+                            Some(ParseError::InternalError(
+                                "missing 'export extern' command".into(),
+                                export_span,
+                            )),
+                        );
+                    };
 
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(Expression {
@@ -809,7 +811,7 @@ pub fn parse_export(
                 if error.is_none() {
                     let decl_name = working_set.get_span_contents(spans[2]);
                     let decl_name = trim_quotes(decl_name);
-                    if let Some(decl_id) = working_set.find_decl(decl_name) {
+                    if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Any) {
                         Some(Exportable::Decl(decl_id))
                     } else {
                         error = error.or_else(|| {
@@ -833,19 +835,19 @@ pub fn parse_export(
                     parse_alias(working_set, &lite_command.parts, expand_aliases_denylist);
                 error = error.or(err);
 
-                let export_alias_decl_id = if let Some(id) = working_set.find_decl(b"export alias")
-                {
-                    id
-                } else {
-                    return (
-                        garbage_pipeline(spans),
-                        None,
-                        Some(ParseError::InternalError(
-                            "missing 'export alias' command".into(),
-                            export_span,
-                        )),
-                    );
-                };
+                let export_alias_decl_id =
+                    if let Some(id) = working_set.find_decl(b"export alias", &Type::Any) {
+                        id
+                    } else {
+                        return (
+                            garbage_pipeline(spans),
+                            None,
+                            Some(ParseError::InternalError(
+                                "missing 'export alias' command".into(),
+                                export_span,
+                            )),
+                        );
+                    };
 
                 // Trying to warp the 'alias' call into the 'export alias' in a very clumsy way
                 if let Some(Expression {
@@ -885,7 +887,7 @@ pub fn parse_export(
                 }
             }
             b"env" => {
-                if let Some(id) = working_set.find_decl(b"export env") {
+                if let Some(id) = working_set.find_decl(b"export env", &Type::Any) {
                     call.decl_id = id;
                 } else {
                     return (
@@ -1190,7 +1192,7 @@ pub fn parse_module(
         };
 
         let module_decl_id = working_set
-            .find_decl(b"module")
+            .find_decl(b"module", &Type::Any)
             .expect("internal error: missing module command");
 
         let call = Box::new(Call {
@@ -1239,7 +1241,7 @@ pub fn parse_use(
         );
     }
 
-    let (call, call_span, use_decl_id) = match working_set.find_decl(b"use") {
+    let (call, call_span, use_decl_id) = match working_set.find_decl(b"use", &Type::Any) {
         Some(decl_id) => {
             let (call, mut err) = parse_internal_call(
                 working_set,
@@ -1472,7 +1474,7 @@ pub fn parse_hide(
         );
     }
 
-    let (call, call_span, hide_decl_id) = match working_set.find_decl(b"hide") {
+    let (call, call_span, hide_decl_id) = match working_set.find_decl(b"hide", &Type::Any) {
         Some(decl_id) => {
             let (call, mut err) = parse_internal_call(
                 working_set,
@@ -1542,33 +1544,34 @@ pub fn parse_hide(
             error = error.or(err);
         }
 
-        let (is_module, module) =
-            if let Some(module_id) = working_set.find_module(&import_pattern.head.name) {
-                (true, working_set.get_module(module_id).clone())
-            } else if import_pattern.members.is_empty() {
-                // The pattern head can be:
-                if let Some(id) = working_set.find_alias(&import_pattern.head.name) {
-                    // an alias,
-                    let mut module = Module::new();
-                    module.add_alias(&import_pattern.head.name, id);
+        let (is_module, module) = if let Some(module_id) =
+            working_set.find_module(&import_pattern.head.name)
+        {
+            (true, working_set.get_module(module_id).clone())
+        } else if import_pattern.members.is_empty() {
+            // The pattern head can be:
+            if let Some(id) = working_set.find_alias(&import_pattern.head.name) {
+                // an alias,
+                let mut module = Module::new();
+                module.add_alias(&import_pattern.head.name, id);
 
-                    (false, module)
-                } else if let Some(id) = working_set.find_decl(&import_pattern.head.name) {
-                    // a custom command,
-                    let mut module = Module::new();
-                    module.add_decl(&import_pattern.head.name, id);
+                (false, module)
+            } else if let Some(id) = working_set.find_decl(&import_pattern.head.name, &Type::Any) {
+                // a custom command,
+                let mut module = Module::new();
+                module.add_decl(&import_pattern.head.name, id);
 
-                    (false, module)
-                } else {
-                    // , or it could be an env var (handled by the engine)
-                    (false, Module::new())
-                }
+                (false, module)
             } else {
-                return (
-                    garbage_pipeline(spans),
-                    Some(ParseError::ModuleNotFound(spans[1])),
-                );
-            };
+                // , or it could be an env var (handled by the engine)
+                (false, Module::new())
+            }
+        } else {
+            return (
+                garbage_pipeline(spans),
+                Some(ParseError::ModuleNotFound(spans[1])),
+            );
+        };
 
         // This kind of inverts the import pattern matching found in parse_use()
         let (aliases_to_hide, decls_to_hide) = if import_pattern.members.is_empty() {
@@ -1696,7 +1699,7 @@ pub fn parse_overlay(
             }
             b"list" => {
                 // TODO: Abstract this code blob, it's repeated all over the place:
-                let call = match working_set.find_decl(b"overlay list") {
+                let call = match working_set.find_decl(b"overlay list", &Type::Any) {
                     Some(decl_id) => {
                         let (call, mut err) = parse_internal_call(
                             working_set,
@@ -1755,7 +1758,7 @@ pub fn parse_overlay(
         }
     }
 
-    let call = match working_set.find_decl(b"overlay") {
+    let call = match working_set.find_decl(b"overlay", &Type::Any) {
         Some(decl_id) => {
             let (call, mut err) = parse_internal_call(
                 working_set,
@@ -1820,7 +1823,7 @@ pub fn parse_overlay_new(
         );
     }
 
-    let (call, call_span) = match working_set.find_decl(b"overlay new") {
+    let (call, call_span) = match working_set.find_decl(b"overlay new", &Type::Any) {
         Some(decl_id) => {
             let (call, mut err) = parse_internal_call(
                 working_set,
@@ -1911,7 +1914,7 @@ pub fn parse_overlay_add(
     }
 
     // TODO: Allow full import pattern as argument (requires custom naming of module/overlay)
-    let (call, call_span) = match working_set.find_decl(b"overlay add") {
+    let (call, call_span) = match working_set.find_decl(b"overlay add", &Type::Any) {
         Some(decl_id) => {
             let (call, mut err) = parse_internal_call(
                 working_set,
@@ -2098,7 +2101,7 @@ pub fn parse_overlay_remove(
         );
     }
 
-    let call = match working_set.find_decl(b"overlay remove") {
+    let call = match working_set.find_decl(b"overlay remove", &Type::Any) {
         Some(decl_id) => {
             let (call, mut err) = parse_internal_call(
                 working_set,
@@ -2209,7 +2212,7 @@ pub fn parse_let(
             return (Pipeline::from_vec(vec![garbage(*span)]), Some(err));
         }
 
-        if let Some(decl_id) = working_set.find_decl(b"let") {
+        if let Some(decl_id) = working_set.find_decl(b"let", &Type::Any) {
             let cmd = working_set.get_decl(decl_id);
             let call_signature = cmd.signature().call_signature();
 
@@ -2313,7 +2316,7 @@ pub fn parse_source(
     let name = working_set.get_span_contents(spans[0]);
 
     if name == b"source" {
-        if let Some(decl_id) = working_set.find_decl(b"source") {
+        if let Some(decl_id) = working_set.find_decl(b"source", &Type::Any) {
             let cwd = working_set.get_cwd();
             // Is this the right call to be using here?
             // Some of the others (`parse_let`) use it, some of them (`parse_hide`) don't.
@@ -2445,7 +2448,7 @@ pub fn parse_register(
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(b"register") {
+    let (call, call_span) = match working_set.find_decl(b"register", &Type::Any) {
         None => {
             return (
                 garbage_pipeline(spans),

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -695,7 +695,7 @@ mod input_types {
         }
 
         fn output_type(&self) -> nu_protocol::Type {
-            Type::Custom
+            Type::Custom("custom".into())
         }
     }
 
@@ -758,11 +758,11 @@ mod input_types {
         }
 
         fn input_type(&self) -> nu_protocol::Type {
-            Type::Custom
+            Type::Custom("custom".into())
         }
 
         fn output_type(&self) -> nu_protocol::Type {
-            Type::Custom
+            Type::Custom("custom".into())
         }
     }
 
@@ -795,7 +795,7 @@ mod input_types {
         }
 
         fn input_type(&self) -> nu_protocol::Type {
-            Type::Custom
+            Type::Custom("custom".into())
         }
     }
 
@@ -842,7 +842,9 @@ mod input_types {
 
         match &expressions[1].expr {
             Expr::Call(call) => {
-                let expected_id = working_set.find_decl(b"group-by", &Type::Custom).unwrap();
+                let expected_id = working_set
+                    .find_decl(b"group-by", &Type::Custom("custom".into()))
+                    .unwrap();
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),
@@ -865,7 +867,9 @@ mod input_types {
         let expressions = &block[2];
         match &expressions[1].expr {
             Expr::Call(call) => {
-                let expected_id = working_set.find_decl(b"agg", &Type::Custom).unwrap();
+                let expected_id = working_set
+                    .find_decl(b"agg", &Type::Custom("custom".into()))
+                    .unwrap();
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -693,10 +693,6 @@ mod input_types {
         ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
             todo!()
         }
-
-        fn output_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
-        }
     }
 
     #[derive(Clone)]
@@ -725,6 +721,41 @@ mod input_types {
             _input: nu_protocol::PipelineData,
         ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
             todo!()
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct ToCustom;
+
+    impl Command for ToCustom {
+        fn name(&self) -> &str {
+            "to-custom"
+        }
+
+        fn usage(&self) -> &str {
+            "Mock converter command"
+        }
+
+        fn signature(&self) -> nu_protocol::Signature {
+            Signature::build(self.name()).category(Category::Custom("custom".into()))
+        }
+
+        fn run(
+            &self,
+            _engine_state: &EngineState,
+            _stack: &mut Stack,
+            _call: &nu_protocol::ast::Call,
+            _input: nu_protocol::PipelineData,
+        ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+            todo!()
+        }
+
+        fn input_type(&self) -> nu_protocol::Type {
+            Type::Any
+        }
+
+        fn output_type(&self) -> nu_protocol::Type {
+            Type::Custom("custom".into())
         }
     }
 
@@ -807,6 +838,7 @@ mod input_types {
             working_set.add_decl(Box::new(GroupByCustom));
             working_set.add_decl(Box::new(GroupByList));
             working_set.add_decl(Box::new(LsTest));
+            working_set.add_decl(Box::new(ToCustom));
             working_set.add_decl(Box::new(Let));
 
             working_set.render()
@@ -822,7 +854,76 @@ mod input_types {
         add_declations(&mut engine_state);
 
         let mut working_set = StateWorkingSet::new(&engine_state);
-        let input = r#"ls | group-by name other"#;
+        let input = r#"ls | to-custom | group-by name other"#;
+
+        let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+
+        assert!(err.is_none());
+        assert!(block.len() == 1);
+
+        let expressions = &block[0];
+        assert!(expressions.len() == 3);
+
+        match &expressions[0].expr {
+            Expr::Call(call) => {
+                let expected_id = working_set.find_decl(b"ls", &Type::Any).unwrap();
+                assert_eq!(call.decl_id, expected_id)
+            }
+            _ => panic!("Expected expression Call not found"),
+        }
+
+        match &expressions[1].expr {
+            Expr::Call(call) => {
+                let expected_id = working_set.find_decl(b"to-custom", &Type::Any).unwrap();
+                assert_eq!(call.decl_id, expected_id)
+            }
+            _ => panic!("Expected expression Call not found"),
+        }
+
+        match &expressions[2].expr {
+            Expr::Call(call) => {
+                let expected_id = working_set
+                    .find_decl(b"group-by", &Type::Custom("custom".into()))
+                    .unwrap();
+                assert_eq!(call.decl_id, expected_id)
+            }
+            _ => panic!("Expected expression Call not found"),
+        }
+    }
+
+    #[test]
+    fn storing_variable_test() {
+        let mut engine_state = EngineState::new();
+        add_declations(&mut engine_state);
+
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let input =
+            r#"let a = (ls | to-custom | group-by name other); let b = (1+3); $a | agg sum"#;
+
+        let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+
+        assert!(err.is_none());
+        assert!(block.len() == 3);
+
+        let expressions = &block[2];
+        match &expressions[1].expr {
+            Expr::Call(call) => {
+                let expected_id = working_set
+                    .find_decl(b"agg", &Type::Custom("custom".into()))
+                    .unwrap();
+                assert_eq!(call.decl_id, expected_id)
+            }
+            _ => panic!("Expected expression Call not found"),
+        }
+    }
+
+    #[test]
+    fn call_non_custom_types_test() {
+        let mut engine_state = EngineState::new();
+        add_declations(&mut engine_state);
+
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let input = r#"ls | group-by name"#;
 
         let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
@@ -842,34 +943,7 @@ mod input_types {
 
         match &expressions[1].expr {
             Expr::Call(call) => {
-                let expected_id = working_set
-                    .find_decl(b"group-by", &Type::Custom("custom".into()))
-                    .unwrap();
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-    }
-
-    #[test]
-    fn storing_variable_test() {
-        let mut engine_state = EngineState::new();
-        add_declations(&mut engine_state);
-
-        let mut working_set = StateWorkingSet::new(&engine_state);
-        let input = r#"let a = (ls | group-by name other); let b = (1+3); $a | agg sum"#;
-
-        let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
-
-        assert!(err.is_none());
-        assert!(block.len() == 3);
-
-        let expressions = &block[2];
-        match &expressions[1].expr {
-            Expr::Call(call) => {
-                let expected_id = working_set
-                    .find_decl(b"agg", &Type::Custom("custom".into()))
-                    .unwrap();
+                let expected_id = working_set.find_decl(b"group-by", &Type::Any).unwrap();
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{ast::Call, BlockId, Example, PipelineData, ShellError, Signature};
+use crate::{ast::Call, BlockId, Example, PipelineData, ShellError, Signature, Type};
 
 use super::{EngineState, Stack};
 
@@ -65,6 +65,16 @@ pub trait Command: Send + Sync + CommandClone {
     // Related terms to help with command search
     fn search_terms(&self) -> Vec<&str> {
         vec![]
+    }
+
+    // Command input type
+    fn input_type(&self) -> Type {
+        Type::Any
+    }
+
+    // Command output type
+    fn output_type(&self) -> Type {
+        Type::Any
     }
 }
 

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -67,12 +67,16 @@ pub trait Command: Send + Sync + CommandClone {
         vec![]
     }
 
-    // Command input type
+    // Command input type. The Type is used during parsing to find the
+    // correct internal command with similar names. The input type is
+    // obtained from the previous expression found in the pipeline
     fn input_type(&self) -> Type {
         Type::Any
     }
 
-    // Command output type
+    // Command output type. The output type is the value from  the command
+    // It is used during parsing to find the next command in case there
+    // are commands with similar names
     fn output_type(&self) -> Type {
         Type::Any
     }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -25,7 +25,7 @@ pub enum Type {
     Any,
     Error,
     Binary,
-    Custom,
+    Custom(String),
     Signature,
 }
 
@@ -51,7 +51,7 @@ impl Type {
             Type::Any => SyntaxShape::Any,
             Type::Error => SyntaxShape::Any,
             Type::Binary => SyntaxShape::Binary,
-            Type::Custom => SyntaxShape::Any,
+            Type::Custom(_) => SyntaxShape::Any,
             Type::Signature => SyntaxShape::Signature,
         }
     }
@@ -95,7 +95,7 @@ impl Display for Type {
             Type::Any => write!(f, "any"),
             Type::Error => write!(f, "error"),
             Type::Binary => write!(f, "binary"),
-            Type::Custom => write!(f, "custom"),
+            Type::Custom(custom) => write!(f, "custom<{}>", custom),
             Type::Signature => write!(f, "signature"),
         }
     }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use crate::SyntaxShape;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Type {
     Int,
     Float,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -417,7 +417,7 @@ impl Value {
             Value::Error { .. } => Type::Error,
             Value::Binary { .. } => Type::Binary,
             Value::CellPath { .. } => Type::CellPath,
-            Value::CustomValue { .. } => Type::Custom,
+            Value::CustomValue { val, .. } => Type::Custom(val.typetag_name().into()),
         }
     }
 


### PR DESCRIPTION
# Description

Introduces input and output types for internal commands
This should allow to overload functions based on the input type

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
