### PR TITLE
Introduce new command - nu check

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -158,6 +158,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             Complete,
             Exec,
             External,
+            NuCheck,
             Ps,
             Sys,
         };

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,6 +1,7 @@
 mod benchmark;
 mod complete;
 mod exec;
+mod nu_check;
 mod ps;
 mod run_external;
 mod sys;
@@ -9,6 +10,7 @@ mod which_;
 pub use benchmark::Benchmark;
 pub use complete::Complete;
 pub use exec::Exec;
+pub use nu_check::NuCheck;
 pub use ps::Ps;
 pub use run_external::{External, ExternalCommand};
 pub use sys::Sys;

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -11,22 +11,23 @@ pub struct NuCheck;
 
 impl Command for NuCheck {
     fn name(&self) -> &str {
-        "nu check"
+        "nu-check"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("nu check")
-            .required("path", SyntaxShape::Filepath, "the file path to check")
+        Signature::build("nu-check")
+            .optional("path", SyntaxShape::Filepath, "File path to parse")
             .switch("as-module", "Parse content as module", Some('m'))
+            .switch("debug", "Show error messages", Some('d'))
             .category(Category::Strings)
     }
 
     fn usage(&self) -> &str {
-        "Check if input could be parsed correctly or not"
+        "Validate and parse input content"
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["syntax", "parse"]
+        vec!["syntax", "parse", "debug"]
     }
 
     fn run(
@@ -34,46 +35,120 @@ impl Command for NuCheck {
         engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let path: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
         let is_module = call.has_flag("as-module");
+        let is_debug = call.has_flag("debug");
+        let config = engine_state.get_config();
+        let mut contents = vec![];
 
         // DO NOT ever try to merge the working_set in this command
         let mut working_set = StateWorkingSet::new(engine_state);
-        let (path, span) = match find_path(path, engine_state, stack, call.head) {
-            Ok((path, span)) => (path, span),
-            Err(error) => return Err(error),
-        };
 
-        let ext: Vec<_> = path.rsplitn(2, '.').collect();
-        if ext[0] != "nu" {
-            return Err(ShellError::GenericError(
-                "Cannot parse input".to_string(),
-                "File extension must be .nu".to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            ));
-        }
+        match input {
+            PipelineData::Value(Value::String { val, span }, ..) => {
+                let contents = Vec::from(val);
+                if is_module {
+                    parse_module(&mut working_set, None, contents, is_debug, span)
+                } else {
+                    parse_script(&mut working_set, contents, None, is_debug, span)
+                }
+            }
+            PipelineData::ListStream(stream, ..) => {
+                let list_stream = stream.into_string(" ", config);
+                let contents = Vec::from(list_stream);
 
-        if is_module {
-            parse_module(path, &mut working_set, call, span)
-        } else {
-            parse_script(path, &mut working_set, call, span)
+                if is_module {
+                    parse_module(&mut working_set, None, contents, is_debug, call.head)
+                } else {
+                    parse_script(&mut working_set, contents, None, is_debug, call.head)
+                }
+            }
+            PipelineData::ExternalStream {
+                stdout: Some(stream),
+                ..
+            } => {
+                let raw_stream: Vec<_> = stream.stream.into_iter().collect();
+                for r in raw_stream {
+                    match r {
+                        Ok(v) => contents.extend(v),
+                        Err(error) => return Err(error),
+                    };
+                }
+
+                if is_module {
+                    parse_module(&mut working_set, None, contents, is_debug, call.head)
+                } else {
+                    parse_script(&mut working_set, contents, None, is_debug, call.head)
+                }
+            }
+            _ => {
+                if path.is_some() {
+                    let path = match find_path(path, engine_state, stack, call.head) {
+                        Ok(path) => path,
+                        Err(error) => return Err(error),
+                    };
+
+                    let ext: Vec<_> = path.rsplitn(2, '.').collect();
+                    if ext[0] != "nu" {
+                        return Err(ShellError::GenericError(
+                            "Cannot parse input".to_string(),
+                            "File extension must be .nu".to_string(),
+                            Some(call.head),
+                            None,
+                            Vec::new(),
+                        ));
+                    }
+
+                    if is_module {
+                        parse_file_module(path, &mut working_set, call, is_debug)
+                    } else {
+                        parse_file_script(path, &mut working_set, call, is_debug)
+                    }
+                } else {
+                    Err(ShellError::GenericError(
+                        "Failed to execute command".to_string(),
+                        "Do not understand the input, please run 'nu-check --help' for more details".to_string(),
+                        Some(call.head),
+                        None,
+                        Vec::new(),
+                    ))
+                }
+            }
         }
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Parse input as script",
-                example: "nu check script.nu",
+                description: "Parse a file as script(Default)",
+                example: "nu-check script.nu",
                 result: None,
             },
             Example {
-                description: "Parse input as module",
-                example: "nu check --as-module module.nu",
+                description: "Parse a file input as module",
+                example: "nu-check --as-module module.nu",
+                result: None,
+            },
+            Example {
+                description: "Parse a file with error message",
+                example: "nu-check -d script.nu",
+                result: None,
+            },
+            Example {
+                description: "Parse an external stream as script with more error message",
+                example: "open foo.nu | nu-check -d script.nu",
+                result: None,
+            },
+            Example {
+                description: "Parse an internal stream as module with more error message",
+                example: "open module.nu | lines | nu-check -d --as-module module.nu",
+                result: None,
+            },
+            Example {
+                description: "Parse a string as script",
+                example: "echo $'two(char nl)lines' | nu-check ",
                 result: None,
             },
         ]
@@ -85,10 +160,10 @@ fn find_path(
     engine_state: &EngineState,
     stack: &mut Stack,
     span: Span,
-) -> Result<(String, Span), ShellError> {
+) -> Result<String, ShellError> {
     let cwd = current_dir(engine_state, stack)?;
 
-    let (path, span) = match path {
+    let path = match path {
         Some(s) => {
             let path_no_whitespace = &s.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
 
@@ -111,88 +186,117 @@ fn find_path(
                     return Err(ShellError::FileNotFound(s.span));
                 }
             };
-            (path.to_string_lossy().to_string(), s.span)
+            path.to_string_lossy().to_string()
         }
         None => {
             return Err(ShellError::NotFound(span));
         }
     };
-    Ok((path, span))
-}
-
-fn parse_script(
-    path: String,
-    working_set: &mut StateWorkingSet,
-    call: &Call,
-    span: Span,
-) -> Result<PipelineData, ShellError> {
-    let (filename, err) = unescape_unquote_string(path.as_bytes(), span);
-    if err.is_none() {
-        if let Ok(contents) = std::fs::read(&path) {
-            let (_, err) = parse(working_set, Some(&filename), &contents, false, &[]);
-
-            if err.is_some() {
-                let msg = format!(r#"Found : {}"#, err.expect("Unable to parse content"));
-                Err(ShellError::GenericError(
-                    "Failed to parse content".to_string(),
-                    msg,
-                    Some(call.head),
-                    Some("If the content is a module, please use --as-module flag".to_string()),
-                    Vec::new(),
-                ))
-            } else {
-                Ok(PipelineData::Value(
-                    Value::string("Parse Success!", span),
-                    None,
-                ))
-            }
-        } else {
-            Err(ShellError::IOError("Can not read path".to_string()))
-        }
-    } else {
-        Err(ShellError::NotFound(span))
-    }
+    Ok(path)
 }
 
 fn parse_module(
+    working_set: &mut StateWorkingSet,
+    filename: Option<String>,
+    contents: Vec<u8>,
+    is_debug: bool,
+    span: Span,
+) -> Result<PipelineData, ShellError> {
+    let start = working_set.next_span_start();
+    working_set.add_file(
+        filename.unwrap_or_else(|| "empty".to_string()),
+        contents.as_ref(),
+    );
+    let end = working_set.next_span_start();
+
+    let new_span = Span::new(start, end);
+    let (_, _, err) = parse_module_block(working_set, new_span, &[]);
+
+    if err.is_some() {
+        if is_debug {
+            let msg = format!(
+                r#"Found : {}"#,
+                err.expect("Unable to parse content as module")
+            );
+            Err(ShellError::GenericError(
+                "Failed to parse module".to_string(),
+                msg,
+                Some(span),
+                Some("If the content is a script, please remove flag".to_string()),
+                Vec::new(),
+            ))
+        } else {
+            Ok(PipelineData::Value(Value::boolean(false, new_span), None))
+        }
+    } else {
+        Ok(PipelineData::Value(Value::boolean(true, new_span), None))
+    }
+}
+
+fn parse_script(
+    working_set: &mut StateWorkingSet,
+    contents: Vec<u8>,
+    filename: Option<&str>,
+    is_debug: bool,
+    span: Span,
+) -> Result<PipelineData, ShellError> {
+    let (_, err) = parse(working_set, filename, &contents, false, &[]);
+    if err.is_some() {
+        let msg = format!(r#"Found : {}"#, err.expect("Unable to parse content"));
+        if is_debug {
+            Err(ShellError::GenericError(
+                "Failed to parse content".to_string(),
+                msg,
+                Some(span),
+                Some("If the content is a module, please use --as-module flag".to_string()),
+                Vec::new(),
+            ))
+        } else {
+            Ok(PipelineData::Value(Value::boolean(false, span), None))
+        }
+    } else {
+        Ok(PipelineData::Value(Value::boolean(true, span), None))
+    }
+}
+
+fn parse_file_script(
     path: String,
     working_set: &mut StateWorkingSet,
     call: &Call,
-    span: Span,
+    is_debug: bool,
 ) -> Result<PipelineData, ShellError> {
-    let (filename, err) = unescape_unquote_string(path.as_bytes(), span);
+    let (filename, err) = unescape_unquote_string(path.as_bytes(), call.head);
     if err.is_none() {
-        if let Ok(contents) = std::fs::read(path) {
-            let start = working_set.next_span_start();
-            working_set.add_file(filename, &contents);
-            let end = working_set.next_span_start();
-
-            let new_span = Span::new(start, end);
-
-            let (_, _, err) = parse_module_block(working_set, new_span, &[]);
-
-            if err.is_some() {
-                let msg = format!(
-                    r#"Found : {}"#,
-                    err.expect("Unable to parse content as module")
-                );
-                Err(ShellError::GenericError(
-                    "Failed to parse module".to_string(),
-                    msg,
-                    Some(call.head),
-                    Some("If the content is a script, please remove flag".to_string()),
-                    Vec::new(),
-                ))
-            } else {
-                Ok(PipelineData::Value(
-                    Value::string("Parse Success!", span),
-                    None,
-                ))
-            }
+        if let Ok(contents) = std::fs::read(&path) {
+            parse_script(
+                working_set,
+                contents,
+                Some(filename.as_str()),
+                is_debug,
+                call.head,
+            )
         } else {
             Err(ShellError::IOError("Can not read path".to_string()))
         }
     } else {
-        Err(ShellError::NotFound(span))
+        Err(ShellError::NotFound(call.head))
+    }
+}
+
+fn parse_file_module(
+    path: String,
+    working_set: &mut StateWorkingSet,
+    call: &Call,
+    is_debug: bool,
+) -> Result<PipelineData, ShellError> {
+    let (filename, err) = unescape_unquote_string(path.as_bytes(), call.head);
+    if err.is_none() {
+        if let Ok(contents) = std::fs::read(path) {
+            parse_module(working_set, Some(filename), contents, is_debug, call.head)
+        } else {
+            Err(ShellError::IOError("Can not read path".to_string()))
+        }
+    } else {
+        Err(ShellError::NotFound(call.head))
     }
 }

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -52,17 +52,17 @@ impl Command for NuCheck {
                 if is_module {
                     parse_module(&mut working_set, None, contents, is_debug, span)
                 } else {
-                    parse_script(&mut working_set, contents, None, is_debug, span)
+                    parse_script(&mut working_set, None, contents, is_debug, span)
                 }
             }
             PipelineData::ListStream(stream, ..) => {
-                let list_stream = stream.into_string(" ", config);
+                let list_stream = stream.into_string("\n", config);
                 let contents = Vec::from(list_stream);
 
                 if is_module {
                     parse_module(&mut working_set, None, contents, is_debug, call.head)
                 } else {
-                    parse_script(&mut working_set, contents, None, is_debug, call.head)
+                    parse_script(&mut working_set, None, contents, is_debug, call.head)
                 }
             }
             PipelineData::ExternalStream {
@@ -80,7 +80,7 @@ impl Command for NuCheck {
                 if is_module {
                     parse_module(&mut working_set, None, contents, is_debug, call.head)
                 } else {
-                    parse_script(&mut working_set, contents, None, is_debug, call.head)
+                    parse_script(&mut working_set, None, contents, is_debug, call.head)
                 }
             }
             _ => {
@@ -94,7 +94,7 @@ impl Command for NuCheck {
                     if ext[0] != "nu" {
                         return Err(ShellError::GenericError(
                             "Cannot parse input".to_string(),
-                            "File extension must be .nu".to_string(),
+                            "File extension must be the type of .nu".to_string(),
                             Some(call.head),
                             None,
                             Vec::new(),
@@ -109,7 +109,7 @@ impl Command for NuCheck {
                 } else {
                     Err(ShellError::GenericError(
                         "Failed to execute command".to_string(),
-                        "Do not understand the input, please run 'nu-check --help' for more details".to_string(),
+                        "Please run 'nu-check --help' for more details".to_string(),
                         Some(call.head),
                         None,
                         Vec::new(),
@@ -122,27 +122,27 @@ impl Command for NuCheck {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Parse a file as script(Default)",
+                description: "Parse a input file as script(Default)",
                 example: "nu-check script.nu",
                 result: None,
             },
             Example {
-                description: "Parse a file input as module",
+                description: "Parse a input file as module",
                 example: "nu-check --as-module module.nu",
                 result: None,
             },
             Example {
-                description: "Parse a file with error message",
+                description: "Parse a input file by showing error message",
                 example: "nu-check -d script.nu",
                 result: None,
             },
             Example {
-                description: "Parse an external stream as script with more error message",
+                description: "Parse an external stream as script by showing error message",
                 example: "open foo.nu | nu-check -d script.nu",
                 result: None,
             },
             Example {
-                description: "Parse an internal stream as module with more error message",
+                description: "Parse an internal stream as module by showing error message",
                 example: "open module.nu | lines | nu-check -d --as-module module.nu",
                 result: None,
             },
@@ -219,10 +219,10 @@ fn parse_module(
                 err.expect("Unable to parse content as module")
             );
             Err(ShellError::GenericError(
-                "Failed to parse module".to_string(),
+                "Failed to parse content".to_string(),
                 msg,
                 Some(span),
-                Some("If the content is a script, please remove flag".to_string()),
+                Some("If the content is intended to be a script, please try to remove `--as-module` flag ".to_string()),
                 Vec::new(),
             ))
         } else {
@@ -235,8 +235,8 @@ fn parse_module(
 
 fn parse_script(
     working_set: &mut StateWorkingSet,
-    contents: Vec<u8>,
     filename: Option<&str>,
+    contents: Vec<u8>,
     is_debug: bool,
     span: Span,
 ) -> Result<PipelineData, ShellError> {
@@ -248,7 +248,7 @@ fn parse_script(
                 "Failed to parse content".to_string(),
                 msg,
                 Some(span),
-                Some("If the content is a module, please use --as-module flag".to_string()),
+                Some("If the content is intended to be a module, please consider flag of `--as-module` ".to_string()),
                 Vec::new(),
             ))
         } else {
@@ -270,8 +270,8 @@ fn parse_file_script(
         if let Ok(contents) = std::fs::read(&path) {
             parse_script(
                 working_set,
-                contents,
                 Some(filename.as_str()),
+                contents,
                 is_debug,
                 call.head,
             )

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -1,0 +1,198 @@
+use nu_engine::{current_dir, CallExt};
+use nu_parser::{parse, parse_module_block, unescape_unquote_string};
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack, StateWorkingSet};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
+};
+
+#[derive(Clone)]
+pub struct NuCheck;
+
+impl Command for NuCheck {
+    fn name(&self) -> &str {
+        "nu check"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("nu check")
+            .required("path", SyntaxShape::Filepath, "the file path to check")
+            .switch("as-module", "Parse content as module", Some('m'))
+            .category(Category::Strings)
+    }
+
+    fn usage(&self) -> &str {
+        "Check if input could be parsed correctly or not"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["syntax", "parse"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let path: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
+        let is_module = call.has_flag("as-module");
+
+        // DO NOT ever try to merge the working_set in this command
+        let mut working_set = StateWorkingSet::new(engine_state);
+        let (path, span) = match find_path(path, engine_state, stack, call.head) {
+            Ok((path, span)) => (path, span),
+            Err(error) => return Err(error),
+        };
+
+        let ext: Vec<_> = path.rsplitn(2, '.').collect();
+        if ext[0] != "nu" {
+            return Err(ShellError::GenericError(
+                "Cannot parse input".to_string(),
+                "File extension must be .nu".to_string(),
+                Some(call.head),
+                None,
+                Vec::new(),
+            ));
+        }
+
+        if is_module {
+            parse_module(path, &mut working_set, call, span)
+        } else {
+            parse_script(path, &mut working_set, call, span)
+        }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Parse input as script",
+                example: "nu check script.nu",
+                result: None,
+            },
+            Example {
+                description: "Parse input as module",
+                example: "nu check --as-module module.nu",
+                result: None,
+            },
+        ]
+    }
+}
+
+fn find_path(
+    path: Option<Spanned<String>>,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    span: Span,
+) -> Result<(String, Span), ShellError> {
+    let cwd = current_dir(engine_state, stack)?;
+
+    let (path, span) = match path {
+        Some(s) => {
+            let path_no_whitespace = &s.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
+
+            let path = match nu_path::canonicalize_with(path_no_whitespace, &cwd) {
+                Ok(p) => {
+                    if !p.is_file() {
+                        return Err(ShellError::GenericError(
+                            "Cannot parse input".to_string(),
+                            "Path is not a file".to_string(),
+                            Some(s.span),
+                            None,
+                            Vec::new(),
+                        ));
+                    } else {
+                        p
+                    }
+                }
+
+                Err(_) => {
+                    return Err(ShellError::FileNotFound(s.span));
+                }
+            };
+            (path.to_string_lossy().to_string(), s.span)
+        }
+        None => {
+            return Err(ShellError::NotFound(span));
+        }
+    };
+    Ok((path, span))
+}
+
+fn parse_script(
+    path: String,
+    working_set: &mut StateWorkingSet,
+    call: &Call,
+    span: Span,
+) -> Result<PipelineData, ShellError> {
+    let (filename, err) = unescape_unquote_string(path.as_bytes(), span);
+    if err.is_none() {
+        if let Ok(contents) = std::fs::read(&path) {
+            let (_, err) = parse(working_set, Some(&filename), &contents, false, &[]);
+
+            if err.is_some() {
+                let msg = format!(r#"Found : {}"#, err.expect("Unable to parse content"));
+                Err(ShellError::GenericError(
+                    "Failed to parse content".to_string(),
+                    msg,
+                    Some(call.head),
+                    Some("If the content is a module, please use --as-module flag".to_string()),
+                    Vec::new(),
+                ))
+            } else {
+                Ok(PipelineData::Value(
+                    Value::string("Parse Success!", span),
+                    None,
+                ))
+            }
+        } else {
+            Err(ShellError::IOError("Can not read path".to_string()))
+        }
+    } else {
+        Err(ShellError::NotFound(span))
+    }
+}
+
+fn parse_module(
+    path: String,
+    working_set: &mut StateWorkingSet,
+    call: &Call,
+    span: Span,
+) -> Result<PipelineData, ShellError> {
+    let (filename, err) = unescape_unquote_string(path.as_bytes(), span);
+    if err.is_none() {
+        if let Ok(contents) = std::fs::read(path) {
+            let start = working_set.next_span_start();
+            working_set.add_file(filename, &contents);
+            let end = working_set.next_span_start();
+
+            let new_span = Span::new(start, end);
+
+            let (_, _, err) = parse_module_block(working_set, new_span, &[]);
+
+            if err.is_some() {
+                let msg = format!(
+                    r#"Found : {}"#,
+                    err.expect("Unable to parse content as module")
+                );
+                Err(ShellError::GenericError(
+                    "Failed to parse module".to_string(),
+                    msg,
+                    Some(call.head),
+                    Some("If the content is a script, please remove flag".to_string()),
+                    Vec::new(),
+                ))
+            } else {
+                Ok(PipelineData::Value(
+                    Value::string("Parse Success!", span),
+                    None,
+                ))
+            }
+        } else {
+            Err(ShellError::IOError("Can not read path".to_string()))
+        }
+    } else {
+        Err(ShellError::NotFound(span))
+    }
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -37,6 +37,7 @@ mod merge;
 mod mkdir;
 mod move_;
 mod network;
+mod nu_check;
 mod open;
 mod parse;
 mod path;

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -1,0 +1,246 @@
+use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn parse_script_success() {
+    Playground::setup("nu_check_test_1", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "script.nu",
+            r#"
+                greet "world"
+
+                def greet [name] {
+                  echo "hello" $name
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check script.nu
+            "#
+        ));
+
+        assert_eq!(actual.out, "Parse Success!".to_string());
+    })
+}
+
+#[test]
+fn parse_script_with_wrong_type() {
+    Playground::setup("nu_check_test_2", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "script.nu",
+            r#"
+                greet "world"
+
+                def greet [name] {
+                  echo "hello" $name
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check --as-module script.nu
+            "#
+        ));
+
+        assert!(actual
+            .err
+            .contains("If the content is a script, please remove flag"));
+    })
+}
+#[test]
+fn parse_script_failure() {
+    Playground::setup("nu_check_test_3", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "script.nu",
+            r#"
+                greet "world"
+
+                def greet [name {
+                  echo "hello" $name
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check script.nu
+            "#
+        ));
+
+        assert!(actual.err.contains("Unexpected end of code"));
+    })
+}
+
+#[test]
+fn parse_module_success() {
+    Playground::setup("nu_check_test_4", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "foo.nu",
+            r#"
+                # foo.nu
+
+                export def hello [name: string] {
+                    $"hello ($name)!"
+                }
+
+                export def hi [where: string] {
+                    $"hi ($where)!"
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check --as-module foo.nu
+            "#
+        ));
+
+        assert_eq!(actual.out, "Parse Success!".to_string());
+    })
+}
+
+#[test]
+fn parse_module_with_wrong_type() {
+    Playground::setup("nu_check_test_5", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "foo.nu",
+            r#"
+                # foo.nu
+
+                export def hello [name: string {
+                    $"hello ($name)!"
+                }
+
+                export def hi [where: string] {
+                    $"hi ($where)!"
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check foo.nu
+            "#
+        ));
+
+        assert!(actual
+            .err
+            .contains("If the content is a module, please use --as-module flag"));
+    })
+}
+#[test]
+fn parse_module_failure() {
+    Playground::setup("nu_check_test_6", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "foo.nu",
+            r#"
+                # foo.nu
+
+                export def hello [name: string {
+                    $"hello ($name)!"
+                }
+
+                export def hi [where: string] {
+                    $"hi ($where)!"
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check --as-module foo.nu
+            "#
+        ));
+
+        assert!(actual.err.contains("Unexpected end of code"));
+    })
+}
+
+#[test]
+fn file_not_exist() {
+    Playground::setup("nu_check_test_7", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check --as-module foo.nu
+            "#
+        ));
+
+        assert!(actual.err.contains("file not found"));
+    })
+}
+
+#[test]
+fn parse_unsupported_file() {
+    Playground::setup("nu_check_test_8", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "foo.txt",
+            r#"
+                # foo.nu
+
+                export def hello [name: string {
+                    $"hello ($name)!"
+                }
+
+                export def hi [where: string] {
+                    $"hi ($where)!"
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check --as-module foo.txt
+            "#
+        ));
+
+        assert!(actual.err.contains("File extension must be .nu"));
+    })
+}
+#[test]
+fn parse_dir_failure() {
+    Playground::setup("nu_check_test_9", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check --as-module ~
+            "#
+        ));
+
+        assert!(actual.err.contains("Path is not a file"));
+    })
+}
+
+#[test]
+fn parse_module_success_2() {
+    Playground::setup("nu_check_test_10", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "foo.nu",
+            r#"
+                # foo.nu
+
+                export env MYNAME { "Arthur, King of the Britons" }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu check --as-module foo.nu
+            "#
+        ));
+
+        assert_eq!(actual.out, "Parse Success!".to_string());
+    })
+}


