### PR TITLE
Support parallel for `all?` command

### DIFF
--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -97,13 +97,10 @@ impl Command for All {
                         call.redirect_stderr,
                     ) {
                         Err(error) => Value::Error { error },
-                        Ok(pipeline_data) => {
-                            if !pipeline_data.into_value(span).is_true() {
-                                Value::Bool { val: false, span }
-                            } else {
-                                Value::Bool { val: true, span }
-                            }
-                        }
+                        Ok(pipeline_data) => Value::Bool {
+                            val: pipeline_data.into_value(span).is_true(),
+                            span,
+                        },
                     }
                 })
                 .collect::<Vec<_>>();

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -112,17 +112,17 @@ impl Command for All {
                 .iter()
                 .all(|item| item == &Value::Bool { val: true, span })
             {
-                return Ok(Value::Bool { val: true, span }.into_pipeline_data());
+                Ok(Value::Bool { val: true, span }.into_pipeline_data())
             } else if result.contains(&Value::Bool { val: false, span }) {
-                return Ok(Value::Bool { val: false, span }.into_pipeline_data());
+                Ok(Value::Bool { val: false, span }.into_pipeline_data())
             } else {
-                return Err(ShellError::GenericError(
+                Err(ShellError::GenericError(
                     "Error occurred during running with parallel flag".to_string(),
                     "Command unable to complete".to_string(),
                     Some(span),
                     None,
                     Vec::new(),
-                ));
+                ))
             }
         } else {
             for value in input.into_interruptible_iter(ctrlc) {

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -67,3 +67,59 @@ fn checks_if_all_returns_error_with_invalid_command() {
 
     assert!(actual.err.contains("can't run executable") || actual.err.contains("type_mismatch"));
 }
+
+#[test]
+fn checks_all_rows_are_true_parallel() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                echo  [ "Andrés", "Andrés", "Andrés" ]
+                | all? -p $it == "Andrés"
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn checks_all_rows_are_false_with_param_parallel() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                [1, 2, 3, 4] | all? -p { |a| $a >= 5 }
+        "#
+    ));
+
+    assert_eq!(actual.out, "false");
+}
+
+#[test]
+fn checks_all_rows_are_true_with_param_parallel() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                [1, 2, 3, 4] | all? -p { |a| $a < 5 }
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn checks_all_columns_of_a_table_is_true_parallel() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                echo [
+                        [  first_name, last_name,   rusty_at, likes  ];
+                        [      Andrés,  Robalino, 10/11/2013,   1    ]
+                        [    Jonathan,    Turner, 10/12/2013,   1    ]
+                        [      Darren, Schroeder, 10/11/2013,   1    ]
+                        [      Yehuda,      Katz, 10/11/2013,   1    ]
+                ]
+                | all? -p likes > 0
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}


### PR DESCRIPTION
# Description

Parallelism support for internal command `all` as requested from #6061 

TODO - I will add parallelism support for other commands in different PRs

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
