### PR TITLE
Add `bits shl` and `bits shr` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "nu-test-support",
  "nu-utils",
  "num 0.4.0",
+ "num-traits",
  "pathdiff",
  "polars",
  "powierza-coefficient",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -58,6 +58,7 @@ meval = "0.2.0"
 mime = "0.3.16"
 notify = "4.0.17"
 num = { version = "0.4.0", optional = true }
+num-traits = "0.2.14"
 pathdiff = "0.2.1"
 powierza-coefficient = "1.0.1"
 quick-xml = "0.23.0"

--- a/crates/nu-command/src/bits/mod.rs
+++ b/crates/nu-command/src/bits/mod.rs
@@ -26,6 +26,18 @@ enum NumberBytes {
     Invalid,
 }
 
+#[derive(Clone, Copy)]
+enum InputNumType {
+    One,
+    Two,
+    Four,
+    Eight,
+    SignedOne,
+    SignedTwo,
+    SignedFour,
+    SignedEight,
+}
+
 fn get_number_bytes(number_bytes: &Option<Spanned<String>>) -> NumberBytes {
     match number_bytes.as_ref() {
         None => NumberBytes::Auto,
@@ -37,5 +49,47 @@ fn get_number_bytes(number_bytes: &Option<Spanned<String>>) -> NumberBytes {
             "auto" => NumberBytes::Auto,
             _ => NumberBytes::Invalid,
         },
+    }
+}
+
+fn get_input_num_type(val: i64, signed: bool, number_size: NumberBytes) -> InputNumType {
+    if signed || val < 0 {
+        match number_size {
+            NumberBytes::One => InputNumType::SignedOne,
+            NumberBytes::Two => InputNumType::SignedTwo,
+            NumberBytes::Four => InputNumType::SignedFour,
+            NumberBytes::Eight => InputNumType::SignedEight,
+            NumberBytes::Auto => {
+                if val <= 0x7F && val >= -(2i64.pow(7)) {
+                    InputNumType::SignedOne
+                } else if val <= 0x7FFF && val >= -(2i64.pow(15)) {
+                    InputNumType::SignedTwo
+                } else if val <= 0x7FFFFFFF && val >= -(2i64.pow(31)) {
+                    InputNumType::SignedFour
+                } else {
+                    InputNumType::SignedEight
+                }
+            }
+            NumberBytes::Invalid => InputNumType::SignedFour,
+        }
+    } else {
+        match number_size {
+            NumberBytes::One => InputNumType::One,
+            NumberBytes::Two => InputNumType::Two,
+            NumberBytes::Four => InputNumType::Four,
+            NumberBytes::Eight => InputNumType::Eight,
+            NumberBytes::Auto => {
+                if val <= 0xFF {
+                    InputNumType::One
+                } else if val <= 0xFFFF {
+                    InputNumType::Two
+                } else if val <= 0xFFFFFFFF {
+                    InputNumType::Four
+                } else {
+                    InputNumType::Eight
+                }
+            }
+            NumberBytes::Invalid => InputNumType::Four,
+        }
     }
 }

