### PR TITLE
add more verbose error messages to mv

### DIFF
--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -288,10 +288,10 @@ fn move_item(from: &Path, from_span: Span, to: &Path) -> Result<(), ShellError> 
             Err(e) => {
                 let error_kind = match e.kind {
                     fs_extra::error::ErrorKind::Io(io) => {
-                        format!("I/O error: {}", io.to_string())
+                        format!("I/O error: {}", io)
                     }
                     fs_extra::error::ErrorKind::StripPrefix(sp) => {
-                        format!("Strip prefix error: {}", sp.to_string())
+                        format!("Strip prefix error: {}", sp)
                     }
                     fs_extra::error::ErrorKind::OsString(os) => {
                         format!("OsString error: {:?}", os.to_str())

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -288,10 +288,10 @@ fn move_item(from: &Path, from_span: Span, to: &Path) -> Result<(), ShellError> 
             Err(e) => {
                 let error_kind = match e.kind {
                     fs_extra::error::ErrorKind::Io(io) => {
-                        format!("I/O error: {:?}", io.to_string())
+                        format!("I/O error: {}", io.to_string())
                     }
                     fs_extra::error::ErrorKind::StripPrefix(sp) => {
-                        format!("Strip prefix error: {:?}", sp.to_string())
+                        format!("Strip prefix error: {}", sp.to_string())
                     }
                     fs_extra::error::ErrorKind::OsString(os) => {
                         format!("OsString error: {:?}", os.to_str())
@@ -300,7 +300,7 @@ fn move_item(from: &Path, from_span: Span, to: &Path) -> Result<(), ShellError> 
                 };
                 Err(ShellError::GenericError(
                     format!(
-                        "Could not move {:?} to {:?}. Error Kind {:?}",
+                        "Could not move {:?} to {:?}. Error Kind: {:?}",
                         from, to, error_kind
                     ),
                     "could not move".into(),

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -300,7 +300,7 @@ fn move_item(from: &Path, from_span: Span, to: &Path) -> Result<(), ShellError> 
                 };
                 Err(ShellError::GenericError(
                     format!(
-                        "Could not move {:?} to {:?}. Error Kind: {:?}",
+                        "Could not move {:?} to {:?}. Error Kind: {}",
                         from, to, error_kind
                     ),
                     "could not move".into(),


### PR DESCRIPTION
# Description

This PR tries to address an issue reported on Discord. Hopefully this is more verbose.
Before
```
Error:
  × Could not move "/tmp/target/debug/deps" to "/tmp/deps". Io error. Look
  │ inside err_kind for more details.
   ╭─[entry #58:1:1]
 1 │ mv */*/* .
   ·    ───┬───
   ·       ╰── could not move
   ╰────
```

After
```
Error:
  × Could not move "/tmp/trash/cargo-installM73Y65/release/deps" to "/tmp/trash/deps".
  │ Error Kind: "I/O error: Directory not empty (os error 39)"
   ╭─[entry #6:1:1]
 1 │ mv */*/* .
   ·    ──┬──
   ·      ╰── could not move
   ╰────
```
# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
