### PR TITLE
Ensure users colors are maintained when highlighting find matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,7 @@ checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
 [[package]]
 name = "papergrid"
 version = "0.4.0"
-source = "git+https://github.com/zhiburt/tabled?rev=cca285b1fc0eac48b8a386c8884092d894d0e7ae#cca285b1fc0eac48b8a386c8884092d894d0e7ae"
+source = "git+https://github.com/zhiburt/tabled?rev=9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278#9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278"
 dependencies = [
  "ansi-str 0.1.1",
  "bytecount",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "tabled"
 version = "0.7.0"
-source = "git+https://github.com/zhiburt/tabled?rev=cca285b1fc0eac48b8a386c8884092d894d0e7ae#cca285b1fc0eac48b8a386c8884092d894d0e7ae"
+source = "git+https://github.com/zhiburt/tabled?rev=9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278#9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278"
 dependencies = [
  "ansi-str 0.2.0",
  "papergrid",
@@ -4797,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "tabled_derive"
 version = "0.3.0"
-source = "git+https://github.com/zhiburt/tabled?rev=cca285b1fc0eac48b8a386c8884092d894d0e7ae#cca285b1fc0eac48b8a386c8884092d894d0e7ae"
+source = "git+https://github.com/zhiburt/tabled?rev=9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278#9c831d5bc5bcd5a7b7a349ce63f746a64bf1c278"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",


### PR DESCRIPTION
# Description

Fixes a bug that @kubouch noticed while using alacritty. That bug was that some colors were not highlighted properly.

Before: (you can see some text having a slightly green shade)
![image](https://user-images.githubusercontent.com/343840/179225747-8e38f2c2-d2a8-4c49-9e77-f997cdcd1ff2.png)
After:
![image](https://user-images.githubusercontent.com/343840/179225586-e8f0c26a-7b22-4662-b526-0f1f8bdfc6d7.png)


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
