### PR TITLE
Remove quotes from external args

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -411,7 +411,7 @@ impl ExternalCommand {
 
         for arg in self.args.iter() {
             let mut arg = Spanned {
-                item: trim_enclosing_quotes(&arg.item),
+                item: remove_quotes(trim_enclosing_quotes(&arg.item)),
                 span: arg.span,
             };
             arg.item = nu_path::expand_to_real_path(arg.item)
@@ -518,15 +518,27 @@ fn shell_arg_escape(arg: &str) -> String {
 fn trim_enclosing_quotes(input: &str) -> String {
     let mut chars = input.chars();
 
-    let res = match (chars.next(), chars.next_back()) {
+    match (chars.next(), chars.next_back()) {
         (Some('"'), Some('"')) => chars.collect(),
         (Some('\''), Some('\'')) => chars.collect(),
         (Some('`'), Some('`')) => chars.collect(),
         _ => input.to_string(),
+    }
+}
+
+fn remove_quotes(input: String) -> String {
+    let chars = input.chars();
+
+    let replace = match chars.last() {
+        Some('"') => Some('"'),
+        Some('\'') => Some('\''),
+        _ => None,
     };
 
-    // To follow Bash convention, all externals receive their arguments without quotes
-    res.replace("\"", "")
+    match replace {
+        Some(char) => input.replace(char, ""),
+        None => input,
+    }
 }
 
 // Receiver used for the RawStream

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -527,17 +527,15 @@ fn trim_enclosing_quotes(input: &str) -> String {
 }
 
 fn remove_quotes(input: String) -> String {
-    let chars = input.chars();
+    let mut chars = input.chars();
 
-    let replace = match chars.last() {
-        Some('"') => Some('"'),
-        Some('\'') => Some('\''),
-        _ => None,
-    };
-
-    match replace {
-        Some(char) => input.replace(char, ""),
-        None => input,
+    match chars.next_back() {
+        Some('"') => chars
+            .collect::<String>()
+            .replacen('"', "", 1)
+            .replace(r#"\""#, "\""),
+        Some('\'') => chars.collect::<String>().replacen('\'', "", 1),
+        _ => input,
     }
 }
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -518,12 +518,15 @@ fn shell_arg_escape(arg: &str) -> String {
 fn trim_enclosing_quotes(input: &str) -> String {
     let mut chars = input.chars();
 
-    match (chars.next(), chars.next_back()) {
+    let res = match (chars.next(), chars.next_back()) {
         (Some('"'), Some('"')) => chars.collect(),
         (Some('\''), Some('\'')) => chars.collect(),
         (Some('`'), Some('`')) => chars.collect(),
         _ => input.to_string(),
-    }
+    };
+
+    // To follow Bash convention, all externals receive their arguments without quotes
+    res.replace("\"", "")
 }
 
 // Receiver used for the RawStream


### PR DESCRIPTION
# Description

To follow Bash convention all arguments to externals should not contain quotes

fixes #4601

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
