### PR TITLE
Fix PipelineData::print when `table` is overridden

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -461,7 +461,7 @@ impl PipelineData {
         match engine_state.find_decl("table".as_bytes(), &[]) {
             Some(decl_id) => {
                 let command = engine_state.get_decl(decl_id);
-                if command.is_custom_command() {
+                if command.get_block_id().is_some() {
                     return self.write_all_and_flush(engine_state, config, no_newline, to_stderr);
                 }
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -460,12 +460,12 @@ impl PipelineData {
 
         match engine_state.find_decl("table".as_bytes(), &[]) {
             Some(decl_id) => {
-                let table = engine_state.get_decl(decl_id).run(
-                    engine_state,
-                    stack,
-                    &Call::new(Span::new(0, 0)),
-                    self,
-                )?;
+                let command = engine_state.get_decl(decl_id);
+                if command.is_custom_command() {
+                    return self.write_all_and_flush(engine_state, config, no_newline, to_stderr);
+                }
+
+                let table = command.run(engine_state, stack, &Call::new(Span::new(0, 0)), self)?;
 
                 table.write_all_and_flush(engine_state, config, no_newline, to_stderr)?;
             }

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -130,3 +130,8 @@ fn help_not_present_in_extern() -> TestResult {
         "Usage:\n  > git fetch",
     )
 }
+
+#[test]
+fn override_table() -> TestResult {
+    run_test(r#"def table [] { "hi" }; table"#, "hi")
+}


### PR DESCRIPTION
# Description

Fixes #6113

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
