### PR TITLE
add `unspanned` flag to error make, add tests

### DIFF
--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -16,6 +16,7 @@ impl Command for ErrorMake {
     fn signature(&self) -> Signature {
         Signature::build("error make")
             .required("error_struct", SyntaxShape::Record, "the error to create")
+            .switch("unspanned", "remove the origin label from the error", Some('u'))
             .category(Category::Core)
     }
 
@@ -36,8 +37,21 @@ impl Command for ErrorMake {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let span = call.head;
         let arg: Value = call.req(engine_state, stack, 0)?;
+        let unspanned = call.has_flag("unspanned");
 
-        Err(make_error(&arg, span).unwrap_or_else(|| {
+        if unspanned {
+        Err(make_error(&arg, None).unwrap_or_else(|| {
+            ShellError::GenericError(
+                "Creating error value not supported.".into(),
+                "unsupported error format".into(),
+                Some(span),
+                None,
+                Vec::new(),
+            )
+        }
+        ))
+        } else {
+        Err(make_error(&arg, Some(span)).unwrap_or_else(|| {
             ShellError::GenericError(
                 "Creating error value not supported.".into(),
                 "unsupported error format".into(),
@@ -46,6 +60,7 @@ impl Command for ErrorMake {
                 Vec::new(),
             )
         }))
+        }
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -69,7 +84,7 @@ impl Command for ErrorMake {
     }
 }
 
-fn make_error(value: &Value, throw_span: Span) -> Option<ShellError> {
+fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
     if let Value::Record { .. } = &value {
         let msg = value.get_data_by_key("msg");
         let label = value.get_data_by_key("label");
@@ -106,7 +121,7 @@ fn make_error(value: &Value, throw_span: Span) -> Option<ShellError> {
                     ) => Some(ShellError::GenericError(
                         message,
                         label_text,
-                        Some(throw_span),
+                        throw_span,
                         None,
                         Vec::new(),
                     )),
@@ -116,7 +131,7 @@ fn make_error(value: &Value, throw_span: Span) -> Option<ShellError> {
             (Some(Value::String { val: message, .. }), None) => Some(ShellError::GenericError(
                 message,
                 "originates from here".to_string(),
-                Some(throw_span),
+                throw_span,
                 None,
                 Vec::new(),
             )),

--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -16,7 +16,11 @@ impl Command for ErrorMake {
     fn signature(&self) -> Signature {
         Signature::build("error make")
             .required("error_struct", SyntaxShape::Record, "the error to create")
-            .switch("unspanned", "remove the origin label from the error", Some('u'))
+            .switch(
+                "unspanned",
+                "remove the origin label from the error",
+                Some('u'),
+            )
             .category(Category::Core)
     }
 
@@ -40,26 +44,25 @@ impl Command for ErrorMake {
         let unspanned = call.has_flag("unspanned");
 
         if unspanned {
-        Err(make_error(&arg, None).unwrap_or_else(|| {
-            ShellError::GenericError(
-                "Creating error value not supported.".into(),
-                "unsupported error format".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
-        }
-        ))
+            Err(make_error(&arg, None).unwrap_or_else(|| {
+                ShellError::GenericError(
+                    "Creating error value not supported.".into(),
+                    "unsupported error format".into(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )
+            }))
         } else {
-        Err(make_error(&arg, Some(span)).unwrap_or_else(|| {
-            ShellError::GenericError(
-                "Creating error value not supported.".into(),
-                "unsupported error format".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
-        }))
+            Err(make_error(&arg, Some(span)).unwrap_or_else(|| {
+                ShellError::GenericError(
+                    "Creating error value not supported.".into(),
+                    "unsupported error format".into(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )
+            }))
         }
     }
 

--- a/crates/nu-command/tests/commands/error_make.rs
+++ b/crates/nu-command/tests/commands/error_make.rs
@@ -1,0 +1,26 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn error_label_works() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        error make {msg:foo label:{text:unseen}}
+        "#
+    ));
+
+    assert!(actual.err.contains("unseen"));
+    assert!(actual.err.contains("╰──"));
+}
+
+#[test]
+fn no_span_if_unspanned() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        error make -u {msg:foo label:{text:unseen}}
+        "#
+    ));
+
+    assert!(!actual.err.contains("unseen"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -15,6 +15,7 @@ mod each;
 mod echo;
 mod empty;
 mod enter;
+mod error_make;
 mod every;
 mod find;
 mod first;


### PR DESCRIPTION
# Description

Title. Fixes #5872.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
