### PR TITLE
Fix alias completion crash

### DIFF
--- a/crates/nu-cli/tests/alias.rs
+++ b/crates/nu-cli/tests/alias.rs
@@ -15,6 +15,9 @@ fn alias_of_command_and_flags() {
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     let suggestions = completer.complete("ll t", 4);
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec!["test_a\\".to_string(), "test_b\\".to_string()];
+    #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
 
     match_suggestions(expected_paths, suggestions)
@@ -31,6 +34,9 @@ fn alias_of_basic_command() {
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     let suggestions = completer.complete("ll t", 4);
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec!["test_a\\".to_string(), "test_b\\".to_string()];
+    #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
 
     match_suggestions(expected_paths, suggestions)
@@ -50,6 +56,9 @@ fn alias_of_another_alias() {
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     let suggestions = completer.complete("lf t", 4);
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec!["test_a\\".to_string(), "test_b\\".to_string()];
+    #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
 
     match_suggestions(expected_paths, suggestions)

--- a/crates/nu-cli/tests/alias.rs
+++ b/crates/nu-cli/tests/alias.rs
@@ -1,0 +1,56 @@
+pub mod support;
+
+use nu_cli::NuCompleter;
+use reedline::Completer;
+use support::{match_suggestions, new_engine};
+
+#[test]
+fn alias_of_command_and_flags() {
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Create an alias
+    let alias = r#"alias ll = ls -l"#;
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let suggestions = completer.complete("ll t", 4);
+    let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn alias_of_basic_command() {
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Create an alias
+    let alias = r#"alias ll = ls "#;
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let suggestions = completer.complete("ll t", 4);
+    let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn alias_of_another_alias() {
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Create an alias
+    let alias = r#"alias ll = ls -la"#;
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+    // Create the second alias
+    let alias = r#"alias lf = ll -f"#;
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let suggestions = completer.complete("lf t", 4);
+    let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
+
+    match_suggestions(expected_paths, suggestions)
+}

--- a/crates/nu-cli/tests/custom_completions.rs
+++ b/crates/nu-cli/tests/custom_completions.rs
@@ -14,7 +14,7 @@ fn variables_completions() {
     def my-command [animal: string@animals] { print $animal }"#;
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
-    // Instatiate a new completer
+    // Instantiate a new completer
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     // Test completions for $nu


### PR DESCRIPTION
# Description

Fix alias completion issue, it will address part of #5780 , #5802.  This PR should fix `alias [tab]` cause nu crashed issue

Out of scope -> #5801, I tested 0.63 which is the last stable release build before I did my previous commit, I could reproduce this issue.

# Tests

## Checklist
- **Basic single alias**: `g` is an alias of `git`
   - [x] `g [enter]`
   - [x] `g [tab]` -> No crash
   ---
- **Alias + sub command**: `cg` is an alias of `cargo`
   - [x] `cg [enter]`
   - [x] `cg [tab]` -> No crash
   - [x] `cg  test [enter]`
   - [x] `cg  test [tab]` -> No crash
   - [x] config export extern command "cargo test" : `cg test[tab]` - `cargo test`
   ---
- **Alias is command + flags**: `li` is an alias of `ll -ls`
   - [x] `li [enter]`
   - [x] `li [tab]` -> No crash
   - [x] `li [first letter of folder name] [tab]` -> completion should work
 ---
- **Alias is command + flags - More test**: `rm` is an alias of `rm -iv`
   - [x] `rm [enter]`
   - [x] `rm [tab]` -> No crash
   - [x] `rm [first letter of folder name] [tab]` -> completion -> `[Enter]` -> interactive confirm dialog
 ---
- **More than one alias**: `g` is an alias of `git`, and `co` is an alias of `checkout`
   - [x] config export extern command "git checkout" : `g co[tab]` -> completion
 ---
- **Alias of an alias**
```
alias ll = _ls -l --sort=time
alias _ls = exa --color=always --group-directories-first --icons
```
   - [x] `ll [enter]`
   - [x] `ll [first letter of folder name] [tab]` -> completion should work
   - [x] `_ls [enter]`
   - [x] `_ls [tan]` -> No crash
   - [x] `_ls [first letter of folder name] [tab]` -> completion should work


Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
