### PR TITLE
throw parser error when multiple short flags are defined without whitespace

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -1,5 +1,5 @@
-use nu_test_support::nu;
 use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
 use std::fs;
 
 #[test]
@@ -17,4 +17,16 @@ def e [arg] {echo $arg}
 
         assert!(actual.out.contains("My echo\\n\\n"));
     });
+}
+
+#[test]
+fn def_errors_with_multiple_short_flags() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ --long(-l)(-o) ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("expected one short flag"));
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3126,6 +3126,10 @@ pub fn parse_signature_helper(
                                         var_id: Some(var_id),
                                         default_value: None,
                                     }));
+                                } else if flags.len() >= 3 {
+                                    error = error.or_else(|| {
+                                        Some(ParseError::Expected("one short flag".into(), span))
+                                    });
                                 } else {
                                     let short_flag = &flags[1];
                                     let short_flag = if !short_flag.starts_with(b"-")


### PR DESCRIPTION
# Description

Fixes #5668. 

```
/home/gabriel/CodingProjects/nushell〉def test-command [ --long(-l)(-o) ] {}                           
Error: nu::parser::parse_mismatch (link)

  × Parse mismatch during operation.
   ╭─[entry #3:1:1]
 1 │ def test-command [ --long(-l)(-o) ] {}
   ·                    ───────┬──────
   ·                           ╰── expected one short flag
   ╰────
```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
