### PR TITLE
Add CustomValue support to plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,6 +2815,7 @@ version = "0.1.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,10 @@ dependencies = [
 [[package]]
 name = "nu_plugin_custom_values"
 version = "0.1.0"
+dependencies = [
+ "nu-plugin",
+ "nu-protocol",
+]
 
 [[package]]
 name = "nu_plugin_example"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "nu-plugin",
  "nu-protocol",
  "serde",
+ "typetag",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2729,7 @@ dependencies = [
 name = "nu-plugin"
 version = "0.65.1"
 dependencies = [
+ "bincode",
  "capnp",
  "nu-engine",
  "nu-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,6 +2810,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu_plugin_custom_values"
+version = "0.1.0"
+
+[[package]]
 name = "nu_plugin_example"
 version = "0.65.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
 	"crates/nu_plugin_gstat",
 	"crates/nu_plugin_example",
 	"crates/nu_plugin_query",
+	"crates/nu_plugin_custom_values",
 	"crates/nu-utils",
 ]
 

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -7,6 +7,7 @@ name = "nu-plugin"
 version = "0.65.1"
 
 [dependencies]
+bincode = "1.3.3"
 capnp = "0.14.3"
 nu-protocol = { path = "../nu-protocol", version = "0.65.1"  }
 nu-engine = { path = "../nu-engine", version = "0.65.1"  }

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -6,5 +6,5 @@ mod serializers;
 mod plugin_capnp;
 
 pub use plugin::{get_signature, serve_plugin, Plugin, PluginDeclaration};
-pub use protocol::{EvaluatedCall, LabeledError};
+pub use protocol::{EvaluatedCall, LabeledError, PluginData};
 pub use serializers::{capnp::CapnpSerializer, json::JsonSerializer, EncodingType};

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -96,11 +96,11 @@ impl Command for PluginDeclaration {
                 value => CallInput::Value(value),
             };
 
-            let plugin_call = PluginCall::CallInfo(Box::new(CallInfo {
+            let plugin_call = PluginCall::CallInfo(CallInfo {
                 name: self.name.clone(),
                 call: EvaluatedCall::try_from_call(call, engine_state, stack)?,
                 input,
-            }));
+            });
             std::thread::spawn(move || {
                 // PluginCall information
                 encoding_clone.encode_call(&plugin_call, &mut stdin_writer)

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -131,6 +131,10 @@ impl Command for PluginDeclaration {
                     Value::CustomValue {
                         val: Box::new(PluginCustomValue {
                             data: plugin_data.data,
+                            filename: self.filename.clone(),
+                            shell: self.shell.clone(),
+                            encoding: self.encoding.clone(),
+                            source: engine_state.get_decl(call.decl_id).name().to_owned(),
                         }),
                         span: plugin_data.span,
                     },

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -127,9 +127,10 @@ impl Command for PluginDeclaration {
                 Ok(PluginResponse::Value(value)) => {
                     Ok(PipelineData::Value(value.as_ref().clone(), None))
                 }
-                Ok(PluginResponse::PluginData(plugin_data)) => Ok(PipelineData::Value(
+                Ok(PluginResponse::PluginData(name, plugin_data)) => Ok(PipelineData::Value(
                     Value::CustomValue {
                         val: Box::new(PluginCustomValue {
+                            name,
                             data: plugin_data.data,
                             filename: self.filename.clone(),
                             shell: self.shell.clone(),

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -1,7 +1,7 @@
 use crate::{EncodingType, EvaluatedCall};
 
 use super::{create_command, OUTPUT_BUFFER_SIZE};
-use crate::protocol::{CallInfo, PluginCall, PluginCustomValue, PluginResponse};
+use crate::protocol::{CallInfo, CallInput, PluginCall, PluginCustomValue, PluginResponse};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
@@ -81,7 +81,7 @@ impl Command for PluginDeclaration {
             let plugin_call = PluginCall::CallInfo(Box::new(CallInfo {
                 name: self.name.clone(),
                 call: EvaluatedCall::try_from_call(call, engine_state, stack)?,
-                input,
+                input: CallInput::Value(input),
             }));
             std::thread::spawn(move || {
                 // PluginCall information

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -1,10 +1,9 @@
 use crate::{EncodingType, EvaluatedCall};
 
-use super::{create_command, OUTPUT_BUFFER_SIZE};
+use super::{call_plugin, create_command};
 use crate::protocol::{
     CallInfo, CallInput, PluginCall, PluginCustomValue, PluginData, PluginResponse,
 };
-use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -75,44 +74,30 @@ impl Command for PluginDeclaration {
         })?;
 
         let input = input.into_value(call.head);
-
-        // Create message to plugin to indicate that signature is required and
-        // send call to plugin asking for signature
-        if let Some(mut stdin_writer) = child.stdin.take() {
-            let encoding_clone = self.encoding.clone();
-            let input = match input {
-                Value::CustomValue { val, span } => {
-                    match val.as_any().downcast_ref::<PluginCustomValue>() {
-                        Some(plugin_data) => CallInput::Data(PluginData {
-                            data: plugin_data.data.clone(),
-                            span,
-                        }),
-                        // TODO: sending random custom values to plugins is probably never the right
-                        // thing to do, we should probably just collapse them here and send base values
-                        // For example what will a plugin do with an SQLiteDatabase?
-                        None => CallInput::Value(Value::CustomValue { val, span }),
-                    }
+        let input = match input {
+            Value::CustomValue { val, span } => {
+                match val.as_any().downcast_ref::<PluginCustomValue>() {
+                    Some(plugin_data) => CallInput::Data(PluginData {
+                        data: plugin_data.data.clone(),
+                        span,
+                    }),
+                    // TODO: sending random custom values to plugins is probably never the right
+                    // thing to do, we should probably just collapse them here and send base values
+                    // For example what will a plugin do with an SQLiteDatabase?
+                    None => CallInput::Value(Value::CustomValue { val, span }),
                 }
-                value => CallInput::Value(value),
-            };
+            }
+            value => CallInput::Value(value),
+        };
 
-            let plugin_call = PluginCall::CallInfo(CallInfo {
-                name: self.name.clone(),
-                call: EvaluatedCall::try_from_call(call, engine_state, stack)?,
-                input,
-            });
-            std::thread::spawn(move || {
-                // PluginCall information
-                encoding_clone.encode_call(&plugin_call, &mut stdin_writer)
-            });
-        }
+        let plugin_call = PluginCall::CallInfo(CallInfo {
+            name: self.name.clone(),
+            call: EvaluatedCall::try_from_call(call, engine_state, stack)?,
+            input,
+        });
 
-        // Deserialize response from plugin to extract the resulting value
-        let pipeline_data = if let Some(stdout_reader) = &mut child.stdout {
-            let reader = stdout_reader;
-            let mut buf_read = BufReader::with_capacity(OUTPUT_BUFFER_SIZE, reader);
-
-            let response = self.encoding.decode_response(&mut buf_read).map_err(|err| {
+        let response =
+            call_plugin(&mut child, plugin_call, &self.encoding, call.head).map_err(|err| {
                 let decl = engine_state.get_decl(call.decl_id);
                 ShellError::GenericError(
                     format!("Unable to decode call for {}", decl.name()),
@@ -123,42 +108,33 @@ impl Command for PluginDeclaration {
                 )
             });
 
-            match response {
-                Ok(PluginResponse::Value(value)) => {
-                    Ok(PipelineData::Value(value.as_ref().clone(), None))
-                }
-                Ok(PluginResponse::PluginData(name, plugin_data)) => Ok(PipelineData::Value(
-                    Value::CustomValue {
-                        val: Box::new(PluginCustomValue {
-                            name,
-                            data: plugin_data.data,
-                            filename: self.filename.clone(),
-                            shell: self.shell.clone(),
-                            encoding: self.encoding.clone(),
-                            source: engine_state.get_decl(call.decl_id).name().to_owned(),
-                        }),
-                        span: plugin_data.span,
-                    },
-                    None,
-                )),
-                Ok(PluginResponse::Error(err)) => Err(err.into()),
-                Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError(
-                    "Plugin missing value".into(),
-                    "Received a signature from plugin instead of value".into(),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )),
-                Err(err) => Err(err),
+        let pipeline_data = match response {
+            Ok(PluginResponse::Value(value)) => {
+                Ok(PipelineData::Value(value.as_ref().clone(), None))
             }
-        } else {
-            Err(ShellError::GenericError(
-                "Error with stdout reader".into(),
-                "no stdout reader".into(),
+            Ok(PluginResponse::PluginData(name, plugin_data)) => Ok(PipelineData::Value(
+                Value::CustomValue {
+                    val: Box::new(PluginCustomValue {
+                        name,
+                        data: plugin_data.data,
+                        filename: self.filename.clone(),
+                        shell: self.shell.clone(),
+                        encoding: self.encoding.clone(),
+                        source: engine_state.get_decl(call.decl_id).name().to_owned(),
+                    }),
+                    span: plugin_data.span,
+                },
+                None,
+            )),
+            Ok(PluginResponse::Error(err)) => Err(err.into()),
+            Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError(
+                "Plugin missing value".into(),
+                "Received a signature from plugin instead of value".into(),
                 Some(call.head),
                 None,
                 Vec::new(),
-            ))
+            )),
+            Err(err) => Err(err),
         };
 
         // We need to call .wait() on the child, or we'll risk summoning the zombie horde

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -12,7 +12,7 @@ use nu_protocol::{Signature, Value};
 
 use super::EvaluatedCall;
 
-const OUTPUT_BUFFER_SIZE: usize = 8192;
+pub(crate) const OUTPUT_BUFFER_SIZE: usize = 8192;
 
 pub trait PluginEncoder: Clone {
     fn encode_call(
@@ -35,7 +35,7 @@ pub trait PluginEncoder: Clone {
     ) -> Result<PluginResponse, ShellError>;
 }
 
-fn create_command(path: &Path, shell: &Option<PathBuf>) -> CommandSys {
+pub(crate) fn create_command(path: &Path, shell: &Option<PathBuf>) -> CommandSys {
     let mut process = match (path.extension(), shell) {
         (_, Some(shell)) => {
             let mut process = std::process::Command::new(shell);

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -188,6 +188,7 @@ pub fn serve_plugin(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                         .encode_response(&response, &mut std::io::stdout())
                         .expect("Error encoding response");
                 }
+                PluginCall::CollapseCustomValue(_) => todo!(),
             }
         }
     }

--- a/crates/nu-plugin/src/plugin_capnp.rs
+++ b/crates/nu-plugin/src/plugin_capnp.rs
@@ -105,12 +105,14 @@ pub mod err {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+        #[inline]
         pub fn has_err(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 0 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+        #[inline]
         pub fn has_ok(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 1 {
                 return false;
@@ -244,6 +246,7 @@ pub mod err {
             self.builder.set_data_field::<u16>(0, 0);
             self.builder.get_pointer_field(0).init_text(size)
         }
+        #[inline]
         pub fn has_err(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 0 {
                 return false;
@@ -272,6 +275,7 @@ pub mod err {
             self.builder.set_data_field::<u16>(0, 1);
             ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0)).init_as()
         }
+        #[inline]
         pub fn has_ok(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 1 {
                 return false;
@@ -460,6 +464,7 @@ pub mod map {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_entries(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -606,6 +611,7 @@ pub mod map {
                 size,
             )
         }
+        #[inline]
         pub fn has_entries(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -758,6 +764,7 @@ pub mod map {
                     ::core::option::Option::None,
                 )
             }
+            #[inline]
             pub fn has_key(&self) -> bool {
                 !self.reader.get_pointer_field(0).is_null()
             }
@@ -770,6 +777,7 @@ pub mod map {
                     ::core::option::Option::None,
                 )
             }
+            #[inline]
             pub fn has_value(&self) -> bool {
                 !self.reader.get_pointer_field(1).is_null()
             }
@@ -909,6 +917,7 @@ pub mod map {
             pub fn init_key(self) -> <Key as ::capnp::traits::Owned<'a>>::Builder {
                 ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(0)).init_as()
             }
+            #[inline]
             pub fn has_key(&self) -> bool {
                 !self.builder.get_pointer_field(0).is_null()
             }
@@ -944,6 +953,7 @@ pub mod map {
             pub fn init_value(self) -> <Value as ::capnp::traits::Owned<'a>>::Builder {
                 ::capnp::any_pointer::Builder::new(self.builder.get_pointer_field(1)).init_as()
             }
+            #[inline]
             pub fn has_value(&self) -> bool {
                 !self.builder.get_pointer_field(1).is_null()
             }
@@ -1243,21 +1253,25 @@ pub mod value {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_span(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+        #[inline]
         pub fn has_string(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 4 {
                 return false;
             }
             !self.reader.get_pointer_field(1).is_null()
         }
+        #[inline]
         pub fn has_list(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 5 {
                 return false;
             }
             !self.reader.get_pointer_field(1).is_null()
         }
+        #[inline]
         pub fn has_record(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 6 {
                 return false;
@@ -1385,6 +1399,7 @@ pub mod value {
         pub fn init_span(self) -> crate::plugin_capnp::span::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+        #[inline]
         pub fn has_span(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -1417,6 +1432,7 @@ pub mod value {
             self.builder.set_data_field::<u16>(0, 4);
             self.builder.get_pointer_field(1).init_text(size)
         }
+        #[inline]
         pub fn has_string(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 4 {
                 return false;
@@ -1446,6 +1462,7 @@ pub mod value {
                 size,
             )
         }
+        #[inline]
         pub fn has_list(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 5 {
                 return false;
@@ -1469,6 +1486,7 @@ pub mod value {
             self.builder.set_data_field::<u16>(0, 6);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
         }
+        #[inline]
         pub fn has_record(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 6 {
                 return false;
@@ -1620,6 +1638,7 @@ pub mod record {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_cols(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -1633,6 +1652,7 @@ pub mod record {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_vals(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -1729,6 +1749,7 @@ pub mod record {
                 size,
             )
         }
+        #[inline]
         pub fn has_cols(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -1763,6 +1784,7 @@ pub mod record {
                 size,
             )
         }
+        #[inline]
         pub fn has_vals(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -1860,6 +1882,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -1870,6 +1893,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_usage(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -1880,6 +1904,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_extra_usage(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
@@ -1890,6 +1915,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_search_terms(&self) -> bool {
             !self.reader.get_pointer_field(3).is_null()
         }
@@ -1903,6 +1929,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_required_positional(&self) -> bool {
             !self.reader.get_pointer_field(4).is_null()
         }
@@ -1916,6 +1943,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_optional_positional(&self) -> bool {
             !self.reader.get_pointer_field(5).is_null()
         }
@@ -1926,6 +1954,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_rest(&self) -> bool {
             !self.reader.get_pointer_field(6).is_null()
         }
@@ -1939,6 +1968,7 @@ pub mod signature {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_named(&self) -> bool {
             !self.reader.get_pointer_field(7).is_null()
         }
@@ -2038,6 +2068,7 @@ pub mod signature {
         pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(0).init_text(size)
         }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -2056,6 +2087,7 @@ pub mod signature {
         pub fn init_usage(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(1).init_text(size)
         }
+        #[inline]
         pub fn has_usage(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -2074,6 +2106,7 @@ pub mod signature {
         pub fn init_extra_usage(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(2).init_text(size)
         }
+        #[inline]
         pub fn has_extra_usage(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
@@ -2102,6 +2135,7 @@ pub mod signature {
                 size,
             )
         }
+        #[inline]
         pub fn has_search_terms(&self) -> bool {
             !self.builder.get_pointer_field(3).is_null()
         }
@@ -2136,6 +2170,7 @@ pub mod signature {
                 size,
             )
         }
+        #[inline]
         pub fn has_required_positional(&self) -> bool {
             !self.builder.get_pointer_field(4).is_null()
         }
@@ -2170,6 +2205,7 @@ pub mod signature {
                 size,
             )
         }
+        #[inline]
         pub fn has_optional_positional(&self) -> bool {
             !self.builder.get_pointer_field(5).is_null()
         }
@@ -2195,6 +2231,7 @@ pub mod signature {
         pub fn init_rest(self) -> crate::plugin_capnp::argument::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(6), 0)
         }
+        #[inline]
         pub fn has_rest(&self) -> bool {
             !self.builder.get_pointer_field(6).is_null()
         }
@@ -2229,6 +2266,7 @@ pub mod signature {
                 size,
             )
         }
+        #[inline]
         pub fn has_named(&self) -> bool {
             !self.builder.get_pointer_field(7).is_null()
         }
@@ -2411,6 +2449,7 @@ pub mod flag {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_long(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -2421,6 +2460,7 @@ pub mod flag {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_short(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -2441,6 +2481,7 @@ pub mod flag {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_desc(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
@@ -2530,6 +2571,7 @@ pub mod flag {
         pub fn init_long(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(0).init_text(size)
         }
+        #[inline]
         pub fn has_long(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -2548,6 +2590,7 @@ pub mod flag {
         pub fn init_short(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(1).init_text(size)
         }
+        #[inline]
         pub fn has_short(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -2584,6 +2627,7 @@ pub mod flag {
         pub fn init_desc(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(2).init_text(size)
         }
+        #[inline]
         pub fn has_desc(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
@@ -2681,6 +2725,7 @@ pub mod argument {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -2691,6 +2736,7 @@ pub mod argument {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_desc(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -2786,6 +2832,7 @@ pub mod argument {
         pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(0).init_text(size)
         }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -2804,6 +2851,7 @@ pub mod argument {
         pub fn init_desc(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(1).init_text(size)
         }
+        #[inline]
         pub fn has_desc(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -2948,6 +2996,7 @@ pub mod evaluated_call {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_head(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -2961,6 +3010,7 @@ pub mod evaluated_call {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_positional(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -2979,6 +3029,7 @@ pub mod evaluated_call {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_named(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
@@ -3075,6 +3126,7 @@ pub mod evaluated_call {
         pub fn init_head(self) -> crate::plugin_capnp::span::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+        #[inline]
         pub fn has_head(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -3109,6 +3161,7 @@ pub mod evaluated_call {
                 size,
             )
         }
+        #[inline]
         pub fn has_positional(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -3156,6 +3209,7 @@ pub mod evaluated_call {
         > {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
         }
+        #[inline]
         pub fn has_named(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
@@ -3192,6 +3246,505 @@ pub mod evaluated_call {
         };
         pub const TYPE_ID: u64 = 0x84fb_ac77_3ee4_48a4;
     }
+}
+
+pub mod plugin_data {
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl<'a> ::capnp::traits::Owned<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
+    }
+    impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
+    }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Pipeline;
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct Reader<'a> {
+        reader: ::capnp::private::layout::StructReader<'a>,
+    }
+
+    impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
+        }
+    }
+    impl<'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
+        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
+            Reader { reader }
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            default: ::core::option::Option<&'a [capnp::Word]>,
+        ) -> ::capnp::Result<Reader<'a>> {
+            ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(
+                reader.get_struct(default)?,
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+            self.reader
+        }
+    }
+
+    impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+            self.reader
+                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        }
+    }
+
+    impl<'a> Reader<'a> {
+        pub fn reborrow(&self) -> Reader<'_> {
+            Reader { ..*self }
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.reader.total_size()
+        }
+        #[inline]
+        pub fn get_data(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn has_data(&self) -> bool {
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn get_span(self) -> ::capnp::Result<crate::plugin_capnp::span::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(1),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn has_span(&self) -> bool {
+            !self.reader.get_pointer_field(1).is_null()
+        }
+    }
+
+    pub struct Builder<'a> {
+        builder: ::capnp::private::layout::StructBuilder<'a>,
+    }
+    impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+        #[inline]
+        fn struct_size() -> ::capnp::private::layout::StructSize {
+            _private::STRUCT_SIZE
+        }
+    }
+    impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
+        }
+    }
+    impl<'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
+        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
+            Builder { builder }
+        }
+    }
+
+    impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+            self.builder
+                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+        fn init_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            _size: u32,
+        ) -> Builder<'a> {
+            ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            default: ::core::option::Option<&'a [capnp::Word]>,
+        ) -> ::capnp::Result<Builder<'a>> {
+            ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(
+                builder.get_struct(_private::STRUCT_SIZE, default)?,
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        fn set_pointer_builder<'b>(
+            pointer: ::capnp::private::layout::PointerBuilder<'b>,
+            value: Reader<'a>,
+            canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_struct(&value.reader, canonicalize)
+        }
+    }
+
+    impl<'a> Builder<'a> {
+        pub fn into_reader(self) -> Reader<'a> {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+        pub fn reborrow(&mut self) -> Builder<'_> {
+            Builder { ..*self }
+        }
+        pub fn reborrow_as_reader(&self) -> Reader<'_> {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.builder.into_reader().total_size()
+        }
+        #[inline]
+        pub fn get_data(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(0),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_data(&mut self, value: ::capnp::data::Reader<'_>) {
+            self.builder.get_pointer_field(0).set_data(value);
+        }
+        #[inline]
+        pub fn init_data(self, size: u32) -> ::capnp::data::Builder<'a> {
+            self.builder.get_pointer_field(0).init_data(size)
+        }
+        #[inline]
+        pub fn has_data(&self) -> bool {
+            !self.builder.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn get_span(self) -> ::capnp::Result<crate::plugin_capnp::span::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(1),
+                ::core::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_span(
+            &mut self,
+            value: crate::plugin_capnp::span::Reader<'_>,
+        ) -> ::capnp::Result<()> {
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.get_pointer_field(1),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_span(self) -> crate::plugin_capnp::span::Builder<'a> {
+            ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
+        }
+        #[inline]
+        pub fn has_span(&self) -> bool {
+            !self.builder.get_pointer_field(1).is_null()
+        }
+    }
+
+    pub struct Pipeline {
+        _typeless: ::capnp::any_pointer::Pipeline,
+    }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+            Pipeline {
+                _typeless: typeless,
+            }
+        }
+    }
+    impl Pipeline {
+        pub fn get_span(&self) -> crate::plugin_capnp::span::Pipeline {
+            ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
+        }
+    }
+    mod _private {
+        use capnp::private::layout;
+        pub const STRUCT_SIZE: layout::StructSize = layout::StructSize {
+            data: 0,
+            pointers: 2,
+        };
+        pub const TYPE_ID: u64 = 0xe394_537e_5286_0449;
+    }
+}
+
+pub mod call_input {
+    pub use self::Which::{PluginData, Value};
+
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl<'a> ::capnp::traits::Owned<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
+    }
+    impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
+    }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Pipeline;
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct Reader<'a> {
+        reader: ::capnp::private::layout::StructReader<'a>,
+    }
+
+    impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
+        }
+    }
+    impl<'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
+        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
+            Reader { reader }
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            default: ::core::option::Option<&'a [capnp::Word]>,
+        ) -> ::capnp::Result<Reader<'a>> {
+            ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(
+                reader.get_struct(default)?,
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+            self.reader
+        }
+    }
+
+    impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+            self.reader
+                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        }
+    }
+
+    impl<'a> Reader<'a> {
+        pub fn reborrow(&self) -> Reader<'_> {
+            Reader { ..*self }
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.reader.total_size()
+        }
+        #[inline]
+        pub fn has_value(&self) -> bool {
+            if self.reader.get_data_field::<u16>(0) != 0 {
+                return false;
+            }
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn has_plugin_data(&self) -> bool {
+            if self.reader.get_data_field::<u16>(0) != 1 {
+                return false;
+            }
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+            match self.reader.get_data_field::<u16>(0) {
+                0 => ::core::result::Result::Ok(Value(
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                1 => ::core::result::Result::Ok(PluginData(
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+            }
+        }
+    }
+
+    pub struct Builder<'a> {
+        builder: ::capnp::private::layout::StructBuilder<'a>,
+    }
+    impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+        #[inline]
+        fn struct_size() -> ::capnp::private::layout::StructSize {
+            _private::STRUCT_SIZE
+        }
+    }
+    impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
+        }
+    }
+    impl<'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
+        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
+            Builder { builder }
+        }
+    }
+
+    impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+            self.builder
+                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+        fn init_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            _size: u32,
+        ) -> Builder<'a> {
+            ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            default: ::core::option::Option<&'a [capnp::Word]>,
+        ) -> ::capnp::Result<Builder<'a>> {
+            ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(
+                builder.get_struct(_private::STRUCT_SIZE, default)?,
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+        fn set_pointer_builder<'b>(
+            pointer: ::capnp::private::layout::PointerBuilder<'b>,
+            value: Reader<'a>,
+            canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_struct(&value.reader, canonicalize)
+        }
+    }
+
+    impl<'a> Builder<'a> {
+        pub fn into_reader(self) -> Reader<'a> {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+        pub fn reborrow(&mut self) -> Builder<'_> {
+            Builder { ..*self }
+        }
+        pub fn reborrow_as_reader(&self) -> Reader<'_> {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.builder.into_reader().total_size()
+        }
+        #[inline]
+        pub fn set_value(
+            &mut self,
+            value: crate::plugin_capnp::value::Reader<'_>,
+        ) -> ::capnp::Result<()> {
+            self.builder.set_data_field::<u16>(0, 0);
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.get_pointer_field(0),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_value(self) -> crate::plugin_capnp::value::Builder<'a> {
+            self.builder.set_data_field::<u16>(0, 0);
+            ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        }
+        #[inline]
+        pub fn has_value(&self) -> bool {
+            if self.builder.get_data_field::<u16>(0) != 0 {
+                return false;
+            }
+            !self.builder.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn set_plugin_data(
+            &mut self,
+            value: crate::plugin_capnp::plugin_data::Reader<'_>,
+        ) -> ::capnp::Result<()> {
+            self.builder.set_data_field::<u16>(0, 1);
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.get_pointer_field(0),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_plugin_data(self) -> crate::plugin_capnp::plugin_data::Builder<'a> {
+            self.builder.set_data_field::<u16>(0, 1);
+            ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        }
+        #[inline]
+        pub fn has_plugin_data(&self) -> bool {
+            if self.builder.get_data_field::<u16>(0) != 1 {
+                return false;
+            }
+            !self.builder.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+            match self.builder.get_data_field::<u16>(0) {
+                0 => ::core::result::Result::Ok(Value(
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                1 => ::core::result::Result::Ok(PluginData(
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
+            }
+        }
+    }
+
+    pub struct Pipeline {
+        _typeless: ::capnp::any_pointer::Pipeline,
+    }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+            Pipeline {
+                _typeless: typeless,
+            }
+        }
+    }
+    impl Pipeline {}
+    mod _private {
+        use capnp::private::layout;
+        pub const STRUCT_SIZE: layout::StructSize = layout::StructSize {
+            data: 1,
+            pointers: 1,
+        };
+        pub const TYPE_ID: u64 = 0xe0a9_a296_3cb2_e15f;
+    }
+    pub enum Which<A0, A1> {
+        Value(A0),
+        PluginData(A1),
+    }
+    pub type WhichReader<'a> = Which<
+        ::capnp::Result<crate::plugin_capnp::value::Reader<'a>>,
+        ::capnp::Result<crate::plugin_capnp::plugin_data::Reader<'a>>,
+    >;
+    pub type WhichBuilder<'a> = Which<
+        ::capnp::Result<crate::plugin_capnp::value::Builder<'a>>,
+        ::capnp::Result<crate::plugin_capnp::plugin_data::Builder<'a>>,
+    >;
 }
 
 pub mod call_info {
@@ -3265,6 +3818,7 @@ pub mod call_info {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -3275,16 +3829,18 @@ pub mod call_info {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_call(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
         #[inline]
-        pub fn get_input(self) -> ::capnp::Result<crate::plugin_capnp::value::Reader<'a>> {
+        pub fn get_input(self) -> ::capnp::Result<crate::plugin_capnp::call_input::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
                 &self.reader.get_pointer_field(2),
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_input(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
@@ -3374,6 +3930,7 @@ pub mod call_info {
         pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(0).init_text(size)
         }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -3399,11 +3956,12 @@ pub mod call_info {
         pub fn init_call(self) -> crate::plugin_capnp::evaluated_call::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
         }
+        #[inline]
         pub fn has_call(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
         #[inline]
-        pub fn get_input(self) -> ::capnp::Result<crate::plugin_capnp::value::Builder<'a>> {
+        pub fn get_input(self) -> ::capnp::Result<crate::plugin_capnp::call_input::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
                 self.builder.get_pointer_field(2),
                 ::core::option::Option::None,
@@ -3412,7 +3970,7 @@ pub mod call_info {
         #[inline]
         pub fn set_input(
             &mut self,
-            value: crate::plugin_capnp::value::Reader<'_>,
+            value: crate::plugin_capnp::call_input::Reader<'_>,
         ) -> ::capnp::Result<()> {
             ::capnp::traits::SetPointerBuilder::set_pointer_builder(
                 self.builder.get_pointer_field(2),
@@ -3421,9 +3979,10 @@ pub mod call_info {
             )
         }
         #[inline]
-        pub fn init_input(self) -> crate::plugin_capnp::value::Builder<'a> {
+        pub fn init_input(self) -> crate::plugin_capnp::call_input::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
         }
+        #[inline]
         pub fn has_input(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
@@ -3443,7 +4002,7 @@ pub mod call_info {
         pub fn get_call(&self) -> crate::plugin_capnp::evaluated_call::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
         }
-        pub fn get_input(&self) -> crate::plugin_capnp::value::Pipeline {
+        pub fn get_input(&self) -> crate::plugin_capnp::call_input::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
         }
     }
@@ -3523,6 +4082,7 @@ pub mod plugin_call {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+        #[inline]
         pub fn has_call_info(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 1 {
                 return false;
@@ -3634,6 +4194,7 @@ pub mod plugin_call {
             self.builder.set_data_field::<u16>(0, 1);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+        #[inline]
         pub fn has_call_info(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 1 {
                 return false;
@@ -3748,18 +4309,21 @@ pub mod plugin_response {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+        #[inline]
         pub fn has_error(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 0 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+        #[inline]
         pub fn has_signature(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 1 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+        #[inline]
         pub fn has_value(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 2 {
                 return false;
@@ -3878,6 +4442,7 @@ pub mod plugin_response {
             self.builder.set_data_field::<u16>(0, 0);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+        #[inline]
         pub fn has_error(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 0 {
                 return false;
@@ -3907,6 +4472,7 @@ pub mod plugin_response {
                 size,
             )
         }
+        #[inline]
         pub fn has_signature(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 1 {
                 return false;
@@ -3930,6 +4496,7 @@ pub mod plugin_response {
             self.builder.set_data_field::<u16>(0, 2);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+        #[inline]
         pub fn has_value(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 2 {
                 return false;
@@ -4069,6 +4636,7 @@ pub mod labeled_error {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_label(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -4079,6 +4647,7 @@ pub mod labeled_error {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_msg(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -4089,6 +4658,7 @@ pub mod labeled_error {
                 ::core::option::Option::None,
             )
         }
+        #[inline]
         pub fn has_span(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
@@ -4178,6 +4748,7 @@ pub mod labeled_error {
         pub fn init_label(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(0).init_text(size)
         }
+        #[inline]
         pub fn has_label(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -4196,6 +4767,7 @@ pub mod labeled_error {
         pub fn init_msg(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(1).init_text(size)
         }
+        #[inline]
         pub fn has_msg(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -4221,6 +4793,7 @@ pub mod labeled_error {
         pub fn init_span(self) -> crate::plugin_capnp::span::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
         }
+        #[inline]
         pub fn has_span(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }

--- a/crates/nu-plugin/src/plugin_capnp.rs
+++ b/crates/nu-plugin/src/plugin_capnp.rs
@@ -4294,7 +4294,7 @@ pub mod plugin_call {
 }
 
 pub mod plugin_response {
-    pub use self::Which::{Error, Signature, Value};
+    pub use self::Which::{Error, PluginData, Signature, Value};
 
     #[derive(Copy, Clone)]
     pub struct Owned(());
@@ -4381,6 +4381,13 @@ pub mod plugin_response {
             !self.reader.get_pointer_field(0).is_null()
         }
         #[inline]
+        pub fn has_plugin_data(&self) -> bool {
+            if self.reader.get_data_field::<u16>(0) != 3 {
+                return false;
+            }
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Error(
@@ -4396,6 +4403,12 @@ pub mod plugin_response {
                     ),
                 )),
                 2 => ::core::result::Result::Ok(Value(
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                3 => ::core::result::Result::Ok(PluginData(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
@@ -4554,6 +4567,32 @@ pub mod plugin_response {
             !self.builder.get_pointer_field(0).is_null()
         }
         #[inline]
+        pub fn set_plugin_data(
+            &mut self,
+            value: crate::plugin_capnp::plugin_response::plugin_data_response::Reader<'_>,
+        ) -> ::capnp::Result<()> {
+            self.builder.set_data_field::<u16>(0, 3);
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.get_pointer_field(0),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_plugin_data(
+            self,
+        ) -> crate::plugin_capnp::plugin_response::plugin_data_response::Builder<'a> {
+            self.builder.set_data_field::<u16>(0, 3);
+            ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        }
+        #[inline]
+        pub fn has_plugin_data(&self) -> bool {
+            if self.builder.get_data_field::<u16>(0) != 3 {
+                return false;
+            }
+            !self.builder.get_pointer_field(0).is_null()
+        }
+        #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Error(
@@ -4569,6 +4608,12 @@ pub mod plugin_response {
                     ),
                 )),
                 2 => ::core::result::Result::Ok(Value(
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                3 => ::core::result::Result::Ok(PluginData(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
@@ -4598,21 +4643,258 @@ pub mod plugin_response {
         };
         pub const TYPE_ID: u64 = 0xb9ba_b3c7_9388_b7db;
     }
-    pub enum Which<A0, A1, A2> {
+    pub enum Which<A0, A1, A2, A3> {
         Error(A0),
         Signature(A1),
         Value(A2),
+        PluginData(A3),
     }
     pub type WhichReader<'a> = Which<
         ::capnp::Result<crate::plugin_capnp::labeled_error::Reader<'a>>,
         ::capnp::Result<::capnp::struct_list::Reader<'a, crate::plugin_capnp::signature::Owned>>,
         ::capnp::Result<crate::plugin_capnp::value::Reader<'a>>,
+        ::capnp::Result<crate::plugin_capnp::plugin_response::plugin_data_response::Reader<'a>>,
     >;
     pub type WhichBuilder<'a> = Which<
         ::capnp::Result<crate::plugin_capnp::labeled_error::Builder<'a>>,
         ::capnp::Result<::capnp::struct_list::Builder<'a, crate::plugin_capnp::signature::Owned>>,
         ::capnp::Result<crate::plugin_capnp::value::Builder<'a>>,
+        ::capnp::Result<crate::plugin_capnp::plugin_response::plugin_data_response::Builder<'a>>,
     >;
+
+    pub mod plugin_data_response {
+        #[derive(Copy, Clone)]
+        pub struct Owned(());
+        impl<'a> ::capnp::traits::Owned<'a> for Owned {
+            type Reader = Reader<'a>;
+            type Builder = Builder<'a>;
+        }
+        impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
+            type Reader = Reader<'a>;
+            type Builder = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        #[derive(Clone, Copy)]
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            #[inline]
+            fn type_id() -> u64 {
+                _private::TYPE_ID
+            }
+        }
+        impl<'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
+            fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
+                Reader { reader }
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::core::option::Option<&'a [capnp::Word]>,
+            ) -> ::capnp::Result<Reader<'a>> {
+                ::core::result::Result::Ok(::capnp::traits::FromStructReader::new(
+                    reader.get_struct(default)?,
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader<'_> {
+                Reader { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            #[inline]
+            pub fn get_name(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_name(&self) -> bool {
+                !self.reader.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_data(self) -> ::capnp::Result<crate::plugin_capnp::plugin_data::Reader<'a>> {
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn has_data(&self) -> bool {
+                !self.reader.get_pointer_field(1).is_null()
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            #[inline]
+            fn struct_size() -> ::capnp::private::layout::StructSize {
+                _private::STRUCT_SIZE
+            }
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            #[inline]
+            fn type_id() -> u64 {
+                _private::TYPE_ID
+            }
+        }
+        impl<'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
+            fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
+                Builder { builder }
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Builder<'a> {
+                ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::core::option::Option<&'a [capnp::Word]>,
+            ) -> ::capnp::Result<Builder<'a>> {
+                ::core::result::Result::Ok(::capnp::traits::FromStructBuilder::new(
+                    builder.get_struct(_private::STRUCT_SIZE, default)?,
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
+            fn set_pointer_builder<'b>(
+                pointer: ::capnp::private::layout::PointerBuilder<'b>,
+                value: Reader<'a>,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+            }
+            pub fn reborrow(&mut self) -> Builder<'_> {
+                Builder { ..*self }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader<'_> {
+                ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.into_reader().total_size()
+            }
+            #[inline]
+            pub fn get_name(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_name(&mut self, value: ::capnp::text::Reader<'_>) {
+                self.builder.get_pointer_field(0).set_text(value);
+            }
+            #[inline]
+            pub fn init_name(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.get_pointer_field(0).init_text(size)
+            }
+            #[inline]
+            pub fn has_name(&self) -> bool {
+                !self.builder.get_pointer_field(0).is_null()
+            }
+            #[inline]
+            pub fn get_data(
+                self,
+            ) -> ::capnp::Result<crate::plugin_capnp::plugin_data::Builder<'a>> {
+                ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                    self.builder.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )
+            }
+            #[inline]
+            pub fn set_data(
+                &mut self,
+                value: crate::plugin_capnp::plugin_data::Reader<'_>,
+            ) -> ::capnp::Result<()> {
+                ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                    self.builder.get_pointer_field(1),
+                    value,
+                    false,
+                )
+            }
+            #[inline]
+            pub fn init_data(self) -> crate::plugin_capnp::plugin_data::Builder<'a> {
+                ::capnp::traits::FromPointerBuilder::init_pointer(
+                    self.builder.get_pointer_field(1),
+                    0,
+                )
+            }
+            #[inline]
+            pub fn has_data(&self) -> bool {
+                !self.builder.get_pointer_field(1).is_null()
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+                Pipeline {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {
+            pub fn get_data(&self) -> crate::plugin_capnp::plugin_data::Pipeline {
+                ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
+            }
+        }
+        mod _private {
+            use capnp::private::layout;
+            pub const STRUCT_SIZE: layout::StructSize = layout::StructSize {
+                data: 0,
+                pointers: 2,
+            };
+            pub const TYPE_ID: u64 = 0xa0e9_dd1c_d7fe_17a7;
+        }
+    }
 }
 
 pub mod labeled_error {

--- a/crates/nu-plugin/src/plugin_capnp.rs
+++ b/crates/nu-plugin/src/plugin_capnp.rs
@@ -4017,7 +4017,7 @@ pub mod call_info {
 }
 
 pub mod plugin_call {
-    pub use self::Which::{CallInfo, Signature};
+    pub use self::Which::{CallInfo, CollapseCustomValue, Signature};
 
     #[derive(Copy, Clone)]
     pub struct Owned(());
@@ -4090,10 +4090,23 @@ pub mod plugin_call {
             !self.reader.get_pointer_field(0).is_null()
         }
         #[inline]
+        pub fn has_collapse_custom_value(&self) -> bool {
+            if self.reader.get_data_field::<u16>(0) != 2 {
+                return false;
+            }
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Signature(())),
                 1 => ::core::result::Result::Ok(CallInfo(
+                    ::capnp::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                2 => ::core::result::Result::Ok(CollapseCustomValue(
                     ::capnp::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
@@ -4202,10 +4215,40 @@ pub mod plugin_call {
             !self.builder.get_pointer_field(0).is_null()
         }
         #[inline]
+        pub fn set_collapse_custom_value(
+            &mut self,
+            value: crate::plugin_capnp::plugin_data::Reader<'_>,
+        ) -> ::capnp::Result<()> {
+            self.builder.set_data_field::<u16>(0, 2);
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.get_pointer_field(0),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_collapse_custom_value(self) -> crate::plugin_capnp::plugin_data::Builder<'a> {
+            self.builder.set_data_field::<u16>(0, 2);
+            ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+        }
+        #[inline]
+        pub fn has_collapse_custom_value(&self) -> bool {
+            if self.builder.get_data_field::<u16>(0) != 2 {
+                return false;
+            }
+            !self.builder.get_pointer_field(0).is_null()
+        }
+        #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(0) {
                 0 => ::core::result::Result::Ok(Signature(())),
                 1 => ::core::result::Result::Ok(CallInfo(
+                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                        self.builder.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    ),
+                )),
+                2 => ::core::result::Result::Ok(CollapseCustomValue(
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
                         self.builder.get_pointer_field(0),
                         ::core::option::Option::None,
@@ -4235,12 +4278,19 @@ pub mod plugin_call {
         };
         pub const TYPE_ID: u64 = 0xde86_64b2_7f80_4db1;
     }
-    pub enum Which<A0> {
+    pub enum Which<A0, A1> {
         Signature(()),
         CallInfo(A0),
+        CollapseCustomValue(A1),
     }
-    pub type WhichReader<'a> = Which<::capnp::Result<crate::plugin_capnp::call_info::Reader<'a>>>;
-    pub type WhichBuilder<'a> = Which<::capnp::Result<crate::plugin_capnp::call_info::Builder<'a>>>;
+    pub type WhichReader<'a> = Which<
+        ::capnp::Result<crate::plugin_capnp::call_info::Reader<'a>>,
+        ::capnp::Result<crate::plugin_capnp::plugin_data::Reader<'a>>,
+    >;
+    pub type WhichBuilder<'a> = Which<
+        ::capnp::Result<crate::plugin_capnp::call_info::Builder<'a>>,
+        ::capnp::Result<crate::plugin_capnp::plugin_data::Builder<'a>>,
+    >;
 }
 
 pub mod plugin_response {

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -20,6 +20,7 @@ pub struct CallInfo {
 pub enum PluginCall {
     Signature,
     CallInfo(Box<CallInfo>),
+    CollapseCustomValue(PluginData),
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 pub struct CallInfo {
     pub name: String,
     pub call: EvaluatedCall,
-    pub input: Value,
+    pub input: CallInput,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum CallInput {
+    Value(Value),
+    Data(PluginData),
 }
 
 // Information sent to the plugin

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -1,7 +1,11 @@
 mod evaluated_call;
+mod plugin_custom_value;
+mod plugin_data;
 
 pub use evaluated_call::EvaluatedCall;
 use nu_protocol::{ShellError, Signature, Span, Value};
+pub use plugin_custom_value::PluginCustomValue;
+pub use plugin_data::PluginData;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -88,4 +92,5 @@ pub enum PluginResponse {
     Error(LabeledError),
     Signature(Vec<Signature>),
     Value(Box<Value>),
+    PluginData(PluginData),
 }

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -99,5 +99,5 @@ pub enum PluginResponse {
     Error(LabeledError),
     Signature(Vec<Signature>),
     Value(Box<Value>),
-    PluginData(PluginData),
+    PluginData(String, PluginData),
 }

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -25,7 +25,7 @@ pub enum CallInput {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PluginCall {
     Signature,
-    CallInfo(Box<CallInfo>),
+    CallInfo(CallInfo),
     CollapseCustomValue(PluginData),
 }
 

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -20,6 +20,8 @@ use super::{PluginCall, PluginData, PluginResponse};
 /// sent to the plugin with a request to collapse it into a base value
 #[derive(Clone, Debug, Serialize)]
 pub struct PluginCustomValue {
+    /// The name of the custom value as defined by the plugin
+    pub name: String,
     pub data: serde_json::Value,
     pub filename: PathBuf,
 
@@ -44,7 +46,7 @@ impl CustomValue for PluginCustomValue {
     }
 
     fn value_string(&self) -> String {
-        self.typetag_name().to_string()
+        self.name.clone()
     }
 
     fn to_base_value(
@@ -130,8 +132,6 @@ impl CustomValue for PluginCustomValue {
     }
 
     fn typetag_name(&self) -> &'static str {
-        // TODO: Is this a good idea? I'd love to be able to get the name of the data type itself
-        // but I don't think there's a way to get a &'static str without leaking which isn't ideal
         "PluginCustomValue"
     }
 

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -22,7 +22,7 @@ use super::{PluginCall, PluginData, PluginResponse};
 pub struct PluginCustomValue {
     /// The name of the custom value as defined by the plugin
     pub name: String,
-    pub data: serde_json::Value,
+    pub data: Vec<u8>,
     pub filename: PathBuf,
 
     // PluginCustomValue must implement Serialize because all CustomValues must implement Serialize

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -1,0 +1,41 @@
+use nu_protocol::{CustomValue, Value};
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PluginCustomValue {
+    pub data: serde_json::Value,
+}
+
+impl CustomValue for PluginCustomValue {
+    fn clone_value(&self, span: nu_protocol::Span) -> nu_protocol::Value {
+        Value::CustomValue {
+            val: Box::new(self.clone()),
+            span,
+        }
+    }
+
+    fn value_string(&self) -> String {
+        self.typetag_name().to_string()
+    }
+
+    fn to_base_value(
+        &self,
+        _span: nu_protocol::Span,
+    ) -> Result<nu_protocol::Value, nu_protocol::ShellError> {
+        todo!()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn typetag_name(&self) -> &'static str {
+        // TODO: Is this a good idea? I'd love to be able to get the name of the data type itself
+        // but I don't think there's a way to get a &'static str without leaking which isn't ideal
+        "PluginCustomValue"
+    }
+
+    fn typetag_deserialize(&self) {
+        unimplemented!("typetag_deserialize")
+    }
+}

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -5,6 +5,14 @@ use serde::Serialize;
 
 use crate::EncodingType;
 
+/// An opaque container for a custom value that is handled fully by a plugin
+///
+/// This is constructed by the main nushell engine when it receives [`PluginResponse::PluginData`]
+/// it stores that data as well as metadata related to the plugin to be able to call the plugin
+/// later.
+/// Since the data in it is opaque to the engine, there are only two final destinations for it:
+/// either it will be sent back to the plugin that generated it across a pipeline, or it will be
+/// sent to the plugin with a request to collapse it into a base value
 #[derive(Clone, Debug, Serialize)]
 pub struct PluginCustomValue {
     pub data: serde_json::Value,

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -100,7 +100,13 @@ impl CustomValue for PluginCustomValue {
 
             match response {
                 Ok(PluginResponse::Value(value)) => Ok(*value),
-                Ok(PluginResponse::PluginData(..)) => todo!(),
+                Ok(PluginResponse::PluginData(..)) => Err(ShellError::GenericError(
+                    "Plugin misbehaving".into(),
+                    "Plugin returned custom data as a response to a collapse call".into(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                )),
                 Ok(PluginResponse::Error(err)) => Err(err.into()),
                 Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError(
                     "Plugin missing value".into(),

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -1,9 +1,25 @@
+use std::path::PathBuf;
+
 use nu_protocol::{CustomValue, Value};
 use serde::Serialize;
+
+use crate::EncodingType;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct PluginCustomValue {
     pub data: serde_json::Value,
+    pub filename: PathBuf,
+
+    // PluginCustomValue must implement Serialize because all CustomValues must implement Serialize
+    // However, the main place where values are serialized and deserialized is when they are being
+    // sent between plugins and nushell's main engine. PluginCustomValue is never meant to be sent
+    // between that boundary
+    #[serde(skip)]
+    pub shell: Option<PathBuf>,
+    #[serde(skip)]
+    pub encoding: EncodingType,
+    #[serde(skip)]
+    pub source: String,
 }
 
 impl CustomValue for PluginCustomValue {

--- a/crates/nu-plugin/src/protocol/plugin_data.rs
+++ b/crates/nu-plugin/src/protocol/plugin_data.rs
@@ -1,7 +1,7 @@
 use nu_protocol::Span;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct PluginData {
     pub data: serde_json::Value,
     pub span: Span,

--- a/crates/nu-plugin/src/protocol/plugin_data.rs
+++ b/crates/nu-plugin/src/protocol/plugin_data.rs
@@ -3,6 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct PluginData {
-    pub data: serde_json::Value,
+    pub data: Vec<u8>,
     pub span: Span,
 }

--- a/crates/nu-plugin/src/protocol/plugin_data.rs
+++ b/crates/nu-plugin/src/protocol/plugin_data.rs
@@ -1,0 +1,8 @@
+use nu_protocol::Span;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct PluginData {
+    pub data: serde_json::Value,
+    pub span: Span,
+}

--- a/crates/nu-plugin/src/protocol/plugin_data.rs
+++ b/crates/nu-plugin/src/protocol/plugin_data.rs
@@ -1,7 +1,7 @@
 use nu_protocol::Span;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct PluginData {
     pub data: serde_json::Value,
     pub span: Span,

--- a/crates/nu-plugin/src/serializers/capnp/call_input.rs
+++ b/crates/nu-plugin/src/serializers/capnp/call_input.rs
@@ -1,0 +1,33 @@
+use super::value;
+use crate::{plugin_capnp::call_input, protocol::CallInput};
+use nu_protocol::{ShellError, Span};
+
+pub(crate) fn serialize_call_input(call_input: &CallInput, builder: call_input::Builder) {
+    match call_input {
+        CallInput::Value(value) => {
+            value::serialize_value(value, builder.init_value());
+        }
+        CallInput::Data(_) => todo!(),
+    };
+}
+
+pub(crate) fn deserialize_call_input(
+    reader: call_input::Reader,
+    head: Span,
+) -> Result<CallInput, ShellError> {
+    match reader.which() {
+        Err(capnp::NotInSchema(_)) => Err(ShellError::PluginFailedToDecode(
+            "value not in schema".into(),
+        )),
+        Ok(call_input::Value(value_reader)) => {
+            let value_reader =
+                value_reader.map_err(|e| ShellError::PluginFailedToDecode(e.to_string()))?;
+
+            Ok(CallInput::Value(value::deserialize_value(
+                value_reader,
+                head,
+            )?))
+        }
+        Ok(call_input::PluginData(_)) => todo!(),
+    }
+}

--- a/crates/nu-plugin/src/serializers/capnp/mod.rs
+++ b/crates/nu-plugin/src/serializers/capnp/mod.rs
@@ -7,7 +7,7 @@ use nu_protocol::ShellError;
 
 use crate::{plugin::PluginEncoder, protocol::PluginResponse};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CapnpSerializer;
 
 impl PluginEncoder for CapnpSerializer {

--- a/crates/nu-plugin/src/serializers/capnp/mod.rs
+++ b/crates/nu-plugin/src/serializers/capnp/mod.rs
@@ -1,4 +1,5 @@
 mod call;
+mod call_input;
 mod plugin_call;
 mod signature;
 mod value;

--- a/crates/nu-plugin/src/serializers/capnp/mod.rs
+++ b/crates/nu-plugin/src/serializers/capnp/mod.rs
@@ -1,6 +1,7 @@
 mod call;
 mod call_input;
 mod plugin_call;
+mod plugin_data;
 mod signature;
 mod value;
 

--- a/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
+++ b/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
@@ -38,6 +38,7 @@ pub fn encode_call(
 
             value::serialize_value(&call_info.input, value_builder);
         }
+        PluginCall::CollapseCustomValue(_) => todo!(),
     };
 
     serialize::write_message(writer, &message)
@@ -217,6 +218,7 @@ mod tests {
         match returned {
             PluginCall::Signature => {}
             PluginCall::CallInfo(_) => panic!("decoded into wrong value"),
+            PluginCall::CollapseCustomValue(_) => panic!("decoded into wrong value"),
         }
     }
 
@@ -290,6 +292,7 @@ mod tests {
                         }
                     });
             }
+            PluginCall::CollapseCustomValue(_) => panic!("returned wrong call type"),
         }
     }
 

--- a/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
+++ b/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
@@ -118,6 +118,7 @@ pub fn encode_response(
             let value_builder = builder.reborrow().init_value();
             value::serialize_value(val, value_builder);
         }
+        PluginResponse::PluginData(..) => todo!(),
     };
 
     serialize::write_message(writer, &message)
@@ -316,6 +317,7 @@ mod tests {
         match returned {
             PluginResponse::Error(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
             PluginResponse::Signature(returned_signature) => {
                 assert!(returned_signature.len() == 1);
                 assert_eq!(signature.name, returned_signature[0].name);
@@ -366,6 +368,7 @@ mod tests {
         match returned {
             PluginResponse::Error(_) => panic!("returned wrong call type"),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
             PluginResponse::Value(returned_value) => {
                 assert_eq!(&value, returned_value.as_ref())
             }
@@ -390,6 +393,7 @@ mod tests {
             PluginResponse::Error(msg) => assert_eq!(error, msg),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
         }
     }
 
@@ -411,6 +415,7 @@ mod tests {
             PluginResponse::Error(msg) => assert_eq!(error, msg),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
         }
     }
 }

--- a/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
+++ b/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
@@ -75,7 +75,7 @@ pub fn decode_call(reader: &mut impl std::io::BufRead) -> Result<PluginCall, She
                 .get_input()
                 .map_err(|e| ShellError::PluginFailedToDecode(e.to_string()))?;
 
-            let input = call_input::deserialize_call_input(input_reader, call.head)?;
+            let input = call_input::deserialize_call_input(input_reader)?;
 
             Ok(PluginCall::CallInfo(CallInfo {
                 name: name.to_string(),

--- a/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
+++ b/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
@@ -81,11 +81,11 @@ pub fn decode_call(reader: &mut impl std::io::BufRead) -> Result<PluginCall, She
 
             let input = value::deserialize_value(input_reader, call.head)?;
 
-            Ok(PluginCall::CallInfo(Box::new(CallInfo {
+            Ok(PluginCall::CallInfo(CallInfo {
                 name: name.to_string(),
                 call,
                 input: CallInput::Value(input),
-            })))
+            }))
         }
     }
 }
@@ -259,12 +259,12 @@ mod tests {
             )],
         };
 
-        let plugin_call = PluginCall::CallInfo(Box::new(CallInfo {
+        let plugin_call = PluginCall::CallInfo(CallInfo {
             name: name.clone(),
             call: call.clone(),
             // TODO: Make another test for callinfo_with_data_input test
             input: CallInput::Value(input.clone()),
-        }));
+        });
 
         let mut buffer: Vec<u8> = Vec::new();
         encode_call(&plugin_call, &mut buffer).expect("unable to serialize message");

--- a/crates/nu-plugin/src/serializers/capnp/plugin_data.rs
+++ b/crates/nu-plugin/src/serializers/capnp/plugin_data.rs
@@ -1,0 +1,79 @@
+use crate::{plugin_capnp::plugin_data, protocol::PluginData};
+use nu_protocol::{ShellError, Span};
+
+pub(crate) fn serialize_plugin_data(plugin_data: &PluginData, mut builder: plugin_data::Builder) {
+    builder.set_data(&plugin_data.data);
+
+    let mut span_builder = builder.init_span();
+    span_builder.set_start(plugin_data.span.start as u64);
+    span_builder.set_end(plugin_data.span.end as u64);
+}
+
+pub(crate) fn deserialize_plugin_data(
+    reader: plugin_data::Reader,
+) -> Result<PluginData, ShellError> {
+    let data = reader
+        .get_data()
+        .map_err(|e| ShellError::PluginFailedToDecode(e.to_string()))?;
+
+    let span_reader = reader
+        .get_span()
+        .map_err(|e| ShellError::PluginFailedToDecode(e.to_string()))?;
+
+    let span = Span {
+        start: span_reader.get_start() as usize,
+        end: span_reader.get_end() as usize,
+    };
+
+    Ok(PluginData {
+        data: data.to_vec(),
+        span,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use capnp::serialize;
+    use nu_protocol::Span;
+
+    pub fn write_buffer(
+        plugin_data: &PluginData,
+        writer: &mut impl std::io::Write,
+    ) -> Result<(), ShellError> {
+        let mut message = ::capnp::message::Builder::new_default();
+
+        let mut builder = message.init_root::<plugin_data::Builder>();
+
+        serialize_plugin_data(plugin_data, builder.reborrow());
+
+        serialize::write_message(writer, &message)
+            .map_err(|e| ShellError::PluginFailedToDecode(e.to_string()))
+    }
+
+    pub fn read_buffer(reader: &mut impl std::io::BufRead) -> Result<PluginData, ShellError> {
+        let message_reader =
+            serialize::read_message(reader, ::capnp::message::ReaderOptions::new()).unwrap();
+
+        let reader = message_reader
+            .get_root::<plugin_data::Reader>()
+            .map_err(|e| ShellError::PluginFailedToDecode(e.to_string()))?;
+
+        deserialize_plugin_data(reader.reborrow())
+    }
+
+    #[test]
+    fn plugin_data_round_trip() {
+        let plugin_data = PluginData {
+            data: vec![1, 2, 3, 4, 5, 6, 7],
+            span: Span { start: 1, end: 20 },
+        };
+
+        let mut buffer: Vec<u8> = Vec::new();
+        write_buffer(&plugin_data, &mut buffer).expect("unable to serialize message");
+        let returned_plugin_data =
+            read_buffer(&mut buffer.as_slice()).expect("unable to deserialize message");
+
+        assert_eq!(plugin_data, returned_plugin_data)
+    }
+}

--- a/crates/nu-plugin/src/serializers/capnp/schema/plugin.capnp
+++ b/crates/nu-plugin/src/serializers/capnp/schema/plugin.capnp
@@ -144,6 +144,7 @@ struct PluginCall {
 	union {
 		signature @0 :Void;
 		callInfo @1 :CallInfo;
+		collapseCustomValue @2 :PluginData;
 	}
 }
 

--- a/crates/nu-plugin/src/serializers/capnp/schema/plugin.capnp
+++ b/crates/nu-plugin/src/serializers/capnp/schema/plugin.capnp
@@ -121,10 +121,22 @@ struct EvaluatedCall {
 	named @2 :Map(Text, Value);
 }
 
+struct PluginData {
+	data @0 :Data;
+	span @1 :Span;
+}
+
+struct CallInput {
+	union {
+		value @0 :Value;
+		pluginData @1 :PluginData;
+	}
+}
+
 struct CallInfo {
 	name @0 :Text;
 	call @1 :EvaluatedCall;
-	input @2 :Value;
+	input @2 :CallInput;
 }
 
 # Main communication structs with the plugin

--- a/crates/nu-plugin/src/serializers/capnp/schema/plugin.capnp
+++ b/crates/nu-plugin/src/serializers/capnp/schema/plugin.capnp
@@ -153,6 +153,12 @@ struct PluginResponse {
 		error @0 :LabeledError;
 		signature @1 :List(Signature);
 		value @2 :Value;
+		pluginData @3 :PluginDataResponse;
+	}
+
+	struct PluginDataResponse {
+		name @0 :Text;
+		data @1 :PluginData;
 	}
 }
 

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -2,7 +2,7 @@ use nu_protocol::ShellError;
 
 use crate::{plugin::PluginEncoder, protocol::PluginResponse};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct JsonSerializer;
 
 impl PluginEncoder for JsonSerializer {

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -172,6 +172,7 @@ mod tests {
         match returned {
             PluginResponse::Error(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
             PluginResponse::Signature(returned_signature) => {
                 assert!(returned_signature.len() == 1);
                 assert_eq!(signature.name, returned_signature[0].name);
@@ -226,6 +227,7 @@ mod tests {
         match returned {
             PluginResponse::Error(_) => panic!("returned wrong call type"),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
             PluginResponse::Value(returned_value) => {
                 assert_eq!(&value, returned_value.as_ref())
             }
@@ -254,6 +256,7 @@ mod tests {
             PluginResponse::Error(msg) => assert_eq!(error, msg),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
         }
     }
 
@@ -279,6 +282,7 @@ mod tests {
             PluginResponse::Error(msg) => assert_eq!(error, msg),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
         }
     }
 }

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -63,6 +63,7 @@ mod tests {
         match returned {
             PluginCall::Signature => {}
             PluginCall::CallInfo(_) => panic!("decoded into wrong value"),
+            PluginCall::CollapseCustomValue(_) => panic!("decoded into wrong value"),
         }
     }
 
@@ -141,6 +142,7 @@ mod tests {
                         }
                     });
             }
+            PluginCall::CollapseCustomValue(_) => panic!("returned wrong call type"),
         }
     }
 

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -44,7 +44,9 @@ impl PluginEncoder for JsonSerializer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{CallInfo, EvaluatedCall, LabeledError, PluginCall, PluginResponse};
+    use crate::protocol::{
+        CallInfo, CallInput, EvaluatedCall, LabeledError, PluginCall, PluginResponse,
+    };
     use nu_protocol::{Signature, Span, Spanned, SyntaxShape, Value};
 
     #[test]
@@ -103,7 +105,8 @@ mod tests {
         let plugin_call = PluginCall::CallInfo(Box::new(CallInfo {
             name: name.clone(),
             call: call.clone(),
-            input: input.clone(),
+            // TODO: Make another test for callinfo_with_data_input test
+            input: CallInput::Value(input.clone()),
         }));
 
         let encoder = JsonSerializer {};
@@ -119,7 +122,7 @@ mod tests {
             PluginCall::Signature => panic!("returned wrong call type"),
             PluginCall::CallInfo(call_info) => {
                 assert_eq!(name, call_info.name);
-                assert_eq!(input, call_info.input);
+                assert_eq!(CallInput::Value(input), call_info.input);
                 assert_eq!(call.head, call_info.call.head);
                 assert_eq!(call.positional.len(), call_info.call.positional.len());
 

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -102,12 +102,12 @@ mod tests {
             )],
         };
 
-        let plugin_call = PluginCall::CallInfo(Box::new(CallInfo {
+        let plugin_call = PluginCall::CallInfo(CallInfo {
             name: name.clone(),
             call: call.clone(),
             // TODO: Make another test for callinfo_with_data_input test
             input: CallInput::Value(input.clone()),
-        }));
+        });
 
         let encoder = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 pub mod capnp;
 pub mod json;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum EncodingType {
     Capnp(capnp::CapnpSerializer),
     Json(json::JsonSerializer),

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 nu-plugin = { path = "../nu-plugin", version = "0.65.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.65.1", features = ["plugin"] }
 serde = { version = "1.0", features = ["derive"] }
+typetag = "0.1.8"

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nu_plugin_custom_values"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 nu-plugin = { path = "../nu-plugin", version = "0.65.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.65.1", features = ["plugin"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nu-plugin = { path = "../nu-plugin", version = "0.65.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.65.1", features = ["plugin"] }

--- a/crates/nu_plugin_custom_values/src/cool_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/cool_custom_value.rs
@@ -1,0 +1,54 @@
+use nu_protocol::{CustomValue, ShellError, Span, Value};
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CoolCustomValue {
+    cool: String,
+}
+
+impl CoolCustomValue {
+    pub fn new(content: &str) -> Self {
+        Self {
+            cool: content.to_owned(),
+        }
+    }
+
+    pub fn into_value(self, span: Span) -> Value {
+        Value::CustomValue {
+            val: Box::new(self),
+            span,
+        }
+    }
+}
+
+impl CustomValue for CoolCustomValue {
+    fn clone_value(&self, span: nu_protocol::Span) -> Value {
+        Value::CustomValue {
+            val: Box::new(self.clone()),
+            span,
+        }
+    }
+
+    fn value_string(&self) -> String {
+        self.typetag_name().to_string()
+    }
+
+    fn to_base_value(&self, span: nu_protocol::Span) -> Result<Value, ShellError> {
+        Ok(Value::String {
+            val: format!("I used to be a custom value! My data was ({})", self.cool),
+            span,
+        })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn typetag_name(&self) -> &'static str {
+        "FirestoreDatabase"
+    }
+
+    fn typetag_deserialize(&self) {
+        unimplemented!("typetag_deserialize")
+    }
+}

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -1,3 +1,6 @@
+mod cool_custom_value;
+
+use cool_custom_value::CoolCustomValue;
 use nu_plugin::{serve_plugin, JsonSerializer, Plugin};
 use nu_plugin::{EvaluatedCall, LabeledError};
 use nu_protocol::{Category, Signature, Value};
@@ -35,8 +38,8 @@ impl Plugin for CustomValuePlugin {
 }
 
 impl CustomValuePlugin {
-    fn generate(&mut self, _call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
-        todo!()
+    fn generate(&mut self, call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
+        Ok(CoolCustomValue::new("abc").into_value(call.head))
     }
 
     fn update(&mut self, _call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -1,3 +1,49 @@
+use nu_plugin::{serve_plugin, JsonSerializer, Plugin};
+use nu_plugin::{EvaluatedCall, LabeledError};
+use nu_protocol::{Category, Signature, Value};
+
+struct CustomValuePlugin;
+
+impl Plugin for CustomValuePlugin {
+    fn signature(&self) -> Vec<nu_protocol::Signature> {
+        vec![
+            Signature::build("custom-value generate")
+                .usage("Signature for a plugin that generates a custom value")
+                .category(Category::Experimental),
+            Signature::build("custom-value update")
+                .usage("Signature for a plugin that updates a custom value")
+                .category(Category::Experimental),
+        ]
+    }
+
+    fn run(
+        &mut self,
+        name: &str,
+        call: &EvaluatedCall,
+        input: &Value,
+    ) -> Result<Value, LabeledError> {
+        match name {
+            "custom-value generate" => self.generate(call, input),
+            "custom-value update" => self.update(call, input),
+            _ => Err(LabeledError {
+                label: "Plugin call with wrong name signature".into(),
+                msg: "the signature used to call the plugin does not match any name in the plugin signature vector".into(),
+                span: Some(call.head),
+            }),
+        }
+    }
+}
+
+impl CustomValuePlugin {
+    fn generate(&mut self, _call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
+        todo!()
+    }
+
+    fn update(&mut self, _call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
+        todo!()
+    }
+}
+
 fn main() {
-    println!("Hello, world!");
+    serve_plugin(&mut CustomValuePlugin, JsonSerializer {})
 }

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -2,7 +2,7 @@ mod cool_custom_value;
 mod second_custom_value;
 
 use cool_custom_value::CoolCustomValue;
-use nu_plugin::{serve_plugin, JsonSerializer, Plugin};
+use nu_plugin::{serve_plugin, CapnpSerializer, Plugin};
 use nu_plugin::{EvaluatedCall, LabeledError};
 use nu_protocol::{Category, ShellError, Signature, Value};
 use second_custom_value::SecondCustomValue;
@@ -74,5 +74,5 @@ impl CustomValuePlugin {
 }
 
 fn main() {
-    serve_plugin(&mut CustomValuePlugin, JsonSerializer {})
+    serve_plugin(&mut CustomValuePlugin, CapnpSerializer {})
 }

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -42,8 +42,12 @@ impl CustomValuePlugin {
         Ok(CoolCustomValue::new("abc").into_value(call.head))
     }
 
-    fn update(&mut self, _call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
-        todo!()
+    fn update(&mut self, call: &EvaluatedCall, input: &Value) -> Result<Value, LabeledError> {
+        let mut cool = CoolCustomValue::try_from_value(input)?;
+
+        cool.cool += "xyz";
+
+        Ok(cool.into_value(call.head))
     }
 }
 

--- a/crates/nu_plugin_custom_values/src/second_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/second_custom_value.rs
@@ -1,0 +1,70 @@
+use nu_protocol::{CustomValue, ShellError, Span, Value};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SecondCustomValue {
+    pub(crate) something: String,
+}
+
+impl SecondCustomValue {
+    pub fn new(content: &str) -> Self {
+        Self {
+            something: content.to_owned(),
+        }
+    }
+
+    pub fn into_value(self, span: Span) -> Value {
+        Value::CustomValue {
+            val: Box::new(self),
+            span,
+        }
+    }
+
+    pub fn try_from_value(value: &Value) -> Result<Self, ShellError> {
+        match value {
+            Value::CustomValue { val, span } => match val.as_any().downcast_ref::<Self>() {
+                Some(value) => Ok(value.clone()),
+                None => Err(ShellError::CantConvert(
+                    "cool".into(),
+                    "non-cool".into(),
+                    *span,
+                    None,
+                )),
+            },
+            x => Err(ShellError::CantConvert(
+                "cool".into(),
+                x.get_type().to_string(),
+                x.span()?,
+                None,
+            )),
+        }
+    }
+}
+
+#[typetag::serde]
+impl CustomValue for SecondCustomValue {
+    fn clone_value(&self, span: nu_protocol::Span) -> Value {
+        Value::CustomValue {
+            val: Box::new(self.clone()),
+            span,
+        }
+    }
+
+    fn value_string(&self) -> String {
+        self.typetag_name().to_string()
+    }
+
+    fn to_base_value(&self, span: nu_protocol::Span) -> Result<Value, ShellError> {
+        Ok(Value::String {
+            val: format!(
+                "I used to be a DIFFERENT custom value! ({})",
+                self.something
+            ),
+            span,
+        })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -26,6 +26,20 @@ fn can_get_custom_value_from_plugin_and_pass_it_over() {
 }
 
 #[test]
+fn can_generate_and_updated_multiple_types_of_custom_values() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("json", "nu_plugin_custom_values"),
+        "custom-value generate2 | custom-value update"
+    );
+
+    assert_eq!(
+        actual.out,
+        "I used to be a DIFFERENT custom value! (xyzabc)"
+    );
+}
+
+#[test]
 fn can_get_describe_plugin_custom_values() {
     let actual = nu_with_plugins!(
         cwd: "tests",

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -1,0 +1,12 @@
+use nu_test_support::nu_with_plugins;
+
+#[test]
+fn can_get_custom_value_from_plugin_and_instantly_collapse_it() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("json", "nu_plugin_custom_values"),
+        "custom-value generate"
+    );
+
+    assert_eq!(actual.out, "I used to be a custom value! My data was (abc)");
+}

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu_with_plugins;
 fn can_get_custom_value_from_plugin_and_instantly_collapse_it() {
     let actual = nu_with_plugins!(
         cwd: "tests",
-        plugin: ("json", "nu_plugin_custom_values"),
+        plugin: ("capnp", "nu_plugin_custom_values"),
         "custom-value generate"
     );
 
@@ -15,7 +15,7 @@ fn can_get_custom_value_from_plugin_and_instantly_collapse_it() {
 fn can_get_custom_value_from_plugin_and_pass_it_over() {
     let actual = nu_with_plugins!(
         cwd: "tests",
-        plugin: ("json", "nu_plugin_custom_values"),
+        plugin: ("capnp", "nu_plugin_custom_values"),
         "custom-value generate | custom-value update"
     );
 
@@ -29,7 +29,7 @@ fn can_get_custom_value_from_plugin_and_pass_it_over() {
 fn can_generate_and_updated_multiple_types_of_custom_values() {
     let actual = nu_with_plugins!(
         cwd: "tests",
-        plugin: ("json", "nu_plugin_custom_values"),
+        plugin: ("capnp", "nu_plugin_custom_values"),
         "custom-value generate2 | custom-value update"
     );
 
@@ -43,7 +43,7 @@ fn can_generate_and_updated_multiple_types_of_custom_values() {
 fn can_get_describe_plugin_custom_values() {
     let actual = nu_with_plugins!(
         cwd: "tests",
-        plugin: ("json", "nu_plugin_custom_values"),
+        plugin: ("capnp", "nu_plugin_custom_values"),
         "custom-value generate | describe"
     );
 

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -10,3 +10,17 @@ fn can_get_custom_value_from_plugin_and_instantly_collapse_it() {
 
     assert_eq!(actual.out, "I used to be a custom value! My data was (abc)");
 }
+
+#[test]
+fn can_get_custom_value_from_plugin_and_pass_it_over() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("json", "nu_plugin_custom_values"),
+        "custom-value generate | custom-value update"
+    );
+
+    assert_eq!(
+        actual.out,
+        "I used to be a custom value! My data was (abcxyz)"
+    );
+}

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -24,3 +24,14 @@ fn can_get_custom_value_from_plugin_and_pass_it_over() {
         "I used to be a custom value! My data was (abcxyz)"
     );
 }
+
+#[test]
+fn can_get_describe_plugin_custom_values() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("json", "nu_plugin_custom_values"),
+        "custom-value generate | describe"
+    );
+
+    assert_eq!(actual.out, "CoolCustomValue");
+}

--- a/tests/plugins/mod.rs
+++ b/tests/plugins/mod.rs
@@ -1,1 +1,2 @@
 mod core_inc;
+mod custom_values;


### PR DESCRIPTION
# Description

See https://github.com/nushell/nushell/pull/6070#issuecomment-1193234554 for up to date status

Builds on top of https://github.com/nushell/nushell/pull/6064 and https://github.com/nushell/nushell/pull/6065 an initial vision of how support for CustomValues could be achieved in plugins
~~This is not complete and I am currently stuck on something that might require some shuffling of responsibility so I decided to make this draft PR to ask firstly if this direction makes sense, and if yes how can I resolve the following issue:~~

~~This PR adds a new variant to `PipelineData`: `PluginData`, the variant is meant to hold an opaque blob of data passed from a plugin, it's currently implemented as a `serde_json::Value` for the sake of debugging but switching over to `Vec<u8>` ought to be simple.~~
~~The idea behind adding the new variant is that the engine has two things it can potentially do with a bunch of `PluginData`:~~
1) ~~It can send it back to the plugin in a pipeline chain i.e: `custom-plugin abc | custom-plugin xyz` where the call to `xyz` would get back the exact `CustomValue` it passed to the engine~~
2) ~~It can _collapse_ the value if it needs to display it or pass it to a non-plugin. Collapsing is done by calling the plugin and asking it to return back a non-`CustomValue`~~

~~Sending back is easy and already added in this PR (though not fully tested yet). Meanwhile the value collapsing plugin infrastructure is already in place but _calling_ that infrastructure is proving to be tricky, because the places where it needs to be called are `PipelineData` methods; `PipelineData` is defined in `nu-protocol` which is depended upon by `nu-plugin`, so we can't depend on `nu-plugin` from `nu-protocol` because that would cause a cyclic dependency 😞 ~~

~~Not sure what direction to go from here, or if this direction is a bad idea in first place. Theoretically if one were to merge `nu-protocol` and `nu-plugin` this ought to work, but I don't think that's very reasonable and I would need the team's approval. Maybe there's something much easier that I am missing, please do point it out if so!~~

cc @elferherrera 