### PR TITLE
Use official virtualenv repo for the CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,10 +135,7 @@ jobs:
       - run: python -m pip install tox
 
       - name: Install virtualenv
-        run: |
-          git clone https://github.com/kubouch/virtualenv.git && \
-          cd virtualenv && \
-          git checkout engine-q-update
+        run: git clone https://github.com/pypa/virtualenv.git          
         shell: bash
 
       - name: Test Nushell in virtualenv


### PR DESCRIPTION
# Description

It still pointed to the engine-q update branch.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
