### PR TITLE
Use simpler reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3851,8 +3851,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d064ec92a21deb048c440b6461ccf0d0babdb5f2160ea9dfac451bc7b4b556e2"
+source = "git+https://github.com/nushell/reedline.git#59f7144d721cd573f629048e753f163f2652334f"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ nu-system = { path = "./crates/nu-system", version = "0.65.1" }
 nu-table = { path = "./crates/nu-table", version = "0.65.1"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.65.1"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.65.1"  }
-reedline = { version = "0.8.0", features = ["bashisms", "sqlite"]}
+reedline = { git = "https://github.com/nushell/reedline.git", features = ["bashisms", "sqlite"]}
 pretty_env_logger = "0.4.0"
 rayon = "1.5.1"
 is_executable = "1.0.1"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -18,7 +18,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.65.1"  }
 nu-utils = { path = "../nu-utils", version = "0.65.1"  }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.65.1"  }
-reedline = { version = "0.8.0", features = ["bashisms", "sqlite"]}
+reedline = { git = "https://github.com/nushell/reedline.git", features = ["bashisms", "sqlite"]}
 crossterm = "0.23.0"
 miette = { version = "5.1.0", features = ["fancy"] }
 thiserror = "1.0.31"

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -148,7 +148,6 @@ pub fn evaluate_repl(
                 engine_state: engine_state.clone(),
                 config: config.clone(),
             }))
-            .with_animation(config.animate_prompt)
             .with_validator(Box::new(NuValidator {
                 engine_state: engine_state.clone(),
             }))

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -84,7 +84,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "1.1.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-reedline = { version = "0.8.0", features = ["bashisms", "sqlite"]}
+reedline = { git = "https://github.com/nushell/reedline.git", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.27.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.16.0", features = ["serde"], optional = true }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -2,8 +2,6 @@ use crate::{ShellError, Span, Value};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-const ANIMATE_PROMPT_DEFAULT: bool = true;
-
 /// Definition of a parsed keybinding from the config object
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ParsedKeybinding {
@@ -56,7 +54,6 @@ pub struct Config {
     pub color_config: HashMap<String, Value>,
     pub use_grid_icons: bool,
     pub footer_mode: FooterMode,
-    pub animate_prompt: bool,
     pub float_precision: i64,
     pub filesize_format: String,
     pub use_ansi_coloring: bool,
@@ -89,7 +86,6 @@ impl Default for Config {
             color_config: HashMap::new(),
             use_grid_icons: false,
             footer_mode: FooterMode::RowCount(25),
-            animate_prompt: ANIMATE_PROMPT_DEFAULT,
             float_precision: 4,
             filesize_format: "auto".into(),
             use_ansi_coloring: true,
@@ -193,13 +189,6 @@ impl Value {
                             };
                         } else {
                             eprintln!("$config.footer_mode is not a string")
-                        }
-                    }
-                    "animate_prompt" => {
-                        if let Ok(b) = value.as_bool() {
-                            config.animate_prompt = b;
-                        } else {
-                            eprintln!("$config.animate_prompt is not a bool")
                         }
                     }
                     "float_precision" => {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -243,7 +243,6 @@ let-env config = {
   quick_completions: true  # set this to false to prevent auto-selecting completions when only one remains
   partial_completions: true  # set this to false to prevent partial filling of the prompt
   completion_algorithm: "prefix"  # prefix, fuzzy
-  animate_prompt: false # redraw the prompt every second
   float_precision: 2
   # buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
   use_ansi_coloring: true

--- a/tests/nu_repl/mod.rs
+++ b/tests/nu_repl/mod.rs
@@ -11,9 +11,9 @@ fn outcome_err(
     engine_state: &EngineState,
     error: &(dyn miette::Diagnostic + Send + Sync + 'static),
 ) -> Outcome {
-    let working_set = StateWorkingSet::new(&engine_state);
+    let working_set = StateWorkingSet::new(engine_state);
 
-    eprintln!("{}", format!("Error: {:?}", CliError(error, &working_set)));
+    eprintln!("Error: {:?}", CliError(error, &working_set));
 
     Outcome {
         out: String::new(),


### PR DESCRIPTION
# Description

This moves us to git reedline, which has a few simplifications (namely no animations or resize repaints). This should hopefully help nushell act a bit more like other shells in the terminal and be less destructive during a resize.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
