### PR TITLE
lazy dataframe reader

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -103,11 +103,30 @@ optional = true
 version = "0.23.2"
 optional = true
 features = [
-	"default", "to_dummies", "parquet", "json", "serde", "serde-lazy",
-	"object", "checked_arithmetic", "strings", "cum_agg", "is_in",
-	"rolling_window", "strings", "rows", "random",
-    "dtype-datetime", "dtype-struct", "lazy", "cross_join",
-	"dynamic_groupby", "dtype-categorical", "concat_str", "arg_where"
+	"arg_where",
+	"checked_arithmetic",
+	"concat_str",
+	"cross_join",
+	"csv-file",
+	"cum_agg",
+	"default",
+    "dtype-datetime",
+	"dtype-struct",
+	"dtype-categorical",
+	"dynamic_groupby",
+	"is_in",
+	"json",
+	"lazy",
+	"object",
+	"parquet",
+	"random",
+	"rolling_window",
+	"rows",
+	"serde",
+	"serde-lazy",
+	"strings",
+	"strings",
+	"to_dummies",
 ]
 
 [target.'cfg(windows)'.dependencies.windows]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -110,7 +110,7 @@ features = [
 	"csv-file",
 	"cum_agg",
 	"default",
-    "dtype-datetime",
+	"dtype-datetime",
 	"dtype-struct",
 	"dtype-categorical",
 	"dynamic_groupby",


### PR DESCRIPTION
# Description

Adds a new lazy flag for `open-df` that crates a lazy frame when reading a parquet or csv file

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
