### PR TITLE
Fix touch panics when using invalid timestamp

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -140,14 +140,24 @@ impl Command for Touch {
                         10 => Some(AddYear::Full),
                         12 => Some(AddYear::FirstDigits),
                         14 => None,
-                        _ => unreachable!(), // This should never happen as the check above should catch it
+                        _ => {
+                            return Err(ShellError::UnsupportedInput(
+                                "input has an invalid timestamp".to_string(),
+                                span,
+                            ))
+                        }
                     }
                 } else {
                     match size {
                         8 => Some(AddYear::Full),
                         10 => Some(AddYear::FirstDigits),
                         12 => None,
-                        _ => unreachable!(), // This should never happen as the check above should catch it
+                        _ => {
+                            return Err(ShellError::UnsupportedInput(
+                                "input has an invalid timestamp".to_string(),
+                                span,
+                            ))
+                        }
                     }
                 };
 

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -766,3 +766,20 @@ fn not_create_file_if_it_not_exists() {
         assert!(!path.exists());
     })
 }
+
+#[test]
+fn test_invalid_timestamp() {
+    Playground::setup("test_invalid_timestamp", |dirs, _sandbox| {
+        let outcome = nu!(
+            cwd: dirs.test(),
+            r#"touch -t 20220729. file.txt"#
+        );
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        let outcome = nu!(
+            cwd: dirs.test(),
+            r#"touch -t 20220729120099 file.txt"#
+        );
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+    })
+}


### PR DESCRIPTION
# Description

There are some cases cause `touch` panic. This PR makes `touch` more robust.

```
/data/source/nushell〉touch -t 20220729. file.txt                                                                                                  07/29/2022 05:49:15 PM
thread 'main' panicked at 'internal error: entered unreachable code', crates/nu-command/src/filesystem/touch.rs:143:30
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
101 nibon7@yoga14s /data/source/nushell (git)-[fix_touch] % nu
/data/source/nushell〉touch -t 20220729120099 file.txt                                                                                             07/29/2022 05:49:25 PM
thread 'main' panicked at 'internal error: entered unreachable code', crates/nu-command/src/filesystem/touch.rs:150:30
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
