### PR TITLE
Clarify external command error

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -389,7 +389,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     /// ## Resolution
     ///
     /// This error is fairly generic. Refer to the specific error message for further details.
-    #[error("External command")]
+    #[error("External command failed")]
     #[diagnostic(code(nu::shell::external_command), url(docsrs), help("{1}"))]
     ExternalCommand(String, String, #[label("{0}")] Span),
 


### PR DESCRIPTION
# Description

I have been staring at `nu::shell::external_command` errors a lot lately, and I think it's confusing that they are just titled "External command". Like, I look at this and think "OK, what about an external command?"

![image](https://user-images.githubusercontent.com/26268125/184408691-dafc9446-0709-4e35-986a-e011c9738dc6.png)

This tiny PR just clarifies that an external command _failed_:

![image](https://user-images.githubusercontent.com/26268125/184408756-f6ff824d-45ae-4ca3-a980-47171e65c67b.png)


# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
