### PR TITLE
fix var names coming from long/short flags

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3226,7 +3226,14 @@ pub fn parse_signature_helper(
                                         String::from_utf8_lossy(short_flag).to_string();
                                     let chars: Vec<char> = short_flag.chars().collect();
                                     let long = String::from_utf8_lossy(&flags[0][2..]).to_string();
-                                    let variable_name = flags[0][2..].to_vec();
+                                    let mut variable_name = flags[0][2..].to_vec();
+
+                                    (0..variable_name.len()).for_each(|idx| {
+                                        if variable_name[idx] == b'-' {
+                                            variable_name[idx] = b'_';
+                                        }
+                                    });
+
                                     if !is_variable(&variable_name) {
                                         error = error.or_else(|| {
                                             Some(ParseError::Expected(


### PR DESCRIPTION
# Description

Fixes one place I missed for automatic var renaming for long flags. There was one case where we had both a long and short flag `--like-this(-l)` that wasn't getting the correct variable rename.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
