### PR TITLE
While starting nu, force PWD to be current working directory

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -334,6 +334,7 @@ mod test {
             ]
             .into_iter(),
             &mut engine_state,
+            Path::new("t"),
         );
 
         let env = engine_state.render_env_vars();

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -67,7 +67,8 @@ macro_rules! nu {
         let target_cwd = $crate::fs::in_directory(&$cwd);
 
         let mut process = match Command::new($crate::fs::executable_path())
-            .env("PWD", &target_cwd)  // setting PWD is enough to set cwd
+            .env("PWD", &target_cwd)
+            .current_dir(target_cwd)
             .env(NATIVE_PATH_ENV_VAR, paths_joined)
             // .arg("--skip-plugins")
             // .arg("--no-history")

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,7 @@ fn main() -> Result<()> {
             }
 
             // First, set up env vars as strings only
-            gather_parent_env_vars(&mut engine_state);
+            gather_parent_env_vars(&mut engine_state, &init_cwd);
             let mut stack = nu_protocol::engine::Stack::new();
 
             if let Some(commands) = &binary_args.commands {


### PR DESCRIPTION
# Description

Fixes: #5050

I don't change `merge_delta()` because it seems hard to change, especially we have some overlays and some stacks.

Instead, The issue seems only happens during start `nu`, so maybe it's just enough to change `gather_parent_env_vars` function.

## The reason to use `init_cwd`:
While gathering parent env vars, the parent `PWD` may not be the same as `current working directory`.
Consider to the following command as the case (assume we execute command inside `/tmp`):

    tmux split-window -v -c "#{pane_current_path}"

Here nu execute external command `tmux`, and tmux starts a new `nushell`, with `init_cwd` value "#{pane_current_path}".

But at the same time `PWD` still remains to be `/tmp`.

In this scenario, the new `nushell`'s PWD should be "#{pane_current_path}" rather init_cwd.

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
