### PR TITLE
fix typo of `port` command

### DIFF
--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -17,7 +17,7 @@ impl Command for SubCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("post")
+        Signature::build("port")
             .optional(
                 "start",
                 SyntaxShape::Int,
@@ -48,7 +48,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "get free port between 3121 and 4000",
+                description: "get a free port between 3121 and 4000",
                 example: "port 3121 4000",
                 result: Some(Value::Int {
                     val: 3121,
@@ -56,7 +56,7 @@ impl Command for SubCommand {
                 }),
             },
             Example {
-                description: "get free port from system",
+                description: "get a free port from system",
                 example: "port",
                 result: None,
             },


### PR DESCRIPTION
# Description

fix typo of `port` command, make `help port` work

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
