### PR TITLE
add a new welcome banner to nushell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "reedline",
  "regex",
  "rstest",
+ "strip-ansi-escapes",
  "sysinfo",
  "thiserror",
 ]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -30,6 +30,7 @@ is_executable = "1.0.1"
 lazy_static = "1.4.0"
 log = "0.4"
 regex = "1.5.4"
+strip-ansi-escapes = "0.1.1"
 sysinfo = "0.24.1"
 
 [features]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -493,8 +493,7 @@ fn get_banner(engine_state: &mut EngineState, stack: &mut Stack) -> String {
     };
 
     let banner = format!(
-        r#"
-{}     __  ,
+        r#"{}     __  ,
 {} .--()°'.' {}Welcome to {}Nushell{}, 
 {}'|, . ,'   {}based on the {}nu{} language,
 {} !_-(_\    {}where all data is structured!

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -506,7 +506,7 @@ Our {}Documentation{} is located at {}http://nushell.sh{}
 {}Nushell{} has been around for:
 {}
 
-{}You can disable this banner using the config nu command
+{}You can disable this banner using the {}config nu{}{} command
 to modify the config.nu file and setting show_banner to false.
 
 let-env config {{
@@ -544,7 +544,10 @@ let-env config {{
         "\x1b[32m",   //before Nushell
         "\x1b[0m",    //after Nushell
         age,
-        "\x1b[2;37m", //before banner disable
+        "\x1b[2;37m", //before banner disable dim white
+        "\x1b[2;36m", //before config nu dim cyan
+        "\x1b[0m",    //after config nu
+        "\x1b[2;37m", //after config nu dim white
         "\x1b[0m",    //after banner disable
     );
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -544,7 +544,7 @@ let-env config {{
         "\x1b[32m",   //before Nushell
         "\x1b[0m",    //after Nushell
         age,
-        "\x1b[1;30m", //before banner disable
+        "\x1b[2;37m", //before banner disable
         "\x1b[0m",    //after banner disable
     );
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -498,20 +498,21 @@ fn get_banner(engine_state: &mut EngineState, stack: &mut Stack) -> String {
 {}'|, . ,'   {}based on the {}nu{} language,
 {} !_-(_\    {}where all data is structured!
 
-Please join our {}Discord{} community at https://discord.gg/NtAbbGn
-Our {}GitHub{} repository is at https://github.com/nushell/nushell
-Our {}Documentation{} is located at http://nushell.sh
+Please join our {}Discord{} community at {}https://discord.gg/NtAbbGn{}
+Our {}GitHub{} repository is at {}https://github.com/nushell/nushell{}
+Our {}Documentation{} is located at {}http://nushell.sh{}
 {}Tweet{} us a {}@nu_shell{}
 
 {}Nushell{} has been around for:
 {}
 
-Disable this banner by changing config.nu like this:
+{}You can disable this banner using the config nu command
+to modify the config.nu file and setting show_banner to false.
 
 let-env config {{
     show_banner: false
     ...
-}}
+}}{}
 "#,
         "\x1b[32m",   //start line 1 green
         "\x1b[32m",   //start line 2
@@ -526,17 +527,25 @@ let-env config {{
         "\x1b[0m",    //before where
         "\x1b[35m",   //before Discord purple
         "\x1b[0m",    //after Discord
+        "\x1b[35m",   //before Discord URL
+        "\x1b[0m",    //after Discord URL
         "\x1b[1;32m", //before GitHub green_bold
         "\x1b[0m",    //after GitHub
+        "\x1b[1;32m", //before GitHub URL
+        "\x1b[0m",    //after GitHub URL
         "\x1b[32m",   //before Documentation
         "\x1b[0m",    //after Documentation
+        "\x1b[32m",   //before Documentation URL
+        "\x1b[0m",    //after Documentation URL
         "\x1b[36m",   //before Tweet blue
         "\x1b[0m",    //after Tweet
         "\x1b[1;36m", //before @nu_shell cyan_bold
         "\x1b[0m",    //after @nu_shell
         "\x1b[32m",   //before Nushell
         "\x1b[0m",    //after Nushell
-        age
+        age,
+        "\x1b[1;30m", //before banner disable
+        "\x1b[0m",    //after banner disable
     );
 
     banner

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -501,7 +501,7 @@ fn get_banner(engine_state: &mut EngineState, stack: &mut Stack) -> String {
 Please join our {}Discord{} community at {}https://discord.gg/NtAbbGn{}
 Our {}GitHub{} repository is at {}https://github.com/nushell/nushell{}
 Our {}Documentation{} is located at {}http://nushell.sh{}
-{}Tweet{} us a {}@nu_shell{}
+{}Tweet{} us at {}@nu_shell{}
 
 {}Nushell{} has been around for:
 {}

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -573,8 +573,6 @@ pub fn eval_string_with_input(
         (output, working_set.render())
     };
 
-    // let cwd = nu_engine::env::current_dir_str(engine_state, stack)?;
-
     if let Err(err) = engine_state.merge_delta(delta) {
         return Err(err);
     }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -81,6 +81,7 @@ pub struct Config {
     pub case_sensitive_completions: bool,
     pub enable_external_completion: bool,
     pub trim_strategy: TrimStrategy,
+    pub show_banner: bool,
 }
 
 impl Default for Config {
@@ -115,6 +116,7 @@ impl Default for Config {
             case_sensitive_completions: false,
             enable_external_completion: true,
             trim_strategy: TRIM_STRATEGY_DEFAULT,
+            show_banner: true,
         }
     }
 }
@@ -388,6 +390,13 @@ impl Value {
                         }
                     }
                     "table_trim" => config.trim_strategy = try_parse_trim_strategy(value, &config)?,
+                    "show_banner" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.show_banner = b;
+                        } else {
+                            eprintln!("$config.show_banner is not a bool")
+                        }
+                    }
                     x => {
                         eprintln!("$config.{} is an unknown config setting", x)
                     }

--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -257,7 +257,6 @@ let-env config = {
   case_sensitive_completions: false # set to true to enable case-sensitive completions
   enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
   max_external_completion_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
-
   # A strategy of managing table view in case of limited space.
   table_trim: {
     methodology: wrapping, # truncating
@@ -266,6 +265,7 @@ let-env config = {
     # A suffix which will be used with 'truncating' methodology
     # truncating_suffix: "..."
   }
+  show_banner: true # true or false to enable or disable the banner
 
   hooks: {
     pre_prompt: [{


### PR DESCRIPTION
# Description

This PR adds a new welcome banner to nushell.
<img width="738" alt="Screen Shot 2022-07-28 at 8 22 46 AM" src="https://user-images.githubusercontent.com/343840/181515830-5bdfacb2-a571-4458-b1bf-4aacba3614fe.png">

The banner can be disabled with `show_banner: false` in the config.nu. It also respects the `use_ansi_coloring` setting if your terminal doesn't support colors,

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
