### PR TITLE
Force floats to output a decimal in nuon

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -86,7 +86,13 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
             span,
         )),
         Value::Filesize { val, .. } => Ok(format!("{}b", *val)),
-        Value::Float { val, .. } => Ok(format!("{}", *val)),
+        Value::Float { val, .. } => {
+            if &val.round() == val {
+                Ok(format!("{}.0", *val))
+            } else {
+                Ok(format!("{}", *val))
+            }
+        }
         Value::Int { val, .. } => Ok(format!("{}", *val)),
         Value::List { vals, .. } => {
             let headers = get_columns(vals);


### PR DESCRIPTION
# Description

`> 1.0 | to nuon` now outputs a float

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
