### PR TITLE
Allow keeping selected environment variables from removed overlay

### DIFF
--- a/crates/nu-command/src/core_commands/overlay/remove.rs
+++ b/crates/nu-command/src/core_commands/overlay/remove.rs
@@ -103,6 +103,8 @@ impl Command for OverlayRemove {
                 }
             }
 
+            stack.remove_overlay(&overlay_name.item);
+
             for (name, val) in env_vars_to_keep {
                 stack.add_env_var(name, val);
             }

--- a/crates/nu-command/src/core_commands/overlay/remove.rs
+++ b/crates/nu-command/src/core_commands/overlay/remove.rs
@@ -21,7 +21,7 @@ impl Command for OverlayRemove {
         Signature::build("overlay remove")
             .optional("name", SyntaxShape::String, "Overlay to remove")
             .switch(
-                "keep-all",
+                "keep-custom",
                 "Keep all newly added symbols within the next activated overlay",
                 Some('k'),
             )
@@ -69,7 +69,7 @@ impl Command for OverlayRemove {
             ));
         }
 
-        if call.has_flag("keep-all") {
+        if call.has_flag("keep-custom") {
             if let Some(overlay_id) = engine_state.find_overlay(overlay_name.item.as_bytes()) {
                 let overlay_frame = engine_state.get_overlay(overlay_id);
                 let origin_module = engine_state.get_module(overlay_frame.origin);
@@ -97,7 +97,9 @@ impl Command for OverlayRemove {
             for name in env_var_names_to_keep.into_iter() {
                 match stack.get_env_var(engine_state, &name.item) {
                     Some(val) => env_vars_to_keep.push((name.item, val.clone())),
-                    None => return Err(ShellError::EnvVarNotFoundAtRuntime(name.item, name.span)),
+                    None => {
+                        return Err(ShellError::EnvVarNotFoundAtRuntime(name.item, name.span))
+                    }
                 }
             }
 

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -238,6 +238,35 @@ impl FromValue for Vec<String> {
     }
 }
 
+impl FromValue for Vec<Spanned<String>> {
+    fn from_value(v: &Value) -> Result<Self, ShellError> {
+        // FIXME: we may want to fail a little nicer here
+        match v {
+            Value::List { vals, .. } => vals
+                .iter()
+                .map(|val| match val {
+                    Value::String { val, span } => Ok(Spanned {
+                        item: val.clone(),
+                        span: *span,
+                    }),
+                    c => Err(ShellError::CantConvert(
+                        "string".into(),
+                        c.get_type().to_string(),
+                        c.span()?,
+                        None,
+                    )),
+                })
+                .collect::<Result<Vec<Spanned<String>>, ShellError>>(),
+            v => Err(ShellError::CantConvert(
+                "string".into(),
+                v.get_type().to_string(),
+                v.span()?,
+                None,
+            )),
+        }
+    }
+}
+
 impl FromValue for Vec<bool> {
     fn from_value(v: &Value) -> Result<Self, ShellError> {
         match v {

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -312,7 +312,7 @@ fn remove_overlay_keep_decl() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"def bagr [] { "bagr" }"#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"bagr"#,
     ];
 
@@ -328,7 +328,7 @@ fn remove_overlay_keep_alias() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"alias bagr = "bagr""#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"bagr"#,
     ];
 
@@ -344,7 +344,7 @@ fn remove_overlay_keep_env() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"let-env BAGR = "bagr""#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"$env.BAGR"#,
     ];
 
@@ -360,7 +360,7 @@ fn remove_overlay_keep_discard_overwritten_decl() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"def foo [] { 'bar' }"#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"foo"#,
     ];
 
@@ -379,7 +379,7 @@ fn remove_overlay_keep_discard_overwritten_alias() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"alias bar = 'baz'"#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"bar"#,
     ];
 
@@ -398,7 +398,7 @@ fn remove_overlay_keep_discard_overwritten_env() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"let-env BAZ = "bagr""#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"$env.BAZ"#,
     ];
 
@@ -416,7 +416,7 @@ fn remove_overlay_keep_decl_in_latest_overlay() {
         r#"def bagr [] { 'bagr' }"#,
         r#"module eggs { }"#,
         r#"overlay add eggs"#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"bagr"#,
     ];
 
