### PR TITLE
trim spaces when converting strings to ints

### DIFF
--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -273,6 +273,7 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
     let i = match input {
         Value::Int { val, .. } => val.to_string(),
         Value::String { val, .. } => {
+            let val = val.trim();
             if val.starts_with("0x") // hex
                 || val.starts_with("0b") // binary
                 || val.starts_with("0o")
@@ -309,10 +310,10 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
             }
         }
     };
-    match i64::from_str_radix(&i, radix) {
+    match i64::from_str_radix(i.trim(), radix) {
         Ok(n) => Value::Int { val: n, span: head },
         Err(_reason) => Value::Error {
-            error: ShellError::CantConvert("int".to_string(), "string".to_string(), head, None),
+            error: ShellError::CantConvert("string".to_string(), "int".to_string(), head, None),
         },
     }
 }


### PR DESCRIPTION
# Description

Found an issue where converting `"12345  " | into int` puked, so I just added `trim()`.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
