### PR TITLE
make history.txt and history.sqlite3 tables have same command column

### DIFF
--- a/crates/nu-command/src/misc/history.rs
+++ b/crates/nu-command/src/misc/history.rs
@@ -116,7 +116,7 @@ impl Command for History {
                                     cols: vec![
                                         "item_id".into(),
                                         "start_timestamp".into(),
-                                        "command_line".to_string(),
+                                        "command".to_string(),
                                         "session_id".into(),
                                         "hostname".into(),
                                         "cwd".into(),


### PR DESCRIPTION
# Description

Prior to this PR if you were using history.txt the `history` command would return a `command` column but if you were using history.sqlite3 the `history` command would return a `command_line` column. This PR homogenizes them to use both use `command` as the column containing the command.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
