### PR TITLE
allow `where` to work with variables

### DIFF
--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -2,7 +2,8 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
+    Signature, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -19,7 +20,13 @@ impl Command for Where {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("where")
-            .required("cond", SyntaxShape::RowCondition, "condition")
+            .optional("cond", SyntaxShape::RowCondition, "condition")
+            .named(
+                "block",
+                SyntaxShape::Block(Some(vec![SyntaxShape::Any])),
+                "use where with a block or variable instead",
+                Some('b'),
+            )
             .category(Category::Filters)
     }
 
@@ -34,112 +41,172 @@ impl Command for Where {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let capture_block: CaptureBlock = call.req(engine_state, stack, 0)?;
+        if let Ok(Some(capture_block)) = call.get_flag::<CaptureBlock>(engine_state, stack, "block")
+        {
+            let metadata = input.metadata();
+            let ctrlc = engine_state.ctrlc.clone();
+            let engine_state = engine_state.clone();
+            let block = engine_state.get_block(capture_block.block_id).clone();
+            let mut stack = stack.captures_to_stack(&capture_block.captures);
+            let orig_env_vars = stack.env_vars.clone();
+            let orig_env_hidden = stack.env_hidden.clone();
+            let span = call.head;
+            let redirect_stdout = call.redirect_stdout;
+            let redirect_stderr = call.redirect_stderr;
 
-        let metadata = input.metadata();
-        let ctrlc = engine_state.ctrlc.clone();
-        let outer_ctrlc = engine_state.ctrlc.clone();
-        let engine_state = engine_state.clone();
-        let block = engine_state.get_block(capture_block.block_id).clone();
-        let mut stack = stack.captures_to_stack(&capture_block.captures);
-        let orig_env_vars = stack.env_vars.clone();
-        let orig_env_hidden = stack.env_hidden.clone();
-        let span = call.head;
-        let redirect_stdout = call.redirect_stdout;
-        let redirect_stderr = call.redirect_stderr;
+            match input {
+                PipelineData::Value(Value::Range { .. }, ..)
+                | PipelineData::Value(Value::List { .. }, ..)
+                | PipelineData::ListStream { .. } => Ok(input
+                    .into_iter()
+                    .filter_map(move |x| {
+                        stack.with_env(&orig_env_vars, &orig_env_hidden);
 
-        match input {
-            PipelineData::Value(Value::Range { .. }, ..)
-            | PipelineData::Value(Value::List { .. }, ..)
-            | PipelineData::ListStream { .. } => Ok(input
-                .into_iter()
-                .filter_map(move |x| {
-                    stack.with_env(&orig_env_vars, &orig_env_hidden);
-
-                    if let Some(var) = block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(*var_id, x.clone());
+                        if let Some(var) = block.signature.get_positional(0) {
+                            if let Some(var_id) = &var.var_id {
+                                stack.add_var(*var_id, x.clone());
+                            }
                         }
-                    }
 
-                    match eval_block(
-                        &engine_state,
-                        &mut stack,
-                        &block,
-                        x.clone().into_pipeline_data(),
-                        redirect_stdout,
-                        redirect_stderr,
-                    ) {
-                        Ok(v) => if v.into_value(span).is_true() {
-                            Some(x) 
-                        } else {
-                            None
-                        },
-                        Err(error) => Some(Value::Error { error }),
-                    }
-                })
-                .into_pipeline_data(ctrlc)),
-            PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(call.head)),
-            PipelineData::ExternalStream {
-                stdout: Some(stream),
-                ..
-            } => Ok(stream
-                .into_iter()
-                .filter_map(move |x| {
-                    stack.with_env(&orig_env_vars, &orig_env_hidden);
-
-                    let x = match x {
-                        Ok(x) => x,
-                        Err(err) => return Some(Value::Error { error: err }),
-                    };
-
-                    if let Some(var) = block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(*var_id, x.clone());
+                        match eval_block(
+                            &engine_state,
+                            &mut stack,
+                            &block,
+                            x.clone().into_pipeline_data(),
+                            redirect_stdout,
+                            redirect_stderr,
+                        ) {
+                            Ok(v) => {
+                                if v.into_value(span).is_true() {
+                                    Some(x)
+                                } else {
+                                    None
+                                }
+                            }
+                            Err(error) => Some(Value::Error { error }),
                         }
-                    }
-
-                    match eval_block(
-                        &engine_state,
-                        &mut stack,
-                        &block,
-                        x.clone().into_pipeline_data(),
-                        redirect_stdout,
-                        redirect_stderr,
-                    ) {
-                        Ok(v) => if v.into_value(span).is_true() {
-                            Some(x) 
-                        } else {
-                            None
-                        },
-                        Err(error) => Some(Value::Error { error }),
-                    }
-                })
-                .into_pipeline_data(ctrlc)),
-            PipelineData::Value(x, ..) => {
-                if let Some(var) = block.signature.get_positional(0) {
-                    if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, x.clone());
-                    }
+                    })
+                    .into_pipeline_data(ctrlc)),
+                PipelineData::ExternalStream { stdout: None, .. } => {
+                    Ok(PipelineData::new(call.head))
                 }
-                Ok(match eval_block(
-                    &engine_state,
-                    &mut stack,
-                    &block,
-                    x.clone().into_pipeline_data(),
-                    redirect_stdout,
-                    redirect_stderr,
-                ) {
-                    Ok(v) => if v.into_value(span).is_true() {
-                        Some(x) 
-                    } else {
-                        None
-                    },
-                    Err(error) => Some(Value::Error { error }),
-                }.into_pipeline_data(ctrlc))
+                PipelineData::ExternalStream {
+                    stdout: Some(stream),
+                    ..
+                } => Ok(stream
+                    .into_iter()
+                    .filter_map(move |x| {
+                        stack.with_env(&orig_env_vars, &orig_env_hidden);
+
+                        let x = match x {
+                            Ok(x) => x,
+                            Err(err) => return Some(Value::Error { error: err }),
+                        };
+
+                        if let Some(var) = block.signature.get_positional(0) {
+                            if let Some(var_id) = &var.var_id {
+                                stack.add_var(*var_id, x.clone());
+                            }
+                        }
+
+                        match eval_block(
+                            &engine_state,
+                            &mut stack,
+                            &block,
+                            x.clone().into_pipeline_data(),
+                            redirect_stdout,
+                            redirect_stderr,
+                        ) {
+                            Ok(v) => {
+                                if v.into_value(span).is_true() {
+                                    Some(x)
+                                } else {
+                                    None
+                                }
+                            }
+                            Err(error) => Some(Value::Error { error }),
+                        }
+                    })
+                    .into_pipeline_data(ctrlc)),
+                PipelineData::Value(x, ..) => {
+                    if let Some(var) = block.signature.get_positional(0) {
+                        if let Some(var_id) = &var.var_id {
+                            stack.add_var(*var_id, x.clone());
+                        }
+                    }
+                    Ok(match eval_block(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        x.clone().into_pipeline_data(),
+                        redirect_stdout,
+                        redirect_stderr,
+                    ) {
+                        Ok(v) => {
+                            if v.into_value(span).is_true() {
+                                Some(x)
+                            } else {
+                                None
+                            }
+                        }
+                        Err(error) => Some(Value::Error { error }),
+                    }
+                    .into_pipeline_data(ctrlc))
+                }
+            }
+            .map(|x| x.set_metadata(metadata))
+        } else {
+            let capture_block: Option<CaptureBlock> = call.opt(engine_state, stack, 0)?;
+            if let Some(block) = capture_block {
+                let span = call.head;
+
+                let metadata = input.metadata();
+                let mut stack = stack.captures_to_stack(&block.captures);
+                let block = engine_state.get_block(block.block_id).clone();
+
+                let ctrlc = engine_state.ctrlc.clone();
+                let engine_state = engine_state.clone();
+
+                let redirect_stdout = call.redirect_stdout;
+                let redirect_stderr = call.redirect_stderr;
+                Ok(input
+                    .into_iter()
+                    .filter_map(move |value| {
+                        if let Some(var) = block.signature.get_positional(0) {
+                            if let Some(var_id) = &var.var_id {
+                                stack.add_var(*var_id, value.clone());
+                            }
+                        }
+                        let result = eval_block(
+                            &engine_state,
+                            &mut stack,
+                            &block,
+                            PipelineData::new(span),
+                            redirect_stdout,
+                            redirect_stderr,
+                        );
+
+                        match result {
+                            Ok(result) => {
+                                let result = result.into_value(span);
+                                if result.is_true() {
+                                    Some(value)
+                                } else {
+                                    None
+                                }
+                            }
+                            Err(err) => Some(Value::Error { error: err }),
+                        }
+                    })
+                    .into_pipeline_data(ctrlc))
+                .map(|x| x.set_metadata(metadata))
+            } else {
+                Err(ShellError::MissingParameter(
+                    "condition".to_string(),
+                    call.head,
+                ))
             }
         }
