### PR TITLE
add bytes length command

### DIFF
--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -1,0 +1,118 @@
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::ast::CellPath;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::Category;
+use nu_protocol::{Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value};
+
+#[derive(Clone)]
+pub struct BytesLen;
+
+impl Command for BytesLen {
+    fn name(&self) -> &str {
+        "bytes length"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("bytes length")
+            .rest(
+                "rest",
+                SyntaxShape::CellPath,
+                "optionally find length of binary by column paths",
+            )
+            .category(Category::Bytes)
+    }
+
+    fn usage(&self) -> &str {
+        "Output the length of any bytes in the pipeline"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["len", "size", "count"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        operate(engine_state, stack, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Return the lengths of multiple strings",
+                example: "0x[1F FF AA AB] | bytes length",
+                result: Some(Value::test_int(4)),
+            },
+            Example {
+                description: "Return the lengths of multiple strings",
+                example: "[0x[1F FF AA AB] 0x[1F]] | bytes length",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(4), Value::test_int(1)],
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn operate(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+) -> Result<PipelineData, ShellError> {
+    let head = call.head;
+    let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+    if column_paths.is_empty() {
+        input.map(move |v| action(&v, head), engine_state.ctrlc.clone())
+    } else {
+        input.map(
+            move |mut v| {
+                for path in &column_paths {
+                    let r =
+                        v.update_cell_path(&path.members, Box::new(move |old| action(old, head)));
+                    if let Err(error) = r {
+                        return Value::Error { error };
+                    }
+                }
+                v
+            },
+            engine_state.ctrlc.clone(),
+        )
+    }
+}
+
+fn action(input: &Value, head: Span) -> Value {
+    match input {
+        Value::Binary { val, .. } => Value::Int {
+            val: val.len() as i64,
+            span: head,
+        },
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Input's type is {}. This command only works with bytes.",
+                    other.get_type()
+                ),
+                head,
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(BytesLen {})
+    }
+}

--- a/crates/nu-command/src/bytes/mod.rs
+++ b/crates/nu-command/src/bytes/mod.rs
@@ -1,0 +1,3 @@
+mod length;
+
+pub use length::BytesLen;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -207,6 +207,11 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             StrUpcase
         };
 
+        // Bytes
+        bind_command! {
+            BytesLen
+        }
+
         // FileSystem
         bind_command! {
             Cd,

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -1,3 +1,4 @@
+mod bytes;
 mod charting;
 mod conversions;
 mod core_commands;
@@ -24,6 +25,7 @@ mod strings;
 mod system;
 mod viewers;
 
+pub use bytes::*;
 pub use charting::*;
 pub use conversions::*;
 pub use core_commands::*;

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -43,6 +43,7 @@ pub enum Category {
     Default,
     Conversions,
     Core,
+    Bytes,
     Date,
     Env,
     Experimental,
@@ -91,6 +92,7 @@ impl std::fmt::Display for Category {
             Category::Chart => "chart",
             Category::Custom(name) => name,
             Category::Deprecated => "deprecated",
+            Category::Bytes => "bytes",
         };
 
         write!(f, "{}", msg)


### PR DESCRIPTION
# Description

Add `bytes len` command

This is my first try to add bytes relative commands mentioned in https://gist.github.com/fdncred/6f5fb149c014c6de039401a6a07d3046/

The behavior is almost consistent with `str length` command, they just have different input type.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
