### PR TITLE
Fix color settings for logger

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -97,8 +97,11 @@ pub fn configure(
     let log_target = LogTarget::from(target);
 
     // Only TermLogger supports color output
-    if !matches!(log_target, LogTarget::File) {
-        set_colored_level(builder, level);
+    if matches!(
+        log_target,
+        LogTarget::Stdout | LogTarget::Stderr | LogTarget::Mixed
+    ) {
+        Level::iter().for_each(|level| set_colored_level(builder, level));
     }
 
     (level.to_level_filter(), log_target)


### PR DESCRIPTION
# Description
This PR fix color settings for logger. Commit fc8512be3 just sets one color for the specified level, and the others colors are default.

* Before fc8512be3
![1](https://user-images.githubusercontent.com/15247421/183874166-03eee882-6a15-4dbb-ae37-b301329fc160.png)

* After fc8512be3
![2](https://user-images.githubusercontent.com/15247421/183874440-3da3033d-d3fa-492a-bc41-72db8bdda6c4.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
