### PR TITLE
Ensure completions only complete commands if there is no prior command

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -206,26 +206,14 @@ impl NuCompleter {
                                 );
                             }
                             flat_shape => {
-                                let mut completer = CommandCompletion::new(
-                                    self.engine_state.clone(),
-                                    &working_set,
-                                    flattened.clone(),
-                                    // flat_idx,
-                                    flat_shape.clone(),
-                                );
-
-                                let out: Vec<_> = self.process_completion(
-                                    &mut completer,
-                                    &working_set,
-                                    prefix.clone(),
-                                    new_span,
-                                    offset,
-                                    pos,
-                                );
-
-                                if out.is_empty() {
-                                    let mut completer =
-                                        FileCompletion::new(self.engine_state.clone());
+                                if flat_idx == 0 {
+                                    let mut completer = CommandCompletion::new(
+                                        self.engine_state.clone(),
+                                        &working_set,
+                                        flattened.clone(),
+                                        // flat_idx,
+                                        flat_shape.clone(),
+                                    );
 
                                     return self.process_completion(
                                         &mut completer,
@@ -235,11 +223,23 @@ impl NuCompleter {
                                         offset,
                                         pos,
                                     );
-                                }
+                                } else {
+                                    let mut completer =
+                                        FileCompletion::new(self.engine_state.clone());
 
-                                return out;
+                                    let out: Vec<_> = self.process_completion(
+                                        &mut completer,
+                                        &working_set,
+                                        prefix.clone(),
+                                        new_span,
+                                        offset,
+                                        pos,
+                                    );
+
+                                    return out;
+                                }
                             }
-                        };
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description

Previously, should nushell encounter a command without defined completions, it would default to completing to another command. This instead defaults it to completing a filepath.

Currently, it seems to break completions like `do` or `sudo`. Drafting until a solution is found.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
