### PR TITLE
add search terms to ignore command

### DIFF
--- a/crates/nu-command/src/core_commands/ignore.rs
+++ b/crates/nu-command/src/core_commands/ignore.rs
@@ -18,6 +18,10 @@ impl Command for Ignore {
         Signature::build("ignore").category(Category::Core)
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["silent", "quiet", "out-null"]
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,


### PR DESCRIPTION
# Description

This PR adds search terms to the `ignore` command. Someone recently asked for this and I couldn't remember what it was, nor could I find it with `help -f quiet`. This should solve that problem.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
