### PR TITLE
allow `-h` flags for `export` subcommands

### DIFF
--- a/crates/nu-command/tests/commands/export_def.rs
+++ b/crates/nu-command/tests/commands/export_def.rs
@@ -9,5 +9,7 @@ fn export_subcommands_help() {
         "#
     ));
 
-    assert!(actual.out.contains("Define a custom command and export it from a module"));
+    assert!(actual
+        .out
+        .contains("Define a custom command and export it from a module"));
 }

--- a/crates/nu-command/tests/commands/export_def.rs
+++ b/crates/nu-command/tests/commands/export_def.rs
@@ -1,0 +1,13 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn export_subcommands_help() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        export def -h
+        "#
+    ));
+
+    assert!(actual.out.contains("Define a custom command and export it from a module"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -17,6 +17,7 @@ mod empty;
 mod enter;
 mod error_make;
 mod every;
+mod export_def;
 mod find;
 mod first;
 mod flatten;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4808,7 +4808,7 @@ pub fn parse_builtin_commands(
             if let Some(decl_id) = working_set.find_decl(&full_decl, &Type::Any) {
                 let parsed_call = parse_internal_call(
                     working_set,
-                    if full_decl == b"export" && lite_command.parts.len() > 1 {
+                    if full_decl == b"export" {
                         lite_command.parts[0]
                     } else {
                         span(&lite_command.parts[0..2])

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4794,11 +4794,30 @@ pub fn parse_builtin_commands(
         b"overlay" => parse_overlay(working_set, &lite_command.parts, expand_aliases_denylist),
         b"source" => parse_source(working_set, &lite_command.parts, expand_aliases_denylist),
         b"export" => {
-            if let Some(decl_id) = working_set.find_decl(b"export", &Type::Any) {
+            let full_decl = if lite_command.parts.len() > 1 {
+                let sub = working_set.get_span_contents(lite_command.parts[1]);
+                match sub {
+                    b"alias" | b"def" | b"def-env" | b"env" | b"extern" | b"use" => {
+                        [b"export ", sub].concat()
+                    }
+                    _ => b"export".to_vec(),
+                }
+            } else {
+                b"export".to_vec()
+            };
+            if let Some(decl_id) = working_set.find_decl(&full_decl, &Type::Any) {
                 let parsed_call = parse_internal_call(
                     working_set,
-                    lite_command.parts[0],
-                    &lite_command.parts[1..],
+                    if full_decl == b"export" && lite_command.parts.len() > 1 {
+                        lite_command.parts[0]
+                    } else {
+                        span(&lite_command.parts[0..2])
+                    },
+                    if full_decl == b"export" {
+                        &lite_command.parts[1..]
+                    } else {
+                        &lite_command.parts[2..]
+                    },
                     decl_id,
                     expand_aliases_denylist,
                 );


### PR DESCRIPTION
# Description

Title. Fixes #6167. Related to #6168. To test, just `export def -h` or another subcommand.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
