### PR TITLE
Fixes `to nuon` for `inf`, `-inf`, and `NaN`

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -87,7 +87,11 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
         )),
         Value::Filesize { val, .. } => Ok(format!("{}b", *val)),
         Value::Float { val, .. } => {
-            if &val.round() == val {
+            if &val.round() == val
+                && val != &f64::NAN
+                && val != &f64::INFINITY
+                && val != &f64::NEG_INFINITY
+            {
                 Ok(format!("{}.0", *val))
             } else {
                 Ok(format!("{}", *val))

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -202,3 +202,39 @@ fn float_doesnt_become_int() {
 
     assert_eq!(actual.out, "1.0")
 }
+
+#[test]
+fn float_inf_parsed_properly() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            inf | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "inf")
+}
+
+#[test]
+fn float_neg_inf_parsed_properly() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            -inf | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "-inf")
+}
+
+#[test]
+fn float_nan_parsed_properly() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            NaN | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "NaN")
+}


### PR DESCRIPTION
# Description

Fixes #5816.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
