### PR TITLE
Move input/output type from Command to Signature

### DIFF
--- a/crates/nu-command/src/database/commands/alias.rs
+++ b/crates/nu-command/src/database/commands/alias.rs
@@ -19,6 +19,8 @@ impl Command for AliasDb {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("alias", SyntaxShape::String, "alias name")
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
@@ -80,14 +82,6 @@ impl Command for AliasDb {
                 }),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/database/commands/and.rs
+++ b/crates/nu-command/src/database/commands/and.rs
@@ -25,19 +25,13 @@ impl Command for AndDb {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("where", SyntaxShape::Any, "Where expression on the table")
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "where"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/collect.rs
+++ b/crates/nu-command/src/database/commands/collect.rs
@@ -15,19 +15,14 @@ impl Command for CollectDb {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("database".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Any)
+            .category(Category::Custom("database".into()))
     }
 
     fn usage(&self) -> &str {
         "Collects a query from a database database connection"
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/describe.rs
+++ b/crates/nu-command/src/database/commands/describe.rs
@@ -15,19 +15,14 @@ impl Command for DescribeDb {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("database".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Any)
+            .category(Category::Custom("database".into()))
     }
 
     fn usage(&self) -> &str {
         "Describes connection and query of the DB object"
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/from.rs
+++ b/crates/nu-command/src/database/commands/from.rs
@@ -35,19 +35,13 @@ impl Command for FromDb {
                 "Alias for the selected table",
                 Some('a'),
             )
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "from"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/group_by.rs
+++ b/crates/nu-command/src/database/commands/group_by.rs
@@ -29,19 +29,13 @@ impl Command for GroupByDb {
                 SyntaxShape::Any,
                 "Select expression(s) on the table",
             )
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "select"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/join.rs
+++ b/crates/nu-command/src/database/commands/join.rs
@@ -41,19 +41,13 @@ impl Command for JoinDb {
             .switch("right", "right outer join", Some('r'))
             .switch("outer", "full outer join", Some('o'))
             .switch("cross", "cross join", Some('c'))
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "join"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/limit.rs
+++ b/crates/nu-command/src/database/commands/limit.rs
@@ -28,6 +28,8 @@ impl Command for LimitDb {
                 SyntaxShape::Int,
                 "Number of rows to extract for query",
             )
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
@@ -59,14 +61,6 @@ impl Command for LimitDb {
                 span: Span::test_data(),
             }),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/open.rs
+++ b/crates/nu-command/src/database/commands/open.rs
@@ -19,6 +19,8 @@ impl Command for OpenDb {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("query", SyntaxShape::Filepath, "SQLite file to be opened")
+            .input_type(Type::Any)
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
@@ -36,14 +38,6 @@ impl Command for OpenDb {
             example: r#"open-db file.sqlite"#,
             result: None,
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/or.rs
+++ b/crates/nu-command/src/database/commands/or.rs
@@ -25,19 +25,13 @@ impl Command for OrDb {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("where", SyntaxShape::Any, "Where expression on the table")
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "where"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/order_by.rs
+++ b/crates/nu-command/src/database/commands/order_by.rs
@@ -31,19 +31,13 @@ impl Command for OrderByDb {
                 SyntaxShape::Any,
                 "Select expression(s) on the table",
             )
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "order-by"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/query.rs
+++ b/crates/nu-command/src/database/commands/query.rs
@@ -23,19 +23,13 @@ impl Command for QueryDb {
                 SyntaxShape::String,
                 "SQL to execute against the database",
             )
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Any)
             .category(Category::Custom("database".into()))
     }
 
     fn usage(&self) -> &str {
         "Query a database using SQL."
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -15,19 +15,14 @@ impl Command for SchemaDb {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("database".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Any)
+            .category(Category::Custom("database".into()))
     }
 
     fn usage(&self) -> &str {
         "Show sqlite database information, including its schema."
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/select.rs
+++ b/crates/nu-command/src/database/commands/select.rs
@@ -27,19 +27,13 @@ impl Command for ProjectionDb {
                 SyntaxShape::Any,
                 "Select expression(s) on the table",
             )
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "select"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/to_db.rs
+++ b/crates/nu-command/src/database/commands/to_db.rs
@@ -19,7 +19,10 @@ impl Command for ToDataBase {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("database".into()))
+        Signature::build(self.name())
+            .input_type(Type::Any)
+            .output_type(Type::Custom("database".into()))
+            .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -32,14 +35,6 @@ impl Command for ToDataBase {
             example: "open db.mysql | into db",
             result: None,
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/where_.rs
+++ b/crates/nu-command/src/database/commands/where_.rs
@@ -25,19 +25,13 @@ impl Command for WhereDb {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("where", SyntaxShape::Any, "Where expression on the table")
+            .input_type(Type::Custom("database".into()))
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "where"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("database".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/expressions/alias.rs
+++ b/crates/nu-command/src/database/expressions/alias.rs
@@ -19,6 +19,8 @@ impl Command for AliasExpr {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("alias", SyntaxShape::String, "alias name")
+            .input_type(Type::Custom("db-expression".into()))
+            .output_type(Type::Custom("db-expression".into()))
             .category(Category::Custom("db-expression".into()))
     }
 
@@ -65,14 +67,6 @@ impl Command for AliasExpr {
                 span: Span::test_data(),
             }),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("db-expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("db-expression".into())
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/database/expressions/and.rs
+++ b/crates/nu-command/src/database/expressions/and.rs
@@ -24,19 +24,13 @@ impl Command for AndExpr {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("and", SyntaxShape::Any, "AND expression")
+            .input_type(Type::Custom("db-expression".into()))
+            .output_type(Type::Custom("db-expression".into()))
             .category(Category::Custom("db-expression".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "and", "expression"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("db-expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("db-expression".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/expressions/as_nu.rs
+++ b/crates/nu-command/src/database/expressions/as_nu.rs
@@ -19,7 +19,10 @@ impl Command for ExprAsNu {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("db-expression".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("db-expression".into()))
+            .output_type(Type::Any)
+            .category(Category::Custom("db-expression".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -41,14 +44,6 @@ impl Command for ExprAsNu {
                 span: Span::test_data(),
             }),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("db-expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn run(

--- a/crates/nu-command/src/database/expressions/field.rs
+++ b/crates/nu-command/src/database/expressions/field.rs
@@ -18,6 +18,8 @@ impl Command for FieldExpr {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("name", SyntaxShape::String, "column name")
+            .input_type(Type::Any)
+            .output_type(Type::Custom("db-expression".into()))
             .category(Category::Custom("db-expression".into()))
     }
 
@@ -48,14 +50,6 @@ impl Command for FieldExpr {
                 span: Span::test_data(),
             }),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("db-expression".into())
     }
 
     fn run(

--- a/crates/nu-command/src/database/expressions/function.rs
+++ b/crates/nu-command/src/database/expressions/function.rs
@@ -21,6 +21,8 @@ impl Command for FunctionExpr {
             .required("name", SyntaxShape::String, "function name")
             .switch("distinct", "distict values", Some('d'))
             .rest("arguments", SyntaxShape::Any, "function arguments")
+            .input_type(Type::Any)
+            .output_type(Type::Custom("db-expression".into()))
             .category(Category::Custom("db-expression".into()))
     }
 
@@ -87,14 +89,6 @@ impl Command for FunctionExpr {
                 }),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("db-expression".into())
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/database/expressions/or.rs
+++ b/crates/nu-command/src/database/expressions/or.rs
@@ -24,19 +24,13 @@ impl Command for OrExpr {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("or", SyntaxShape::Any, "OR expression")
+            .input_type(Type::Custom("db-expression".into()))
+            .output_type(Type::Custom("db-expression".into()))
             .category(Category::Custom("db-expression".into()))
     }
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["database", "or", "expression"]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("db-expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("db-expression".into())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/expressions/over.rs
+++ b/crates/nu-command/src/database/expressions/over.rs
@@ -23,6 +23,8 @@ impl Command for OverExpr {
                 SyntaxShape::Any,
                 "columns to partition the window function",
             )
+            .input_type(Type::Custom("db-expression".into()))
+            .output_type(Type::Custom("db-expression".into()))
             .category(Category::Custom("db-expression".into()))
     }
 
@@ -88,14 +90,6 @@ impl Command for OverExpr {
                 }),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("db-expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("db-expression".into())
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/database/test_database.rs
+++ b/crates/nu-command/src/database/test_database.rs
@@ -29,6 +29,8 @@ impl Command for CustomOpen {
                 nu_protocol::SyntaxShape::String,
                 "the filename to use",
             )
+            .input_type(Type::Any)
+            .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
 
@@ -44,14 +46,6 @@ impl Command for CustomOpen {
 
         let db = SQLiteDatabase::new(path);
         Ok(db.into_value(call.head).into_pipeline_data())
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("database".into())
     }
 }
 

--- a/crates/nu-command/src/dataframe/eager/append.rs
+++ b/crates/nu-command/src/dataframe/eager/append.rs
@@ -23,6 +23,8 @@ impl Command for AppendDF {
         Signature::build(self.name())
             .required("other", SyntaxShape::Any, "dataframe to be appended")
             .switch("col", "appends in col orientation", Some('c'))
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -85,14 +87,6 @@ impl Command for AppendDF {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/describe.rs
+++ b/crates/nu-command/src/dataframe/eager/describe.rs
@@ -29,6 +29,8 @@ impl Command for DescribeDF {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Custom("dataframe".into()))
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .named(
                 "quantiles",
                 SyntaxShape::Table,
@@ -93,14 +95,6 @@ impl Command for DescribeDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/drop.rs
+++ b/crates/nu-command/src/dataframe/eager/drop.rs
@@ -23,6 +23,8 @@ impl Command for DropDF {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .rest("rest", SyntaxShape::Any, "column names to be dropped")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -39,14 +41,6 @@ impl Command for DropDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
@@ -34,6 +34,8 @@ impl Command for DropDuplicates {
                 "keeps last duplicate value (by default keeps first)",
                 Some('l'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -56,14 +58,6 @@ impl Command for DropDuplicates {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -27,6 +27,8 @@ impl Command for DropNulls {
                 SyntaxShape::Table,
                 "subset of columns to drop nulls",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -76,14 +78,6 @@ impl Command for DropNulls {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/dtypes.rs
+++ b/crates/nu-command/src/dataframe/eager/dtypes.rs
@@ -18,7 +18,10 @@ impl Command for DataTypes {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -40,14 +43,6 @@ impl Command for DataTypes {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -19,7 +19,10 @@ impl Command for Dummies {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -91,14 +94,6 @@ impl Command for Dummies {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -29,6 +29,8 @@ impl Command for FilterWith {
                 SyntaxShape::Any,
                 "boolean mask used to filter data",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
 
@@ -60,14 +62,6 @@ impl Command for FilterWith {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/first.rs
+++ b/crates/nu-command/src/dataframe/eager/first.rs
@@ -21,6 +21,8 @@ impl Command for FirstDF {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .optional("rows", SyntaxShape::Int, "Number of rows for head")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -37,14 +39,6 @@ impl Command for FirstDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -24,6 +24,8 @@ impl Command for GetDF {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .rest("rest", SyntaxShape::Any, "column names to sort dataframe")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -40,14 +42,6 @@ impl Command for GetDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/last.rs
+++ b/crates/nu-command/src/dataframe/eager/last.rs
@@ -21,6 +21,8 @@ impl Command for LastDF {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .optional("rows", SyntaxShape::Int, "Number of rows for tail")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -37,14 +39,6 @@ impl Command for LastDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/melt.rs
+++ b/crates/nu-command/src/dataframe/eager/melt.rs
@@ -48,6 +48,8 @@ impl Command for MeltDF {
                 "optional name for value column",
                 Some('l'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -107,14 +109,6 @@ impl Command for MeltDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/open.rs
+++ b/crates/nu-command/src/dataframe/eager/open.rs
@@ -58,6 +58,8 @@ impl Command for OpenDataFrame {
                 "Columns to be selected from csv file. CSV and Parquet file",
                 None,
             )
+            .input_type(Type::Any)
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -67,14 +69,6 @@ impl Command for OpenDataFrame {
             example: "open test.csv",
             result: None,
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/rename.rs
+++ b/crates/nu-command/src/dataframe/eager/rename.rs
@@ -33,6 +33,8 @@ impl Command for RenameDF {
                 SyntaxShape::Any,
                 "New names for the selected column(s). A string or list of strings",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
 
@@ -92,14 +94,6 @@ impl Command for RenameDF {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/sample.rs
+++ b/crates/nu-command/src/dataframe/eager/sample.rs
@@ -41,6 +41,8 @@ impl Command for SampleDF {
             )
             .switch("replace", "sample with replace", Some('e'))
             .switch("shuffle", "shuffle sample", Some('u'))
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -57,14 +59,6 @@ impl Command for SampleDF {
                 result: None, // No expected value because sampling is random
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/shape.rs
+++ b/crates/nu-command/src/dataframe/eager/shape.rs
@@ -21,7 +21,10 @@ impl Command for ShapeDF {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -37,14 +40,6 @@ impl Command for ShapeDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/slice.rs
+++ b/crates/nu-command/src/dataframe/eager/slice.rs
@@ -25,6 +25,8 @@ impl Command for SliceDF {
         Signature::build(self.name())
             .required("offset", SyntaxShape::Int, "start of slice")
             .required("size", SyntaxShape::Int, "size of slice")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -41,14 +43,6 @@ impl Command for SliceDF {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -29,6 +29,8 @@ impl Command for TakeDF {
                 SyntaxShape::Any,
                 "list of indices used to take data",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -69,14 +71,6 @@ impl Command for TakeDF {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-command/src/dataframe/eager/to_csv.rs
@@ -32,6 +32,8 @@ impl Command for ToCSV {
                 Some('d'),
             )
             .switch("no-header", "Indicates if file doesn't have header", None)
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Any)
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -48,14 +50,6 @@ impl Command for ToCSV {
                 result: None,
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -19,7 +19,10 @@ impl Command for ToDataFrame {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Any)
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -101,14 +104,6 @@ impl Command for ToDataFrame {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-command/src/dataframe/eager/to_nu.rs
@@ -28,6 +28,8 @@ impl Command for ToNu {
                 Some('n'),
             )
             .switch("tail", "shows tail rows", Some('t'))
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Any)
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -62,14 +64,6 @@ impl Command for ToNu {
                 }),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-command/src/dataframe/eager/to_parquet.rs
@@ -25,6 +25,8 @@ impl Command for ToParquet {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("file", SyntaxShape::Filepath, "file path to save dataframe")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Any)
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -34,14 +36,6 @@ impl Command for ToParquet {
             example: "[[a b]; [1 2] [3 4]] | into df | to parquet test.parquet",
             result: None,
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/eager/with_column.rs
+++ b/crates/nu-command/src/dataframe/eager/with_column.rs
@@ -27,6 +27,8 @@ impl Command for WithColumn {
                 SyntaxShape::Any,
                 "series to be added or expressions used to define the new columns",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
 
@@ -89,14 +91,6 @@ impl Command for WithColumn {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/expressions/alias.rs
+++ b/crates/nu-command/src/dataframe/expressions/alias.rs
@@ -26,6 +26,8 @@ impl Command for ExprAlias {
                 SyntaxShape::String,
                 "Alias name for the expression",
             )
+            .input_type(Type::Custom("expression".into()))
+            .output_type(Type::Custom("expression".into()))
             .category(Category::Custom("expression".into()))
     }
 
@@ -55,14 +57,6 @@ impl Command for ExprAlias {
                 Some(record)
             },
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("expression".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/expressions/as_nu.rs
+++ b/crates/nu-command/src/dataframe/expressions/as_nu.rs
@@ -19,7 +19,10 @@ impl Command for ExprAsNu {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("expression".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("expression".into()))
+            .output_type(Type::Any)
+            .category(Category::Custom("expression".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -41,14 +44,6 @@ impl Command for ExprAsNu {
                 span: Span::test_data(),
             }),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/expressions/col.rs
+++ b/crates/nu-command/src/dataframe/expressions/col.rs
@@ -26,6 +26,8 @@ impl Command for ExprCol {
                 SyntaxShape::String,
                 "Name of column to be used",
             )
+            .input_type(Type::Any)
+            .output_type(Type::Custom("expression".into()))
             .category(Category::Custom("expression".into()))
     }
 
@@ -48,14 +50,6 @@ impl Command for ExprCol {
                 span: Span::test_data(),
             }),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("expression".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
@@ -25,19 +25,14 @@ macro_rules! expr_command {
             }
 
             fn signature(&self) -> Signature {
-                Signature::build(self.name()).category(Category::Custom("expression".into()))
+                Signature::build(self.name())
+                    .input_type(Type::Custom("expression".into()))
+                    .output_type(Type::Custom("expression".into()))
+                    .category(Category::Custom("expression".into()))
             }
 
             fn examples(&self) -> Vec<Example> {
                 $examples
-            }
-
-            fn input_type(&self) -> Type {
-                Type::Custom("expression".into())
-            }
-
-            fn output_type(&self) -> Type {
-                Type::Custom("expression".into())
             }
 
             fn run(

--- a/crates/nu-command/src/dataframe/expressions/lit.rs
+++ b/crates/nu-command/src/dataframe/expressions/lit.rs
@@ -25,6 +25,8 @@ impl Command for ExprLit {
                 SyntaxShape::Any,
                 "literal to construct the expression",
             )
+            .input_type(Type::Any)
+            .output_type(Type::Custom("expression".into()))
             .category(Category::Custom("expression".into()))
     }
 
@@ -47,14 +49,6 @@ impl Command for ExprLit {
                 span: Span::test_data(),
             }),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("expression".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-command/src/dataframe/expressions/otherwise.rs
@@ -25,6 +25,8 @@ impl Command for ExprOtherwise {
                 SyntaxShape::Any,
                 "expressioini to apply when no when predicate matches",
             )
+            .input_type(Type::Any)
+            .output_type(Type::Custom("expression".into()))
             .category(Category::Custom("expression".into()))
     }
 
@@ -75,14 +77,6 @@ impl Command for ExprOtherwise {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("expression".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-command/src/dataframe/expressions/quantile.rs
@@ -26,6 +26,8 @@ impl Command for ExprQuantile {
                 SyntaxShape::Number,
                 "quantile value for quantile operation",
             )
+            .input_type(Type::Custom("expression".into()))
+            .output_type(Type::Custom("expression".into()))
             .category(Category::Custom("expression".into()))
     }
 
@@ -51,14 +53,6 @@ impl Command for ExprQuantile {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("expression".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/expressions/when.rs
+++ b/crates/nu-command/src/dataframe/expressions/when.rs
@@ -31,6 +31,8 @@ impl Command for ExprWhen {
                 SyntaxShape::Any,
                 "expression that will be applied when predicate is true",
             )
+            .input_type(Type::Custom("expression".into()))
+            .output_type(Type::Custom("expression".into()))
             .category(Category::Custom("expression".into()))
     }
 
@@ -81,14 +83,6 @@ impl Command for ExprWhen {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("expression".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("expression".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-command/src/dataframe/lazy/aggregate.rs
@@ -26,6 +26,8 @@ impl Command for LazyAggregate {
                 SyntaxShape::Any,
                 "Expression(s) that define the aggregations to be applied",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -99,14 +101,6 @@ impl Command for LazyAggregate {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/collect.rs
+++ b/crates/nu-command/src/dataframe/lazy/collect.rs
@@ -20,7 +20,10 @@ impl Command for LazyCollect {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("lazyframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("lazyframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -42,14 +45,6 @@ impl Command for LazyCollect {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-command/src/dataframe/lazy/fetch.rs
@@ -26,6 +26,8 @@ impl Command for LazyFetch {
                 SyntaxShape::Int,
                 "number of rows to be fetched from lazyframe",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -48,14 +50,6 @@ impl Command for LazyFetch {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/fill_na.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_na.rs
@@ -25,6 +25,8 @@ impl Command for LazyFillNA {
                 SyntaxShape::Any,
                 "Expression to use to fill the NAN values",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -34,14 +36,6 @@ impl Command for LazyFillNA {
             example: "",
             result: None,
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/fill_null.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_null.rs
@@ -25,6 +25,8 @@ impl Command for LazyFillNull {
                 SyntaxShape::Any,
                 "Expression to use to fill the null values",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -47,14 +49,6 @@ impl Command for LazyFillNull {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/groupby.rs
+++ b/crates/nu-command/src/dataframe/lazy/groupby.rs
@@ -26,6 +26,8 @@ impl Command for ToLazyGroupBy {
                 SyntaxShape::Any,
                 "Expression(s) that define the lazy group by",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -99,14 +101,6 @@ impl Command for ToLazyGroupBy {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/join.rs
+++ b/crates/nu-command/src/dataframe/lazy/join.rs
@@ -38,6 +38,8 @@ impl Command for LazyJoin {
                 "Suffix to use on columns with same name",
                 Some('s'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -158,14 +160,6 @@ impl Command for LazyJoin {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/macro_commands.rs
+++ b/crates/nu-command/src/dataframe/lazy/macro_commands.rs
@@ -23,19 +23,14 @@ macro_rules! lazy_command {
             }
 
             fn signature(&self) -> Signature {
-                Signature::build(self.name()).category(Category::Custom("lazyframe".into()))
+                Signature::build(self.name())
+                    .input_type(Type::Custom("dataframe".into()))
+                    .output_type(Type::Custom("dataframe".into()))
+                    .category(Category::Custom("lazyframe".into()))
             }
 
             fn examples(&self) -> Vec<Example> {
                 $examples
-            }
-
-            fn input_type(&self) -> Type {
-                Type::Custom("dataframe".into())
-            }
-
-            fn output_type(&self) -> Type {
-                Type::Custom("dataframe".into())
             }
 
             fn run(

--- a/crates/nu-command/src/dataframe/lazy/quantile.rs
+++ b/crates/nu-command/src/dataframe/lazy/quantile.rs
@@ -26,6 +26,8 @@ impl Command for LazyQuantile {
                 SyntaxShape::Number,
                 "quantile value for quantile operation",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -42,14 +44,6 @@ impl Command for LazyQuantile {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/select.rs
+++ b/crates/nu-command/src/dataframe/lazy/select.rs
@@ -27,6 +27,8 @@ impl Command for LazySelect {
                 SyntaxShape::Any,
                 "Expression(s) that define the column selection",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -43,14 +45,6 @@ impl Command for LazySelect {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
@@ -32,6 +32,8 @@ impl Command for LazySortBy {
                 "Reverse sorting. Default is false",
                 Some('r'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -85,14 +87,6 @@ impl Command for LazySortBy {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/lazy/to_lazy.rs
+++ b/crates/nu-command/src/dataframe/lazy/to_lazy.rs
@@ -19,7 +19,10 @@ impl Command for ToLazyFrame {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("lazyframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Any)
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("lazyframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -28,14 +31,6 @@ impl Command for ToLazyFrame {
             example: "[[a b];[1 2] [3 4]] | into lazy",
             result: None,
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -19,7 +19,10 @@ impl Command for AllFalse {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -51,14 +54,6 @@ impl Command for AllFalse {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -19,7 +19,10 @@ impl Command for AllTrue {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -51,14 +54,6 @@ impl Command for AllTrue {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -20,7 +20,10 @@ impl Command for ArgMax {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -36,14 +39,6 @@ impl Command for ArgMax {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -20,7 +20,10 @@ impl Command for ArgMin {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -36,14 +39,6 @@ impl Command for ArgMin {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/cumulative.rs
+++ b/crates/nu-command/src/dataframe/series/cumulative.rs
@@ -56,6 +56,8 @@ impl Command for Cumulative {
         Signature::build(self.name())
             .required("type", SyntaxShape::String, "rolling operation")
             .switch("reverse", "Reverse cumulative calculation", Some('r'))
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -78,14 +80,6 @@ impl Command for Cumulative {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/as_date.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_date.rs
@@ -31,7 +31,9 @@ impl Command for AsDate {
         Signature::build(self.name())
             .required("format", SyntaxShape::String, "formatting date string")
             .switch("not-exact", "the format string may be contained in the date (e.g. foo-2021-01-01-bar could match 2021-01-01)", Some('n'))
-            .category(Category::Custom("dataframe".into()))
+                        .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+.category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -40,14 +42,6 @@ impl Command for AsDate {
             example: r#"["2021-12-30" "2021-12-31"] | into df | as-datetime "%Y-%m-%d""#,
             result: None,
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_datetime.rs
@@ -40,7 +40,9 @@ impl Command for AsDateTime {
         Signature::build(self.name())
             .required("format", SyntaxShape::String, "formatting date time string")
             .switch("not-exact", "the format string may be contained in the date (e.g. foo-2021-01-01-bar could match 2021-01-01)", Some('n'))
-            .category(Category::Custom("dataframe".into()))
+                        .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+.category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -73,14 +75,6 @@ impl Command for AsDateTime {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_day.rs
@@ -20,7 +20,10 @@ impl Command for GetDay {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetDay {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_hour.rs
@@ -20,7 +20,10 @@ impl Command for GetHour {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetHour {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_minute.rs
@@ -20,7 +20,10 @@ impl Command for GetMinute {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetMinute {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_month.rs
@@ -20,7 +20,10 @@ impl Command for GetMonth {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetMonth {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
@@ -20,7 +20,10 @@ impl Command for GetNanosecond {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetNanosecond {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
@@ -20,7 +20,10 @@ impl Command for GetOrdinal {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetOrdinal {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_second.rs
@@ -20,7 +20,10 @@ impl Command for GetSecond {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetSecond {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_week.rs
@@ -20,7 +20,10 @@ impl Command for GetWeek {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetWeek {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_weekday.rs
@@ -20,7 +20,10 @@ impl Command for GetWeekDay {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetWeekDay {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_year.rs
@@ -20,7 +20,10 @@ impl Command for GetYear {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -38,14 +41,6 @@ impl Command for GetYear {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -23,6 +23,8 @@ impl Command for ArgSort {
         Signature::build(self.name())
             .switch("reverse", "reverse order", Some('r'))
             .switch("nulls-last", "nulls ordered last", Some('n'))
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -65,14 +67,6 @@ impl Command for ArgSort {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -20,7 +20,10 @@ impl Command for ArgTrue {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -36,14 +39,6 @@ impl Command for ArgTrue {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -20,7 +20,10 @@ impl Command for ArgUnique {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -36,14 +39,6 @@ impl Command for ArgUnique {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
@@ -29,6 +29,8 @@ impl Command for SetWithIndex {
                 "list of indices indicating where to set the value",
                 Some('i'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -54,14 +56,6 @@ impl Command for SetWithIndex {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
@@ -20,7 +20,10 @@ impl Command for IsDuplicated {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -44,14 +47,6 @@ impl Command for IsDuplicated {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_in.rs
@@ -23,6 +23,8 @@ impl Command for IsIn {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("other", SyntaxShape::Any, "right series")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -48,14 +50,6 @@ impl Command for IsIn {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
@@ -19,7 +19,10 @@ impl Command for IsNotNull {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -42,14 +45,6 @@ impl Command for IsNotNull {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/masks/is_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_null.rs
@@ -19,7 +19,10 @@ impl Command for IsNull {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -42,14 +45,6 @@ impl Command for IsNull {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_unique.rs
@@ -20,7 +20,10 @@ impl Command for IsUnique {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -44,14 +47,6 @@ impl Command for IsUnique {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -21,7 +21,10 @@ impl Command for NotSeries {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -41,14 +44,6 @@ impl Command for NotSeries {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/masks/set.rs
+++ b/crates/nu-command/src/dataframe/series/masks/set.rs
@@ -29,6 +29,8 @@ impl Command for SetSeries {
                 "mask indicating insertions",
                 Some('m'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -53,14 +55,6 @@ impl Command for SetSeries {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/n_null.rs
+++ b/crates/nu-command/src/dataframe/series/n_null.rs
@@ -19,7 +19,10 @@ impl Command for NNull {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -36,14 +39,6 @@ impl Command for NNull {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -18,7 +18,10 @@ impl Command for NUnique {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -34,14 +37,6 @@ impl Command for NUnique {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/rolling.rs
+++ b/crates/nu-command/src/dataframe/series/rolling.rs
@@ -59,6 +59,8 @@ impl Command for Rolling {
         Signature::build(self.name())
             .required("type", SyntaxShape::String, "rolling operation")
             .required("window", SyntaxShape::Int, "Window size for rolling")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -99,14 +101,6 @@ impl Command for Rolling {
                 ),
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/shift.rs
+++ b/crates/nu-command/src/dataframe/series/shift.rs
@@ -30,6 +30,8 @@ impl Command for Shift {
                 "Expression used to fill the null values (lazy df)",
                 Some('f'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
 
@@ -46,14 +48,6 @@ impl Command for Shift {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-command/src/dataframe/series/string/concatenate.rs
@@ -27,6 +27,8 @@ impl Command for Concatenate {
                 SyntaxShape::Any,
                 "Other array with string to be concatenated",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -48,14 +50,6 @@ impl Command for Concatenate {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/contains.rs
+++ b/crates/nu-command/src/dataframe/series/string/contains.rs
@@ -27,6 +27,8 @@ impl Command for Contains {
                 SyntaxShape::String,
                 "Regex pattern to be searched",
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -47,14 +49,6 @@ impl Command for Contains {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/replace.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace.rs
@@ -34,6 +34,8 @@ impl Command for Replace {
                 "replacing string",
                 Some('r'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -54,14 +56,6 @@ impl Command for Replace {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace_all.rs
@@ -34,6 +34,8 @@ impl Command for ReplaceAll {
                 "replacing string",
                 Some('r'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -54,14 +56,6 @@ impl Command for ReplaceAll {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_lengths.rs
@@ -20,7 +20,10 @@ impl Command for StrLengths {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -36,14 +39,6 @@ impl Command for StrLengths {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_slice.rs
@@ -24,6 +24,8 @@ impl Command for StrSlice {
         Signature::build(self.name())
             .required("start", SyntaxShape::Int, "start of slice")
             .named("length", SyntaxShape::Int, "optional length", Some('l'))
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -44,14 +46,6 @@ impl Command for StrSlice {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-command/src/dataframe/series/string/strftime.rs
@@ -23,6 +23,8 @@ impl Command for StrFTime {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("fmt", SyntaxShape::String, "Format rule")
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -44,14 +46,6 @@ impl Command for StrFTime {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
@@ -20,7 +20,10 @@ impl Command for ToLowerCase {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -40,14 +43,6 @@ impl Command for ToLowerCase {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
@@ -20,7 +20,10 @@ impl Command for ToUpperCase {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -40,14 +43,6 @@ impl Command for ToUpperCase {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/unique.rs
+++ b/crates/nu-command/src/dataframe/series/unique.rs
@@ -40,6 +40,8 @@ impl Command for Unique {
                 "Keep the same order as the original DataFrame (lazy df)",
                 Some('k'),
             )
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
 
@@ -63,14 +65,6 @@ impl Command for Unique {
                 result: None,
             },
         ]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-command/src/dataframe/series/value_counts.rs
+++ b/crates/nu-command/src/dataframe/series/value_counts.rs
@@ -19,7 +19,10 @@ impl Command for ValueCount {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Custom("dataframe".into()))
+        Signature::build(self.name())
+            .input_type(Type::Custom("dataframe".into()))
+            .output_type(Type::Custom("dataframe".into()))
+            .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -41,14 +44,6 @@ impl Command for ValueCount {
                 .into_value(Span::test_data()),
             ),
         }]
-    }
-
-    fn input_type(&self) -> Type {
-        Type::Custom("dataframe".into())
-    }
-
-    fn output_type(&self) -> Type {
-        Type::Custom("dataframe".into())
     }
 
     fn run(

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2598,10 +2598,10 @@ pub fn parse_register(
     // the plugin is called to get the signatures or to use the given signature
     let signature = call.positional_nth(1).map(|expr| {
         let signature = working_set.get_span_contents(expr.span);
-        serde_json::from_slice::<Signature>(signature).map_err(|_| {
+        serde_json::from_slice::<Signature>(signature).map_err(|e| {
             ParseError::LabeledError(
                 "Signature deserialization error".into(),
-                "unable to deserialize signature".into(),
+                format!("unable to deserialize signature: {}", e),
                 spans[0],
             )
         })

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -748,7 +748,7 @@ pub fn parse_internal_call(
 
     let decl = working_set.get_decl(decl_id);
     let signature = decl.signature();
-    let output = decl.output_type();
+    let output = signature.output_type.clone();
 
     working_set.type_scope.add_type(output.clone());
 

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -753,7 +753,10 @@ mod input_types {
         }
 
         fn signature(&self) -> nu_protocol::Signature {
-            Signature::build(self.name()).category(Category::Custom("custom".into()))
+            Signature::build(self.name())
+                .input_type(Type::Any)
+                .output_type(Type::Custom("custom".into()))
+                .category(Category::Custom("custom".into()))
         }
 
         fn run(
@@ -764,14 +767,6 @@ mod input_types {
             _input: nu_protocol::PipelineData,
         ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
             todo!()
-        }
-
-        fn input_type(&self) -> nu_protocol::Type {
-            Type::Any
-        }
-
-        fn output_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
         }
     }
 
@@ -791,6 +786,8 @@ mod input_types {
             Signature::build(self.name())
                 .required("column", SyntaxShape::String, "column name")
                 .required("other", SyntaxShape::String, "other value")
+                .input_type(Type::Custom("custom".into()))
+                .output_type(Type::Custom("custom".into()))
                 .category(Category::Custom("custom".into()))
         }
 
@@ -802,14 +799,6 @@ mod input_types {
             _input: nu_protocol::PipelineData,
         ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
             todo!()
-        }
-
-        fn input_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
-        }
-
-        fn output_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
         }
     }
 
@@ -828,6 +817,7 @@ mod input_types {
         fn signature(&self) -> nu_protocol::Signature {
             Signature::build(self.name())
                 .required("operation", SyntaxShape::String, "operation")
+                .input_type(Type::Custom("custom".into()))
                 .category(Category::Custom("custom".into()))
         }
 
@@ -839,10 +829,6 @@ mod input_types {
             _input: nu_protocol::PipelineData,
         ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
             todo!()
-        }
-
-        fn input_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
         }
     }
 
@@ -888,15 +874,9 @@ mod input_types {
         fn signature(&self) -> nu_protocol::Signature {
             Signature::build(self.name())
                 .rest("operation", SyntaxShape::Any, "operation")
+                .input_type(Type::Custom("custom".into()))
+                .output_type(Type::Custom("custom".into()))
                 .category(Category::Custom("custom".into()))
-        }
-
-        fn input_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
-        }
-
-        fn output_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
         }
 
         fn run(
@@ -923,15 +903,10 @@ mod input_types {
         }
 
         fn signature(&self) -> nu_protocol::Signature {
-            Signature::build(self.name()).category(Category::Custom("custom".into()))
-        }
-
-        fn input_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
-        }
-
-        fn output_type(&self) -> nu_protocol::Type {
-            Type::Custom("custom".into())
+            Signature::build(self.name())
+                .input_type(Type::Custom("custom".into()))
+                .output_type(Type::Custom("custom".into()))
+                .category(Category::Custom("custom".into()))
         }
 
         fn run(

--- a/crates/nu-plugin/src/serializers/capnp/signature.rs
+++ b/crates/nu-plugin/src/serializers/capnp/signature.rs
@@ -1,5 +1,5 @@
 use crate::plugin_capnp::{argument, flag, signature, Category as PluginCategory, Shape};
-use nu_protocol::{Category, Flag, PositionalArg, ShellError, Signature, SyntaxShape};
+use nu_protocol::{Category, Flag, PositionalArg, ShellError, Signature, SyntaxShape, Type};
 
 pub(crate) fn serialize_signature(signature: &Signature, mut builder: signature::Builder) {
     builder.set_name(signature.name.as_str());
@@ -199,6 +199,8 @@ pub(crate) fn deserialize_signature(reader: signature::Reader) -> Result<Signatu
         .map(deserialize_flag)
         .collect::<Result<Vec<Flag>, ShellError>>()?;
 
+    // FIXME: add input/output type to deserialize
+
     Ok(Signature {
         name: name.to_string(),
         usage: usage.to_string(),
@@ -207,6 +209,8 @@ pub(crate) fn deserialize_signature(reader: signature::Reader) -> Result<Signatu
         required_positional,
         optional_positional,
         rest_positional,
+        input_type: Type::Any,
+        output_type: Type::Any,
         named,
         is_filter,
         creates_scope: false,

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{ast::Call, BlockId, Example, PipelineData, ShellError, Signature, Type};
+use crate::{ast::Call, BlockId, Example, PipelineData, ShellError, Signature};
 
 use super::{EngineState, Stack};
 
@@ -61,20 +61,6 @@ pub trait Command: Send + Sync + CommandClone {
     // Related terms to help with command search
     fn search_terms(&self) -> Vec<&str> {
         vec![]
-    }
-
-    // Command input type. The Type is used during parsing to find the
-    // correct internal command with similar names. The input type is
-    // obtained from the previous expression found in the pipeline
-    fn input_type(&self) -> Type {
-        Type::Any
-    }
-
-    // Command output type. The output type is the value from  the command
-    // It is used during parsing to find the next command in case there
-    // are commands with similar names
-    fn output_type(&self) -> Type {
-        Type::Any
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -977,7 +977,7 @@ impl<'a> StateWorkingSet<'a> {
 
     pub fn add_decl(&mut self, decl: Box<dyn Command>) -> DeclId {
         let name = decl.name().as_bytes().to_vec();
-        let input_type = decl.input_type();
+        let input_type = decl.signature().input_type;
 
         self.delta.decls.push(decl);
         let decl_id = self.num_decls() - 1;

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -10,6 +10,7 @@ use crate::BlockId;
 use crate::PipelineData;
 use crate::ShellError;
 use crate::SyntaxShape;
+use crate::Type;
 use crate::VarId;
 use std::fmt::Write;
 
@@ -106,6 +107,8 @@ pub struct Signature {
     pub optional_positional: Vec<PositionalArg>,
     pub rest_positional: Option<PositionalArg>,
     pub named: Vec<Flag>,
+    pub input_type: Type,
+    pub output_type: Type,
     pub is_filter: bool,
     pub creates_scope: bool,
     // Signature category used to classify commands stored in the list of declarations
@@ -135,6 +138,8 @@ impl Signature {
             required_positional: vec![],
             optional_positional: vec![],
             rest_positional: None,
+            input_type: Type::Any,
+            output_type: Type::Any,
             named: vec![],
             is_filter: false,
             creates_scope: false,
@@ -311,6 +316,18 @@ impl Signature {
             default_value: None,
         });
 
+        self
+    }
+
+    /// Changes the input type of the command signature
+    pub fn input_type(mut self, input_type: Type) -> Signature {
+        self.input_type = input_type;
+        self
+    }
+
+    /// Changes the output type of the command signature
+    pub fn output_type(mut self, output_type: Type) -> Signature {
+        self.output_type = output_type;
         self
     }
 


### PR DESCRIPTION
# Description

A refactor to move the input and output type of a command from `Command` to `Signature`. This should give us one place to set it regardless of whether the command was an internal command or a custom command.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
