### PR TITLE
Fix load order of config files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,16 +205,8 @@ fn main() -> Result<()> {
                     NUSHELL_FOLDER,
                     is_perf_true(),
                 );
+
                 // only want to load config and env if relative argument is provided.
-                if binary_args.config_file.is_some() {
-                    config_files::read_config_file(
-                        &mut engine_state,
-                        &mut stack,
-                        binary_args.config_file,
-                        is_perf_true(),
-                        false,
-                    );
-                }
                 if binary_args.env_file.is_some() {
                     config_files::read_config_file(
                         &mut engine_state,
@@ -222,6 +214,16 @@ fn main() -> Result<()> {
                         binary_args.env_file,
                         is_perf_true(),
                         true,
+                    );
+                }
+
+                if binary_args.config_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.config_file,
+                        is_perf_true(),
+                        false,
                     );
                 }
 
@@ -250,16 +252,8 @@ fn main() -> Result<()> {
                     NUSHELL_FOLDER,
                     is_perf_true(),
                 );
+
                 // only want to load config and env if relative argument is provided.
-                if binary_args.config_file.is_some() {
-                    config_files::read_config_file(
-                        &mut engine_state,
-                        &mut stack,
-                        binary_args.config_file,
-                        is_perf_true(),
-                        false,
-                    );
-                }
                 if binary_args.env_file.is_some() {
                     config_files::read_config_file(
                         &mut engine_state,
@@ -267,6 +261,16 @@ fn main() -> Result<()> {
                         binary_args.env_file,
                         is_perf_true(),
                         true,
+                    );
+                }
+
+                if binary_args.config_file.is_some() {
+                    config_files::read_config_file(
+                        &mut engine_state,
+                        &mut stack,
+                        binary_args.config_file,
+                        is_perf_true(),
+                        false,
                     );
                 }
 


### PR DESCRIPTION
# Description

Just a quick fix to load the env config and regular config in command/file mode in the right order (env.nu needs to be loaded before config.nu).

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
