### PR TITLE
fix: remove path expand for PATH

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -35,12 +35,12 @@ let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
 # Note: The conversions happen *after* config.nu is loaded
 let-env ENV_CONVERSIONS = {
   "PATH": {
-    from_string: { |s| $s | split row (char esep) | path expand }
-    to_string: { |v| $v | path expand | str collect (char esep) }
+    from_string: { |s| $s | split row (char esep) }
+    to_string: { |v| $v | str collect (char esep) }
   }
   "Path": {
-    from_string: { |s| $s | split row (char esep) | path expand }
-    to_string: { |v| $v | path expand | str collect (char esep) }
+    from_string: { |s| $s | split row (char esep) }
+    to_string: { |v| $v | str collect (char esep) }
   }
 }
 


### PR DESCRIPTION
# Description

Fixes: #6239
Co-authored-by: Vivian Wang <dramforever@live.com>

In default environment configuration, nushell expands paths in PATH.
This in an issue for operating systems that implement
transaction/atomicity through symlinks such as NixOS
(probably same issue arises when using Nix or home-manager standalone),
since the older expanded paths from older "system generations"
might not exist after creating or using newer "system generation".
So system is neither able to find some paths in PATH
and, thus, nor the PATHs' binaries.

This reverts #5692.

(i'm unable to run the tests, if someone can do so that would be nice)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass