### PR TITLE
Fix parser panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,6 +2685,7 @@ name = "nu-parser"
 version = "0.64.0"
 dependencies = [
  "chrono",
+ "itertools",
  "log",
  "miette 4.7.1",
  "nu-path",

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.64.0"
 
 [dependencies]
 chrono = "0.4.19"
+itertools = "0.10"
 miette = "4.5.0"
 thiserror = "1.0.29"
 serde_json = "1.0"

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -22,6 +22,7 @@ use crate::parse_keywords::{
     parse_use,
 };
 
+use itertools::Itertools;
 use log::trace;
 use std::{
     collections::{HashMap, HashSet},
@@ -1206,9 +1207,13 @@ fn parse_binary_with_base(
 }
 
 fn decode_with_base(s: &str, base: u32, digits_per_byte: usize) -> Result<Vec<u8>, ParseIntError> {
-    (0..s.len())
-        .step_by(digits_per_byte)
-        .map(|i| u8::from_str_radix(&s[i..i + digits_per_byte], base))
+    s.chars()
+        .chunks(digits_per_byte)
+        .into_iter()
+        .map(|chunk| {
+            let str: String = chunk.collect();
+            u8::from_str_radix(&str, base)
+        })
         .collect()
 }
 

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -160,6 +160,22 @@ pub fn parse_binary_with_invalid_octal_format() {
 }
 
 #[test]
+pub fn parse_binary_with_multi_byte_char() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    // found using fuzzing, Rust can panic if you slice into this string
+    let contents = b"0x[\xEF\xBF\xBD]";
+    let (block, err) = parse(&mut working_set, None, contents, true, &[]);
+
+    assert!(err.is_none());
+    assert!(block.len() == 1);
+    let expressions = &block[0];
+    assert!(expressions.len() == 1);
+    assert!(!matches!(&expressions[0].expr, Expr::Binary(_)))
+}
+
+#[test]
 pub fn parse_string() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);


### PR DESCRIPTION
# Description

I tried fuzzing the parser and found a panic when parsing multi-byte characters; `decode_with_base()` was doing an unsafe slice into a `&str` and it would panic with 'byte index is not a char boundary' if given a multi-byte character. Not especially likely to happen, but I figured I might as well fix it.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
