### PR TITLE
add -e flag to print, to print the value to stderr

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -21,6 +21,7 @@ impl Command for Print {
                 "print without inserting a newline for the line ending",
                 Some('n'),
             )
+            .switch("stderr", "print to stderr instead of stdout", Some('e'))
             .category(Category::Strings)
     }
 
@@ -48,11 +49,12 @@ Since this command has no output, there is no point in piping it with other comm
     ) -> Result<PipelineData, ShellError> {
         let args: Vec<Value> = call.rest(engine_state, stack, 0)?;
         let no_newline = call.has_flag("no-newline");
+        let to_stderr = call.has_flag("stderr");
         let head = call.head;
 
         for arg in args {
             arg.into_pipeline_data()
-                .print(engine_state, stack, no_newline)?;
+                .print(engine_state, stack, no_newline, to_stderr)?;
         }
 
         Ok(PipelineData::new(head))

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -247,7 +247,7 @@ pub fn eval_source(
                 set_last_exit_code(stack, 0);
             }
 
-            if let Err(err) = pipeline_data.print(engine_state, stack, false) {
+            if let Err(err) = pipeline_data.print(engine_state, stack, false, false) {
                 let working_set = StateWorkingSet::new(engine_state);
 
                 report_error(&working_set, &err);

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -216,7 +216,7 @@ impl Command for Watch {
 
                     match eval_result {
                         Ok(val) => {
-                            val.print(engine_state, stack, false)?;
+                            val.print(engine_state, stack, false, false)?;
                         }
                         Err(err) => {
                             let working_set = StateWorkingSet::new(engine_state);

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -44,6 +44,7 @@ mod open;
 mod parse;
 mod path;
 mod prepend;
+mod print;
 #[cfg(feature = "database")]
 mod query;
 mod random;

--- a/crates/nu-command/tests/commands/print.rs
+++ b/crates/nu-command/tests/commands/print.rs
@@ -1,0 +1,23 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn print_to_stdout() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            "print 'hello world'"
+        )
+    );
+    assert!(actual.out.contains("hello world"));
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn print_to_stderr() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            "print -e 'hello world'"
+        )
+    );
+    assert!(actual.out.is_empty());
+    assert!(actual.err.contains("hello world"));
+}

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::{EngineState, Stack, StateWorkingSet},
     format_error, Config, ListStream, RawStream, ShellError, Span, Value,
 };
-use nu_utils::{stdout_write_all_and_flush, stdout_write_all_as_binary_and_flush};
+use nu_utils::{stdout_write_all_and_flush, stdout_write_all_and_flush};
 use std::sync::{atomic::AtomicBool, Arc};
 
 /// The foundational abstraction for input and output to commands
@@ -436,7 +436,7 @@ impl PipelineData {
                 for s in stream {
                     let s_live = s?;
                     let bin_output = s_live.as_binary()?;
-                    stdout_write_all_as_binary_and_flush(bin_output)?
+                    stdout_write_all_and_flush(bin_output)?
                 }
             }
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::{EngineState, Stack, StateWorkingSet},
     format_error, Config, ListStream, RawStream, ShellError, Span, Value,
 };
-use nu_utils::{stdout_write_all_and_flush, stdout_write_all_and_flush};
+use nu_utils::{stderr_write_all_and_flush, stdout_write_all_and_flush};
 use std::sync::{atomic::AtomicBool, Arc};
 
 /// The foundational abstraction for input and output to commands
@@ -414,11 +414,16 @@ impl PipelineData {
         }
     }
 
+    /// Consume and print self data immediately.
+    ///
+    /// `no_newline` controls if we need to attach newline character to output.
+    /// `to_stderr` controls if data is output to stderr, when the value is false, the data is ouput to stdout.
     pub fn print(
         self,
         engine_state: &EngineState,
         stack: &mut Stack,
         no_newline: bool,
+        to_stderr: bool,
     ) -> Result<(), ShellError> {
         // If the table function is in the declarations, then we can use it
         // to create the table value that will be printed in the terminal
@@ -436,7 +441,12 @@ impl PipelineData {
                 for s in stream {
                     let s_live = s?;
                     let bin_output = s_live.as_binary()?;
-                    stdout_write_all_and_flush(bin_output)?
+
+                    if !to_stderr {
+                        stdout_write_all_and_flush(bin_output)?
+                    } else {
+                        stderr_write_all_and_flush(bin_output)?
+                    }
                 }
             }
 
@@ -472,7 +482,11 @@ impl PipelineData {
                         out.push('\n');
                     }
 
-                    stdout_write_all_and_flush(out)?
+                    if !to_stderr {
+                        stdout_write_all_and_flush(out)?
+                    } else {
+                        stderr_write_all_and_flush(out)?
+                    }
                 }
             }
             None => {
@@ -491,7 +505,11 @@ impl PipelineData {
                         out.push('\n');
                     }
 
-                    stdout_write_all_and_flush(out)?
+                    if !to_stderr {
+                        stdout_write_all_and_flush(out)?
+                    } else {
+                        stderr_write_all_and_flush(out)?
+                    }
                 }
             }
         };

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod utils;
 
