### PR TITLE
Binary into int

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,6 +2565,7 @@ dependencies = [
  "Inflector",
  "alphanumeric-sort",
  "base64",
+ "byteorder",
  "bytesize",
  "calamine",
  "chrono",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -28,6 +28,7 @@ nu-ansi-term = "0.46.0"
 # Potential dependencies for extras
 alphanumeric-sort = "1.4.4"
 base64 = "0.13.0"
+byteorder = "1.4.3"
 bytesize = "1.1.0"
 calamine = "0.18.0"
 chrono = { version = "0.4.19", features = ["serde"] }

--- a/crates/nu-command/tests/commands/into_int.rs
+++ b/crates/nu-command/tests/commands/into_int.rs
@@ -35,3 +35,15 @@ fn into_int_int() {
 
     assert!(actual.out.contains('1'));
 }
+
+#[test]
+fn into_int_binary() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo 0x[01010101] | into int
+        "#
+    ));
+
+    assert!(actual.out.contains("16843009"));
+}


### PR DESCRIPTION
# Description

Adds support to `into int` to handle binary input (with an optional flag for switching to little endian)

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
