### PR TITLE
report error when process immediately terminates with a signal

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -326,6 +326,12 @@ impl ExternalCommand {
                                     span,
                                 ));
                             }
+                        } else if let Some(sig) = status.signal().and_then(signal_name) {
+                            return Err(ShellError::ExternalCommand(
+                                format!("{sig} (signal)"),
+                                "Child process terminated by signal".to_string(),
+                                span,
+                            ));
                         }
                     }
                 }


### PR DESCRIPTION
updates #5960

this is not a good solution to the problem because it uses
existing code that depends on exit status being sent within
100 milliseconds.

# Description

This is a minimal change to address the immediate problem I was having. A real fix requires a larger refactor.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
