### PR TITLE
Fix `to md --pretty` when rendering a list

### DIFF
--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -54,6 +54,11 @@ impl Command for ToMd {
                     "# Welcome to Nushell\n| foo | bar |\n| --- | --- |\n| 1   | 2   |",
                 )),
             },
+            Example {
+                description: "Render a list",
+                example: "[0 1 2] | to md --pretty",
+                result: Some(Value::test_string("0\n1\n2")),
+            },
         ]
     }
 
@@ -291,7 +296,7 @@ fn get_output_string(
         }
 
         for i in 0..row.len() {
-            if pretty {
+            if pretty && column_widths.get(i).is_some() {
                 output_string.push(' ');
                 output_string.push_str(&get_padded_string(row[i].clone(), column_widths[i], ' '));
                 output_string.push(' ');


### PR DESCRIPTION
# Description
Fixes #5931

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
