### PR TITLE
Reduce dev-deps by narrowing `rstest` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,12 +1330,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,8 +4015,6 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
 dependencies = [
- "futures",
- "futures-timer",
  "rstest_macros",
  "rustc_version 0.4.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ assert_cmd = "2.0.2"
 pretty_assertions = "1.0.0"
 serial_test = "0.8.0"
 hamcrest2 = "0.3.0"
-rstest = "0.15.0"
+rstest = {version = "0.15.0", default-features = false}
 itertools = "0.10.3"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.66.3"
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.66.3"  }
 nu-command = { path = "../nu-command", version = "0.66.3" }
-rstest = "0.15.0"
+rstest = {version = "0.15.0", default-features = false}
 
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.66.3"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -133,4 +133,4 @@ hamcrest2 = "0.3.0"
 dirs-next = "2.0.0"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-rstest = "0.15.0"
+rstest = {version = "0.15.0", default-features = false}


### PR DESCRIPTION
# Description

`rstest = 0.12` added support for asynchronous timeouts during testing
thus requiring a larger set of dependencies. Since `rstest = 0.14` this
can be disabled if not used.

Should keep build times for local or CI tests in check.
On nushell the effect should be less pronounced than for reedline (nushell/reedline#458) as we are already swimming in dependencies

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
