### PR TITLE
New clippy fix for Rust 1.62

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -89,12 +89,13 @@ fn get_documentation(
     {
         long_desc.push_str("\nParameters:\n");
         for positional in &sig.required_positional {
-            long_desc.push_str(&format!(
-                "  (optional) {} <{:?}>: {}\n",
+            let _ = writeln!(
+                long_desc,
+                "  (optional) {} <{:?}>: {}",
                 positional.name,
                 document_shape(positional.shape.clone()),
                 positional.desc
-            ));
+            );
         }
         for positional in &sig.optional_positional {
             let _ = writeln!(


### PR DESCRIPTION
# Description

A clippy fix for new warnings introduced in the latest Rust

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
