### PR TITLE
add `split list` subcommand to split up lists

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -119,6 +119,7 @@ pub fn create_default_context() -> EngineState {
             SkipWhile,
             Sort,
             SortBy,
+            SplitList,
             Transpose,
             Uniq,
             Upsert,

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -14,7 +14,7 @@ impl Command for SubCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("split row")
+        Signature::build("split list")
             .required(
                 "separator",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, Signature, Span, SyntaxShape, Value, IntoPipelineData,
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -48,8 +48,22 @@ impl Command for SubCommand {
                 example: "[a, b, c, d, e, f, g] | split list d",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::List{ vals: vec![Value::test_string("a"),Value::test_string("b"),Value::test_string("c"),], span: Span::test_data(),},
-                        Value::List{ vals: vec![Value::test_string("e"),Value::test_string("f"),Value::test_string("g"),], span: Span::test_data(),},
+                        Value::List {
+                            vals: vec![
+                                Value::test_string("a"),
+                                Value::test_string("b"),
+                                Value::test_string("c"),
+                            ],
+                            span: Span::test_data(),
+                        },
+                        Value::List {
+                            vals: vec![
+                                Value::test_string("e"),
+                                Value::test_string("f"),
+                                Value::test_string("g"),
+                            ],
+                            span: Span::test_data(),
+                        },
                     ],
                     span: Span::test_data(),
                 }),
@@ -59,8 +73,20 @@ impl Command for SubCommand {
                 example: "[[1,2], [2,3], [3,4]] | split list [2,3]",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::List{ vals: vec![Value::List{vals: vec![Value::test_int(1),Value::test_int(2),], span: Span::test_data()},], span: Span::test_data(),},
-                        Value::List{ vals: vec![Value::List{vals: vec![Value::test_int(3),Value::test_int(4),], span: Span::test_data()},], span: Span::test_data(),},
+                        Value::List {
+                            vals: vec![Value::List {
+                                vals: vec![Value::test_int(1), Value::test_int(2)],
+                                span: Span::test_data(),
+                            }],
+                            span: Span::test_data(),
+                        },
+                        Value::List {
+                            vals: vec![Value::List {
+                                vals: vec![Value::test_int(3), Value::test_int(4)],
+                                span: Span::test_data(),
+                            }],
+                            span: Span::test_data(),
+                        },
                     ],
                     span: Span::test_data(),
                 }),
@@ -81,15 +107,24 @@ fn split_list(
     let iter = input.into_interruptible_iter(engine_state.ctrlc.clone());
     for val in iter {
         if val == separator && !temp_list.is_empty() {
-            returned_list.push(Value::List { vals: temp_list.clone(), span: call.head, });
+            returned_list.push(Value::List {
+                vals: temp_list.clone(),
+                span: call.head,
+            });
             temp_list = Vec::new();
-        }
-        else {
+        } else {
             temp_list.push(val);
         }
     }
     if !temp_list.is_empty() {
-        returned_list.push(Value::List { vals: temp_list.clone(), span: call.head, });
+        returned_list.push(Value::List {
+            vals: temp_list.clone(),
+            span: call.head,
+        });
     }
-    Ok(Value::List { vals: returned_list, span: call.head }.into_pipeline_data())
+    Ok(Value::List {
+        vals: returned_list,
+        span: call.head,
+    }
+    .into_pipeline_data())
 }

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -1,0 +1,95 @@
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, PipelineData, Signature, Span, SyntaxShape, Value, IntoPipelineData,
+};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "split list"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("split row")
+            .required(
+                "separator",
+                SyntaxShape::Any,
+                "the value that denotes what separates the list",
+            )
+            .category(Category::Filters)
+    }
+
+    fn usage(&self) -> &str {
+        "Split a list into multiple lists using a separator"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["list", "separate", "divide"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        split_list(engine_state, stack, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Split a list of chars into two lists",
+                example: "[a, b, c, d, e, f, g] | split list d",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::List{ vals: vec![Value::test_string("a"),Value::test_string("b"),Value::test_string("c"),], span: Span::test_data(),},
+                        Value::List{ vals: vec![Value::test_string("e"),Value::test_string("f"),Value::test_string("g"),], span: Span::test_data(),},
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Split a list of lists into two lists of lists",
+                example: "[[1,2], [2,3], [3,4]] | split list [2,3]",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::List{ vals: vec![Value::List{vals: vec![Value::test_int(1),Value::test_int(2),], span: Span::test_data()},], span: Span::test_data(),},
+                        Value::List{ vals: vec![Value::List{vals: vec![Value::test_int(3),Value::test_int(4),], span: Span::test_data()},], span: Span::test_data(),},
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn split_list(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+    let separator: Value = call.req(engine_state, stack, 0)?;
+    let mut temp_list = Vec::new();
+    let mut returned_list = Vec::new();
+    let iter = input.into_interruptible_iter(engine_state.ctrlc.clone());
+    for val in iter {
+        if val == separator && !temp_list.is_empty() {
+            returned_list.push(Value::List { vals: temp_list.clone(), span: call.head, });
+            temp_list = Vec::new();
+        }
+        else {
+            temp_list.push(val);
+        }
+    }
+    if !temp_list.is_empty() {
+        returned_list.push(Value::List { vals: temp_list.clone(), span: call.head, });
+    }
+    Ok(Value::List { vals: returned_list, span: call.head }.into_pipeline_data())
+}

--- a/crates/nu-command/src/strings/split/mod.rs
+++ b/crates/nu-command/src/strings/split/mod.rs
@@ -1,11 +1,11 @@
 pub mod chars;
 pub mod column;
 pub mod command;
-pub mod row;
 pub mod list;
+pub mod row;
 
 pub use chars::SubCommand as SplitChars;
 pub use column::SubCommand as SplitColumn;
 pub use command::SplitCommand as Split;
-pub use row::SubCommand as SplitRow;
 pub use list::SubCommand as SplitList;
+pub use row::SubCommand as SplitRow;

--- a/crates/nu-command/src/strings/split/mod.rs
+++ b/crates/nu-command/src/strings/split/mod.rs
@@ -2,8 +2,10 @@ pub mod chars;
 pub mod column;
 pub mod command;
 pub mod row;
+pub mod list;
 
 pub use chars::SubCommand as SplitChars;
 pub use column::SubCommand as SplitColumn;
 pub use command::SplitCommand as Split;
 pub use row::SubCommand as SplitRow;
+pub use list::SubCommand as SplitList;


### PR DESCRIPTION
# Description

Fixes #6059.

Main reason why I put this as a separate subcommand is so it can be under the "filter" category and so it can take in separators of any Value. 

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
