### PR TITLE
feat: add `--binary(-b)` option to `hash` commands

### DIFF
--- a/crates/nu-command/src/hash/md5.rs
+++ b/crates/nu-command/src/hash/md5.rs
@@ -12,10 +12,21 @@ impl HashDigest for Md5 {
     fn examples() -> Vec<Example> {
         vec![
             Example {
-                description: "md5 encode a string",
+                description: "get a hexadecimaly encoded string of the md5 digest of a string",
                 example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash md5",
                 result: Some(Value::String {
                     val: "c3fcd3d76192e4007dfb496cca67e13b".to_owned(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "get the md5 digest of a string in binary",
+                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash md5 --binary",
+                result: Some(Value::Binary {
+                    val: vec![
+                        0xc3, 0xfc, 0xd3, 0xd7, 0x61, 0x92, 0xe4, 0x00, 0x7d, 0xfb, 0x49, 0x6c,
+                        0xca, 0x67, 0xe1, 0x3b,
+                    ],
                     span: Span::test_data(),
                 }),
             },
@@ -48,7 +59,7 @@ mod tests {
             val: "c3fcd3d76192e4007dfb496cca67e13b".to_owned(),
             span: Span::test_data(),
         };
-        let actual = generic_digest::action::<Md5>(&binary);
+        let actual = generic_digest::action::<Md5>(false, &binary);
         assert_eq!(actual, expected);
     }
 
@@ -62,7 +73,7 @@ mod tests {
             val: "5f80e231382769b0102b1164cf722d83".to_owned(),
             span: Span::test_data(),
         };
-        let actual = generic_digest::action::<Md5>(&binary);
+        let actual = generic_digest::action::<Md5>(false, &binary);
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/hash/sha256.rs
+++ b/crates/nu-command/src/hash/sha256.rs
@@ -12,11 +12,23 @@ impl HashDigest for Sha256 {
     fn examples() -> Vec<Example> {
         vec![
             Example {
-                description: "sha256 encode a string",
+                description: "get a hexadecimaly encoded string of the sha256 digest of a string",
                 example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash sha256",
                 result: Some(Value::String {
                     val: "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73"
                         .to_owned(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "get the sha256 digest of a string in binary",
+                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash sha256 --binary",
+                result: Some(Value::Binary {
+                    val: vec![
+                        0x71, 0xc4, 0x80, 0xdf, 0x93, 0xd6, 0xae, 0x2f, 0x1e, 0xfa, 0xd1, 0x44,
+                        0x7c, 0x66, 0xc9, 0x52, 0x5e, 0x31, 0x62, 0x18, 0xcf, 0x51, 0xfc, 0x8d,
+                        0x9e, 0xd8, 0x32, 0xf2, 0xda, 0xf1, 0x8b, 0x73,
+                    ],
                     span: Span::test_data(),
                 }),
             },
@@ -49,7 +61,7 @@ mod tests {
             val: "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73".to_owned(),
             span: Span::test_data(),
         };
-        let actual = generic_digest::action::<Sha256>(&binary);
+        let actual = generic_digest::action::<Sha256>(false, &binary);
         assert_eq!(actual, expected);
     }
 
@@ -63,7 +75,7 @@ mod tests {
             val: "c47a10dc272b1221f0380a2ae0f7d7fa830b3e378f2f5309bbf13f61ad211913".to_owned(),
             span: Span::test_data(),
         };
-        let actual = generic_digest::action::<Sha256>(&binary);
+        let actual = generic_digest::action::<Sha256>(false, &binary);
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -23,7 +23,7 @@ impl Command for DecodeBase64 {
             )
             .switch(
                 "binary",
-                "do not decode payload as UTF-8 and output binary",
+                "Output a binary value instead of decoding payload as UTF-8",
                 Some('b'),
             )
             .rest(


### PR DESCRIPTION
# Description

This adds a `--binary(-b)` option to `hash` family commands.

For instance,

```
echo 'abcdefghijklmnopqrstuvwxyz' | hash sha256 --binary
```

Will returns the hash as a binary value instead of a hexadecimaly encoded string.

One can get a shorter digest representation by encoding to the base64 representation instead of hexadecimal:

![image](https://user-images.githubusercontent.com/3809077/175802075-3ce728c0-5621-4b47-ab7b-f0e9c08848ae.png)

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
