### PR TITLE
compatible with old rustc version

### DIFF
--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -63,7 +63,11 @@ impl Command for BytesAdd {
     ) -> Result<PipelineData, ShellError> {
         let added_data: Vec<u8> = call.req(engine_state, stack, 0)?;
         let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
-        let column_paths = (!column_paths.is_empty()).then_some(column_paths);
+        let column_paths = if column_paths.is_empty() {
+            None
+        } else {
+            Some(column_paths)
+        };
         let index: Option<usize> = call.get_flag(engine_state, stack, "index")?;
         let end = call.has_flag("end");
 

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -54,7 +54,11 @@ impl Command for BytesEndsWith {
     ) -> Result<PipelineData, ShellError> {
         let pattern: Vec<u8> = call.req(engine_state, stack, 0)?;
         let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
-        let column_paths = (!column_paths.is_empty()).then_some(column_paths);
+        let column_paths = if column_paths.is_empty() {
+            None
+        } else {
+            Some(column_paths)
+        };
         let arg = Arguments {
             pattern,
             column_paths,

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -50,7 +50,11 @@ impl Command for BytesLen {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
-        let column_paths = (!column_paths.is_empty()).then_some(column_paths);
+        let column_paths = if column_paths.is_empty() {
+            None
+        } else {
+            Some(column_paths)
+        };
         let arg = Arguments { column_paths };
         operate(length, arg, input, call.head, engine_state.ctrlc.clone())
     }

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -56,7 +56,11 @@ impl Command for BytesReplace {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 2)?;
-        let column_paths = (!column_paths.is_empty()).then_some(column_paths);
+        let column_paths = if column_paths.is_empty() {
+            None
+        } else {
+            Some(column_paths)
+        };
         let find = call.req::<Vec<u8>>(engine_state, stack, 0)?;
         if find.is_empty() {
             return Err(ShellError::UnsupportedInput(

--- a/crates/nu-command/src/bytes/reverse.rs
+++ b/crates/nu-command/src/bytes/reverse.rs
@@ -51,7 +51,11 @@ impl Command for BytesReverse {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
-        let column_paths = (!column_paths.is_empty()).then_some(column_paths);
+        let column_paths = if column_paths.is_empty() {
+            None
+        } else {
+            Some(column_paths)
+        };
         let arg = Arguments { column_paths };
         operate(reverse, arg, input, call.head, engine_state.ctrlc.clone())
     }

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -54,7 +54,11 @@ impl Command for BytesStartsWith {
     ) -> Result<PipelineData, ShellError> {
         let pattern: Vec<u8> = call.req(engine_state, stack, 0)?;
         let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
-        let column_paths = (!column_paths.is_empty()).then_some(column_paths);
+        let column_paths = if column_paths.is_empty() {
+            None
+        } else {
+            Some(column_paths)
+        };
         let arg = Arguments {
             pattern,
             column_paths,


### PR DESCRIPTION
# Description

Fixes: #5973 

`bool_to_option` is stabled in 1.62, which is the latest version, I think it's ok to make `nu` compatible with 1.60

# Tests

Make sure you've done the following:

- [] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
