### PR TITLE
remove the nana filename string, add some exclusions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ debian/nu/
 # Coverage tools
 lcov.info
 tarpaulin-report.html
+
+# Visual Studio
+.vs/*
+*.rsproj
+*.rsproj.user
+*.sln

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -5,6 +5,7 @@ use crate::{
     util::{eval_source, get_guaranteed_cwd, report_error, report_error_new},
     NuHighlighter, NuValidator, NushellPrompt,
 };
+use fancy_regex::Regex;
 use lazy_static::lazy_static;
 use log::{info, trace, warn};
 use miette::{IntoDiagnostic, Result};
@@ -18,7 +19,6 @@ use nu_protocol::{
     Type, Value, VarId,
 };
 use reedline::{DefaultHinter, Emacs, SqliteBackedHistory, Vi};
-use regex::Regex;
 use std::io::{self, Write};
 use std::{sync::atomic::Ordering, time::Instant};
 use strip_ansi_escapes::strip;
@@ -494,7 +494,7 @@ fn get_banner(engine_state: &mut EngineState, stack: &mut Stack) -> String {
 
     let banner = format!(
         r#"{}     __  ,
-{} .--()°'.' {}Welcome to {}Nushell{}, 
+{} .--()°'.' {}Welcome to {}Nushell{},
 {}'|, . ,'   {}based on the {}nu{} language,
 {} !_-(_\    {}where all data is structured!
 
@@ -565,13 +565,7 @@ pub fn eval_string_with_input(
 ) -> Result<Value, ShellError> {
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);
-        let (output, _) = parse(
-            &mut working_set,
-            Some("nana"),
-            source.as_bytes(),
-            false,
-            &[],
-        );
+        let (output, _) = parse(&mut working_set, None, source.as_bytes(), false, &[]);
 
         (output, working_set.render())
     };
@@ -909,7 +903,7 @@ lazy_static! {
 fn looks_like_path(orig: &str) -> bool {
     #[cfg(windows)]
     {
-        if DRIVE_PATH_REGEX.is_match(orig) {
+        if DRIVE_PATH_REGEX.is_match(orig).unwrap_or(false) {
             return true;
         }
     }


### PR DESCRIPTION
# Description

This removes the "nana" string from the `eval_string_with_input` function. I also added some Visual Studio items to the .gitignore file.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
