### PR TITLE
Prevent mv panic again

### DIFF
--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -119,7 +119,7 @@ impl Command for Mv {
                 return Err(ShellError::GenericError(
                     format!(
                         "Not possible to move {:?} to itself",
-                        filename.file_name().expect("Invalid file name")
+                        filename.file_name().unwrap_or(filename.as_os_str())
                     ),
                     "cannot move to itself".into(),
                     Some(spanned_destination.span),
@@ -155,18 +155,17 @@ impl Command for Mv {
                 if let Err(error) = result {
                     Some(Value::Error { error })
                 } else if verbose {
-                    let val = if result.expect("Error value when unwrapping mv result") {
-                        format!(
+                    let val = match result {
+                        Ok(true) => format!(
                             "moved {:} to {:}",
                             entry.to_string_lossy(),
                             destination.to_string_lossy()
-                        )
-                    } else {
-                        format!(
+                        ),
+                        _ => format!(
                             "{:} not moved to {:}",
                             entry.to_string_lossy(),
                             destination.to_string_lossy()
-                        )
+                        ),
                     };
                     Some(Value::String { val, span })
                 } else {


### PR DESCRIPTION
# Description

This PR just apply commit from #6158 and fixes `mv -v / /` panics on linux

Closes #6170

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
