### PR TITLE
Allow using the system's copy of zstd for Polars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,6 +2677,7 @@ dependencies = [
  "wax",
  "which",
  "windows",
+ "zstd",
 ]
 
 [[package]]
@@ -5637,4 +5638,5 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ trash-support = ["nu-command/trash-support"]
 
 # Dataframe feature for nushell
 dataframe = ["nu-command/dataframe"]
+system-zstd = ["nu-command/system-zstd"]
 
 # Database commands for nushell
 database = ["nu-command/database"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -89,6 +89,7 @@ reedline = { version = "0.9.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.16.0", features = ["serde"], optional = true }
+zstd = { version = "*", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 umask = "2.0.0"
@@ -124,6 +125,7 @@ trash-support = ["trash"]
 which-support = ["which"]
 plugin = ["nu-parser/plugin"]
 dataframe = ["polars", "num"]
+system-zstd = ["zstd/pkg-config"]
 database = ["sqlparser", "rusqlite"]
 
 [build-dependencies]


### PR DESCRIPTION
# Description

This allows using the system's copy of `zstd` (which is a dependency of Polars), over compiling the one bundled in `zstd-sys`.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
