### PR TITLE
Rework output formatting / colorization of `ls` and `find`

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -109,7 +109,7 @@ pub fn print_table_or_error(
 
     // Make sure everything has finished
     if let Some(exit_code) = exit_code {
-        let mut exit_code: Vec<_> = exit_code.into_iter().collect();
+        let mut exit_code: Vec<_> = exit_code.into_iter().map(|(value, _)| value).collect();
         exit_code
             .pop()
             .and_then(|last_exit_code| match last_exit_code {

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -233,7 +233,7 @@ pub fn eval_source(
     match eval_block(engine_state, stack, &block, input, false, false) {
         Ok(mut pipeline_data) => {
             if let PipelineData::ExternalStream { exit_code, .. } = &mut pipeline_data {
-                if let Some(exit_code) = exit_code.take().and_then(|it| it.last()) {
+                if let Some((exit_code, _)) = exit_code.take().and_then(|it| it.last()) {
                     stack.add_env_var("LAST_EXIT_CODE".to_string(), exit_code);
                 } else {
                     set_last_exit_code(stack, 0);

--- a/crates/nu-command/src/core_commands/echo.rs
+++ b/crates/nu-command/src/core_commands/echo.rs
@@ -34,7 +34,7 @@ impl Command for Echo {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        call.rest(engine_state, stack, 0).map(|to_be_echoed| {
+        call.rest(engine_state, stack, 0).map(|to_be_echoed: Vec<Value>| {
             let n = to_be_echoed.len();
             match n.cmp(&1usize) {
                 //  More than one value is converted in a stream of values

--- a/crates/nu-command/src/core_commands/echo.rs
+++ b/crates/nu-command/src/core_commands/echo.rs
@@ -34,28 +34,32 @@ impl Command for Echo {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        call.rest(engine_state, stack, 0).map(|to_be_echoed: Vec<Value>| {
-            let n = to_be_echoed.len();
-            match n.cmp(&1usize) {
-                //  More than one value is converted in a stream of values
-                std::cmp::Ordering::Greater => PipelineData::ListStream(
-                    ListStream::from_stream(to_be_echoed.into_iter(), engine_state.ctrlc.clone()),
-                    None,
-                ),
+        call.rest(engine_state, stack, 0)
+            .map(|to_be_echoed: Vec<Value>| {
+                let n = to_be_echoed.len();
+                match n.cmp(&1usize) {
+                    //  More than one value is converted in a stream of values
+                    std::cmp::Ordering::Greater => PipelineData::ListStream(
+                        ListStream::from_stream(
+                            to_be_echoed.into_iter(),
+                            engine_state.ctrlc.clone(),
+                        ),
+                        None,
+                    ),
 
-                //  But a single value can be forwarded as it is
-                std::cmp::Ordering::Equal => PipelineData::Value(to_be_echoed[0].clone(), None),
+                    //  But a single value can be forwarded as it is
+                    std::cmp::Ordering::Equal => PipelineData::Value(to_be_echoed[0].clone(), None),
 
-                //  When there are no elements, we echo the empty string
-                std::cmp::Ordering::Less => PipelineData::Value(
-                    Value::String {
-                        val: "".to_string(),
-                        span: call.head,
-                    },
-                    None,
-                ),
-            }
-        })
+                    //  When there are no elements, we echo the empty string
+                    std::cmp::Ordering::Less => PipelineData::Value(
+                        Value::String {
+                            val: "".to_string(),
+                            span: call.head,
+                        },
+                        None,
+                    ),
+                }
+            })
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -91,7 +91,7 @@ impl Command for For {
             Value::List { vals, .. } => {
                 Ok(ListStream::from_stream(vals.into_iter(), ctrlc.clone())
                     .enumerate()
-                    .map(move |(idx, x)| {
+                    .map(move |(idx, (x, _))| {
                         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                         stack.add_var(

--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -71,18 +71,11 @@ impl Command for Metadata {
                 Ok(build_metadata_record(&val, &input.metadata(), head).into_pipeline_data())
             }
             None => {
-                let mut cols = vec![];
-                let mut vals = vec![];
-                if let Some(metadata) = &input.metadata() {
-                    let PipelineMetadata {
-                        pipeline_data_formatter
-                    } = metadata;
+                let cols = vec![];
+                let vals = vec![];
 
-                    cols.push("formatter".into());
-                    vals.push(Value::String {
-                        val: format!("{:?}", pipeline_data_formatter),
-                        span: head,
-                    })
+                if let Some(metadata) = &input.metadata() {
+                    let PipelineMetadata {} = metadata;
                 }
 
                 Ok(Value::Record {
@@ -133,17 +126,8 @@ fn build_metadata_record(arg: &Value, metadata: &Option<PipelineMetadata>, head:
         });
     }
 
-
-    if let Some(metadata) = &metadata {
-        let PipelineMetadata {
-            pipeline_data_formatter
-        } = metadata;
-
-        cols.push("source".into());
-        vals.push(Value::String {
-            val: format!("{:?}", pipeline_data_formatter),
-            span: head,
-        })
+    if let Some(metadata) = metadata {
+        let PipelineMetadata {} = metadata;
     }
 
     Value::Record {

--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, Expr, Expression};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, DataSource, Example, IntoPipelineData, PipelineData, PipelineMetadata, Signature,
+    Category, Example, IntoPipelineData, PipelineData, PipelineMetadata, Signature,
     Span, SyntaxShape, Value,
 };
 
@@ -73,18 +73,16 @@ impl Command for Metadata {
             None => {
                 let mut cols = vec![];
                 let mut vals = vec![];
-                if let Some(x) = &input.metadata() {
-                    match x {
-                        PipelineMetadata {
-                            data_source: DataSource::Ls,
-                        } => {
-                            cols.push("source".into());
-                            vals.push(Value::String {
-                                val: "ls".into(),
-                                span: head,
-                            })
-                        }
-                    }
+                if let Some(metadata) = &input.metadata() {
+                    let PipelineMetadata {
+                        pipeline_data_formatter
+                    } = metadata;
+
+                    cols.push("formatter".into());
+                    vals.push(Value::String {
+                        val: format!("{:?}", pipeline_data_formatter),
+                        span: head,
+                    })
                 }
 
                 Ok(Value::Record {
@@ -135,18 +133,17 @@ fn build_metadata_record(arg: &Value, metadata: &Option<PipelineMetadata>, head:
         });
     }
 
-    if let Some(x) = &metadata {
-        match x {
-            PipelineMetadata {
-                data_source: DataSource::Ls,
-            } => {
-                cols.push("source".into());
-                vals.push(Value::String {
-                    val: "ls".into(),
-                    span: head,
-                })
-            }
-        }
+
+    if let Some(metadata) = &metadata {
+        let PipelineMetadata {
+            pipeline_data_formatter
+        } = metadata;
+
+        cols.push("source".into());
+        vals.push(Value::String {
+            val: format!("{:?}", pipeline_data_formatter),
+            span: head,
+        })
     }
 
     Value::Record {

--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -2,8 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, Expr, Expression};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, PipelineMetadata, Signature,
-    Span, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, PipelineMetadata, Signature, Span,
+    SyntaxShape, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -91,7 +91,7 @@ fn getcol(
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
         PipelineData::ListStream(stream, ..) => {
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_columns(&v);
 
             Ok(input_cols

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -115,7 +115,7 @@ fn dropcol(
         PipelineData::ListStream(stream, ..) => {
             let mut output = vec![];
 
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_input_cols(v.clone());
             let kc = get_keep_columns(input_cols, columns);
             keep_columns = get_cellpath_columns(kc, span);

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -364,7 +364,7 @@ fn find_with_rest_and_highlight(
         PipelineData::ListStream(stream, meta) => {
             Ok(ListStream::from_stream(
                 stream
-                    .map(move |mut x| match &mut x {
+                    .map(move |(mut x, _)| match &mut x {
                         Value::Record { cols, vals, span } => {
                             let mut output = vec![];
                             for val in vals {

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+
 use crate::help::highlight_search_string;
 use fancy_regex::Regex;
-use lscolors::Style as LsColors_Style;
+use lscolors::{Style as LsColors_Style, LsColors};
 use nu_ansi_term::{Color::Default, Style};
 use nu_color_config::get_color_config;
 use nu_engine::{env_to_string, eval_block, CallExt};
@@ -8,7 +10,7 @@ use nu_protocol::{
     ast::Call,
     engine::{CaptureBlock, Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, ListStream, PipelineData, ShellError,
-    Signature, Span, SyntaxShape, Value,
+    Signature, Span, SyntaxShape, Value, ValueFormatter, Config,
 };
 use nu_utils::get_ls_colors;
 
@@ -313,6 +315,7 @@ fn find_with_rest_and_highlight(
         None => None,
     };
     let ls_colors = get_ls_colors(ls_colors_env_str);
+    let record_formatter = record_formatter(terms, config.clone(), ls_colors, string_style);
 
     match input {
         PipelineData::Value(_, _) => input.filter(
@@ -346,7 +349,7 @@ fn find_with_rest_and_highlight(
                         if let Ok(span) = val.span() {
                             let lower_val = Value::string(
                                 val.into_string("", &config).to_lowercase(),
-                                Span::test_data(),
+                                span,
                             );
 
                             term.r#in(span, &lower_val, span)
@@ -362,124 +365,82 @@ fn find_with_rest_and_highlight(
             ctrlc,
         ),
         PipelineData::ListStream(stream, meta) => {
-            Ok(ListStream::from_stream(
-                stream
-                    .map(move |(mut x, _)| match &mut x {
-                        Value::Record { cols, vals, span } => {
-                            let mut output = vec![];
-                            for val in vals {
-                                let val_str = val.into_string("", &config);
-                                let lower_val = val.into_string("", &config).to_lowercase();
-                                let mut term_added_to_output = false;
-                                for term in terms.clone() {
-                                    let term_str = term.into_string("", &config);
-                                    let lower_term = term.into_string("", &config).to_lowercase();
-                                    if lower_val.contains(&lower_term) {
-                                        if config.use_ls_colors {
-                                            // Get the original LS_COLORS color
-                                            let style = ls_colors.style_for_path(val_str.clone());
-                                            let ansi_style = style
-                                                .map(LsColors_Style::to_crossterm_style)
-                                                .unwrap_or_default();
+            let stream = stream
+                .filter_map(move |(value, _)| {
+                    let lower_value = if let Ok(span) = value.span() {
+                        Value::string(
+                            value.into_string("", &filter_config).to_lowercase(),
+                            span,
+                        )
+                    } else {
+                        value.clone()
+                    };
 
-                                            let ls_colored_val =
-                                                ansi_style.apply(&val_str).to_string();
-                                            let hi = match highlight_search_string(
-                                                &ls_colored_val,
-                                                &term_str,
-                                                &string_style,
-                                            ) {
-                                                Ok(hi) => hi,
-                                                Err(_) => string_style
-                                                    .paint(term_str.to_string())
-                                                    .to_string(),
-                                            };
-                                            output.push(Value::String {
-                                                val: hi,
-                                                span: *span,
-                                            });
-                                            term_added_to_output = true;
-                                        } else {
-                                            // No LS_COLORS support, so just use the original value
-                                            let hi = match highlight_search_string(
-                                                &val_str,
-                                                &term_str,
-                                                &string_style,
-                                            ) {
-                                                Ok(hi) => hi,
-                                                Err(_) => string_style
-                                                    .paint(term_str.to_string())
-                                                    .to_string(),
-                                            };
-                                            output.push(Value::String {
-                                                val: hi,
-                                                span: *span,
-                                            });
-                                        }
-                                    }
-                                }
-                                if !term_added_to_output {
-                                    output.push(val.clone());
-                                }
-                            }
-                            Value::Record {
-                                cols: cols.to_vec(),
-                                vals: output,
-                                span: *span,
-                            }
+                    let (matched, formatter) = match &value {
+                        Value::Bool { .. }
+                        | Value::Int { .. }
+                        | Value::Filesize { .. }
+                        | Value::Duration { .. }
+                        | Value::Date { .. }
+                        | Value::Range { .. }
+                        | Value::Float { .. }
+                        | Value::Block { .. }
+                        | Value::Nothing { .. }
+                        | Value::Error { .. } => {
+                            let matched = lower_terms.iter().any(|lower_term| {
+                                lower_value
+                                    .eq(span, lower_term, span)
+                                    .map_or(false, |value| value.is_true())
+                            });
+
+                            (matched, None)
+                        },
+                        Value::String { .. }
+                        | Value::List { .. }
+                        | Value::CellPath { .. }
+                        | Value::CustomValue { .. } => {
+                            let matched = lower_terms.iter().any(|lower_term| {
+                                lower_term
+                                    .r#in(span, &lower_value, span)
+                                    .map_or(false, |value| value.is_true())
+                            });
+
+                            (matched, None)
                         }
-                        _ => x,
-                    })
-                    .filter(move |value| {
-                        let lower_value = if let Ok(span) = value.span() {
-                            Value::string(
-                                value.into_string("", &filter_config).to_lowercase(),
-                                span,
-                            )
-                        } else {
-                            value.clone()
-                        };
+                        Value::Record { vals, .. } => {
+                            let matched = lower_terms.iter().any(|lower_term| {
+                                vals.iter().any(|val| {
+                                    let lower_val = match val.span() {
+                                        Ok(_) => Cow::Owned(Value::string(
+                                            val.into_string("", &filter_config).to_lowercase(),
+                                            span,
+                                        )),
+                                        Err(_) => Cow::Borrowed(val),
+                                    };
 
-                        lower_terms.iter().any(|term| match value {
-                            Value::Bool { .. }
-                            | Value::Int { .. }
-                            | Value::Filesize { .. }
-                            | Value::Duration { .. }
-                            | Value::Date { .. }
-                            | Value::Range { .. }
-                            | Value::Float { .. }
-                            | Value::Block { .. }
-                            | Value::Nothing { .. }
-                            | Value::Error { .. } => lower_value
-                                .eq(span, term, span)
-                                .map_or(false, |value| value.is_true()),
-                            Value::String { .. }
-                            | Value::List { .. }
-                            | Value::CellPath { .. }
-                            | Value::CustomValue { .. } => term
-                                .r#in(span, &lower_value, span)
-                                .map_or(false, |value| value.is_true()),
-                            Value::Record { vals, .. } => vals.iter().any(|val| {
-                                if let Ok(span) = val.span() {
-                                    let lower_val = Value::string(
-                                        val.into_string("", &filter_config).to_lowercase(),
-                                        Span::test_data(),
-                                    );
+                                    lower_term.r#in(span, &lower_val, span)
+                                        .map_or(false, |value| value.is_true())
+                                })
+                            });
 
-                                    term.r#in(span, &lower_val, span)
-                                        .map_or(false, |value| value.is_true())
-                                } else {
-                                    term.r#in(span, val, span)
-                                        .map_or(false, |value| value.is_true())
-                                }
-                            }),
-                            Value::Binary { .. } => false,
-                        }) != invert
-                    }),
-                ctrlc.clone(),
+                            (matched, Some(record_formatter.clone()))
+                        },
+                        Value::Binary { .. } => (false, None),
+                    };
+
+                    if matched != invert {
+                        Some((value, formatter))
+                    } else {
+                        None
+                    }
+                });
+
+
+            Ok(
+                ListStream::from_stream(stream,ctrlc.clone())
+                .into_pipeline_data(ctrlc)
+                .set_metadata(meta)
             )
-            .into_pipeline_data(ctrlc)
-            .set_metadata(meta))
         }
         PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(span)),
         PipelineData::ExternalStream {
@@ -533,6 +494,59 @@ fn find_with_rest_and_highlight(
             Ok(output.into_pipeline_data(ctrlc))
         }
     }
+}
+
+fn record_formatter(terms: Vec<Value>, config: Config, ls_colors: LsColors, string_style: Style) -> ValueFormatter {
+    ValueFormatter::from_fn(move |value| {
+        let (cols, mut vals, span) = match value {
+            Value::Record { cols, vals, span } => (cols, vals, span),
+            _ => return value,
+        };
+
+        'vals: for val in &mut vals {
+            let val_str = val.into_string("", &config);
+            let lower_val = val.into_string("", &config).to_lowercase();
+
+            for term in terms.iter() {
+                let term_str = term.into_string("", &config);
+                let lower_term = term.into_string("", &config).to_lowercase();
+
+                if lower_val.contains(&lower_term) {
+                    let val_str = if config.use_ls_colors {
+                        // Get the original LS_COLORS color
+                        let style = ls_colors.style_for_path(val_str.clone());
+                        let ansi_style = style
+                            .map(LsColors_Style::to_crossterm_style)
+                            .unwrap_or_default();
+                        let val_str = ansi_style.apply(&val_str).to_string();
+
+                        Cow::Owned(val_str)
+                    } else {
+                        // No LS_COLORS support, so just use the original value
+                        Cow::Borrowed(&val_str)
+                    };
+
+                    let highlighted = match highlight_search_string(
+                        &val_str,
+                        &term_str,
+                        &string_style,
+                    ) {
+                        Ok(highlighted) => highlighted,
+                        Err(_) => string_style
+                            .paint(term_str.to_string())
+                            .to_string(),
+                    };
+
+                    *val = Value::string(highlighted, span);
+
+                    // only highlight the first found match of a val
+                    continue 'vals;
+                }
+            }
+        }
+
+        Value::Record { cols, vals, span }
+    })
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -107,7 +107,7 @@ fn getcol(
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
         PipelineData::ListStream(stream, ..) => {
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_columns(&v);
 
             Ok(input_cols

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -69,7 +69,7 @@ impl Command for Lines {
 
                 let iter = stream
                     .into_iter()
-                    .filter_map(move |value| {
+                    .filter_map(move |(value, _)| {
                         if let Value::String { val, span } = value {
                             if split_char != "\r\n" && val.contains("\r\n") {
                                 split_char = "\r\n";

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -170,7 +170,7 @@ impl Command for ParEach {
             PipelineData::ListStream(stream, ..) => Ok(stream
                 .enumerate()
                 .par_bridge()
-                .map(move |(idx, x)| {
+                .map(move |(idx, (x, _))| {
                     let block = engine_state.get_block(block_id);
 
                     let mut stack = stack.clone();

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -125,7 +125,7 @@ fn reject(
         PipelineData::ListStream(stream, ..) => {
             let mut output = vec![];
 
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_input_cols(v.clone());
             let kc = get_keep_columns(input_cols, columns);
             keep_columns = get_cellpath_columns(kc, span);

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -146,7 +146,7 @@ fn select(
                 .set_metadata(metadata))
         }
         PipelineData::ListStream(stream, metadata, ..) => Ok(stream
-            .map(move |x| {
+            .map(move |(x, _)| {
                 if !columns.is_empty() {
                     let mut cols = vec![];
                     let mut vals = vec![];

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -44,7 +44,7 @@ impl Command for Wrap {
                 })
                 .into_pipeline_data(engine_state.ctrlc.clone())),
             PipelineData::ListStream(stream, ..) => Ok(stream
-                .map(move |x| Value::Record {
+                .map(move |(x, _)| Value::Record {
                     cols: vec![name.clone()],
                     vals: vec![x],
                     span,

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -62,7 +62,9 @@ pub fn calculate(
     mf: impl Fn(&[Value], &Span) -> Result<Value, ShellError>,
 ) -> Result<Value, ShellError> {
     match values {
-        PipelineData::ListStream(s, ..) => helper_for_tables(&s.map(|(v, _)| v).collect::<Vec<Value>>(), name, mf),
+        PipelineData::ListStream(s, ..) => {
+            helper_for_tables(&s.map(|(v, _)| v).collect::<Vec<Value>>(), name, mf)
+        }
         PipelineData::Value(Value::List { ref vals, .. }, ..) => match &vals[..] {
             [Value::Record { .. }, _end @ ..] => helper_for_tables(vals, name, mf),
             _ => mf(vals, &name),

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -62,7 +62,7 @@ pub fn calculate(
     mf: impl Fn(&[Value], &Span) -> Result<Value, ShellError>,
 ) -> Result<Value, ShellError> {
     match values {
-        PipelineData::ListStream(s, ..) => helper_for_tables(&s.collect::<Vec<Value>>(), name, mf),
+        PipelineData::ListStream(s, ..) => helper_for_tables(&s.map(|(v, _)| v).collect::<Vec<Value>>(), name, mf),
         PipelineData::Value(Value::List { ref vals, .. }, ..) => match &vals[..] {
             [Value::Record { .. }, _end @ ..] => helper_for_tables(vals, name, mf),
             _ => mf(vals, &name),

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -70,7 +70,7 @@ impl Command for Complete {
                 }
 
                 if let Some(exit_code) = exit_code {
-                    let mut v: Vec<_> = exit_code.collect();
+                    let mut v: Vec<_> = exit_code.map(|(v, _)| v).collect();
 
                     if let Some(v) = v.pop() {
                         cols.push("exit_code".to_string());

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -90,7 +90,7 @@ prints out the list properly."#
             }
             PipelineData::ListStream(stream, ..) => {
                 // dbg!("value::stream");
-                let data = convert_to_list(stream, config, call.head);
+                let data = convert_to_list(stream.map(|(v, _)| v), config, call.head);
                 if let Some(items) = data {
                     Ok(create_grid_output(
                         items,

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -3,8 +3,8 @@ use nu_engine::{column::get_columns, CallExt};
 use nu_protocol::{
     ast::{Call, PathMember},
     engine::{Command, EngineState, Stack, StateWorkingSet},
-    format_error, Category, Config, Example, IntoPipelineData, ListStream,
-    PipelineData, RawStream, ShellError, Signature, Span, SyntaxShape, Value,
+    format_error, Category, Config, Example, IntoPipelineData, ListStream, PipelineData, RawStream,
+    ShellError, Signature, Span, SyntaxShape, Value,
 };
 use nu_table::{Alignments, StyledString, TableTheme, TextStyle};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -140,14 +140,9 @@ impl Command for Table {
                 row_offset,
                 ctrlc,
             ),
-            PipelineData::ListStream(stream, _metadata) => handle_row_stream(
-                engine_state,
-                stack,
-                stream,
-                call,
-                row_offset,
-                ctrlc,
-            ),
+            PipelineData::ListStream(stream, _metadata) => {
+                handle_row_stream(engine_state, stack, stream, call, row_offset, ctrlc)
+            }
             PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
                 let mut output = vec![];
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -248,7 +248,7 @@ fn eval_external(
         match exit_code {
             Some(exit_code_stream) => {
                 let ctrlc = exit_code_stream.ctrlc.clone();
-                let exit_code: Vec<Value> = exit_code_stream.into_iter().collect();
+                let exit_code: Vec<Value> = exit_code_stream.into_iter().map(|(value, _)| value).collect();
                 if let Some(Value::Int { val: code, .. }) = exit_code.last() {
                     // if exit_code is not 0, it indicates error occured, return back Err.
                     if *code != 0 {
@@ -775,7 +775,7 @@ pub fn eval_block(
                     };
 
                     if let Some(exit_code) = exit_code {
-                        let mut v: Vec<_> = exit_code.collect();
+                        let mut v: Vec<_> = exit_code.map(|(value, _)| value).collect();
 
                         if let Some(v) = v.pop() {
                             stack.add_env_var("LAST_EXIT_CODE".into(), v);

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -248,7 +248,10 @@ fn eval_external(
         match exit_code {
             Some(exit_code_stream) => {
                 let ctrlc = exit_code_stream.ctrlc.clone();
-                let exit_code: Vec<Value> = exit_code_stream.into_iter().map(|(value, _)| value).collect();
+                let exit_code: Vec<Value> = exit_code_stream
+                    .into_iter()
+                    .map(|(value, _)| value)
+                    .collect();
                 if let Some(Value::Int { val: code, .. }) = exit_code.last() {
                     // if exit_code is not 0, it indicates error occured, return back Err.
                     if *code != 0 {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -7,7 +7,7 @@ mod unit;
 
 use crate::ast::Operator;
 use crate::ast::{CellPath, PathMember};
-use crate::ShellError;
+use crate::{ShellError, ValueFormatter};
 use crate::{did_you_mean, BlockId, Config, Span, Spanned, Type, VarId};
 use byte_unit::ByteUnit;
 use chrono::{DateTime, Duration, FixedOffset};
@@ -1124,6 +1124,12 @@ impl Default for Value {
         Value::Nothing {
             span: Span { start: 0, end: 0 },
         }
+    }
+}
+
+impl From<Value> for (Value, Option<ValueFormatter>) {
+    fn from(val: Value) -> Self {
+        (val, None)
     }
 }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -7,8 +7,8 @@ mod unit;
 
 use crate::ast::Operator;
 use crate::ast::{CellPath, PathMember};
-use crate::{ShellError, ValueFormatter};
 use crate::{did_you_mean, BlockId, Config, Span, Spanned, Type, VarId};
+use crate::{ShellError, ValueFormatter};
 use byte_unit::ByteUnit;
 use chrono::{DateTime, Duration, FixedOffset};
 use chrono_humanize::HumanTime;

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -183,11 +183,11 @@ impl ListStream {
     }
 
     pub fn from_stream(
-        input: impl Iterator<Item = Value> + Send + 'static,
+        input: impl Iterator<Item = impl Into<(Value, Option<ValueFormatter>)> + 'static> + Send + 'static,
         ctrlc: Option<Arc<AtomicBool>>,
     ) -> ListStream {
         ListStream {
-            stream: Box::new(input.map(|value| (value, None))),
+            stream: Box::new(input.map(Into::into)),
             ctrlc,
         }
     }

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -183,7 +183,9 @@ impl ListStream {
     }
 
     pub fn from_stream(
-        input: impl Iterator<Item = impl Into<(Value, Option<ValueFormatter>)> + 'static> + Send + 'static,
+        input: impl Iterator<Item = impl Into<(Value, Option<ValueFormatter>)> + 'static>
+            + Send
+            + 'static,
         ctrlc: Option<Arc<AtomicBool>>,
     ) -> ListStream {
         ListStream {


### PR DESCRIPTION
# Description

Context: https://github.com/nushell/nushell/issues/6315

This PR adds a mechanism for commands to optionally format list stream values for presentation to the user.
`ls` and `find` (partially) have been ported to this new mechanism.
The reason for this change is that `find` previously added colorization by modifying the pipe stream, making subsequent processing difficult, as can be seen in https://github.com/nushell/nushell/pull/6220.
Furthermore, hardcoding colorization for specific commands using metadata (like it has been done for `ls`) is not very flexible, does not scale well, and requires the logic for formatting to be in the wrong place (i.e. the `table` viewer).

As a byproduct, this PR also fixes [some bugs in `find`](https://github.com/nushell/nushell/issues/6315#issuecomment-1214371993).

# Tests

```
[[name]; ["hello"] ["world"] ["foo"] ["bar"]] | each {$in} | find ll | get 0.name | into binary
```
Should print the same as
```
"hello" | into binary
```
i.e. there shouldn't be any ansi escapes included in the binary string.

Old output (bad):
![grafik](https://user-images.githubusercontent.com/628445/184550480-62a1dc73-5d57-460c-9e5b-dab4ec29442c.png)

New output (good):
![grafik](https://user-images.githubusercontent.com/628445/184550519-ce9ad0eb-30d7-4b0e-9f8a-3e7f2f3be6d1.png)

(The `each {$in}` is just there to turn the table into a list stream internally. `find` only highlights list streams properly atm.)

Additionally, the output of
```
[[name]; ["hello"] ["world"] ["foo"] ["bar"]] | each {$in} | find ll
```
should still be colorized:
![grafik](https://user-images.githubusercontent.com/628445/184550693-b4ee4597-8cc6-44ff-81e8-978831ef8441.png)


Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
    - there is a failing test, but it was already failing before:
    ```
    ---- conversions::into::string::test::test_examples stdout ----
    input: 5 | into string -d 3
    result: String { val: "5,000", span: Span { start: 4, end: 15 } }
    done: 893.601µs
    thread 'conversions::into::string::test::test_examples' panicked at 'the example result is different to expected value: String { val: "5,000", span: Span { start: 4, end: 15 } } != String { val: "5.000", span: Span { start: 0, end: 0 } }', crates/nu-command/src/example_test.rs:139:25
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    ```
