### PR TITLE
adds better error for failed string-to-duration conversions

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -155,9 +155,10 @@ fn string_to_duration(s: &str, span: Span) -> Result<i64, ShellError> {
         }
     }
 
-    Err(ShellError::CantConvert(
+    Err(ShellError::CantConvertWithValue(
         "duration".to_string(),
         "string".to_string(),
+        s.to_string(),
         span,
         Some("supported units are ns, us, ms, sec, min, hr, day, and wk".to_string()),
     ))

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -269,6 +269,21 @@ pub enum ShellError {
         #[help] Option<String>,
     ),
 
+    /// Failed to convert a value of one type into a different type. Includes hint for what the first value is.
+    ///
+    /// ## Resolution
+    ///
+    /// Not all values can be coerced this way. Check the supported type(s) and try again.
+    #[error("Can't convert to {0}.")]
+    #[diagnostic(code(nu::shell::cant_convert_with_value), url(docsrs))]
+    CantConvertWithValue(
+        String,
+        String,
+        String,
+        #[label("can't convert {1} `{2}` to {0}")] Span,
+        #[help] Option<String>,
+    ),
+
     /// An environment variable cannot be represented as a string.
     ///
     /// ## Resolution


### PR DESCRIPTION
# Description

Fixes #5975. New error can probably be used for other issues of a similar kind. 

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.
```
/home/gabriel/CodingProjects/nushell〉echo [[value]; ['1.1ms'] ['12s'] ['2min'] ['3hr'] ['4day'] ['5wk']] | into duration value     07/07/2022 04:49:40 PM
Error: nu::shell::cant_convert_with_value (link)

  × Can't convert to duration.
   ╭─[entry #1:1:1]
 1 │ echo [[value]; ['1.1ms'] ['12s'] ['2min'] ['3hr'] ['4day'] ['5wk']] | into duration value
   ·                                                                       ──────┬──────
   ·                                                                             ╰── can't convert string `12s` to duration
   ╰────
  help: supported units are ns, us, ms, sec, min, hr, day, and wk
```

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
