### PR TITLE
Make default env works better with bash style PATH

### DIFF
--- a/docs/sample_config/default_env.nu
+++ b/docs/sample_config/default_env.nu
@@ -35,11 +35,11 @@ let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
 # Note: The conversions happen *after* config.nu is loaded
 let-env ENV_CONVERSIONS = {
   "PATH": {
-    from_string: { |s| $s | split row (char esep) }
+    from_string: { |s| $s | split row (char esep) | path expand }
     to_string: { |v| $v | path expand | str collect (char esep) }
   }
   "Path": {
-    from_string: { |s| $s | split row (char esep) }
+    from_string: { |s| $s | split row (char esep) | path expand }
     to_string: { |v| $v | path expand | str collect (char esep) }
   }
 }


### PR DESCRIPTION
# Description

I've added two path in `env.nu`
```
let-env PATH = ($env.PATH | split row (char esep) | prepend '~/.cargo/bin')
let-env PATH = ($env.PATH | split row (char esep) | prepend '~/anaconda3/bin')
```

And after using [conda.nu](https://github.com/nushell/nu_scripts/blob/main/virtual_environments/conda.nu), the PATH becomes something like this:
```
~/.cargo/bin:~/anaconda3/bin
```

Then I can't execute `cargo` command...

Change `from_string` would fix this behavior

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
