### PR TITLE
`extern` command should be treated as external

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -142,7 +142,7 @@ fn help(
 
                 cols.push("is_custom".into());
                 vals.push(Value::Bool {
-                    val: decl.get_block_id().is_some(),
+                    val: decl.is_custom_command(),
                     span: head,
                 });
 
@@ -243,7 +243,7 @@ fn help(
 
                 cols.push("is_custom".into());
                 vals.push(Value::Bool {
-                    val: decl.get_block_id().is_some(),
+                    val: decl.is_custom_command(),
                     span: head,
                 });
 

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -95,7 +95,7 @@ fn get_entry_in_aliases(engine_state: &EngineState, name: &str, span: Span) -> O
 
 fn get_entry_in_commands(engine_state: &EngineState, name: &str, span: Span) -> Option<Value> {
     if let Some(decl_id) = engine_state.find_decl(name.as_bytes(), &[]) {
-        let (msg, is_builtin) = if engine_state.get_decl(decl_id).get_block_id().is_some() {
+        let (msg, is_builtin) = if engine_state.get_decl(decl_id).is_custom_command() {
             ("Nushell custom command", false)
         } else {
             ("Nushell built-in command", true)

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1056,7 +1056,7 @@ pub fn create_scope(
             cols.push("is_builtin".to_string());
             // we can only be a is_builtin or is_custom, not both
             vals.push(Value::Bool {
-                val: decl.get_block_id().is_none(),
+                val: !decl.is_custom_command(),
                 span,
             });
 
@@ -1074,7 +1074,7 @@ pub fn create_scope(
 
             cols.push("is_custom".to_string());
             vals.push(Value::Bool {
-                val: decl.get_block_id().is_some(),
+                val: decl.is_custom_command(),
                 span,
             });
 

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -30,6 +30,10 @@ impl Command for KnownExternal {
         true
     }
 
+    fn is_builtin(&self) -> bool {
+        false
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1079,26 +1079,32 @@ pub fn parse_call(
             }
         }
 
-        trace!("parsing: internal call");
+        let decl = working_set.get_decl(decl_id);
+        if decl.is_builtin() {
+            trace!("parsing: internal call");
 
-        // parse internal command
-        let parsed_call = parse_internal_call(
-            working_set,
-            span(&spans[cmd_start..pos]),
-            &spans[pos..],
-            decl_id,
-            expand_aliases_denylist,
-        );
+            // parse internal command
+            let parsed_call = parse_internal_call(
+                working_set,
+                span(&spans[cmd_start..pos]),
+                &spans[pos..],
+                decl_id,
+                expand_aliases_denylist,
+            );
 
-        (
-            Expression {
-                expr: Expr::Call(parsed_call.call),
-                span: span(spans),
-                ty: parsed_call.output,
-                custom_completion: None,
-            },
-            parsed_call.error,
-        )
+            (
+                Expression {
+                    expr: Expr::Call(parsed_call.call),
+                    span: span(spans),
+                    ty: parsed_call.output,
+                    custom_completion: None,
+                },
+                parsed_call.error,
+            )
+        } else {
+            trace!("parsing: `extern` custom command as external call");
+            parse_external_call(working_set, spans, expand_aliases_denylist)
+        }
     } else {
         // We might be parsing left-unbounded range ("..10")
         let bytes = working_set.get_span_contents(spans[0]);

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -37,6 +37,16 @@ pub trait Command: Send + Sync + CommandClone {
         false
     }
 
+    // This is an enhanced method to determine if a command is custom command or not
+    // since extern "foo" [] and def "foo" [] behaves differently
+    fn is_custom_command(&self) -> bool {
+        if self.get_block_id().is_some() {
+            true
+        } else {
+            self.is_known_external()
+        }
+    }
+
     // Is a sub command
     fn is_sub(&self) -> bool {
         self.name().contains(' ')

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -12,7 +12,23 @@ fn known_external_runs() -> TestResult {
 fn known_external_unknown_flag() -> TestResult {
     fail_test(
         r#"extern "cargo version" []; cargo version --no-such-flag"#,
-        "command doesn't have flag",
+        "Found argument '--no-such-flag' which wasn't expected, or isn't valid in this context",
+    )
+}
+
+#[test]
+fn known_external_not_defined_flag() -> TestResult {
+    run_test_contains(
+        r#"extern "cargo version" []; cargo version --help"#,
+        "Show version information",
+    )
+}
+
+#[test]
+fn known_external_is_custom() -> TestResult {
+    run_test_contains(
+        r#"extern "cargo version" []; help commands | where is_custom == true | get name"#,
+        "cargo version",
     )
 }
 


### PR DESCRIPTION
# Description

Giving the recent issue tickets, users have been getting confused with `extern` custom command, this pr is trying to make `extern` working as external command from parser, say you defined a custom command mentioned in #6020(And many more similar issues), when you run `npm`, nu will tell you the positional arg is missing, this could be annoying because `extern` should be run as external command without overhead

---

Also, this pr tries to tweak how nu currently identifies a command as `is_custom` or not: The current logic is to  only check `get_block_id()`, however, `KnownExternal` uses the default implementation which returns `None`. 

The fix is to combine `get_block_id` and `is_known_external` 

## Demo and Screenshots with PR change

![image](https://user-images.githubusercontent.com/85712372/179842475-adc8ed9e-ebae-4a58-9498-4779d0dcd332.png)

![Extern](https://user-images.githubusercontent.com/85712372/179842687-d4169e12-1d8f-4d01-9f34-cf16b149da9c.gif)


# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
