### PR TITLE
Placeholder for plugin data

### DIFF
--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -1,10 +1,10 @@
 mod plugin;
 mod protocol;
-mod serializers;
+pub mod serializers;
 
 #[allow(dead_code)]
 mod plugin_capnp;
 
-pub use plugin::{get_signature, serve_plugin, Plugin, PluginDeclaration};
+pub use plugin::{get_signature, plugin_data::PluginData, serve_plugin, Plugin, PluginDeclaration};
 pub use protocol::{EvaluatedCall, LabeledError};
 pub use serializers::{capnp::CapnpSerializer, json::JsonSerializer, EncodingType};

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -1,6 +1,6 @@
 mod plugin;
 mod protocol;
-pub mod serializers;
+mod serializers;
 
 #[allow(dead_code)]
 mod plugin_capnp;

--- a/crates/nu-plugin/src/plugin/plugin_data.rs
+++ b/crates/nu-plugin/src/plugin/plugin_data.rs
@@ -1,0 +1,90 @@
+use nu_protocol::{CustomValue, ShellError, Span, Value};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PluginData {
+    data: Vec<u8>,
+}
+
+impl PluginData {
+    pub fn new(data: Vec<u8>) -> Self {
+        Self { data }
+    }
+
+    pub fn into_value(self, span: Span) -> Value {
+        Value::CustomValue {
+            val: Box::new(self),
+            span,
+        }
+    }
+
+    pub fn into_data(self) -> Vec<u8> {
+        self.data
+    }
+
+    pub fn can_downcast(value: &Value) -> bool {
+        if let Value::CustomValue { val, .. } = value {
+            val.as_any().downcast_ref::<Self>().is_some()
+        } else {
+            false
+        }
+    }
+
+    pub fn try_from_value(value: Value) -> Result<Self, ShellError> {
+        match value {
+            Value::CustomValue { val, span } => match val.as_any().downcast_ref::<Self>() {
+                Some(data) => Ok(Self {
+                    data: data.data.clone(),
+                }),
+                None => Err(ShellError::CantConvert(
+                    "pipeline data".into(),
+                    "custom value".into(),
+                    span,
+                    None,
+                )),
+            },
+            x => Err(ShellError::CantConvert(
+                "pipeline data".into(),
+                x.get_type().to_string(),
+                x.span()?,
+                None,
+            )),
+        }
+    }
+}
+
+impl CustomValue for PluginData {
+    fn typetag_name(&self) -> &'static str {
+        "plugin data"
+    }
+
+    fn typetag_deserialize(&self) {
+        unimplemented!("typetag_deserialize")
+    }
+
+    fn clone_value(&self, span: Span) -> Value {
+        let cloned = Self {
+            data: self.data.clone(),
+        };
+
+        Value::CustomValue {
+            val: Box::new(cloned),
+            span,
+        }
+    }
+
+    fn value_string(&self) -> String {
+        self.typetag_name().to_string()
+    }
+
+    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+        Ok(Value::String {
+            val: "plugin data".into(),
+            span,
+        })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -8,7 +8,28 @@ use serde::{Deserialize, Serialize};
 pub struct CallInfo {
     pub name: String,
     pub call: EvaluatedCall,
-    pub input: Value,
+    pub input: CallInput,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum CallInput {
+    Value(Value),
+    Data(Vec<u8>),
+}
+
+impl CallInput {
+    pub fn into_value(self) -> Value {
+        match self {
+            Self::Value(value) => value,
+            Self::Data(_) => todo!(),
+        }
+    }
+}
+
+impl From<Value> for CallInput {
+    fn from(value: Value) -> Self {
+        CallInput::Value(value)
+    }
 }
 
 // Information sent to the plugin
@@ -88,4 +109,5 @@ pub enum PluginResponse {
     Error(LabeledError),
     Signature(Vec<Signature>),
     Value(Box<Value>),
+    PluginData(Vec<u8>),
 }

--- a/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
+++ b/crates/nu-plugin/src/serializers/capnp/plugin_call.rs
@@ -36,7 +36,8 @@ pub fn encode_call(
                 .get_input()
                 .map_err(|e| ShellError::PluginFailedToEncode(e.to_string()))?;
 
-            value::serialize_value(&call_info.input, value_builder);
+            let value = call_info.input.clone().into_value();
+            value::serialize_value(&value, value_builder);
         }
     };
 
@@ -79,7 +80,7 @@ pub fn decode_call(reader: &mut impl std::io::BufRead) -> Result<PluginCall, She
             Ok(PluginCall::CallInfo(Box::new(CallInfo {
                 name: name.to_string(),
                 call,
-                input,
+                input: input.into(),
             })))
         }
     }
@@ -118,6 +119,7 @@ pub fn encode_response(
             let value_builder = builder.reborrow().init_value();
             value::serialize_value(val, value_builder);
         }
+        _ => todo!(),
     };
 
     serialize::write_message(writer, &message)
@@ -202,7 +204,7 @@ pub fn decode_response(reader: &mut impl std::io::BufRead) -> Result<PluginRespo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{EvaluatedCall, LabeledError, PluginCall, PluginResponse};
+    use crate::protocol::{CallInput, EvaluatedCall, LabeledError, PluginCall, PluginResponse};
     use nu_protocol::{Signature, Span, Spanned, SyntaxShape, Value};
 
     #[test]