### PR DESCRIPTION
# Description

To address #5825 - The idea is to apply `nu-check` to pre-validate an input file, give user some appropriate messages if parsing failed

What is covered and what is not

- [x] - New command `nu-check` to pre-validate and parse content
- [x] - Support both `script` and `module`
- [x] - "Operate on a string or a raw output: open foo.nu | nu-check" 

---
### Update:
1. Change command from`nu check` to `nu-check`
2. Support pipe of `string`, `ListStream` and `ExternalStream` 
3.  Change the default output is either `true` or `false`
4.  New flag `-d` to show more error message
5.  Add more tests

- Pipe with ListStream
![parse_liststream](https://user-images.githubusercontent.com/85712372/175757740-1b57db71-c19d-4beb-a2c4-2b50f4ee8cdf.gif)
---

### Test coverage
- [x] Successfully parse file as script
- [x] Successfully pipe with string as script
- [x] Successfully pipe with List Stream as script
- [x] Successfully pipe with external rawStream as script
- [x] Successfully parse file as module
- [x] Successfully parse file as module
- [x] Failed to parse file as script
- [x] Failed to parse file as module
- [x] File not found
- [x] Unsupported file extension


Demos

- Parse script success
![parse_success](https://user-images.githubusercontent.com/85712372/175455470-6f1a960a-7066-4824-91e6-da1403357d98.gif)

- Parse script failure
![parse_failure](https://user-images.githubusercontent.com/85712372/175455775-57736786-8af3-481d-a881-73fcdf468ac8.gif)



# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
