### PR TITLE
fix python plugin example

### DIFF
--- a/crates/nu_plugin_python/plugin.py
+++ b/crates/nu_plugin_python/plugin.py
@@ -41,6 +41,8 @@ def signatures():
                 "name": "nu-python",
                 "usage": "Signature test for Python",
                 "extra_usage": "",
+                "input_type": "Any",
+                "output_type": "Any",
                 "required_positional": [
                     {
                         "name": "a",


### PR DESCRIPTION
# Description

Just find that python plugin example is broken due to signature changed, this pr make a little fix

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
