### PR TITLE
make path exists work on expanded path

### DIFF
--- a/crates/nu-command/tests/commands/path/exists.rs
+++ b/crates/nu-command/tests/commands/path/exists.rs
@@ -51,3 +51,9 @@ fn checks_if_double_dot_exists() {
         assert_eq!(actual.out, "true");
     })
 }
+
+#[test]
+fn checks_if_relative_path_exists() {
+    let actual = nu!(cwd: ".", "'~' | path exists");
+    assert_eq!(actual.out, "true");
+}

--- a/crates/nu-command/tests/commands/path/exists.rs
+++ b/crates/nu-command/tests/commands/path/exists.rs
@@ -53,7 +53,7 @@ fn checks_if_double_dot_exists() {
 }
 
 #[test]
-fn checks_if_relative_path_exists() {
+fn checks_tilde_relative_path_exists() {
     let actual = nu!(cwd: ".", "'~' | path exists");
     assert_eq!(actual.out, "true");
 }


### PR DESCRIPTION
# Description

Relative: #5882

Occasionally, I'm also facing the issue today while wrting nu script:-0, and found someway to fix it, hope that can solve the issue.

~(Mark as draft for now and see if it works in windows...)~

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
