### PR TITLE
Fix drop nth with open end range on 32-bit platforms

### DIFF
--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -137,8 +137,15 @@ impl Command for DropNth {
 
                 // check for equality to isize::MAX because for some reason,
                 // the parser returns isize::MAX when we provide a range without upper bound (e.g., 5.. )
-                let to = to as usize;
+                let mut to = to as usize;
                 let from = from as usize;
+
+                if let PipelineData::Value(Value::List { ref vals, span: _ }, _) = input {
+                    let max = from + vals.len() - 1;
+                    if to > max {
+                        to = max;
+                    }
+                };
 
                 if to > 0 && to as isize == isize::MAX {
                     lower_bound = Some(from);


### PR DESCRIPTION
Fixes #5793

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
