### PR TITLE
ensure `required` positionals don't show up as `optional` when `help`

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -89,12 +89,13 @@ fn get_documentation(
     {
         long_desc.push_str("\nParameters:\n");
         for positional in &sig.required_positional {
-            long_desc.push_str(&format!(
+            let _ = writeln!(
+                long_desc,
                 "  {} <{:?}>: {}",
                 positional.name,
                 document_shape(positional.shape.clone()),
                 positional.desc
-            ));
+            );
         }
         for positional in &sig.optional_positional {
             let _ = writeln!(

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -90,7 +90,7 @@ fn get_documentation(
         long_desc.push_str("\nParameters:\n");
         for positional in &sig.required_positional {
             long_desc.push_str(&format!(
-                "  (required) {} <{:?}>: {}\n",
+                "  {} <{:?}>: {}",
                 positional.name,
                 document_shape(positional.shape.clone()),
                 positional.desc

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -90,7 +90,7 @@ fn get_documentation(
         long_desc.push_str("\nParameters:\n");
         for positional in &sig.required_positional {
             long_desc.push_str(&format!(
-                "  (optional) {} <{:?}>: {}\n",
+                "  (required) {} <{:?}>: {}\n",
                 positional.name,
                 document_shape(positional.shape.clone()),
                 positional.desc


### PR DESCRIPTION
# Description

Title. Previously, every positional was showing up as optional.

necessary CI edit: I'm not sure what's happening to the CI, but pretty sure this has to be an error in the CI, not in my code... unless it turns out changing the text actually affects commands related to the network. which seems unlikely. Furthermore, only the MacOS nu-tests is failing, so I can't exactly check this on my own machine.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
