### PR TITLE
Downgrade typetag to 0.1.8

### DIFF
--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -19,7 +19,7 @@ chrono-humanize = "0.2.1"
 byte-unit = "4.0.9"
 serde_json = { version = "1.0", optional = true }
 nu-json = { path = "../nu-json", version = "0.65.1"  }
-typetag = "0.2.1"
+typetag = "0.1.8"
 num-format = "0.4.0"
 sys-locale = "0.2.0"
 regex = "1.5.4"


### PR DESCRIPTION
# Description

Downgrade crate of typetag to 0.18, this change will make `nu` not dependent on the latest rust which is 1.62 as stable

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
