### PR TITLE
Faster SQLite reads

### DIFF
--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -425,18 +425,8 @@ fn open_sqlite_db(path: &Path, call_span: Span) -> Result<Connection, nu_protoco
 }
 
 fn run_sql_query(conn: Connection, sql: &Spanned<String>) -> Result<Value, rusqlite::Error> {
-    let mut stmt = conn.prepare(&sql.item)?;
-    let results = stmt.query([])?;
-
-    let nu_records = results
-        .mapped(|row| Result::Ok(convert_sqlite_row_to_nu_value(row, sql.span)))
-        .into_iter()
-        .collect::<Result<Vec<Value>, rusqlite::Error>>()?;
-
-    Ok(Value::List {
-        vals: nu_records,
-        span: sql.span,
-    })
+    let stmt = conn.prepare(&sql.item)?;
+    prepared_statement_to_nu_list(stmt, sql.span)
 }
 
 fn read_single_table(
@@ -444,14 +434,30 @@ fn read_single_table(
     table_name: String,
     call_span: Span,
 ) -> Result<Value, rusqlite::Error> {
-    let mut stmt = conn.prepare(&format!("SELECT * FROM {}", table_name))?;
-    let results = stmt.query([])?;
+    let stmt = conn.prepare(&format!("SELECT * FROM {}", table_name))?;
+    prepared_statement_to_nu_list(stmt, call_span)
+}
 
+fn prepared_statement_to_nu_list(
+    mut stmt: rusqlite::Statement,
+    call_span: Span,
+) -> Result<Value, rusqlite::Error> {
+    let column_names = stmt
+        .column_names()
+        .iter()
+        .map(|c| c.to_string())
+        .collect::<Vec<String>>();
+    let results = stmt.query([])?;
     let nu_records = results
-        .mapped(|row| Result::Ok(convert_sqlite_row_to_nu_value(row, call_span)))
+        .mapped(|row| {
+            Result::Ok(convert_sqlite_row_to_nu_value(
+                row,
+                call_span,
+                column_names.clone(),
+            ))
+        })
         .into_iter()
         .collect::<Result<Vec<Value>, rusqlite::Error>>()?;
-
     Ok(Value::List {
         vals: nu_records,
         span: call_span,
@@ -470,19 +476,9 @@ fn read_entire_sqlite_db(conn: Connection, call_span: Span) -> Result<Value, rus
         let table_name: String = row?;
         table_names.push(table_name.clone());
 
-        let mut rows = Vec::new();
-        let mut table_stmt = conn.prepare(&format!("select * from [{}]", table_name))?;
-        let mut table_rows = table_stmt.query([])?;
-        while let Some(table_row) = table_rows.next()? {
-            rows.push(convert_sqlite_row_to_nu_value(table_row, call_span))
-        }
-
-        let table_record = Value::List {
-            vals: rows,
-            span: call_span,
-        };
-
-        tables.push(table_record);
+        let table_stmt = conn.prepare(&format!("select * from [{}]", table_name))?;
+        let rows = prepared_statement_to_nu_list(table_stmt, call_span)?;
+        tables.push(rows);
     }
 
     Ok(Value::Record {
@@ -492,19 +488,16 @@ fn read_entire_sqlite_db(conn: Connection, call_span: Span) -> Result<Value, rus
     })
 }
 
-pub fn convert_sqlite_row_to_nu_value(row: &Row, span: Span) -> Value {
-    let mut vals = Vec::new();
-    let colnamestr = row.as_ref().column_names().to_vec();
-    let colnames = colnamestr.iter().map(|s| s.to_string()).collect();
+pub fn convert_sqlite_row_to_nu_value(row: &Row, span: Span, column_names: Vec<String>) -> Value {
+    let mut vals = Vec::with_capacity(column_names.len());
 
-    for (i, c) in row.as_ref().column_names().iter().enumerate() {
-        let _column = c.to_string();
+    for i in 0..column_names.len() {
         let val = convert_sqlite_value_to_nu_value(row.get_ref_unwrap(i), span);
         vals.push(val);
     }
 
     Value::Record {
-        cols: colnames,
+        cols: column_names,
         vals,
         span,
     }


### PR DESCRIPTION
# Description

The SQLite code that I wrote a while back was slow. I profiled it, made some tweaks, and it's now about 2.5 times faster.

## Deets

I downloaded `TPC-H-small.db` from [here](https://github.com/lovasoa/TPCH-sqlite) and ran `open TPC-H-small.db` with [Superluminal](https://superluminal.eu/) attached. Most time was being spent in `convert_sqlite_row_to_nu_value`:

<img width="495" alt="image" src="https://user-images.githubusercontent.com/26268125/182078519-c1616ff5-6d8f-4143-967b-953dea06d803.png">

A few things jumped out at me:
- that `let_column = c.to_string();` line is expensive and doing nothing (oops!)
- we're doing a *lot* of unnecessary work getting column names for every row. things would be a lot faster if we only got column names once per result set
- we know the size of `vals` ahead of time so we can use `Vec::with_capacity()`

As I worked, I measured timings with `hyperfine 'nu.exe open-sqlite.nu'`. This PR speeds things up from 1,355ms to 533ms.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
