### PR TITLE
Suggest alternative when command not found

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -162,14 +162,14 @@ impl ExternalCommand {
                 // If we try to run an external but can't, there's a good chance
                 // that the user entered the wrong command name
                 let suggestion = suggest_command(&self.name.item, engine_state);
-                let error_message = match suggestion {
-                    Some(s) => format!("{err} (did you mean '{s}'?)"),
-                    None => err.to_string(),
+                let label = match suggestion {
+                    Some(s) => format!("did you mean '{s}'?"),
+                    None => "can't run executable".into(),
                 };
 
                 Err(ShellError::ExternalCommand(
-                    "can't run executable".to_string(),
-                    error_message,
+                    label,
+                    err.to_string(),
                     self.name.span,
                 ))
             }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -2,6 +2,7 @@ use fancy_regex::Regex;
 use itertools::Itertools;
 use nu_engine::env_to_strings;
 use nu_engine::CallExt;
+use nu_protocol::did_you_mean;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::{ast::Call, engine::Command, ShellError, Signature, SyntaxShape, Value};
 use nu_protocol::{Category, Example, ListStream, PipelineData, RawStream, Span, Spanned};
@@ -157,11 +158,21 @@ impl ExternalCommand {
         }
 
         match child {
-            Err(err) => Err(ShellError::ExternalCommand(
-                "can't run executable".to_string(),
-                err.to_string(),
-                self.name.span,
-            )),
+            Err(err) => {
+                // If we try to run an external but can't, there's a good chance
+                // that the user entered the wrong command name
+                let suggestion = suggest_command(&self.name.item, engine_state);
+                let error_message = match suggestion {
+                    Some(s) => format!("{err} (did you mean '{s}'?)"),
+                    None => err.to_string(),
+                };
+
+                Err(ShellError::ExternalCommand(
+                    "can't run executable".to_string(),
+                    error_message,
+                    self.name.span,
+                ))
+            }
             Ok(mut child) => {
                 if !input.is_nothing() {
                     let mut engine_state = engine_state.clone();
@@ -510,6 +521,24 @@ impl ExternalCommand {
         let mut process = std::process::Command::new("sh");
         process.arg("-c").arg(cmd_with_args);
         process
+    }
+}
+
+/// Given an invalid command name, try to suggest an alternative
+fn suggest_command(attempted_command: &str, engine_state: &EngineState) -> Option<String> {
+    let commands = engine_state.get_signatures(false);
+    let command_name_lower = attempted_command.to_lowercase();
+    let search_term_match = commands.iter().find(|sig| {
+        sig.search_terms
+            .iter()
+            .any(|term| term.to_lowercase() == command_name_lower)
+    });
+    match search_term_match {
+        Some(sig) => Some(sig.name.clone()),
+        None => {
+            let command_names: Vec<String> = commands.iter().map(|sig| sig.name.clone()).collect();
+            did_you_mean(&command_names, attempted_command)
+        }
     }
 }
 

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -65,5 +65,5 @@ fn checks_if_all_returns_error_with_invalid_command() {
         "#
     ));
 
-    assert!(actual.err.contains("can't run executable") || actual.err.contains("type_mismatch"));
+    assert!(actual.err.contains("can't run executable") || actual.err.contains("did you mean"));
 }

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -41,5 +41,5 @@ fn checks_if_any_returns_error_with_invalid_command() {
         "#
     ));
 
-    assert!(actual.err.contains("can't run executable") || actual.err.contains("type_mismatch"));
+    assert!(actual.err.contains("can't run executable") || actual.err.contains("did you mean"));
 }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -107,6 +107,19 @@ fn passes_binary_data_between_externals() {
     )
 }
 
+#[test]
+fn command_not_found_error_suggests_search_term() {
+    // 'distinct' is not a command, but it is a search term for 'uniq'
+    let actual = nu!(cwd: ".", "ls | distinct");
+    assert!(actual.err.contains("uniq"));
+}
+
+#[test]
+fn command_not_found_error_suggests_typo_fix() {
+    let actual = nu!(cwd: ".", "benhcmark { echo 'foo'}");
+    assert!(actual.err.contains("benchmark"));
+}
+
 mod it_evaluation {
     use super::nu;
     use nu_test_support::fs::Stub::{EmptyFile, FileWithContent, FileWithContentToBeTrimmed};


### PR DESCRIPTION
# Description

Closes #4996. When the user tries to run `foo` but the command can't be found:
1. Check if `foo` matches any search terms for other commands
2. Check if `foo` is similar to other command names (maybe it's a typo)

### Before
![image](https://user-images.githubusercontent.com/26268125/183279337-ac56b3c2-b2cf-406e-b975-3ceb1d84018e.png)

### After
![image](https://user-images.githubusercontent.com/26268125/183279361-5765d534-78aa-4c98-a3cd-80d79db27d48.png)

### Before
![image](https://user-images.githubusercontent.com/26268125/183279450-34edfd7b-3bee-4c2d-9f5f-62d2a5a9b63d.png)


### After
![image](https://user-images.githubusercontent.com/26268125/183279421-19a4cb44-c130-4ef9-bc11-cc8d08504b6a.png)

# Future Work

Once this is in place, we could probably delete the deprecated internal commands (as long as the right search terms exist for their replacements).

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
