### PR TITLE
first stab at minimizing ansi escapes

### DIFF
--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -1,7 +1,7 @@
 use crate::table_theme::TableTheme;
 use crate::wrap::{column_width, split_sublines, wrap, Alignment, Subline, WrappedCell};
 use crate::{StyledString, TextStyle};
-use nu_ansi_term::Style;
+use nu_ansi_term::{AnsiString, AnsiStrings, Style};
 use nu_protocol::{Config, FooterMode};
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -62,7 +62,7 @@ impl WrappedTable {
         color_hm: &HashMap<String, Style>,
     ) -> String {
         let column_count = self.column_widths.len();
-        let mut output = String::new();
+        let mut output: Vec<AnsiString> = Vec::new();
         let sep_color = color_hm
             .get("separator")
             .unwrap_or(&Style::default())
@@ -72,139 +72,70 @@ impl WrappedTable {
             SeparatorPosition::Top => {
                 for column in self.column_widths.iter().enumerate() {
                     if column.0 == 0 && self.theme.print_left_border {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.top_left.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.top_left.to_string()));
                     }
 
                     for _ in 0..*column.1 {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.top_horizontal.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.top_horizontal.to_string()));
                     }
 
-                    output.push_str(
-                        &sep_color
-                            .paint(&self.theme.top_horizontal.to_string())
-                            .to_string(),
-                    );
-                    output.push_str(
-                        &sep_color
-                            .paint(&self.theme.top_horizontal.to_string())
-                            .to_string(),
-                    );
+                    output.push(sep_color.paint(self.theme.top_horizontal.to_string()));
+                    output.push(sep_color.paint(self.theme.top_horizontal.to_string()));
                     if column.0 == column_count - 1 {
                         if self.theme.print_right_border {
-                            output.push_str(
-                                &sep_color
-                                    .paint(&self.theme.top_right.to_string())
-                                    .to_string(),
-                            );
+                            output.push(sep_color.paint(self.theme.top_right.to_string()));
                         }
                     } else {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.top_center.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.top_center.to_string()));
                     }
                 }
-                output.push('\n');
+                output.push(AnsiString::from("\n".to_string()));
             }
             SeparatorPosition::Middle => {
                 for column in self.column_widths.iter().enumerate() {
                     if column.0 == 0 && self.theme.print_left_border {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.middle_left.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.middle_left.to_string()));
                     }
 
                     for _ in 0..*column.1 {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.middle_horizontal.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.middle_horizontal.to_string()));
                     }
 
-                    output.push_str(
-                        &sep_color
-                            .paint(&self.theme.middle_horizontal.to_string())
-                            .to_string(),
-                    );
-                    output.push_str(
-                        &sep_color
-                            .paint(&self.theme.middle_horizontal.to_string())
-                            .to_string(),
-                    );
+                    output.push(sep_color.paint(self.theme.middle_horizontal.to_string()));
+                    output.push(sep_color.paint(self.theme.middle_horizontal.to_string()));
 
                     if column.0 == column_count - 1 {
                         if self.theme.print_right_border {
-                            output.push_str(
-                                &sep_color
-                                    .paint(&self.theme.middle_right.to_string())
-                                    .to_string(),
-                            );
+                            output.push(sep_color.paint(self.theme.middle_right.to_string()));
                         }
                     } else {
-                        output
-                            .push_str(&sep_color.paint(&self.theme.center.to_string()).to_string());
+                        output.push(sep_color.paint(self.theme.center.to_string()));
                     }
                 }
-                output.push('\n');
+                output.push(AnsiString::from("\n".to_string()));
             }
             SeparatorPosition::Bottom => {
                 for column in self.column_widths.iter().enumerate() {
                     if column.0 == 0 && self.theme.print_left_border {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.bottom_left.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.bottom_left.to_string()));
                     }
                     for _ in 0..*column.1 {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.bottom_horizontal.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.bottom_horizontal.to_string()));
                     }
-                    output.push_str(
-                        &sep_color
-                            .paint(&self.theme.bottom_horizontal.to_string())
-                            .to_string(),
-                    );
-                    output.push_str(
-                        &sep_color
-                            .paint(&self.theme.bottom_horizontal.to_string())
-                            .to_string(),
-                    );
+                    output.push(sep_color.paint(self.theme.bottom_horizontal.to_string()));
+                    output.push(sep_color.paint(self.theme.bottom_horizontal.to_string()));
 
                     if column.0 == column_count - 1 {
                         if self.theme.print_right_border {
-                            output.push_str(
-                                &sep_color
-                                    .paint(&self.theme.bottom_right.to_string())
-                                    .to_string(),
-                            );
+                            output.push(sep_color.paint(self.theme.bottom_right.to_string()));
                         }
                     } else {
-                        output.push_str(
-                            &sep_color
-                                .paint(&self.theme.bottom_center.to_string())
-                                .to_string(),
-                        );
+                        output.push(sep_color.paint(self.theme.bottom_center.to_string()));
                     }
                 }
             }
         }
-        output
+        AnsiStrings(&output[..]).to_string()
     }
 
     fn print_cell_contents(


### PR DESCRIPTION
# Description

Related to #5821, this should minimize the ansi escape sequences. In the "turtle" test, this change took it from a string length of 7,727,109 to 1,423,131. I still need to look deeper but this is a start.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
