### PR TITLE
add throw error to `mv`

### DIFF
--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -88,6 +88,15 @@ impl Command for Mv {
 
         let span = call.head;
 
+        // an empty sources is same meaning to a non-existent destionation
+        // because, if there is only one argument, the first is bound to spanned_destination.
+        if spanned_sources.is_empty() {
+            return Err(ShellError::MoveNotPossibleSingle(
+                "missing destination".to_string(),
+                span,
+            ));
+        }
+
         Ok(spanned_sources
             .into_iter()
             .flat_map(move |spanned_source| {


### PR DESCRIPTION
# Description

fix #6159 

I've added a simple output error if there is no destination in the `mv`.
But I'm not sure if this is the right direction. Because, ideally, the error should be output through the required option.
I think these concerns are also related to this issue (#6164)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
