### PR TITLE
fix excessive ansi escape sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "ansi-str"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb0ceb8c444d026166795e474e9dfe54b443bdc07cc21bd6c5073f5e637482"
+checksum = "e04d04a41a1463228d6eed971b9cdadd86b5577c69c09fd2379c57fe5e159071"
 dependencies = [
  "ansi-parser",
 ]

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -17,5 +17,5 @@ nu-protocol = { path = "../nu-protocol", version = "0.64.1" }
 regex = "1.4"
 unicode-width = "0.1.8"
 strip-ansi-escapes = "0.1.1"
-ansi-str = "0.1.1"
+ansi-str = "0.2.0"
 atty = "0.2.14"


### PR DESCRIPTION
# Description

With some amazing work by @zhiburt, this simple change fixes the "turtle" problem.

Here's the "turtle" problme
```
> def turtle [column: string] { wrap $column | table }
> "turtle" | turtle 1 | turtle 2 | turtle 3 | turtle 4 | turtle 5 | str length
```
Previously, this would return over 7 million bytes. I made a change to get it down to 1.5 million. This change gets it to 2086. :)



# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
