### PR TITLE
Add --directory (-D) flag to ls, list the directory itself instead of its contents

### DIFF
--- a/crates/nu-cli/tests/flag_completions.rs
+++ b/crates/nu-cli/tests/flag_completions.rs
@@ -14,15 +14,17 @@ fn flag_completions() {
     // Test completions for the 'ls' flags
     let suggestions = completer.complete("ls -", 4);
 
-    assert_eq!(12, suggestions.len());
+    assert_eq!(14, suggestions.len());
 
     let expected: Vec<String> = vec![
         "--all".into(),
+        "--directory".into(),
         "--du".into(),
         "--full-paths".into(),
         "--help".into(),
         "--long".into(),
         "--short-names".into(),
+        "-D".into(),
         "-a".into(),
         "-d".into(),
         "-f".into(),

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -56,6 +56,11 @@ impl Command for Ls {
                 "Display the apparent directory size in place of the directory metadata size",
                 Some('d'),
             )
+            .switch(
+                "directory",
+                "List the specified directory itself instead of its contents",
+                Some('D'),
+            )
             .category(Category::FileSystem)
     }
 
@@ -71,6 +76,7 @@ impl Command for Ls {
         let short_names = call.has_flag("short-names");
         let full_paths = call.has_flag("full-paths");
         let du = call.has_flag("du");
+        let directory = call.has_flag("directory");
         let ctrl_c = engine_state.ctrlc.clone();
         let call_span = call.head;
         let cwd = current_dir(engine_state, stack)?;
@@ -83,7 +89,8 @@ impl Command for Ls {
                 let mut p = expand_to_real_path(p.item);
 
                 let expanded = nu_path::expand_path_with(&p, &cwd);
-                if expanded.is_dir() {
+                // Avoid checking and pushing "*" to the path when directory (do not show contents) flag is true
+                if !directory && expanded.is_dir() {
                     if permission_denied(&p) {
                         #[cfg(unix)]
                         let error_msg = format!(
@@ -116,7 +123,10 @@ impl Command for Ls {
                 (p, p_tag, absolute_path)
             }
             None => {
-                if is_empty_dir(current_dir(engine_state, stack)?) {
+                // Avoid pushing "*" to the default path when directory (do not show contents) flag is true
+                if directory {
+                    (PathBuf::from("."), call_span, false)
+                } else if is_empty_dir(current_dir(engine_state, stack)?) {
                     return Ok(Value::nothing(call_span).into_pipeline_data());
                 } else {
                     (PathBuf::from("./*"), call_span, false)
@@ -178,13 +188,30 @@ impl Command for Ls {
                         Some(path.to_string_lossy().to_string())
                     } else if let Some(prefix) = &prefix {
                         if let Ok(remainder) = path.strip_prefix(&prefix) {
-                            let new_prefix = if let Some(pfx) = diff_paths(&prefix, &cwd) {
-                                pfx
-                            } else {
-                                prefix.to_path_buf()
-                            };
+                            if directory {
+                                // When the path is the same as the cwd, path_diff should be "."
+                                let path_diff =
+                                    if let Some(path_diff_not_dot) = diff_paths(&path, &cwd) {
+                                        let path_diff_not_dot = path_diff_not_dot.to_string_lossy();
+                                        if path_diff_not_dot.is_empty() {
+                                            ".".to_string()
+                                        } else {
+                                            path_diff_not_dot.to_string()
+                                        }
+                                    } else {
+                                        path.to_string_lossy().to_string()
+                                    };
 
-                            Some(new_prefix.join(remainder).to_string_lossy().to_string())
+                                Some(path_diff)
+                            } else {
+                                let new_prefix = if let Some(pfx) = diff_paths(&prefix, &cwd) {
+                                    pfx
+                                } else {
+                                    prefix.to_path_buf()
+                                };
+
+                                Some(new_prefix.join(remainder).to_string_lossy().to_string())
+                            }
                         } else {
                             Some(path.to_string_lossy().to_string())
                         }
@@ -266,6 +293,12 @@ impl Command for Ls {
                 description:
                     "List all dirs in your home directory which have not been modified in 7 days",
                 example: "ls -s ~ | where type == dir && modified < ((date now) - 7day)",
+                result: None,
+            },
+            Example {
+                description: "List given paths, show directories themselves",
+                example:
+                    "['/path/to/directory' '/path/to/file'] | each { |it| ls -D $it } | flatten",
                 result: None,
             },
         ]


### PR DESCRIPTION
# Description

Add --directory (-D) flag to ls, list the directory itself instead of its contents.
Now we can list a specified directory itself:
```shell
/home/moxuze〉['/usr/bin' '/usr/bin/nu'] | each { |it| ls -D $it } | flatten
╭───┬─────────────┬──────┬──────────┬────────────────╮
│ # │    name     │ type │   size   │    modified    │
├───┼─────────────┼──────┼──────────┼────────────────┤
│ 0 │ /usr/bin    │ dir  │ 56.0 KiB │ 32 minutes ago │
│ 1 │ /usr/bin/nu │ file │ 38.7 MiB │ 9 hours ago    │
╰───┴─────────────┴──────┴──────────┴────────────────╯
/home/moxuze〉['./.' '.' '..' './nushell' 'nushell/install-all.sh'] | each { |it| ls -D $it } | flatten
╭───┬────────────────────────┬──────┬─────────┬───────────────╮
│ # │          name          │ type │  size   │   modified    │
├───┼────────────────────────┼──────┼─────────┼───────────────┤
│ 0 │ .                      │ dir  │ 4.0 KiB │ 4 minutes ago │
│ 1 │ .                      │ dir  │ 4.0 KiB │ 4 minutes ago │
│ 2 │ ..                     │ dir  │ 4.0 KiB │ 3 months ago  │
│ 3 │ nushell                │ dir  │ 4.0 KiB │ 10 hours ago  │
│ 4 │ nushell/install-all.sh │ file │   826 B │ 10 hours ago  │
╰───┴────────────────────────┴──────┴─────────┴───────────────╯
```

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