@@ -255,7 +257,7 @@ mod tests {
         let plugin_call = PluginCall::CallInfo(Box::new(CallInfo {
             name: name.clone(),
             call: call.clone(),
-            input: input.clone(),
+            input: input.clone().into(),
         }));
 
         let mut buffer: Vec<u8> = Vec::new();
@@ -266,7 +268,7 @@ mod tests {
             PluginCall::Signature => panic!("returned wrong call type"),
             PluginCall::CallInfo(call_info) => {
                 assert_eq!(name, call_info.name);
-                assert_eq!(input, call_info.input);
+                assert_eq!(CallInput::Value(input), call_info.input);
                 assert_eq!(call.head, call_info.call.head);
                 assert_eq!(call.positional.len(), call_info.call.positional.len());
 
@@ -346,6 +348,7 @@ mod tests {
                     returned_signature[0].rest_positional,
                 );
             }
+            _ => todo!(),
         }
     }
 
@@ -369,6 +372,7 @@ mod tests {
             PluginResponse::Value(returned_value) => {
                 assert_eq!(&value, returned_value.as_ref())
             }
+            _ => todo!(),
         }
     }
 
@@ -390,6 +394,7 @@ mod tests {
             PluginResponse::Error(msg) => assert_eq!(error, msg),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            _ => todo!(),
         }
     }
 
@@ -411,6 +416,7 @@ mod tests {
             PluginResponse::Error(msg) => assert_eq!(error, msg),
             PluginResponse::Signature(_) => panic!("returned wrong call type"),
             PluginResponse::Value(_) => panic!("returned wrong call type"),
+            _ => todo!(),
         }
     }
 }

--- a/crates/nu_plugin_example/src/example.rs
+++ b/crates/nu_plugin_example/src/example.rs
@@ -1,4 +1,4 @@
-use nu_plugin::{EvaluatedCall, LabeledError};
+use nu_plugin::{EvaluatedCall, LabeledError, PluginData};
 use nu_protocol::Value;
 pub struct Example;
 
@@ -90,5 +90,16 @@ impl Example {
             msg: "error message pointing to call head span".into(),
             span: Some(call.head),
         })
+    }
+
+    pub fn test4(&self, call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
+        let data = PluginData::new(vec![0, 0, 0, 1]);
+        Ok(data.into_value(call.head))
+    }
+
+    pub fn test5(&self, call: &EvaluatedCall, input: &Value) -> Result<Value, LabeledError> {
+        eprintln!("input: {:?}", input);
+
+        Ok(Value::Nothing { span: call.head })
     }
 }

--- a/crates/nu_plugin_example/src/main.rs
+++ b/crates/nu_plugin_example/src/main.rs
@@ -1,4 +1,4 @@
-use nu_plugin::{serve_plugin, CapnpSerializer};
+use nu_plugin::{serve_plugin, JsonSerializer};
 use nu_plugin_example::Example;
 
 fn main() {
@@ -6,7 +6,7 @@ fn main() {
     // used to encode and decode the messages. The available options are
     // CapnpSerializer and JsonSerializer. Both are defined in the serializer
     // folder in nu-plugin.
-    serve_plugin(&mut Example {}, CapnpSerializer {})
+    serve_plugin(&mut Example {}, JsonSerializer {})
 
     // Note
     // When creating plugins in other languages one needs to consider how a plugin

--- a/crates/nu_plugin_example/src/nu/mod.rs
+++ b/crates/nu_plugin_example/src/nu/mod.rs
@@ -35,6 +35,12 @@ impl Plugin for Example {
                 .named("named", SyntaxShape::String, "named string", Some('n'))
                 .rest("rest", SyntaxShape::String, "rest value string")
                 .category(Category::Experimental),
+            Signature::build("nu-example-4")
+                .usage("Signature test 4 for plugin. Returns plugin data")
+                .category(Category::Experimental),
+            Signature::build("nu-example-5")
+                .usage("Signature test 5 for plugin. Receives plugin data as input")
+                .category(Category::Experimental),
         ]
     }
 
@@ -49,6 +55,8 @@ impl Plugin for Example {
             "nu-example-1" => self.test1(call, input),
             "nu-example-2" => self.test2(call, input),
             "nu-example-3" => self.test3(call, input),
+            "nu-example-4" => self.test4(call, input),
+            "nu-example-5" => self.test5(call, input),
             _ => Err(LabeledError {
                 label: "Plugin call with wrong name signature".into(),
                 msg: "the signature used to call the plugin does not match any name in the plugin signature vector".into(),


### PR DESCRIPTION
Plugins don't have a way to store data than only they can understand. They are limited to the data values available in Nushell. This can be restricting since some plugins may want to use their own data structures to process.

The idea of this PR is to use CustomValue trait to create a PluginData type that can store raw data from a plugin. The data generated from the plugin is stored as a `Vec<u8>` which can be easily encoded/decoded by whatever framework a plugin wants to use. Nu will hold this data and pass it back to the plugin as a raw vector

The `nu_plugin_example` crate has two new functions that show how it can be used. The `nu-example-4` function creates a custom value and `nu-example-5` prints the value of the received custom value.

cc. @Mathspy have a look at this approach. It is less intrusive with nu_protocol and everything is concentrated in nu_plugin