### PR TITLE
add config option to limit external command completions

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -43,20 +43,21 @@ impl CommandCompletion {
 
                     if let Ok(mut contents) = std::fs::read_dir(path) {
                         while let Some(Ok(item)) = contents.next() {
-                            if executables.len() < self.engine_state.config.max_external_command_completions as usize
-                            && !executables.contains(
-                                &item
-                                    .path()
-                                    .file_name()
-                                    .map(|x| x.to_string_lossy().to_string())
-                                    .unwrap_or_default(),
-                            ) && matches!(
-                                item.path()
-                                    .file_name()
-                                    .map(|x| match_algorithm
+                            if executables.len()
+                                < self.engine_state.config.max_external_command_completions as usize
+                                && !executables.contains(
+                                    &item
+                                        .path()
+                                        .file_name()
+                                        .map(|x| x.to_string_lossy().to_string())
+                                        .unwrap_or_default(),
+                                )
+                                && matches!(
+                                    item.path().file_name().map(|x| match_algorithm
                                         .matches_str(&x.to_string_lossy(), prefix)),
-                                Some(true)
-                            ) && is_executable::is_executable(&item.path())
+                                    Some(true)
+                                )
+                                && is_executable::is_executable(&item.path())
                             {
                                 if let Ok(name) = item.file_name().into_string() {
                                     executables.push(name);

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -43,7 +43,8 @@ impl CommandCompletion {
 
                     if let Ok(mut contents) = std::fs::read_dir(path) {
                         while let Some(Ok(item)) = contents.next() {
-                            if !executables.contains(
+                            if executables.len() < self.engine_state.config.max_external_command_completions as usize
+                            && !executables.contains(
                                 &item
                                     .path()
                                     .file_name()

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -43,7 +43,7 @@ impl CommandCompletion {
 
                     if let Ok(mut contents) = std::fs::read_dir(path) {
                         while let Some(Ok(item)) = contents.next() {
-                            if self.engine_state.config.max_external_command_completions
+                            if self.engine_state.config.max_external_completion_results
                                 > executables.len() as i64
                                 && !executables.contains(
                                     &item

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -43,8 +43,8 @@ impl CommandCompletion {
 
                     if let Ok(mut contents) = std::fs::read_dir(path) {
                         while let Some(Ok(item)) = contents.next() {
-                            if executables.len()
-                                < self.engine_state.config.max_external_command_completions as usize
+                            if self.engine_state.config.max_external_command_completions
+                                > executables.len() as i64
                                 && !executables.contains(
                                     &item
                                         .path()

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -59,7 +59,7 @@ pub struct Config {
     pub use_grid_icons: bool,
     pub footer_mode: FooterMode,
     pub float_precision: i64,
-    pub max_external_command_completions: i64,
+    pub max_external_completion_results: i64,
     pub filesize_format: String,
     pub use_ansi_coloring: bool,
     pub quick_completions: bool,
@@ -93,7 +93,7 @@ impl Default for Config {
             use_grid_icons: false,
             footer_mode: FooterMode::RowCount(25),
             float_precision: 4,
-            max_external_command_completions: 100,
+            max_external_completion_results: 100,
             filesize_format: "auto".into(),
             use_ansi_coloring: true,
             quick_completions: true,
@@ -251,11 +251,11 @@ impl Value {
                             eprintln!("$config.partial_completions is not a bool")
                         }
                     }
-                    "max_external_completions" => {
+                    "max_external_completion_results" => {
                         if let Ok(i) = value.as_integer() {
-                            config.max_external_command_completions = i;
+                            config.max_external_completion_results = i;
                         } else {
-                            eprintln!("$config.max_external_command_completions is not an integer")
+                            eprintln!("$config.max_external_completion_results is not an integer")
                         }
                     }
                     "completion_algorithm" => {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -253,8 +253,8 @@ impl Value {
                     }
                     "max_external_command_completions" => {
                         if let Ok(i) = value.as_integer() {
-                            config.max_external_command_completions= i;
-                        } else { 
+                            config.max_external_command_completions = i;
+                        } else {
                             eprintln!("$config.max_external_command_completions is not an integer")
                         }
                     }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -251,7 +251,7 @@ impl Value {
                             eprintln!("$config.partial_completions is not a bool")
                         }
                     }
-                    "max_external_command_completions" => {
+                    "max_external_completions" => {
                         if let Ok(i) = value.as_integer() {
                             config.max_external_command_completions = i;
                         } else {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -59,6 +59,7 @@ pub struct Config {
     pub use_grid_icons: bool,
     pub footer_mode: FooterMode,
     pub float_precision: i64,
+    pub max_external_command_completions: i64,
     pub filesize_format: String,
     pub use_ansi_coloring: bool,
     pub quick_completions: bool,
@@ -92,6 +93,7 @@ impl Default for Config {
             use_grid_icons: false,
             footer_mode: FooterMode::RowCount(25),
             float_precision: 4,
+            max_external_command_completions: 100,
             filesize_format: "auto".into(),
             use_ansi_coloring: true,
             quick_completions: true,
@@ -247,6 +249,13 @@ impl Value {
                             config.partial_completions = b;
                         } else {
                             eprintln!("$config.partial_completions is not a bool")
+                        }
+                    }
+                    "max_external_command_completions" => {
+                        if let Ok(i) = value.as_integer() {
+                            config.max_external_command_completions= i;
+                        } else { 
+                            eprintln!("$config.max_external_command_completions is not an integer")
                         }
                     }
                     "completion_algorithm" => {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -256,6 +256,7 @@ let-env config = {
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   case_sensitive_completions: false # set to true to enable case-sensitive completions
   enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
+  max_external_command_completions: 100
 
   # A strategy of managing table view in case of limited space.
   table_trim: {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -256,7 +256,7 @@ let-env config = {
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   case_sensitive_completions: false # set to true to enable case-sensitive completions
   enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
-  max_external_completions: 100 # setting it lower can improve completion performance at the cost of omitting some options
+  max_external_completion_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
 
   # A strategy of managing table view in case of limited space.
   table_trim: {

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -256,7 +256,7 @@ let-env config = {
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   case_sensitive_completions: false # set to true to enable case-sensitive completions
   enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
-  max_external_command_completions: 100
+  max_external_completions: 100 # setting it lower can improve completion performance at the cost of omitting some options
 
   # A strategy of managing table view in case of limited space.
   table_trim: {


### PR DESCRIPTION
# Description

For increased configurability. No related issue, just something I like.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

I'm not sure how to test this change, so... just use it?

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
