### PR TITLE
move application reset mode ansi sequence after cmdline execute

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -312,7 +312,6 @@ pub fn evaluate_repl(
                 }
 
                 if shell_integration {
-                    run_ansi_sequence(RESET_APPLICATION_MODE)?;
                     run_ansi_sequence(PRE_EXECUTE_MARKER)?;
                 }
 
@@ -429,6 +428,7 @@ pub fn evaluate_repl(
                         // ESC]2;stringBEL -- Set window title to string
                         run_ansi_sequence(&format!("\x1b]2;{}\x07", maybe_abbrev_path))?;
                     }
+                    run_ansi_sequence(RESET_APPLICATION_MODE)?;
                 }
             }
             Ok(Signal::CtrlC) => {


### PR DESCRIPTION
# Description

This PR moves the application reset mode ansi sequence to after the command line executes. So, theoretically, if dotnet or ssh or whatever messes up arrow keys, when the return happens, this reset should fix it.

related to #6145 

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
