### PR TITLE
Add plugin CLI argument

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -1,10 +1,14 @@
 use crate::util::{eval_source, report_error};
 #[cfg(feature = "plugin")]
 use log::info;
+#[cfg(feature = "plugin")]
 use nu_parser::ParseError;
+#[cfg(feature = "plugin")]
 use nu_path::canonicalize_with;
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
-use nu_protocol::{HistoryFileFormat, PipelineData, Span, Spanned};
+#[cfg(feature = "plugin")]
+use nu_protocol::Spanned;
+use nu_protocol::{HistoryFileFormat, PipelineData, Span};
 use std::path::PathBuf;
 
 #[cfg(feature = "plugin")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
                 }
                 "--config" | "--env-config" => args.next().map(|a| escape_quote_string(&a)),
                 #[cfg(feature = "plugin")]
-                "--plugin" => args.next().map(|a| escape_quote_string(&a)),
+                "--plugin-config" => args.next().map(|a| escape_quote_string(&a)),
                 "--log-level" | "--testbin" | "--threads" | "-t" => args.next(),
                 _ => None,
             };
@@ -412,7 +412,7 @@ fn parse_commandline_args(
             let testbin: Option<Expression> = call.get_flag_expr("testbin");
             let perf = call.has_flag("perf");
             #[cfg(feature = "plugin")]
-            let plugin_file: Option<Expression> = call.get_flag_expr("plugin");
+            let plugin_file: Option<Expression> = call.get_flag_expr("plugin-config");
             let config_file: Option<Expression> = call.get_flag_expr("config");
             let env_file: Option<Expression> = call.get_flag_expr("env-config");
             let log_level: Option<Expression> = call.get_flag_expr("log-level");
@@ -584,7 +584,7 @@ impl Command for Nu {
         #[cfg(feature = "plugin")]
         {
             signature.named(
-                "plugin",
+                "plugin-config",
                 SyntaxShape::String,
                 "start with an alternate plugin signature file",
                 None,


### PR DESCRIPTION
# Description

While working on supporting CustomValues in Plugins I stumbled upon the test utilities defined in [nu-test-support][nu-test-support] and thought these will come in handy, but they end up being outdated.
They haven't been used since engine-q's was merged, so they are currently using the old way nushell handled plugins, where it would just look into a specific folder for plugins and call them without signatures or registration. While fixing that I realized that there is currently no way to tell nushell to load and save signatures into a specific path, and so those integration tests could end up potentially conflicting with each other and with the local plugins the person running them is using.

So this adds a new CLI argument to specify where to store and load plugin signatures from

I am not super sure of the way I implemented this, mainly I was a bit confused about the distinction between [src/config_files.rs][src/config_files.rs] and [crates/nu-cli/src/config_files.rs][crates/nu-cli/src/config_files.rs]. Should I be moving the plugin loading function from the `nu-cli` one to the root one?

[nu-test-support]: https://github.com/nushell/nushell/blob/9d0be7d96fa0e960bcc702a523ca62f0c53b765c/crates/nu-test-support/src/macros.rs#L106
[src/config_files.rs]: https://github.com/nushell/nushell/blob/9d0be7d96fa0e960bcc702a523ca62f0c53b765c/src/config_files.rs
[crates/nu-cli/src/config_files.rs]: https://github.com/nushell/nushell/blob/9d0be7d96fa0e960bcc702a523ca62f0c53b765c/crates/nu-cli/src/config_files.rs

# Tests

Make sure you've done the following:

- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
