### PR TITLE
Fix ls panics when a file or directory not exists

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -147,9 +147,13 @@ impl Command for Ls {
                         Some(glob_options)
                     };
                     let (prefix, paths) =
-                        nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options)
-                            .expect("glob failure");
-
+                        match nu_engine::glob_from(&glob_path, &cwd, call_span, glob_options) {
+                            Ok((prefix, paths)) => (prefix, paths),
+                            Err(e) => {
+                                shell_errors.push(e);
+                                return Vec::from([Value::nothing(call_span)]).into_iter();
+                            }
+                        };
                     let mut paths_peek = paths.peekable();
                     if paths_peek.peek().is_none() {
                         shell_errors.push(ShellError::GenericError(

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -527,3 +527,11 @@ fn can_list_system_folder() {
     ));
     assert_eq!(ls_with_filter.err, "");
 }
+
+#[test]
+fn list_a_directory_not_exists() {
+    Playground::setup("ls_test_directory_not_exists", |dirs, _sandbox| {
+        let actual = nu!(cwd: dirs.test(), "ls a_directory_not_exists");
+        assert!(actual.err.contains("directory not found"));
+    })
+}


### PR DESCRIPTION
# Description

Fixes #6146

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
