### PR TITLE
allow for easy reset of config files with a single command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -343,6 +343,7 @@ pub fn create_default_context(cwd: impl AsRef<Path>) -> EngineState {
             WithEnv,
             ConfigNu,
             ConfigEnv,
+            ConfigReset,
             ConfigMeta,
         };
 

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -4,6 +4,7 @@ use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature,
 };
 use std::io::Write;
+use std::time::SystemTime;
 
 #[derive(Clone)]
 pub struct ConfigReset;
@@ -17,6 +18,7 @@ impl Command for ConfigReset {
         Signature::build(self.name())
             .switch("nu", "reset only nu config, config.nu", Some('n'))
             .switch("env", "reset only env config, env.nu", Some('e'))
+            .switch("without-backup", "do not make a backup", Some('w'))
             .category(Category::Env)
     }
 
@@ -41,6 +43,7 @@ impl Command for ConfigReset {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let only_nu = call.has_flag("nu");
         let only_env = call.has_flag("env");
+        let no_backup = call.has_flag("without-backup");
         let span = call.head;
         let mut config_path = match nu_path::config_dir() {
             Some(path) => path,
@@ -59,14 +62,28 @@ impl Command for ConfigReset {
             let mut nu_config = config_path.clone();
             nu_config.push("config.nu");
             let config_file = include_str!("../../../../../docs/sample_config/default_config.nu");
-            let mut backup_path = config_path.clone();
-            backup_path.push("oldconfig.nu");
-            if std::fs::rename(nu_config.clone(), backup_path).is_err() {
-                return Err(ShellError::FileNotFoundCustom("config.nu could not be backed up".into(), span));
+            if !no_backup {
+                let mut backup_path = config_path.clone();
+                backup_path.push(format!(
+                    "oldconfig-{}.nu",
+                    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+                        Ok(n) => n.as_secs().to_string(),
+                        Err(_) => "time error".to_string(),
+                    }
+                ));
+                if std::fs::rename(nu_config.clone(), backup_path).is_err() {
+                    return Err(ShellError::FileNotFoundCustom(
+                        "config.nu could not be backed up".into(),
+                        span,
+                    ));
+                }
             }
             if let Ok(mut file) = std::fs::File::create(nu_config) {
                 if writeln!(&mut file, "{}", config_file).is_err() {
-                    return Err(ShellError::FileNotFoundCustom("config.nu could not be written to".into(), span)); 
+                    return Err(ShellError::FileNotFoundCustom(
+                        "config.nu could not be written to".into(),
+                        span,
+                    ));
                 }
             }
         }
@@ -74,14 +91,28 @@ impl Command for ConfigReset {
             let mut env_config = config_path.clone();
             env_config.push("env.nu");
             let config_file = include_str!("../../../../../docs/sample_config/default_env.nu");
-            let mut backup_path = config_path.clone();
-            backup_path.push("oldenv.nu");
-            if std::fs::rename(env_config.clone(), backup_path).is_err() {
-                return Err(ShellError::FileNotFoundCustom("env.nu could not be backed up".into(), span));
+            if !no_backup {
+                let mut backup_path = config_path.clone();
+                backup_path.push(format!(
+                    "oldenv-{}.nu",
+                    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+                        Ok(n) => n.as_secs().to_string(),
+                        Err(_) => "time error".to_string(),
+                    }
+                ));
+                if std::fs::rename(env_config.clone(), backup_path).is_err() {
+                    return Err(ShellError::FileNotFoundCustom(
+                        "env.nu could not be backed up".into(),
+                        span,
+                    ));
+                }
             }
             if let Ok(mut file) = std::fs::File::create(env_config) {
                 if writeln!(&mut file, "{}", config_file).is_err() {
-                    return Err(ShellError::FileNotFoundCustom("env.nu could not be written to".into(), span)); 
+                    return Err(ShellError::FileNotFoundCustom(
+                        "env.nu could not be written to".into(),
+                        span,
+                    ));
                 }
             }
         }

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -1,0 +1,90 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, PipelineData, ShellError, Signature,
+};
+use std::io::Write;
+
+#[derive(Clone)]
+pub struct ConfigReset;
+
+impl Command for ConfigReset {
+    fn name(&self) -> &str {
+        "config reset"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .switch("nu", "reset only nu config, config.nu", Some('n'))
+            .switch("env", "reset only env config, env.nu", Some('e'))
+            .category(Category::Env)
+    }
+
+    fn usage(&self) -> &str {
+        "Reset nushell environment configurations to default, and saves old config files in the config location"
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "reset nushell configuration files",
+            example: "config reset",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let only_nu = call.has_flag("nu");
+        let only_env = call.has_flag("env");
+        let span = call.head;
+        let mut config_path = match nu_path::config_dir() {
+            Some(path) => path,
+            None => {
+                return Err(ShellError::GenericError(
+                    "Could not find config path".to_string(),
+                    "Could not find config path".to_string(),
+                    None,
+                    None,
+                    Vec::new(),
+                ));
+            }
+        };
+        config_path.push("nushell");
+        if !only_env {
+            let mut nu_config = config_path.clone();
+            nu_config.push("config.nu");
+            let config_file = include_str!("../../../../../docs/sample_config/default_config.nu");
+            let mut backup_path = config_path.clone();
+            backup_path.push("oldconfig.nu");
+            if std::fs::rename(nu_config.clone(), backup_path).is_err() {
+                return Err(ShellError::FileNotFoundCustom("config.nu could not be backed up".into(), span));
+            }
+            if let Ok(mut file) = std::fs::File::create(nu_config) {
+                if writeln!(&mut file, "{}", config_file).is_err() {
+                    return Err(ShellError::FileNotFoundCustom("config.nu could not be written to".into(), span)); 
+                }
+            }
+        }
+        if !only_nu {
+            let mut env_config = config_path.clone();
+            env_config.push("env.nu");
+            let config_file = include_str!("../../../../../docs/sample_config/default_env.nu");
+            let mut backup_path = config_path.clone();
+            backup_path.push("oldenv.nu");
+            if std::fs::rename(env_config.clone(), backup_path).is_err() {
+                return Err(ShellError::FileNotFoundCustom("env.nu could not be backed up".into(), span));
+            }
+            if let Ok(mut file) = std::fs::File::create(env_config) {
+                if writeln!(&mut file, "{}", config_file).is_err() {
+                    return Err(ShellError::FileNotFoundCustom("env.nu could not be written to".into(), span)); 
+                }
+            }
+        }
+        Ok(PipelineData::new(span))
+    }
+}

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -21,7 +21,7 @@ impl Command for ConfigReset {
     }
 
     fn usage(&self) -> &str {
-        "Reset nushell environment configurations to default, and saves old config files in the config location"
+        "Reset nushell environment configurations to default, and saves old config files in the config location as oldconfig.nu and oldenv.nu"
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -1,10 +1,10 @@
+use chrono::{Local, SecondsFormat};
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, PipelineData, ShellError, Signature,
 };
 use std::io::Write;
-use std::time::SystemTime;
 
 #[derive(Clone)]
 pub struct ConfigReset;
@@ -66,10 +66,7 @@ impl Command for ConfigReset {
                 let mut backup_path = config_path.clone();
                 backup_path.push(format!(
                     "oldconfig-{}.nu",
-                    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                        Ok(n) => n.as_secs().to_string(),
-                        Err(_) => "time error".to_string(),
-                    }
+                    Local::now().to_rfc3339_opts(SecondsFormat::Secs, true),
                 ));
                 if std::fs::rename(nu_config.clone(), backup_path).is_err() {
                     return Err(ShellError::FileNotFoundCustom(
@@ -95,10 +92,7 @@ impl Command for ConfigReset {
                 let mut backup_path = config_path.clone();
                 backup_path.push(format!(
                     "oldenv-{}.nu",
-                    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                        Ok(n) => n.as_secs().to_string(),
-                        Err(_) => "time error".to_string(),
-                    }
+                    Local::now().to_rfc3339_opts(SecondsFormat::Secs, true),
                 ));
                 if std::fs::rename(env_config.clone(), backup_path).is_err() {
                     return Err(ShellError::FileNotFoundCustom(

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -1,4 +1,4 @@
-use chrono::{Local, SecondsFormat};
+use chrono::Local;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
@@ -66,7 +66,7 @@ impl Command for ConfigReset {
                 let mut backup_path = config_path.clone();
                 backup_path.push(format!(
                     "oldconfig-{}.nu",
-                    Local::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+                    Local::now().format("%F-%H-%M-%S"),
                 ));
                 if std::fs::rename(nu_config.clone(), backup_path).is_err() {
                     return Err(ShellError::FileNotFoundCustom(
@@ -90,10 +90,7 @@ impl Command for ConfigReset {
             let config_file = include_str!("../../../../../docs/sample_config/default_env.nu");
             if !no_backup {
                 let mut backup_path = config_path.clone();
-                backup_path.push(format!(
-                    "oldenv-{}.nu",
-                    Local::now().to_rfc3339_opts(SecondsFormat::Secs, true),
-                ));
+                backup_path.push(format!("oldenv-{}.nu", Local::now().format("%F-%H-%M-%S"),));
                 if std::fs::rename(env_config.clone(), backup_path).is_err() {
                     return Err(ShellError::FileNotFoundCustom(
                         "env.nu could not be backed up".into(),

--- a/crates/nu-command/src/env/config/mod.rs
+++ b/crates/nu-command/src/env/config/mod.rs
@@ -1,7 +1,9 @@
 mod config_;
 mod config_env;
 mod config_nu;
+mod config_reset;
 mod utils;
 pub use config_::ConfigMeta;
 pub use config_env::ConfigEnv;
 pub use config_nu::ConfigNu;
+pub use config_reset::ConfigReset;

--- a/crates/nu-command/src/env/mod.rs
+++ b/crates/nu-command/src/env/mod.rs
@@ -7,6 +7,7 @@ mod with_env;
 pub use config::ConfigEnv;
 pub use config::ConfigMeta;
 pub use config::ConfigNu;
+pub use config::ConfigReset;
 pub use env_command::Env;
 pub use let_env::LetEnv;
 pub use load_env::LoadEnv;


### PR DESCRIPTION
# Description

Even though nobody requested it, I found it was a bit irritating to copy the config file into config.nu and env.nu each time, so I made a command to make the process faster. Also, it backs up the old files so accidents shouldn't be catastrophic.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

I'm not sure how to test for this, so... try it out?

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
