### PR TITLE
Clippy and remove unused is_binary

### DIFF
--- a/crates/nu-cli/tests/alias.rs
+++ b/crates/nu-cli/tests/alias.rs
@@ -10,7 +10,7 @@ fn alias_of_command_and_flags() {
 
     // Create an alias
     let alias = r#"alias ll = ls -l"#;
-    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
@@ -29,7 +29,7 @@ fn alias_of_basic_command() {
 
     // Create an alias
     let alias = r#"alias ll = ls "#;
-    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
@@ -51,7 +51,7 @@ fn alias_of_another_alias() {
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
     // Create the second alias
     let alias = r#"alias lf = ll -f"#;
-    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 

--- a/crates/nu-cli/tests/file_completions.rs
+++ b/crates/nu-cli/tests/file_completions.rs
@@ -47,8 +47,8 @@ fn command_ls_completion() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    let target_dir = format!("ls ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let target_dir = "ls ";
+    let suggestions = completer.complete(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![
@@ -79,8 +79,8 @@ fn command_open_completion() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    let target_dir = format!("open ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let target_dir = "open ";
+    let suggestions = completer.complete(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![
@@ -112,8 +112,8 @@ fn command_rm_completion() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    let target_dir = format!("rm ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let target_dir = "rm ";
+    let suggestions = completer.complete(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![
@@ -145,8 +145,8 @@ fn command_cp_completion() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    let target_dir = format!("cp ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let target_dir = "cp ";
+    let suggestions = completer.complete(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![
@@ -178,8 +178,8 @@ fn command_save_completion() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    let target_dir = format!("save ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let target_dir = "save ";
+    let suggestions = completer.complete(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![
@@ -211,8 +211,8 @@ fn command_touch_completion() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    let target_dir = format!("touch ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let target_dir = "touch ";
+    let suggestions = completer.complete(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![
@@ -244,8 +244,8 @@ fn command_watch_completion() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    let target_dir = format!("watch ");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let target_dir = "watch ";
+    let suggestions = completer.complete(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1033,12 +1033,6 @@ pub fn create_scope(
                 span,
             });
 
-            cols.push("is_binary".to_string());
-            vals.push(Value::Bool {
-                val: decl.is_binary(),
-                span,
-            });
-
             cols.push("is_builtin".to_string());
             // we can only be a is_builtin or is_custom, not both
             vals.push(Value::Bool {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -986,7 +986,7 @@ mod input_types {
 
     fn add_declations(engine_state: &mut EngineState) {
         let delta = {
-            let mut working_set = StateWorkingSet::new(&engine_state);
+            let mut working_set = StateWorkingSet::new(engine_state);
             working_set.add_decl(Box::new(Let));
             working_set.add_decl(Box::new(AggCustom));
             working_set.add_decl(Box::new(GroupByCustom));

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -23,10 +23,6 @@ pub trait Command: Send + Sync + CommandClone {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError>;
 
-    fn is_binary(&self) -> bool {
-        false
-    }
-
     fn examples(&self) -> Vec<Example> {
         Vec::new()
     }


### PR DESCRIPTION
# Description

Looks like the `is_binary` of `Command` doesn't seem to be used. Whether something is binary or not should probably instead be part of the output type of the Signature. We also encode binary as just part of the stream as well.

Also fixed the clippy warnings I saw
 
# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
