### PR TITLE
more verbose error handling

### DIFF
--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -191,7 +191,10 @@ pub fn action(input: &Value, span: Span, radix: u32) -> Value {
             span,
         },
         _ => Value::Error {
-            error: ShellError::UnsupportedInput("'into int' for unsupported type".into(), span),
+            error: ShellError::UnsupportedInput(
+                format!("'into int' for unsupported type '{}'", input.get_type()),
+                span,
+            ),
         },
     }
 }


### PR DESCRIPTION
# Description

when `into int` fails, specify the type that it couldn't convert.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
