### PR TITLE
Fix path_contains_hidden_folder

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -499,11 +499,7 @@ fn is_hidden_dir(dir: impl AsRef<Path>) -> bool {
 }
 
 fn path_contains_hidden_folder(path: &Path, folders: &[PathBuf]) -> bool {
-    let path_str = path.to_str().expect("failed to read path");
-    if folders
-        .iter()
-        .any(|p| path_str.starts_with(&p.to_str().expect("failed to read hidden paths")))
-    {
+    if folders.iter().any(|p| path.starts_with(p.as_path())) {
         return true;
     }
     false

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -535,3 +535,28 @@ fn list_a_directory_not_exists() {
         assert!(actual.err.contains("directory not found"));
     })
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn list_directory_contains_invalid_utf8() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    Playground::setup(
+        "ls_test_directory_contains_invalid_utf8",
+        |dirs, _sandbox| {
+            let v: [u8; 4] = [7, 196, 144, 188];
+            let s = OsStr::from_bytes(&v);
+
+            let cwd = dirs.test();
+            let path = cwd.join(s);
+
+            std::fs::create_dir_all(&path).expect("failed to create directory");
+
+            let actual = nu!(cwd, "ls");
+
+            assert!(actual.out.contains("warning: get non-utf8 filename"));
+            assert!(actual.err.contains("No matches found for"));
+        },
+    )
+}


### PR DESCRIPTION
# Description

No need to convert `Path` to `&str` and the convention may return None if `Path` contains non-UTF-8 strings.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
