### PR TITLE
fix plugin path with whitespace

### DIFF
--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -362,9 +362,18 @@ impl EngineState {
                     // No need to check the None option
                     let (path, encoding, shell) =
                         decl.is_plugin().expect("plugin should have file name");
-                    let file_name = path
+                    let mut file_name = path
                         .to_str()
-                        .expect("path was checked during registration as a str");
+                        .expect("path was checked during registration as a str")
+                        .to_string();
+
+                    // Fix files or folders with quotes
+                    if file_name.contains('\'')
+                        || file_name.contains('"')
+                        || file_name.contains(' ')
+                    {
+                        file_name = format!("`{}`", file_name);
+                    }
 
                     serde_json::to_string_pretty(&decl.signature())
                         .map(|signature| {


### PR DESCRIPTION
# Description

Try to fix some part of:  #5856

---------------
But the following may not coverred:
> Also, the windows path will not be considered as a file path and the slash needs to be changed manually.

<img width="764" alt="图片" src="https://user-images.githubusercontent.com/22256154/175607625-2e386421-5e33-4cbf-a9ae-99bdd11ad937.png">

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
