### PR TITLE
Add 'as' keyword to 'overlay add'

### DIFF
--- a/crates/nu-command/src/core_commands/overlay/add.rs
+++ b/crates/nu-command/src/core_commands/overlay/add.rs
@@ -24,6 +24,11 @@ impl Command for OverlayAdd {
                 SyntaxShape::String,
                 "Module name to create overlay for",
             )
+            .optional(
+                "as",
+                SyntaxShape::Keyword(b"as".to_vec(), Box::new(SyntaxShape::String)),
+                "as keyword followed by a new name",
+            )
             .switch(
                 "prefix",
                 "Prepend module name to the imported commands and aliases",
@@ -50,66 +55,85 @@ impl Command for OverlayAdd {
     ) -> Result<PipelineData, ShellError> {
         let name_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
 
-        let maybe_overlay_name = if engine_state
+        let (overlay_name, overlay_name_span) = if let Some(kw_expression) = call.positional_nth(1)
+        {
+            // If renamed via the 'as' keyword, use the new name as the overlay name
+            if let Some(new_name_expression) = kw_expression.as_keyword() {
+                if let Some(new_name) = new_name_expression.as_string() {
+                    (new_name, new_name_expression.span)
+                } else {
+                    return Err(ShellError::NushellFailedSpanned(
+                        "Wrong keyword type".to_string(),
+                        "keyword argument not a string".to_string(),
+                        new_name_expression.span,
+                    ));
+                }
+            } else {
+                return Err(ShellError::NushellFailedSpanned(
+                    "Wrong keyword type".to_string(),
+                    "keyword argument not a keyword".to_string(),
+                    kw_expression.span,
+                ));
+            }
+        } else if engine_state
             .find_overlay(name_arg.item.as_bytes())
             .is_some()
         {
-            Some(name_arg.item.clone())
+            (name_arg.item, name_arg.span)
         } else if let Some(os_str) = Path::new(&name_arg.item).file_stem() {
-            os_str.to_str().map(|name| name.to_string())
-        } else {
-            None
-        };
-
-        if let Some(overlay_name) = maybe_overlay_name {
-            if let Some(overlay_id) = engine_state.find_overlay(overlay_name.as_bytes()) {
-                let old_module_id = engine_state.get_overlay(overlay_id).origin;
-
-                stack.add_overlay(overlay_name.clone());
-
-                if let Some(new_module_id) = engine_state.find_module(overlay_name.as_bytes(), &[])
-                {
-                    if !stack.has_env_overlay(&overlay_name, engine_state)
-                        || (old_module_id != new_module_id)
-                    {
-                        // Add environment variables only if:
-                        // a) adding a new overlay
-                        // b) refreshing an active overlay (the origin module changed)
-                        let module = engine_state.get_module(new_module_id);
-
-                        for (name, block_id) in module.env_vars() {
-                            let name = if let Ok(s) = String::from_utf8(name.clone()) {
-                                s
-                            } else {
-                                return Err(ShellError::NonUtf8(call.head));
-                            };
-
-                            let block = engine_state.get_block(block_id);
-
-                            let val = eval_block(
-                                engine_state,
-                                stack,
-                                block,
-                                PipelineData::new(call.head),
-                                false,
-                                true,
-                            )?
-                            .into_value(call.head);
-
-                            stack.add_env_var(name, val);
-                        }
-                    }
-                }
+            if let Some(name) = os_str.to_str() {
+                (name.to_string(), name_arg.span)
             } else {
-                return Err(ShellError::OverlayNotFoundAtRuntime(
-                    name_arg.item,
-                    name_arg.span,
-                ));
+                return Err(ShellError::NonUtf8(name_arg.span));
             }
         } else {
             return Err(ShellError::OverlayNotFoundAtRuntime(
                 name_arg.item,
                 name_arg.span,
+            ));
+        };
+
+        if let Some(overlay_id) = engine_state.find_overlay(overlay_name.as_bytes()) {
+            let old_module_id = engine_state.get_overlay(overlay_id).origin;
+
+            stack.add_overlay(overlay_name.clone());
+
+            if let Some(new_module_id) = engine_state.find_module(overlay_name.as_bytes(), &[]) {
+                if !stack.has_env_overlay(&overlay_name, engine_state)
+                    || (old_module_id != new_module_id)
+                {
+                    // Add environment variables only if:
+                    // a) adding a new overlay
+                    // b) refreshing an active overlay (the origin module changed)
+                    let module = engine_state.get_module(new_module_id);
+
+                    for (name, block_id) in module.env_vars() {
+                        let name = if let Ok(s) = String::from_utf8(name.clone()) {
+                            s
+                        } else {
+                            return Err(ShellError::NonUtf8(call.head));
+                        };
+
+                        let block = engine_state.get_block(block_id);
+
+                        let val = eval_block(
+                            engine_state,
+                            stack,
+                            block,
+                            PipelineData::new(call.head),
+                            false,
+                            true,
+                        )?
+                        .into_value(call.head);
+
+                        stack.add_env_var(name, val);
+                    }
+                }
+            }
+        } else {
+            return Err(ShellError::OverlayNotFoundAtRuntime(
+                overlay_name,
+                overlay_name_span,
             ));
         }
 

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -160,6 +160,10 @@ pub enum ParseError {
     )]
     CantRemoveDefaultOverlay(String, #[label = "can't remove overlay"] Span),
 
+    #[error("Cannot add overlay.")]
+    #[diagnostic(code(nu::parser::cant_add_overlay_help), url(docsrs), help("{0}"))]
+    CantAddOverlayHelp(String, #[label = "cannot add this overlay"] Span),
+
     #[error("Not found.")]
     #[diagnostic(code(nu::parser::not_found), url(docsrs))]
     NotFound(#[label = "did not find anything under this name"] Span),
@@ -342,6 +346,7 @@ impl ParseError {
             ParseError::OverlayPrefixMismatch(_, _, s) => *s,
             ParseError::CantRemoveLastOverlay(s) => *s,
             ParseError::CantRemoveDefaultOverlay(_, s) => *s,
+            ParseError::CantAddOverlayHelp(_, s) => *s,
             ParseError::NotFound(s) => *s,
             ParseError::DuplicateCommandDef(s) => *s,
             ParseError::UnknownCommand(s) => *s,

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -633,3 +633,106 @@ fn overlay_keep_pwd() {
     assert_eq!(actual.out, "samples");
     assert_eq!(actual_repl.out, "samples");
 }
+
+#[test]
+fn overlay_wrong_rename_type() {
+    let inp = &[r#"module spam {}"#, r#"overlay add spam as { echo foo }"#];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+
+    assert!(actual.err.contains("parse_mismatch"));
+}
+
+#[test]
+fn overlay_add_renamed() {
+    let inp = &[
+        r#"module spam { export def foo [] { "foo" } }"#,
+        r#"overlay add spam as eggs --prefix"#,
+        r#"eggs foo"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert_eq!(actual.out, "foo");
+    assert_eq!(actual_repl.out, "foo");
+}
+
+#[test]
+fn overlay_add_renamed_from_file() {
+    let inp = &[
+        r#"overlay add samples/spam.nu as eggs --prefix"#,
+        r#"eggs foo"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert_eq!(actual.out, "foo");
+    assert_eq!(actual_repl.out, "foo");
+}
+
+#[test]
+fn overlay_cant_rename_existing_overlay() {
+    let inp = &[
+        r#"module spam { export def foo [] { "foo" } }"#,
+        r#"overlay add spam"#,
+        r#"overlay remove spam"#,
+        r#"overlay add spam as eggs"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert!(actual.err.contains("cant_add_overlay_help"));
+    assert!(actual_repl.err.contains("cant_add_overlay_help"));
+}
+
+#[test]
+fn overlay_can_add_renamed_overlay() {
+    let inp = &[
+        r#"module spam { export def foo [] { "foo" } }"#,
+        r#"overlay add spam as eggs --prefix"#,
+        r#"overlay add spam --prefix"#,
+        r#"(spam foo) + (eggs foo)"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert_eq!(actual.out, "foofoo");
+    assert_eq!(actual_repl.out, "foofoo");
+}
+
+#[test]
+fn overlay_remove_renamed_overlay() {
+    let inp = &[
+        r#"module spam { export def foo [] { "foo" } }"#,
+        r#"overlay add spam as eggs"#,
+        r#"overlay remove eggs"#,
+        r#"foo"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert!(actual.err.contains("did you mean"));
+    assert!(actual_repl.err.contains("did you mean"));
+}
+
+#[test]
+fn overlay_remove_and_add_renamed_overlay() {
+    let inp = &[
+        r#"module spam { export def foo [] { "foo" } }"#,
+        r#"overlay add spam as eggs"#,
+        r#"overlay remove eggs"#,
+        r#"overlay add eggs"#,
+        r#"foo"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert_eq!(actual.out, "foo");
+    assert_eq!(actual_repl.out, "foo");
+}


### PR DESCRIPTION
# Description

You can now customize the overlay's name using a new `as` keyword:
```
> module spam { export def foo [] { "foo" } }

> overlay add spam as eggs

> overlay list | last
eggs

> foo
foo

> overlay remove eggs
```

This can be useful if you have a generic script name, such as virtualenv's `activate.nu` but you want some more descriptive name for your overlay.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
