### PR TITLE
Prevent mv panic

### DIFF
--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -84,7 +84,7 @@ impl Command for Mv {
 
         let ctrlc = engine_state.ctrlc.clone();
 
-        let path = current_dir(engine_state, stack).expect("Failed current_dir");
+        let path = current_dir(engine_state, stack)?;
 
         let span = call.head;
 
@@ -141,7 +141,7 @@ impl Command for Mv {
                         let err = ShellError::GenericError(
                             format!(
                                 "Not possible to move {:?} to itself",
-                                filename.file_name().expect("Invalid file name")
+                                filename.file_name().unwrap_or(filename.as_os_str())
                             ),
                             "cannot move to itself".into(),
                             Some(spanned_destination.span),
@@ -178,18 +178,17 @@ impl Command for Mv {
                         if let Err(error) = result {
                             Some(Value::Error { error })
                         } else if verbose {
-                            let val = if result.expect("Error value when unwrapping mv result") {
-                                format!(
+                            let val = match result {
+                                Ok(true) => format!(
                                     "moved {:} to {:}",
                                     entry.to_string_lossy(),
                                     destination.to_string_lossy()
-                                )
-                            } else {
-                                format!(
+                                ),
+                                _ => format!(
                                     "{:} not moved to {:}",
                                     entry.to_string_lossy(),
                                     destination.to_string_lossy()
-                                )
+                                ),
                             };
                             Some(Value::String { val, span })
                         } else {


### PR DESCRIPTION
# Description

This fixes `mv -v / /` panics on linux

# Tests

Make sure you've done the following:

- [] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
