### PR TITLE
fix bug where `thin` theme wasn't getting applied correctly

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -569,10 +569,11 @@ impl Iterator for PagingTableCreator {
 fn load_theme_from_config(config: &Config) -> TableTheme {
     match config.table_mode.as_str() {
         "basic" => nu_table::TableTheme::basic(),
-        "compact" => nu_table::TableTheme::compact(),
-        "compact_double" => nu_table::TableTheme::compact_double(),
+        "thin" => nu_table::TableTheme::thin(),
         "light" => nu_table::TableTheme::light(),
+        "compact" => nu_table::TableTheme::compact(),
         "with_love" => nu_table::TableTheme::with_love(),
+        "compact_double" => nu_table::TableTheme::compact_double(),
         "rounded" => nu_table::TableTheme::rounded(),
         "reinforced" => nu_table::TableTheme::reinforced(),
         "heavy" => nu_table::TableTheme::heavy(),


### PR DESCRIPTION
# Description

There was a bug that prevented the `thin` table theme from being used. You can use it now. This is what `thin` looks like.
![image](https://user-images.githubusercontent.com/343840/176247224-5581752b-2d58-4e33-9386-db7a33368fb3.png)


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