-pub use utils::{enable_vt_processing, stdout_write_all_and_flush};
+pub use utils::{enable_vt_processing, stderr_write_all_and_flush, stdout_write_all_and_flush};

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -1,5 +1,3 @@
 pub mod utils;
 
-pub use utils::{
-    enable_vt_processing, stdout_write_all_and_flush, stdout_write_all_as_binary_and_flush,
-};
+pub use utils::{enable_vt_processing, stdout_write_all_and_flush};

--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -24,19 +24,12 @@ pub fn enable_vt_processing() -> Result<()> {
     Ok(())
 }
 
-pub fn stdout_write_all_and_flush(output: String) -> Result<()> {
+pub fn stdout_write_all_and_flush<R>(output: R) -> Result<()>
+where
+    R: AsRef<[u8]>,
+{
     let stdout = std::io::stdout();
-    let ret = match stdout.lock().write_all(output.as_bytes()) {
-        Ok(_) => Ok(stdout.lock().flush()?),
-        Err(err) => Err(err),
-    };
-
-    ret
-}
-
-pub fn stdout_write_all_as_binary_and_flush(output: &[u8]) -> Result<()> {
-    let stdout = std::io::stdout();
-    let ret = match stdout.lock().write_all(output) {
+    let ret = match stdout.lock().write_all(output.as_ref()) {
         Ok(_) => Ok(stdout.lock().flush()?),
         Err(err) => Err(err),
     };

--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -24,13 +24,26 @@ pub fn enable_vt_processing() -> Result<()> {
     Ok(())
 }
 
-pub fn stdout_write_all_and_flush<R>(output: R) -> Result<()>
+pub fn stdout_write_all_and_flush<T>(output: T) -> Result<()>
 where
-    R: AsRef<[u8]>,
+    T: AsRef<[u8]>,
 {
     let stdout = std::io::stdout();
     let ret = match stdout.lock().write_all(output.as_ref()) {
         Ok(_) => Ok(stdout.lock().flush()?),
+        Err(err) => Err(err),
+    };
+
+    ret
+}
+
+pub fn stderr_write_all_and_flush<T>(output: T) -> Result<()>
+where
+    T: AsRef<[u8]>,
+{
+    let stderr = std::io::stderr();
+    let ret = match stderr.lock().write_all(output.as_ref()) {
+        Ok(_) => Ok(stderr.lock().flush()?),
         Err(err) => Err(err),
     };
 


### PR DESCRIPTION
# Description

This pr addresses the issue: #3816

But it doesn't `echo` to stderr(actuall I don't know how to do this...), instead, make `print` support output to stderr.

## A little refactor
Also, `stdout_write_all_and_flush` and `stdout_write_all_as_binary_and_flush` is refactored into one generic function `stdout_write_all_and_flush`, which supports both `String` and `&[u8]` parameter.

## Additional Note

Refer to the comment: https://github.com/nushell/nushell/issues/3816#issuecomment-1113276223

> I'd propose print -o for "other" or "output":

Stream # | Description | Introduced in | Write Cmdlet
-- | -- | -- | --
1 | Success Stream | PowerShell 2.0 | Write-Output
2 | Error Stream | PowerShell 2.0 | Write-Error
3 | Warning Stream | PowerShell 3.0 | Write-Warning
4 | Verbose Stream | PowerShell 3.0 | Write-Verbose
5 | Debug Stream | PowerShell 3.0 | Write-Debug
6 | Information Stream | PowerShell 5.0 | Write-Information

Sorry for that I don't implement it like this, for 2 reasons:
1. it seems that `Warning Stream`, `Verbose stream`, `Debug Stream`, `Information Stream` is something special in powershell, I can't find it in linux or mac
2. Also, rust only provide `stdout` and `stderr`, we don't have something like `stdwarn`, `stdverbose`.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
