### PR TITLE
fix arg parse

### DIFF
--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,6 +1,3 @@
-use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
-
 pub fn escape_quote_string(input: &str) -> String {
     let mut output = String::with_capacity(input.len() + 2);
     output.push('"');
@@ -16,199 +13,80 @@ pub fn escape_quote_string(input: &str) -> String {
     output
 }
 
-fn looks_like_flag(input: &str) -> bool {
-    if !input.starts_with('-') {
-        false
-        // it does not start with  '-'
-    } else if !input.starts_with("--") {
-        if input.len() > 2
-            && input.chars().nth(2).expect("this should never trigger") != '='
-            && input.chars().nth(2).expect("this should never trigger") != ' '
-        {
-            false
-            // while it start with '-', it is not of the form '-x=y' or '-x y'
-        } else {
-            input.len() >= 2
+// Escape rules:
+// input argument contains ' '(like abc def), we will convert it to `abc def`.
+// input argument contains --version='xx yy', we will convert it to --version=`'xx yy'`
+// input argument contains " or \, we will try to escape input.
+pub fn escape_for_script_arg(input: &str) -> String {
+    // handle for flag, maybe we need to escape the value.
+    if input.starts_with("--") {
+        if let Some((arg_name, arg_val)) = input.split_once('=') {
+            // only want to escape arg_val.
+            let arg_val = if arg_val.contains(' ') {
+                format!("`{}`", arg_val)
+            } else if arg_val.contains('"') || arg_val.contains('\\') {
+                escape_quote_string(arg_val)
+            } else {
+                arg_val.into()
+            };
+            return format!("{}={}", arg_name, arg_val);
         }
+    }
+
+    if input.contains(' ') {
+        format!("`{}`", input)
+    } else if input.contains('"') || input.contains('\\') {
+        escape_quote_string(input)
     } else {
-        input.len() > 2
-        // it is either a flag --x or a '--'
-    }
-}
-
-fn escape_quote_string_when_flags_are_unclear(input: &str) -> String {
-    // internal use only. When reading the file for flags goes wrong, revert back to a manual check
-    // for flags.
-    let mut output = String::new();
-    if !looks_like_flag(input) {
-        output.push('"');
-        for c in input.chars() {
-            if c == '"' || c == '\\' {
-                output.push('\\');
-            }
-            output.push(c);
-        }
-        output.push('"');
-        output
-    } else if input.contains(' ') || input.contains('=') {
-        // this is a flag that requires delicate handling
-        let mut flag_tripped = false;
-        for c in input.chars() {
-            if c == '"' || c == '\\' {
-                output.push('\\');
-            }
-            output.push(c);
-            if (c == ' ' || c == '=') && !flag_tripped {
-                flag_tripped = true;
-                output.push('"');
-            }
-        }
-        output.push('"');
-        output
-    } else {
-        // this is a normal flag, aka "--x"
-        String::from(input)
-    }
-}
-
-pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
-    // use when you want to cross-compare to a file to ensure flags are checked properly
-    let file = File::open(file);
-    match file {
-        Ok(f) => escape_quote_string_with_reader(f, input),
-        _ => escape_quote_string_when_flags_are_unclear(input),
-    }
-}
-
-fn escape_quote_string_with_reader<R>(input: R, input_arg: &str) -> String
-where
-    R: Read,
-{
-    let lines = BufReader::new(input).lines();
-
-    for line in lines {
-        let mut flag_start = false;
-        let mut word = String::new();
-        let line_or = line.unwrap_or_else(|_| String::from(" "));
-        if line_or.contains('-') {
-            for n in line_or.chars() {
-                if n == '-' {
-                    flag_start = true;
-                }
-                if n == ' ' || n == ':' || n == ')' {
-                    flag_start = false;
-                }
-                if flag_start {
-                    word.push(n);
-                }
-            }
-        }
-
-        if word.contains(input_arg) {
-            return input_arg.to_string();
-        } else if let Some((arg_name, arg_val)) = input_arg.split_once('=') {
-            if word.contains(arg_name) && arg_val.contains(' ') {
-                return format!("{}=`{}`", arg_name, arg_val);
-            }
-        }
-    }
-    if input_arg.contains(' ') {
-        format!("`{}`", input_arg)
-    } else if input_arg.contains('"') || input_arg.contains('\\') {
-        escape_quote_string(input_arg)
-    } else {
-        input_arg.to_string()
+        input.to_string()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::escape_quote_string_with_reader;
+    use super::escape_for_script_arg;
 
     #[test]
     fn test_not_extra_quote() {
-        let body = r#"
-        def main [x: int] {
-            $x + 10
-        }
-        "#;
-        let input_file = body.as_bytes();
         // check for input arg like this:
         // nu b.nu 8
-        assert_eq!(
-            escape_quote_string_with_reader(input_file, "8"),
-            "8".to_string()
-        );
+        assert_eq!(escape_for_script_arg("8"), "8".to_string());
     }
 
     #[test]
     fn test_arg_with_flag() {
-        let body = r#"
-        def main [kernel: string, --version: string] {
-            echo $kernel;
-            echo $version
-        }
-        "#;
-        let input_file = body.as_bytes();
         // check for input arg like this:
         // nu b.nu linux --version=v5.2
+        assert_eq!(escape_for_script_arg("linux"), "linux".to_string());
         assert_eq!(
-            escape_quote_string_with_reader(input_file, "linux"),
-            "linux".to_string()
-        );
-        assert_eq!(
-            escape_quote_string_with_reader(input_file, "--version=v5.2"),
+            escape_for_script_arg("--version=v5.2"),
             "--version=v5.2".to_string()
         );
 
         // check for input arg like this:
         // nu b.nu linux --version v5.2
-        assert_eq!(
-            escape_quote_string_with_reader(input_file, "--version"),
-            "--version".to_string()
-        );
-        assert_eq!(
-            escape_quote_string_with_reader(input_file, "v5.2"),
-            "v5.2".to_string()
-        );
+        assert_eq!(escape_for_script_arg("--version"), "--version".to_string());
+        assert_eq!(escape_for_script_arg("v5.2"), "v5.2".to_string());
     }
 
     #[test]
     fn test_flag_arg_with_values_contains_space() {
-        let body = r#"
-        def main [kernel: string, --version: string, --arch: string] {
-            echo $kernel
-            echo $version
-            echo $arch
-        }
-        "#;
-        let input_file = body.as_bytes();
-
         // check for input arg like this:
         // nu b.nu test_ver --version='xx yy' --arch=ghi
         assert_eq!(
-            escape_quote_string_with_reader(input_file, "--version='xx yy'"),
+            escape_for_script_arg("--version='xx yy'"),
             "--version=`'xx yy'`".to_string()
         );
         assert_eq!(
-            escape_quote_string_with_reader(input_file, "--arch=ghi"),
+            escape_for_script_arg("--arch=ghi"),
             "--arch=ghi".to_string()
         );
     }
 
     #[test]
     fn test_escape() {
-        let body = r#"
-        def main [x: any] {
-            echo $x
-        }"#;
-        let input_file = body.as_bytes();
-
         // check for input arg like this:
         // nu b.nu '"'
-        assert_eq!(
-            escape_quote_string_with_reader(input_file, r#"""#),
-            r#""\"""#.to_string()
-        );
+        assert_eq!(escape_for_script_arg(r#"""#), r#""\"""#.to_string());
     }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 
 pub fn escape_quote_string(input: &str) -> String {
     let mut output = String::with_capacity(input.len() + 2);
@@ -75,46 +75,140 @@ pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
     // use when you want to cross-compare to a file to ensure flags are checked properly
     let file = File::open(file);
     match file {
-        Ok(f) => {
-            let lines = BufReader::new(f).lines();
-            for line in lines {
-                let mut flag_start = false;
-                let mut word = String::new();
-                let line_or = line.unwrap_or_else(|_| String::from(" "));
-                if line_or.contains('-') {
-                    for n in line_or.chars() {
-                        if n == '-' {
-                            flag_start = true;
-                        }
-                        if n == ' ' || n == ':' || n == ')' {
-                            flag_start = false;
-                        }
-                        if flag_start {
-                            word.push(n);
-                        }
-                    }
-                }
+        Ok(f) => escape_quote_string_with_reader(f, input),
+        _ => escape_quote_string_when_flags_are_unclear(input),
+    }
+}
 
-                if word.contains(input) {
-                    return input.to_string();
-                } else {
-                    if let Some((arg_name, arg_val)) = input.split_once('=') {
-                        if word.contains(arg_name) {
-                            if arg_val.contains(' ') {
-                                return format!("{}=`{}`", arg_name, arg_val);
-                            }
-                        }
-                    }
+fn escape_quote_string_with_reader<R>(input: R, input_arg: &str) -> String
+where
+    R: Read,
+{
+    let lines = BufReader::new(input).lines();
+
+    for line in lines {
+        let mut flag_start = false;
+        let mut word = String::new();
+        let line_or = line.unwrap_or_else(|_| String::from(" "));
+        if line_or.contains('-') {
+            for n in line_or.chars() {
+                if n == '-' {
+                    flag_start = true;
                 }
-            }
-            if input.contains(' ') {
-                format!("`{}`", input)
-            } else if input.contains('"') || input.contains('\\') {
-                escape_quote_string(input)
-            } else {
-                input.to_string()
+                if n == ' ' || n == ':' || n == ')' {
+                    flag_start = false;
+                }
+                if flag_start {
+                    word.push(n);
+                }
             }
         }
-        _ => escape_quote_string_when_flags_are_unclear(input),
+
+        if word.contains(input_arg) {
+            return input_arg.to_string();
+        } else if let Some((arg_name, arg_val)) = input_arg.split_once('=') {
+            if word.contains(arg_name) && arg_val.contains(' ') {
+                return format!("{}=`{}`", arg_name, arg_val);
+            }
+        }
+    }
+    if input_arg.contains(' ') {
+        format!("`{}`", input_arg)
+    } else if input_arg.contains('"') || input_arg.contains('\\') {
+        escape_quote_string(input_arg)
+    } else {
+        input_arg.to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::escape_quote_string_with_reader;
+
+    #[test]
+    fn test_not_extra_quote() {
+        let body = r#"
+        def main [x: int] {
+            $x + 10
+        }
+        "#;
+        let input_file = body.as_bytes();
+        // check for input arg like this:
+        // nu b.nu 8
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, "8"),
+            "8".to_string()
+        );
+    }
+
+    #[test]
+    fn test_arg_with_flag() {
+        let body = r#"
+        def main [kernel: string, --version: string] {
+            echo $kernel;
+            echo $version
+        }
+        "#;
+        let input_file = body.as_bytes();
+        // check for input arg like this:
+        // nu b.nu linux --version=v5.2
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, "linux"),
+            "linux".to_string()
+        );
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, "--version=v5.2"),
+            "--version=v5.2".to_string()
+        );
+
+        // check for input arg like this:
+        // nu b.nu linux --version v5.2
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, "--version"),
+            "--version".to_string()
+        );
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, "v5.2"),
+            "v5.2".to_string()
+        );
+    }
+
+    #[test]
+    fn test_flag_arg_with_values_contains_space() {
+        let body = r#"
+        def main [kernel: string, --version: string, --arch: string] {
+            echo $kernel
+            echo $version
+            echo $arch
+        }
+        "#;
+        let input_file = body.as_bytes();
+
+        // check for input arg like this:
+        // nu b.nu test_ver --version='xx yy' --arch=ghi
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, "--version='xx yy'"),
+            "--version=`'xx yy'`".to_string()
+        );
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, "--arch=ghi"),
+            "--arch=ghi".to_string()
+        );
+    }
+
+    #[test]
+    fn test_escape() {
+        let body = r#"
+        def main [x: any] {
+            echo $x
+        }"#;
+        let input_file = body.as_bytes();
+
+        // check for input arg like this:
+        // nu b.nu '"'
+        assert_eq!(
+            escape_quote_string_with_reader(input_file, r#"""#),
+            r#""\"""#.to_string()
+        );
     }
 }

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -94,18 +94,26 @@ pub fn escape_quote_string_with_file(input: &str, file: &str) -> String {
                         }
                     }
                 }
