### PR TITLE
Simplify print_table_or_error

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -86,20 +86,7 @@ pub fn print_table_or_error(
 
             match table {
                 Ok(table) => {
-                    for item in table {
-                        if let Value::Error { error } = item {
-                            let working_set = StateWorkingSet::new(engine_state);
-
-                            report_error(&working_set, &error);
-
-                            std::process::exit(1);
-                        }
-
-                        let mut out = item.into_string("\n", config);
-                        out.push('\n');
-
-                        let _ = stdout_write_all_and_flush(out).map_err(|err| eprintln!("{}", err));
-                    }
+                    print_or_exit(table, engine_state, config);
                 }
                 Err(error) => {
                     let working_set = StateWorkingSet::new(engine_state);
@@ -111,20 +98,7 @@ pub fn print_table_or_error(
             }
         }
         None => {
-            for item in pipeline_data {
-                if let Value::Error { error } = item {
-                    let working_set = StateWorkingSet::new(engine_state);
-
-                    report_error(&working_set, &error);
-
-                    std::process::exit(1);
-                }
-
-                let mut out = item.into_string("\n", config);
-                out.push('\n');
-
-                let _ = stdout_write_all_and_flush(out).map_err(|err| eprintln!("{}", err));
-            }
+            print_or_exit(pipeline_data, engine_state, config);
         }
     };
 
@@ -139,5 +113,22 @@ pub fn print_table_or_error(
             })
     } else {
         None
+    }
+}
+
+fn print_or_exit(pipeline_data: PipelineData, engine_state: &mut EngineState, config: &Config) {
+    for item in pipeline_data {
+        if let Value::Error { error } = item {
+            let working_set = StateWorkingSet::new(engine_state);
+
+            report_error(&working_set, &error);
+
+            std::process::exit(1);
+        }
+
+        let mut out = item.into_string("\n", config);
+        out.push('\n');
+
+        let _ = stdout_write_all_and_flush(out).map_err(|err| eprintln!("{}", err));
     }
 }


### PR DESCRIPTION
# Description

Simplify print_table_or_error

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
