### PR TITLE
Fix less.exe downloading for windows release pkgs, close #5868

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -102,8 +102,8 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
     let releaseStem = $'($bin)-($version)-($target)'
 
     $'(char nl)Download less related stuffs...'; hr-line
-    aria2c https://github.com/jftuga/less-Windows/releases/download/less-v590/less.exe -o $'($dist)\less.exe'
-    aria2c https://raw.githubusercontent.com/jftuga/less-Windows/master/LICENSE -o $'($dist)\LICENSE-for-less.txt'
+    aria2c https://github.com/jftuga/less-Windows/releases/download/less-v590/less.exe -o less.exe
+    aria2c https://raw.githubusercontent.com/jftuga/less-Windows/master/LICENSE -o LICENSE-for-less.txt
 
     # Create Windows msi release package
     if (get-env _EXTRA_) == 'msi' {

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -102,8 +102,8 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
     let releaseStem = $'($bin)-($version)-($target)'
 
     $'(char nl)Download less related stuffs...'; hr-line
-    curl https://github.com/jftuga/less-Windows/releases/download/less-v590/less.exe -o $'($dist)\less.exe'
-    curl https://raw.githubusercontent.com/jftuga/less-Windows/master/LICENSE -o $'($dist)\LICENSE-for-less.txt'
+    aria2c https://github.com/jftuga/less-Windows/releases/download/less-v590/less.exe -o $'($dist)\less.exe'
+    aria2c https://raw.githubusercontent.com/jftuga/less-Windows/master/LICENSE -o $'($dist)\LICENSE-for-less.txt'
 
     # Create Windows msi release package
     if (get-env _EXTRA_) == 'msi' {


### PR DESCRIPTION
# Description

Fix less.exe downloading for windows release pkgs, close #5868
Workflow running result: https://github.com/hustcer/nu-release/runs/7050290502?check_suite_focus=true, and less related stuffs have been downloaded and packed successfully.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
