### PR TITLE
sqlite query without collect

### DIFF
--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -366,16 +366,21 @@ impl CustomValue for SQLiteDatabase {
     }
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
-        let db = open_sqlite_db(self.connection.as_path(span)?, span)?;
-        read_entire_sqlite_db(db, span).map_err(|e| {
-            ShellError::GenericError(
-                "Failed to read from SQLite database".into(),
-                e.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
-        })
+        match self.statement {
+            None => {
+                let db = open_sqlite_db(self.connection.as_path(span)?, span)?;
+                read_entire_sqlite_db(db, span).map_err(|e| {
+                    ShellError::GenericError(
+                        "Failed to read from SQLite database".into(),
+                        e.to_string(),
+                        Some(span),
+                        None,
+                        Vec::new(),
+                    )
+                })
+            }
+            Some(_) => self.collect(span),
+        }
     }
 
     fn as_any(&self) -> &dyn std::any::Any {


### PR DESCRIPTION
# Description

The collect command is optional when querying a sqlite file using nushell commands

```
open "history.sqlite3" 
| from table history 
| select * 
| limit 10 
| where ((field duration_ms) > 1000) 
| and ((field exit_status) == 101)
```

@fdncred I think you wanted something like this

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
