### PR TITLE
Make path::canonicalize::canonicalize_dot test case more reliable

### DIFF
--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -96,21 +96,19 @@ fn canonicalize_absolute_path_relative_to() {
 
 #[test]
 fn canonicalize_dot() {
-    let cwd = std::env::current_dir().expect("Could not get current directory");
-
-    let actual = canonicalize_with(".", cwd).expect("Failed to canonicalize");
     let expected = std::env::current_dir().expect("Could not get current directory");
+
+    let actual = canonicalize_with(".", expected.as_path()).expect("Failed to canonicalize");
 
     assert_eq!(actual, expected);
 }
 
 #[test]
 fn canonicalize_many_dots() {
-    let cwd = std::env::current_dir().expect("Could not get current directory");
-
-    let actual =
-        canonicalize_with("././/.//////./././//.///", cwd).expect("Failed to canonicalize");
     let expected = std::env::current_dir().expect("Could not get current directory");
+
+    let actual = canonicalize_with("././/.//////./././//.///", expected.as_path())
+        .expect("Failed to canonicalize");
 
     assert_eq!(actual, expected);
 }


### PR DESCRIPTION
# Description

`std::env::current_dir()` sometimes returns different path before and after `canonicalize_with()` during the test.

Fixes #6139

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
