### PR TITLE
fixes ansi escape leakage from ill-behaved externals, again!

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -1,6 +1,6 @@
 use reedline::DefaultPrompt;
-
 use {
+    nu_utils::enable_vt_processing,
     reedline::{
         Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
     },
@@ -86,6 +86,11 @@ impl NushellPrompt {
 
 impl Prompt for NushellPrompt {
     fn render_prompt_left(&self) -> Cow<str> {
+        #[cfg(windows)]
+        {
+            let _ = enable_vt_processing();
+        }
+
         if let Some(prompt_string) = &self.left_prompt_string {
             prompt_string.replace('\n', "\r\n").into()
         } else {

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -1,6 +1,7 @@
+#[cfg(windows)]
+use nu_utils::enable_vt_processing;
 use reedline::DefaultPrompt;
 use {
-    nu_utils::enable_vt_processing,
     reedline::{
         Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
     },


### PR DESCRIPTION
# Description

Closes #6003 

Ill-behaved externals like `git gui`, and really all the `git for windows` tools, seem to break vt processing. I'm not sure why. This hack fixes that by enabling vt processing each time the left prompt is rendered. There could be edge cases where we need to put this same hack in `render_prompt_right`, `render_prompt_indicator`, etc. but for now, let's just put it in `render_prompt_left`.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
