### PR TITLE
root/admin prompt is red now

### DIFF
--- a/docs/sample_config/default_env.nu
+++ b/docs/sample_config/default_env.nu
@@ -1,7 +1,11 @@
 # Nushell Environment Config File
 
 def create_left_prompt [] {
-    let path_segment = ($env.PWD)
+    let path_segment = if (is-admin) {
+        $"(ansi red_bold)($env.PWD)"
+    } else {
+        $"(ansi green_bold)($env.PWD)"
+    }
 
     $path_segment
 }


### PR DESCRIPTION
I really miss bash's visual way of signalising root, i.e. blue: user, red: root

So I brought it to nushell (since you've added `is-admin` the code is fully portable and easily-readable) and hope you'll like it

# Description
I simply added `is-admin` check to the left prompt. Changed `env.nu` will generate `ansi red_bold` path for admin users and remain `ansi green_bold` for standard users

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
