### PR TITLE
load default env when user don't specified env path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,12 @@ fn main() -> Result<()> {
                         is_perf_true(),
                         true,
                     );
+                } else {
+                    config_files::read_default_env_file(
+                        &mut engine_state,
+                        &mut stack,
+                        is_perf_true(),
+                    )
                 }
 
                 if binary_args.config_file.is_some() {
@@ -262,6 +268,12 @@ fn main() -> Result<()> {
                         is_perf_true(),
                         true,
                     );
+                } else {
+                    config_files::read_default_env_file(
+                        &mut engine_state,
+                        &mut stack,
+                        is_perf_true(),
+                    )
                 }
 
                 if binary_args.config_file.is_some() {


### PR DESCRIPTION
# Description

Fixes: https://github.com/nushell/nushell/issues/5841, #5983
Doesn't affect: https://github.com/nushell/nushell/issues/5544
But this issue is still exists: https://github.com/nushell/nushell/issues/5986, and I can reproduce it in latest main, so it may not belongs to config loading relative issue


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
