### PR TITLE
Handle Windows drive paths in auto-cd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ dependencies = [
  "nu-test-support",
  "nu-utils",
  "reedline",
+ "regex",
  "sysinfo",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "crossterm",
  "fuzzy-matcher",
  "is_executable",
+ "lazy_static",
  "log",
  "miette 5.1.0",
  "nu-ansi-term",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -27,6 +27,7 @@ fuzzy-matcher = "0.3.7"
 log = "0.4"
 is_executable = "1.0.1"
 chrono = "0.4.19"
+regex = "1.5.4"
 sysinfo = "0.24.1"
 
 [features]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -24,9 +24,10 @@ miette = { version = "5.1.0", features = ["fancy"] }
 thiserror = "1.0.31"
 fuzzy-matcher = "0.3.7"
 
-log = "0.4"
-is_executable = "1.0.1"
 chrono = "0.4.19"
+is_executable = "1.0.1"
+lazy_static = "1.4.0"
+log = "0.4"
 regex = "1.5.4"
 sysinfo = "0.24.1"
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -16,6 +16,7 @@ use nu_protocol::{
     BlockId, HistoryFileFormat, PipelineData, PositionalArg, ShellError, Span, Type, Value, VarId,
 };
 use reedline::{DefaultHinter, Emacs, SqliteBackedHistory, Vi};
+#[cfg(windows)]
 use regex::Regex;
 use std::io::{self, Write};
 use std::{sync::atomic::Ordering, time::Instant};

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -17,7 +17,6 @@ use nu_protocol::{
     BlockId, HistoryFileFormat, PipelineData, PositionalArg, ShellError, Span, Type, Value, VarId,
 };
 use reedline::{DefaultHinter, Emacs, SqliteBackedHistory, Vi};
-#[cfg(windows)]
 use regex::Regex;
 use std::io::{self, Write};
 use std::{sync::atomic::Ordering, time::Instant};
@@ -754,7 +753,6 @@ fn run_ansi_sequence(seq: &str) -> Result<(), ShellError> {
     })
 }
 
-#[cfg(windows)]
 lazy_static! {
     // Absolute paths with a drive letter, like 'C:', 'D:\', 'E:\foo'
     static ref DRIVE_PATH_REGEX: Regex =


### PR DESCRIPTION
# Description

Fixes #6043. This change tweaks the auto-cd functionality (ex: type `~/foo` and Nu changes the PWD to `~/foo` - no `cd` needed) to support absolute paths with drive letters on Windows.

# Example

```
C:\Users\reill\source\nushell〉D:
D:\〉
```
Previously typing `D:` would fail silently - the PWD would not be changed, and `$env.LAST_EXIT_CODE` was 0.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass **(did not do because I'm on a slow laptop, will let tests run in CI)**