### PR TITLE
change default keybinding in default config

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -457,7 +457,7 @@ let-env config = {
     }
     {
       name: vars_menu
-      modifier: alt
+      modifier: control
       keycode: char_o
       mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: vars_menu }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -436,6 +436,17 @@ let-env config = {
         ]
        }
     }
+    {
+      name: yank
+      modifier: control
+      keycode: char_y
+      mode: emacs
+      event: {
+        until: [
+          {edit: pastecutbufferafter}
+        ]
+      }
+    }
     # Keybindings used to trigger the user defined menus
     {
       name: commands_menu
@@ -446,8 +457,8 @@ let-env config = {
     }
     {
       name: vars_menu
-      modifier: control
-      keycode: char_y
+      modifier: alt
+      keycode: char_o
       mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: vars_menu }
     }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -458,7 +458,7 @@ let-env config = {
     {
       name: vars_menu
       modifier: control
-      keycode: char_o
+      keycode: alt_o
       mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: vars_menu }
     }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -457,8 +457,8 @@ let-env config = {
     }
     {
       name: vars_menu
-      modifier: control
-      keycode: alt_o
+      modifier: alt
+      keycode: char_o
       mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: vars_menu }
     }


### PR DESCRIPTION
# Description

Introduce new keybinding `ctrl-y` in default, I use it heavily with `ctrl-k`...

And move var menu from `ctrl-y` to `alt-o`, the `alt-o` comes from [pycharm navigate to symbol](https://www.jetbrains.com/pycharm/guide/tips/navigate-to-symbol/), which is using `Alt-Cmd-O in macOS`

`alt-o` looks similar to it, so I chose `alt-o`

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
