### PR TITLE
escape single quotes and remove ansi escape sequences

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -246,7 +246,17 @@ fn nu_value_to_string(value: Value, separator: &str, config: &Config) -> String 
                 nu_value_to_string(val.to, ", ", config)
             )
         }
-        Value::String { val, .. } => val,
+        Value::String { val, .. } => {
+            // don't store ansi escape sequences in the database
+            let stripped = {
+                match strip_ansi_escapes::strip(&val) {
+                    Ok(item) => String::from_utf8(item).unwrap_or(val),
+                    Err(_) => val,
+                }
+            };
+            // escape single quotes
+            stripped.replace("'", "''")
+        }
         Value::List { vals: val, .. } => val
             .iter()
             .map(|x| nu_value_to_string(x.clone(), ", ", config))

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -140,7 +140,7 @@ fn action(
                                     })
                                     .join(",")
                             }
-                            // Number is formats so keep them without quotes
+                            // Number formats so keep them without quotes
                             Value::Int { val: _, span: _ }
                             | Value::Float { val: _, span: _ }
                             | Value::Filesize { val: _, span: _ }
@@ -255,7 +255,7 @@ fn nu_value_to_string(value: Value, separator: &str, config: &Config) -> String 
                 }
             };
             // escape single quotes
-            stripped.replace("'", "''")
+            stripped.replace('\'', "''")
         }
         Value::List { vals: val, .. } => val
             .iter()


### PR DESCRIPTION
# Description

This PR escapes single quotes and removes ansi escape sequences prior to storing strings in the sqlite database. I discovered these by testing `help commands | into sqlite commands.db`.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
