### PR TITLE
fix documentation of plugin encodings

### DIFF
--- a/crates/nu_plugin_gstat/README.md
+++ b/crates/nu_plugin_gstat/README.md
@@ -10,4 +10,4 @@ To install:
 
 To register (from inside Nushell):
 ```
-> register <path to installed plugin> --encoding capnp
+> register <path to installed plugin> --encoding json

--- a/crates/nu_plugin_query/README.md
+++ b/crates/nu_plugin_query/README.md
@@ -10,4 +10,4 @@ To install:
 
 To register (from inside Nushell):
 ```
-> register <path to installed plugin> --encoding capnp
+> register <path to installed plugin> --encoding json


### PR DESCRIPTION
The readme files for `nu_plugin_gstat` and `nu_plugin_query` state that they should be registered with the capnp encoding, but these plugins actually use the json encoding. Attempting to follow the instructions for capnp results in a not-particularly-helpful error message:

```
Error:
  × Error getting signatures
   ╭─[entry #119:1:1]
 1 │ register ~/.cargo/bin/nu_plugin_query --encoding capnp
   · ────┬───
   ·     ╰── Plugin failed to decode: Failed: Too many segments: 1917133436
   ╰────
```