### PR TITLE
Bump chrono dependency to fix panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e9c9abb82613923ec78d7a461595d52491ba7240f3c64c0bbe0e6d98e0fce0"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi-str"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,10 +531,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
+ "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
@@ -1699,11 +1709,12 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.37"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d0b780e72fefba5e04a8359137b0a5687a44cc893dbda904fcf8a93f2f07e7"
+checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
 dependencies = [
- "core-foundation",
+ "android_system_properties",
+ "core-foundation-sys",
  "js-sys",
  "wasm-bindgen",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [dependencies]
-chrono = { version = "0.4.20", features = ["serde"] }
+chrono = { version = "0.4.21", features = ["serde"] }
 crossterm = "0.24.0"
 ctrlc = "3.2.1"
 log = "0.4"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -21,7 +21,7 @@ nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.66.4"  }
 reedline = { version = "0.9.0", features = ["bashisms", "sqlite"]}
 
-chrono = "0.4.20"
+chrono = "0.4.21"
 crossterm = "0.24.0"
 fancy-regex = "0.10.0"
 fuzzy-matcher = "0.3.7"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -32,7 +32,7 @@ base64 = "0.13.0"
 byteorder = "1.4.3"
 bytesize = "1.1.0"
 calamine = "0.18.0"
-chrono = { version = "0.4.20", features = ["serde"] }
+chrono = { version = "0.4.21", features = ["serde"] }
 chrono-humanize = "0.2.1"
 chrono-tz = "0.6.3"
 crossterm = "0.24.0"

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -224,7 +224,7 @@ mod tests {
             [dependencies]
             rustyline = "4.1.0"
             sysinfo = "0.8.4"
-            chrono = { version = "0.4.20", features = ["serde"] }
+            chrono = { version = "0.4.21", features = ["serde"] }
             "#,
             ),
             Span::test_data(),

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -12,7 +12,7 @@ nu-path = { path = "../nu-path", version = "0.66.4"  }
 nu-glob = { path = "../nu-glob", version = "0.66.4" }
 nu-utils = { path = "../nu-utils", version = "0.66.4"  }
 
-chrono = { version="0.4.20", features=["serde"] }
+chrono = { version="0.4.21", features=["serde"] }
 sysinfo = "0.25.2"
 
 [features]

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -7,7 +7,7 @@ name = "nu-parser"
 version = "0.66.4"
 
 [dependencies]
-chrono = "0.4.20"
+chrono = "0.4.21"
 itertools = "0.10"
 miette = "5.1.0"
 thiserror = "1.0.31"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -14,7 +14,7 @@ nu-path = { path = "../nu-path", version = "0.66.4"  }
 nu-json = { path = "../nu-json", version = "0.66.4"  }
 
 byte-unit = "4.0.9"
-chrono = { version="0.4.20", features=["serde"] }
+chrono = { version="0.4.21", features=["serde"] }
 chrono-humanize = "0.2.1"
 fancy-regex = "0.10.0"
 indexmap = { version="1.7", features=["serde-1"] }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -24,6 +24,6 @@ errno = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["tlhelp32", "fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi", "std", "securitybaseapi"] }
-chrono = "0.4"
+chrono = "0.4.21"
 ntapi = "0.3"
 once_cell = "1.0"

--- a/tests/fixtures/formats/cargo_sample.toml
+++ b/tests/fixtures/formats/cargo_sample.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 rustyline = "4.1.0"
 sysinfo = "0.8.4"
-chrono = { version = "0.4.20", features = ["serde"] }
+chrono = { version = "0.4.21", features = ["serde"] }
 chrono-tz = "0.6.3"
 derive-new = "0.5.6"
 prettytable-rs = "0.8.0"


### PR DESCRIPTION
# Description

Bumping `chrono` to hopefully fix an issue reported on Discord:

> hi, since 0.66.3, i get this when trying to run nu on aarch64 (rpi 4) https://paste.debian.net/1250272/
thanks
ls /root/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.20/src/offset/local/unix.rs 
/root/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.20/src/offset/local/unix.rs

I'm unable to reproduce that on my Raspberry Pi, but it is probably [this `chrono` issue](https://github.com/chronotope/chrono/issues/755#issuecomment-1209543845) which is fixed in [v0.4.21](https://github.com/chronotope/chrono/releases/tag/v0.4.21)

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass

^I am currently unable to run that test on my machine because it OOMs, will let CI do it.