### PR TITLE
Revert "make module imports in scripts used for relative path."

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -18,7 +18,6 @@ pub(crate) fn read_config_file(
     config_file: Option<Spanned<String>>,
     is_perf_true: bool,
     is_env_config: bool,
-    interactive: bool,
 ) {
     // Load config startup file
     if let Some(file) = config_file {
@@ -47,13 +46,7 @@ pub(crate) fn read_config_file(
 
         config_path.push(if is_env_config { ENV_FILE } else { CONFIG_FILE });
 
-        let config_file = if is_env_config {
-            include_str!("../docs/sample_config/default_env.nu")
-        } else {
-            include_str!("../docs/sample_config/default_config.nu")
-        };
-
-        if !config_path.exists() && interactive {
+        if !config_path.exists() {
             let file_msg = if is_env_config {
                 "environment config"
             } else {
@@ -70,6 +63,12 @@ pub(crate) fn read_config_file(
             std::io::stdin()
                 .read_line(&mut answer)
                 .expect("Failed to read user input");
+
+            let config_file = if is_env_config {
+                include_str!("../docs/sample_config/default_env.nu")
+            } else {
+                include_str!("../docs/sample_config/default_config.nu")
+            };
 
             match answer.to_lowercase().trim() {
                 "y" | "" => {
@@ -94,19 +93,6 @@ pub(crate) fn read_config_file(
                     return;
                 }
             }
-        } else {
-            // Just use the contents of "default_config.nu" or "default_env.nu"
-            eval_source(
-                engine_state,
-                stack,
-                config_file.as_bytes(),
-                if is_env_config {
-                    "default_env.nu"
-                } else {
-                    "default_config.nu"
-                },
-                PipelineData::new(Span::new(0, 0)),
-            );
         }
 
         eval_config_contents(config_path, engine_state, stack);

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,14 +206,6 @@ fn main() -> Result<()> {
                     is_perf_true(),
                 );
                 // only want to load config and env if relative argument is provided.
-                config_files::read_config_file(
-                    &mut engine_state,
-                    &mut stack,
-                    binary_args.env_file,
-                    is_perf_true(),
-                    true,
-                    false,
-                );
                 if binary_args.config_file.is_some() {
                     config_files::read_config_file(
                         &mut engine_state,
@@ -221,7 +213,15 @@ fn main() -> Result<()> {
                         binary_args.config_file,
                         is_perf_true(),
                         false,
-                        false,
+                    );
+                }
+                if binary_args.env_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.env_file,
+                        is_perf_true(),
+                        true,
                     );
                 }
 
@@ -251,14 +251,6 @@ fn main() -> Result<()> {
                     is_perf_true(),
                 );
                 // only want to load config and env if relative argument is provided.
-                config_files::read_config_file(
-                    &mut engine_state,
-                    &mut stack,
-                    binary_args.env_file,
-                    is_perf_true(),
-                    true,
-                    false,
-                );
                 if binary_args.config_file.is_some() {
                     config_files::read_config_file(
                         &mut engine_state,
@@ -266,7 +258,15 @@ fn main() -> Result<()> {
                         binary_args.config_file,
                         is_perf_true(),
                         false,
-                        false,
+                    );
+                }
+                if binary_args.env_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.env_file,
+                        is_perf_true(),
+                        true,
                     );
                 }
 
@@ -323,15 +323,8 @@ fn setup_config(
         info!("read_config_file {}:{}:{}", file!(), line!(), column!());
     }
 
-    config_files::read_config_file(engine_state, stack, env_file, is_perf_true(), true, true);
-    config_files::read_config_file(
-        engine_state,
-        stack,
-        config_file,
-        is_perf_true(),
-        false,
-        true,
-    );
+    config_files::read_config_file(engine_state, stack, env_file, is_perf_true(), true);
+    config_files::read_config_file(engine_state, stack, config_file, is_perf_true(), false);
 
     if is_login_shell {
         config_files::read_loginshell_file(engine_state, stack, is_perf_true());


### PR DESCRIPTION
Reverts nushell/nushell#5913

I'll revert this until we find a better solution for reading the config files. See https://github.com/nushell/nushell/issues/5983, https://github.com/nushell/nushell/issues/5986.

Reopens: https://github.com/nushell/nushell/issues/5841, https://github.com/nushell/nushell/issues/5544