-                if word.contains(input) || {
-                    let s: Vec<&str> = input.split('=').collect();
-                    word.contains(s[0])
-                } {
+
+                if word.contains(input) {
                     return input.to_string();
+                } else {
+                    if let Some((arg_name, arg_val)) = input.split_once('=') {
+                        if word.contains(arg_name) {
+                            if arg_val.contains(' ') {
+                                return format!("{}=`{}`", arg_name, arg_val);
+                            }
+                        }
+                    }
                 }
             }
-            let mut final_word = String::new();
-            final_word.push('"');
-            final_word.push_str(input);
-            final_word.push('"');
-            final_word
+            if input.contains(' ') {
+                format!("`{}`", input)
+            } else if input.contains('"') || input.contains('\\') {
+                escape_quote_string(input)
+            } else {
+                input.to_string()
+            }
         }
         _ => escape_quote_string_when_flags_are_unclear(input),
     }

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -8,7 +8,7 @@ mod parse_keywords;
 mod parser;
 mod type_check;
 
-pub use deparse::{escape_quote_string, escape_quote_string_with_file};
+pub use deparse::{escape_quote_string, escape_for_script_arg};
 pub use errors::ParseError;
 pub use flatten::{flatten_block, flatten_expression, flatten_pipeline, FlatShape};
 pub use known_external::KnownExternal;

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -8,7 +8,7 @@ mod parse_keywords;
 mod parser;
 mod type_check;
 
