### PR TITLE
Change `query` command to `query db`

### DIFF
--- a/crates/nu-command/src/database/commands/query.rs
+++ b/crates/nu-command/src/database/commands/query.rs
@@ -13,17 +13,17 @@ pub struct QueryDb;
 
 impl Command for QueryDb {
     fn name(&self) -> &str {
-        "query"
+        "query db"
     }
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required(
-                "query",
+                "SQL",
                 SyntaxShape::String,
                 "SQL to execute against the database",
             )
-            .input_type(Type::Custom("database".into()))
+            .input_type(Type::Any)
             .output_type(Type::Any)
             .category(Category::Custom("database".into()))
     }
@@ -34,8 +34,8 @@ impl Command for QueryDb {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Execute a query statement using the database connection",
-            example: r#"open foo.db | into db | query "SELECT * FROM Bar""#,
+            description: "Execute SQL against a SQLite database",
+            example: r#"open foo.db | query db "SELECT * FROM Bar""#,
             result: None,
         }]
     }

--- a/crates/nu-command/tests/commands/query/db.rs
+++ b/crates/nu-command/tests/commands/query/db.rs
@@ -7,8 +7,7 @@ fn can_query_single_table() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             open sample.db
-            | into db
-            | query "select * from strings"
+            | query db "select * from strings"
             | where x =~ ell
             | length
         "#
@@ -24,8 +23,7 @@ fn invalid_sql_fails() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             open sample.db
-            | into db
-            | query "select *asdfasdf"
+            | query db "select *asdfasdf"
         "#
     ));
 
@@ -38,7 +36,7 @@ fn invalid_input_fails() {
     let actual = nu!(
     cwd: "tests/fixtures/formats", pipeline(
         r#"
-            "foo" | into db | query "select * from asdf"
+            "foo" | query db "select * from asdf"
         "#
     ));
 


### PR DESCRIPTION
# Description

This PR changes how to execute raw SQL against a SQLite database. Before:
```
open foo.db | into-db | query "select *..." 
OR
open-db foo.db | query "select *..."
```

After:
```
open foo.db | query db "select *..."
```

This effectively reverts to the `query` behavior we had ~3 months ago. IMO it's better to be explicit than rely on types at parse time, and `query db` is consistent with how the commands in the `query` plugin (`query json`, `query xml`, `query web`) work.

# Tests

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