--- a/crates/nu-command/src/bits/mod.rs
+++ b/crates/nu-command/src/bits/mod.rs
@@ -40,7 +40,7 @@ enum InputNumType {
 
 fn get_number_bytes(number_bytes: &Option<Spanned<String>>) -> NumberBytes {
     match number_bytes.as_ref() {
-        None => NumberBytes::Auto,
+        None => NumberBytes::Eight,
         Some(size) => match size.item.as_str() {
             "1" => NumberBytes::One,
             "2" => NumberBytes::Two,

--- a/crates/nu-command/src/bits/mod.rs
+++ b/crates/nu-command/src/bits/mod.rs
@@ -6,6 +6,8 @@ mod shift_left;
 mod shift_right;
 mod xor;
 
+use nu_protocol::Spanned;
+
 pub use and::SubCommand as BitsAnd;
 pub use bits_::Bits;
 pub use not::SubCommand as BitsNot;
@@ -21,4 +23,19 @@ enum NumberBytes {
     Four,
     Eight,
     Auto,
+    Invalid,
+}
+
+fn get_number_bytes(number_bytes: &Option<Spanned<String>>) -> NumberBytes {
+    match number_bytes.as_ref() {
+        None => NumberBytes::Auto,
+        Some(size) => match size.item.as_str() {
+            "1" => NumberBytes::One,
+            "2" => NumberBytes::Two,
+            "4" => NumberBytes::Four,
+            "8" => NumberBytes::Eight,
+            "auto" => NumberBytes::Auto,
+            _ => NumberBytes::Invalid,
+        },
+    }
 }

--- a/crates/nu-command/src/bits/mod.rs
+++ b/crates/nu-command/src/bits/mod.rs
@@ -2,10 +2,23 @@ mod and;
 mod bits_;
 mod not;
 mod or;
+mod shift_left;
+mod shift_right;
 mod xor;
 
 pub use and::SubCommand as BitsAnd;
 pub use bits_::Bits;
 pub use not::SubCommand as BitsNot;
 pub use or::SubCommand as BitsOr;
+pub use shift_left::SubCommand as BitsShiftLeft;
+pub use shift_right::SubCommand as BitsShiftRight;
 pub use xor::SubCommand as BitsXor;
+
+#[derive(Clone, Copy)]
+enum NumberBytes {
+    One,
+    Two,
+    Four,
+    Eight,
+    Auto,
+}

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -53,7 +53,7 @@ impl Command for SubCommand {
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput(
-                    "the size of number is invalid".to_string(),
+                    "Only 1, 2, 4, 8, or \"auto\" bytes are supported as word sizes".to_string(),
                     val.span,
                 ));
             }

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -53,7 +53,7 @@ impl Command for SubCommand {
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput(
-                    "Only 1, 2, 4, 8, or \"auto\" bytes are supported as word sizes".to_string(),
+                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
                     val.span,
                 ));
             }

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -1,3 +1,4 @@
+use super::NumberBytes;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -7,15 +8,6 @@ use nu_protocol::{
 
 #[derive(Clone)]
 pub struct SubCommand;
-
-#[derive(Clone, Copy)]
-enum NumberBytes {
-    One,
-    Two,
-    Four,
-    Eight,
-    Auto,
-}
 
 impl Command for SubCommand {
     fn name(&self) -> &str {
@@ -83,7 +75,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Apply the logical negation to a list of numbers",
+                description: "Apply logical negation to a list of numbers",
                 example: "[4 3 2] | bits not",
                 result: Some(Value::List {
                     vals: vec![
@@ -96,7 +88,7 @@ impl Command for SubCommand {
             },
             Example {
                 description:
-                    "Apply the logical negation to a list of numbers, treat input as 2 bytes number",
+                    "Apply logical negation to a list of numbers, treat input as 2 bytes number",
                 example: "[4 3 2] | bits not -n 2",
                 result: Some(Value::List {
                     vals: vec![
@@ -109,7 +101,7 @@ impl Command for SubCommand {
             },
             Example {
                 description:
-                    "Apply the logical negation to a list of numbers, treat input as signed number",
+                    "Apply logical negation to a list of numbers, treat input as signed number",
                 example: "[4 3 2] | bits not -s",
                 result: Some(Value::List {
                     vals: vec![

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -72,9 +72,9 @@ impl Command for SubCommand {
                 example: "[4 3 2] | bits not",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::test_int(251),
-                        Value::test_int(252),
-                        Value::test_int(253),
+                        Value::test_int(140737488355323),
+                        Value::test_int(140737488355324),
+                        Value::test_int(140737488355325),
                     ],
                     span: Span::test_data(),
                 }),

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -13,11 +13,11 @@ pub struct SubCommand;
 
 impl Command for SubCommand {
     fn name(&self) -> &str {
-        "bits shift-left"
+        "bits shl"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("bits shift-left")
+        Signature::build("bits shl")
             .required("bits", SyntaxShape::Int, "number of bits to shift left")
             .switch(
                 "signed",
@@ -73,7 +73,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Shift left a number by 7 bits",
-                example: "2 | bits shift-left 7",
+                example: "2 | bits shl 7",
                 result: Some(Value::Int {
                     val: 0,
                     span: Span::test_data(),
@@ -81,7 +81,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Shift left a number with 2 bytes by 7 bits",
-                example: "2 | bits shift-left 7 -n 2",
+                example: "2 | bits shl 7 -n 2",
                 result: Some(Value::Int {
                     val: 256,
                     span: Span::test_data(),
@@ -89,7 +89,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Shift left a signed number by 1 bit",
-                example: "0x7F | bits shift-left 1 -s",
+                example: "0x7F | bits shl 1 -s",
                 result: Some(Value::Int {
                     val: -2,
                     span: Span::test_data(),
@@ -97,7 +97,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Shift left a list of numbers",
-                example: "[5 3 2] | bits shift-left 2",
+                example: "[5 3 2] | bits shl 2",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(20), Value::test_int(12), Value::test_int(8)],
                     span: Span::test_data(),

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .named(
                 "number-bytes",
                 SyntaxShape::String,
-                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `auto`",
+                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )
             .category(Category::Bits)

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -95,7 +95,7 @@ impl Command for SubCommand {
                 }),
             },
             Example {
-                description: "Shift left a signed number by 1 bits",
+                description: "Shift left a signed number by 1 bit",
                 example: "0x7F | bits shift-left 1 -s",
                 result: Some(Value::Int {
                     val: -2,
@@ -139,8 +139,11 @@ where
         }
         None => Value::Error {
             error: ShellError::GenericError(
-                "Shift left overflow".to_string(),
-                format!("{} shift left {} bits will be overflow", val, shift_bits),
+                "Shift left failed".to_string(),
+                format!(
+                    "{} shift left {} bits failed, you may shift too many bits",
+                    val, shift_bits
+                ),
                 Some(span),
                 None,
                 Vec::new(),
@@ -153,7 +156,8 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
     match value {
         Value::Int { val, span } => {
             use NumberBytes::*;
-            let shift_bits = (((bits % 64) + 64) % 64) as u32;
+            // let shift_bits = (((bits % 64) + 64) % 64) as u32;
+            let shift_bits = bits as u32;
             if signed || val < 0 {
                 match number_size {
                     One => get_shift_left(val as i8, shift_bits, span),

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -75,15 +75,15 @@ impl Command for SubCommand {
                 description: "Shift left a number by 7 bits",
                 example: "2 | bits shl 7",
                 result: Some(Value::Int {
-                    val: 0,
+                    val: 256,
                     span: Span::test_data(),
                 }),
             },
             Example {
-                description: "Shift left a number with 2 bytes by 7 bits",
-                example: "2 | bits shl 7 -n 2",
+                description: "Shift left a number with 1 byte by 7 bits",
+                example: "2 | bits shl 7 -n 1",
                 result: Some(Value::Int {
-                    val: 256,
+                    val: 0,
                     span: Span::test_data(),
                 }),
             },
@@ -91,7 +91,7 @@ impl Command for SubCommand {
                 description: "Shift left a signed number by 1 bit",
                 example: "0x7F | bits shl 1 -s",
                 result: Some(Value::Int {
-                    val: -2,
+                    val: 254,
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .named(
                 "number-bytes",
                 SyntaxShape::String,
-                "the size of number in bytes, it can be 1, 2, 4, 8, auto, default value `auto`",
+                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `auto`",
                 Some('n'),
             )
             .category(Category::Bits)
@@ -57,7 +57,7 @@ impl Command for SubCommand {
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput(
-                    "Only 1, 2, 4, 8, or \"auto\" bytes are supported as word sizes".to_string(),
+                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
                     val.span,
                 ));
             }

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -1,0 +1,217 @@
+use super::NumberBytes;
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
+};
+use num_traits::CheckedShl;
+use std::fmt::Display;
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "bits shift-left"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("bits shift-left")
+            .required("bits", SyntaxShape::Int, "number of bits to shift left")
+            .switch(
+                "signed",
+                "always treat input number as a signed number",
+                Some('s'),
+            )
+            .named(
+                "number-bytes",
+                SyntaxShape::String,
+                "the size of unsigned number in bytes, it can be 1, 2, 4, 8, auto, default value `auto`",
+                Some('n'),
+            )
+            .category(Category::Bits)
+    }
+
+    fn usage(&self) -> &str {
+        "Bitwise shift left for integers"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["shl"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let bits: usize = call.req(engine_state, stack, 0)?;
+        let signed = call.has_flag("signed");
+        let number_bytes: Option<Spanned<String>> =
+            call.get_flag(engine_state, stack, "number-bytes")?;
+        let number_bytes = match number_bytes.as_ref() {
+            None => NumberBytes::Auto,
+            Some(size) => match size.item.as_str() {
+                "1" => NumberBytes::One,
+                "2" => NumberBytes::Two,
+                "4" => NumberBytes::Four,
+                "8" => NumberBytes::Eight,
+                "auto" => NumberBytes::Auto,
+                _ => {
+                    return Err(ShellError::UnsupportedInput(
+                        "the size of number is invalid".to_string(),
+                        size.span,
+                    ))
+                }
+            },
+        };
+
+        input.map(
+            move |value| operate(value, bits, head, signed, number_bytes),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Shift left a number by 7 bits",
+                example: "2 | bits shift-left 7",
+                result: Some(Value::Int {
+                    val: 0,
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Shift left a number with 2 bytes by 7 bits",
+                example: "2 | bits shift-left 7 -n 2",
+                result: Some(Value::Int {
+                    val: 256,
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Shift left a signed number by 1 bits",
+                example: "0x7F | bits shift-left 1 -s",
+                result: Some(Value::Int {
+                    val: -2,
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Shift left a list of numbers",
+                example: "[5 3 2] | bits shift-left 2",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(20), Value::test_int(12), Value::test_int(8)],
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn get_shift_left<T: CheckedShl + Display + Copy>(val: T, shift_bits: u32, span: Span) -> Value
+where
+    i64: std::convert::TryFrom<T>,
+{
+    match val.checked_shl(shift_bits) {
+        Some(val) => {
+            let shift_result = i64::try_from(val);
+            match shift_result {
+                Ok(val) => Value::Int { val, span },
+                Err(_) => Value::Error {
+                    error: ShellError::GenericError(
+                        "Shift left result beyond the range of 64 bit signed number".to_string(),
+                        format!(
+                            "{} of the specified number of bytes shift left {} bits exceed limit",
+                            val, shift_bits
+                        ),
+                        Some(span),
+                        None,
+                        Vec::new(),
+                    ),
+                },
+            }
+        }
+        None => Value::Error {
+            error: ShellError::GenericError(
+                "Shift left overflow".to_string(),
+                format!("{} shift left {} bits will be overflow", val, shift_bits),
+                Some(span),
+                None,
+                Vec::new(),
+            ),
+        },
+    }
+}
+
+fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: NumberBytes) -> Value {
+    match value {
+        Value::Int { val, span } => {
+            use NumberBytes::*;
+            let shift_bits = (((bits % 64) + 64) % 64) as u32;
+            if signed || val < 0 {
+                match number_size {
+                    One => get_shift_left(val as i8, shift_bits, span),
+                    Two => get_shift_left(val as i16, shift_bits, span),
+                    Four => get_shift_left(val as i32, shift_bits, span),
+                    Eight => get_shift_left(val as i64, shift_bits, span),
+                    Auto => {
+                        if val <= 0x7F && val >= -(2i64.pow(7)) {
+                            get_shift_left(val as i8, shift_bits, span)
+                        } else if val <= 0x7FFF && val >= -(2i64.pow(15)) {
+                            get_shift_left(val as i16, shift_bits, span)
+                        } else if val <= 0x7FFFFFFF && val >= -(2i64.pow(31)) {
+                            get_shift_left(val as i32, shift_bits, span)
+                        } else {
+                            get_shift_left(val as i64, shift_bits, span)
+                        }
+                    }
+                }
+            } else {
+                match number_size {
+                    One => get_shift_left(val as u8, shift_bits, span),
+                    Two => get_shift_left(val as u16, shift_bits, span),
+                    Four => get_shift_left(val as u32, shift_bits, span),
+                    Eight => get_shift_left(val as u64, shift_bits, span),
+                    Auto => {
+                        if val <= 0xFF {
+                            get_shift_left(val as u8, shift_bits, span)
+                        } else if val <= 0xFFFF {
+                            get_shift_left(val as u16, shift_bits, span)
+                        } else if val <= 0xFFFFFFFF {
+                            get_shift_left(val as u32, shift_bits, span)
+                        } else {
+                            get_shift_left(val as u64, shift_bits, span)
+                        }
+                    }
+                }
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only integer values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -1,4 +1,4 @@
-use super::{get_number_bytes, NumberBytes};
+use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -148,49 +148,19 @@ where
 fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: NumberBytes) -> Value {
     match value {
         Value::Int { val, span } => {
-            use NumberBytes::*;
+            use InputNumType::*;
             // let bits = (((bits % 64) + 64) % 64) as u32;
             let bits = bits as u32;
-            if signed || val < 0 {
-                match number_size {
-                    One => get_shift_left(val as i8, bits, span),
-                    Two => get_shift_left(val as i16, bits, span),
-                    Four => get_shift_left(val as i32, bits, span),
-                    Eight => get_shift_left(val as i64, bits, span),
-                    Auto => {
-                        if val <= 0x7F && val >= -(2i64.pow(7)) {
-                            get_shift_left(val as i8, bits, span)
-                        } else if val <= 0x7FFF && val >= -(2i64.pow(15)) {
-                            get_shift_left(val as i16, bits, span)
-                        } else if val <= 0x7FFFFFFF && val >= -(2i64.pow(31)) {
-                            get_shift_left(val as i32, bits, span)
-                        } else {
-                            get_shift_left(val as i64, bits, span)
-                        }
-                    }
-                    // This case shouldn't happen here, as it's handled before
-                    Invalid => Value::Int { val, span },
-                }
-            } else {
-                match number_size {
-                    One => get_shift_left(val as u8, bits, span),
-                    Two => get_shift_left(val as u16, bits, span),
-                    Four => get_shift_left(val as u32, bits, span),
-                    Eight => get_shift_left(val as u64, bits, span),
-                    Auto => {
-                        if val <= 0xFF {
-                            get_shift_left(val as u8, bits, span)
-                        } else if val <= 0xFFFF {
-                            get_shift_left(val as u16, bits, span)
-                        } else if val <= 0xFFFFFFFF {
-                            get_shift_left(val as u32, bits, span)
-                        } else {
-                            get_shift_left(val as u64, bits, span)
-                        }
-                    }
-                    // This case shouldn't happen here, as it's handled before
-                    Invalid => Value::Int { val, span },
-                }
+            let input_type = get_input_num_type(val, signed, number_size);
+            match input_type {
+                One => get_shift_left(val as u8, bits, span),
+                Two => get_shift_left(val as u16, bits, span),
+                Four => get_shift_left(val as u32, bits, span),
+                Eight => get_shift_left(val as u64, bits, span),
+                SignedOne => get_shift_left(val as i8, bits, span),
+                SignedTwo => get_shift_left(val as i16, bits, span),
+                SignedFour => get_shift_left(val as i32, bits, span),
+                SignedEight => get_shift_left(val as i64, bits, span),
             }
         }
         other => Value::Error {

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -107,11 +107,11 @@ impl Command for SubCommand {
     }
 }
 
-fn get_shift_left<T: CheckedShl + Display + Copy>(val: T, shift_bits: u32, span: Span) -> Value
+fn get_shift_left<T: CheckedShl + Display + Copy>(val: T, bits: u32, span: Span) -> Value
 where
     i64: std::convert::TryFrom<T>,
 {
-    match val.checked_shl(shift_bits) {
+    match val.checked_shl(bits) {
         Some(val) => {
             let shift_result = i64::try_from(val);
             match shift_result {
@@ -121,7 +121,7 @@ where
                         "Shift left result beyond the range of 64 bit signed number".to_string(),
                         format!(
                             "{} of the specified number of bytes shift left {} bits exceed limit",
-                            val, shift_bits
+                            val, bits
                         ),
                         Some(span),
                         None,
@@ -135,7 +135,7 @@ where
                 "Shift left failed".to_string(),
                 format!(
                     "{} shift left {} bits failed, you may shift too many bits",
-                    val, shift_bits
+                    val, bits
                 ),
                 Some(span),
                 None,
@@ -149,23 +149,23 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
     match value {
         Value::Int { val, span } => {
             use NumberBytes::*;
-            // let shift_bits = (((bits % 64) + 64) % 64) as u32;
-            let shift_bits = bits as u32;
+            // let bits = (((bits % 64) + 64) % 64) as u32;
+            let bits = bits as u32;
             if signed || val < 0 {
                 match number_size {
-                    One => get_shift_left(val as i8, shift_bits, span),
-                    Two => get_shift_left(val as i16, shift_bits, span),
-                    Four => get_shift_left(val as i32, shift_bits, span),
-                    Eight => get_shift_left(val as i64, shift_bits, span),
+                    One => get_shift_left(val as i8, bits, span),
+                    Two => get_shift_left(val as i16, bits, span),
+                    Four => get_shift_left(val as i32, bits, span),
+                    Eight => get_shift_left(val as i64, bits, span),
                     Auto => {
                         if val <= 0x7F && val >= -(2i64.pow(7)) {
-                            get_shift_left(val as i8, shift_bits, span)
+                            get_shift_left(val as i8, bits, span)
                         } else if val <= 0x7FFF && val >= -(2i64.pow(15)) {
-                            get_shift_left(val as i16, shift_bits, span)
+                            get_shift_left(val as i16, bits, span)
                         } else if val <= 0x7FFFFFFF && val >= -(2i64.pow(31)) {
-                            get_shift_left(val as i32, shift_bits, span)
+                            get_shift_left(val as i32, bits, span)
                         } else {
-                            get_shift_left(val as i64, shift_bits, span)
+                            get_shift_left(val as i64, bits, span)
                         }
                     }
                     // This case shouldn't happen here, as it's handled before
@@ -173,19 +173,19 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
                 }
             } else {
                 match number_size {
-                    One => get_shift_left(val as u8, shift_bits, span),
-                    Two => get_shift_left(val as u16, shift_bits, span),
-                    Four => get_shift_left(val as u32, shift_bits, span),
-                    Eight => get_shift_left(val as u64, shift_bits, span),
+                    One => get_shift_left(val as u8, bits, span),
+                    Two => get_shift_left(val as u16, bits, span),
+                    Four => get_shift_left(val as u32, bits, span),
+                    Eight => get_shift_left(val as u64, bits, span),
                     Auto => {
                         if val <= 0xFF {
-                            get_shift_left(val as u8, shift_bits, span)
+                            get_shift_left(val as u8, bits, span)
                         } else if val <= 0xFFFF {
-                            get_shift_left(val as u16, shift_bits, span)
+                            get_shift_left(val as u16, bits, span)
                         } else if val <= 0xFFFFFFFF {
-                            get_shift_left(val as u32, shift_bits, span)
+                            get_shift_left(val as u32, bits, span)
                         } else {
-                            get_shift_left(val as u64, shift_bits, span)
+                            get_shift_left(val as u64, bits, span)
                         }
                     }
                     // This case shouldn't happen here, as it's handled before

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -57,7 +57,7 @@ impl Command for SubCommand {
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput(
-                    "the size of number is invalid".to_string(),
+                    "Only 1, 2, 4, 8, or \"auto\" bytes are supported as word sizes".to_string(),
                     val.span,
                 ));
             }

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -38,7 +38,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["shl"]
+        vec!["shift left"]
     }
 
     fn run(

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .named(
                 "number-bytes",
                 SyntaxShape::String,
-                "the size of number in bytes, it can be 1, 2, 4, 8, auto, default value `auto`",
+                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `auto`",
                 Some('n'),
             )
             .category(Category::Bits)

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -1,4 +1,4 @@
-use super::{get_number_bytes, NumberBytes};
+use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -132,48 +132,19 @@ where
 fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: NumberBytes) -> Value {
     match value {
         Value::Int { val, span } => {
-            use NumberBytes::*;
+            use InputNumType::*;
+            // let bits = (((bits % 64) + 64) % 64) as u32;
             let bits = bits as u32;
-            if signed || val < 0 {
-                match number_size {
-                    One => get_shift_right(val as i8, bits, span),
-                    Two => get_shift_right(val as i16, bits, span),
-                    Four => get_shift_right(val as i32, bits, span),
-                    Eight => get_shift_right(val as i64, bits, span),
-                    Auto => {
-                        if val <= 0x7F && val >= -(2i64.pow(7)) {
-                            get_shift_right(val as i8, bits, span)
-                        } else if val <= 0x7FFF && val >= -(2i64.pow(15)) {
-                            get_shift_right(val as i16, bits, span)
-                        } else if val <= 0x7FFFFFFF && val >= -(2i64.pow(31)) {
-                            get_shift_right(val as i32, bits, span)
-                        } else {
-                            get_shift_right(val as i64, bits, span)
-                        }
-                    }
-                    // This case shouldn't happen here, as it's handled before
-                    Invalid => Value::Int { val, span },
-                }
-            } else {
-                match number_size {
-                    One => get_shift_right(val as u8, bits, span),
-                    Two => get_shift_right(val as u16, bits, span),
-                    Four => get_shift_right(val as u32, bits, span),
-                    Eight => get_shift_right(val as u64, bits, span),
-                    Auto => {
-                        if val <= 0xFF {
-                            get_shift_right(val as u8, bits, span)
-                        } else if val <= 0xFFFF {
-                            get_shift_right(val as u16, bits, span)
-                        } else if val <= 0xFFFFFFFF {
-                            get_shift_right(val as u32, bits, span)
-                        } else {
-                            get_shift_right(val as u64, bits, span)
-                        }
-                    }
-                    // This case shouldn't happen here, as it's handled before
-                    Invalid => Value::Int { val, span },
-                }
+            let input_type = get_input_num_type(val, signed, number_size);
+            match input_type {
+                One => get_shift_right(val as u8, bits, span),
+                Two => get_shift_right(val as u16, bits, span),
+                Four => get_shift_right(val as u32, bits, span),
+                Eight => get_shift_right(val as u64, bits, span),
+                SignedOne => get_shift_right(val as i8, bits, span),
+                SignedTwo => get_shift_right(val as i16, bits, span),
+                SignedFour => get_shift_right(val as i32, bits, span),
+                SignedEight => get_shift_right(val as i64, bits, span),
             }
         }
         other => Value::Error {

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .named(
                 "number-bytes",
                 SyntaxShape::String,
-                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `auto`",
+                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )
             .category(Category::Bits)

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -1,0 +1,107 @@
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "bits shift-right"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("bits shift-right")
+            .required("bits", SyntaxShape::Int, "number of bits to shift right")
+            .category(Category::Bits)
+    }
+
+    fn usage(&self) -> &str {
+        "Bitwise shift right for integers"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["shr"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let bits: usize = call.req(engine_state, stack, 0)?;
+
+        input.map(
+            move |value| operate(value, bits, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Shift right a number with 2 bits",
+                example: "8 | bits shift-right 2",
+                result: Some(Value::Int {
+                    val: 2,
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Shift right a list of numbers",
+                example: "[15 35 2] | bits shift-right 2",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(3), Value::test_int(8), Value::test_int(0)],
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn operate(value: Value, bits: usize, head: Span) -> Value {
+    match value {
+        Value::Int { val, span } => {
+            let shift_bits = (bits % 64) as u32;
+            match val.checked_shr(shift_bits) {
+                Some(val) => Value::Int { val, span },
+                None => Value::Error {
+                    error: ShellError::GenericError(
+                        "Shift right overflow".to_string(),
+                        format!("{} shift right {} bits will be overflow", val, shift_bits),
+                        Some(span),
+                        None,
+                        Vec::new(),
+                    ),
+                },
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only integer values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -38,7 +38,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["shr"]
+        vec!["shift right"]
     }
 
     fn run(

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -57,7 +57,7 @@ impl Command for SubCommand {
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput(
-                    "the size of number is invalid".to_string(),
+                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
                     val.span,
                 ));
             }

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -13,11 +13,11 @@ pub struct SubCommand;
 
 impl Command for SubCommand {
     fn name(&self) -> &str {
-        "bits shift-right"
+        "bits shr"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("bits shift-right")
+        Signature::build("bits shr")
             .required("bits", SyntaxShape::Int, "number of bits to shift right")
             .switch(
                 "signed",
@@ -73,7 +73,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Shift right a number with 2 bits",
-                example: "8 | bits shift-right 2",
+                example: "8 | bits shr 2",
                 result: Some(Value::Int {
                     val: 2,
                     span: Span::test_data(),
@@ -81,7 +81,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Shift right a list of numbers",
-                example: "[15 35 2] | bits shift-right 2",
+                example: "[15 35 2] | bits shr 2",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(3), Value::test_int(8), Value::test_int(0)],
                     span: Span::test_data(),

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -68,13 +68,16 @@ impl Command for SubCommand {
 fn operate(value: Value, bits: usize, head: Span) -> Value {
     match value {
         Value::Int { val, span } => {
-            let shift_bits = (bits % 64) as u32;
+            let shift_bits = bits as u32;
             match val.checked_shr(shift_bits) {
                 Some(val) => Value::Int { val, span },
                 None => Value::Error {
                     error: ShellError::GenericError(
-                        "Shift right overflow".to_string(),
-                        format!("{} shift right {} bits will be overflow", val, shift_bits),
+                        "Shift right failed".to_string(),
+                        format!(
+                            "{} shift right {} bits failed, you may shift too many bits",
+                            val, shift_bits
+                        ),
                         Some(span),
                         None,
                         Vec::new(),

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -47,7 +47,7 @@ impl Command for BytesAdd {
     }
 
     fn usage(&self) -> &str {
-        "add specified bytes to the input"
+        "Add specified bytes to the input"
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -41,7 +41,7 @@ impl Command for BytesRemove {
     }
 
     fn usage(&self) -> &str {
-        "remove bytes"
+        "Remove bytes"
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -214,6 +214,8 @@ pub fn create_default_context() -> EngineState {
             BitsNot,
             BitsOr,
             BitsXor,
+            BitsShiftLeft,
+            BitsShiftRight,
         }
 
         // Bytes

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -35,7 +35,7 @@ impl Command for DecodeBase64 {
     }
 
     fn usage(&self) -> &str {
-        "base64 decode a value"
+        "Base64 decode a value"
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -31,7 +31,7 @@ impl Command for EncodeBase64 {
     }
 
     fn usage(&self) -> &str {
-        "base64 encode a value"
+        "Base64 encode a value"
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/src/tests/test_bits.rs
+++ b/src/tests/test_bits.rs
@@ -47,30 +47,30 @@ fn bits_xor_list() -> TestResult {
 
 #[test]
 fn bits_shift_left() -> TestResult {
-    run_test("2 | bits shift-left 3", "16")
+    run_test("2 | bits shl 3", "16")
 }
 
 #[test]
 fn bits_shift_left_negative() -> TestResult {
-    run_test("-3 | bits shift-left 5", "-96")
+    run_test("-3 | bits shl 5", "-96")
 }
 
 #[test]
 fn bits_shift_left_list() -> TestResult {
-    run_test("[1 2 7 32 9 10] | bits shift-left 3 | str collect '.'", "8.16.56.256.72.80")
+    run_test("[1 2 7 32 9 10] | bits shl 3 | str collect '.'", "8.16.56.256.72.80")
 }
 
 #[test]
 fn bits_shift_right() -> TestResult {
-    run_test("8 | bits shift-right 2", "2")
+    run_test("8 | bits shr 2", "2")
 }
 
 #[test]
 fn bits_shift_right_negative() -> TestResult {
-    run_test("-32 | bits shift-right 2", "-8")
+    run_test("-32 | bits shr 2", "-8")
 }
 
 #[test]
 fn bits_shift_right_list() -> TestResult {
-    run_test("[12 98 7 64 900 10] | bits shift-right 3 | str collect '.'", "1.12.0.8.112.1")
+    run_test("[12 98 7 64 900 10] | bits shr 3 | str collect '.'", "1.12.0.8.112.1")
 }

--- a/src/tests/test_bits.rs
+++ b/src/tests/test_bits.rs
@@ -44,3 +44,33 @@ fn bits_xor_negative() -> TestResult {
 fn bits_xor_list() -> TestResult {
     run_test("[1 2 3 8 9 10] | bits xor 2 | str collect '.'", "3.0.1.10.11.8")
 }
+
+#[test]
+fn bits_shift_left() -> TestResult {
+    run_test("2 | bits shift-left 3", "16")
+}
+
+#[test]
+fn bits_shift_left_negative() -> TestResult {
+    run_test("-3 | bits shift-left 5", "-96")
+}
+
+#[test]
+fn bits_shift_left_list() -> TestResult {
+    run_test("[1 2 7 32 9 10] | bits shift-left 3 | str collect '.'", "8.16.56.256.72.80")
+}
+
+#[test]
+fn bits_shift_right() -> TestResult {
+    run_test("8 | bits shift-right 2", "2")
+}
+
+#[test]
+fn bits_shift_right_negative() -> TestResult {
+    run_test("-32 | bits shift-right 2", "-8")
+}
+
+#[test]
+fn bits_shift_right_list() -> TestResult {
+    run_test("[12 98 7 64 900 10] | bits shift-right 3 | str collect '.'", "1.12.0.8.112.1")
+}


### PR DESCRIPTION
# Description

Add `bits shl` and `bits shr` command, need carefully review:
```shell
2 | bits shl 7
---
0

2 | bits shl 7 -n 2
---
256

0x7F | bits shl 1 -s
---
-2

[5 3 2] | bits shl 2
---
 0   20
 1   12
 2    8

8 | bits shr 2
---
2

[15 35 2] | bits shr 2
---
 0   3
 1   8
 2   0
```

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
