### PR TITLE
Revert "Allow using the system's copy of zstd for Polars"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,7 +2657,6 @@ dependencies = [
  "wax",
  "which",
  "windows",
- "zstd",
 ]
 
 [[package]]
@@ -5627,5 +5626,4 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ trash-support = ["nu-command/trash-support"]
 
 # Dataframe feature for nushell
 dataframe = ["nu-command/dataframe"]
-system-zstd = ["nu-command/system-zstd"]
 
 # Database commands for nushell
 database = ["nu-command/database"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -89,7 +89,6 @@ reedline = { version = "0.9.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.16.0", features = ["serde"], optional = true }
-zstd = { version = "*", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 umask = "2.0.0"
@@ -125,7 +124,6 @@ trash-support = ["trash"]
 which-support = ["which"]
 plugin = ["nu-parser/plugin"]
 dataframe = ["polars", "num"]
-system-zstd = ["zstd/pkg-config"]
 database = ["sqlparser", "rusqlite"]
 
 [build-dependencies]


### PR DESCRIPTION
Reverts nushell/nushell#6232

We need to revert because this stops our testing with --all-features