### PR TITLE
plugin show signature

### DIFF
--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -268,70 +268,64 @@ fn print_help(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
     println!("Nushell Plugin");
     println!("Encoder: {}", encoder.name());
 
-    let message: Vec<String> = plugin
-        .signature()
-        .iter()
-        .map(|signature| {
-            let mut help = String::new();
+    let mut help = String::new();
 
-            let res = write!(help, "\nCommand: {}", signature.name)
-                .and_then(|_| writeln!(help, "\nUsage:\n > {}", signature.usage))
-                .and_then(|_| {
-                    if !signature.extra_usage.is_empty() {
-                        writeln!(help, "\nExtra usage:\n > {}", signature.extra_usage)
-                    } else {
-                        Ok(())
-                    }
-                })
-                .and_then(|_| {
-                    let flags = get_flags_section(signature);
-                    write!(help, "{}", flags)
-                })
-                .and_then(|_| writeln!(help, "\nParameters:"))
-                .and_then(|_| {
-                    signature
-                        .required_positional
-                        .iter()
-                        .try_for_each(|positional| {
-                            writeln!(
-                                help,
-                                "  {} <{:?}>: {}",
-                                positional.name, positional.shape, positional.desc
-                            )
-                        })
-                })
-                .and_then(|_| {
-                    signature
-                        .optional_positional
-                        .iter()
-                        .try_for_each(|positional| {
-                            writeln!(
-                                help,
-                                "  (optional) {} <{:?}>: {}",
-                                positional.name, positional.shape, positional.desc
-                            )
-                        })
-                })
-                .and_then(|_| {
-                    if let Some(rest_positional) = &signature.rest_positional {
+    plugin.signature().iter().for_each(|signature| {
+        let res = write!(help, "\nCommand: {}", signature.name)
+            .and_then(|_| writeln!(help, "\nUsage:\n > {}", signature.usage))
+            .and_then(|_| {
+                if !signature.extra_usage.is_empty() {
+                    writeln!(help, "\nExtra usage:\n > {}", signature.extra_usage)
+                } else {
+                    Ok(())
+                }
+            })
+            .and_then(|_| {
+                let flags = get_flags_section(signature);
+                write!(help, "{}", flags)
+            })
+            .and_then(|_| writeln!(help, "\nParameters:"))
+            .and_then(|_| {
+                signature
+                    .required_positional
+                    .iter()
+                    .try_for_each(|positional| {
                         writeln!(
                             help,
-                            "  ...{} <{:?}>: {}",
-                            rest_positional.name, rest_positional.shape, rest_positional.desc
+                            "  {} <{:?}>: {}",
+                            positional.name, positional.shape, positional.desc
                         )
-                    } else {
-                        Ok(())
-                    }
-                });
+                    })
+            })
+            .and_then(|_| {
+                signature
+                    .optional_positional
+                    .iter()
+                    .try_for_each(|positional| {
+                        writeln!(
+                            help,
+                            "  (optional) {} <{:?}>: {}",
+                            positional.name, positional.shape, positional.desc
+                        )
+                    })
+            })
+            .and_then(|_| {
+                if let Some(rest_positional) = &signature.rest_positional {
+                    writeln!(
+                        help,
+                        "  ...{} <{:?}>: {}",
+                        rest_positional.name, rest_positional.shape, rest_positional.desc
+                    )
+                } else {
+                    Ok(())
+                }
+            })
+            .and_then(|_| writeln!(help, "======================"));
 
-            match res {
-                Ok(()) => help,
-                Err(e) => format!("error: {}", e),
-            }
-        })
-        .collect();
+        if res.is_err() {
+            println!("{:?}", res)
+        }
+    });
 
-    let message = message.join("======================\n");
-
-    println!("{}", message)
+    println!("{}", help)
 }

--- a/crates/nu-plugin/src/serializers/capnp/mod.rs
+++ b/crates/nu-plugin/src/serializers/capnp/mod.rs
@@ -13,6 +13,10 @@ use crate::{plugin::PluginEncoder, protocol::PluginResponse};
 pub struct CapnpSerializer;
 
 impl PluginEncoder for CapnpSerializer {
+    fn name(&self) -> &str {
+        "Capnp Serializer"
+    }
+
     fn encode_call(
         &self,
         plugin_call: &crate::protocol::PluginCall,

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -6,6 +6,10 @@ use crate::{plugin::PluginEncoder, protocol::PluginResponse};
 pub struct JsonSerializer;
 
 impl PluginEncoder for JsonSerializer {
+    fn name(&self) -> &str {
+        "Json Serializer"
+    }
+
     fn encode_call(
         &self,
         plugin_call: &crate::protocol::PluginCall,


### PR DESCRIPTION
# Description

This adds a `help` flag to compiled plugins. The plugin can be called using this flag (`--help`, `-h`) and a help message will be printed showing the type of encoder the plugin uses and the commands signature that it will register to nushell

Example
```
 >: ./target/debug/nu_plugin_example --help
Nushell Plugin
Encoder: Capnp Serializer

Command: nu-example-1
Usage:
 > Signature test 1 for plugin. Returns Value::Nothing

Flags:
  -h, --help
      Display this help message
  -f, --flag
      a flag for the signature
  -n, --named <String>
      named string

Parameters:
  a <Int>: required integer value
  b <String>: required string value
  (optional) opt <Int>: Optional number
  ...rest <String>: rest value string
======================

Command: nu-example-2
Usage:
 > Signature test 2 for plugin. Returns list of records

Flags:
  -h, --help
      Display this help message
  -f, --flag
      a flag for the signature
  -n, --named <String>
      named string

Parameters:
  a <Int>: required integer value
  b <String>: required string value
  (optional) opt <Int>: Optional number
  ...rest <String>: rest value string
======================

Command: nu-example-3
Usage:
 > Signature test 3 for plugin. Returns labeled error

Flags:
  -h, --help
      Display this help message
  -f, --flag
      a flag for the signature
  -n, --named <String>
      named string

Parameters:
  a <Int>: required integer value
  b <String>: required string value
  (optional) opt <Int>: Optional number
  ...rest <String>: rest value string
```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
