### PR TITLE
allow uppercase chars to be captured during suppressed input

### DIFF
--- a/crates/nu-command/src/platform/input.rs
+++ b/crates/nu-command/src/platform/input.rs
@@ -98,7 +98,12 @@ impl Command for Input {
                     match crossterm::event::read() {
                         Ok(Event::Key(k)) => match k.code {
                             // TODO: maintain keycode parity with existing command
-                            KeyCode::Char(_) if k.modifiers != KeyModifiers::NONE => continue,
+                            KeyCode::Char(_)
+                                if k.modifiers == KeyModifiers::ALT
+                                    || k.modifiers == KeyModifiers::CONTROL =>
+                            {
+                                continue
+                            }
                             KeyCode::Char(c) => buf.push(c),
                             KeyCode::Backspace => {
                                 let _ = buf.pop();


### PR DESCRIPTION
# Description

closes #6198 
This PR fixes a bug where `echo (input 'Uppercase text: ' -s)` wouldn't capture uppercase letters.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
