### PR TITLE
Make `g -` switch to the last used shell 

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -395,9 +395,23 @@ pub fn evaluate_repl(
                         0
                     };
 
+                    let last_shell = stack.get_env_var(engine_state, "NUSHELL_LAST_SHELL");
+                    let last_shell = if let Some(v) = last_shell {
+                        v.as_integer().unwrap_or_default() as usize
+                    } else {
+                        0
+                    };
+
                     shells[current_shell] = Value::String { val: path, span };
 
                     stack.add_env_var("NUSHELL_SHELLS".into(), Value::List { vals: shells, span });
+                    stack.add_env_var(
+                        "NUSHELL_LAST_SHELL".into(),
+                        Value::Int {
+                            val: last_shell as i64,
+                            span,
+                        },
+                    );
                 } else {
                     trace!("eval source: {}", s);
 

--- a/crates/nu-command/src/shells/enter.rs
+++ b/crates/nu-command/src/shells/enter.rs
@@ -66,6 +66,14 @@ impl Command for Enter {
         let mut shells = get_shells(engine_state, stack, cwd);
         let mut current_shell = get_current_shell(engine_state, stack);
 
+        stack.add_env_var(
+            "NUSHELL_LAST_SHELL".into(),
+            Value::Int {
+                val: current_shell as i64,
+                span: call.head,
+            },
+        );
+
         if current_shell + 1 > shells.len() {
             shells.push(new_path.clone());
             current_shell = shells.len();

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -1,4 +1,4 @@
-use super::{get_current_shell, get_shells};
+use super::{get_current_shell, get_last_shell, get_shells};
 use nu_engine::{current_dir, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -60,8 +60,13 @@ impl Command for Exit {
 
         let mut shells = get_shells(engine_state, stack, cwd);
         let mut current_shell = get_current_shell(engine_state, stack);
+        let mut last_shell = get_last_shell(engine_state, stack);
 
         shells.remove(current_shell);
+
+        if current_shell <= last_shell {
+            last_shell = 0;
+        }
 
         if current_shell == shells.len() && !shells.is_empty() {
             current_shell -= 1;
@@ -83,6 +88,13 @@ impl Command for Exit {
                 "NUSHELL_CURRENT_SHELL".into(),
                 Value::Int {
                     val: current_shell as i64,
+                    span: call.head,
+                },
+            );
+            stack.add_env_var(
+                "NUSHELL_LAST_SHELL".into(),
+                Value::Int {
+                    val: last_shell as i64,
                     span: call.head,
                 },
             );

--- a/crates/nu-command/src/shells/g.rs
+++ b/crates/nu-command/src/shells/g.rs
@@ -53,16 +53,16 @@ impl Command for GotoShell {
                 let index = if shell_span.item == "-" {
                     get_last_shell(engine_state, stack)
                 } else {
-                    match shell_span.item.parse::<usize>() {
-                        Ok(index) => index,
-                        Err(_) => return Err(ShellError::NotFound(shell_span.span)),
-                    }
+                    shell_span
+                        .item
+                        .parse::<usize>()
+                        .map_err(|_| ShellError::NotFound(shell_span.span))?
                 };
 
-                let new_path = match shells.get(index) {
-                    Some(v) => v.clone(),
-                    None => return Err(ShellError::NotFound(shell_span.span)),
-                };
+                let new_path = shells
+                    .get(index)
+                    .ok_or(ShellError::NotFound(shell_span.span))?
+                    .to_owned();
 
                 let current_shell = get_current_shell(engine_state, stack);
 

--- a/crates/nu-command/src/shells/g.rs
+++ b/crates/nu-command/src/shells/g.rs
@@ -132,8 +132,8 @@ impl Command for GotoShell {
                 result: None,
             },
             Example {
-                description: "Make two directories and enter new shells for them, use `g` to jump to the last used shell",
-                example: r#"mkdir foo bar; enter foo; enter ../bar;  g 0; g -"#,
+                description: "Make two directories and enter new shells for them, use `g -` to jump to the last used shell",
+                example: r#"mkdir foo bar; enter foo; enter ../bar; g -"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/shells/mod.rs
+++ b/crates/nu-command/src/shells/mod.rs
@@ -34,3 +34,12 @@ pub fn get_current_shell(engine_state: &EngineState, stack: &mut Stack) -> usize
         0
     }
 }
+
+fn get_last_shell(engine_state: &EngineState, stack: &mut Stack) -> usize {
+    let last_shell = stack.get_env_var(engine_state, "NUSHELL_LAST_SHELL");
+    if let Some(v) = last_shell {
+        v.as_integer().unwrap_or_default() as usize
+    } else {
+        0
+    }
+}

--- a/crates/nu-command/src/shells/n.rs
+++ b/crates/nu-command/src/shells/n.rs
@@ -36,6 +36,13 @@ impl Command for NextShell {
 
         let shells = get_shells(engine_state, stack, cwd);
         let mut current_shell = get_current_shell(engine_state, stack);
+        stack.add_env_var(
+            "NUSHELL_LAST_SHELL".into(),
+            Value::Int {
+                val: current_shell as i64,
+                span: call.head,
+            },
+        );
 
         current_shell += 1;
 

--- a/crates/nu-command/src/shells/p.rs
+++ b/crates/nu-command/src/shells/p.rs
@@ -36,6 +36,13 @@ impl Command for PrevShell {
 
         let shells = get_shells(engine_state, stack, cwd);
         let mut current_shell = get_current_shell(engine_state, stack);
+        stack.add_env_var(
+            "NUSHELL_LAST_SHELL".into(),
+            Value::Int {
+                val: current_shell as i64,
+                span: call.head,
+            },
+        );
 
         if current_shell == 0 {
             current_shell = shells.len() - 1;

--- a/crates/nu-command/tests/commands/g.rs
+++ b/crates/nu-command/tests/commands/g.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::{nu, pipeline, playground::Playground};
 
 #[test]
 fn list_shells() {
@@ -28,4 +28,64 @@ fn enter_not_exist_shell() {
     ));
 
     assert!(actual.err.contains("Not found"));
+}
+
+#[test]
+fn switch_to_last_used_shell_1() {
+    Playground::setup("switch_last_used_shell_1", |dirs, sandbox| {
+        sandbox.mkdir("foo").mkdir("bar");
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            pipeline(
+            r#"enter foo; enter ../bar; g 0; g -;g | get active.2"#
+        ));
+
+        assert_eq!(actual.out, "true");
+    })
+}
+
+#[test]
+fn switch_to_last_used_shell_2() {
+    Playground::setup("switch_last_used_shell_2", |dirs, sandbox| {
+        sandbox.mkdir("foo").mkdir("bar");
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            pipeline(
+            r#"enter foo; enter ../bar; n; g -;g | get active.2"#
+        ));
+
+        assert_eq!(actual.out, "true");
+    })
+}
+
+#[test]
+fn switch_to_last_used_shell_3() {
+    Playground::setup("switch_last_used_shell_3", |dirs, sandbox| {
+        sandbox.mkdir("foo").mkdir("bar");
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            pipeline(
+            r#"enter foo; enter ../bar; p; g -;g | get active.2"#
+        ));
+
+        assert_eq!(actual.out, "true");
+    })
+}
+
+#[test]
+fn switch_to_last_used_shell_4() {
+    Playground::setup("switch_last_used_shell_4", |dirs, sandbox| {
+        sandbox.mkdir("foo").mkdir("bar");
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            pipeline(
+            r#"enter foo; enter ../bar; g 2; exit; g -;g | get active.0"#
+        ));
+
+        assert_eq!(actual.out, "true");
+    })
 }


### PR DESCRIPTION
# Description

This PR makes `g -` switch to the last used shell, part of #6223.

![Screenshot from 2022-08-06 22-00-00](https://user-images.githubusercontent.com/15247421/183252268-f73ae6e0-bcfa-4cf2-a88c-8e23667e5e50.png)


# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
