### PR TITLE
make ci use rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,12 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
+        # makes ci use rust-toolchain.toml
+        # with:
+        #   profile: minimal
+        #   toolchain: ${{ matrix.rust }}
+        #   override: true
+        #   components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -75,10 +76,11 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+        # makes ci use rust-toolchain.toml
+        # with:
+        #   profile: minimal
+        #   toolchain: ${{ matrix.rust }}
+        #   override: true
 
       # Temporarily disabled; the cache was getting huge (2.6GB compressed) on Windows and causing issues.
       # TODO: investigate why the cache was so big
@@ -112,10 +114,11 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+        # makes ci use rust-toolchain.toml
+        # with:
+        #   profile: minimal
+        #   toolchain: ${{ matrix.rust }}
+        #   override: true
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -135,7 +138,7 @@ jobs:
       - run: python -m pip install tox
 
       - name: Install virtualenv
-        run: git clone https://github.com/pypa/virtualenv.git          
+        run: git clone https://github.com/pypa/virtualenv.git
         shell: bash
 
       - name: Test Nushell in virtualenv
@@ -162,10 +165,11 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+        # makes ci use rust-toolchain.toml
+        # with:
+        #   profile: minimal
+        #   toolchain: ${{ matrix.rust }}
+        #   override: true
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         # makes ci use rust-toolchain.toml
         # with:
         #   profile: minimal
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         # makes ci use rust-toolchain.toml
         # with:
         #   profile: minimal
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         # makes ci use rust-toolchain.toml
         # with:
         #   profile: minimal
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         # makes ci use rust-toolchain.toml
         # with:
         #   profile: minimal


### PR DESCRIPTION
# Description

This PR is supposed to make the CI use the rust-toolchain.toml so we can pin to a specific version of rust. However, I'm concerned that this might make our build times longer because I had to change from profile minimal to default which has more components. I'm trying to follow the instructions [here](https://github.com/actions-rs/toolchain#the-toolchain-file). This is mostly a test to see what it does.

I also had to switch the rust action because the one we were using is not supported and had bugs around the rust-toolchain flie. I switched it to this https://github.com/marketplace/actions/setup-rust-toolchain-for-github-ci?version=v1.3.0

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
