### PR TITLE
bump lscolors to v12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,8 +2120,8 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.11.1"
-source = "git+https://github.com/sharkdp/lscolors.git?branch=master#bfc0d457b75640bd2d8d9bf16895c9ccd0b98722"
+version = "0.12.0"
+source = "git+https://github.com/sharkdp/lscolors.git?branch=master#5516bc727f66e7931a62585034ca8cc3ecf3f699"
 dependencies = [
  "ansi_term",
  "crossterm 0.24.0",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -53,7 +53,7 @@ is-root = "0.1.2"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 log = "0.4.14"
-lscolors = { version = "0.11.0", features = ["crossterm"]}
+lscolors = { version = "0.12.0", features = ["crossterm"]}
 md5 = { package = "md-5", version = "0.10.0" }
 meval = "0.2.0"
 mime = "0.3.16"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -12,7 +12,7 @@ name = "utils"
 path = "src/main.rs"
 
 [dependencies]
-lscolors = { version = "0.11.0", features = ["crossterm"]}
+lscolors = { version = "0.12.0", features = ["crossterm"]}
 
 [target.'cfg(windows)'.dependencies]
 crossterm_winapi = "0.9.0"


### PR DESCRIPTION
# Description

Bump lscolors crate to the latest version supporting crossterm 24.0

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
