### PR TITLE
Standardise to commands

### DIFF
--- a/crates/nu-command/src/dataframe/eager/append.rs
+++ b/crates/nu-command/src/dataframe/eager/append.rs
@@ -30,7 +30,7 @@ impl Command for AppendDF {
         vec![
             Example {
                 description: "Appends a dataframe as new columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | to-df);
+                example: r#"let a = ([[a b]; [1 2] [3 4]] | to df);
     $a | append $a"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -57,7 +57,7 @@ impl Command for AppendDF {
             },
             Example {
                 description: "Appends a dataframe merging at the end of columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | to-df);
+                example: r#"let a = ([[a b]; [1 2] [3 4]] | to df);
     $a | append $a --col"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![

--- a/crates/nu-command/src/dataframe/eager/append.rs
+++ b/crates/nu-command/src/dataframe/eager/append.rs
@@ -30,7 +30,7 @@ impl Command for AppendDF {
         vec![
             Example {
                 description: "Appends a dataframe as new columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | to df);
+                example: r#"let a = ([[a b]; [1 2] [3 4]] | into df);
     $a | append $a"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -57,7 +57,7 @@ impl Command for AppendDF {
             },
             Example {
                 description: "Appends a dataframe merging at the end of columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | to df);
+                example: r#"let a = ([[a b]; [1 2] [3 4]] | into df);
     $a | append $a --col"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![

--- a/crates/nu-command/src/dataframe/eager/describe.rs
+++ b/crates/nu-command/src/dataframe/eager/describe.rs
@@ -40,7 +40,7 @@ impl Command for DescribeDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "dataframe description",
-            example: "[[a b]; [1 1] [1 1]] | to-df | describe",
+            example: "[[a b]; [1 1] [1 1]] | to df | describe",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/describe.rs
+++ b/crates/nu-command/src/dataframe/eager/describe.rs
@@ -40,7 +40,7 @@ impl Command for DescribeDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "dataframe description",
-            example: "[[a b]; [1 1] [1 1]] | to df | describe",
+            example: "[[a b]; [1 1] [1 1]] | into df | describe",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/drop.rs
+++ b/crates/nu-command/src/dataframe/eager/drop.rs
@@ -29,7 +29,7 @@ impl Command for DropDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop column a",
-            example: "[[a b]; [1 2] [3 4]] | to df | drop a",
+            example: "[[a b]; [1 2] [3 4]] | into df | drop a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "b".to_string(),

--- a/crates/nu-command/src/dataframe/eager/drop.rs
+++ b/crates/nu-command/src/dataframe/eager/drop.rs
@@ -29,7 +29,7 @@ impl Command for DropDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop column a",
-            example: "[[a b]; [1 2] [3 4]] | to-df | drop a",
+            example: "[[a b]; [1 2] [3 4]] | to df | drop a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "b".to_string(),

--- a/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
@@ -40,7 +40,7 @@ impl Command for DropDuplicates {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop duplicates",
-            example: "[[a b]; [1 2] [3 4] [1 2]] | to df | drop-duplicates",
+            example: "[[a b]; [1 2] [3 4] [1 2]] | into df | drop-duplicates",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
@@ -40,7 +40,7 @@ impl Command for DropDuplicates {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop duplicates",
-            example: "[[a b]; [1 2] [3 4] [1 2]] | to-df | drop-duplicates",
+            example: "[[a b]; [1 2] [3 4] [1 2]] | to df | drop-duplicates",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -34,7 +34,7 @@ impl Command for DropNulls {
         vec![
             Example {
                 description: "drop null values in dataframe",
-                example: r#"let df = ([[a b]; [1 2] [3 0] [1 2]] | to-df);
+                example: r#"let df = ([[a b]; [1 2] [3 0] [1 2]] | to df);
     let res = ($df.b / $df.b);
     let a = ($df | with-column $res --name res);
     $a | drop-nulls"#,
@@ -59,7 +59,7 @@ impl Command for DropNulls {
             },
             Example {
                 description: "drop null values in dataframe",
-                example: r#"let s = ([1 2 0 0 3 4] | to-df);
+                example: r#"let s = ([1 2 0 0 3 4] | to df);
     ($s / $s) | drop-nulls"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -34,7 +34,7 @@ impl Command for DropNulls {
         vec![
             Example {
                 description: "drop null values in dataframe",
-                example: r#"let df = ([[a b]; [1 2] [3 0] [1 2]] | to df);
+                example: r#"let df = ([[a b]; [1 2] [3 0] [1 2]] | into df);
     let res = ($df.b / $df.b);
     let a = ($df | with-column $res --name res);
     $a | drop-nulls"#,
@@ -59,7 +59,7 @@ impl Command for DropNulls {
             },
             Example {
                 description: "drop null values in dataframe",
-                example: r#"let s = ([1 2 0 0 3 4] | to df);
+                example: r#"let s = ([1 2 0 0 3 4] | into df);
     ($s / $s) | drop-nulls"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/eager/dtypes.rs
+++ b/crates/nu-command/src/dataframe/eager/dtypes.rs
@@ -24,7 +24,7 @@ impl Command for DataTypes {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Dataframe dtypes",
-            example: "[[a b]; [1 2] [3 4]] | to-df | dtypes",
+            example: "[[a b]; [1 2] [3 4]] | to df | dtypes",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/dtypes.rs
+++ b/crates/nu-command/src/dataframe/eager/dtypes.rs
@@ -24,7 +24,7 @@ impl Command for DataTypes {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Dataframe dtypes",
-            example: "[[a b]; [1 2] [3 4]] | to df | dtypes",
+            example: "[[a b]; [1 2] [3 4]] | into df | dtypes",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -11,7 +11,7 @@ pub struct Dummies;
 
 impl Command for Dummies {
     fn name(&self) -> &str {
-        "to-dummies"
+        "dummies"
     }
 
     fn usage(&self) -> &str {
@@ -26,7 +26,7 @@ impl Command for Dummies {
         vec![
             Example {
                 description: "Create new dataframe with dummy variables from a dataframe",
-                example: "[[a b]; [1 2] [3 4]] | to-df | to-dummies",
+                example: "[[a b]; [1 2] [3 4]] | to df | dummies",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -52,7 +52,7 @@ impl Command for Dummies {
             },
             Example {
                 description: "Create new dataframe with dummy variables from a series",
-                example: "[1 2 2 3 3] | to-df | to-dummies",
+                example: "[1 2 2 3 3] | to df | dummies",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -26,7 +26,7 @@ impl Command for Dummies {
         vec![
             Example {
                 description: "Create new dataframe with dummy variables from a dataframe",
-                example: "[[a b]; [1 2] [3 4]] | to df | dummies",
+                example: "[[a b]; [1 2] [3 4]] | into df | dummies",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -52,7 +52,7 @@ impl Command for Dummies {
             },
             Example {
                 description: "Create new dataframe with dummy variables from a series",
-                example: "[1 2 2 3 3] | to df | dummies",
+                example: "[1 2 2 3 3] | into df | dummies",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -36,8 +36,8 @@ impl Command for FilterWith {
         vec![
             Example {
                 description: "Filter dataframe using a bool mask",
-                example: r#"let mask = ([true false] | to df);
-    [[a b]; [1 2] [3 4]] | to df | filter-with $mask"#,
+                example: r#"let mask = ([true false] | into df);
+    [[a b]; [1 2] [3 4]] | into df | filter-with $mask"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(1)]),
@@ -49,7 +49,7 @@ impl Command for FilterWith {
             },
             Example {
                 description: "Filter dataframe using an expression",
-                example: "[[a b]; [1 2] [3 4]] | to df | filter-with ((col a) > 1)",
+                example: "[[a b]; [1 2] [3 4]] | into df | filter-with ((col a) > 1)",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -36,8 +36,8 @@ impl Command for FilterWith {
         vec![
             Example {
                 description: "Filter dataframe using a bool mask",
-                example: r#"let mask = ([true false] | to-df);
-    [[a b]; [1 2] [3 4]] | to-df | filter-with $mask"#,
+                example: r#"let mask = ([true false] | to df);
+    [[a b]; [1 2] [3 4]] | to df | filter-with $mask"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(1)]),
@@ -49,7 +49,7 @@ impl Command for FilterWith {
             },
             Example {
                 description: "Filter dataframe using an expression",
-                example: "[[a b]; [1 2] [3 4]] | to-df | filter-with ((col a) > 1)",
+                example: "[[a b]; [1 2] [3 4]] | to df | filter-with ((col a) > 1)",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-command/src/dataframe/eager/first.rs
+++ b/crates/nu-command/src/dataframe/eager/first.rs
@@ -27,7 +27,7 @@ impl Command for FirstDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe with head rows",
-            example: "[[a b]; [1 2] [3 4]] | to-df | first 1",
+            example: "[[a b]; [1 2] [3 4]] | to df | first 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(1)]),

--- a/crates/nu-command/src/dataframe/eager/first.rs
+++ b/crates/nu-command/src/dataframe/eager/first.rs
@@ -27,7 +27,7 @@ impl Command for FirstDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe with head rows",
-            example: "[[a b]; [1 2] [3 4]] | to df | first 1",
+            example: "[[a b]; [1 2] [3 4]] | into df | first 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(1)]),

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -30,7 +30,7 @@ impl Command for GetDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns the selected column",
-            example: "[[a b]; [1 2] [3 4]] | to-df | get a",
+            example: "[[a b]; [1 2] [3 4]] | to df | get a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -30,7 +30,7 @@ impl Command for GetDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns the selected column",
-            example: "[[a b]; [1 2] [3 4]] | to df | get a",
+            example: "[[a b]; [1 2] [3 4]] | into df | get a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),

--- a/crates/nu-command/src/dataframe/eager/last.rs
+++ b/crates/nu-command/src/dataframe/eager/last.rs
@@ -27,7 +27,7 @@ impl Command for LastDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe with last rows",
-            example: "[[a b]; [1 2] [3 4]] | to df | last 1",
+            example: "[[a b]; [1 2] [3 4]] | into df | last 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-command/src/dataframe/eager/last.rs
+++ b/crates/nu-command/src/dataframe/eager/last.rs
@@ -27,7 +27,7 @@ impl Command for LastDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe with last rows",
-            example: "[[a b]; [1 2] [3 4]] | to-df | last 1",
+            example: "[[a b]; [1 2] [3 4]] | to df | last 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-command/src/dataframe/eager/list.rs
+++ b/crates/nu-command/src/dataframe/eager/list.rs
@@ -25,7 +25,7 @@ impl Command for ListDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a new dataframe and shows it in the dataframe list",
-            example: r#"let test = ([[a b];[1 2] [3 4]] | to df);
+            example: r#"let test = ([[a b];[1 2] [3 4]] | into df);
     ls-df"#,
             result: None,
         }]

--- a/crates/nu-command/src/dataframe/eager/list.rs
+++ b/crates/nu-command/src/dataframe/eager/list.rs
@@ -25,7 +25,7 @@ impl Command for ListDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a new dataframe and shows it in the dataframe list",
-            example: r#"let test = ([[a b];[1 2] [3 4]] | to-df);
+            example: r#"let test = ([[a b];[1 2] [3 4]] | to df);
     ls-df"#,
             result: None,
         }]

--- a/crates/nu-command/src/dataframe/eager/melt.rs
+++ b/crates/nu-command/src/dataframe/eager/melt.rs
@@ -54,7 +54,8 @@ impl Command for MeltDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "melt dataframe",
-            example: "[[a b c d]; [x 1 4 a] [y 2 5 b] [z 3 6 c]] | to df | melt -c [b c] -v [a d]",
+            example:
+                "[[a b c d]; [x 1 4 a] [y 2 5 b] [z 3 6 c]] | into df | melt -c [b c] -v [a d]",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/melt.rs
+++ b/crates/nu-command/src/dataframe/eager/melt.rs
@@ -54,7 +54,7 @@ impl Command for MeltDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "melt dataframe",
-            example: "[[a b c d]; [x 1 4 a] [y 2 5 b] [z 3 6 c]] | to-df | melt -c [b c] -v [a d]",
+            example: "[[a b c d]; [x 1 4 a] [y 2 5 b] [z 3 6 c]] | to df | melt -c [b c] -v [a d]",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/rename.rs
+++ b/crates/nu-command/src/dataframe/eager/rename.rs
@@ -40,7 +40,7 @@ impl Command for RenameDF {
         vec![
             Example {
                 description: "Renames a series",
-                example: "[5 6 7 8] | to-df | rename '0' new_name",
+                example: "[5 6 7 8] | to df | rename '0' new_name",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "new_name".to_string(),
@@ -57,7 +57,7 @@ impl Command for RenameDF {
             },
             Example {
                 description: "Renames a dataframe column",
-                example: "[[a b]; [1 2] [3 4]] | to-df | rename a a_new",
+                example: "[[a b]; [1 2] [3 4]] | to df | rename a a_new",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -75,7 +75,7 @@ impl Command for RenameDF {
             },
             Example {
                 description: "Renames two dataframe columns",
-                example: "[[a b]; [1 2] [3 4]] | to-df | rename [a b] [a_new b_new]",
+                example: "[[a b]; [1 2] [3 4]] | to df | rename [a b] [a_new b_new]",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/rename.rs
+++ b/crates/nu-command/src/dataframe/eager/rename.rs
@@ -40,7 +40,7 @@ impl Command for RenameDF {
         vec![
             Example {
                 description: "Renames a series",
-                example: "[5 6 7 8] | to df | rename '0' new_name",
+                example: "[5 6 7 8] | into df | rename '0' new_name",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "new_name".to_string(),
@@ -57,7 +57,7 @@ impl Command for RenameDF {
             },
             Example {
                 description: "Renames a dataframe column",
-                example: "[[a b]; [1 2] [3 4]] | to df | rename a a_new",
+                example: "[[a b]; [1 2] [3 4]] | into df | rename a a_new",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -75,7 +75,7 @@ impl Command for RenameDF {
             },
             Example {
                 description: "Renames two dataframe columns",
-                example: "[[a b]; [1 2] [3 4]] | to df | rename [a b] [a_new b_new]",
+                example: "[[a b]; [1 2] [3 4]] | into df | rename [a b] [a_new b_new]",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/sample.rs
+++ b/crates/nu-command/src/dataframe/eager/sample.rs
@@ -48,12 +48,12 @@ impl Command for SampleDF {
         vec![
             Example {
                 description: "Sample rows from dataframe",
-                example: "[[a b]; [1 2] [3 4]] | to df | sample -n 1",
+                example: "[[a b]; [1 2] [3 4]] | into df | sample -n 1",
                 result: None, // No expected value because sampling is random
             },
             Example {
                 description: "Shows sample row using fraction and replace",
-                example: "[[a b]; [1 2] [3 4] [5 6]] | to df | sample -f 0.5 -e",
+                example: "[[a b]; [1 2] [3 4] [5 6]] | into df | sample -f 0.5 -e",
                 result: None, // No expected value because sampling is random
             },
         ]

--- a/crates/nu-command/src/dataframe/eager/sample.rs
+++ b/crates/nu-command/src/dataframe/eager/sample.rs
@@ -48,12 +48,12 @@ impl Command for SampleDF {
         vec![
             Example {
                 description: "Sample rows from dataframe",
-                example: "[[a b]; [1 2] [3 4]] | to-df | sample -n 1",
+                example: "[[a b]; [1 2] [3 4]] | to df | sample -n 1",
                 result: None, // No expected value because sampling is random
             },
             Example {
                 description: "Shows sample row using fraction and replace",
-                example: "[[a b]; [1 2] [3 4] [5 6]] | to-df | sample -f 0.5 -e",
+                example: "[[a b]; [1 2] [3 4] [5 6]] | to df | sample -f 0.5 -e",
                 result: None, // No expected value because sampling is random
             },
         ]

--- a/crates/nu-command/src/dataframe/eager/shape.rs
+++ b/crates/nu-command/src/dataframe/eager/shape.rs
@@ -27,7 +27,7 @@ impl Command for ShapeDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shows row and column shape",
-            example: "[[a b]; [1 2] [3 4]] | to-df | shape",
+            example: "[[a b]; [1 2] [3 4]] | to df | shape",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("rows".to_string(), vec![Value::test_int(2)]),

--- a/crates/nu-command/src/dataframe/eager/shape.rs
+++ b/crates/nu-command/src/dataframe/eager/shape.rs
@@ -27,7 +27,7 @@ impl Command for ShapeDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shows row and column shape",
-            example: "[[a b]; [1 2] [3 4]] | to df | shape",
+            example: "[[a b]; [1 2] [3 4]] | into df | shape",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("rows".to_string(), vec![Value::test_int(2)]),

--- a/crates/nu-command/src/dataframe/eager/slice.rs
+++ b/crates/nu-command/src/dataframe/eager/slice.rs
@@ -31,7 +31,7 @@ impl Command for SliceDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe from a slice of the rows",
-            example: "[[a b]; [1 2] [3 4]] | to-df | slice 0 1",
+            example: "[[a b]; [1 2] [3 4]] | to df | slice 0 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(1)]),

--- a/crates/nu-command/src/dataframe/eager/slice.rs
+++ b/crates/nu-command/src/dataframe/eager/slice.rs
@@ -31,7 +31,7 @@ impl Command for SliceDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe from a slice of the rows",
-            example: "[[a b]; [1 2] [3 4]] | to df | slice 0 1",
+            example: "[[a b]; [1 2] [3 4]] | into df | slice 0 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(1)]),

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -36,8 +36,8 @@ impl Command for TakeDF {
         vec![
             Example {
                 description: "Takes selected rows from dataframe",
-                example: r#"let df = ([[a b]; [4 1] [5 2] [4 3]] | to-df);
-    let indices = ([0 2] | to-df);
+                example: r#"let df = ([[a b]; [4 1] [5 2] [4 3]] | to df);
+    let indices = ([0 2] | to df);
     $df | take $indices"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -56,8 +56,8 @@ impl Command for TakeDF {
             },
             Example {
                 description: "Takes selected rows from series",
-                example: r#"let series = ([4 1 5 2 4 3] | to-df);
-    let indices = ([0 2] | to-df);
+                example: r#"let series = ([4 1 5 2 4 3] | to df);
+    let indices = ([0 2] | to df);
     $series | take $indices"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -36,8 +36,8 @@ impl Command for TakeDF {
         vec![
             Example {
                 description: "Takes selected rows from dataframe",
-                example: r#"let df = ([[a b]; [4 1] [5 2] [4 3]] | to df);
-    let indices = ([0 2] | to df);
+                example: r#"let df = ([[a b]; [4 1] [5 2] [4 3]] | into df);
+    let indices = ([0 2] | into df);
     $df | take $indices"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -56,8 +56,8 @@ impl Command for TakeDF {
             },
             Example {
                 description: "Takes selected rows from series",
-                example: r#"let series = ([4 1 5 2 4 3] | to df);
-    let indices = ([0 2] | to df);
+                example: r#"let series = ([4 1 5 2 4 3] | into df);
+    let indices = ([0 2] | into df);
     $series | take $indices"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-command/src/dataframe/eager/to_csv.rs
@@ -39,12 +39,12 @@ impl Command for ToCSV {
         vec![
             Example {
                 description: "Saves dataframe to csv file",
-                example: "[[a b]; [1 2] [3 4]] | to df | to csv test.csv",
+                example: "[[a b]; [1 2] [3 4]] | into df | to csv test.csv",
                 result: None,
             },
             Example {
                 description: "Saves dataframe to csv file using other delimiter",
-                example: "[[a b]; [1 2] [3 4]] | to df | to csv test.csv -d '|'",
+                example: "[[a b]; [1 2] [3 4]] | into df | to csv test.csv -d '|'",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-command/src/dataframe/eager/to_csv.rs
@@ -15,7 +15,7 @@ pub struct ToCSV;
 
 impl Command for ToCSV {
     fn name(&self) -> &str {
-        "to-csv"
+        "to csv"
     }
 
     fn usage(&self) -> &str {
@@ -39,12 +39,12 @@ impl Command for ToCSV {
         vec![
             Example {
                 description: "Saves dataframe to csv file",
-                example: "[[a b]; [1 2] [3 4]] | to-df | to-csv test.csv",
+                example: "[[a b]; [1 2] [3 4]] | to df | to csv test.csv",
                 result: None,
             },
             Example {
                 description: "Saves dataframe to csv file using other delimiter",
-                example: "[[a b]; [1 2] [3 4]] | to-df | to-csv test.csv -d '|'",
+                example: "[[a b]; [1 2] [3 4]] | to df | to csv test.csv -d '|'",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -11,7 +11,7 @@ pub struct ToDataFrame;
 
 impl Command for ToDataFrame {
     fn name(&self) -> &str {
-        "to-df"
+        "to df"
     }
 
     fn usage(&self) -> &str {
@@ -26,7 +26,7 @@ impl Command for ToDataFrame {
         vec![
             Example {
                 description: "Takes a dictionary and creates a dataframe",
-                example: "[[a b];[1 2] [3 4]] | to-df",
+                example: "[[a b];[1 2] [3 4]] | to df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -44,7 +44,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list of tables and creates a dataframe",
-                example: "[[1 2 a] [3 4 b] [5 6 c]] | to-df",
+                example: "[[1 2 a] [3 4 b] [5 6 c]] | to df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -70,7 +70,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list and creates a dataframe",
-                example: "[a b c] | to-df",
+                example: "[a b c] | to df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),
@@ -86,7 +86,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list of booleans and creates a dataframe",
-                example: "[true true false] | to-df",
+                example: "[true true false] | to df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -11,7 +11,7 @@ pub struct ToDataFrame;
 
 impl Command for ToDataFrame {
     fn name(&self) -> &str {
-        "to df"
+        "into df"
     }
 
     fn usage(&self) -> &str {
@@ -26,7 +26,7 @@ impl Command for ToDataFrame {
         vec![
             Example {
                 description: "Takes a dictionary and creates a dataframe",
-                example: "[[a b];[1 2] [3 4]] | to df",
+                example: "[[a b];[1 2] [3 4]] | into df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -44,7 +44,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list of tables and creates a dataframe",
-                example: "[[1 2 a] [3 4 b] [5 6 c]] | to df",
+                example: "[[1 2 a] [3 4 b] [5 6 c]] | into df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -70,7 +70,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list and creates a dataframe",
-                example: "[a b c] | to df",
+                example: "[a b c] | into df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),
@@ -86,7 +86,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list of booleans and creates a dataframe",
-                example: "[true true false] | to df",
+                example: "[true true false] | into df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-command/src/dataframe/eager/to_nu.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 
 use super::super::values::NuDataFrame;
@@ -12,7 +12,7 @@ pub struct ToNu;
 
 impl Command for ToNu {
     fn name(&self) -> &str {
-        "to-nu"
+        "to nu"
     }
 
     fn usage(&self) -> &str {
@@ -32,16 +32,34 @@ impl Command for ToNu {
     }
 
     fn examples(&self) -> Vec<Example> {
+        let cols = vec!["a".into(), "b".into()];
+        let rec_1 = Value::Record {
+            cols: cols.clone(),
+            vals: vec![Value::test_int(1), Value::test_int(2)],
+            span: Span::test_data(),
+        };
+        let rec_2 = Value::Record {
+            cols,
+            vals: vec![Value::test_int(3), Value::test_int(4)],
+            span: Span::test_data(),
+        };
+
         vec![
             Example {
                 description: "Shows head rows from dataframe",
-                example: "[[a b]; [1 2] [3 4]] | to-df | to nu",
-                result: None,
+                example: "[[a b]; [1 2] [3 4]] | to df | to nu",
+                result: Some(Value::List {
+                    vals: vec![rec_1, rec_2.clone()],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Shows tail rows from dataframe",
-                example: "[[a b]; [1 2] [3 4] [5 6]] | to-df | to nu -t -n 1",
-                result: None,
+                example: "[[a b]; [1 2] [5 6] [3 4]] | to df | to nu -t -n 1",
+                result: Some(Value::List {
+                    vals: vec![rec_2],
+                    span: Span::test_data(),
+                }),
             },
         ]
     }
@@ -71,7 +89,7 @@ fn command(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let rows: Option<usize> = call.get_flag(engine_state, stack, "n-rows")?;
+    let rows: Option<usize> = call.get_flag(engine_state, stack, "rows")?;
     let tail: bool = call.has_flag("tail");
 
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
@@ -87,10 +105,23 @@ fn command(
         }
     };
 
+    println!("len: {}", values.len());
+
     let value = Value::List {
         vals: values,
         span: call.head,
     };
 
     Ok(PipelineData::Value(value, None))
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::super::test_dataframe::test_dataframe;
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        test_dataframe(vec![Box::new(ToNu {})])
+    }
 }

--- a/crates/nu-command/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-command/src/dataframe/eager/to_nu.rs
@@ -12,11 +12,11 @@ pub struct ToNu;
 
 impl Command for ToNu {
     fn name(&self) -> &str {
-        "to nu"
+        "into nu"
     }
 
     fn usage(&self) -> &str {
-        "Converts a section of the dataframe to Nushell Table"
+        "Converts a section of the dataframe into nushell Table"
     }
 
     fn signature(&self) -> Signature {
@@ -47,7 +47,7 @@ impl Command for ToNu {
         vec![
             Example {
                 description: "Shows head rows from dataframe",
-                example: "[[a b]; [1 2] [3 4]] | to df | to nu",
+                example: "[[a b]; [1 2] [3 4]] | into df | into nu",
                 result: Some(Value::List {
                     vals: vec![rec_1, rec_2.clone()],
                     span: Span::test_data(),
@@ -55,7 +55,7 @@ impl Command for ToNu {
             },
             Example {
                 description: "Shows tail rows from dataframe",
-                example: "[[a b]; [1 2] [5 6] [3 4]] | to df | to nu -t -n 1",
+                example: "[[a b]; [1 2] [5 6] [3 4]] | into df | into nu -t -n 1",
                 result: Some(Value::List {
                     vals: vec![rec_2],
                     span: Span::test_data(),

--- a/crates/nu-command/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-command/src/dataframe/eager/to_parquet.rs
@@ -15,7 +15,7 @@ pub struct ToParquet;
 
 impl Command for ToParquet {
     fn name(&self) -> &str {
-        "to-parquet"
+        "to parquet"
     }
 
     fn usage(&self) -> &str {
@@ -31,7 +31,7 @@ impl Command for ToParquet {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Saves dataframe to parquet file",
-            example: "[[a b]; [1 2] [3 4]] | to-df | to-parquet test.parquet",
+            example: "[[a b]; [1 2] [3 4]] | to df | to parquet test.parquet",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-command/src/dataframe/eager/to_parquet.rs
@@ -31,7 +31,7 @@ impl Command for ToParquet {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Saves dataframe to parquet file",
-            example: "[[a b]; [1 2] [3 4]] | to df | to parquet test.parquet",
+            example: "[[a b]; [1 2] [3 4]] | into df | to parquet test.parquet",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/eager/with_column.rs
+++ b/crates/nu-command/src/dataframe/eager/with_column.rs
@@ -35,8 +35,8 @@ impl Command for WithColumn {
             Example {
                 description: "Adds a series to the dataframe",
                 example: r#"[[a b]; [1 2] [3 4]]
-    | to-df
-    | with-column ([5 6] | to-df) --name c"#,
+    | to df
+    | with-column ([5 6] | to df) --name c"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -59,7 +59,7 @@ impl Command for WithColumn {
             Example {
                 description: "Adds a series to the dataframe",
                 example: r#"[[a b]; [1 2] [3 4]]
-    | to-lazy
+    | to lazy
     | with-column [
         ((col a) * 2 | as "c")
         ((col a) * 3 | as "d")

--- a/crates/nu-command/src/dataframe/eager/with_column.rs
+++ b/crates/nu-command/src/dataframe/eager/with_column.rs
@@ -35,8 +35,8 @@ impl Command for WithColumn {
             Example {
                 description: "Adds a series to the dataframe",
                 example: r#"[[a b]; [1 2] [3 4]]
-    | to df
-    | with-column ([5 6] | to df) --name c"#,
+    | into df
+    | with-column ([5 6] | into df) --name c"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -59,7 +59,7 @@ impl Command for WithColumn {
             Example {
                 description: "Adds a series to the dataframe",
                 example: r#"[[a b]; [1 2] [3 4]]
-    | to lazy
+    | into lazy
     | with-column [
         ((col a) * 2 | as "c")
         ((col a) * 3 | as "d")

--- a/crates/nu-command/src/dataframe/expressions/alias.rs
+++ b/crates/nu-command/src/dataframe/expressions/alias.rs
@@ -32,7 +32,7 @@ impl Command for ExprAlias {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates and alias expression",
-            example: "col a | as new_a | to-nu",
+            example: "col a | as new_a | to nu",
             result: {
                 let cols = vec!["expr".into(), "value".into()];
                 let expr = Value::test_string("column");

--- a/crates/nu-command/src/dataframe/expressions/alias.rs
+++ b/crates/nu-command/src/dataframe/expressions/alias.rs
@@ -32,7 +32,7 @@ impl Command for ExprAlias {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates and alias expression",
-            example: "col a | as new_a | to nu",
+            example: "col a | as new_a | into nu",
             result: {
                 let cols = vec!["expr".into(), "value".into()];
                 let expr = Value::test_string("column");

--- a/crates/nu-command/src/dataframe/expressions/as_nu.rs
+++ b/crates/nu-command/src/dataframe/expressions/as_nu.rs
@@ -11,7 +11,7 @@ pub struct ExprAsNu;
 
 impl Command for ExprAsNu {
     fn name(&self) -> &str {
-        "to-nu"
+        "to nu"
     }
 
     fn usage(&self) -> &str {
@@ -25,7 +25,7 @@ impl Command for ExprAsNu {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Convert a col expression into a nushell value",
-            example: "col a | to-nu",
+            example: "col a | to nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![

--- a/crates/nu-command/src/dataframe/expressions/as_nu.rs
+++ b/crates/nu-command/src/dataframe/expressions/as_nu.rs
@@ -11,11 +11,11 @@ pub struct ExprAsNu;
 
 impl Command for ExprAsNu {
     fn name(&self) -> &str {
-        "to nu"
+        "into nu"
     }
 
     fn usage(&self) -> &str {
-        "Convert expression to a nu value for access and exploration"
+        "Convert expression into a nu value for access and exploration"
     }
 
     fn signature(&self) -> Signature {
@@ -25,7 +25,7 @@ impl Command for ExprAsNu {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Convert a col expression into a nushell value",
-            example: "col a | to nu",
+            example: "col a | into nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![

--- a/crates/nu-command/src/dataframe/expressions/col.rs
+++ b/crates/nu-command/src/dataframe/expressions/col.rs
@@ -32,7 +32,7 @@ impl Command for ExprCol {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a named column expression and converts it to a nu object",
-            example: "col a | to nu",
+            example: "col a | into nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![

--- a/crates/nu-command/src/dataframe/expressions/col.rs
+++ b/crates/nu-command/src/dataframe/expressions/col.rs
@@ -32,7 +32,7 @@ impl Command for ExprCol {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a named column expression and converts it to a nu object",
-            example: "col a | to-nu",
+            example: "col a | to nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![

--- a/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
@@ -250,7 +250,7 @@ expr_command!(
     vec![Example {
         description: "Max aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | max)"#,
         result: Some(
@@ -281,7 +281,7 @@ expr_command!(
     vec![Example {
         description: "Min aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | min)"#,
         result: Some(
@@ -312,7 +312,7 @@ expr_command!(
     vec![Example {
         description: "Sum aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | sum)"#,
         result: Some(
@@ -343,7 +343,7 @@ expr_command!(
     vec![Example {
         description: "Mean aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | mean)"#,
         result: Some(
@@ -374,7 +374,7 @@ expr_command!(
     vec![Example {
         description: "Median aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | median)"#,
         result: Some(
@@ -405,7 +405,7 @@ expr_command!(
     vec![Example {
         description: "Std aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | std)"#,
         result: Some(
@@ -436,7 +436,7 @@ expr_command!(
     vec![Example {
         description: "Var aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | var)"#,
         result: Some(

--- a/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
@@ -250,7 +250,7 @@ expr_command!(
     vec![Example {
         description: "Max aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | max)"#,
         result: Some(
@@ -281,7 +281,7 @@ expr_command!(
     vec![Example {
         description: "Min aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | min)"#,
         result: Some(
@@ -312,7 +312,7 @@ expr_command!(
     vec![Example {
         description: "Sum aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | sum)"#,
         result: Some(
@@ -343,7 +343,7 @@ expr_command!(
     vec![Example {
         description: "Mean aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | mean)"#,
         result: Some(
@@ -374,7 +374,7 @@ expr_command!(
     vec![Example {
         description: "Median aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | median)"#,
         result: Some(
@@ -405,7 +405,7 @@ expr_command!(
     vec![Example {
         description: "Std aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | std)"#,
         result: Some(
@@ -436,7 +436,7 @@ expr_command!(
     vec![Example {
         description: "Var aggregation for a group by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | var)"#,
         result: Some(

--- a/crates/nu-command/src/dataframe/expressions/lit.rs
+++ b/crates/nu-command/src/dataframe/expressions/lit.rs
@@ -31,7 +31,7 @@ impl Command for ExprLit {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Created a literal expression and converts it to a nu object",
-            example: "lit 2 | to-nu",
+            example: "lit 2 | to nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![

--- a/crates/nu-command/src/dataframe/expressions/lit.rs
+++ b/crates/nu-command/src/dataframe/expressions/lit.rs
@@ -31,7 +31,7 @@ impl Command for ExprLit {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Created a literal expression and converts it to a nu object",
-            example: "lit 2 | to nu",
+            example: "lit 2 | into nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![

--- a/crates/nu-command/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-command/src/dataframe/expressions/otherwise.rs
@@ -43,7 +43,7 @@ impl Command for ExprOtherwise {
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | to lazy
+   | into lazy
    | with-column (
        when ((col a) > 2) 4 | otherwise 5 | as c
      )

--- a/crates/nu-command/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-command/src/dataframe/expressions/otherwise.rs
@@ -43,7 +43,7 @@ impl Command for ExprOtherwise {
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | to-lazy
+   | to lazy
    | with-column (
        when ((col a) > 2) 4 | otherwise 5 | as c
      )

--- a/crates/nu-command/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-command/src/dataframe/expressions/quantile.rs
@@ -33,7 +33,7 @@ impl Command for ExprQuantile {
         vec![Example {
             description: "Quantile aggregation for a group by",
             example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to df
+    | into df
     | group-by a
     | agg (col b | quantile 0.5)"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-command/src/dataframe/expressions/quantile.rs
@@ -33,7 +33,7 @@ impl Command for ExprQuantile {
         vec![Example {
             description: "Quantile aggregation for a group by",
             example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | to-df
+    | to df
     | group-by a
     | agg (col b | quantile 0.5)"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/expressions/when.rs
+++ b/crates/nu-command/src/dataframe/expressions/when.rs
@@ -49,7 +49,7 @@ impl Command for ExprWhen {
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | to-lazy
+   | to lazy
    | with-column (
        when ((col a) > 2) 4 | otherwise 5 | as c
      )

--- a/crates/nu-command/src/dataframe/expressions/when.rs
+++ b/crates/nu-command/src/dataframe/expressions/when.rs
@@ -49,7 +49,7 @@ impl Command for ExprWhen {
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | to lazy
+   | into lazy
    | with-column (
        when ((col a) > 2) 4 | otherwise 5 | as c
      )

--- a/crates/nu-command/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-command/src/dataframe/lazy/aggregate.rs
@@ -34,7 +34,7 @@ impl Command for LazyAggregate {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to df
+    | into df
     | group-by a
     | agg [
         (col b | min | as "b_min")
@@ -67,7 +67,7 @@ impl Command for LazyAggregate {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to lazy
+    | into lazy
     | group-by a
     | agg [
         (col b | min | as "b_min")

--- a/crates/nu-command/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-command/src/dataframe/lazy/aggregate.rs
@@ -34,7 +34,7 @@ impl Command for LazyAggregate {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to-df
+    | to df
     | group-by a
     | agg [
         (col b | min | as "b_min")
@@ -67,7 +67,7 @@ impl Command for LazyAggregate {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to-lazy
+    | to lazy
     | group-by a
     | agg [
         (col b | min | as "b_min")

--- a/crates/nu-command/src/dataframe/lazy/collect.rs
+++ b/crates/nu-command/src/dataframe/lazy/collect.rs
@@ -26,7 +26,7 @@ impl Command for LazyCollect {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop duplicates",
-            example: "[[a b]; [1 2] [3 4]] | to-lazy | collect",
+            example: "[[a b]; [1 2] [3 4]] | to lazy | collect",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/lazy/collect.rs
+++ b/crates/nu-command/src/dataframe/lazy/collect.rs
@@ -26,7 +26,7 @@ impl Command for LazyCollect {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop duplicates",
-            example: "[[a b]; [1 2] [3 4]] | to lazy | collect",
+            example: "[[a b]; [1 2] [3 4]] | into lazy | collect",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-command/src/dataframe/lazy/fetch.rs
@@ -32,7 +32,7 @@ impl Command for LazyFetch {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Fetch a rows from the dataframe",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | to df | fetch 2",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | into df | fetch 2",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-command/src/dataframe/lazy/fetch.rs
@@ -32,7 +32,7 @@ impl Command for LazyFetch {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Fetch a rows from the dataframe",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | fetch 2",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | to df | fetch 2",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/lazy/fill_null.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_null.rs
@@ -31,7 +31,7 @@ impl Command for LazyFillNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Fills the null values by 0",
-            example: "[1 2 2 3 3] | to df | shift 2 | fill-null 0",
+            example: "[1 2 2 3 3] | into df | shift 2 | fill-null 0",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/lazy/fill_null.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_null.rs
@@ -31,7 +31,7 @@ impl Command for LazyFillNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Fills the null values by 0",
-            example: "[1 2 2 3 3] | to-df | shift 2 | fill-null 0",
+            example: "[1 2 2 3 3] | to df | shift 2 | fill-null 0",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/lazy/groupby.rs
+++ b/crates/nu-command/src/dataframe/lazy/groupby.rs
@@ -34,7 +34,7 @@ impl Command for ToLazyGroupBy {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to df
+    | into df
     | group-by a
     | agg [
         (col b | min | as "b_min")
@@ -67,7 +67,7 @@ impl Command for ToLazyGroupBy {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to lazy
+    | into lazy
     | group-by a
     | agg [
         (col b | min | as "b_min")

--- a/crates/nu-command/src/dataframe/lazy/groupby.rs
+++ b/crates/nu-command/src/dataframe/lazy/groupby.rs
@@ -34,7 +34,7 @@ impl Command for ToLazyGroupBy {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to-df
+    | to df
     | group-by a
     | agg [
         (col b | min | as "b_min")
@@ -67,7 +67,7 @@ impl Command for ToLazyGroupBy {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | to-lazy
+    | to lazy
     | group-by a
     | agg [
         (col b | min | as "b_min")

--- a/crates/nu-command/src/dataframe/lazy/join.rs
+++ b/crates/nu-command/src/dataframe/lazy/join.rs
@@ -45,8 +45,8 @@ impl Command for LazyJoin {
         vec![
             Example {
                 description: "Join two lazy dataframes",
-                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | to lazy);
-    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | to lazy);
+                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | into lazy);
+    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | into lazy);
     $df_a | join $df_b a foo | collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -102,8 +102,8 @@ impl Command for LazyJoin {
             },
             Example {
                 description: "Join one eager dataframe with a lazy dataframe",
-                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | to df);
-    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | to lazy);
+                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | into df);
+    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | into lazy);
     $df_a | join $df_b a foo"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![

--- a/crates/nu-command/src/dataframe/lazy/join.rs
+++ b/crates/nu-command/src/dataframe/lazy/join.rs
@@ -45,8 +45,8 @@ impl Command for LazyJoin {
         vec![
             Example {
                 description: "Join two lazy dataframes",
-                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | to-lazy);
-    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | to-lazy);
+                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | to lazy);
+    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | to lazy);
     $df_a | join $df_b a foo | collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -102,8 +102,8 @@ impl Command for LazyJoin {
             },
             Example {
                 description: "Join one eager dataframe with a lazy dataframe",
-                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | to-df);
-    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | to-lazy);
+                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | to df);
+    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | to lazy);
     $df_a | join $df_b a foo"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![

--- a/crates/nu-command/src/dataframe/lazy/macro_commands.rs
+++ b/crates/nu-command/src/dataframe/lazy/macro_commands.rs
@@ -73,7 +73,7 @@ lazy_command!(
     "Reverses the LazyFrame",
     vec![Example {
         description: "Reverses the dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | reverse",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | reverse",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -101,7 +101,7 @@ lazy_command!(
     "Caches operations in a new LazyFrame",
     vec![Example {
         description: "Caches the result into a new LazyFrame",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | reverse | cache",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | reverse | cache",
         result: None,
     }],
     cache,
@@ -116,7 +116,7 @@ lazy_command!(
     "Aggregates columns to their max value",
     vec![Example {
         description: "Max value from columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | to df | max",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | into df | max",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(6)],),
@@ -138,7 +138,7 @@ lazy_command!(
     "Aggregates columns to their min value",
     vec![Example {
         description: "Min value from columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | to df | min",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | into df | min",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(1)],),
@@ -160,7 +160,7 @@ lazy_command!(
     "Aggregates columns to their sum value",
     vec![Example {
         description: "Sums all columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | to df | sum",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | into df | sum",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(11)],),
@@ -182,7 +182,7 @@ lazy_command!(
     "Aggregates columns to their mean value",
     vec![Example {
         description: "Mean value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | mean",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | mean",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),
@@ -204,7 +204,7 @@ lazy_command!(
     "Aggregates columns to their median value",
     vec![Example {
         description: "Median value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | median",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | median",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),
@@ -226,7 +226,7 @@ lazy_command!(
     "Aggregates columns to their std value",
     vec![Example {
         description: "Std value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | std",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | std",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(2.0)],),
@@ -248,7 +248,7 @@ lazy_command!(
     "Aggregates columns to their var value",
     vec![Example {
         description: "Var value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | var",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | var",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),

--- a/crates/nu-command/src/dataframe/lazy/macro_commands.rs
+++ b/crates/nu-command/src/dataframe/lazy/macro_commands.rs
@@ -73,7 +73,7 @@ lazy_command!(
     "Reverses the LazyFrame",
     vec![Example {
         description: "Reverses the dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | reverse",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | reverse",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -101,7 +101,7 @@ lazy_command!(
     "Caches operations in a new LazyFrame",
     vec![Example {
         description: "Caches the result into a new LazyFrame",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | reverse | cache",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | reverse | cache",
         result: None,
     }],
     cache,
@@ -116,7 +116,7 @@ lazy_command!(
     "Aggregates columns to their max value",
     vec![Example {
         description: "Max value from columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | to-df | max",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | to df | max",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(6)],),
@@ -138,7 +138,7 @@ lazy_command!(
     "Aggregates columns to their min value",
     vec![Example {
         description: "Min value from columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | to-df | min",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | to df | min",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(1)],),
@@ -160,7 +160,7 @@ lazy_command!(
     "Aggregates columns to their sum value",
     vec![Example {
         description: "Sums all columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | to-df | sum",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | to df | sum",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(11)],),
@@ -182,7 +182,7 @@ lazy_command!(
     "Aggregates columns to their mean value",
     vec![Example {
         description: "Mean value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | mean",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | mean",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),
@@ -204,7 +204,7 @@ lazy_command!(
     "Aggregates columns to their median value",
     vec![Example {
         description: "Median value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | median",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | median",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),
@@ -226,7 +226,7 @@ lazy_command!(
     "Aggregates columns to their std value",
     vec![Example {
         description: "Std value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | std",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | std",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(2.0)],),
@@ -248,7 +248,7 @@ lazy_command!(
     "Aggregates columns to their var value",
     vec![Example {
         description: "Var value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | var",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | to df | var",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),

--- a/crates/nu-command/src/dataframe/lazy/quantile.rs
+++ b/crates/nu-command/src/dataframe/lazy/quantile.rs
@@ -32,7 +32,7 @@ impl Command for LazyQuantile {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "quantile value from columns in a dataframe",
-            example: "[[a b]; [6 2] [1 4] [4 1]] | to-df | quantile 0.5",
+            example: "[[a b]; [6 2] [1 4] [4 1]] | to df | quantile 0.5",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_float(4.0)]),

--- a/crates/nu-command/src/dataframe/lazy/quantile.rs
+++ b/crates/nu-command/src/dataframe/lazy/quantile.rs
@@ -32,7 +32,7 @@ impl Command for LazyQuantile {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "quantile value from columns in a dataframe",
-            example: "[[a b]; [6 2] [1 4] [4 1]] | to df | quantile 0.5",
+            example: "[[a b]; [6 2] [1 4] [4 1]] | into df | quantile 0.5",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_float(4.0)]),

--- a/crates/nu-command/src/dataframe/lazy/select.rs
+++ b/crates/nu-command/src/dataframe/lazy/select.rs
@@ -33,7 +33,7 @@ impl Command for LazySelect {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Select a column from the dataframe",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | to df | select a",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | into df | select a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),

--- a/crates/nu-command/src/dataframe/lazy/select.rs
+++ b/crates/nu-command/src/dataframe/lazy/select.rs
@@ -33,7 +33,7 @@ impl Command for LazySelect {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Select a column from the dataframe",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | to-df | select a",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | to df | select a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),

--- a/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
@@ -39,7 +39,7 @@ impl Command for LazySortBy {
         vec![
             Example {
                 description: "Sort dataframe by one column",
-                example: "[[a b]; [6 2] [1 4] [4 1]] | to df | sort-by a",
+                example: "[[a b]; [6 2] [1 4] [4 1]] | into df | sort-by a",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -57,7 +57,8 @@ impl Command for LazySortBy {
             },
             Example {
                 description: "Sort column using two columns",
-                example: "[[a b]; [6 2] [1 1] [1 4] [2 4]] | to df | sort-by [a b] -r [false true]",
+                example:
+                    "[[a b]; [6 2] [1 1] [1 4] [2 4]] | into df | sort-by [a b] -r [false true]",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
@@ -39,7 +39,7 @@ impl Command for LazySortBy {
         vec![
             Example {
                 description: "Sort dataframe by one column",
-                example: "[[a b]; [6 2] [1 4] [4 1]] | to-df | sort-by a",
+                example: "[[a b]; [6 2] [1 4] [4 1]] | to df | sort-by a",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -57,7 +57,7 @@ impl Command for LazySortBy {
             },
             Example {
                 description: "Sort column using two columns",
-                example: "[[a b]; [6 2] [1 1] [1 4] [2 4]] | to-df | sort-by [a b] -r [false true]",
+                example: "[[a b]; [6 2] [1 1] [1 4] [2 4]] | to df | sort-by [a b] -r [false true]",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/to_lazy.rs
+++ b/crates/nu-command/src/dataframe/lazy/to_lazy.rs
@@ -11,7 +11,7 @@ pub struct ToLazyFrame;
 
 impl Command for ToLazyFrame {
     fn name(&self) -> &str {
-        "to lazy"
+        "into lazy"
     }
 
     fn usage(&self) -> &str {
@@ -25,7 +25,7 @@ impl Command for ToLazyFrame {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Takes a dictionary and creates a lazy dataframe",
-            example: "[[a b];[1 2] [3 4]] | to lazy",
+            example: "[[a b];[1 2] [3 4]] | into lazy",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/lazy/to_lazy.rs
+++ b/crates/nu-command/src/dataframe/lazy/to_lazy.rs
@@ -11,7 +11,7 @@ pub struct ToLazyFrame;
 
 impl Command for ToLazyFrame {
     fn name(&self) -> &str {
-        "to-lazy"
+        "to lazy"
     }
 
     fn usage(&self) -> &str {
@@ -25,7 +25,7 @@ impl Command for ToLazyFrame {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Takes a dictionary and creates a lazy dataframe",
-            example: "[[a b];[1 2] [3 4]] | to-lazy",
+            example: "[[a b];[1 2] [3 4]] | to lazy",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -26,7 +26,7 @@ impl Command for AllFalse {
         vec![
             Example {
                 description: "Returns true if all values are false",
-                example: "[false false false] | to-df | all-false",
+                example: "[false false false] | to df | all-false",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_false".to_string(),
@@ -38,7 +38,7 @@ impl Command for AllFalse {
             },
             Example {
                 description: "Checks the result from a comparison",
-                example: r#"let s = ([5 6 2 10] | to-df);
+                example: r#"let s = ([5 6 2 10] | to df);
     let res = ($s > 9);
     $res | all-false"#,
                 result: Some(

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -26,7 +26,7 @@ impl Command for AllFalse {
         vec![
             Example {
                 description: "Returns true if all values are false",
-                example: "[false false false] | to df | all-false",
+                example: "[false false false] | into df | all-false",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_false".to_string(),
@@ -38,7 +38,7 @@ impl Command for AllFalse {
             },
             Example {
                 description: "Checks the result from a comparison",
-                example: r#"let s = ([5 6 2 10] | to df);
+                example: r#"let s = ([5 6 2 10] | into df);
     let res = ($s > 9);
     $res | all-false"#,
                 result: Some(

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -26,7 +26,7 @@ impl Command for AllTrue {
         vec![
             Example {
                 description: "Returns true if all values are true",
-                example: "[true true true] | to df | all-true",
+                example: "[true true true] | into df | all-true",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_true".to_string(),
@@ -38,7 +38,7 @@ impl Command for AllTrue {
             },
             Example {
                 description: "Checks the result from a comparison",
-                example: r#"let s = ([5 6 2 8] | to df);
+                example: r#"let s = ([5 6 2 8] | into df);
     let res = ($s > 9);
     $res | all-true"#,
                 result: Some(

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -26,7 +26,7 @@ impl Command for AllTrue {
         vec![
             Example {
                 description: "Returns true if all values are true",
-                example: "[true true true] | to-df | all-true",
+                example: "[true true true] | to df | all-true",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_true".to_string(),
@@ -38,7 +38,7 @@ impl Command for AllTrue {
             },
             Example {
                 description: "Checks the result from a comparison",
-                example: r#"let s = ([5 6 2 8] | to-df);
+                example: r#"let s = ([5 6 2 8] | to df);
     let res = ($s > 9);
     $res | all-true"#,
                 result: Some(

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -26,7 +26,7 @@ impl Command for ArgMax {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns index for max value",
-            example: "[1 3 2] | to-df | arg-max",
+            example: "[1 3 2] | to df | arg-max",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_max".to_string(),

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -26,7 +26,7 @@ impl Command for ArgMax {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns index for max value",
-            example: "[1 3 2] | to df | arg-max",
+            example: "[1 3 2] | into df | arg-max",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_max".to_string(),

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -26,7 +26,7 @@ impl Command for ArgMin {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns index for min value",
-            example: "[1 3 2] | to df | arg-min",
+            example: "[1 3 2] | into df | arg-min",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_min".to_string(),

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -26,7 +26,7 @@ impl Command for ArgMin {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns index for min value",
-            example: "[1 3 2] | to-df | arg-min",
+            example: "[1 3 2] | to df | arg-min",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_min".to_string(),

--- a/crates/nu-command/src/dataframe/series/cumulative.rs
+++ b/crates/nu-command/src/dataframe/series/cumulative.rs
@@ -62,7 +62,7 @@ impl Command for Cumulative {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Cumulative sum for a series",
-            example: "[1 2 3 4 5] | to-df | cumulative sum",
+            example: "[1 2 3 4 5] | to df | cumulative sum",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0_cumulative_sum".to_string(),

--- a/crates/nu-command/src/dataframe/series/cumulative.rs
+++ b/crates/nu-command/src/dataframe/series/cumulative.rs
@@ -62,7 +62,7 @@ impl Command for Cumulative {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Cumulative sum for a series",
-            example: "[1 2 3 4 5] | to df | cumulative sum",
+            example: "[1 2 3 4 5] | into df | cumulative sum",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0_cumulative_sum".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/as_date.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_date.rs
@@ -37,7 +37,7 @@ impl Command for AsDate {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Converts string to date",
-            example: r#"["2021-12-30" "2021-12-31"] | to df | as-datetime "%Y-%m-%d""#,
+            example: r#"["2021-12-30" "2021-12-31"] | into df | as-datetime "%Y-%m-%d""#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/series/date/as_date.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_date.rs
@@ -37,7 +37,7 @@ impl Command for AsDate {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Converts string to date",
-            example: r#"["2021-12-30" "2021-12-31"] | to-df | as-datetime "%Y-%m-%d""#,
+            example: r#"["2021-12-30" "2021-12-31"] | to df | as-datetime "%Y-%m-%d""#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_datetime.rs
@@ -46,7 +46,7 @@ impl Command for AsDateTime {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Converts string to datetime",
-            example: r#"["2021-12-30 00:00:00" "2021-12-31 00:00:00"] | to-df | as-datetime "%Y-%m-%d %H:%M:%S""#,
+            example: r#"["2021-12-30 00:00:00" "2021-12-31 00:00:00"] | to df | as-datetime "%Y-%m-%d %H:%M:%S""#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "datetime".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_datetime.rs
@@ -46,7 +46,7 @@ impl Command for AsDateTime {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Converts string to datetime",
-            example: r#"["2021-12-30 00:00:00" "2021-12-31 00:00:00"] | to df | as-datetime "%Y-%m-%d %H:%M:%S""#,
+            example: r#"["2021-12-30 00:00:00" "2021-12-31 00:00:00"] | into df | as-datetime "%Y-%m-%d %H:%M:%S""#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "datetime".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_day.rs
@@ -27,7 +27,7 @@ impl Command for GetDay {
         vec![Example {
             description: "Returns day from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-day"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_day.rs
@@ -27,7 +27,7 @@ impl Command for GetDay {
         vec![Example {
             description: "Returns day from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-day"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_hour.rs
@@ -27,7 +27,7 @@ impl Command for GetHour {
         vec![Example {
             description: "Returns hour from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-hour"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_hour.rs
@@ -27,7 +27,7 @@ impl Command for GetHour {
         vec![Example {
             description: "Returns hour from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-hour"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_minute.rs
@@ -27,7 +27,7 @@ impl Command for GetMinute {
         vec![Example {
             description: "Returns minute from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-minute"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_minute.rs
@@ -27,7 +27,7 @@ impl Command for GetMinute {
         vec![Example {
             description: "Returns minute from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-minute"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_month.rs
@@ -27,7 +27,7 @@ impl Command for GetMonth {
         vec![Example {
             description: "Returns month from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-month"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_month.rs
@@ -27,7 +27,7 @@ impl Command for GetMonth {
         vec![Example {
             description: "Returns month from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-month"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
@@ -27,7 +27,7 @@ impl Command for GetNanosecond {
         vec![Example {
             description: "Returns nanosecond from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-nanosecond"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
@@ -27,7 +27,7 @@ impl Command for GetNanosecond {
         vec![Example {
             description: "Returns nanosecond from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-nanosecond"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
@@ -27,7 +27,7 @@ impl Command for GetOrdinal {
         vec![Example {
             description: "Returns ordinal from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-ordinal"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
@@ -27,7 +27,7 @@ impl Command for GetOrdinal {
         vec![Example {
             description: "Returns ordinal from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-ordinal"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_second.rs
@@ -27,7 +27,7 @@ impl Command for GetSecond {
         vec![Example {
             description: "Returns second from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-second"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_second.rs
@@ -27,7 +27,7 @@ impl Command for GetSecond {
         vec![Example {
             description: "Returns second from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-second"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_week.rs
@@ -27,7 +27,7 @@ impl Command for GetWeek {
         vec![Example {
             description: "Returns week from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-week"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_week.rs
@@ -27,7 +27,7 @@ impl Command for GetWeek {
         vec![Example {
             description: "Returns week from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-week"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_weekday.rs
@@ -27,7 +27,7 @@ impl Command for GetWeekDay {
         vec![Example {
             description: "Returns weekday from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-weekday"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_weekday.rs
@@ -27,7 +27,7 @@ impl Command for GetWeekDay {
         vec![Example {
             description: "Returns weekday from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-weekday"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_year.rs
@@ -27,7 +27,7 @@ impl Command for GetYear {
         vec![Example {
             description: "Returns year from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | get-year"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_year.rs
@@ -27,7 +27,7 @@ impl Command for GetYear {
         vec![Example {
             description: "Returns year from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | get-year"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -30,7 +30,7 @@ impl Command for ArgSort {
         vec![
             Example {
                 description: "Returns indexes for a sorted series",
-                example: "[1 2 2 3 3] | to df | arg-sort",
+                example: "[1 2 2 3 3] | into df | arg-sort",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "arg_sort".to_string(),
@@ -48,7 +48,7 @@ impl Command for ArgSort {
             },
             Example {
                 description: "Returns indexes for a sorted series",
-                example: "[1 2 2 3 3] | to df | arg-sort -r",
+                example: "[1 2 2 3 3] | into df | arg-sort -r",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "arg_sort".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -30,7 +30,7 @@ impl Command for ArgSort {
         vec![
             Example {
                 description: "Returns indexes for a sorted series",
-                example: "[1 2 2 3 3] | to-df | arg-sort",
+                example: "[1 2 2 3 3] | to df | arg-sort",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "arg_sort".to_string(),
@@ -48,7 +48,7 @@ impl Command for ArgSort {
             },
             Example {
                 description: "Returns indexes for a sorted series",
-                example: "[1 2 2 3 3] | to-df | arg-sort -r",
+                example: "[1 2 2 3 3] | to df | arg-sort -r",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "arg_sort".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -26,7 +26,7 @@ impl Command for ArgTrue {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns indexes where values are true",
-            example: "[false true false] | to-df | arg-true",
+            example: "[false true false] | to df | arg-true",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_true".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -26,7 +26,7 @@ impl Command for ArgTrue {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns indexes where values are true",
-            example: "[false true false] | to df | arg-true",
+            example: "[false true false] | into df | arg-true",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_true".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -26,7 +26,7 @@ impl Command for ArgUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns indexes for unique values",
-            example: "[1 2 2 3 3] | to-df | arg-unique",
+            example: "[1 2 2 3 3] | to df | arg-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -26,7 +26,7 @@ impl Command for ArgUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns indexes for unique values",
-            example: "[1 2 2 3 3] | to df | arg-unique",
+            example: "[1 2 2 3 3] | into df | arg-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
@@ -35,8 +35,8 @@ impl Command for SetWithIndex {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Set value in selected rows from series",
-            example: r#"let series = ([4 1 5 2 4 3] | to df);
-    let indices = ([0 2] | to df);
+            example: r#"let series = ([4 1 5 2 4 3] | into df);
+    let indices = ([0 2] | into df);
     $series | set-with-idx 6 -i $indices"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
@@ -35,8 +35,8 @@ impl Command for SetWithIndex {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Set value in selected rows from series",
-            example: r#"let series = ([4 1 5 2 4 3] | to-df);
-    let indices = ([0 2] | to-df);
+            example: r#"let series = ([4 1 5 2 4 3] | to df);
+    let indices = ([0 2] | to df);
     $series | set-with-idx 6 -i $indices"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
@@ -26,7 +26,7 @@ impl Command for IsDuplicated {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask indicating duplicated values",
-            example: "[5 6 6 6 8 8 8] | to df | is-duplicated",
+            example: "[5 6 6 6 8 8 8] | into df | is-duplicated",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_duplicated".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
@@ -26,7 +26,7 @@ impl Command for IsDuplicated {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask indicating duplicated values",
-            example: "[5 6 6 6 8 8 8] | to-df | is-duplicated",
+            example: "[5 6 6 6 8 8 8] | to df | is-duplicated",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_duplicated".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_in.rs
@@ -29,8 +29,8 @@ impl Command for IsIn {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Checks if elements from a series are contained in right series",
-            example: r#"let other = ([1 3 6] | to df);
-    [5 6 6 6 8 8 8] | to df | is-in $other"#,
+            example: r#"let other = ([1 3 6] | into df);
+    [5 6 6 6 8 8 8] | into df | is-in $other"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_in".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_in.rs
@@ -29,8 +29,8 @@ impl Command for IsIn {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Checks if elements from a series are contained in right series",
-            example: r#"let other = ([1 3 6] | to-df);
-    [5 6 6 6 8 8 8] | to-df | is-in $other"#,
+            example: r#"let other = ([1 3 6] | to df);
+    [5 6 6 6 8 8 8] | to df | is-in $other"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_in".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
@@ -25,7 +25,7 @@ impl Command for IsNotNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask where values are not null",
-            example: r#"let s = ([5 6 0 8] | to df);
+            example: r#"let s = ([5 6 0 8] | into df);
     let res = ($s / $s);
     $res | is-not-null"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
@@ -25,7 +25,7 @@ impl Command for IsNotNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask where values are not null",
-            example: r#"let s = ([5 6 0 8] | to-df);
+            example: r#"let s = ([5 6 0 8] | to df);
     let res = ($s / $s);
     $res | is-not-null"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/series/masks/is_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_null.rs
@@ -25,7 +25,7 @@ impl Command for IsNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask where values are null",
-            example: r#"let s = ([5 6 0 8] | to df);
+            example: r#"let s = ([5 6 0 8] | into df);
     let res = ($s / $s);
     $res | is-null"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/series/masks/is_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_null.rs
@@ -25,7 +25,7 @@ impl Command for IsNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask where values are null",
-            example: r#"let s = ([5 6 0 8] | to-df);
+            example: r#"let s = ([5 6 0 8] | to df);
     let res = ($s / $s);
     $res | is-null"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_unique.rs
@@ -26,7 +26,7 @@ impl Command for IsUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask indicating unique values",
-            example: "[5 6 6 6 8 8 8] | to df | is-unique",
+            example: "[5 6 6 6 8 8 8] | into df | is-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_unique.rs
@@ -26,7 +26,7 @@ impl Command for IsUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask indicating unique values",
-            example: "[5 6 6 6 8 8 8] | to-df | is-unique",
+            example: "[5 6 6 6 8 8 8] | to df | is-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -27,7 +27,7 @@ impl Command for NotSeries {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Inverts boolean mask",
-            example: "[true false true] | to df | df-not",
+            example: "[true false true] | into df | df-not",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -27,7 +27,7 @@ impl Command for NotSeries {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Inverts boolean mask",
-            example: "[true false true] | to-df | df-not",
+            example: "[true false true] | to df | df-not",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/set.rs
+++ b/crates/nu-command/src/dataframe/series/masks/set.rs
@@ -35,7 +35,7 @@ impl Command for SetSeries {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shifts the values by a given period",
-            example: r#"let s = ([1 2 2 3 3] | to-df | shift 2);
+            example: r#"let s = ([1 2 2 3 3] | to df | shift 2);
     let mask = ($s | is-null);
     $s | set 0 --mask $mask"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/series/masks/set.rs
+++ b/crates/nu-command/src/dataframe/series/masks/set.rs
@@ -35,7 +35,7 @@ impl Command for SetSeries {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shifts the values by a given period",
-            example: r#"let s = ([1 2 2 3 3] | to df | shift 2);
+            example: r#"let s = ([1 2 2 3 3] | into df | shift 2);
     let mask = ($s | is-null);
     $s | set 0 --mask $mask"#,
             result: Some(

--- a/crates/nu-command/src/dataframe/series/n_null.rs
+++ b/crates/nu-command/src/dataframe/series/n_null.rs
@@ -25,7 +25,7 @@ impl Command for NNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Counts null values",
-            example: r#"let s = ([1 1 0 0 3 3 4] | to-df);
+            example: r#"let s = ([1 1 0 0 3 3 4] | to df);
     ($s / $s) | count-null"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/n_null.rs
+++ b/crates/nu-command/src/dataframe/series/n_null.rs
@@ -25,7 +25,7 @@ impl Command for NNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Counts null values",
-            example: r#"let s = ([1 1 0 0 3 3 4] | to df);
+            example: r#"let s = ([1 1 0 0 3 3 4] | into df);
     ($s / $s) | count-null"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -24,7 +24,7 @@ impl Command for NUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Counts unique values",
-            example: "[1 1 2 2 3 3 4] | to df | n-unique",
+            example: "[1 1 2 2 3 3 4] | into df | n-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "count_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -24,7 +24,7 @@ impl Command for NUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Counts unique values",
-            example: "[1 1 2 2 3 3 4] | to-df | n-unique",
+            example: "[1 1 2 2 3 3 4] | to df | n-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "count_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/rolling.rs
+++ b/crates/nu-command/src/dataframe/series/rolling.rs
@@ -66,7 +66,7 @@ impl Command for Rolling {
         vec![
             Example {
                 description: "Rolling sum for a series",
-                example: "[1 2 3 4 5] | to df | rolling sum 2 | drop-nulls",
+                example: "[1 2 3 4 5] | into df | rolling sum 2 | drop-nulls",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0_rolling_sum".to_string(),
@@ -83,7 +83,7 @@ impl Command for Rolling {
             },
             Example {
                 description: "Rolling max for a series",
-                example: "[1 2 3 4 5] | to df | rolling max 2 | drop-nulls",
+                example: "[1 2 3 4 5] | into df | rolling max 2 | drop-nulls",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0_rolling_max".to_string(),

--- a/crates/nu-command/src/dataframe/series/rolling.rs
+++ b/crates/nu-command/src/dataframe/series/rolling.rs
@@ -66,7 +66,7 @@ impl Command for Rolling {
         vec![
             Example {
                 description: "Rolling sum for a series",
-                example: "[1 2 3 4 5] | to-df | rolling sum 2 | drop-nulls",
+                example: "[1 2 3 4 5] | to df | rolling sum 2 | drop-nulls",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0_rolling_sum".to_string(),
@@ -83,7 +83,7 @@ impl Command for Rolling {
             },
             Example {
                 description: "Rolling max for a series",
-                example: "[1 2 3 4 5] | to-df | rolling max 2 | drop-nulls",
+                example: "[1 2 3 4 5] | to df | rolling max 2 | drop-nulls",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0_rolling_max".to_string(),

--- a/crates/nu-command/src/dataframe/series/shift.rs
+++ b/crates/nu-command/src/dataframe/series/shift.rs
@@ -36,7 +36,7 @@ impl Command for Shift {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shifts the values by a given period",
-            example: "[1 2 2 3 3] | to-df | shift 2 | drop-nulls",
+            example: "[1 2 2 3 3] | to df | shift 2 | drop-nulls",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/shift.rs
+++ b/crates/nu-command/src/dataframe/series/shift.rs
@@ -36,7 +36,7 @@ impl Command for Shift {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shifts the values by a given period",
-            example: "[1 2 2 3 3] | to df | shift 2 | drop-nulls",
+            example: "[1 2 2 3 3] | into df | shift 2 | drop-nulls",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-command/src/dataframe/series/string/concatenate.rs
@@ -33,8 +33,8 @@ impl Command for Concatenate {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Concatenate string",
-            example: r#"let other = ([za xs cd] | to df);
-    [abc abc abc] | to df | concatenate $other"#,
+            example: r#"let other = ([za xs cd] | into df);
+    [abc abc abc] | into df | concatenate $other"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-command/src/dataframe/series/string/concatenate.rs
@@ -33,8 +33,8 @@ impl Command for Concatenate {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Concatenate string",
-            example: r#"let other = ([za xs cd] | to-df);
-    [abc abc abc] | to-df | concatenate $other"#,
+            example: r#"let other = ([za xs cd] | to df);
+    [abc abc abc] | to df | concatenate $other"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/contains.rs
+++ b/crates/nu-command/src/dataframe/series/string/contains.rs
@@ -33,7 +33,7 @@ impl Command for Contains {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns boolean indicating if pattern was found",
-            example: "[abc acb acb] | to df | contains ab",
+            example: "[abc acb acb] | into df | contains ab",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/contains.rs
+++ b/crates/nu-command/src/dataframe/series/string/contains.rs
@@ -33,7 +33,7 @@ impl Command for Contains {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns boolean indicating if pattern was found",
-            example: "[abc acb acb] | to-df | contains ab",
+            example: "[abc acb acb] | to df | contains ab",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/replace.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace.rs
@@ -40,7 +40,7 @@ impl Command for Replace {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Replaces string",
-            example: "[abc abc abc] | to-df | replace -p ab -r AB",
+            example: "[abc abc abc] | to df | replace -p ab -r AB",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/replace.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace.rs
@@ -40,7 +40,7 @@ impl Command for Replace {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Replaces string",
-            example: "[abc abc abc] | to df | replace -p ab -r AB",
+            example: "[abc abc abc] | into df | replace -p ab -r AB",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace_all.rs
@@ -40,7 +40,7 @@ impl Command for ReplaceAll {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Replaces string",
-            example: "[abac abac abac] | to-df | replace-all -p a -r A",
+            example: "[abac abac abac] | to df | replace-all -p a -r A",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace_all.rs
@@ -40,7 +40,7 @@ impl Command for ReplaceAll {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Replaces string",
-            example: "[abac abac abac] | to df | replace-all -p a -r A",
+            example: "[abac abac abac] | into df | replace-all -p a -r A",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_lengths.rs
@@ -26,7 +26,7 @@ impl Command for StrLengths {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns string lengths",
-            example: "[a ab abc] | to df | str-lengths",
+            example: "[a ab abc] | into df | str-lengths",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_lengths.rs
@@ -26,7 +26,7 @@ impl Command for StrLengths {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns string lengths",
-            example: "[a ab abc] | to-df | str-lengths",
+            example: "[a ab abc] | to df | str-lengths",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_slice.rs
@@ -30,7 +30,7 @@ impl Command for StrSlice {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates slices from the strings",
-            example: "[abcded abc321 abc123] | to df | str-slice 1 -l 2",
+            example: "[abcded abc321 abc123] | into df | str-slice 1 -l 2",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_slice.rs
@@ -30,7 +30,7 @@ impl Command for StrSlice {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates slices from the strings",
-            example: "[abcded abc321 abc123] | to-df | str-slice 1 -l 2",
+            example: "[abcded abc321 abc123] | to df | str-slice 1 -l 2",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-command/src/dataframe/series/string/strftime.rs
@@ -30,7 +30,7 @@ impl Command for StrFTime {
         vec![Example {
             description: "Formats date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to df);
+    let df = ([$dt $dt] | into df);
     $df | strftime "%Y/%m/%d""#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-command/src/dataframe/series/string/strftime.rs
@@ -30,7 +30,7 @@ impl Command for StrFTime {
         vec![Example {
             description: "Formats date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | to-df);
+    let df = ([$dt $dt] | to df);
     $df | strftime "%Y/%m/%d""#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
@@ -12,7 +12,7 @@ pub struct ToLowerCase;
 
 impl Command for ToLowerCase {
     fn name(&self) -> &str {
-        "to-lowercase"
+        "lowercase"
     }
 
     fn usage(&self) -> &str {
@@ -26,7 +26,7 @@ impl Command for ToLowerCase {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Modifies strings to lowercase",
-            example: "[Abc aBc abC] | to-df | to-lowercase",
+            example: "[Abc aBc abC] | to df | lowercase",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
@@ -26,7 +26,7 @@ impl Command for ToLowerCase {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Modifies strings to lowercase",
-            example: "[Abc aBc abC] | to df | lowercase",
+            example: "[Abc aBc abC] | into df | lowercase",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
@@ -12,7 +12,7 @@ pub struct ToUpperCase;
 
 impl Command for ToUpperCase {
     fn name(&self) -> &str {
-        "to-uppercase"
+        "uppercase"
     }
 
     fn usage(&self) -> &str {
@@ -26,7 +26,7 @@ impl Command for ToUpperCase {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Modifies strings to uppercase",
-            example: "[Abc aBc abC] | to-df | to-uppercase",
+            example: "[Abc aBc abC] | to df | uppercase",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
@@ -26,7 +26,7 @@ impl Command for ToUpperCase {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Modifies strings to uppercase",
-            example: "[Abc aBc abC] | to df | uppercase",
+            example: "[Abc aBc abC] | into df | uppercase",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/unique.rs
+++ b/crates/nu-command/src/dataframe/series/unique.rs
@@ -47,7 +47,7 @@ impl Command for Unique {
         vec![
             Example {
                 description: "Returns unique values from a series",
-                example: "[2 2 2 2 2] | to-df | unique",
+                example: "[2 2 2 2 2] | to df | unique",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/unique.rs
+++ b/crates/nu-command/src/dataframe/series/unique.rs
@@ -47,7 +47,7 @@ impl Command for Unique {
         vec![
             Example {
                 description: "Returns unique values from a series",
-                example: "[2 2 2 2 2] | to df | unique",
+                example: "[2 2 2 2 2] | into df | unique",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/value_counts.rs
+++ b/crates/nu-command/src/dataframe/series/value_counts.rs
@@ -25,7 +25,7 @@ impl Command for ValueCount {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Calculates value counts",
-            example: "[5 5 5 5 6 6] | to df | value-counts",
+            example: "[5 5 5 5 6 6] | into df | value-counts",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/series/value_counts.rs
+++ b/crates/nu-command/src/dataframe/series/value_counts.rs
@@ -25,7 +25,7 @@ impl Command for ValueCount {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Calculates value counts",
-            example: "[5 5 5 5 6 6] | to-df | value-counts",
+            example: "[5 5 5 5 6 6] | to df | value-counts",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(


### PR DESCRIPTION
# Description

Dataframes commands use to have`-` for `to` commands. Now that they can be used without `dfr` prefix it makes sense to make them have the same syntax  

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
