### PR TITLE
Fix unused import warning on Linux+Mac

### DIFF
--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -1,4 +1,4 @@
-use nu_test_support::fs::Stub::{EmptyFile, FileWithContent};
+use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
@@ -265,6 +265,7 @@ fn single_quote_does_not_expand_path_glob_windows() {
 #[cfg(windows)]
 #[test]
 fn can_run_batch_files() {
+    use nu_test_support::fs::Stub::FileWithContent;
     Playground::setup("run a Windows batch file", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContent(
             "foo.cmd",
@@ -282,6 +283,7 @@ fn can_run_batch_files() {
 #[cfg(windows)]
 #[test]
 fn can_run_batch_files_without_cmd_extension() {
+    use nu_test_support::fs::Stub::FileWithContent;
     Playground::setup(
         "run a Windows batch file without specifying the extension",
         |dirs, sandbox| {
@@ -302,6 +304,7 @@ fn can_run_batch_files_without_cmd_extension() {
 #[cfg(windows)]
 #[test]
 fn can_run_batch_files_without_bat_extension() {
+    use nu_test_support::fs::Stub::FileWithContent;
     Playground::setup(
         "run a Windows batch file without specifying the extension",
         |dirs, sandbox| {


### PR DESCRIPTION
# Description

Sorry for the noise, this PR just fixes up [an unused import compiler warning that WindSoilder noticed](https://github.com/nushell/nushell/pull/6279#pullrequestreview-1067566454). I'm surprised Clippy let this through in CI, worth digging into that sometime.

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
