### PR TITLE
Add $OLDPWD example for cd

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -188,6 +188,11 @@ impl Command for Cd {
                 example: r#"cd d/s/9"#,
                 result: None,
             },
+            Example {
+                description: "Change to the previous working directory ($OLDPWD)",
+                example: r#"cd -"#,
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -56,7 +56,7 @@ fn test_cd_html_color_flag_dark_false() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; <span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span><span style='color:#037979;'>~<span style='color:black;font-weight:normal;'><br><br>  Change to a directory via abbreviations<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>d/s/9<span style='color:black;font-weight:normal;'><br><br></body></html></span></span>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; <span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span><span style='color:#037979;'>~<span style='color:black;font-weight:normal;'><br><br>  Change to a directory via abbreviations<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>d/s/9<span style='color:black;font-weight:normal;'><br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>-<span style='color:black;font-weight:normal;'><br><br></body></html></span></span>"
     );
 }
 
@@ -71,6 +71,6 @@ fn test_no_color_flag() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display this help message<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; cd -<br><br></body></html>"
     );
 }


### PR DESCRIPTION
# Description

Just adds an example of using `cd -` to change to the previous working directory. Last example in this screenshot:

![image](https://user-images.githubusercontent.com/26268125/182005812-413117ae-18c0-46fb-9e87-3ffed6ca69c2.png)


# Tests


Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