-pub use deparse::{escape_quote_string, escape_for_script_arg};
+pub use deparse::{escape_for_script_arg, escape_quote_string};
 pub use errors::ParseError;
 pub use flatten::{flatten_block, flatten_expression, flatten_pipeline, FlatShape};
 pub use known_external::KnownExternal;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use nu_cli::{
 };
 use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
-use nu_parser::{escape_quote_string, escape_for_script_arg, parse};
+use nu_parser::{escape_for_script_arg, escape_quote_string, parse};
 use nu_protocol::{
     ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use nu_cli::{
 };
 use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
-use nu_parser::{escape_quote_string, escape_quote_string_with_file, parse};
+use nu_parser::{escape_quote_string, escape_for_script_arg, parse};
 use nu_protocol::{
     ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},
@@ -93,7 +93,7 @@ fn main() -> Result<()> {
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         if !script_name.is_empty() {
-            args_to_script.push(escape_quote_string_with_file(&arg, &script_name));
+            args_to_script.push(escape_for_script_arg(&arg));
         } else if arg.starts_with('-') {
             // Cool, it's a flag
             let flag_value = match arg.as_ref() {


### PR DESCRIPTION
# Description

Fixes: #5472 
Fixes: #5753 

## General idea
By default, we don't want to `escape input arguments`, except the following case:
1. input argument contains `' '`(like `abc def`), we will convert it to \`abc def\` (It's the original behavior)
2. input argument contains `--version='xx yy'`, we will convert it to --version=\`xx yy\`
3. input argument contains `"` or `\`, we will try to escape input.

In other cases, keep input arguments to the same.

## About change
I rewrite original `escape_quote_string_with_file` to `escape_for_script_arg`.

It seems that we don't really need to read and parse script file to make escape working.

## About testing

I have manually tests for the following scenario which shows in some issues (#5371 , #5532):
```
# a.nu
# with test code:
# nu a.nu 3
def main [x: int] {
  $x + 10
}


# b.nu
# with test code:
# nu b.nu linux --version v5.2
# nu b.nu linux --version=v5.2
def main [kernel: string, --version: string] {
    echo $kernel;
    echo $version
}

# c.nu
# nu c.nu test_ver --version='xx yy' --arch=ghi
# nu c.nu 'test_ver' --version=version --arch="ghi"
def main [kernel: string, --version: string, --arch: string] {
    echo $kernel
    echo $version
    echo $arch
}


# d.nu
# nu d.nu asdf --arch asfd
def main [kernel: string, --version: string, --arch: string] {
    echo $kernel
    echo $version
    echo $arch
}


# e.nu
# nu script.nu '"'
def main [x: any] {
  echo $x
}
```

For testing code, it seems that our `nu!` macro doesn't works well with something like:
```
nu!(cwd: ".", "nu script.nu");
```

So I just make unit tests for relative function to test escaping result.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
