### PR TITLE
fix small bug converting string to int

### DIFF
--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -291,7 +291,7 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
                 };
             Ok(num)
         }
-        _ => match a_string.parse::<i64>() {
+        _ => match trimmed.parse::<i64>() {
             Ok(n) => Ok(n),
             Err(_) => match a_string.parse::<f64>() {
                 Ok(f) => Ok(f as i64),
@@ -299,7 +299,10 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
                     "int".to_string(),
                     "string".to_string(),
                     span,
-                    None,
+                    Some(format!(
+                        r#"string "{}" does not represent a valid integer"#,
+                        trimmed
+                    )),
                 )),
             },
         },


### PR DESCRIPTION
# Description

Fixed a small bug that prevented `"000123" | into int` from working.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