-        .map(|x| x.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -3,7 +3,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, SyntaxShape, Value,
+    Signature, SyntaxShape, Value, Span,
 };
 
 #[derive(Clone)]
@@ -230,6 +230,21 @@ impl Command for Where {
                 description: "List all files that were modified in the last two weeks",
                 example: "ls | where modified >= (date now) - 2wk",
                 result: None,
+            },
+            Example {
+                description: "Get all numbers above 3 with an existing block condition",
+                example: "let a = {$in > 3}; [1, 2, 5, 6] | where -b $a",
+                result: Some(Value::List {
+                    vals: vec![Value::Int {
+                        val: 5,
+                        span: Span::test_data(),
+                    },
+                    Value::Int {
+                         val: 6,
+                      span: Span::test_data(),
+                     }],
+                    span: Span::test_data(),
+                }),
             },
         ]
     }

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -2,7 +2,7 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, Signature, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -34,50 +34,111 @@ impl Command for Where {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let span = call.head;
+        let capture_block: CaptureBlock = call.req(engine_state, stack, 0)?;
 
         let metadata = input.metadata();
-
-        let block: CaptureBlock = call.req(engine_state, stack, 0)?;
-        let mut stack = stack.captures_to_stack(&block.captures);
-        let block = engine_state.get_block(block.block_id).clone();
-
         let ctrlc = engine_state.ctrlc.clone();
+        let outer_ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
-
+        let block = engine_state.get_block(capture_block.block_id).clone();
+        let mut stack = stack.captures_to_stack(&capture_block.captures);
+        let orig_env_vars = stack.env_vars.clone();
+        let orig_env_hidden = stack.env_hidden.clone();
+        let span = call.head;
         let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
 
-        Ok(input
-            .into_iter()
-            .filter_map(move |value| {
+        match input {
+            PipelineData::Value(Value::Range { .. }, ..)
+            | PipelineData::Value(Value::List { .. }, ..)
+            | PipelineData::ListStream { .. } => Ok(input
+                .into_iter()
+                .filter_map(move |x| {
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
+
+                    if let Some(var) = block.signature.get_positional(0) {
+                        if let Some(var_id) = &var.var_id {
+                            stack.add_var(*var_id, x.clone());
+                        }
+                    }
+
+                    match eval_block(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        x.clone().into_pipeline_data(),
+                        redirect_stdout,
+                        redirect_stderr,
+                    ) {
+                        Ok(v) => if v.into_value(span).is_true() {
+                            Some(x) 
+                        } else {
+                            None
+                        },
+                        Err(error) => Some(Value::Error { error }),
+                    }
+                })
+                .into_pipeline_data(ctrlc)),
+            PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(call.head)),
+            PipelineData::ExternalStream {
+                stdout: Some(stream),
+                ..
+            } => Ok(stream
+                .into_iter()
+                .filter_map(move |x| {
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
+
+                    let x = match x {
+                        Ok(x) => x,
+                        Err(err) => return Some(Value::Error { error: err }),
+                    };
+
+                    if let Some(var) = block.signature.get_positional(0) {
+                        if let Some(var_id) = &var.var_id {
+                            stack.add_var(*var_id, x.clone());
+                        }
+                    }
+
+                    match eval_block(
+                        &engine_state,
+                        &mut stack,
+                        &block,
+                        x.clone().into_pipeline_data(),
+                        redirect_stdout,
+                        redirect_stderr,
+                    ) {
+                        Ok(v) => if v.into_value(span).is_true() {
+                            Some(x) 
+                        } else {
+                            None
+                        },
+                        Err(error) => Some(Value::Error { error }),
+                    }
+                })
+                .into_pipeline_data(ctrlc)),
+            PipelineData::Value(x, ..) => {
                 if let Some(var) = block.signature.get_positional(0) {
                     if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, value.clone());
+                        stack.add_var(*var_id, x.clone());
                     }
                 }
-                let result = eval_block(
+                Ok(match eval_block(
                     &engine_state,
                     &mut stack,
                     &block,
-                    PipelineData::new(span),
+                    x.clone().into_pipeline_data(),
                     redirect_stdout,
                     redirect_stderr,
-                );
-
-                match result {
-                    Ok(result) => {
-                        let result = result.into_value(span);
-                        if result.is_true() {
-                            Some(value)
-                        } else {
-                            None
-                        }
-                    }
-                    Err(err) => Some(Value::Error { error: err }),
-                }
-            })
-            .into_pipeline_data(ctrlc))
+                ) {
+                    Ok(v) => if v.into_value(span).is_true() {
+                        Some(x) 
+                    } else {
+                        None
+                    },
+                    Err(error) => Some(Value::Error { error }),
+                }.into_pipeline_data(ctrlc))
+            }
+        }
         .map(|x| x.set_metadata(metadata))
     }
 

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -3,7 +3,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, SyntaxShape, Value, Span,
+    Signature, Span, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -235,14 +235,16 @@ impl Command for Where {
                 description: "Get all numbers above 3 with an existing block condition",
                 example: "let a = {$in > 3}; [1, 2, 5, 6] | where -b $a",
                 result: Some(Value::List {
-                    vals: vec![Value::Int {
-                        val: 5,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                         val: 6,
-                      span: Span::test_data(),
-                     }],
+                    vals: vec![
+                        Value::Int {
+                            val: 5,
+                            span: Span::test_data(),
+                        },
+                        Value::Int {
+                            val: 6,
+                            span: Span::test_data(),
+                        },
+                    ],
                     span: Span::test_data(),
                 }),
             },


### PR DESCRIPTION
# Description

Fixes #5547. Adds an extra `named`, so the change is non-breaking.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
