### PR TITLE
Temporary: ignore Windows tests that fail on a local machine

### DIFF
--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -198,6 +198,7 @@ fn failed_command_with_semicolon_will_not_execute_following_cmds_windows() {
 
 #[cfg(windows)]
 #[test]
+#[ignore = "fails on local Windows machines"]
 // This test case might fail based on the running shell on Windows - CMD vs PowerShell, the reason is
 //
 // Test command 1 - `dir * `
@@ -230,6 +231,7 @@ fn double_quote_does_not_expand_path_glob_windows() {
 
 #[cfg(windows)]
 #[test]
+#[ignore = "fails on local Windows machines"]
 // This test case might fail based on the running shell on Windows - CMD vs PowerShell, the reason is
 //
 // Test command 1 - `dir * `


### PR DESCRIPTION
# Description

Related to #6252. We have 2 Windows tests related to quote expansion that always fail on my local machine (a fairly vanilla Windows 11 Pro install). 

I'm not confident that the tests are currently doing the right thing, given that they depend on unusual behaviour in CI. The original author of those tests doesn't have time to fix them right now; I would like to ignore the tests until they do have time.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
