### PR TITLE
Fix short-flag completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "nu-utils",
  "reedline",
  "regex",
+ "rstest 0.12.0",
  "sysinfo",
  "thiserror",
 ]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.65.1"
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.65.1"  }
 nu-command = { path = "../nu-command", version = "0.65.1" }
+rstest = "0.12.0"
 
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.65.1"  }

--- a/crates/nu-cli/tests/custom_completions.rs
+++ b/crates/nu-cli/tests/custom_completions.rs
@@ -2,10 +2,24 @@ pub mod support;
 
 use nu_cli::NuCompleter;
 use reedline::Completer;
+use rstest::{fixture, rstest};
 use support::{match_suggestions, new_engine};
 
-#[test]
-fn variables_completions() {
+#[fixture]
+fn completer() -> NuCompleter {
+    // Create a new engine
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Add record value as example
+    let record = "def tst [--mod -s] {}";
+    assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
+
+    // Instantiate a new completer
+    NuCompleter::new(std::sync::Arc::new(engine), stack)
+}
+
+#[fixture]
+fn completer_strings() -> NuCompleter {
     // Create a new engine
     let (dir, _, mut engine, mut stack) = new_engine();
 
@@ -15,15 +29,41 @@ fn variables_completions() {
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    NuCompleter::new(std::sync::Arc::new(engine), stack)
+}
 
-    // Test completions for $nu
-    let suggestions = completer.complete("my-command ", 11);
+#[rstest]
+fn variables_completions_double_dash_argument(mut completer: NuCompleter) {
+    let suggestions = completer.complete("tst --", 6);
+    let expected: Vec<String> = vec!["--help".into(), "--mod".into()];
+    // dbg!(&expected, &suggestions);
+    match_suggestions(expected, suggestions);
+}
 
-    assert_eq!(3, suggestions.len());
+#[rstest]
+fn variables_completions_single_dash_argument(mut completer: NuCompleter) {
+    let suggestions = completer.complete("tst -", 5);
+    let expected: Vec<String> = vec!["--help".into(), "--mod".into(), "-h".into(), "-s".into()];
+    match_suggestions(expected, suggestions);
+}
 
+#[rstest]
+fn variables_completions_command(mut completer_strings: NuCompleter) {
+    let suggestions = completer_strings.complete("my-command ", 9);
+    let expected: Vec<String> = vec!["my-command".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn variables_completions_subcommands(mut completer_strings: NuCompleter) {
+    let suggestions = completer_strings.complete("my-command ", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
 
-    // Match results
+#[rstest]
+fn variables_completions_subcommands_2(mut completer_strings: NuCompleter) {
+    let suggestions = completer_strings.complete("my-command ", 11);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
     match_suggestions(expected, suggestions);
 }

--- a/crates/nu-cli/tests/file_completions.rs
+++ b/crates/nu-cli/tests/file_completions.rs
@@ -30,8 +30,8 @@ fn file_completions() {
     // Match the results
     match_suggestions(expected_paths, suggestions);
 
-    // Test completions for the completions/another folder
-    let target_dir = format!("cd {}", folder(dir.join("another")));
+    // Test completions for a file
+    let target_dir = format!("cp {}", folder(dir.join("another")));
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     // Create the expected values

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -59,6 +59,15 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
 
 // match a list of suggestions with the expected values
 pub fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
+    let expected_len = expected.len();
+    let suggestions_len = suggestions.len();
+    if expected_len != suggestions_len {
+        panic!(
+            "\nexpected {expected_len} suggestions but got {suggestions_len}: \n\
+            Suggestions: {suggestions:#?} \n\
+            Expected: {expected:#?}\n"
+        )
+    }
     expected.iter().zip(suggestions).for_each(|it| {
         assert_eq!(it.0, &it.1.value);
     });

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -791,7 +791,18 @@ pub fn parse_internal_call(
             &signature,
         );
 
-        if let Some(short_flags) = short_flags {
+        if let Some(mut short_flags) = short_flags {
+            if short_flags.is_empty() {
+                short_flags.push(Flag {
+                    long: "".to_string(),
+                    short: Some('a'),
+                    arg: None,
+                    required: false,
+                    desc: "".to_string(),
+                    var_id: None,
+                    default_value: None,
+                })
+            }
             error = error.or(err);
             for flag in short_flags {
                 if let Some(arg_shape) = flag.arg {


### PR DESCRIPTION
# Description
Fixes https://github.com/nushell/nushell/issues/5949
Fixes completions by adding a short_flag containing 'a' when short flags are present, but the parser returned an empty vector due to no matches from the definition. Also improves tests by checking for mismatched expected/suggested length and providing a formatted panic message on failure, this also alerted me to a test for file completions that should have been failing due to having an empty vector.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
