### PR TITLE
Fix panic when opening symlink which points to an inaccessible directory

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -88,14 +88,14 @@ impl Command for Open {
 
         if permission_denied(&path) {
             #[cfg(unix)]
-            let error_msg = format!(
-                "The permissions of {:o} do not allow access for this user",
-                path.metadata()
-                    .expect("this shouldn't be called since we already know there is a dir")
-                    .permissions()
-                    .mode()
-                    & 0o0777
-            );
+            let error_msg = match path.metadata() {
+                Ok(md) => format!(
+                    "The permissions of {:o} do not allow access for this user",
+                    md.permissions().mode() & 0o0777
+                ),
+                Err(e) => e.to_string(),
+            };
+
             #[cfg(not(unix))]
             let error_msg = String::from("Permission denied");
             Err(ShellError::GenericError(


### PR DESCRIPTION
# Description

Fixes #6027

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
