### PR TITLE
tweak the find hit highlighting

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -85,6 +85,7 @@ fn help(
 
     if let Some(f) = find {
         let replace_string = White.on(Red).paint(f.item.clone()).to_string();
+        let org_search_string = f.item.clone();
         let search_string = f.item.to_lowercase();
         let mut found_cmds_vec = Vec::new();
 
@@ -112,7 +113,7 @@ fn help(
                 cols.push("name".into());
                 vals.push(Value::String {
                     val: if key_match {
-                        key.as_str().replace(&key, &replace_string)
+                        key.as_str().replace(&org_search_string, &replace_string)
                     } else {
                         key
                     },
@@ -146,7 +147,7 @@ fn help(
                 cols.push("usage".into());
                 vals.push(Value::String {
                     val: if use_match {
-                        usage.as_str().replace(&usage, &replace_string)
+                        usage.as_str().replace(&org_search_string, &replace_string)
                     } else {
                         usage
                     },
@@ -163,7 +164,7 @@ fn help(
                                 .iter()
                                 .map(|term| {
                                     if term.to_lowercase().contains(&search_string) {
-                                        term.replace(term, &replace_string.clone())
+                                        term.replace(&org_search_string, &replace_string.clone())
                                     } else {
                                         term.clone()
                                     }


### PR DESCRIPTION
# Description

A follow on to PR #5979 to fix the highlighting.
<img width="1712" alt="Screen Shot 2022-07-07 at 10 55 36 AM" src="https://user-images.githubusercontent.com/343840/177818059-58687697-3379-4a78-8aaf-7be10fe19397.png">


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
