### PR TITLE
Make `open` test independent of locale

### DIFF
--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -214,12 +214,11 @@ fn errors_if_file_not_found() {
         cwd: "tests/fixtures/formats",
         "open i_dont_exist.txt"
     );
-
-    #[cfg(windows)]
-    let expected = "The system cannot find the file specified. (os error 2)";
-
-    #[cfg(not(windows))]
-    let expected = "No such file or directory (os error 2)";
+    // Common error code between unixes and Windows for "No such file or directory"
+    //
+    // This seems to be not directly affected by localization compared to the OS
+    // provided error message
+    let expected = "(os error 2)";
 
     assert!(
         actual.err.contains(expected),


### PR DESCRIPTION
The test was reading the operating system error message which is
dependent on the system locale.

![grafik](https://user-images.githubusercontent.com/15833959/182402609-dae4c4ad-888c-4866-a5a4-f65355d8bf5f.png)


Just test for the `(os error 2)` errorcode instead.
This should support both
unixoid systems and Windows in more locales.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
