### PR TITLE
Allow cp multiple files at once

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -1,11 +1,15 @@
+use std::collections::HashMap;
 use std::fs::read_link;
 use std::path::PathBuf;
 
+use itertools::Itertools;
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
+use nu_glob::GlobResult;
 use nu_path::{canonicalize_with, expand_path_with};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::span::span as merge_spans;
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
     Spanned, SyntaxShape, Value,
@@ -41,7 +45,12 @@ impl Command for Cp {
 
     fn signature(&self) -> Signature {
         Signature::build("cp")
-            .required("source", SyntaxShape::GlobPattern, "the place to copy from")
+            .rest(
+                "source(s)",
+                SyntaxShape::String,
+                "the place(s) to copy from",
+            )
+            // .required("source", SyntaxShape::GlobPattern, "the place to copy from")
             .required("destination", SyntaxShape::Filepath, "the place to copy to")
             .switch(
                 "recursive",
@@ -71,14 +80,15 @@ impl Command for Cp {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let src: Spanned<String> = call.req(engine_state, stack, 0)?;
-        let dst: Spanned<String> = call.req(engine_state, stack, 1)?;
+        let mut src_vec: Vec<Spanned<String>> = call.rest(engine_state, stack, 0)?;
+        // read dst as final argument
+        let dst: Spanned<String> = src_vec.pop().expect("Final argument is destination");
+
         let recursive = call.has_flag("recursive");
         let verbose = call.has_flag("verbose");
         let interactive = call.has_flag("interactive");
 
         let current_dir_path = current_dir(engine_state, stack)?;
-        let source = current_dir_path.join(src.item.as_str());
         let destination = current_dir_path.join(dst.item.as_str());
 
         let path_last_char = destination.as_os_str().to_string_lossy().chars().last();
@@ -92,24 +102,54 @@ impl Command for Cp {
         let ctrlc = engine_state.ctrlc.clone();
         let span = call.head;
 
-        let sources: Vec<_> = match nu_glob::glob_with(&source.to_string_lossy(), GLOB_PARAMS) {
-            Ok(files) => files.collect(),
-            Err(e) => {
-                return Err(ShellError::GenericError(
-                    e.to_string(),
-                    "invalid pattern".to_string(),
-                    Some(src.span),
-                    None,
-                    Vec::new(),
-                ))
+        let mut sources: Vec<PathBuf> = vec![];
+        let mut path_to_span: HashMap<PathBuf, Span> = HashMap::new();
+
+        for src in &src_vec {
+            let source = current_dir_path.join(src.item.as_str());
+            let glob_results: Vec<GlobResult> =
+                match nu_glob::glob_with(&source.to_string_lossy(), GLOB_PARAMS) {
+                    Ok(files) => files.collect(),
+                    Err(e) => {
+                        return Err(ShellError::GenericError(
+                            e.to_string(),
+                            "invalid pattern".to_string(),
+                            Some(src.span),
+                            None,
+                            Vec::new(),
+                        ))
+                    }
+                };
+
+            let mut new_sources: Vec<PathBuf> = vec![];
+            for glob_result in glob_results {
+                match glob_result {
+                    Ok(path) => {
+                        path_to_span.insert(path.clone(), src.span);
+                        new_sources.push(path);
+                    }
+                    Err(e) => {
+                        return Err(ShellError::GenericError(
+                            e.to_string(),
+                            "glob iteration error".to_string(),
+                            Some(src.span),
+                            None,
+                            Vec::new(),
+                        ))
+                    }
+                }
             }
-        };
+
+            sources.append(&mut new_sources);
+        }
 
         if sources.is_empty() {
             return Err(ShellError::GenericError(
                 "No matches found".into(),
                 "no matches found".into(),
-                Some(src.span),
+                Some(merge_spans(
+                    &src_vec.into_iter().map(|src| src.span).collect_vec(),
+                )),
                 None,
                 Vec::new(),
             ));
@@ -125,21 +165,25 @@ impl Command for Cp {
             ));
         }
 
-        let any_source_is_dir = sources.iter().any(|f| matches!(f, Ok(f) if f.is_dir()));
+        let any_source_is_dir = sources.iter().find(|f| f.is_dir());
 
-        if any_source_is_dir && !recursive {
-            return Err(ShellError::GenericError(
-                "Directories must be copied using \"--recursive\"".into(),
-                "resolves to a directory (not copied)".into(),
-                Some(src.span),
-                None,
-                Vec::new(),
-            ));
+        if let Some(dir_source) = any_source_is_dir {
+            if !recursive {
+                return Err(ShellError::GenericError(
+                    "Directories must be copied using \"--recursive\"".into(),
+                    "resolves to a directory (not copied)".into(),
+                    Some(*path_to_span.get(dir_source).unwrap_or_else(|| {
+                        panic!("Key {:?} should exist", dir_source.as_os_str())
+                    })),
+                    None,
+                    Vec::new(),
+                ));
+            }
         }
 
         let mut result = Vec::new();
 
-        for entry in sources.into_iter().flatten() {
+        for entry in sources.into_iter() {
             let mut sources = FileStructure::new();
             sources.walk_decorate(&entry, engine_state, stack)?;
 
@@ -163,7 +207,8 @@ impl Command for Cp {
                         let res = if src == dst {
                             let message = format!(
                                 "src {:?} and dst {:?} are identical(not copied)",
-                                source, destination
+                                src.as_os_str(),
+                                destination
                             );
 
                             return Err(ShellError::GenericError(

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_glob::GlobResult;
+use nu_path::dots::expand_ndots;
 use nu_path::{canonicalize_with, expand_path_with};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -89,7 +90,7 @@ impl Command for Cp {
         let interactive = call.has_flag("interactive");
 
         let current_dir_path = current_dir(engine_state, stack)?;
-        let destination = current_dir_path.join(dst.item.as_str());
+        let destination = expand_ndots(current_dir_path.join(dst.item.as_str()));
 
         let path_last_char = destination.as_os_str().to_string_lossy().chars().last();
         let is_directory = path_last_char == Some('/') || path_last_char == Some('\\');

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -18,6 +18,22 @@ fn copies_a_file() {
 }
 
 #[test]
+fn copies_multiple_files() {
+    Playground::setup("cp_test_1_1", |dirs, sandbox| {
+        sandbox
+            .with_files(vec![EmptyFile("a.txt"), EmptyFile("b.txt")])
+            .mkdir("dest");
+        nu!(
+            cwd: dirs.test(),
+            "cp a.txt b.txt dest",
+        );
+
+        assert!(dirs.test().join("dest/a.txt").exists());
+        assert!(dirs.test().join("dest/b.txt").exists());
+    });
+}
+
+#[test]
 fn copies_the_file_inside_directory_if_path_to_copy_is_directory() {
     Playground::setup("cp_test_2", |dirs, _| {
         let expected_file = AbsoluteFile::new(dirs.test().join("sample.ini"));

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -9,7 +9,7 @@ mod module;
 mod pipeline_data;
 mod shell_error;
 mod signature;
-mod span;
+pub mod span;
 mod syntax_shape;
 mod ty;
 mod value;


### PR DESCRIPTION
# Description

Follow-up to #6103 to keep `mv` and `cp` signatures consistent.

Turn the required "source" argument into a rest "source(s)" argument, then build a flattened `sources: Vec<PathBuf>` for later iteration.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
