### PR TITLE
Errors when `let in`, `let env` and similar commands are passed.

### DIFF
--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -1,0 +1,15 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn let_parse_error() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        let in = 3
+        "#
+    ));
+
+    assert!(actual
+        .err
+        .contains("'in' is the name of a builtin Nushell variable"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -30,6 +30,7 @@ mod into_filesize;
 mod into_int;
 mod last;
 mod length;
+mod let_;
 mod lines;
 mod ls;
 mod math;

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -92,9 +92,7 @@ pub enum ParseError {
     #[diagnostic(
         code(nu::parser::let_builtin_var),
         url(docsrs),
-        help(
-            "'{0}' is the name of a builtin Nushell variable. `let` cannot assign to it."
-        )
+        help("'{0}' is the name of a builtin Nushell variable. `let` cannot assign to it.")
     )]
     LetBuiltinVar(String, #[label("already a builtin variable")] Span),
 

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -88,6 +88,16 @@ pub enum ParseError {
     )]
     LetInPipeline(String, String, #[label("let in pipeline")] Span),
 
+    #[error("Let used with builtin variable name.")]
+    #[diagnostic(
+        code(nu::parser::let_builtin_var),
+        url(docsrs),
+        help(
+            "'{0}' is the name of a builtin Nushell variable. `let` cannot assign to it."
+        )
+    )]
+    LetBuiltinVar(String, #[label("already a builtin variable")] Span),
+
     #[error("Incorrect value")]
     #[diagnostic(code(nu::parser::incorrect_value), url(docsrs), help("{2}"))]
     IncorrectValue(String, #[label("unexpected {0}")] Span, String),
@@ -311,6 +321,7 @@ impl ParseError {
             ParseError::UnexpectedKeyword(_, s) => *s,
             ParseError::BuiltinCommandInPipeline(_, s) => *s,
             ParseError::LetInPipeline(_, _, s) => *s,
+            ParseError::LetBuiltinVar(_, s) => *s,
             ParseError::IncorrectValue(_, s, _) => *s,
             ParseError::MultipleRestParams(s) => *s,
             ParseError::VariableNotFound(s) => *s,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2248,7 +2248,6 @@ pub fn parse_let(
     let name = working_set.get_span_contents(spans[0]);
 
     if name == b"let" {
-
         if let Some((span, err)) = check_name(working_set, spans) {
             return (Pipeline::from_vec(vec![garbage(*span)]), Some(err));
         }
@@ -2258,7 +2257,6 @@ pub fn parse_let(
             let call_signature = cmd.signature().call_signature();
 
             if spans.len() >= 4 {
-
                 // This is a bit of by-hand parsing to get around the issue where we want to parse in the reverse order
                 // so that the var-id created by the variable isn't visible in the expression that init it
                 for span in spans.iter().enumerate() {
@@ -2288,30 +2286,23 @@ pub fn parse_let(
                             parse_var_with_opt_type(working_set, &spans[1..(span.0)], &mut idx);
                         error = error.or(err);
 
-                        let var_name = String::from_utf8_lossy(working_set.get_span_contents(spans[1])).to_string();
+                        let var_name =
+                            String::from_utf8_lossy(working_set.get_span_contents(spans[1]))
+                                .to_string();
 
                         if var_name == "in" {
+                            error = error
+                                .or(Some(ParseError::LetBuiltinVar("in".to_string(), spans[1])));
+                        } else if var_name == "nu" {
+                            error = error
+                                .or(Some(ParseError::LetBuiltinVar("nu".to_string(), spans[1])));
+                        } else if var_name == "env" {
+                            error = error
+                                .or(Some(ParseError::LetBuiltinVar("env".to_string(), spans[1])));
+                        } else if var_name == "nothing" {
                             error = error.or(Some(ParseError::LetBuiltinVar(
-                                "in".to_string(), 
-                                spans[1]
-                            )));
-                        }
-                        else if var_name == "nu" {
-                            error = error.or(Some(ParseError::LetBuiltinVar(
-                                "nu".to_string(), 
-                                spans[1]
-                            )));
-                        }
-                        else if var_name == "env" {
-                            error = error.or(Some(ParseError::LetBuiltinVar(
-                                "env".to_string(), 
-                                spans[1]
-                            )));
-                        }
-                        else if var_name == "nothing" { 
-                            error = error.or(Some(ParseError::LetBuiltinVar(
-                                "nothing".to_string(), 
-                                spans[1]
+                                "nothing".to_string(),
+                                spans[1],
                             )));
                         }
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2248,6 +2248,7 @@ pub fn parse_let(
     let name = working_set.get_span_contents(spans[0]);
 
     if name == b"let" {
+
         if let Some((span, err)) = check_name(working_set, spans) {
             return (Pipeline::from_vec(vec![garbage(*span)]), Some(err));
         }
@@ -2257,6 +2258,7 @@ pub fn parse_let(
             let call_signature = cmd.signature().call_signature();
 
             if spans.len() >= 4 {
+
                 // This is a bit of by-hand parsing to get around the issue where we want to parse in the reverse order
                 // so that the var-id created by the variable isn't visible in the expression that init it
                 for span in spans.iter().enumerate() {
@@ -2285,6 +2287,33 @@ pub fn parse_let(
                         let (lvalue, err) =
                             parse_var_with_opt_type(working_set, &spans[1..(span.0)], &mut idx);
                         error = error.or(err);
+
+                        let var_name = String::from_utf8_lossy(working_set.get_span_contents(spans[1])).to_string();
+
+                        if var_name == "in" {
+                            error = error.or(Some(ParseError::LetBuiltinVar(
+                                "in".to_string(), 
+                                spans[1]
+                            )));
+                        }
+                        else if var_name == "nu" {
+                            error = error.or(Some(ParseError::LetBuiltinVar(
+                                "nu".to_string(), 
+                                spans[1]
+                            )));
+                        }
+                        else if var_name == "env" {
+                            error = error.or(Some(ParseError::LetBuiltinVar(
+                                "env".to_string(), 
+                                spans[1]
+                            )));
+                        }
+                        else if var_name == "nothing" { 
+                            error = error.or(Some(ParseError::LetBuiltinVar(
+                                "nothing".to_string(), 
+                                spans[1]
+                            )));
+                        }
 
                         let var_id = lvalue.as_var();
                         let rhs_type = rvalue.ty.clone();

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2287,7 +2287,7 @@ pub fn parse_let(
                         error = error.or(err);
 
                         let var_name =
-                            String::from_utf8_lossy(working_set.get_span_contents(spans[1]))
+                            String::from_utf8_lossy(working_set.get_span_contents(lvalue.span))
                                 .to_string();
 
                         if ["in", "nu", "env", "nothing"].contains(&var_name.as_str()) {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2291,9 +2291,8 @@ pub fn parse_let(
                                 .to_string();
 
                         if ["in", "nu", "env", "nothing"].contains(&var_name.as_str()) {
-                            error = error.or_else(|| {
-                                Some(ParseError::LetBuiltinVar(var_name, lvalue.span))
-                            });
+                            error = error
+                                .or_else(|| Some(ParseError::LetBuiltinVar(var_name, lvalue.span)));
                         }
 
                         let var_id = lvalue.as_var();

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2290,21 +2290,9 @@ pub fn parse_let(
                             String::from_utf8_lossy(working_set.get_span_contents(spans[1]))
                                 .to_string();
 
-                        if var_name == "in" {
+                        if ["in", "nu", "env", "nothing"].contains(&var_name.as_str()) {
                             error = error.or_else(|| {
-                                Some(ParseError::LetBuiltinVar("in".to_string(), spans[1]))
-                            });
-                        } else if var_name == "nu" {
-                            error = error.or_else(|| {
-                                Some(ParseError::LetBuiltinVar("nu".to_string(), spans[1]))
-                            });
-                        } else if var_name == "env" {
-                            error = error.or_else(|| {
-                                Some(ParseError::LetBuiltinVar("env".to_string(), spans[1]))
-                            });
-                        } else if var_name == "nothing" {
-                            error = error.or_else(|| {
-                                Some(ParseError::LetBuiltinVar("nothing".to_string(), spans[1]))
+                                Some(ParseError::LetBuiltinVar(var_name, lvalue.span))
                             });
                         }
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2291,8 +2291,8 @@ pub fn parse_let(
                                 .to_string();
 
                         if ["in", "nu", "env", "nothing"].contains(&var_name.as_str()) {
-                            error = error
-                                .or(Some(ParseError::LetBuiltinVar(var_name, lvalue.span)));
+                            error =
+                                error.or(Some(ParseError::LetBuiltinVar(var_name, lvalue.span)));
                         }
 
                         let var_id = lvalue.as_var();

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2291,19 +2291,21 @@ pub fn parse_let(
                                 .to_string();
 
                         if var_name == "in" {
-                            error = error
-                                .or(Some(ParseError::LetBuiltinVar("in".to_string(), spans[1])));
+                            error = error.or_else(|| {
+                                Some(ParseError::LetBuiltinVar("in".to_string(), spans[1]))
+                            });
                         } else if var_name == "nu" {
-                            error = error
-                                .or(Some(ParseError::LetBuiltinVar("nu".to_string(), spans[1])));
+                            error = error.or_else(|| {
+                                Some(ParseError::LetBuiltinVar("nu".to_string(), spans[1]))
+                            });
                         } else if var_name == "env" {
-                            error = error
-                                .or(Some(ParseError::LetBuiltinVar("env".to_string(), spans[1])));
+                            error = error.or_else(|| {
+                                Some(ParseError::LetBuiltinVar("env".to_string(), spans[1]))
+                            });
                         } else if var_name == "nothing" {
-                            error = error.or(Some(ParseError::LetBuiltinVar(
-                                "nothing".to_string(),
-                                spans[1],
-                            )));
+                            error = error.or_else(|| {
+                                Some(ParseError::LetBuiltinVar("nothing".to_string(), spans[1]))
+                            });
                         }
 
                         let var_id = lvalue.as_var();

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2292,7 +2292,7 @@ pub fn parse_let(
 
                         if ["in", "nu", "env", "nothing"].contains(&var_name.as_str()) {
                             error = error
-                                .or_else(|| Some(ParseError::LetBuiltinVar(var_name, lvalue.span)));
+                                .or(Some(ParseError::LetBuiltinVar(var_name, lvalue.span)));
                         }
 
                         let var_id = lvalue.as_var();


### PR DESCRIPTION
# Description

Fixes #5848. 

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
