### PR TITLE
Add repository info to all workspace crates

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "CLI-related functionality for Nushell"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Color configuration code used by Nushell"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-config"
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Nushell's built-in commands"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
 edition = "2021"
 license = "MIT"
 name = "nu-command"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Nushell's evaluation engine"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT/Apache-2.0"
 description = """
 Fork of glob. Support for matching file paths against Unix shell style patterns.
 """
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-glob"
 edition = "2021"
 categories = ["filesystem"]
 

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers", "Christian Zangl <laktak@cdak.net>"]
 description = "Fork of serde-hjson"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Nushell's parser"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Path handling library for Nushell"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Functionality for building Nushell plugins"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["Andrei Volnin <wolandr@gmail.com>", "The Nushell Project Developers"]
 description = "Pretty hex dump of bytes slice in the common style."
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Nushell's internal protocols, including its abstract syntax tree"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
 version = "0.66.4"
 edition = "2021"

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Nushell table printing"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Nushell grid printing"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Support for writing Nushell tests"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-support"
 edition = "2018"
 license = "MIT"
 name = "nu-test-support"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "Nushell utility functions"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
 edition = "2021"
 license = "MIT"
 name = "nu-utils"

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nu_plugin_custom_values"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_custom_values"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "A version incrementer plugin for Nushell"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_example"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "A git status plugin for Nushell"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "A version incrementer plugin for Nushell"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["The Nushell Project Developers"]
 description = "A Nushell plugin to query JSON, XML, and various web data"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"


### PR DESCRIPTION
This helps people who find these crates on crates.io

# Description

Currently on crates.io, crates like nu-glob look like they have no public repo. I found nu-glob while looking for a better-maintained glob crate, but then I had a devil of a time finding the nushell project :) I didn't know it existed so I didn't know where to look.

Adding the repository links to all sub crates means the repo is only one click away.

# Tests

Unfortunately this is not testable until the crates are published.

No code changes.