### PR TITLE
Should we keep old semantics of `uniq` command?

### DIFF
--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -62,12 +62,18 @@ impl Command for Uniq {
             Example {
                 description: "Only print duplicate lines, one for each group",
                 example: "[1 2 2] | uniq -d",
-                result: Some(Value::test_int(2)),
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(2)],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Only print unique lines lines",
                 example: "[1 2 2] | uniq -u",
-                result: Some(Value::test_int(1)),
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(1)],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Ignore differences in case when comparing",

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -2,9 +2,7 @@ use std::collections::VecDeque;
 
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
-};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Span, Value};
 
 #[derive(Clone)]
 pub struct Uniq;
@@ -188,21 +186,12 @@ fn uniq(
         }
     }
 
-    // keeps the original Nushell semantics
-    if values_vec_deque.len() == 1 {
-        if let Some(x) = values_vec_deque.pop_front() {
-            Ok(x.into_pipeline_data().set_metadata(metadata))
-        } else {
-            Err(ShellError::NushellFailed("No input given...".to_string()))
-        }
-    } else {
-        Ok(Value::List {
-            vals: values_vec_deque.into_iter().collect(),
-            span: head,
-        }
-        .into_pipeline_data()
-        .set_metadata(metadata))
+    Ok(Value::List {
+        vals: values_vec_deque.into_iter().collect(),
+        span: head,
     }
+    .into_pipeline_data()
+    .set_metadata(metadata))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

I am opening this PR for discussing of whether this is a good idea or not, especially since it's a breaking change.

Currently the `uniq` command behaves in a very surprising way where if it's passed a `list` and only one thing remains it returns that thing instead of returning a `list` containing one thing. There's at least one place where this matters that I have encountered which is autocompletions.
Currently if an `@` autocompletion function returns a `string` instead of a `list<string>`, it fails silently at displaying any autocompletions. One could argue autocompletions should be fixed so that returning a string just autocompletes with that string, and although that would fix the issue I encountered last night and is probably a desirable change, it still leaves `uniq` in a weird spot where it returns a different type based on properties of the input as well as the input type instead of based solely on the input type. In contrast `where`, the main filter, if passed a `list` always returns a `list`, at least as far as I can tell.

If the old behavior is important to preserve (Not sure why, feel free to tell me, I am quite curious! ❤️) would either of the following be acceptable:
- [ ] Gate the old behavior behind a flag (also a breaking change)
- [ ] Add a flag to enable the new behavior (not breaking)

Thank you ❤️ 

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
