### PR TITLE
Fix panic when building without git

### DIFF
--- a/crates/nu-command/build.rs
+++ b/crates/nu-command/build.rs
@@ -3,16 +3,18 @@ use std::process::Command;
 fn main() -> shadow_rs::SdResult<()> {
     // Look up the current Git commit ourselves instead of relying on shadow_rs,
     // because shadow_rs does it in a really slow-to-compile way (it builds libgit2)
-    let hash = get_git_hash().expect("failed to get latest git commit hash");
+    let hash = get_git_hash().unwrap_or_default();
     println!("cargo:rustc-env=NU_COMMIT_HASH={}", hash);
 
     shadow_rs::new()
 }
 
-fn get_git_hash() -> Result<String, std::io::Error> {
-    let out = Command::new("git").args(["rev-parse", "HEAD"]).output()?;
-    Ok(String::from_utf8(out.stdout)
-        .expect("could not convert stdout to string")
-        .trim()
-        .to_string())
+fn get_git_hash() -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|hash| hash.trim().to_string())
 }


### PR DESCRIPTION
# Description

When building a release tarball without `git`, the build script panics. This PR prevents this panic, and it doesn't do any harm.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
