### PR TITLE
Prevents panic when parsing JSON containing large number

### DIFF
--- a/crates/nu-json/src/util.rs
+++ b/crates/nu-json/src/util.rs
@@ -212,10 +212,8 @@ impl<Iter: Iterator<Item = u8>> ParseNumber<Iter> {
                                 if let Ok(n) = res.parse::<i64>() {
                                     return Ok(Number::I64(n));
                                 }
-                            } else {
-                                if let Ok(n) = res.parse::<u64>() {
-                                    return Ok(Number::U64(n));
-                                }
+                            } else if let Ok(n) = res.parse::<u64>() {
+                                return Ok(Number::U64(n));
                             }
                         }
 

--- a/crates/nu-json/src/util.rs
+++ b/crates/nu-json/src/util.rs
@@ -208,11 +208,14 @@ impl<Iter: Iterator<Item = u8>> ParseNumber<Iter> {
                         }
 
                         if !is_float {
-                            if let Ok(n) = res.parse::<i64>() {
-                                if res.starts_with('-') {
+                            if res.starts_with('-') {
+                                if let Ok(n) = res.parse::<i64>() {
                                     return Ok(Number::I64(n));
-                                } else {
-                                    return Ok(Number::U64(n as u64));
+                                }
+                            }
+                            else {
+                                if let Ok(n) = res.parse::<u64>() {
+                                    return Ok(Number::U64(n));
                                 }
                             }
                         }

--- a/crates/nu-json/src/util.rs
+++ b/crates/nu-json/src/util.rs
@@ -1,8 +1,6 @@
 use std::io;
 use std::str;
 
-use num_traits::ToPrimitive;
-
 use super::error::{Error, ErrorCode, Result};
 
 pub struct StringReader<Iter: Iterator<Item = u8>> {
@@ -210,15 +208,15 @@ impl<Iter: Iterator<Item = u8>> ParseNumber<Iter> {
                         }
 
                         if !is_float {
-                            if let Ok(n) = res.parse::<i64>() { 
-                                if res.starts_with('-') { 
-                                    return Ok(Number::I64(n)); 
-                                } else { 
-                                    return Ok(Number::U64(n as u64)); 
-                                } 
+                            if let Ok(n) = res.parse::<i64>() {
+                                if res.starts_with('-') {
+                                    return Ok(Number::I64(n));
+                                } else {
+                                    return Ok(Number::U64(n as u64));
+                                }
                             }
                         }
-                        
+
                         match res.parse::<f64>() {
                             Ok(n) => Ok(Number::F64(n)),
                             _ => Err(Error::Syntax(ErrorCode::InvalidNumber, 0, 0)),

--- a/crates/nu-json/src/util.rs
+++ b/crates/nu-json/src/util.rs
@@ -212,8 +212,7 @@ impl<Iter: Iterator<Item = u8>> ParseNumber<Iter> {
                                 if let Ok(n) = res.parse::<i64>() {
                                     return Ok(Number::I64(n));
                                 }
-                            }
-                            else {
+                            } else {
                                 if let Ok(n) = res.parse::<u64>() {
                                     return Ok(Number::U64(n));
                                 }


### PR DESCRIPTION
# Description

Fixes #5907... hopefully.

@jntrnr suggested reading the numbers as f64 and then attempting a conversion to int if it works. This PR tries to read it as I64/U64 first, and if that fails reads it and passes it as a float. It might not be ideal. 

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
