### PR TITLE
Restore `nu_with_plugins` test macro

### DIFF
--- a/crates/nu-test-support/src/commands.rs
+++ b/crates/nu-test-support/src/commands.rs
@@ -51,3 +51,47 @@
 //     }
 // }
 // }
+
+use std::{
+    io::Read,
+    process::{Command, Stdio},
+};
+
+pub fn ensure_binary_present(package: &str) {
+    let cargo_path = env!("CARGO");
+    let mut arguments = vec!["build", "--package", package, "--quiet"];
+
+    let profile = std::env::var("NUSHELL_CARGO_TARGET");
+    if let Ok(profile) = &profile {
+        arguments.push("--profile");
+        arguments.push(profile);
+    }
+
+    let mut command = Command::new(cargo_path)
+        .args(arguments)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn cargo build command");
+
+    let stderr = command.stderr.take();
+
+    let success = command
+        .wait()
+        .expect("failed to wait cargo build command")
+        .success();
+
+    if let Some(mut stderr) = stderr {
+        let mut buffer = String::new();
+        stderr
+            .read_to_string(&mut buffer)
+            .expect("failed to read cargo build stderr");
+        if !buffer.is_empty() {
+            println!("=== cargo build stderr\n{}", buffer);
+        }
+    }
+
+    if !success {
+        panic!("cargo build failed");
+    }
+}

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -104,35 +104,29 @@ macro_rules! nu {
 
 #[macro_export]
 macro_rules! nu_with_plugins {
-    (cwd: $cwd:expr, $path:expr, $($part:expr),*) => {{
+    (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $path:expr, $($plugins:expr),*) => {{
         use $crate::fs::DisplayPath;
 
         let path = format!($path, $(
-            $part.display_path()
+            $plugins.display_path()
         ),*);
 
-        nu_with_plugins!($cwd, &path)
+        nu_with_plugins!($cwd, $format, $plugin_name, &path)
     }};
 
-    (cwd: $cwd:expr, $path:expr) => {{
-        nu_with_plugins!($cwd, $path)
+    (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $path:expr) => {{
+        nu_with_plugins!($cwd, $format, $plugin_name, $path)
     }};
 
-    ($cwd:expr, $path:expr) => {{
+    ($cwd:expr, $format:expr, $plugin_name:expr, $path:expr) => {{
         pub use std::error::Error;
         pub use std::io::prelude::*;
         pub use std::process::{Command, Stdio};
+        pub use tempfile::tempdir;
         pub use $crate::NATIVE_PATH_ENV_VAR;
 
-        let commands = &*format!(
-            "
-                            {}
-                            exit",
-            $crate::fs::DisplayPath::display_path(&$path)
-        );
-
         let test_bins = $crate::fs::binaries();
-        let test_bins = nu_path::canonicalize(&test_bins).unwrap_or_else(|e| {
+        let test_bins = nu_path::canonicalize_with(&test_bins, ".").unwrap_or_else(|e| {
             panic!(
                 "Couldn't canonicalize dummy binaries path {}: {:?}",
                 test_bins.display(),
@@ -140,34 +134,30 @@ macro_rules! nu_with_plugins {
             )
         });
 
-        let mut paths = $crate::shell_os_paths();
-        paths.insert(0, test_bins);
+        let temp = tempdir().expect("couldn't create a temporary directory");
+        let temp_plugin_file = temp.path().join("plugin.nu");
+        std::fs::File::create(&temp_plugin_file).expect("couldn't create temporary plugin file");
 
-        let paths_joined = match std::env::join_paths(paths) {
-            Ok(all) => all,
-            Err(_) => panic!("Couldn't join paths for PATH var."),
-        };
+        let commands = &*format!(
+            "--commands \"register -e {} {};{}\" --plugin-config {}",
+            $format,
+            $crate::fs::DisplayPath::display_path(&test_bins.join($plugin_name)),
+            $crate::fs::DisplayPath::display_path($path),
+            $crate::fs::DisplayPath::display_path(&temp_plugin_file)
+        );
 
         let target_cwd = $crate::fs::in_directory(&$cwd);
-
         let mut process = match Command::new($crate::fs::executable_path())
-            .env("PWD", &target_cwd)  // setting PWD is enough to set cwd
-            .env(NATIVE_PATH_ENV_VAR, paths_joined)
+            .current_dir(&target_cwd)
+            .env("PWD", &target_cwd) // setting PWD is enough to set cwd
+            .arg(commands)
             .stdout(Stdio::piped())
-            .stdin(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
         {
             Ok(child) => child,
             Err(why) => panic!("Can't run test {}", why.to_string()),
         };
-
-        let stdin = process.stdin.as_mut().expect("couldn't open stdin");
-        stdin
-            .write_all(commands.as_bytes())
-            .expect("couldn't write to stdin");
-
-        stdin.flush()?
 
         let output = process
             .wait_with_output()
@@ -176,9 +166,9 @@ macro_rules! nu_with_plugins {
         let out = $crate::macros::read_std(&output.stdout);
         let err = String::from_utf8_lossy(&output.stderr);
 
-            println!("=== stderr\n{}", err);
+        println!("=== stderr\n{}", err);
 
-        $crate::Outcome::new(out,err.into_owned())
+        $crate::Outcome::new(out, err.into_owned())
     }};
 }
 

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -104,21 +104,21 @@ macro_rules! nu {
 
 #[macro_export]
 macro_rules! nu_with_plugins {
-    (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $path:expr, $($plugins:expr),*) => {{
+    (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $command:expr, $($plugins:expr),*) => {{
         use $crate::fs::DisplayPath;
 
-        let path = format!($path, $(
+        let command = format!($path, $(
             $plugins.display_path()
         ),*);
 
-        nu_with_plugins!($cwd, $format, $plugin_name, &path)
+        nu_with_plugins!($cwd, $format, $plugin_name, &command)
     }};
 
-    (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $path:expr) => {{
-        nu_with_plugins!($cwd, $format, $plugin_name, $path)
+    (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $command:expr) => {{
+        nu_with_plugins!($cwd, $format, $plugin_name, $command)
     }};
 
-    ($cwd:expr, $format:expr, $plugin_name:expr, $path:expr) => {{
+    ($cwd:expr, $format:expr, $plugin_name:expr, $command:expr) => {{
         pub use std::error::Error;
         pub use std::io::prelude::*;
         pub use std::process::{Command, Stdio};
@@ -142,7 +142,7 @@ macro_rules! nu_with_plugins {
             "--commands \"register -e {} {};{}\" --plugin-config {}",
             $format,
             $crate::fs::DisplayPath::display_path(&test_bins.join($plugin_name)),
-            $crate::fs::DisplayPath::display_path($path),
+            $crate::fs::DisplayPath::display_path($command),
             $crate::fs::DisplayPath::display_path(&temp_plugin_file)
         );
 

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -104,16 +104,6 @@ macro_rules! nu {
 
 #[macro_export]
 macro_rules! nu_with_plugins {
-    (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $command:expr, $($plugins:expr),*) => {{
-        use $crate::fs::DisplayPath;
-
-        let command = format!($path, $(
-            $plugins.display_path()
-        ),*);
-
-        nu_with_plugins!($cwd, $format, $plugin_name, &command)
-    }};
-
     (cwd: $cwd:expr, plugin: ($format:expr, $plugin_name:expr), $command:expr) => {{
         nu_with_plugins!($cwd, $format, $plugin_name, $command)
     }};

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -131,6 +131,8 @@ macro_rules! nu_with_plugins {
         let temp_plugin_file = temp.path().join("plugin.nu");
         std::fs::File::create(&temp_plugin_file).expect("couldn't create temporary plugin file");
 
+        $($crate::commands::ensure_binary_present($plugin_name);)+
+
         let commands = &*format!(
             concat!(
                 "--commands \"",

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -5,6 +5,7 @@ mod nu_repl;
 mod overlays;
 mod parsing;
 mod path;
+#[cfg(feature = "plugin")]
 mod plugins;
 mod scope;
 mod shell;

--- a/tests/plugins/core_inc.rs
+++ b/tests/plugins/core_inc.rs
@@ -6,6 +6,7 @@ use nu_test_support::playground::Playground;
 fn can_only_apply_one() {
     let actual = nu_with_plugins!(
         cwd: "tests/fixtures/formats",
+        plugin: ("json", "nu_plugin_inc"),
         "open cargo_sample.toml | first 1 | inc package.version --major --minor"
     );
 
@@ -27,6 +28,7 @@ fn by_one_with_field_passed() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
+            plugin: ("json", "nu_plugin_inc"),
             "open sample.toml | inc package.edition | get package.edition"
         );
 
@@ -47,6 +49,7 @@ fn by_one_with_no_field_passed() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
+            plugin: ("json", "nu_plugin_inc"),
             "open sample.toml | get package.contributors | inc"
         );
 
@@ -67,6 +70,7 @@ fn semversion_major_inc() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
+            plugin: ("json", "nu_plugin_inc"),
             "open sample.toml | inc package.version -M | get package.version"
         );
 
@@ -87,6 +91,7 @@ fn semversion_minor_inc() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
+            plugin: ("json", "nu_plugin_inc"),
             "open sample.toml | inc package.version --minor | get package.version"
         );
 
@@ -107,6 +112,7 @@ fn semversion_patch_inc() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
+            plugin: ("json", "nu_plugin_inc"),
             "open sample.toml | inc package.version --patch | get package.version"
         );
 
@@ -127,6 +133,7 @@ fn semversion_without_passing_field() {
 
         let actual = nu_with_plugins!(
             cwd: dirs.test(),
+            plugin: ("json", "nu_plugin_inc"),
             "open sample.toml | get package.version | inc --patch"
         );
 

--- a/tests/plugins/core_inc.rs
+++ b/tests/plugins/core_inc.rs
@@ -3,16 +3,23 @@ use nu_test_support::nu_with_plugins;
 use nu_test_support::playground::Playground;
 
 #[test]
-fn can_only_apply_one() {
+fn chooses_highest_increment_if_given_more_than_one() {
     let actual = nu_with_plugins!(
         cwd: "tests/fixtures/formats",
         plugin: ("json", "nu_plugin_inc"),
-        "open cargo_sample.toml | first 1 | inc package.version --major --minor"
+        "open cargo_sample.toml | first 1 | inc package.version --major --minor | get package.version"
     );
 
-    assert!(actual
-        .err
-        .contains("Usage: inc field [--major|--minor|--patch]"));
+    assert_eq!(actual.out, "1.0.0");
+
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("json", "nu_plugin_inc"),
+        // Regardless of order of arguments
+        "open cargo_sample.toml | first 1 | inc package.version --minor --major | get package.version"
+    );
+
+    assert_eq!(actual.out, "1.0.0");
 }
 
 #[test]

--- a/tests/plugins/mod.rs
+++ b/tests/plugins/mod.rs
@@ -1,2 +1,2 @@
-#[cfg(features = "inc")]
+#[cfg(feature = "plugin")]
 mod core_inc;

--- a/tests/plugins/mod.rs
+++ b/tests/plugins/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(feature = "plugin")]
 mod core_inc;


### PR DESCRIPTION
# Description

Builds on top of https://github.com/nushell/nushell/pull/6064 and restores `nu_with_plugins` test macro as well as re-enabling the integration test suite for `nu_plugin_inc`. I have also reworked `nu_with_plugins` slightly to support multiple plugins (something I intend to use in #6070)
And as discussed with @rgwood on Discord I went with running `cargo build` from the tests that need it which seems not to have impacted CI time by much

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
