### PR TITLE
when spawned process during register plugin, pass env to child process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "itertools",
  "log",
  "miette 5.1.1",
+ "nu-engine",
  "nu-path",
  "nu-plugin",
  "nu-protocol",

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 nu-path = {path = "../nu-path", version = "0.66.3" }
 nu-protocol = { path = "../nu-protocol", version = "0.66.3" }
 nu-plugin = { path = "../nu-plugin", optional = true, version = "0.66.3"  }
+nu-engine = { path = "../nu-engine", version = "0.66.3" }
 log = "0.4"
 
 [features]

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2785,8 +2785,8 @@ pub fn parse_register(
         },
     };
 
-    // We needs current envs for `python` based plugin
-    // Or we'll likely to get a problem when plugin is implemented in a virtual Python environment.
+    // We need the current environment variables for `python` based plugins
+    // Or we'll likely have a problem when a plugin is implemented in a virtual Python environment.
     let stack = Stack::new();
     let current_envs =
         nu_engine::env::env_to_strings(working_set.permanent_state, &stack).unwrap_or_default();

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2623,7 +2623,8 @@ pub fn parse_register(
     expand_aliases_denylist: &[usize],
 ) -> (Pipeline, Option<ParseError>) {
     use nu_plugin::{get_signature, EncodingType, PluginDeclaration};
-    use nu_protocol::Signature;
+    use nu_protocol::{engine::Stack, Signature};
+
     let cwd = working_set.get_cwd();
 
     // Checking that the function is used with the correct name
@@ -2784,6 +2785,11 @@ pub fn parse_register(
         },
     };
 
+    // We needs current envs for `python` based plugin
+    // Or we'll likely to get a problem when plugin is implemented in a virtual Python environment.
+    let stack = Stack::new();
+    let current_envs =
+        nu_engine::env::env_to_strings(working_set.permanent_state, &stack).unwrap_or_default();
     let error = match signature {
         Some(signature) => arguments.and_then(|(path, encoding)| {
             signature.map(|signature| {
@@ -2793,7 +2799,7 @@ pub fn parse_register(
             })
         }),
         None => arguments.and_then(|(path, encoding)| {
-            get_signature(path.as_path(), &encoding, &shell)
+            get_signature(path.as_path(), &encoding, &shell, &current_envs)
                 .map_err(|err| {
                     ParseError::LabeledError(
                         "Error getting signatures".into(),

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -61,8 +61,8 @@ impl Command for PluginDeclaration {
         // Create PipelineData
         let source_file = Path::new(&self.filename);
         let mut plugin_cmd = create_command(source_file, &self.shell);
-        // We needs current envs for `python` based plugin
-        // Or we'll likely to get a problem when plugin is implemented in a virtual Python environment.
+        // We need the current environment variables for `python` based plugins
+        // Or we'll likely have a problem when a plugin is implemented in a virtual Python environment.       
         let current_envs = nu_engine::env::env_to_strings(engine_state, stack).unwrap_or_default();
         plugin_cmd.envs(current_envs);
 

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -62,7 +62,7 @@ impl Command for PluginDeclaration {
         let source_file = Path::new(&self.filename);
         let mut plugin_cmd = create_command(source_file, &self.shell);
         // We need the current environment variables for `python` based plugins
-        // Or we'll likely have a problem when a plugin is implemented in a virtual Python environment.       
+        // Or we'll likely have a problem when a plugin is implemented in a virtual Python environment.
         let current_envs = nu_engine::env::env_to_strings(engine_state, stack).unwrap_or_default();
         plugin_cmd.envs(current_envs);
 

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -61,6 +61,10 @@ impl Command for PluginDeclaration {
         // Create PipelineData
         let source_file = Path::new(&self.filename);
         let mut plugin_cmd = create_command(source_file, &self.shell);
+        // We needs current envs for `python` based plugin
+        // Or we'll likely to get a problem when plugin is implemented in a virtual Python environment.
+        let current_envs = nu_engine::env::env_to_strings(engine_state, stack).unwrap_or_default();
+        plugin_cmd.envs(current_envs);
 
         let mut child = plugin_cmd.spawn().map_err(|err| {
             let decl = engine_state.get_decl(call.decl_id);

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -1,6 +1,7 @@
 mod declaration;
 pub use declaration::PluginDeclaration;
 use nu_engine::documentation::get_flags_section;
+use std::collections::HashMap;
 
 use crate::protocol::{CallInput, LabeledError, PluginCall, PluginData, PluginResponse};
 use crate::EncodingType;
@@ -117,9 +118,11 @@ pub fn get_signature(
     path: &Path,
     encoding: &EncodingType,
     shell: &Option<PathBuf>,
+    current_envs: &HashMap<String, String>,
 ) -> Result<Vec<Signature>, ShellError> {
     let mut plugin_cmd = create_command(path, shell);
 
+    plugin_cmd.envs(current_envs);
     let mut child = plugin_cmd.spawn().map_err(|err| {
         ShellError::PluginFailedToLoad(format!("Error spawning child process: {}", err))
     })?;


### PR DESCRIPTION
# Description

while using python based plugin, I find myself get the following error:

![Screen Shot 2022-08-08 at 11 01 35](https://user-images.githubusercontent.com/22256154/183330275-e026aea5-ddd4-460c-a375-4e82a5f9059c.png)

After investigate, I found it's because when spawn child process, it doesn't take ENVs from current env, this may be not important for rust based plugin, but it's crucial for python(or maybe other languages which have virtual environments) based plugin.

This pr is going to fix the problem, so it matches the following comment in python plugin example:
https://github.com/nushell/nushell/blob/8b55757a0b82fa4fba81feaf70eb0f6e97aaab9c/crates/nu_plugin_python/plugin.py#L16-L17



# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
