### PR TITLE
Make login.nu work when using nu as a login shell 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,9 @@ fn main() -> Result<()> {
     // Would be nice if we had a way to parse this. The first flags we see will be going to nushell
     // then it'll be the script name
     // then the args to the script
-    let mut args = std::env::args().skip(1);
+    let mut args = std::env::args();
+    let argv0 = args.next();
+
     while let Some(arg) = args.next() {
         if !script_name.is_empty() {
             args_to_script.push(escape_for_script_arg(&arg));
@@ -121,6 +123,12 @@ fn main() -> Result<()> {
     }
 
     args_to_nushell.insert(0, "nu".into());
+
+    if let Some(argv0) = argv0 {
+        if argv0.starts_with("-") {
+            args_to_nushell.push("--login".into());
+        }
+    }
 
     let nushell_commandline_args = args_to_nushell.join(" ");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn main() -> Result<()> {
     args_to_nushell.insert(0, "nu".into());
 
     if let Some(argv0) = argv0 {
-        if argv0.starts_with("-") {
+        if argv0.starts_with('-') {
             args_to_nushell.push("--login".into());
         }
     }


### PR DESCRIPTION
# Description

Tested with `ssh`, `su -` and `sudo -i -u` on linux

detailed implementation for bash and zsh:

https://github.com/bminor/bash/blob/f3a35a2d601a55f337f8ca02a541f8c033682247/shell.c#L1759-L1772
https://github.com/zsh-users/zsh/blob/00d20ed15e18f5af682f0daec140d6b8383c479a/Src/init.c#L251-L258

Fixes #6055

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
