### PR TITLE
Don't panic if nu failed to create config files 

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -86,8 +86,11 @@ pub(crate) fn read_config_file(
                             return;
                         }
                     },
-                    Err(e) => {
-                        eprintln!("Unable to create {}: {}", config_file, e);
+                    Err(_) => {
+                        eprintln!(
+                            "Unable to create {}, sourcing default file instead",
+                            config_file
+                        );
                         eval_default_config(engine_state, stack, config_file, is_env_config);
                         return;
                     }

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -71,11 +71,19 @@ pub(crate) fn read_config_file(
             };
 
             match answer.to_lowercase().trim() {
-                "y" | "" => {
-                    let mut output = File::create(&config_path).expect("Unable to create file");
-                    write!(output, "{}", config_file).expect("Unable to write to config file");
-                    println!("Config file created at: {}", config_path.to_string_lossy());
-                }
+                "y" | "" => match File::create(&config_path) {
+                    Ok(mut output) => match write!(output, "{}", config_file) {
+                        Ok(_) => {
+                            println!("Config file created at: {}", config_path.to_string_lossy())
+                        }
+                        Err(e) => eprintln!(
+                            "Unable to write to {}: {}",
+                            config_path.to_string_lossy(),
+                            e
+                        ),
+                    },
+                    Err(e) => eprintln!("Unable to create {}: {}", config_file, e),
+                },
                 _ => {
                     println!("Continuing without config file");
                     // Just use the contents of "default_config.nu" or "default_env.nu"

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -76,11 +76,10 @@ pub(crate) fn read_config_file(
                         Ok(_) => {
                             println!("Config file created at: {}", config_path.to_string_lossy())
                         }
-                        Err(e) => {
+                        Err(_) => {
                             eprintln!(
-                                "Unable to write to {}: {}",
+                                "Unable to write to {}, sourcing default file instead",
                                 config_path.to_string_lossy(),
-                                e
                             );
                             eval_default_config(engine_state, stack, config_file, is_env_config);
                             return;


### PR DESCRIPTION
# Description

Don't panic if nu failed to create config files.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
