### PR TITLE
Bump `powierza-coefficient` to `1.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,9 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "powierza-coefficient"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caa43783252cf8c4c66dd1cc381a5929cc95f6530da7abd1f9cdb97e2065842"
+checksum = "64e2c03bca73af2a7a2c021a6b3b4991658b760b2e0a84e3e425a9c9eda2ba7f"
 
 [[package]]
 name = "ppv-lite86"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -59,7 +59,7 @@ mime = "0.3.16"
 notify = "4.0.17"
 num = { version = "0.4.0", optional = true }
 pathdiff = "0.2.1"
-powierza-coefficient = "1.0"
+powierza-coefficient = "1.0.1"
 quick-xml = "0.23.0"
 rand = "0.8"
 rayon = "1.5.1"


### PR DESCRIPTION
# Description

This PR bumps [`powierza-coefficient`](https://crates.io/crates/powierza-coefficient) to `1.0.1`, **which fixes a bug in the algorithm.** The previous version has been yanked but it is still being downloaded. As I understand it, it's because you have it set in your `Cargo.lock`.

# Tests

I was unable to build or test your crate because of an error in the build process. [I've already filed an issue in `libproc` repo to resolve it.](https://github.com/andrewdavidmackenzie/libproc-rs/issues/82)

However, I've tested the new version of the dependency itself and I haven't made any changes in the API.