### PR TITLE
update reedline config based on recent reedline changes

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -875,7 +875,16 @@ fn edit_from_record(
         "moveleft" => EditCommand::MoveLeft,
         "moveright" => EditCommand::MoveRight,
         "movewordleft" => EditCommand::MoveWordLeft,
+        "movebigwordleft" => EditCommand::MoveBigWordLeft,
         "movewordright" => EditCommand::MoveWordRight,
+        "movewordrightend" => EditCommand::MoveWordRightEnd,
+        "movebigwordrightend" => EditCommand::MoveBigWordRightEnd,
+        "movewordrightstart" => EditCommand::MoveWordRightStart,
+        "movebigwordrightstart" => EditCommand::MoveBigWordRightStart,
+        "movetoposition" => {
+            let value = extract_value("value", cols, vals, span)?;
+            EditCommand::MoveToPosition(value.as_integer()? as usize)
+        }
         "insertchar" => {
             let value = extract_value("value", cols, vals, span)?;
             let char = extract_char(value, config)?;
@@ -888,6 +897,7 @@ fn edit_from_record(
         "insertnewline" => EditCommand::InsertNewline,
         "backspace" => EditCommand::Backspace,
         "delete" => EditCommand::Delete,
+        "cutchar" => EditCommand::CutChar,
         "backspaceword" => EditCommand::BackspaceWord,
         "deleteword" => EditCommand::DeleteWord,
         "clear" => EditCommand::Clear,
@@ -898,7 +908,11 @@ fn edit_from_record(
         "cuttoend" => EditCommand::CutToEnd,
         "cuttolineend" => EditCommand::CutToLineEnd,
         "cutwordleft" => EditCommand::CutWordLeft,
+        "cutbigwordleft" => EditCommand::CutBigWordLeft,
         "cutwordright" => EditCommand::CutWordRight,
+        "cutbigwordright" => EditCommand::CutBigWordRight,
+        "cutwordrighttonext" => EditCommand::CutWordRightToNext,
+        "cutbigwordrighttonext" => EditCommand::CutBigWordRightToNext,
         "pastecutbufferbefore" => EditCommand::PasteCutBufferBefore,
         "pastecutbufferafter" => EditCommand::PasteCutBufferAfter,
         "uppercaseword" => EditCommand::UppercaseWord,


### PR DESCRIPTION
# Description

This updates the reedline_config with recent addtions to reedline, namely new `EditCommand`s like `MoveBigWordLeft`

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
