### PR TITLE
Calculate history duration properly (sqlite)

### DIFF
--- a/crates/nu-command/src/misc/history.rs
+++ b/crates/nu-command/src/misc/history.rs
@@ -178,7 +178,7 @@ impl Command for History {
                                         },
                                         Value::Duration {
                                             val: match entry.duration {
-                                                Some(d) => d.as_millis().try_into().unwrap_or(0),
+                                                Some(d) => d.as_nanos().try_into().unwrap_or(0),
                                                 None => 0,
                                             },
                                             span: head,


### PR DESCRIPTION
# Description

Fixes #5819. It seems to work on my end.

How to reproduce: run a command, time it, `history`. I used `sudo apt update` and got ~4s in the `history`, which is correct.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
