### PR TITLE
add ability to convert timestamp_millis()

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -261,6 +261,7 @@ fn action(
             None => {
                 // be able to convert chrono::Utc::now()
                 let dt = match ts.to_string().len() {
+                    x if x > 13 => Utc.timestamp_nanos(ts).into(),
                     x if x > 10 => Utc.timestamp_millis(ts).into(),
                     _ => Utc.timestamp(ts, 0).into(),
                 };

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -146,6 +146,15 @@ impl Command for SubCommand {
                 example: "1614434140 | into datetime -o +9",
                 result: None,
             },
+            Example {
+                description:
+                    "Convert timestamps like the sqlite history t",
+                example: "1656165681720 | into datetime",
+                result: Some(Value::Date {
+                    val: Utc.timestamp_millis(1656165681720).into(),
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }


### PR DESCRIPTION
# Description

Adds the ability to convert things like the sqlite history start_timestamp
`1656165681720 | into datetime`

added nanos too, technically [chrono supports it](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.timestamp_nanos) but our code does not. I figured I'd leave it in there anyway.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
