### PR TITLE
use `from table` to remove into-db command

### DIFF
--- a/crates/nu-command/src/database/commands/alias.rs
+++ b/crates/nu-command/src/database/commands/alias.rs
@@ -32,17 +32,16 @@ impl Command for AliasDb {
         vec![
             Example {
                 description: "Creates an alias for a selected table",
-                example: r#"open db.mysql
-    | into db
+                example: r#"open db.sqlite
+    | from table table_1
     | select a
-    | from table_1
     | as t1
     | describe"#,
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {
@@ -55,22 +54,20 @@ impl Command for AliasDb {
             },
             Example {
                 description: "Creates an alias for a derived table",
-                example: r#"open db.mysql
-    | into db
-    | select a
-    | from (
-        open db.mysql
-        | into db
+                example: r#"open db.sqlite
+    | from table (
+        open db.sqlite
+        | from table table_a
         | select a b
-        | from table_a
       )
+    | select a
     | as t1
     | describe"#,
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/commands/and.rs
+++ b/crates/nu-command/src/database/commands/and.rs
@@ -38,10 +38,9 @@ impl Command for AndDb {
         vec![
             Example {
                 description: "Selects a column from a database with an AND clause",
-                example: r#"open db.mysql
-    | into db
+                example: r#"open db.sqlite
+    | from table table_1
     | select a
-    | from table_1
     | where ((field a) > 1)
     | and ((field b) == 1)
     | describe"#,
@@ -49,7 +48,7 @@ impl Command for AndDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {
@@ -62,10 +61,9 @@ impl Command for AndDb {
             },
             Example {
                 description: "Creates a AND clause combined with an expression AND",
-                example: r#"open db.mysql
-    | into db
+                example: r#"open db.sqlite
+    | from table table_1
     | select a
-    | from table_1
     | where ((field a) > 1 | and ((field a) < 10))
     | and ((field b) == 1)
     | describe"#,
@@ -73,7 +71,7 @@ impl Command for AndDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/commands/collect.rs
+++ b/crates/nu-command/src/database/commands/collect.rs
@@ -28,7 +28,7 @@ impl Command for CollectDb {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Collect from a select query",
-            example: "open foo.db | into db | select a | from table_1 | collect",
+            example: "open foo.db | from table table_1 db | select a | collect",
             result: None,
         }]
     }

--- a/crates/nu-command/src/database/commands/describe.rs
+++ b/crates/nu-command/src/database/commands/describe.rs
@@ -28,7 +28,7 @@ impl Command for DescribeDb {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Describe SQLite database constructed query",
-            example: "open foo.db | into db | select col_1 | from table_1 | describe",
+            example: "open foo.db | from table table_1 | select col_1 | describe",
             result: Some(Value::Record {
                 cols: vec!["connection".into(), "query".into()],
                 vals: vec![

--- a/crates/nu-command/src/database/commands/from.rs
+++ b/crates/nu-command/src/database/commands/from.rs
@@ -15,7 +15,7 @@ pub struct FromDb;
 
 impl Command for FromDb {
     fn name(&self) -> &str {
-        "from"
+        "from table"
     }
 
     fn usage(&self) -> &str {
@@ -35,7 +35,7 @@ impl Command for FromDb {
                 "Alias for the selected table",
                 Some('a'),
             )
-            .input_type(Type::Custom("database".into()))
+            .input_type(Type::Any)
             .output_type(Type::Custom("database".into()))
             .category(Category::Custom("database".into()))
     }
@@ -47,12 +47,12 @@ impl Command for FromDb {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Selects a table from database",
-            example: "open db.mysql | into db | from table_a | describe",
+            example: "open db.sqlite | from table table_a | describe",
             result: Some(Value::Record {
                 cols: vec!["connection".into(), "query".into()],
                 vals: vec![
                     Value::String {
-                        val: "db.mysql".into(),
+                        val: "db.sqlite".into(),
                         span: Span::test_data(),
                     },
                     Value::String {

--- a/crates/nu-command/src/database/commands/group_by.rs
+++ b/crates/nu-command/src/database/commands/group_by.rs
@@ -42,9 +42,8 @@ impl Command for GroupByDb {
         vec![
             Example {
                 description: "groups by column a and calculates the max",
-                example: r#"open db.mysql
-    | into db
-    | from table_a
+                example: r#"open db.sqlite
+    | from table table_a
     | select (fn max a)
     | group-by a
     | describe"#,
@@ -52,7 +51,7 @@ impl Command for GroupByDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {
@@ -65,9 +64,8 @@ impl Command for GroupByDb {
             },
             Example {
                 description: "groups by column column a and counts records",
-                example: r#"open db.mysql
-    | into db
-    | from table_a
+                example: r#"open db.sqlite
+    | from table table_a
     | select (fn count *)
     | group-by a
     | describe"#,
@@ -75,7 +73,7 @@ impl Command for GroupByDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/commands/join.rs
+++ b/crates/nu-command/src/database/commands/join.rs
@@ -54,17 +54,16 @@ impl Command for JoinDb {
         vec![
             Example {
                 description: "joins two tables on col_b",
-                example: r#"open db.mysql
-    | into db
-    | select col_a
-    | from table_1 --as t1
+                example: r#"open db.sqlite
+    | from table table_1 --as t1
     | join table_2 col_b --as t2
+    | select col_a
     | describe"#,
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {
@@ -78,22 +77,20 @@ impl Command for JoinDb {
             },
             Example {
                 description: "joins a table with a derived table using aliases",
-                example: r#"open db.mysql
-    | into db
-    | select col_a
-    | from table_1 --as t1
+                example: r#"open db.sqlite
+    | from table table_1 --as t1
     | join (
-        open db.mysql
-        | into db
+        open db.sqlite
+        | from table table_2
         | select col_c
-        | from table_2
       ) ((field t1.col_a) == (field t2.col_c)) --as t2 --right
+    | select col_a
     | describe"#,
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/commands/limit.rs
+++ b/crates/nu-command/src/database/commands/limit.rs
@@ -40,9 +40,8 @@ impl Command for LimitDb {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Limits selection from table",
-            example: r#"open db.mysql
-    | into db
-    | from table_a
+            example: r#"open db.sqlite
+    | from table table_a
     | select a
     | limit 10
     | describe"#,
@@ -50,7 +49,7 @@ impl Command for LimitDb {
                 cols: vec!["connection".into(), "query".into()],
                 vals: vec![
                     Value::String {
-                        val: "db.mysql".into(),
+                        val: "db.sqlite".into(),
                         span: Span::test_data(),
                     },
                     Value::String {

--- a/crates/nu-command/src/database/commands/or.rs
+++ b/crates/nu-command/src/database/commands/or.rs
@@ -38,10 +38,9 @@ impl Command for OrDb {
         vec![
             Example {
                 description: "selects a column from a database with an OR clause",
-                example: r#"open db.mysql
-    | into db
+                example: r#"open db.sqlite
+    | from table table_1
     | select a
-    | from table_1
     | where ((field a) > 1)
     | or ((field b) == 1)
     | describe"#,
@@ -49,7 +48,7 @@ impl Command for OrDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {
@@ -62,10 +61,9 @@ impl Command for OrDb {
             },
             Example {
                 description: "Creates an OR clause in the column names and a column",
-                example: r#"open db.mysql
-    | into db
+                example: r#"open db.sqlite
+    | from table table_1
     | select a
-    | from table_1
     | where ((field a) > 1 | or ((field a) < 10))
     | or ((field b) == 1)
     | describe"#,
@@ -73,7 +71,7 @@ impl Command for OrDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/commands/order_by.rs
+++ b/crates/nu-command/src/database/commands/order_by.rs
@@ -44,9 +44,8 @@ impl Command for OrderByDb {
         vec![
             Example {
                 description: "orders query by a column",
-                example: r#"open db.mysql
-    | into db
-    | from table_a
+                example: r#"open db.sqlite
+    | from table table_a
     | select a
     | order-by a
     | describe"#,
@@ -54,7 +53,7 @@ impl Command for OrderByDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {
@@ -67,9 +66,8 @@ impl Command for OrderByDb {
             },
             Example {
                 description: "orders query by column a ascending and by column b",
-                example: r#"open db.mysql
-    | into db
-    | from table_a
+                example: r#"open db.sqlite
+    | from table table_a
     | select a
     | order-by a --ascending
     | order-by b
@@ -78,7 +76,7 @@ impl Command for OrderByDb {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -16,7 +16,7 @@ impl Command for SchemaDb {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_type(Type::Custom("database".into()))
+            .input_type(Type::Any)
             .output_type(Type::Any)
             .category(Category::Custom("database".into()))
     }
@@ -28,7 +28,7 @@ impl Command for SchemaDb {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Show the schema of a SQLite database",
-            example: r#"open foo.db | into db | schema"#,
+            example: r#"open foo.db | schema"#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/database/commands/select.rs
+++ b/crates/nu-command/src/database/commands/select.rs
@@ -40,12 +40,12 @@ impl Command for ProjectionDb {
         vec![
             Example {
                 description: "selects a column from a database",
-                example: "open db.mysql | into db | select a | describe",
+                example: "open db.sqlite | into db | select a | describe",
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {
@@ -58,16 +58,16 @@ impl Command for ProjectionDb {
             },
             Example {
                 description: "selects columns from a database using alias",
-                example: r#"open db.mysql
+                example: r#"open db.sqlite
     | into db
     | select (field a | as new_a) b c
-    | from table_1
+    | from table table_1
     | describe"#,
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/commands/to_db.rs
+++ b/crates/nu-command/src/database/commands/to_db.rs
@@ -18,6 +18,10 @@ impl Command for ToDataBase {
         "Converts into an open db connection"
     }
 
+    fn extra_usage(&self) -> &str {
+        "This function is used as type hint for parser, specially if the query is not started with 'from table'"
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_type(Type::Any)
@@ -32,7 +36,7 @@ impl Command for ToDataBase {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Converts an open file into a db object",
-            example: "open db.mysql | into db",
+            example: "open db.sqlite | into db",
             result: None,
         }]
     }

--- a/crates/nu-command/src/database/commands/where_.rs
+++ b/crates/nu-command/src/database/commands/where_.rs
@@ -37,17 +37,16 @@ impl Command for WhereDb {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "selects a column from a database with a where clause",
-            example: r#"open db.mysql
-    | into db
+            example: r#"open db.sqlite
+    | from table table_1
     | select a
-    | from table_1
     | where ((field a) > 1)
     | describe"#,
             result: Some(Value::Record {
                 cols: vec!["connection".into(), "query".into()],
                 vals: vec![
                     Value::String {
-                        val: "db.mysql".into(),
+                        val: "db.sqlite".into(),
                         span: Span::test_data(),
                     },
                     Value::String {

--- a/crates/nu-command/src/database/expressions/function.rs
+++ b/crates/nu-command/src/database/expressions/function.rs
@@ -68,7 +68,7 @@ impl Command for FunctionExpr {
             },
             Example {
                 description: "orders query by a column",
-                example: r#"open db.mysql
+                example: r#"open db.sqlite
     | into db
     | select (fn lead col_a)
     | from table_a
@@ -77,7 +77,7 @@ impl Command for FunctionExpr {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/expressions/function.rs
+++ b/crates/nu-command/src/database/expressions/function.rs
@@ -69,9 +69,8 @@ impl Command for FunctionExpr {
             Example {
                 description: "orders query by a column",
                 example: r#"open db.sqlite
-    | into db
+    | from table table_a
     | select (fn lead col_a)
-    | from table_a
     | describe"#,
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],

--- a/crates/nu-command/src/database/expressions/over.rs
+++ b/crates/nu-command/src/database/expressions/over.rs
@@ -69,7 +69,7 @@ impl Command for OverExpr {
         },
             Example {
                 description: "orders query by a column",
-                example: r#"open db.mysql
+                example: r#"open db.sqlite
     | into db
     | select (fn lead col_a | over col_b)
     | from table_a
@@ -78,7 +78,7 @@ impl Command for OverExpr {
                     cols: vec!["connection".into(), "query".into()],
                     vals: vec![
                         Value::String {
-                            val: "db.mysql".into(),
+                            val: "db.sqlite".into(),
                             span: Span::test_data(),
                         },
                         Value::String {

--- a/crates/nu-command/src/database/expressions/over.rs
+++ b/crates/nu-command/src/database/expressions/over.rs
@@ -70,9 +70,8 @@ impl Command for OverExpr {
             Example {
                 description: "orders query by a column",
                 example: r#"open db.sqlite
-    | into db
+    | from table table_a
     | select (fn lead col_a | over col_b)
-    | from table_a
     | describe"#,
                 result: Some(Value::Record {
                     cols: vec!["connection".into(), "query".into()],


### PR DESCRIPTION
# Description

Change db command `from` to `from table` to eliminate the need to use `into db` when using db commands.
`into db` is used as type hint for the parser to understand that the next commands that will be used are the `db` commands and not the regular `nu` commands

Examples
Before
```
open db.sqlite
| into db
| from table_1
| select a
| as t1
```

Suggested change
```
open db.sqlite
| from table table_1
| select a
| as t1
```

Note. Also the name of the test file was changed from `db.mysql` to `db.sqlite` to better represent what type of files are being opened

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
