### PR TITLE
Return error early if seconds part of timestamp is invalid

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -121,7 +121,15 @@ impl Command for Touch {
 
                 // Checks for the seconds stamp and removes the '.' delimiter if any
                 let (val, has_sec): (String, bool) = match stamp.split_once('.') {
-                    Some((dtime, sec)) => (format!("{}{}", dtime, sec), true),
+                    Some((dtime, sec)) => match sec.parse::<u8>() {
+                        Ok(sec) if sec < 60 => (format!("{}{}", dtime, sec), true),
+                        _ => {
+                            return Err(ShellError::UnsupportedInput(
+                                "input has an invalid timestamp".to_string(),
+                                span,
+                            ))
+                        }
+                    },
                     None => (stamp.to_string(), false),
                 };
 

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -180,6 +180,34 @@ fn errors_if_change_modified_time_of_file_with_invalid_timestamp() {
         );
 
         assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -t 082412.3012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -t 0824.123012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -t 08.24123012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -t 0.824123012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
     })
 }
 
@@ -398,6 +426,34 @@ fn errors_if_change_access_time_of_file_with_invalid_timestamp() {
         outcome = nu!(
             cwd: dirs.test(),
             "touch -a -t 01908241230 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -a -t 082412.3012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -a -t 0824.123012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -a -t 08.24123012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -a -t 0.824123012 file.txt"
         );
 
         assert!(outcome.err.contains("input has an invalid timestamp"));
@@ -631,6 +687,34 @@ fn errors_if_change_modified_and_access_time_of_file_with_invalid_timestamp() {
         outcome = nu!(
             cwd: dirs.test(),
             "touch -t 01908241230 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -a -t 082412.3012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -a -t 0824.123012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -a -t 08.24123012 file.txt"
+        );
+
+        assert!(outcome.err.contains("input has an invalid timestamp"));
+
+        outcome = nu!(
+            cwd: dirs.test(),
+            "touch -m -a -t 0.824123012 file.txt"
         );
 
         assert!(outcome.err.contains("input has an invalid timestamp"));


### PR DESCRIPTION
# Description

This PR checks seconds part of a timestamp early. Current implementation treats  `08.24123012` or `082412.3012` as `08241230.12`, so `touch -t 08.24123012 file.txt` and `touch -t 08241230.12` have the same effect, both access time and modification time are the same.

```
/data/source/nushell〉touch -t 08.24123012 file1.txt                                                                                     07/31/2022 09:13:32 AM
/data/source/nushell〉stat file1.txt                                                                                                     07/31/2022 09:13:39 AM
  File: file1.txt
  Size: 0         	Blocks: 0          IO Block: 4096   regular empty file
Device: 10304h/66308d	Inode: 17713961    Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/  nibon7)   Gid: ( 1000/  nibon7)
Access: 2022-08-24 12:30:12.000000000 +0800
Modify: 2022-08-24 12:30:12.000000000 +0800
Change: 2022-07-31 09:13:39.878912971 +0800
 Birth: 2022-07-31 09:13:39.878912971 +0800
/data/source/nushell〉touch -t 08241230.12 file2.txt                                                                                     07/31/2022 09:13:43 AM
/data/source/nushell〉stat file2.txt                                                                                                     07/31/2022 09:13:56 AM
  File: file2.txt
  Size: 0         	Blocks: 0          IO Block: 4096   regular empty file
Device: 10304h/66308d	Inode: 17714297    Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/  nibon7)   Gid: ( 1000/  nibon7)
Access: 2022-08-24 12:30:12.000000000 +0800
Modify: 2022-08-24 12:30:12.000000000 +0800
Change: 2022-07-31 09:13:56.232911454 +0800
 Birth: 2022-07-31 09:13:56.232911454 +0800
```

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
