### PR TITLE
Pin reedline v0.7.0 for the nushell v0.64.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,8 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.6.0"
-source = "git+https://github.com/nushell/reedline?branch=main#12dc30ce0ae99b58cfa8f13a51b056e9b4022c2d"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8163ab90fabf0b8978b824743bb7a384394501b4b40c198a146c0eb9670ca4"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ nu-system = { path = "./crates/nu-system", version = "0.63.1" }
 nu-table = { path = "./crates/nu-table", version = "0.63.1"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.63.1"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.63.1"  }
-reedline = { version = "0.6.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.7.0", features = ["bashisms", "sqlite"]}
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
 is_executable = "1.0.1"
@@ -119,6 +119,3 @@ debug = false
 [[bin]]
 name = "nu"
 path = "src/main.rs"
-
-[patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main"}

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -17,7 +17,7 @@ nu-parser = { path = "../nu-parser", version = "0.63.1"  }
 nu-protocol = { path = "../nu-protocol", version = "0.63.1"  }
 nu-utils = { path = "../nu-utils", version = "0.63.1"  }
 nu-ansi-term = "0.46.0"
-reedline = { version = "0.6.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.7.0", features = ["bashisms", "sqlite"]}
 nu-color-config = { path = "../nu-color-config", version = "0.63.1"  }
 crossterm = "0.23.0"
 miette = { version = "4.5.0", features = ["fancy"] }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -83,7 +83,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-reedline = { version = "0.6.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.7.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.4.0", features = ["diagnostics"] }
 rusqlite = { version = "0.27.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.16.0", features = ["serde"], optional = true }


### PR DESCRIPTION
# Description

Includes the new History API and sqlite history backend

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
