### PR TITLE
Fix environment merging in hooks

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -786,9 +786,6 @@ pub fn eval_hook(
                         for var_id in var_ids.iter() {
                             stack.vars.remove(var_id);
                         }
-
-                        let cwd = get_guaranteed_cwd(engine_state, stack);
-                        engine_state.merge_env(stack, cwd)?;
                     }
                     Value::Block {
                         val: block_id,
@@ -796,8 +793,6 @@ pub fn eval_hook(
                         ..
                     } => {
                         run_hook_block(engine_state, stack, block_id, arguments, block_span)?;
-                        let cwd = get_guaranteed_cwd(engine_state, stack);
-                        engine_state.merge_env(stack, cwd)?;
                     }
                     other => {
                         return Err(ShellError::UnsupportedConfigValue(
@@ -824,6 +819,9 @@ pub fn eval_hook(
             ));
         }
     }
+
+    let cwd = get_guaranteed_cwd(engine_state, stack);
+    engine_state.merge_env(stack, cwd)?;
 
     Ok(())
 }


### PR DESCRIPTION
# Description

I hoped to fix https://github.com/nushell/nushell/issues/5994 which I didn't but I found a small error where environment was not merged into the engine state in one of the branches. With this PR,the environment should be merged every time.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
