### PR TITLE
Patch `lscolors` to not blink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,8 +2101,7 @@ dependencies = [
 [[package]]
 name = "lscolors"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24e014efe73b727e5792b6f422a23c04b10ba9d8cdc74b197a25a08db7eac86"
+source = "git+https://github.com/sholderbach/lscolors.git?branch=no-underline-color#2c07f2d103aadf2ba6f687e2efe4d21eac026a89"
 dependencies = [
  "ansi_term",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,3 +123,4 @@ path = "src/main.rs"
 
 [patch.crates-io]
 reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+lscolors = { git = "https://github.com/sholderbach/lscolors.git", branch = "no-underline-color" }


### PR DESCRIPTION
# Description

Unreleased patch for the `lscolors` -> `crossterm` translation, where I
introduced a bug/incompatibility with several terminal emulators causing
blinking

https://github.com/nushell/nushell/pull/6172#issuecomment-1201856518

Refers to patch, can be replaced once a new `lscolors` version is
released:

https://github.com/sharkdp/lscolors/pull/51


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
