### PR TITLE
add bytes root command

### DIFF
--- a/crates/nu-command/src/bytes/bytes_.rs
+++ b/crates/nu-command/src/bytes/bytes_.rs
@@ -38,7 +38,7 @@ impl Command for Bytes {
 
 #[cfg(test)]
 mod test {
-    use crate::Str;
+    use crate::Bytes;
 
     #[test]
     fn test_examples() {

--- a/crates/nu-command/src/bytes/bytes_.rs
+++ b/crates/nu-command/src/bytes/bytes_.rs
@@ -1,0 +1,49 @@
+use nu_engine::get_full_help;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, IntoPipelineData, PipelineData, Signature, Value,
+};
+
+#[derive(Clone)]
+pub struct Bytes;
+
+impl Command for Bytes {
+    fn name(&self) -> &str {
+        "bytes"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("bytes").category(Category::Bytes)
+    }
+
+    fn usage(&self) -> &str {
+        "Various commands for working with byte data"
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Ok(Value::String {
+            val: get_full_help(&Bytes.signature(), &Bytes.examples(), engine_state, stack),
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Str;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(Bytes {})
+    }
+}

--- a/crates/nu-command/src/bytes/mod.rs
+++ b/crates/nu-command/src/bytes/mod.rs
@@ -1,10 +1,13 @@
+mod bytes_;
 mod length;
 mod starts_with;
+
 use nu_protocol::ast::CellPath;
 use nu_protocol::{PipelineData, ShellError, Span, Value};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+pub use bytes_::Bytes;
 pub use length::BytesLen;
 pub use starts_with::BytesStartsWith;
 

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -209,6 +209,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
 
         // Bytes
         bind_command! {
+            Bytes,
             BytesLen,
             BytesStartsWith
         }


### PR DESCRIPTION
# Description

This PR just adds the root `bytes` command so you can type `> bytes` and see all the other sub commands.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
