### PR TITLE
filesize conversion

### DIFF
--- a/crates/nu-protocol/src/value/from.rs
+++ b/crates/nu-protocol/src/value/from.rs
@@ -16,6 +16,8 @@ impl Value {
     pub fn as_i64(&self) -> Result<i64, ShellError> {
         match self {
             Value::Int { val, .. } => Ok(*val),
+            Value::Filesize { val, .. } => Ok(*val),
+            Value::Duration { val, .. } => Ok(*val),
             x => Err(ShellError::CantConvert(
                 "i64".into(),
                 x.get_type().to_string(),


### PR DESCRIPTION
# Description

Adds filesize conversion to dataframe

it partially solves #5764. Need better conversion for complex nushell types and should check not to do aggregations on object types

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
