### PR TITLE
Change C-u and C-k to be readline compatible, move old C-u to C-s

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -447,6 +447,28 @@ let-env config = {
         ]
       }
     }
+    {
+      name: unix-line-discard
+      modifier: control
+      keycode: char_u
+      mode: [emacs, vi_normal, vi_insert]
+      event: {
+        until: [
+          {edit: cutfromlinestart}
+        ]
+      }
+    }
+    {
+      name: kill-line
+      modifier: control
+      keycode: char_k
+      mode: [emacs, vi_normal, vi_insert]
+      event: {
+        until: [
+          {edit: cuttolineend}
+        ]
+      }
+    }
     # Keybindings used to trigger the user defined menus
     {
       name: commands_menu
@@ -465,7 +487,7 @@ let-env config = {
     {
       name: commands_with_description
       modifier: control
-      keycode: char_u
+      keycode: char_s
       mode: [emacs, vi_normal, vi_insert]
       event: { send: menu name: commands_with_description }
     }


### PR DESCRIPTION
# Description

Per #5912:

- Change `C-u` to `unix-line-discard`
- Add `C-k` for `kill-line`
- Change `commands-with-description` to `C-s` (for **s**earch); in readline `C-s` is bound to `forward-search-history`, but there's not much of a better option. `C-s` is also compatible with fishshell's `pager-toggle-search`, which is the closest equivalent I could think of.

(You can find the [default readline keybindings here](https://unix.stackexchange.com/questions/303479/what-are-readlines-modes-keymaps-and-their-default-bindings)).

- I was also surprised to see that `C-y` got changed already, `git blame` says it happened just 5 hours ago :)

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
