### PR TITLE
Revert "Return error when external command core dumped (#5908)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,7 +2573,6 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.2",
  "shadow-rs",
- "signal-hook",
  "sqlparser",
  "strip-ansi-escapes",
  "sysinfo 0.23.13",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -92,7 +92,6 @@ sqlparser = { version = "0.16.0", features = ["serde"], optional = true }
 [target.'cfg(unix)'.dependencies]
 umask = "2.0.0"
 users = "0.11.0"
-signal-hook = { version = "0.3.14", default-features = false }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
 version = "2.1.3"

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -194,9 +194,6 @@ impl ExternalCommand {
                 let (stderr_tx, stderr_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
                 let (exit_code_tx, exit_code_rx) = mpsc::channel();
 
-                #[cfg(unix)]
-                let (exit_status_tx, exit_status_rx) = mpsc::channel();
-
                 std::thread::spawn(move || {
                     // If this external is not the last expression, then its output is piped to a channel
                     // and we create a ListStream that can be consumed
@@ -286,9 +283,6 @@ impl ExternalCommand {
                             span,
                         )),
                         Ok(x) => {
-                            #[cfg(unix)]
-                            let _ = exit_status_tx.send(x);
-
                             if let Some(code) = x.code() {
                                 let _ = exit_code_tx.send(Value::Int {
                                     val: code as i64,
@@ -309,26 +303,6 @@ impl ExternalCommand {
                 let stdout_receiver = ChannelReceiver::new(stdout_rx);
                 let stderr_receiver = ChannelReceiver::new(stderr_rx);
                 let exit_code_receiver = ValueReceiver::new(exit_code_rx);
-
-                #[cfg(unix)]
-                {
-                    use signal_hook::low_level::signal_name;
-                    use std::os::unix::process::ExitStatusExt;
-                    use std::time::Duration;
-
-                    // The receiver will block 100ms if there's no sender
-                    if let Ok(status) = exit_status_rx.recv_timeout(Duration::from_millis(100)) {
-                        if status.core_dumped() {
-                            if let Some(sig) = status.signal().and_then(signal_name) {
-                                return Err(ShellError::ExternalCommand(
-                                    format!("{sig} (core dumped)"),
-                                    "Child process core dumped".to_string(),
-                                    span,
-                                ));
-                            }
-                        }
-                    }
-                }
 
                 Ok(PipelineData::ExternalStream {
                     stdout: if redirect_stdout {


### PR DESCRIPTION
This reverts PR #5908. I believe that we misunderstood how that PR works when reviewing it, and it adds complexity to `run_external` without effectively addressing the original issue (#5903).

The call to `exit_status_rx.recv_timeout(Duration::from_millis(100))` runs immediately after the external process starts up, and so it only catches core dumps that happen ~100ms into that process's lifetime.

I think we will need to take a different approach to effectively report on process exit information (like the terminating signal, whether there was a core dump). Maybe we can do what we already do for exit codes (see `Pipeline Data::ExternalStream::exit_code`) but for an entire `std::process::ExitStatus` struct.