### PR TITLE
make module imports in scripts used for relative path.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,7 @@ fn main() -> Result<()> {
                     binary_args.env_file,
                     is_perf_true(),
                     true,
+                    false,
                 );
                 if binary_args.config_file.is_some() {
                     config_files::read_config_file(
@@ -219,6 +220,7 @@ fn main() -> Result<()> {
                         &mut stack,
                         binary_args.config_file,
                         is_perf_true(),
+                        false,
                         false,
                     );
                 }
@@ -255,6 +257,7 @@ fn main() -> Result<()> {
                     binary_args.env_file,
                     is_perf_true(),
                     true,
+                    false,
                 );
                 if binary_args.config_file.is_some() {
                     config_files::read_config_file(
@@ -262,6 +265,7 @@ fn main() -> Result<()> {
                         &mut stack,
                         binary_args.config_file,
                         is_perf_true(),
+                        false,
                         false,
                     );
                 }
@@ -319,8 +323,15 @@ fn setup_config(
         info!("read_config_file {}:{}:{}", file!(), line!(), column!());
     }
 
-    config_files::read_config_file(engine_state, stack, env_file, is_perf_true(), true);
-    config_files::read_config_file(engine_state, stack, config_file, is_perf_true(), false);
+    config_files::read_config_file(engine_state, stack, env_file, is_perf_true(), true, true);
+    config_files::read_config_file(
+        engine_state,
+        stack,
+        config_file,
+        is_perf_true(),
+        false,
+        true,
+    );
 
     if is_login_shell {
         config_files::read_loginshell_file(engine_state, stack, is_perf_true());

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,13 @@ fn main() -> Result<()> {
                     is_perf_true(),
                 );
                 // only want to load config and env if relative argument is provided.
+                config_files::read_config_file(
+                    &mut engine_state,
+                    &mut stack,
+                    binary_args.env_file,
+                    is_perf_true(),
+                    true,
+                );
                 if binary_args.config_file.is_some() {
                     config_files::read_config_file(
                         &mut engine_state,
@@ -213,15 +220,6 @@ fn main() -> Result<()> {
                         binary_args.config_file,
                         is_perf_true(),
                         false,
-                    );
-                }
-                if binary_args.env_file.is_some() {
-                    config_files::read_config_file(
-                        &mut engine_state,
-                        &mut stack,
-                        binary_args.env_file,
-                        is_perf_true(),
-                        true,
                     );
                 }
 
@@ -251,6 +249,13 @@ fn main() -> Result<()> {
                     is_perf_true(),
                 );
                 // only want to load config and env if relative argument is provided.
+                config_files::read_config_file(
+                    &mut engine_state,
+                    &mut stack,
+                    binary_args.env_file,
+                    is_perf_true(),
+                    true,
+                );
                 if binary_args.config_file.is_some() {
                     config_files::read_config_file(
                         &mut engine_state,
@@ -258,15 +263,6 @@ fn main() -> Result<()> {
                         binary_args.config_file,
                         is_perf_true(),
                         false,
-                    );
-                }
-                if binary_args.env_file.is_some() {
-                    config_files::read_config_file(
-                        &mut engine_state,
-                        &mut stack,
-                        binary_args.env_file,
-                        is_perf_true(),
-                        true,
                     );
                 }
 


### PR DESCRIPTION
# Description

Fixes: #5841

The issue is caused by when running nu script, env path is not loaded so `NU_LIB_DIRS` is not defined

## Additional Note
It's conflict with #5544, especially the comment: https://github.com/nushell/nushell/issues/5544#issuecomment-1133582699

> One argument against loading config by default when running scripts is portability. If you rely on implicit loading of your local config and send the script to your friend's machine, the friend won't be able to run it.

But I think load env makes more convenient to user who writing script with module, and it's less harmful to portability.

It also fixes config loading order, refer to doc: 
> Nushell uses a configuration system that loads+runs two Nushell script files at launch time: First, env.nu, then config.nu

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
