### PR TITLE
Fix print_table_or_error when `table` is overridden

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -77,23 +77,28 @@ pub fn print_table_or_error(
 
     match engine_state.find_decl("table".as_bytes(), &[]) {
         Some(decl_id) => {
-            let table = engine_state.get_decl(decl_id).run(
-                engine_state,
-                stack,
-                &Call::new(Span::new(0, 0)),
-                pipeline_data,
-            );
+            let command = engine_state.get_decl(decl_id);
+            if command.get_block_id().is_some() {
+                print_or_exit(pipeline_data, engine_state, config);
+            } else {
+                let table = command.run(
+                    engine_state,
+                    stack,
+                    &Call::new(Span::new(0, 0)),
+                    pipeline_data,
+                );
 
-            match table {
-                Ok(table) => {
-                    print_or_exit(table, engine_state, config);
-                }
-                Err(error) => {
-                    let working_set = StateWorkingSet::new(engine_state);
+                match table {
+                    Ok(table) => {
+                        print_or_exit(table, engine_state, config);
+                    }
+                    Err(error) => {
+                        let working_set = StateWorkingSet::new(engine_state);
 
-                    report_error(&working_set, &error);
+                        report_error(&working_set, &error);
 
-                    std::process::exit(1);
+                        std::process::exit(1);
+                    }
                 }
             }
         }

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -1,4 +1,5 @@
 use crate::tests::{fail_test, run_test, run_test_contains, TestResult};
+use nu_test_support::nu;
 
 #[test]
 fn no_scope_leak1() -> TestResult {
@@ -134,4 +135,10 @@ fn help_not_present_in_extern() -> TestResult {
 #[test]
 fn override_table() -> TestResult {
     run_test(r#"def table [] { "hi" }; table"#, "hi")
+}
+
+#[test]
+fn override_table_eval_file() {
+    let actual = nu!(cwd: ".", r#"def table [] { "hi" }; table"#);
+    assert_eq!(actual.out, "hi");
 }


### PR DESCRIPTION


# Description
Similar to #6113, when run command from string, the same error occurs.

```sh
nu -c "def table [] { \"hi\" }; table"
```


# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
