### PR TITLE
Tweak how nu identifies custom command

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -142,7 +142,7 @@ fn help(
 
                 cols.push("is_custom".into());
                 vals.push(Value::Bool {
-                    val: decl.get_block_id().is_some(),
+                    val: decl.is_custom_command(),
                     span: head,
                 });
 
@@ -243,7 +243,7 @@ fn help(
 
                 cols.push("is_custom".into());
                 vals.push(Value::Bool {
-                    val: decl.get_block_id().is_some(),
+                    val: decl.is_custom_command(),
                     span: head,
                 });
 

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -95,7 +95,7 @@ fn get_entry_in_aliases(engine_state: &EngineState, name: &str, span: Span) -> O
 
 fn get_entry_in_commands(engine_state: &EngineState, name: &str, span: Span) -> Option<Value> {
     if let Some(decl_id) = engine_state.find_decl(name.as_bytes(), &[]) {
-        let (msg, is_builtin) = if engine_state.get_decl(decl_id).get_block_id().is_some() {
+        let (msg, is_builtin) = if engine_state.get_decl(decl_id).is_custom_command() {
             ("Nushell custom command", false)
         } else {
             ("Nushell built-in command", true)

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1101,7 +1101,7 @@ pub fn create_scope(
             cols.push("is_builtin".to_string());
             // we can only be a is_builtin or is_custom, not both
             vals.push(Value::Bool {
-                val: decl.get_block_id().is_none(),
+                val: !decl.is_custom_command(),
                 span,
             });
 
@@ -1119,7 +1119,7 @@ pub fn create_scope(
 
             cols.push("is_custom".to_string());
             vals.push(Value::Bool {
-                val: decl.get_block_id().is_some(),
+                val: decl.is_custom_command(),
                 span,
             });
 

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -30,6 +30,10 @@ impl Command for KnownExternal {
         true
     }
 
+    fn is_builtin(&self) -> bool {
+        false
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -37,6 +37,16 @@ pub trait Command: Send + Sync + CommandClone {
         false
     }
 
+    // This is an enhanced method to determine if a command is custom command or not
+    // since extern "foo" [] and def "foo" [] behaves differently
+    fn is_custom_command(&self) -> bool {
+        if self.get_block_id().is_some() {
+            true
+        } else {
+            self.is_known_external()
+        }
+    }
+
     // Is a sub command
     fn is_sub(&self) -> bool {
         self.name().contains(' ')


### PR DESCRIPTION
# Description

Tweak how nu currently identifies a command as is_custom or not: The current logic is to only check get_block_id(), however, KnownExternal uses the default implementation which returns None.

The fix is to combine get_block_id and is_known_external

Currently
<img width="776" alt="image" src="https://user-images.githubusercontent.com/85712372/181854748-ec998809-3103-4a6f-a22e-243c9d6437b4.png">

With the change 
<img width="776" alt="image" src="https://user-images.githubusercontent.com/85712372/179842475-adc8ed9e-ebae-4a58-9498-4779d0dcd332.png">

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
