### PR TITLE
Split merging of parser delta and stack environment

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -45,11 +45,6 @@ pub fn evaluate_commands(
         (output, working_set.render())
     };
 
-    let mut config = engine_state.get_config().clone();
-    if let Some(t_mode) = table_mode {
-        config.table_mode = t_mode.as_string()?;
-    }
-
     // Update permanent state
     if let Err(err) = engine_state.merge_delta(delta) {
         let working_set = StateWorkingSet::new(engine_state);
@@ -59,6 +54,10 @@ pub fn evaluate_commands(
     // Run the block
     let exit_code = match eval_block(engine_state, stack, &block, input, false, false) {
         Ok(pipeline_data) => {
+            let mut config = engine_state.get_config().clone();
+            if let Some(t_mode) = table_mode {
+                config.table_mode = t_mode.as_string()?;
+            }
             crate::eval_file::print_table_or_error(engine_state, stack, pipeline_data, &mut config)
         }
         Err(err) => {

--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -5,21 +5,27 @@ use nu_engine::{convert_env_values, eval_block};
 use nu_parser::parse;
 use nu_protocol::engine::Stack;
 use nu_protocol::{
-    engine::{EngineState, StateDelta, StateWorkingSet},
+    engine::{EngineState, StateWorkingSet},
     PipelineData, Spanned, Value,
 };
-use std::path::Path;
 
+/// Run a command (or commands) given to us by the user
 pub fn evaluate_commands(
     commands: &Spanned<String>,
-    init_cwd: &Path,
     engine_state: &mut EngineState,
     stack: &mut Stack,
     input: PipelineData,
     is_perf_true: bool,
     table_mode: Option<Value>,
 ) -> Result<Option<i64>> {
-    // Run a command (or commands) given to us by the user
+    // Translate environment variables from Strings to Values
+    if let Some(e) = convert_env_values(engine_state, stack) {
+        let working_set = StateWorkingSet::new(engine_state);
+        report_error(&working_set, &e);
+        std::process::exit(1);
+    }
+
+    // Parse the source code
     let (block, delta) = {
         if let Some(ref t_mode) = table_mode {
             let mut config = engine_state.get_config().clone();
@@ -39,41 +45,18 @@ pub fn evaluate_commands(
         (output, working_set.render())
     };
 
-    if let Err(err) = engine_state.merge_delta(delta, None, init_cwd) {
-        let working_set = StateWorkingSet::new(engine_state);
-        report_error(&working_set, &err);
-    }
-
     let mut config = engine_state.get_config().clone();
     if let Some(t_mode) = table_mode {
         config.table_mode = t_mode.as_string()?;
     }
 
-    // Merge the delta in case env vars changed in the config
-    match nu_engine::env::current_dir(engine_state, stack) {
-        Ok(cwd) => {
-            if let Err(e) =
-                engine_state.merge_delta(StateDelta::new(engine_state), Some(stack), cwd)
-            {
-                let working_set = StateWorkingSet::new(engine_state);
-                report_error(&working_set, &e);
-                std::process::exit(1);
-            }
-        }
-        Err(e) => {
-            let working_set = StateWorkingSet::new(engine_state);
-            report_error(&working_set, &e);
-            std::process::exit(1);
-        }
-    }
-
-    // Translate environment variables from Strings to Values
-    if let Some(e) = convert_env_values(engine_state, stack) {
+    // Update permanent state
+    if let Err(err) = engine_state.merge_delta(delta) {
         let working_set = StateWorkingSet::new(engine_state);
-        report_error(&working_set, &e);
-        std::process::exit(1);
+        report_error(&working_set, &err);
     }
 
+    // Run the block
     let exit_code = match eval_block(engine_state, stack, &block, input, false, false) {
         Ok(pipeline_data) => {
             crate::eval_file::print_table_or_error(engine_state, stack, pipeline_data, &mut config)

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -1,7 +1,7 @@
 use crate::util::{eval_source, report_error};
 #[cfg(feature = "plugin")]
 use log::info;
-use nu_protocol::engine::{EngineState, Stack, StateDelta, StateWorkingSet};
+use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
 use nu_protocol::{HistoryFileFormat, PipelineData, Span};
 use std::path::PathBuf;
 
@@ -69,12 +69,10 @@ pub fn eval_config_contents(
                 PipelineData::new(Span::new(0, 0)),
             );
 
-            // Merge the delta in case env vars changed in the config
+            // Merge the environment in case env vars changed in the config
             match nu_engine::env::current_dir(engine_state, stack) {
                 Ok(cwd) => {
-                    if let Err(e) =
-                        engine_state.merge_delta(StateDelta::new(engine_state), Some(stack), cwd)
-                    {
+                    if let Err(e) = engine_state.merge_env(stack, cwd) {
                         let working_set = StateWorkingSet::new(engine_state);
                         report_error(&working_set, &e);
                     }

--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -24,7 +24,7 @@ pub use prompt::NushellPrompt;
 pub use repl::evaluate_repl;
 pub use repl::{eval_env_change_hook, eval_hook};
 pub use syntax_highlight::NuHighlighter;
-pub use util::{eval_source, gather_parent_env_vars, get_init_cwd, report_error};
+pub use util::{eval_source, gather_parent_env_vars, get_init_cwd, report_error, report_error_new};
 pub use validation::NuValidator;
 
 #[cfg(feature = "plugin")]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -122,12 +122,6 @@ pub fn evaluate_repl(
             );
         }
 
-        // if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
-        //     let path = cwd.as_string()?;
-        //     let _ = std::env::set_current_dir(path);
-        //     engine_state.add_env_var("PWD".into(), cwd);
-        // }
-
         let cwd = get_guaranteed_cwd(engine_state, stack);
 
         // Before doing anything, merge the environment from the previous REPL iteration into the
@@ -421,14 +415,6 @@ pub fn evaluate_repl(
                         span: Span { start: 0, end: 0 },
                     },
                 );
-
-                // FIXME: permanent state changes like this hopefully in time can be removed
-                // and be replaced by just passing the cwd in where needed
-                // if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
-                //     let path = cwd.as_string()?;
-                //     let _ = std::env::set_current_dir(path);
-                //     engine_state.add_env_var("PWD".into(), cwd);
-                // }
 
                 if history_supports_meta && !s.is_empty() {
                     line_editor

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -4,7 +4,7 @@ use nu_command::create_default_context;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
-    engine::{EngineState, Stack, StateDelta, StateWorkingSet},
+    engine::{EngineState, Stack, StateWorkingSet},
     PipelineData, ShellError, Span, Value,
 };
 use nu_test_support::fs;
@@ -23,13 +23,10 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
     dir_str.push(SEP);
 
     // Create a new engine with default context
-    let mut engine_state = create_default_context(&dir);
+    let mut engine_state = create_default_context();
 
     // New stack
     let mut stack = Stack::new();
-
-    // New delta state
-    let delta = StateDelta::new(&engine_state);
 
     // Add pwd as env var
     stack.add_env_var(
@@ -53,8 +50,8 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
         },
     );
 
-    // Merge delta
-    let merge_result = engine_state.merge_delta(delta, Some(&mut stack), &dir);
+    // Merge environment into the permanent state
+    let merge_result = engine_state.merge_env(&mut stack, &dir);
     assert!(merge_result.is_ok());
 
     (dir, dir_str, engine_state, stack)
@@ -97,6 +94,11 @@ pub fn merge_input(
 
         (block, working_set.render())
     };
+
+    if let Err(err) = engine_state.merge_delta(delta) {
+        return Err(err);
+    }
+
     assert!(eval_block(
         engine_state,
         stack,
@@ -112,6 +114,6 @@ pub fn merge_input(
     )
     .is_ok());
 
-    // Merge delta
-    engine_state.merge_delta(delta, Some(stack), &dir)
+    // Merge environment into the permanent state
+    engine_state.merge_env(stack, &dir)
 }

--- a/crates/nu-command/src/database/test_database.rs
+++ b/crates/nu-command/src/database/test_database.rs
@@ -75,7 +75,9 @@ pub fn test_database(cmds: Vec<Box<dyn Command + 'static>>) {
         working_set.render()
     };
 
-    engine_state.merge_delta(delta).unwrap();
+    engine_state
+        .merge_delta(delta)
+        .expect("Error merging delta");
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -101,7 +103,9 @@ pub fn test_database(cmds: Vec<Box<dyn Command + 'static>>) {
             (output, working_set.render())
         };
 
-        engine_state.merge_delta(delta).unwrap();
+        engine_state
+            .merge_delta(delta)
+            .expect("Error merging delta");
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/database/test_database.rs
+++ b/crates/nu-command/src/database/test_database.rs
@@ -75,8 +75,7 @@ pub fn test_database(cmds: Vec<Box<dyn Command + 'static>>) {
         working_set.render()
     };
 
-    let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let _ = engine_state.merge_delta(delta, None, &cwd);
+    engine_state.merge_delta(delta).unwrap();
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -102,7 +101,7 @@ pub fn test_database(cmds: Vec<Box<dyn Command + 'static>>) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta, None, &cwd);
+        engine_state.merge_delta(delta).unwrap();
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -37,8 +37,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
         working_set.render()
     };
 
-    let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let _ = engine_state.merge_delta(delta, None, &cwd);
+    engine_state.merge_delta(delta).unwrap();
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -64,7 +63,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta, None, &cwd);
+        engine_state.merge_delta(delta).unwrap();
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -37,7 +37,9 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
         working_set.render()
     };
 
-    engine_state.merge_delta(delta).unwrap();
+    engine_state
+        .merge_delta(delta)
+        .expect("Error merging delta");
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -63,7 +65,9 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
             (output, working_set.render())
         };
 
-        engine_state.merge_delta(delta).unwrap();
+        engine_state
+            .merge_delta(delta)
+            .expect("Error merging delta");
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -1,10 +1,8 @@
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
-use std::path::Path;
-
 use crate::*;
 
-pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
+pub fn create_default_context() -> EngineState {
     let mut engine_state = EngineState::new();
 
     let delta = {
@@ -433,7 +431,9 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
         working_set.render()
     };
 
-    let _ = engine_state.merge_delta(delta, None, &cwd);
+    if let Err(err) = engine_state.merge_delta(delta) {
+        eprintln!("Error creating default context: {:?}", err);
+    }
 
     engine_state
 }

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -57,7 +57,8 @@ pub fn test_examples(cmd: impl Command + 'static) {
     };
 
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let _ = engine_state.merge_delta(delta, None, &cwd);
+
+    engine_state.merge_delta(delta).unwrap();
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -76,11 +77,8 @@ pub fn test_examples(cmd: impl Command + 'static) {
                 span: Span::test_data(),
             },
         );
-        let _ = engine_state.merge_delta(
-            StateWorkingSet::new(&*engine_state).render(),
-            Some(&mut stack),
-            &cwd,
-        );
+
+        engine_state.merge_env(&mut stack, &cwd).unwrap();
 
         let (block, delta) = {
             let mut working_set = StateWorkingSet::new(&*engine_state);
@@ -99,7 +97,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
             (output, working_set.render())
         };
 
-        let _ = engine_state.merge_delta(delta, None, &cwd);
+        engine_state.merge_delta(delta).unwrap();
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -58,7 +58,9 @@ pub fn test_examples(cmd: impl Command + 'static) {
 
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
 
-    engine_state.merge_delta(delta).unwrap();
+    engine_state
+        .merge_delta(delta)
+        .expect("Error merging delta");
 
     for example in examples {
         // Skip tests that don't have results to compare to
@@ -78,7 +80,9 @@ pub fn test_examples(cmd: impl Command + 'static) {
             },
         );
 
-        engine_state.merge_env(&mut stack, &cwd).unwrap();
+        engine_state
+            .merge_env(&mut stack, &cwd)
+            .expect("Error merging environment");
 
         let (block, delta) = {
             let mut working_set = StateWorkingSet::new(&*engine_state);
@@ -97,7 +101,9 @@ pub fn test_examples(cmd: impl Command + 'static) {
             (output, working_set.render())
         };
 
-        engine_state.merge_delta(delta).unwrap();
+        engine_state
+            .merge_delta(delta)
+            .expect("Error merging delta");
 
         let mut stack = Stack::new();
 

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -13,8 +13,7 @@ fn quickcheck_parse(data: String) -> bool {
     let (lite_block, err2) = nu_parser::lite_parse(&tokens);
 
     if err.is_none() && err2.is_none() {
-        let cwd = std::env::current_dir().expect("Could not get current working directory.");
-        let context = create_default_context(cwd);
+        let context = create_default_context();
         {
             let mut working_set = StateWorkingSet::new(&context);
             working_set.add_file("quickcheck".into(), data.as_bytes());

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -977,8 +977,7 @@ mod input_types {
             working_set.render()
         };
 
-        let cwd = std::env::current_dir().expect("Could not get current working directory.");
-        let _ = engine_state.merge_delta(delta, None, &cwd);
+        engine_state.merge_delta(delta).unwrap();
     }
 
     #[test]
@@ -1154,8 +1153,7 @@ mod input_types {
             (block, working_set.render())
         };
 
-        let cwd = std::env::current_dir().expect("Could not get current working directory.");
-        let _ = engine_state.merge_delta(delta, None, &cwd);
+        engine_state.merge_delta(delta).unwrap();
 
         let expressions = &block[0];
         match &expressions[3].expr {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -977,7 +977,9 @@ mod input_types {
             working_set.render()
         };
 
-        engine_state.merge_delta(delta).unwrap();
+        engine_state
+            .merge_delta(delta)
+            .expect("Error merging delta");
     }
 
     #[test]
@@ -998,7 +1000,9 @@ mod input_types {
 
         match &expressions[0].expr {
             Expr::Call(call) => {
-                let expected_id = working_set.find_decl(b"ls", &Type::Any).unwrap();
+                let expected_id = working_set
+                    .find_decl(b"ls", &Type::Any)
+                    .expect("Error merging delta");
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -120,12 +120,7 @@ impl EngineState {
     ///
     /// When we want to preserve what the parser has created, we can take its output (the `StateDelta`) and
     /// use this function to merge it into the global state.
-    pub fn merge_delta(
-        &mut self,
-        mut delta: StateDelta,
-        stack: Option<&mut Stack>,
-        cwd: impl AsRef<Path>,
-    ) -> Result<(), ShellError> {
+    pub fn merge_delta(&mut self, mut delta: StateDelta) -> Result<(), ShellError> {
         // Take the mutable reference and extend the permanent state from the working set
         self.files.extend(delta.files);
         self.file_contents.extend(delta.file_contents);
@@ -199,28 +194,34 @@ impl EngineState {
             return result;
         }
 
-        if let Some(stack) = stack {
-            for mut scope in stack.env_vars.drain(..) {
-                for (overlay_name, mut env) in scope.drain() {
-                    if let Some(env_vars) = self.env_vars.get_mut(&overlay_name) {
-                        // Updating existing overlay
-                        for (k, v) in env.drain() {
-                            if k == "config" {
-                                self.config = v.clone().into_config().unwrap_or_default();
-                            }
+        Ok(())
+    }
 
-                            env_vars.insert(k, v);
+    /// Merge the environment from the runtime Stack into the engine state
+    pub fn merge_env(
+        &mut self,
+        stack: &mut Stack,
+        cwd: impl AsRef<Path>,
+    ) -> Result<(), ShellError> {
+        for mut scope in stack.env_vars.drain(..) {
+            for (overlay_name, mut env) in scope.drain() {
+                if let Some(env_vars) = self.env_vars.get_mut(&overlay_name) {
+                    // Updating existing overlay
+                    for (k, v) in env.drain() {
+                        if k == "config" {
+                            self.config = v.clone().into_config().unwrap_or_default();
                         }
-                    } else {
-                        // Pushing a new overlay
-                        self.env_vars.insert(overlay_name, env);
+
+                        env_vars.insert(k, v);
                     }
+                } else {
+                    // Pushing a new overlay
+                    self.env_vars.insert(overlay_name, env);
                 }
             }
         }
 
-        // FIXME: permanent state changes like this hopefully in time can be removed
-        // and be replaced by just passing the cwd in where needed
+        // TODO: better error
         std::env::set_current_dir(cwd)?;
 
         Ok(())
@@ -2036,8 +2037,7 @@ mod engine_state_tests {
             working_set.render()
         };
 
-        let cwd = std::env::current_dir().expect("Could not get current working directory.");
-        engine_state.merge_delta(delta, None, &cwd)?;
+        engine_state.merge_delta(delta)?;
 
         assert_eq!(engine_state.num_files(), 2);
         assert_eq!(&engine_state.files[0].0, "test.nu");

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1914,12 +1914,6 @@ impl Default for ScopeFrame {
     }
 }
 
-// impl Default for OverlayFrame {
-//     fn default() -> Self {
-//         Self::new()
-//     }
-// }
-
 impl Default for EngineState {
     fn default() -> Self {
         Self::new()

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -158,9 +158,7 @@ pub(crate) fn read_default_env_file(
     // Merge the environment in case env vars changed in the config
     match nu_engine::env::current_dir(engine_state, stack) {
         Ok(cwd) => {
-            if let Err(e) =
-                engine_state.merge_env(stack, cwd)
-            {
+            if let Err(e) = engine_state.merge_env(stack, cwd) {
                 let working_set = StateWorkingSet::new(engine_state);
                 report_error(&working_set, &e);
             }

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -2,7 +2,7 @@ use log::info;
 use nu_cli::{eval_config_contents, eval_source, report_error};
 use nu_parser::ParseError;
 use nu_path::canonicalize_with;
-use nu_protocol::engine::{EngineState, Stack, StateDelta, StateWorkingSet};
+use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
 use nu_protocol::{PipelineData, Span, Spanned};
 use std::fs::File;
 use std::io::Write;
@@ -155,11 +155,11 @@ pub(crate) fn read_default_env_file(
     if is_perf_true {
         info!("read_config_file {}:{}:{}", file!(), line!(), column!());
     }
-    // Merge the delta in case env vars changed in the config
+    // Merge the environment in case env vars changed in the config
     match nu_engine::env::current_dir(engine_state, stack) {
         Ok(cwd) => {
             if let Err(e) =
-                engine_state.merge_delta(StateDelta::new(engine_state), Some(stack), cwd)
+                engine_state.merge_env(stack, cwd)
             {
                 let working_set = StateWorkingSet::new(engine_state);
                 report_error(&working_set, &e);

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -90,6 +90,21 @@ pub(crate) fn read_config_file(
                         },
                         PipelineData::new(Span::new(0, 0)),
                     );
+
+                    // Merge the environment in case env vars changed in the config
+                    match nu_engine::env::current_dir(engine_state, stack) {
+                        Ok(cwd) => {
+                            if let Err(e) = engine_state.merge_env(stack, cwd) {
+                                let working_set = StateWorkingSet::new(engine_state);
+                                report_error(&working_set, &e);
+                            }
+                        }
+                        Err(e) => {
+                            let working_set = StateWorkingSet::new(engine_state);
+                            report_error(&working_set, &e);
+                        }
+                    }
+
                     return;
                 }
             }
@@ -102,6 +117,7 @@ pub(crate) fn read_config_file(
         info!("read_config_file {}:{}:{}", file!(), line!(), column!());
     }
 }
+
 pub(crate) fn read_loginshell_file(
     engine_state: &mut EngineState,
     stack: &mut Stack,

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -183,9 +183,9 @@ fn env_change_simple_block_list_shadow_env_var() {
         &env_change_hook(
             "FOO",
             r#"[
-            { let-env SPAM = "foo" }
-            { let-env SPAM = "spam" }
-        ]"#,
+                { let-env SPAM = "foo" }
+                { let-env SPAM = "spam" }
+            ]"#,
         ),
         "let-env FOO = 1",
         "$env.SPAM",
@@ -215,7 +215,6 @@ fn env_change_block_preserve_env_var() {
 fn pre_prompt_define_command() {
     let inp = &[
         &pre_prompt_hook_code(r#"'def foo [] { "got foo!" }'"#),
-        "",
         "foo",
     ];
 
@@ -229,7 +228,6 @@ fn pre_prompt_define_command() {
 fn pre_prompt_simple_block_preserve_env_var() {
     let inp = &[
         &pre_prompt_hook(r#"{ let-env SPAM = "spam" }"#),
-        "",
         "$env.SPAM",
     ];
 
@@ -244,11 +242,10 @@ fn pre_prompt_simple_block_list_shadow_env_var() {
     let inp = &[
         &pre_prompt_hook(
             r#"[
-            { let-env SPAM = "foo" }
-            { let-env SPAM = "spam" }
-        ]"#,
+                { let-env SPAM = "foo" }
+                { let-env SPAM = "spam" }
+            ]"#,
         ),
-        "",
         "$env.SPAM",
     ];
 
@@ -262,7 +259,6 @@ fn pre_prompt_simple_block_list_shadow_env_var() {
 fn pre_prompt_block_preserve_env_var() {
     let inp = &[
         &pre_prompt_hook_code(r#"{ let-env SPAM = "spam" }"#),
-        "",
         "$env.SPAM",
     ];
 
@@ -276,7 +272,6 @@ fn pre_prompt_block_preserve_env_var() {
 fn pre_execution_define_command() {
     let inp = &[
         &pre_execution_hook_code(r#"'def foo [] { "got foo!" }'"#),
-        "",
         "foo",
     ];
 
@@ -290,7 +285,6 @@ fn pre_execution_define_command() {
 fn pre_execution_simple_block_preserve_env_var() {
     let inp = &[
         &pre_execution_hook(r#"{ let-env SPAM = "spam" }"#),
-        "",
         "$env.SPAM",
     ];
 
@@ -309,7 +303,6 @@ fn pre_execution_simple_block_list_shadow_env_var() {
             { let-env SPAM = "spam" }
         ]"#,
         ),
-        "",
         "$env.SPAM",
     ];
 
@@ -323,7 +316,6 @@ fn pre_execution_simple_block_list_shadow_env_var() {
 fn pre_execution_block_preserve_env_var() {
     let inp = &[
         &pre_execution_hook_code(r#"{ let-env SPAM = "spam" }"#),
-        "",
         "$env.SPAM",
     ];
 
@@ -450,7 +442,6 @@ fn err_hook_wrong_env_type_2() {
             }
         }"#,
         "",
-        "",
     ];
 
     let actual_repl = nu_repl("tests/hooks", inp);
@@ -551,11 +542,7 @@ fn err_hook_parse_error() {
 
 #[test]
 fn err_hook_dont_allow_string() {
-    let inp = &[
-        &pre_prompt_hook(r#"'def foo [] { "got foo!" }'"#),
-        "",
-        "foo",
-    ];
+    let inp = &[&pre_prompt_hook(r#"'def foo [] { "got foo!" }'"#), "foo"];
 
     let actual_repl = nu_repl("tests/hooks", inp);
 


### PR DESCRIPTION
# Description

Previously, the environment from the stack was merged into the permanent state withing `merge_delta()`. This caused issues with hooks not having an up-to-date config because it still used the old environment. If you go to the diff and find the hooks tests, you see I was able to delete extra `""` lines which represent pressing "Enter" in the REPL that you needed to press if you wanted the config changes to affect hooks properly.

Now, the stack environment is merged into the permanent state at the very beginning of each REPL line to ensure that whatever that relies on the environment values from the engine state (e.g., the config or cwd) gets the updated value.



# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.
- [ ] See if it fixes https://github.com/nushell/nushell/issues/5986 (it doesn't)

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
