### PR TITLE
Add search terms to 'math' commands

### DIFF
--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -18,6 +18,10 @@ impl Command for SubCommand {
         "Applies the floor function to a list of numbers"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["floor"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["middle", "average"]
+        vec!["middle", "median"]
     }
 
     fn run(

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -44,7 +44,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["common", "often", "average"]
+        vec!["common", "often"]
     }
 
     fn run(

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -21,6 +21,10 @@ impl Command for SubCommand {
         "Finds the variance of a list of numbers or tables"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["deviation", "dispersion", "variance", "variation"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,


### PR DESCRIPTION
Hi. I have never contributed to nushell before. I thought I would start with this issue.

# Description

Related to #5093 

- Added search terms to `floor` and `stddev`
- Removed "average" from the search terms for `mode` and `median`. I thought it would be misleading to have "average" as part of the search terms for `median` and `mode` since they are used to measure slightly different properties of a dataset (middle value and most frequently occurring element respectively). 

The search terms show up in the output of `help commands` as well as in the individual `help math [command]` outputs.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
