### PR TITLE
exit with non-zero exit code when script ends with non-zero exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,16 @@ fn main() -> Result<()> {
                     input,
                     is_perf_true(),
                 );
+
+                let last_exit_code = stack.get_env_var(&engine_state, "LAST_EXIT_CODE");
+                if let Some(last_exit_code) = last_exit_code {
+                    let value = last_exit_code.as_integer();
+                    if let Ok(value) = value {
+                        if value != 0 {
+                            std::process::exit(value as i32);
+                        }
+                    }
+                }
                 if is_perf_true() {
                     info!("eval_file execution {}:{}:{}", file!(), line!(), column!());
                 }


### PR DESCRIPTION
# Description

Checks the last exit code when running a script, if non-zero, exits nu with that exit code

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
