### PR TITLE
add more shell integration ansi escapes in support of vscode

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -15,6 +15,10 @@ pub(crate) const PROMPT_INDICATOR: &str = "PROMPT_INDICATOR";
 pub(crate) const PROMPT_INDICATOR_VI_INSERT: &str = "PROMPT_INDICATOR_VI_INSERT";
 pub(crate) const PROMPT_INDICATOR_VI_NORMAL: &str = "PROMPT_INDICATOR_VI_NORMAL";
 pub(crate) const PROMPT_MULTILINE_INDICATOR: &str = "PROMPT_MULTILINE_INDICATOR";
+// According to Daniel Imms @Tyriar, we need to do these this way:
+// <133 A><prompt><133 B><command><133 C><command output>
+const PRE_PROMPT_MARKER: &str = "\x1b]133;A\x1b\\";
+const POST_PROMPT_MARKER: &str = "\x1b]133;B\x1b\\";
 
 fn get_prompt_string(
     prompt: &str,
@@ -97,6 +101,20 @@ pub(crate) fn update_prompt<'prompt>(
         &mut stack,
         is_perf_true,
     );
+
+    // Now that we have the prompt string lets ansify it.
+    // <133 A><prompt><133 B><command><133 C><command output>
+    let left_prompt_string = if config.shell_integration {
+        match left_prompt_string {
+            Some(prompt_string) => Some(format!(
+                "{}{}{}",
+                PRE_PROMPT_MARKER, prompt_string, POST_PROMPT_MARKER
+            )),
+            None => left_prompt_string,
+        }
+    } else {
+        left_prompt_string
+    };
 
     let right_prompt_string = get_prompt_string(
         PROMPT_COMMAND_RIGHT,

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -425,19 +425,19 @@ pub fn evaluate_repl(
                 }
 
                 if shell_integration {
-                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
+                    run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
                 }
             }
             Ok(Signal::CtrlC) => {
                 // `Reedline` clears the line content. New prompt is shown
                 if shell_integration {
-                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
+                    run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
                 }
             }
             Ok(Signal::CtrlD) => {
                 // When exiting clear to a new line
                 if shell_integration {
-                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
+                    run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
                 }
                 println!();
                 break;
@@ -448,7 +448,7 @@ pub fn evaluate_repl(
                     println!("Error: {:?}", err);
                 }
                 if shell_integration {
-                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
+                    run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
                 }
             }
         }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -22,9 +22,14 @@ use std::io::{self, Write};
 use std::{sync::atomic::Ordering, time::Instant};
 use sysinfo::SystemExt;
 
-const PRE_PROMPT_MARKER: &str = "\x1b]133;A\x1b\\";
+// According to Daniel Imms @Tyriar, we need to do these this way:
+// <133 A><prompt><133 B><command><133 C><command output>
+// These first two have been moved to prompt_update to get as close as possible to the prompt.
+// const PRE_PROMPT_MARKER: &str = "\x1b]133;A\x1b\\";
+// const POST_PROMPT_MARKER: &str = "\x1b]133;B\x1b\\";
 const PRE_EXECUTE_MARKER: &str = "\x1b]133;C\x1b\\";
-const CMD_FINISHED_MARKER: &str = "\x1b]133;D\x1b\\";
+// This one is in get_command_finished_marker() now so we can capture the exit codes properly.
+// const CMD_FINISHED_MARKER: &str = "\x1b]133;D;{}\x1b\\";
 const RESET_APPLICATION_MODE: &str = "\x1b[?1l";
 
 pub fn evaluate_repl(
@@ -262,12 +267,6 @@ pub fn evaluate_repl(
         }
 
         let config = engine_state.get_config();
-
-        let shell_integration = config.shell_integration;
-        if shell_integration {
-            run_ansi_sequence(PRE_PROMPT_MARKER)?;
-        }
-
         let prompt =
             prompt_update::update_prompt(config, engine_state, stack, &mut nu_prompt, is_perf_true);
 
@@ -283,6 +282,7 @@ pub fn evaluate_repl(
         }
 
         let input = line_editor.read_line(prompt);
+        let shell_integration = config.shell_integration;
 
         match input {
             Ok(Signal::Success(s)) => {
@@ -425,20 +425,19 @@ pub fn evaluate_repl(
                 }
 
                 if shell_integration {
-                    // FIXME: use variant with exit code, if apropriate
-                    run_ansi_sequence(CMD_FINISHED_MARKER)?;
+                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
                 }
             }
             Ok(Signal::CtrlC) => {
                 // `Reedline` clears the line content. New prompt is shown
                 if shell_integration {
-                    run_ansi_sequence(CMD_FINISHED_MARKER)?;
+                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
                 }
             }
             Ok(Signal::CtrlD) => {
                 // When exiting clear to a new line
                 if shell_integration {
-                    run_ansi_sequence(CMD_FINISHED_MARKER)?;
+                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
                 }
                 println!();
                 break;
@@ -449,13 +448,21 @@ pub fn evaluate_repl(
                     println!("Error: {:?}", err);
                 }
                 if shell_integration {
-                    run_ansi_sequence(CMD_FINISHED_MARKER)?;
+                    run_ansi_sequence(&get_command_finished_marker(&stack, &engine_state))?;
                 }
             }
         }
     }
 
     Ok(())
+}
+
+pub fn get_command_finished_marker(stack: &Stack, engine_state: &EngineState) -> String {
+    let exit_code = stack
+        .get_env_var(engine_state, "LAST_EXIT_CODE")
+        .and_then(|e| e.as_i64().ok());
+
+    format!("\x1b]133;D;{}\x1b\\", exit_code.unwrap_or(0))
 }
 
 pub fn eval_env_change_hook(


### PR DESCRIPTION
# Description

This PR supports more shell integration ansi escapes so we can see little blue, gray, red dots in vscode's terminal.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
