### PR TITLE
Use local time for logger

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset, Utc};
+use chrono::{DateTime, Local};
 use core::fmt;
 use log::Level;
 use log::LevelFilter;
@@ -32,11 +32,8 @@ pub fn my_formatted_timed_builder() -> Builder {
         });
 
         let dt = match DateTime::parse_from_rfc3339(&f.timestamp_millis().to_string()) {
-            Ok(d) => d,
-            Err(_) => {
-                let n = Utc::now();
-                DateTime::<FixedOffset>::from(n)
-            }
+            Ok(d) => d.with_timezone(&Local),
+            Err(_) => Local::now(),
         };
         let time = dt.format("%Y-%m-%d %I:%M:%S%.3f %p");
         writeln!(f, "{}|{}|{}|{}", time, level, target, record.args(),)


### PR DESCRIPTION
# Description
I think local time is more friendly :joy: 
```
nibon7@yoga14s /data/source/nushell (git)-[log_time] % ./target/debug/nu --log-level info
2022-07-26 03:56:15.061 AM|INFO |nu|start logging src/main.rs:156:67
/data/source/nushell〉^date +"%Y-%m-%d %I:%M:%S %p"                                                                                                07/26/2022 11:56:15 AM
2022-07-26 11:56:18 AM
```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
