### PR TITLE
Clippy fix for Rust 1.63

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -116,7 +116,8 @@ impl CommandCompletion {
 
         let partial = working_set.get_span_contents(span);
         let partial = String::from_utf8_lossy(partial).to_string();
-        let results = if find_externals {
+
+        if find_externals {
             let results_external = self
                 .external_command_completion(&partial, match_algorithm)
                 .into_iter()
@@ -148,9 +149,7 @@ impl CommandCompletion {
             results
         } else {
             results
-        };
-
-        results
+        }
     }
 }
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -245,7 +245,7 @@ impl NuCompleter {
             }
         }
 
-        return vec![];
+        vec![]
     }
 }
 

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -311,7 +311,7 @@ fn action(
                 Some(dt) => match DateTime::parse_from_str(val, &dt.0) {
                     Ok(d) => Value::Date { val: d, span: head },
                     Err(reason) => {
-                        return Value::Error {
+                        Value::Error {
                             error: ShellError::CantConvert(
                                 format!("could not parse as datetime using format '{}'", dt.0),
                                 reason.to_string(),

--- a/crates/nu-command/src/database/commands/alias.rs
+++ b/crates/nu-command/src/database/commands/alias.rs
@@ -145,15 +145,13 @@ fn alias_db(
                     Vec::new(),
                 )),
             },
-            s => {
-                return Err(ShellError::GenericError(
-                    "Connection doesn't define a query".into(),
-                    format!("Expected a connection with query. Got {}", s),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                ))
-            }
+            s => Err(ShellError::GenericError(
+                "Connection doesn't define a query".into(),
+                format!("Expected a connection with query. Got {}", s),
+                Some(call.head),
+                None,
+                Vec::new(),
+            )),
         },
     }
 }

--- a/crates/nu-command/src/database/values/definitions/db.rs
+++ b/crates/nu-command/src/database/values/definitions/db.rs
@@ -3,7 +3,7 @@ use super::db_table::DbTable;
 // Thank you gobang
 // https://github.com/TaKO8Ki/gobang/blob/main/database-tree/src/lib.rs
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Db {
     pub name: String,
     pub tables: Vec<DbTable>,

--- a/crates/nu-command/src/database/values/definitions/db_schema.rs
+++ b/crates/nu-command/src/database/values/definitions/db_schema.rs
@@ -1,6 +1,6 @@
 use super::db_table::DbTable;
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DbSchema {
     pub name: String,
     pub tables: Vec<DbTable>,

--- a/crates/nu-command/src/database/values/definitions/db_table.rs
+++ b/crates/nu-command/src/database/values/definitions/db_table.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct DbTable {
     pub name: String,
     pub create_time: Option<chrono::DateTime<chrono::Utc>>,

--- a/crates/nu-command/src/database/values/definitions/mod.rs
+++ b/crates/nu-command/src/database/values/definitions/mod.rs
@@ -11,7 +11,7 @@ pub mod db_row;
 pub mod db_schema;
 pub mod db_table;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ConnectionDb {
     Path(PathBuf),
 }

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/mod.rs
@@ -446,7 +446,7 @@ impl NuDataFrame {
         // sorting dataframe by the first column
         let column_names = self.as_ref().get_column_names();
         let first_col = column_names
-            .get(0)
+            .first()
             .expect("already checked that dataframe is different than 0");
 
         // if unable to sort, then unable to compare

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -206,7 +206,7 @@ impl Iterator for DropNthIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(row) = self.rows.get(0) {
+            if let Some(row) = self.rows.first() {
                 if self.current == *row {
                     self.rows.remove(0);
                     self.current += 1;

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -207,7 +207,7 @@ impl Iterator for NthIterator {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if !self.skip {
-                if let Some(row) = self.rows.get(0) {
+                if let Some(row) = self.rows.first() {
                     if self.current == *row {
                         self.rows.remove(0);
                         self.current += 1;
@@ -220,7 +220,7 @@ impl Iterator for NthIterator {
                 } else {
                     return None;
                 }
-            } else if let Some(row) = self.rows.get(0) {
+            } else if let Some(row) = self.rows.first() {
                 if self.current == *row {
                     self.rows.remove(0);
                     self.current += 1;

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -153,7 +153,7 @@ impl Command for Sort {
                 }
 
                 let iter = vec.into_iter();
-                match &*metadata {
+                match metadata {
                     Some(m) => Ok(iter
                         .into_pipeline_data_with_metadata(m.clone(), engine_state.ctrlc.clone())),
                     None => Ok(iter.into_pipeline_data(engine_state.ctrlc.clone())),

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -158,7 +158,7 @@ impl Command for SortBy {
         }
 
         let iter = vec.into_iter();
-        match &*metadata {
+        match metadata {
             Some(m) => {
                 Ok(iter.into_pipeline_data_with_metadata(m.clone(), engine_state.ctrlc.clone()))
             }

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -217,7 +217,7 @@ fn process_range(
         Value::String { val: s, .. } => {
             let indexes: Vec<&str> = s.split(',').collect();
 
-            let start_index = indexes.get(0).unwrap_or(&&min_index_str[..]).to_string();
+            let start_index = indexes.first().unwrap_or(&&min_index_str[..]).to_string();
 
             let end_index = indexes.get(1).unwrap_or(&&max_index_str[..]).to_string();
 

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -247,7 +247,7 @@ fn process_arguments(options: &Arguments, head: Span) -> Result<(isize, isize), 
             let idx: Vec<&str> = val.split(',').collect();
 
             let start = idx
-                .get(0)
+                .first()
                 .ok_or_else(|| {
                     ShellError::UnsupportedInput("could not perform substring".to_string(), head)
                 })?

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -412,7 +412,7 @@ fn lists_with_directory_flag() {
         ));
         let expected = [".", ".", "..", "../dir_files", "../dir_files/nushell.json"].join("");
         #[cfg(windows)]
-        let expected = expected.replace("/", "\\");
+        let expected = expected.replace('/', "\\");
         assert_eq!(
             actual.out, expected,
             "column names are incorrect for ls --directory (-D)"

--- a/crates/nu-command/tests/commands/network/port.rs
+++ b/crates/nu-command/tests/commands/network/port.rs
@@ -41,10 +41,7 @@ fn port_with_already_usage() {
             return;
         }
     }
-    assert!(
-        false,
-        "already check port report AddrInUse for seveval times, but still failed."
-    );
+    panic!("already check port report AddrInUse for seveval times, but still failed.");
 }
 
 #[test]

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -845,7 +845,7 @@ fn extract_custom_completion_from_arg(engine_state: &EngineState, shape: &Syntax
     return match shape {
         SyntaxShape::Custom(_, custom_completion_decl_id) => {
             let custom_completion_command = engine_state.get_decl(*custom_completion_decl_id);
-            let custom_completion_command_name: &str = &*custom_completion_command.name();
+            let custom_completion_command_name: &str = custom_completion_command.name();
             custom_completion_command_name.to_string()
         }
         _ => "".to_string(),

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -992,7 +992,7 @@ mod test {
                 .and_then(|p| match p.components().next().unwrap() {
                     Component::Prefix(prefix_component) => {
                         let path = Path::new(prefix_component.as_os_str()).join("*");
-                        Some(path.to_path_buf())
+                        Some(path)
                     }
                     _ => panic!("no prefix in this path"),
                 })

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1117,7 +1117,7 @@ pub fn parse_call(
         // We might be parsing left-unbounded range ("..10")
         let bytes = working_set.get_span_contents(spans[0]);
         trace!("parsing: range {:?} ", bytes);
-        if let (Some(b'.'), Some(b'.')) = (bytes.get(0), bytes.get(1)) {
+        if let (Some(b'.'), Some(b'.')) = (bytes.first(), bytes.get(1)) {
             trace!("-- found leading range indicator");
             let (range_expr, range_err) =
                 parse_range(working_set, spans[0], expand_aliases_denylist);

--- a/crates/nu-plugin/src/protocol/plugin_data.rs
+++ b/crates/nu-plugin/src/protocol/plugin_data.rs
@@ -1,7 +1,7 @@
 use nu_protocol::Span;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct PluginData {
     pub data: Vec<u8>,
     pub span: Span,

--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -15,7 +15,7 @@ pub fn format_error(
     working_set: &StateWorkingSet,
     error: &(dyn miette::Diagnostic + Send + Sync + 'static),
 ) -> String {
-    return format!("Error: {:?}", CliError(error, working_set));
+    format!("Error: {:?}", CliError(error, working_set))
 }
 
 impl std::fmt::Debug for CliError<'_> {

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -2,7 +2,7 @@ use miette::SourceSpan;
 use serde::{Deserialize, Serialize};
 
 /// A spanned area of interest, generic over what kind of thing is of interest
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Spanned<T>
 where
     T: Clone + std::fmt::Debug,

--- a/crates/nu-term-grid/src/grid.rs
+++ b/crates/nu-term-grid/src/grid.rs
@@ -163,7 +163,7 @@ impl From<String> for Cell {
 impl<'a> From<&'a str> for Cell {
     fn from(string: &'a str) -> Self {
         Self {
-            width: unicode_width_strip_ansi(&*string),
+            width: unicode_width_strip_ansi(string),
             contents: string.into(),
             alignment: Alignment::Left,
         }
@@ -243,7 +243,7 @@ impl Dimensions {
 /// Everything needed to format the cells with the grid options.
 ///
 /// For more information, see the [`grid` crate documentation](index.html).
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct Grid {
     options: GridOptions,
     cells: Vec<Cell>,
@@ -428,7 +428,7 @@ impl Grid {
 ///
 /// This type implements `Display`, so you can get the textual version
 /// of the grid by calling `.to_string()`.
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct Display<'grid> {
     /// The grid to display.
     grid: &'grid Grid,


### PR DESCRIPTION
Take more sensitive lints into account

Somewhat ugly in some cases is the replacement of `.get(0)` with
`.first()`

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
