### PR TITLE
allow `into int` to convert octal numbers and 0 padded strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,7 @@ checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
 [[package]]
 name = "papergrid"
 version = "0.4.0"
-source = "git+https://github.com/zhiburt/tabled?rev=cca285b1fc0eac48b8a386c8884092d894d0e7ae#cca285b1fc0eac48b8a386c8884092d894d0e7ae"
+source = "git+https://github.com/zhiburt/tabled?rev=9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278#9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278"
 dependencies = [
  "ansi-str 0.1.1",
  "bytecount",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "tabled"
 version = "0.7.0"
-source = "git+https://github.com/zhiburt/tabled?rev=cca285b1fc0eac48b8a386c8884092d894d0e7ae#cca285b1fc0eac48b8a386c8884092d894d0e7ae"
+source = "git+https://github.com/zhiburt/tabled?rev=9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278#9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278"
 dependencies = [
  "ansi-str 0.2.0",
  "papergrid",
@@ -4797,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "tabled_derive"
 version = "0.3.0"
-source = "git+https://github.com/zhiburt/tabled?rev=cca285b1fc0eac48b8a386c8884092d894d0e7ae#cca285b1fc0eac48b8a386c8884092d894d0e7ae"
+source = "git+https://github.com/zhiburt/tabled?rev=9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278#9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -258,10 +258,29 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
     let i = match input {
         Value::Int { val, .. } => val.to_string(),
         Value::String { val, .. } => {
-            if val.starts_with("0x") || val.starts_with("0b") {
+            if val.starts_with("0x") // hex
+                || val.starts_with("0b") // binary
+                || val.starts_with("0o")
+            // octal
+            {
                 match int_from_string(val, head) {
                     Ok(x) => return Value::Int { val: x, span: head },
                     Err(e) => return Value::Error { error: e },
+                }
+            } else if val.starts_with("00") {
+                // It's a padded string
+                match i64::from_str_radix(val, radix) {
+                    Ok(n) => return Value::Int { val: n, span: head },
+                    Err(e) => {
+                        return Value::Error {
+                            error: ShellError::CantConvert(
+                                "string".to_string(),
+                                "int".to_string(),
+                                head,
+                                Some(e.to_string()),
+                            ),
+                        }
+                    }
                 }
             }
             val.to_string()
@@ -314,6 +333,20 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
                         ),
                     )),
                 };
+            Ok(num)
+        }
+        o if o.starts_with("0o") => {
+            let num = match i64::from_str_radix(o.trim_start_matches("0o"), 8) {
+                Ok(n) => n,
+                Err(_reason) => {
+                    return Err(ShellError::CantConvert(
+                        "int".to_string(),
+                        "string".to_string(),
+                        span,
+                        Some(r#"octal digits following "0o" should be in 0-7"#.to_string()),
+                    ))
+                }
+            };
             Ok(num)
         }
         _ => match trimmed.parse::<i64>() {

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -102,6 +102,21 @@ impl Command for SubCommand {
                 example: "'FF' |  into int -r 16",
                 result: Some(Value::test_int(255)),
             },
+            Example {
+                description: "Convert octal string to integer",
+                example: "'0o10132' | into int",
+                result: Some(Value::test_int(4186)),
+            },
+            Example {
+                description: "Convert 0 padded string to integer",
+                example: "'0010132' | into int",
+                result: Some(Value::test_int(10132)),
+            },
+            Example {
+                description: "Convert 0 padded string to integer with radix",
+                example: "'0010132' | into int -r 8",
+                result: Some(Value::test_int(4186)),
+            },
         ]
     }
 }


### PR DESCRIPTION
# Description

1. Allow `into int` to convert with `"0o10132" | into int`. 
2. Allow `into int` to convert with `"0010132" | into int`.
3. Allow `into int` to convert with `"0010132" | into int -r 8"`.
# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