@@ -434,7 +434,7 @@ fn remove_overlay_keep_alias_in_latest_overlay() {
         r#"alias bagr = 'bagr'"#,
         r#"module eggs { }"#,
         r#"overlay add eggs"#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"bagr"#,
     ];
 
@@ -452,7 +452,7 @@ fn remove_overlay_keep_env_in_latest_overlay() {
         r#"let-env BAGR = "bagr""#,
         r#"module eggs { }"#,
         r#"overlay add eggs"#,
-        r#"overlay remove --keep-all spam"#,
+        r#"overlay remove --keep-custom spam"#,
         r#"$env.BAGR"#,
     ];
 

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -520,6 +520,6 @@ fn overlay_keep_pwd() {
     let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
     let actual_repl = nu_repl("tests/overlays", inp);
 
-    assert_eq!(actual.out, "overlay");
-    assert_eq!(actual_repl.out, "overlay");
+    assert_eq!(actual.out, "samples");
+    assert_eq!(actual_repl.out, "samples");
 }

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -312,7 +312,7 @@ fn remove_overlay_keep_decl() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"def bagr [] { "bagr" }"#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"bagr"#,
     ];
 
@@ -328,7 +328,7 @@ fn remove_overlay_keep_alias() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"alias bagr = "bagr""#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"bagr"#,
     ];
 
@@ -344,7 +344,7 @@ fn remove_overlay_keep_env() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"let-env BAGR = "bagr""#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"$env.BAGR"#,
     ];
 
@@ -360,7 +360,7 @@ fn remove_overlay_keep_discard_overwritten_decl() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"def foo [] { 'bar' }"#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"foo"#,
     ];
 
@@ -379,7 +379,7 @@ fn remove_overlay_keep_discard_overwritten_alias() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"alias bar = 'baz'"#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"bar"#,
     ];
 
@@ -398,7 +398,7 @@ fn remove_overlay_keep_discard_overwritten_env() {
     let inp = &[
         r#"overlay add samples/spam.nu"#,
         r#"let-env BAZ = "bagr""#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"$env.BAZ"#,
     ];
 
@@ -416,7 +416,7 @@ fn remove_overlay_keep_decl_in_latest_overlay() {
         r#"def bagr [] { 'bagr' }"#,
         r#"module eggs { }"#,
         r#"overlay add eggs"#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"bagr"#,
     ];
 
@@ -434,7 +434,7 @@ fn remove_overlay_keep_alias_in_latest_overlay() {
         r#"alias bagr = 'bagr'"#,
         r#"module eggs { }"#,
         r#"overlay add eggs"#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"bagr"#,
     ];
 
@@ -452,7 +452,7 @@ fn remove_overlay_keep_env_in_latest_overlay() {
         r#"let-env BAGR = "bagr""#,
         r#"module eggs { }"#,
         r#"overlay add eggs"#,
-        r#"overlay remove --keep-custom spam"#,
+        r#"overlay remove --keep-all spam"#,
         r#"$env.BAGR"#,
     ];
 
@@ -506,4 +506,20 @@ fn overlay_new() {
 
     assert_eq!(actual.out, "spam");
     assert_eq!(actual_repl.out, "spam");
+}
+
+#[test]
+fn overlay_keep_pwd() {
+    let inp = &[
+        r#"overlay new spam"#,
+        r#"cd samples"#,
+        r#"overlay remove --keep-env [ PWD ] spam"#,
+        r#"$env.PWD | path basename"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu_repl("tests/overlays", inp);
+
+    assert_eq!(actual.out, "overlay");
+    assert_eq!(actual_repl.out, "overlay");
 }


### PR DESCRIPTION
# Description

Adds a new flag `--keep-env` to `overlay remove` that lets you specify which environment variables you want to preserve from the removed overlay.

Also renames the `--keep-custom` flag to `--keep-all`. I found the new name more descriptive given the new flag.

Fixes #6004. In the future, we might want to allow keeping defs / aliases etc. in a similar way but now at least keeping the env vars was needed and it's simple to do.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
