### PR TITLE
add notes for def_env

### DIFF
--- a/crates/nu-command/src/core_commands/def_env.rs
+++ b/crates/nu-command/src/core_commands/def_env.rs
@@ -28,7 +28,33 @@ impl Command for DefEnv {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nushell.html
+
+=== EXTRA NOTE ===
+All blocks are scoped, includes variable definition and environment variable changes.
+
+Because of this, the following doesn't works for you:
+
+def-env cd_with_fallback [arg = ""] {
+    let fall_back_path = "/tmp"
+    if $arg != "" {
+        cd $arg
+    } else {
+        cd $fall_back_path
+    }
+}
+
+Instead, you have to use cd in the top level scope:
+
+def-env cd_with_fallback [arg = ""] {
+    let fall_back_path = "/tmp"
+    let path = if $arg != "" {
+        $arg
+    } else {
+        $fall_back_path
+    }
+    cd $path
+}"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/def_env.rs
+++ b/crates/nu-command/src/core_commands/def_env.rs
@@ -31,9 +31,9 @@ impl Command for DefEnv {
   https://www.nushell.sh/book/thinking_in_nushell.html
 
 === EXTRA NOTE ===
-All blocks are scoped, includes variable definition and environment variable changes.
+All blocks are scoped, including variable definition and environment variable changes.
 
-Because of this, the following doesn't works for you:
+Because of this, the following doesn't work:
 
 def-env cd_with_fallback [arg = ""] {
     let fall_back_path = "/tmp"

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -28,7 +28,33 @@ impl Command for ExportDefEnv {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nushell.html
+
+=== EXTRA NOTE ===
+All blocks are scoped, includes variable definition and environment variable changes.
+
+Because of this, the following doesn't works for you:
+
+export def-env cd_with_fallback [arg = ""] {
+    let fall_back_path = "/tmp"
+    if $arg != "" {
+        cd $arg
+    } else {
+        cd $fall_back_path
+    }
+}
+
+Instead, you have to use cd in the top level scope:
+
+export def-env cd_with_fallback [arg = ""] {
+    let fall_back_path = "/tmp"
+    let path = if $arg != "" {
+        $arg
+    } else {
+        $fall_back_path
+    }
+    cd $path
+}"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -31,9 +31,9 @@ impl Command for ExportDefEnv {
   https://www.nushell.sh/book/thinking_in_nushell.html
 
 === EXTRA NOTE ===
-All blocks are scoped, includes variable definition and environment variable changes.
+All blocks are scoped, including variable definition and environment variable changes.
 
-Because of this, the following doesn't works for you:
+Because of this, the following doesn't work:
 
 export def-env cd_with_fallback [arg = ""] {
     let fall_back_path = "/tmp"


### PR DESCRIPTION
# Description

Closes #5762 
Closes #5024 

Add more notes for `def-env` and `export def-env`, to stop confusing user.

I've thought about if we should put these message [our book](https://www.nushell.sh/book/thinking_in_nushell.html#nushell-s-environment-is-scoped).

But finally I think put these information inside `def-env` and `export def-env` is more clearer for me...

# Tests

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
