### PR TITLE
Fix color parsing

### DIFF
--- a/crates/nu-color-config/src/nu_style.rs
+++ b/crates/nu-color-config/src/nu_style.rs
@@ -11,12 +11,12 @@ pub struct NuStyle {
 pub fn parse_nustyle(nu_style: NuStyle) -> Style {
     // get the nu_ansi_term::Color foreground color
     let fg_color = match nu_style.fg {
-        Some(fg) => color_from_hex(&fg).expect("error with foreground color"),
+        Some(fg) => color_from_hex(&fg).unwrap_or_default(),
         _ => None,
     };
     // get the nu_ansi_term::Color background color
     let bg_color = match nu_style.bg {
-        Some(bg) => color_from_hex(&bg).expect("error with background color"),
+        Some(bg) => color_from_hex(&bg).unwrap_or_default(),
         _ => None,
     };
     // get the attributes


### PR DESCRIPTION
# Description

Fix panic when passing invalid color code.

![Screenshot from 2022-08-05 17-21-59](https://user-images.githubusercontent.com/15247421/183065575-c2491244-fe8e-4c4e-9706-34be628071ef.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
