### PR TITLE
Quickly patch wrong 'export' command name

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4790,7 +4790,7 @@ pub fn parse_builtin_commands(
         b"overlay" => parse_overlay(working_set, &lite_command.parts, expand_aliases_denylist),
         b"source" => parse_source(working_set, &lite_command.parts, expand_aliases_denylist),
         b"export" => {
-            if let Some(decl_id) = working_set.find_decl(b"alias", &Type::Any) {
+            if let Some(decl_id) = working_set.find_decl(b"export", &Type::Any) {
                 let parsed_call = parse_internal_call(
                     working_set,
                     lite_command.parts[0],


### PR DESCRIPTION
It was looked up as `alias` which explains issue #6167. Proper fix is still needed to enable the -h flag for `export` subcommands.

# Description

(description of your pull request here)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
