### PR TITLE
Allow multiple patterns in ls command

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -147,7 +147,8 @@ impl Command for Ls {
                         Some(glob_options)
                     };
                     let (prefix, paths) =
-                        nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options).expect("glob failure");
+                        nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options)
+                            .expect("glob failure");
 
                     let mut paths_peek = paths.peekable();
                     if paths_peek.peek().is_none() {
@@ -394,7 +395,7 @@ impl Command for Ls {
 
         Ok(glob_results
             .into_iter()
-            .filter(|result| !matches!(result, Value::Nothing{..}))
+            .filter(|result| !matches!(result, Value::Nothing { .. }))
             .into_pipeline_data_with_metadata(
                 PipelineMetadata {
                     data_source: DataSource::Ls,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -1,14 +1,16 @@
 use crate::DirBuilder;
 use crate::DirInfo;
 use chrono::{DateTime, Local, LocalResult, TimeZone, Utc};
+use itertools::Itertools;
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_glob::MatchOptions;
 use nu_path::expand_to_real_path;
+use nu_protocol::IntoPipelineData;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, DataSource, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
+    Category, DataSource, Example, IntoInterruptiblePipelineData, PipelineData,
     PipelineMetadata, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
 use pathdiff::diff_paths;
@@ -38,7 +40,7 @@ impl Command for Ls {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("ls")
             // Using a string instead of a glob pattern shape so it won't auto-expand
-            .optional("pattern", SyntaxShape::String, "the glob pattern to use")
+            .rest("pattern(s)", SyntaxShape::String, "the glob pattern(s) to use")
             .switch("all", "Show hidden files", Some('a'))
             .switch(
                 "long",
@@ -81,17 +83,20 @@ impl Command for Ls {
         let call_span = call.head;
         let cwd = current_dir(engine_state, stack)?;
 
-        let pattern_arg: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
+        let mut shell_errors: Vec<ShellError> = vec![];
+        let pattern_args: Vec<Spanned<String>> = call.rest(engine_state, stack, 0)?;
+        let glob_results = if pattern_args.len() > 0 {
+            pattern_args.into_iter().flat_map(|pattern_arg| {
 
-        let (path, p_tag, absolute_path) = match pattern_arg {
-            Some(p) => {
-                let p_tag = p.span;
-                let mut p = expand_to_real_path(p.item);
+                let mut path = expand_to_real_path(pattern_arg.clone().item);
+                let p_tag = pattern_arg.clone().span;
+                let cwd = cwd.clone();
+                let ctrl_c = ctrl_c.clone();
 
-                let expanded = nu_path::expand_path_with(&p, &cwd);
+                let expanded = nu_path::expand_path_with(&path, &cwd);
                 // Avoid checking and pushing "*" to the path when directory (do not show contents) flag is true
                 if !directory && expanded.is_dir() {
-                    if permission_denied(&p) {
+                    if permission_denied(&path) {
                         #[cfg(unix)]
                         let error_msg = format!(
                             "The permissions of {:o} do not allow access for this user",
@@ -106,7 +111,7 @@ impl Command for Ls {
                         );
                         #[cfg(not(unix))]
                         let error_msg = String::from("Permission denied");
-                        return Err(ShellError::GenericError(
+                        shell_errors.push(ShellError::GenericError(
                             "Permission denied".to_string(),
                             error_msg,
                             Some(p_tag),
@@ -115,146 +120,270 @@ impl Command for Ls {
                         ));
                     }
                     if is_empty_dir(&expanded) {
-                        return Ok(Value::nothing(call_span).into_pipeline_data());
+                        return Vec::from([Value::nothing(call_span)]).into_iter();
                     }
-                    p.push("*");
+                    path.push("*");
                 }
-                let absolute_path = p.is_absolute();
-                (p, p_tag, absolute_path)
-            }
-            None => {
-                // Avoid pushing "*" to the default path when directory (do not show contents) flag is true
-                if directory {
-                    (PathBuf::from("."), call_span, false)
-                } else if is_empty_dir(current_dir(engine_state, stack)?) {
-                    return Ok(Value::nothing(call_span).into_pipeline_data());
+                
+                let absolute_path = path.is_absolute();
+
+                let hidden_dir_specified = is_hidden_dir(&path);
+
+                let glob_path = Spanned {
+                    item: path.display().to_string(),
+                    span: p_tag,
+                };
+
+                let glob_options = if all {
+                    None
                 } else {
-                    (PathBuf::from("./*"), call_span, false)
+                    let mut glob_options = MatchOptions::new();
+                    glob_options.recursive_match_hidden_dir = false;
+                    Some(glob_options)
+                };
+                let (prefix, paths) = nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options).unwrap();
+
+                let mut paths_peek = paths.peekable();
+                if paths_peek.peek().is_none() {
+                    shell_errors.push(ShellError::GenericError(
+                        format!("No matches found for {}", &path.display().to_string()),
+                        "".to_string(),
+                        None,
+                        Some("no matches found".to_string()),
+                        Vec::new(),
+                    ));
                 }
-            }
-        };
 
-        let hidden_dir_specified = is_hidden_dir(&path);
+                let mut hidden_dirs = vec![];
 
-        let glob_path = Spanned {
-            item: path.display().to_string(),
-            span: p_tag,
-        };
+                paths_peek
+                    .into_iter()
+                    .filter_map(move |x| match x {
+                        Ok(path) => {
+                            let metadata = match std::fs::symlink_metadata(&path) {
+                                Ok(metadata) => Some(metadata),
+                                Err(_) => None,
+                            };
+                            if path_contains_hidden_folder(&path, &hidden_dirs) {
+                                return None;
+                            }
 
-        let glob_options = if all {
-            None
-        } else {
-            let mut glob_options = MatchOptions::new();
-            glob_options.recursive_match_hidden_dir = false;
-            Some(glob_options)
-        };
-        let (prefix, paths) = nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options)?;
+                            if !all && !hidden_dir_specified && is_hidden_dir(&path) {
+                                if path.is_dir() {
+                                    hidden_dirs.push(path);
+                                }
+                                return None;
+                            }
 
-        let mut paths_peek = paths.peekable();
-        if paths_peek.peek().is_none() {
-            return Err(ShellError::GenericError(
-                format!("No matches found for {}", &path.display().to_string()),
-                "".to_string(),
-                None,
-                Some("no matches found".to_string()),
-                Vec::new(),
-            ));
-        }
+                            let display_name = if short_names {
+                                path.file_name().map(|os| os.to_string_lossy().to_string())
+                            } else if full_paths || absolute_path {
+                                Some(path.to_string_lossy().to_string())
+                            } else if let Some(prefix) = &prefix {
+                                if let Ok(remainder) = path.strip_prefix(&prefix) {
+                                    if directory {
+                                        // When the path is the same as the cwd, path_diff should be "."
+                                        let path_diff =
+                                            if let Some(path_diff_not_dot) = diff_paths(&path, &cwd) {
+                                                let path_diff_not_dot = path_diff_not_dot.to_string_lossy();
+                                                if path_diff_not_dot.is_empty() {
+                                                    ".".to_string()
+                                                } else {
+                                                    path_diff_not_dot.to_string()
+                                                }
+                                            } else {
+                                                path.to_string_lossy().to_string()
+                                            };
 
-        let mut hidden_dirs = vec![];
-
-        Ok(paths_peek
-            .into_iter()
-            .filter_map(move |x| match x {
-                Ok(path) => {
-                    let metadata = match std::fs::symlink_metadata(&path) {
-                        Ok(metadata) => Some(metadata),
-                        Err(_) => None,
-                    };
-                    if path_contains_hidden_folder(&path, &hidden_dirs) {
-                        return None;
-                    }
-
-                    if !all && !hidden_dir_specified && is_hidden_dir(&path) {
-                        if path.is_dir() {
-                            hidden_dirs.push(path);
-                        }
-                        return None;
-                    }
-
-                    let display_name = if short_names {
-                        path.file_name().map(|os| os.to_string_lossy().to_string())
-                    } else if full_paths || absolute_path {
-                        Some(path.to_string_lossy().to_string())
-                    } else if let Some(prefix) = &prefix {
-                        if let Ok(remainder) = path.strip_prefix(&prefix) {
-                            if directory {
-                                // When the path is the same as the cwd, path_diff should be "."
-                                let path_diff =
-                                    if let Some(path_diff_not_dot) = diff_paths(&path, &cwd) {
-                                        let path_diff_not_dot = path_diff_not_dot.to_string_lossy();
-                                        if path_diff_not_dot.is_empty() {
-                                            ".".to_string()
-                                        } else {
-                                            path_diff_not_dot.to_string()
-                                        }
+                                        Some(path_diff)
                                     } else {
-                                        path.to_string_lossy().to_string()
+                                        let new_prefix = if let Some(pfx) = diff_paths(&prefix, &cwd) {
+                                            pfx
+                                        } else {
+                                            prefix.to_path_buf()
+                                        };
+
+                                        Some(new_prefix.join(remainder).to_string_lossy().to_string())
+                                    }
+                                } else {
+                                    Some(path.to_string_lossy().to_string())
+                                }
+                            } else {
+                                Some(path.to_string_lossy().to_string())
+                            }
+                            .ok_or_else(|| {
+                                ShellError::GenericError(
+                                    format!("Invalid file name: {:}", path.to_string_lossy()),
+                                    "invalid file name".into(),
+                                    Some(call_span),
+                                    None,
+                                    Vec::new(),
+                                )
+                            });
+
+                            match display_name {
+                                Ok(name) => {
+                                    let entry = dir_entry_dict(
+                                        &path,
+                                        &name,
+                                        metadata.as_ref(),
+                                        call_span,
+                                        long,
+                                        du,
+                                        ctrl_c.clone(),
+                                    );
+                                    match entry {
+                                        Ok(value) => Some(value),
+                                        Err(err) => Some(Value::Error { error: err }),
+                                    }
+                                }
+                                Err(err) => Some(Value::Error { error: err }),
+                            }
+                        }
+                        _ => Some(Value::Nothing { span: call_span }),
+                    })
+                    .collect_vec()
+                    .into_iter()
+
+            })
+            .collect_vec()
+        } else {
+            let (path, p_tag, absolute_path) = if directory {
+                (PathBuf::from("."), call_span, false)
+            } else if is_empty_dir(current_dir(engine_state, stack)?) {
+                return Ok(Value::nothing(call_span).into_pipeline_data());
+            } else {
+                (PathBuf::from("./*"), call_span, false)
+            };
+
+            let hidden_dir_specified = is_hidden_dir(&path);
+
+            let glob_path = Spanned {
+                item: path.display().to_string(),
+                span: p_tag,
+            };
+
+            let glob_options = if all {
+                None
+            } else {
+                let mut glob_options = MatchOptions::new();
+                glob_options.recursive_match_hidden_dir = false;
+                Some(glob_options)
+            };
+            let (prefix, paths) = nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options)?;
+
+            let mut paths_peek = paths.peekable();
+            if paths_peek.peek().is_none() {
+                return Err(ShellError::GenericError(
+                    format!("No matches found for {}", &path.display().to_string()),
+                    "".to_string(),
+                    None,
+                    Some("no matches found".to_string()),
+                    Vec::new(),
+                ));
+            }
+
+            let mut hidden_dirs = vec![];
+
+            paths_peek
+                .into_iter()
+                .filter_map(move |x| match x {
+                    Ok(path) => {
+                        let metadata = match std::fs::symlink_metadata(&path) {
+                            Ok(metadata) => Some(metadata),
+                            Err(_) => None,
+                        };
+                        if path_contains_hidden_folder(&path, &hidden_dirs) {
+                            return None;
+                        }
+
+                        if !all && !hidden_dir_specified && is_hidden_dir(&path) {
+                            if path.is_dir() {
+                                hidden_dirs.push(path);
+                            }
+                            return None;
+                        }
+
+                        let display_name = if short_names {
+                            path.file_name().map(|os| os.to_string_lossy().to_string())
+                        } else if full_paths || absolute_path {
+                            Some(path.to_string_lossy().to_string())
+                        } else if let Some(prefix) = &prefix {
+                            if let Ok(remainder) = path.strip_prefix(&prefix) {
+                                if directory {
+                                    // When the path is the same as the cwd, path_diff should be "."
+                                    let path_diff =
+                                        if let Some(path_diff_not_dot) = diff_paths(&path, &cwd) {
+                                            let path_diff_not_dot = path_diff_not_dot.to_string_lossy();
+                                            if path_diff_not_dot.is_empty() {
+                                                ".".to_string()
+                                            } else {
+                                                path_diff_not_dot.to_string()
+                                            }
+                                        } else {
+                                            path.to_string_lossy().to_string()
+                                        };
+
+                                    Some(path_diff)
+                                } else {
+                                    let new_prefix = if let Some(pfx) = diff_paths(&prefix, &cwd) {
+                                        pfx
+                                    } else {
+                                        prefix.to_path_buf()
                                     };
 
-                                Some(path_diff)
+                                    Some(new_prefix.join(remainder).to_string_lossy().to_string())
+                                }
                             } else {
-                                let new_prefix = if let Some(pfx) = diff_paths(&prefix, &cwd) {
-                                    pfx
-                                } else {
-                                    prefix.to_path_buf()
-                                };
-
-                                Some(new_prefix.join(remainder).to_string_lossy().to_string())
+                                Some(path.to_string_lossy().to_string())
                             }
                         } else {
                             Some(path.to_string_lossy().to_string())
                         }
-                    } else {
-                        Some(path.to_string_lossy().to_string())
-                    }
-                    .ok_or_else(|| {
-                        ShellError::GenericError(
-                            format!("Invalid file name: {:}", path.to_string_lossy()),
-                            "invalid file name".into(),
-                            Some(call_span),
-                            None,
-                            Vec::new(),
-                        )
-                    });
+                        .ok_or_else(|| {
+                            ShellError::GenericError(
+                                format!("Invalid file name: {:}", path.to_string_lossy()),
+                                "invalid file name".into(),
+                                Some(call_span),
+                                None,
+                                Vec::new(),
+                            )
+                        });
 
-                    match display_name {
-                        Ok(name) => {
-                            let entry = dir_entry_dict(
-                                &path,
-                                &name,
-                                metadata.as_ref(),
-                                call_span,
-                                long,
-                                du,
-                                ctrl_c.clone(),
-                            );
-                            match entry {
-                                Ok(value) => Some(value),
-                                Err(err) => Some(Value::Error { error: err }),
+                        match display_name {
+                            Ok(name) => {
+                                let entry = dir_entry_dict(
+                                    &path,
+                                    &name,
+                                    metadata.as_ref(),
+                                    call_span,
+                                    long,
+                                    du,
+                                    ctrl_c.clone(),
+                                );
+                                match entry {
+                                    Ok(value) => Some(value),
+                                    Err(err) => Some(Value::Error { error: err }),
+                                }
                             }
+                            Err(err) => Some(Value::Error { error: err }),
                         }
-                        Err(err) => Some(Value::Error { error: err }),
                     }
-                }
-                _ => Some(Value::Nothing { span: call_span }),
-            })
-            .into_pipeline_data_with_metadata(
-                PipelineMetadata {
-                    data_source: DataSource::Ls,
-                },
-                engine_state.ctrlc.clone(),
-            ))
+                    _ => Some(Value::Nothing { span: call_span }),
+                })
+                .collect_vec()
+        };
+
+        if shell_errors.len() > 0 {
+            return Err(shell_errors.pop().unwrap());
+        }
+
+        Ok(glob_results.into_iter().filter(|result| match result { Value::Nothing { .. } => false, _ => true }).into_pipeline_data_with_metadata(
+            PipelineMetadata {
+                data_source: DataSource::Ls,
+            },
+            engine_state.ctrlc.clone(),
+        ))
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -277,6 +406,11 @@ impl Command for Ls {
             Example {
                 description: "List all rust files",
                 example: "ls *.rs",
+                result: None,
+            },
+            Example {
+                description: "List all rust files and all toml files",
+                example: "ls *.rs *.toml",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -6,12 +6,12 @@ use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_glob::MatchOptions;
 use nu_path::expand_to_real_path;
-use nu_protocol::IntoPipelineData;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::IntoPipelineData;
 use nu_protocol::{
-    Category, DataSource, Example, IntoInterruptiblePipelineData, PipelineData,
-    PipelineMetadata, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
+    Category, DataSource, Example, IntoInterruptiblePipelineData, PipelineData, PipelineMetadata,
+    ShellError, Signature, Span, Spanned, SyntaxShape, Value,
 };
 use pathdiff::diff_paths;
 
@@ -40,7 +40,11 @@ impl Command for Ls {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("ls")
             // Using a string instead of a glob pattern shape so it won't auto-expand
-            .rest("pattern(s)", SyntaxShape::String, "the glob pattern(s) to use")
+            .rest(
+                "pattern(s)",
+                SyntaxShape::String,
+                "the glob pattern(s) to use",
+            )
             .switch("all", "Show hidden files", Some('a'))
             .switch(
                 "long",
@@ -86,19 +90,20 @@ impl Command for Ls {
         let mut shell_errors: Vec<ShellError> = vec![];
         let pattern_args: Vec<Spanned<String>> = call.rest(engine_state, stack, 0)?;
         let glob_results = if pattern_args.len() > 0 {
-            pattern_args.into_iter().flat_map(|pattern_arg| {
+            pattern_args
+                .into_iter()
+                .flat_map(|pattern_arg| {
+                    let mut path = expand_to_real_path(pattern_arg.clone().item);
+                    let p_tag = pattern_arg.clone().span;
+                    let cwd = cwd.clone();
+                    let ctrl_c = ctrl_c.clone();
 
-                let mut path = expand_to_real_path(pattern_arg.clone().item);
-                let p_tag = pattern_arg.clone().span;
-                let cwd = cwd.clone();
-                let ctrl_c = ctrl_c.clone();
-
-                let expanded = nu_path::expand_path_with(&path, &cwd);
-                // Avoid checking and pushing "*" to the path when directory (do not show contents) flag is true
-                if !directory && expanded.is_dir() {
-                    if permission_denied(&path) {
-                        #[cfg(unix)]
-                        let error_msg = format!(
+                    let expanded = nu_path::expand_path_with(&path, &cwd);
+                    // Avoid checking and pushing "*" to the path when directory (do not show contents) flag is true
+                    if !directory && expanded.is_dir() {
+                        if permission_denied(&path) {
+                            #[cfg(unix)]
+                            let error_msg = format!(
                             "The permissions of {:o} do not allow access for this user",
                             expanded
                                 .metadata()
@@ -109,83 +114,86 @@ impl Command for Ls {
                                 .mode()
                                 & 0o0777
                         );
-                        #[cfg(not(unix))]
-                        let error_msg = String::from("Permission denied");
+                            #[cfg(not(unix))]
+                            let error_msg = String::from("Permission denied");
+                            shell_errors.push(ShellError::GenericError(
+                                "Permission denied".to_string(),
+                                error_msg,
+                                Some(p_tag),
+                                None,
+                                Vec::new(),
+                            ));
+                        }
+                        if is_empty_dir(&expanded) {
+                            return Vec::from([Value::nothing(call_span)]).into_iter();
+                        }
+                        path.push("*");
+                    }
+
+                    let absolute_path = path.is_absolute();
+
+                    let hidden_dir_specified = is_hidden_dir(&path);
+
+                    let glob_path = Spanned {
+                        item: path.display().to_string(),
+                        span: p_tag,
+                    };
+
+                    let glob_options = if all {
+                        None
+                    } else {
+                        let mut glob_options = MatchOptions::new();
+                        glob_options.recursive_match_hidden_dir = false;
+                        Some(glob_options)
+                    };
+                    let (prefix, paths) =
+                        nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options).unwrap();
+
+                    let mut paths_peek = paths.peekable();
+                    if paths_peek.peek().is_none() {
                         shell_errors.push(ShellError::GenericError(
-                            "Permission denied".to_string(),
-                            error_msg,
-                            Some(p_tag),
+                            format!("No matches found for {}", &path.display().to_string()),
+                            "".to_string(),
                             None,
+                            Some("no matches found".to_string()),
                             Vec::new(),
                         ));
                     }
-                    if is_empty_dir(&expanded) {
-                        return Vec::from([Value::nothing(call_span)]).into_iter();
-                    }
-                    path.push("*");
-                }
-                
-                let absolute_path = path.is_absolute();
 
-                let hidden_dir_specified = is_hidden_dir(&path);
+                    let mut hidden_dirs = vec![];
 
-                let glob_path = Spanned {
-                    item: path.display().to_string(),
-                    span: p_tag,
-                };
-
-                let glob_options = if all {
-                    None
-                } else {
-                    let mut glob_options = MatchOptions::new();
-                    glob_options.recursive_match_hidden_dir = false;
-                    Some(glob_options)
-                };
-                let (prefix, paths) = nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options).unwrap();
-
-                let mut paths_peek = paths.peekable();
-                if paths_peek.peek().is_none() {
-                    shell_errors.push(ShellError::GenericError(
-                        format!("No matches found for {}", &path.display().to_string()),
-                        "".to_string(),
-                        None,
-                        Some("no matches found".to_string()),
-                        Vec::new(),
-                    ));
-                }
-
-                let mut hidden_dirs = vec![];
-
-                paths_peek
-                    .into_iter()
-                    .filter_map(move |x| match x {
-                        Ok(path) => {
-                            let metadata = match std::fs::symlink_metadata(&path) {
-                                Ok(metadata) => Some(metadata),
-                                Err(_) => None,
-                            };
-                            if path_contains_hidden_folder(&path, &hidden_dirs) {
-                                return None;
-                            }
-
-                            if !all && !hidden_dir_specified && is_hidden_dir(&path) {
-                                if path.is_dir() {
-                                    hidden_dirs.push(path);
+                    paths_peek
+                        .into_iter()
+                        .filter_map(move |x| match x {
+                            Ok(path) => {
+                                let metadata = match std::fs::symlink_metadata(&path) {
+                                    Ok(metadata) => Some(metadata),
+                                    Err(_) => None,
+                                };
+                                if path_contains_hidden_folder(&path, &hidden_dirs) {
+                                    return None;
                                 }
-                                return None;
-                            }
 
-                            let display_name = if short_names {
-                                path.file_name().map(|os| os.to_string_lossy().to_string())
-                            } else if full_paths || absolute_path {
-                                Some(path.to_string_lossy().to_string())
-                            } else if let Some(prefix) = &prefix {
-                                if let Ok(remainder) = path.strip_prefix(&prefix) {
-                                    if directory {
-                                        // When the path is the same as the cwd, path_diff should be "."
-                                        let path_diff =
-                                            if let Some(path_diff_not_dot) = diff_paths(&path, &cwd) {
-                                                let path_diff_not_dot = path_diff_not_dot.to_string_lossy();
+                                if !all && !hidden_dir_specified && is_hidden_dir(&path) {
+                                    if path.is_dir() {
+                                        hidden_dirs.push(path);
+                                    }
+                                    return None;
+                                }
+
+                                let display_name = if short_names {
+                                    path.file_name().map(|os| os.to_string_lossy().to_string())
+                                } else if full_paths || absolute_path {
+                                    Some(path.to_string_lossy().to_string())
+                                } else if let Some(prefix) = &prefix {
+                                    if let Ok(remainder) = path.strip_prefix(&prefix) {
+                                        if directory {
+                                            // When the path is the same as the cwd, path_diff should be "."
+                                            let path_diff = if let Some(path_diff_not_dot) =
+                                                diff_paths(&path, &cwd)
+                                            {
+                                                let path_diff_not_dot =
+                                                    path_diff_not_dot.to_string_lossy();
                                                 if path_diff_not_dot.is_empty() {
                                                     ".".to_string()
                                                 } else {
@@ -195,58 +203,63 @@ impl Command for Ls {
                                                 path.to_string_lossy().to_string()
                                             };
 
-                                        Some(path_diff)
-                                    } else {
-                                        let new_prefix = if let Some(pfx) = diff_paths(&prefix, &cwd) {
-                                            pfx
+                                            Some(path_diff)
                                         } else {
-                                            prefix.to_path_buf()
-                                        };
+                                            let new_prefix =
+                                                if let Some(pfx) = diff_paths(&prefix, &cwd) {
+                                                    pfx
+                                                } else {
+                                                    prefix.to_path_buf()
+                                                };
 
-                                        Some(new_prefix.join(remainder).to_string_lossy().to_string())
+                                            Some(
+                                                new_prefix
+                                                    .join(remainder)
+                                                    .to_string_lossy()
+                                                    .to_string(),
+                                            )
+                                        }
+                                    } else {
+                                        Some(path.to_string_lossy().to_string())
                                     }
                                 } else {
                                     Some(path.to_string_lossy().to_string())
                                 }
-                            } else {
-                                Some(path.to_string_lossy().to_string())
-                            }
-                            .ok_or_else(|| {
-                                ShellError::GenericError(
-                                    format!("Invalid file name: {:}", path.to_string_lossy()),
-                                    "invalid file name".into(),
-                                    Some(call_span),
-                                    None,
-                                    Vec::new(),
-                                )
-                            });
+                                .ok_or_else(|| {
+                                    ShellError::GenericError(
+                                        format!("Invalid file name: {:}", path.to_string_lossy()),
+                                        "invalid file name".into(),
+                                        Some(call_span),
+                                        None,
+                                        Vec::new(),
+                                    )
+                                });
 
-                            match display_name {
-                                Ok(name) => {
-                                    let entry = dir_entry_dict(
-                                        &path,
-                                        &name,
-                                        metadata.as_ref(),
-                                        call_span,
-                                        long,
-                                        du,
-                                        ctrl_c.clone(),
-                                    );
-                                    match entry {
-                                        Ok(value) => Some(value),
-                                        Err(err) => Some(Value::Error { error: err }),
+                                match display_name {
+                                    Ok(name) => {
+                                        let entry = dir_entry_dict(
+                                            &path,
+                                            &name,
+                                            metadata.as_ref(),
+                                            call_span,
+                                            long,
+                                            du,
+                                            ctrl_c.clone(),
+                                        );
+                                        match entry {
+                                            Ok(value) => Some(value),
+                                            Err(err) => Some(Value::Error { error: err }),
+                                        }
                                     }
+                                    Err(err) => Some(Value::Error { error: err }),
                                 }
-                                Err(err) => Some(Value::Error { error: err }),
                             }
-                        }
-                        _ => Some(Value::Nothing { span: call_span }),
-                    })
-                    .collect_vec()
-                    .into_iter()
-
-            })
-            .collect_vec()
+                            _ => Some(Value::Nothing { span: call_span }),
+                        })
+                        .collect_vec()
+                        .into_iter()
+                })
+                .collect_vec()
         } else {
             let (path, p_tag, absolute_path) = if directory {
                 (PathBuf::from("."), call_span, false)
@@ -312,17 +325,18 @@ impl Command for Ls {
                             if let Ok(remainder) = path.strip_prefix(&prefix) {
                                 if directory {
                                     // When the path is the same as the cwd, path_diff should be "."
-                                    let path_diff =
-                                        if let Some(path_diff_not_dot) = diff_paths(&path, &cwd) {
-                                            let path_diff_not_dot = path_diff_not_dot.to_string_lossy();
-                                            if path_diff_not_dot.is_empty() {
-                                                ".".to_string()
-                                            } else {
-                                                path_diff_not_dot.to_string()
-                                            }
+                                    let path_diff = if let Some(path_diff_not_dot) =
+                                        diff_paths(&path, &cwd)
+                                    {
+                                        let path_diff_not_dot = path_diff_not_dot.to_string_lossy();
+                                        if path_diff_not_dot.is_empty() {
+                                            ".".to_string()
                                         } else {
-                                            path.to_string_lossy().to_string()
-                                        };
+                                            path_diff_not_dot.to_string()
+                                        }
+                                    } else {
+                                        path.to_string_lossy().to_string()
+                                    };
 
                                     Some(path_diff)
                                 } else {
@@ -378,12 +392,18 @@ impl Command for Ls {
             return Err(shell_errors.pop().unwrap());
         }
 
-        Ok(glob_results.into_iter().filter(|result| match result { Value::Nothing { .. } => false, _ => true }).into_pipeline_data_with_metadata(
-            PipelineMetadata {
-                data_source: DataSource::Ls,
-            },
-            engine_state.ctrlc.clone(),
-        ))
+        Ok(glob_results
+            .into_iter()
+            .filter(|result| match result {
+                Value::Nothing { .. } => false,
+                _ => true,
+            })
+            .into_pipeline_data_with_metadata(
+                PipelineMetadata {
+                    data_source: DataSource::Ls,
+                },
+                engine_state.ctrlc.clone(),
+            ))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -336,6 +336,28 @@ fn lists_files_including_starting_with_dot() {
 }
 
 #[test]
+fn lists_regular_files_using_multiple_asterisk_wildcards() {
+    Playground::setup("ls_test_10", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
+            EmptyFile("amigos.txt"),
+            EmptyFile("arepas.clu"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ls *.txt *.clu
+                | length
+            "#
+        ));
+
+        assert_eq!(actual.out, "4");
+    })
+}
+
+#[test]
 fn list_all_columns() {
     Playground::setup("ls_test_all_columns", |dirs, sandbox| {
         sandbox.with_files(vec![


### PR DESCRIPTION
# Description

Related to #6045.

Taking @jntrnr 's advice to read glob patterns as rest arg, then iterating over the rest arg using `.flat_map()` to collect `Value`s.

Currently dealing with `ShellError`s by collecting them in a `vec!` and returning the last one using `.pop()` if there are any. This is suboptimal since it means a command with some successful results fails if there is one failure. I'm open to suggestions here.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass

I have four tests failing but they are failing on the `main` branch as well:
```
failures:
    path::canonicalize::canonicalize_nested_symlink_relative_to
    path::canonicalize::canonicalize_nested_symlink_within_symlink_dir_relative_to
    path::canonicalize::canonicalize_symlink
    path::canonicalize::canonicalize_symlink_relative_to
```
