### PR TITLE
build: update `miette` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,13 +2203,13 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "4.7.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c90329e44f9208b55f45711f9558cec15d7ef8295cc65ecd6d4188ae8edc58c"
+checksum = "6ec753a43fd71bb5f28751c9ec17fbe89d6d26ca8282d1e1f82f5ac3dbd5581e"
 dependencies = [
  "atty",
  "backtrace",
- "miette-derive 4.7.1",
+ "miette-derive 5.1.0",
  "once_cell",
  "owo-colors",
  "supports-color",
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "4.7.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5bc45b761bcf1b5e6e6c4128cd93b84c218721a8d9b894aa0aff4ed180174c"
+checksum = "fdfc33ea15c5446600f91d319299dd40301614afff7143cdfa9bf4c09da3ca64"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2484,7 +2484,7 @@ dependencies = [
  "is_executable",
  "itertools",
  "log",
- "miette 4.7.1",
+ "miette 5.1.0",
  "nu-ansi-term",
  "nu-cli",
  "nu-color-config",
@@ -2532,7 +2532,7 @@ dependencies = [
  "fuzzy-matcher",
  "is_executable",
  "log",
- "miette 4.7.1",
+ "miette 5.1.0",
  "nu-ansi-term",
  "nu-color-config",
  "nu-command",
@@ -2688,7 +2688,7 @@ dependencies = [
  "chrono",
  "itertools",
  "log",
- "miette 4.7.1",
+ "miette 5.1.0",
  "nu-path",
  "nu-plugin",
  "nu-protocol",
@@ -2733,7 +2733,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "indexmap",
- "miette 4.7.1",
+ "miette 5.1.0",
  "nu-json",
  "nu-utils",
  "num-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 crossterm = "0.23.0"
 ctrlc = "3.2.1"
 log = "0.4"
-miette = "4.5.0"
+miette = "5.1.0"
 nu-ansi-term = "0.46.0"
 nu-cli = { path="./crates/nu-cli", version = "0.64.1"  }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.64.1"  }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -20,7 +20,7 @@ nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.64.1"  }
 reedline = { version = "0.7.0", features = ["bashisms", "sqlite"]}
 crossterm = "0.23.0"
-miette = { version = "4.5.0", features = ["fancy"] }
+miette = { version = "5.1.0", features = ["fancy"] }
 thiserror = "1.0.29"
 fuzzy-matcher = "0.3.7"
 

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.64.1"
 [dependencies]
 chrono = "0.4.19"
 itertools = "0.10"
-miette = "4.5.0"
+miette = "5.1.0"
 thiserror = "1.0.29"
 serde_json = "1.0"
 nu-path = {path = "../nu-path", version = "0.64.1" }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.64.1"
 [dependencies]
 nu-utils = { path = "../nu-utils", version = "0.64.1"  }
 thiserror = "1.0.29"
-miette = { version = "4.5.0", features = ["fancy"] }
+miette = { version = "5.1.0", features = ["fancy"] }
 serde = {version = "1.0.130", features = ["derive"]}
 chrono = { version="0.4.19", features=["serde"] }
 indexmap = { version="1.7", features=["serde-1"] }

--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -1,5 +1,5 @@
 use crate::engine::StateWorkingSet;
-use miette::{LabeledSpan, MietteHandlerOpts, ReportHandler, Severity, SourceCode};
+use miette::{LabeledSpan, MietteHandlerOpts, ReportHandler, RgbColors, Severity, SourceCode};
 use thiserror::Error;
 
 /// This error exists so that we can defer SourceCode handling. It simply
@@ -24,14 +24,15 @@ impl std::fmt::Debug for CliError<'_> {
 
         let miette_handler = MietteHandlerOpts::new()
             // For better support of terminal themes use the ANSI coloring
-            .rgb_colors(false)
-            .ansi_colors(true)
+            .rgb_colors(RgbColors::Never)
             // If ansi support is disabled in the config disable the eye-candy
             .color(ansi_support)
             .unicode(ansi_support)
             .terminal_links(ansi_support)
             .build();
+
         miette_handler.debug(self, f)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
# Description

Originally, I was trying to fix an highlighting offset issue with wide chars and emojis in errors, but came to the conclusion that there is no good solution because we can't assume everything is monospace anymore (emoji and Japanese characters appear roughly twice as big as normal characters in my terminal). If there exist a solution, it appears to be quite complex to implement in current codebase.

So this simply updates `miette` to the latest available version instead.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
