### PR TITLE
Add more tests for completion

### DIFF
--- a/crates/nu-cli/tests/file_completions.rs
+++ b/crates/nu-cli/tests/file_completions.rs
@@ -40,3 +40,267 @@ fn file_completions() {
     // Match the results
     match_suggestions(expected_paths, suggestions);
 }
+
+//  Basic file system commands should have path completion working without a necessary starting character
+#[test]
+fn command_ls_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("ls ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+#[test]
+fn command_open_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("open ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn command_rm_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("rm ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn command_mv_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("mv ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn command_cp_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("cp ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn command_save_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("save ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn command_touch_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("touch ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn command_watch_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("watch ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}

--- a/crates/nu-cli/tests/file_completions.rs
+++ b/crates/nu-cli/tests/file_completions.rs
@@ -239,77 +239,12 @@ fn command_touch_completion() {
 }
 
 #[test]
-fn command_glob_completion() {
-    let (_, _, engine, stack) = new_engine();
-
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
-
-    let target_dir = format!("glob ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
-
-    #[cfg(windows)]
-    let expected_paths: Vec<String> = vec![
-        "nushell".to_string(),
-        "test_a\\".to_string(),
-        "test_b\\".to_string(),
-        "another\\".to_string(),
-        "custom_completion.nu".to_string(),
-        ".hidden_file".to_string(),
-        ".hidden_folder\\".to_string(),
-    ];
-    #[cfg(not(windows))]
-    let expected_paths: Vec<String> = vec![
-        "nushell".to_string(),
-        "test_a/".to_string(),
-        "test_b/".to_string(),
-        "another/".to_string(),
-        "custom_completion.nu".to_string(),
-        ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
-    ];
-
-    match_suggestions(expected_paths, suggestions)
-}
-#[test]
 fn command_watch_completion() {
     let (_, _, engine, stack) = new_engine();
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     let target_dir = format!("watch ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
-
-    #[cfg(windows)]
-    let expected_paths: Vec<String> = vec![
-        "nushell".to_string(),
-        "test_a\\".to_string(),
-        "test_b\\".to_string(),
-        "another\\".to_string(),
-        "custom_completion.nu".to_string(),
-        ".hidden_file".to_string(),
-        ".hidden_folder\\".to_string(),
-    ];
-    #[cfg(not(windows))]
-    let expected_paths: Vec<String> = vec![
-        "nushell".to_string(),
-        "test_a/".to_string(),
-        "test_b/".to_string(),
-        "another/".to_string(),
-        "custom_completion.nu".to_string(),
-        ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
-    ];
-
-    match_suggestions(expected_paths, suggestions)
-}
-
-#[test]
-fn command_util_completion() {
-    let (_, _, engine, stack) = new_engine();
-
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
-
-    let target_dir = format!("util ");
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     #[cfg(windows)]

--- a/crates/nu-cli/tests/file_completions.rs
+++ b/crates/nu-cli/tests/file_completions.rs
@@ -41,7 +41,6 @@ fn file_completions() {
     match_suggestions(expected_paths, suggestions);
 }
 
-//  Basic file system commands should have path completion working without a necessary starting character
 #[test]
 fn command_ls_completion() {
     let (_, _, engine, stack) = new_engine();
@@ -56,10 +55,10 @@ fn command_ls_completion() {
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
-        "another/".to_string(),
+        "another\\".to_string(),
         "custom_completion.nu".to_string(),
         ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
+        ".hidden_folder\\".to_string(),
     ];
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec![
@@ -88,10 +87,10 @@ fn command_open_completion() {
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
-        "another/".to_string(),
+        "another\\".to_string(),
         "custom_completion.nu".to_string(),
         ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
+        ".hidden_folder\\".to_string(),
     ];
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec![
@@ -121,43 +120,10 @@ fn command_rm_completion() {
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
-        "another/".to_string(),
+        "another\\".to_string(),
         "custom_completion.nu".to_string(),
         ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
-    ];
-    #[cfg(not(windows))]
-    let expected_paths: Vec<String> = vec![
-        "nushell".to_string(),
-        "test_a/".to_string(),
-        "test_b/".to_string(),
-        "another/".to_string(),
-        "custom_completion.nu".to_string(),
-        ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
-    ];
-
-    match_suggestions(expected_paths, suggestions)
-}
-
-#[test]
-fn command_mv_completion() {
-    let (_, _, engine, stack) = new_engine();
-
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
-
-    let target_dir = format!("mv ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
-
-    #[cfg(windows)]
-    let expected_paths: Vec<String> = vec![
-        "nushell".to_string(),
-        "test_a\\".to_string(),
-        "test_b\\".to_string(),
-        "another/".to_string(),
-        "custom_completion.nu".to_string(),
-        ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
+        ".hidden_folder\\".to_string(),
     ];
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec![
@@ -187,10 +153,10 @@ fn command_cp_completion() {
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
-        "another/".to_string(),
+        "another\\".to_string(),
         "custom_completion.nu".to_string(),
         ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
+        ".hidden_folder\\".to_string(),
     ];
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec![
@@ -220,10 +186,10 @@ fn command_save_completion() {
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
-        "another/".to_string(),
+        "another\\".to_string(),
         "custom_completion.nu".to_string(),
         ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
+        ".hidden_folder\\".to_string(),
     ];
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec![
@@ -253,10 +219,10 @@ fn command_touch_completion() {
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
-        "another/".to_string(),
+        "another\\".to_string(),
         "custom_completion.nu".to_string(),
         ".hidden_file".to_string(),
-        ".hidden_folder/".to_string(),
+        ".hidden_folder\\".to_string(),
     ];
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec![
@@ -273,6 +239,38 @@ fn command_touch_completion() {
 }
 
 #[test]
+fn command_glob_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("glob ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another\\".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder\\".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+#[test]
 fn command_watch_completion() {
     let (_, _, engine, stack) = new_engine();
 
@@ -286,10 +284,43 @@ fn command_watch_completion() {
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
+        "another\\".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder\\".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
         "another/".to_string(),
         "custom_completion.nu".to_string(),
         ".hidden_file".to_string(),
         ".hidden_folder/".to_string(),
+    ];
+
+    match_suggestions(expected_paths, suggestions)
+}
+
+#[test]
+fn command_util_completion() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let target_dir = format!("util ");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    #[cfg(windows)]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another\\".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder\\".to_string(),
     ];
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec![


### PR DESCRIPTION
# Description

A follow-up pr to add more tests for file-system commands completion -> Prior to PR #5805 and Issue #5801

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
