### PR TITLE
run_external: only suggest alternatives when file not found

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -205,34 +205,43 @@ impl ExternalCommand {
 
         match child {
             Err(err) => {
-                // recommend a replacement if the user tried a deprecated command
-                let command_name_lower = self.name.item.to_lowercase();
-                let deprecated = crate::deprecated_commands();
-                if deprecated.contains_key(&command_name_lower) {
-                    let replacement = match deprecated.get(&command_name_lower) {
-                        Some(s) => s.clone(),
-                        None => "".to_string(),
-                    };
-                    return Err(ShellError::DeprecatedCommand(
-                        command_name_lower,
-                        replacement,
+                match err.kind() {
+                    // If file not found, try suggesting alternative commands to the user
+                    std::io::ErrorKind::NotFound => {
+                        // recommend a replacement if the user tried a deprecated command
+                        let command_name_lower = self.name.item.to_lowercase();
+                        let deprecated = crate::deprecated_commands();
+                        if deprecated.contains_key(&command_name_lower) {
+                            let replacement = match deprecated.get(&command_name_lower) {
+                                Some(s) => s.clone(),
+                                None => "".to_string(),
+                            };
+                            return Err(ShellError::DeprecatedCommand(
+                                command_name_lower,
+                                replacement,
+                                self.name.span,
+                            ));
+                        }
+
+                        let suggestion = suggest_command(&self.name.item, engine_state);
+                        let label = match suggestion {
+                            Some(s) => format!("did you mean '{s}'?"),
+                            None => "can't run executable".into(),
+                        };
+
+                        Err(ShellError::ExternalCommand(
+                            label,
+                            err.to_string(),
+                            self.name.span,
+                        ))
+                    }
+                    // otherwise, a default error message
+                    _ => Err(ShellError::ExternalCommand(
+                        "can't run executable".into(),
+                        err.to_string(),
                         self.name.span,
-                    ));
+                    )),
                 }
-
-                // If we try to run an external but can't, there's a good chance
-                // that the user entered the wrong command name
-                let suggestion = suggest_command(&self.name.item, engine_state);
-                let label = match suggestion {
-                    Some(s) => format!("did you mean '{s}'?"),
-                    None => "can't run executable".into(),
-                };
-
-                Err(ShellError::ExternalCommand(
-                    label,
-                    err.to_string(),
-                    self.name.span,
-                ))
             }
             Ok(mut child) => {
                 if !input.is_nothing() {


### PR DESCRIPTION
# Description

Update the new "did you mean X?" error suggestions so they only occur for "file not found" errors.

I noticed that the suggestions don't make much sense for other errors like "permission denied" and "invalid executable format"; in those situations, we can assume that the user entered the right command name but it failed for another reason.

Here's a screenshot of the new behaviour, note that we don't offer a suggestion for the first error:
![image](https://user-images.githubusercontent.com/26268125/184467553-00a33e00-4e22-426b-a90b-e3b09b5ae39d.png)

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
