### PR TITLE
point to the latest main branch for lscolors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,8 +2119,8 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.11.0"
-source = "git+https://github.com/sholderbach/lscolors.git?branch=no-underline-color#2c07f2d103aadf2ba6f687e2efe4d21eac026a89"
+version = "0.11.1"
+source = "git+https://github.com/sharkdp/lscolors.git?branch=master#bfc0d457b75640bd2d8d9bf16895c9ccd0b98722"
 dependencies = [
  "ansi_term",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,4 +123,4 @@ path = "src/main.rs"
 
 [patch.crates-io]
 reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
-lscolors = { git = "https://github.com/sholderbach/lscolors.git", branch = "no-underline-color" }
+lscolors = { git = "https://github.com/sharkdp/lscolors.git", branch = "master" }


### PR DESCRIPTION
# Description

The lscolors crate landed a PR https://github.com/sharkdp/lscolors/pull/52 to fix underlines, namely 58 and 59. This PR points the dependency there.


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
