### PR TITLE
Fix 'skip' support for binary streams

### DIFF
--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -93,18 +93,17 @@ impl Command for Skip {
                             let bytes = val.as_bytes();
                             if bytes.len() < remaining {
                                 remaining -= bytes.len();
-                                output.extend_from_slice(bytes)
+                                //output.extend_from_slice(bytes)
                             } else {
-                                output.extend_from_slice(&bytes[0..remaining]);
+                                output.extend_from_slice(&bytes[remaining..]);
                                 break;
                             }
                         }
                         Value::Binary { val: bytes, .. } => {
                             if bytes.len() < remaining {
                                 remaining -= bytes.len();
-                                output.extend_from_slice(&bytes)
                             } else {
-                                output.extend_from_slice(&bytes[0..remaining]);
+                                output.extend_from_slice(&bytes[remaining..]);
                                 break;
                             }
                         }

--- a/crates/nu-command/tests/commands/skip/mod.rs
+++ b/crates/nu-command/tests/commands/skip/mod.rs
@@ -1,2 +1,3 @@
+mod skip_;
 mod until;
 mod while_;

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -1,0 +1,16 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn binary_skip() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open sample_data.ods --raw | 
+            skip 2 | 
+            take 2 | 
+            into int
+        "#
+    ));
+
+    assert_eq!(actual.out, "772");
+}


### PR DESCRIPTION
# Description

Found this one doing a recent video - `skip` was previously implemented to work like `take` for binary streams. Oops. Flipped it around so it should work for binary streams now.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
