### PR TITLE
move the shell integration title setting to the right place

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -314,22 +314,22 @@ pub fn evaluate_repl(
                 if shell_integration {
                     run_ansi_sequence(RESET_APPLICATION_MODE)?;
                     run_ansi_sequence(PRE_EXECUTE_MARKER)?;
-                    if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
-                        let path = cwd.as_string()?;
-                        // Try to abbreviate string for windows title
-                        let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
-                            path.replace(&p.as_path().display().to_string(), "~")
-                        } else {
-                            path
-                        };
+                    // if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
+                    //     let path = cwd.as_string()?;
+                    //     // Try to abbreviate string for windows title
+                    //     let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
+                    //         path.replace(&p.as_path().display().to_string(), "~")
+                    //     } else {
+                    //         path
+                    //     };
 
-                        // Set window title too
-                        // https://tldp.org/HOWTO/Xterm-Title-3.html
-                        // ESC]0;stringBEL -- Set icon name and window title to string
-                        // ESC]1;stringBEL -- Set icon name to string
-                        // ESC]2;stringBEL -- Set window title to string
-                        run_ansi_sequence(&format!("\x1b]2;{}\x07", maybe_abbrev_path))?;
-                    }
+                    //     // Set window title too
+                    //     // https://tldp.org/HOWTO/Xterm-Title-3.html
+                    //     // ESC]0;stringBEL -- Set icon name and window title to string
+                    //     // ESC]1;stringBEL -- Set icon name to string
+                    //     // ESC]2;stringBEL -- Set window title to string
+                    //     run_ansi_sequence(&format!("\x1b]2;{}\x07", maybe_abbrev_path))?;
+                    // }
                 }
 
                 let start_time = Instant::now();
@@ -429,6 +429,22 @@ pub fn evaluate_repl(
 
                 if shell_integration {
                     run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
+                    if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
+                        let path = cwd.as_string()?;
+                        // Try to abbreviate string for windows title
+                        let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
+                            path.replace(&p.as_path().display().to_string(), "~")
+                        } else {
+                            path
+                        };
+
+                        // Set window title too
+                        // https://tldp.org/HOWTO/Xterm-Title-3.html
+                        // ESC]0;stringBEL -- Set icon name and window title to string
+                        // ESC]1;stringBEL -- Set icon name to string
+                        // ESC]2;stringBEL -- Set window title to string
+                        run_ansi_sequence(&format!("\x1b]2;{}\x07", maybe_abbrev_path))?;
+                    }
                 }
             }
             Ok(Signal::CtrlC) => {


### PR DESCRIPTION
# Description

closes #6111 

We had the shell integration title setting routine happening before the command executed which means that $env.PWD wasn't set to the new location yet. So, I moved it to when the command finishes which should make it update at the appropriate time now.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
