### PR TITLE
Revert "`extern` command should be treated as external"

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -142,7 +142,7 @@ fn help(
 
                 cols.push("is_custom".into());
                 vals.push(Value::Bool {
-                    val: decl.is_custom_command(),
+                    val: decl.get_block_id().is_some(),
                     span: head,
                 });
 
@@ -243,7 +243,7 @@ fn help(
 
                 cols.push("is_custom".into());
                 vals.push(Value::Bool {
-                    val: decl.is_custom_command(),
+                    val: decl.get_block_id().is_some(),
                     span: head,
                 });
 

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -95,7 +95,7 @@ fn get_entry_in_aliases(engine_state: &EngineState, name: &str, span: Span) -> O
 
 fn get_entry_in_commands(engine_state: &EngineState, name: &str, span: Span) -> Option<Value> {
     if let Some(decl_id) = engine_state.find_decl(name.as_bytes(), &[]) {
-        let (msg, is_builtin) = if engine_state.get_decl(decl_id).is_custom_command() {
+        let (msg, is_builtin) = if engine_state.get_decl(decl_id).get_block_id().is_some() {
             ("Nushell custom command", false)
         } else {
             ("Nushell built-in command", true)

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1121,7 +1121,7 @@ pub fn create_scope(
             cols.push("is_builtin".to_string());
             // we can only be a is_builtin or is_custom, not both
             vals.push(Value::Bool {
-                val: !decl.is_custom_command(),
+                val: decl.get_block_id().is_none(),
                 span,
             });
 
@@ -1139,7 +1139,7 @@ pub fn create_scope(
 
             cols.push("is_custom".to_string());
             vals.push(Value::Bool {
-                val: decl.is_custom_command(),
+                val: decl.get_block_id().is_some(),
                 span,
             });
 

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -30,10 +30,6 @@ impl Command for KnownExternal {
         true
     }
 
-    fn is_builtin(&self) -> bool {
-        false
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1079,32 +1079,26 @@ pub fn parse_call(
             }
         }
 
-        let decl = working_set.get_decl(decl_id);
-        if decl.is_builtin() {
-            trace!("parsing: internal call");
+        trace!("parsing: internal call");
 
-            // parse internal command
-            let parsed_call = parse_internal_call(
-                working_set,
-                span(&spans[cmd_start..pos]),
-                &spans[pos..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+        // parse internal command
+        let parsed_call = parse_internal_call(
+            working_set,
+            span(&spans[cmd_start..pos]),
+            &spans[pos..],
+            decl_id,
+            expand_aliases_denylist,
+        );
 
-            (
-                Expression {
-                    expr: Expr::Call(parsed_call.call),
-                    span: span(spans),
-                    ty: parsed_call.output,
-                    custom_completion: None,
-                },
-                parsed_call.error,
-            )
-        } else {
-            trace!("parsing: `extern` custom command as external call");
-            parse_external_call(working_set, spans, expand_aliases_denylist)
-        }
+        (
+            Expression {
+                expr: Expr::Call(parsed_call.call),
+                span: span(spans),
+                ty: parsed_call.output,
+                custom_completion: None,
+            },
+            parsed_call.error,
+        )
     } else {
         // We might be parsing left-unbounded range ("..10")
         let bytes = working_set.get_span_contents(spans[0]);

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -37,16 +37,6 @@ pub trait Command: Send + Sync + CommandClone {
         false
     }
 
-    // This is an enhanced method to determine if a command is custom command or not
-    // since extern "foo" [] and def "foo" [] behaves differently
-    fn is_custom_command(&self) -> bool {
-        if self.get_block_id().is_some() {
-            true
-        } else {
-            self.is_known_external()
-        }
-    }
-
     // Is a sub command
     fn is_sub(&self) -> bool {
         self.name().contains(' ')

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -12,23 +12,7 @@ fn known_external_runs() -> TestResult {
 fn known_external_unknown_flag() -> TestResult {
     fail_test(
         r#"extern "cargo version" []; cargo version --no-such-flag"#,
-        "Found argument '--no-such-flag' which wasn't expected, or isn't valid in this context",
-    )
-}
-
-#[test]
-fn known_external_not_defined_flag() -> TestResult {
-    run_test_contains(
-        r#"extern "cargo version" []; cargo version --help"#,
-        "Show version information",
-    )
-}
-
-#[test]
-fn known_external_is_custom() -> TestResult {
-    run_test_contains(
-        r#"extern "cargo version" []; help commands | where is_custom == true | get name"#,
-        "cargo version",
+        "command doesn't have flag",
     )
 }
 


### PR DESCRIPTION
Reverts nushell/nushell#6083

The original PR seems to break custom completions. As we're right near the next Nushell release, I want to see if we can fix them and then try this PR again in the future once we have a better approach.