### PR TITLE
Add support for optional list stream output formatting

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -109,7 +109,7 @@ pub fn print_table_or_error(
 
     // Make sure everything has finished
     if let Some(exit_code) = exit_code {
-        let mut exit_code: Vec<_> = exit_code.into_iter().collect();
+        let mut exit_code: Vec<_> = exit_code.into_iter().map(|(value, _)| value).collect();
         exit_code
             .pop()
             .and_then(|last_exit_code| match last_exit_code {

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -233,7 +233,7 @@ pub fn eval_source(
     match eval_block(engine_state, stack, &block, input, false, false) {
         Ok(mut pipeline_data) => {
             if let PipelineData::ExternalStream { exit_code, .. } = &mut pipeline_data {
-                if let Some(exit_code) = exit_code.take().and_then(|it| it.last()) {
+                if let Some((exit_code, _)) = exit_code.take().and_then(|it| it.last()) {
                     stack.add_env_var("LAST_EXIT_CODE".to_string(), exit_code);
                 } else {
                     set_last_exit_code(stack, 0);

--- a/crates/nu-command/src/core_commands/echo.rs
+++ b/crates/nu-command/src/core_commands/echo.rs
@@ -34,7 +34,7 @@ impl Command for Echo {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        call.rest(engine_state, stack, 0).map(|to_be_echoed| {
+        call.rest(engine_state, stack, 0).map(|to_be_echoed: Vec<Value>| {
             let n = to_be_echoed.len();
             match n.cmp(&1usize) {
                 //  More than one value is converted in a stream of values

--- a/crates/nu-command/src/core_commands/echo.rs
+++ b/crates/nu-command/src/core_commands/echo.rs
@@ -34,28 +34,32 @@ impl Command for Echo {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        call.rest(engine_state, stack, 0).map(|to_be_echoed: Vec<Value>| {
-            let n = to_be_echoed.len();
-            match n.cmp(&1usize) {
-                //  More than one value is converted in a stream of values
-                std::cmp::Ordering::Greater => PipelineData::ListStream(
-                    ListStream::from_stream(to_be_echoed.into_iter(), engine_state.ctrlc.clone()),
-                    None,
-                ),
+        call.rest(engine_state, stack, 0)
+            .map(|to_be_echoed: Vec<Value>| {
+                let n = to_be_echoed.len();
+                match n.cmp(&1usize) {
+                    //  More than one value is converted in a stream of values
+                    std::cmp::Ordering::Greater => PipelineData::ListStream(
+                        ListStream::from_stream(
+                            to_be_echoed.into_iter(),
+                            engine_state.ctrlc.clone(),
+                        ),
+                        None,
+                    ),
 
-                //  But a single value can be forwarded as it is
-                std::cmp::Ordering::Equal => PipelineData::Value(to_be_echoed[0].clone(), None),
+                    //  But a single value can be forwarded as it is
+                    std::cmp::Ordering::Equal => PipelineData::Value(to_be_echoed[0].clone(), None),
 
-                //  When there are no elements, we echo the empty string
-                std::cmp::Ordering::Less => PipelineData::Value(
-                    Value::String {
-                        val: "".to_string(),
-                        span: call.head,
-                    },
-                    None,
-                ),
-            }
-        })
+                    //  When there are no elements, we echo the empty string
+                    std::cmp::Ordering::Less => PipelineData::Value(
+                        Value::String {
+                            val: "".to_string(),
+                            span: call.head,
+                        },
+                        None,
+                    ),
+                }
+            })
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -91,7 +91,7 @@ impl Command for For {
             Value::List { vals, .. } => {
                 Ok(ListStream::from_stream(vals.into_iter(), ctrlc.clone())
                     .enumerate()
-                    .map(move |(idx, x)| {
+                    .map(move |(idx, (x, _))| {
                         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                         stack.add_var(

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -91,7 +91,7 @@ fn getcol(
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
         PipelineData::ListStream(stream, ..) => {
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_columns(&v);
 
             Ok(input_cols

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -115,7 +115,7 @@ fn dropcol(
         PipelineData::ListStream(stream, ..) => {
             let mut output = vec![];
 
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_input_cols(v.clone());
             let kc = get_keep_columns(input_cols, columns);
             keep_columns = get_cellpath_columns(kc, span);

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -364,7 +364,7 @@ fn find_with_rest_and_highlight(
         PipelineData::ListStream(stream, meta) => {
             Ok(ListStream::from_stream(
                 stream
-                    .map(move |mut x| match &mut x {
+                    .map(move |(mut x, _)| match &mut x {
                         Value::Record { cols, vals, span } => {
                             let mut output = vec![];
                             for val in vals {

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -107,7 +107,7 @@ fn getcol(
                 .into_pipeline_data(engine_state.ctrlc.clone()))
         }
         PipelineData::ListStream(stream, ..) => {
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_columns(&v);
 
             Ok(input_cols

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -69,7 +69,7 @@ impl Command for Lines {
 
                 let iter = stream
                     .into_iter()
-                    .filter_map(move |value| {
+                    .filter_map(move |(value, _)| {
                         if let Value::String { val, span } = value {
                             if split_char != "\r\n" && val.contains("\r\n") {
                                 split_char = "\r\n";

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -170,7 +170,7 @@ impl Command for ParEach {
             PipelineData::ListStream(stream, ..) => Ok(stream
                 .enumerate()
                 .par_bridge()
-                .map(move |(idx, x)| {
+                .map(move |(idx, (x, _))| {
                     let block = engine_state.get_block(block_id);
 
                     let mut stack = stack.clone();

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -125,7 +125,7 @@ fn reject(
         PipelineData::ListStream(stream, ..) => {
             let mut output = vec![];
 
-            let v: Vec<_> = stream.into_iter().collect();
+            let v: Vec<_> = stream.into_iter().map(|(v, _)| v).collect();
             let input_cols = get_input_cols(v.clone());
             let kc = get_keep_columns(input_cols, columns);
             keep_columns = get_cellpath_columns(kc, span);

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -146,7 +146,7 @@ fn select(
                 .set_metadata(metadata))
         }
         PipelineData::ListStream(stream, metadata, ..) => Ok(stream
-            .map(move |x| {
+            .map(move |(x, _)| {
                 if !columns.is_empty() {
                     let mut cols = vec![];
                     let mut vals = vec![];

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -44,7 +44,7 @@ impl Command for Wrap {
                 })
                 .into_pipeline_data(engine_state.ctrlc.clone())),
             PipelineData::ListStream(stream, ..) => Ok(stream
-                .map(move |x| Value::Record {
+                .map(move |(x, _)| Value::Record {
                     cols: vec![name.clone()],
                     vals: vec![x],
                     span,

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -62,7 +62,9 @@ pub fn calculate(
     mf: impl Fn(&[Value], &Span) -> Result<Value, ShellError>,
 ) -> Result<Value, ShellError> {
     match values {
-        PipelineData::ListStream(s, ..) => helper_for_tables(&s.map(|(v, _)| v).collect::<Vec<Value>>(), name, mf),
+        PipelineData::ListStream(s, ..) => {
+            helper_for_tables(&s.map(|(v, _)| v).collect::<Vec<Value>>(), name, mf)
+        }
         PipelineData::Value(Value::List { ref vals, .. }, ..) => match &vals[..] {
             [Value::Record { .. }, _end @ ..] => helper_for_tables(vals, name, mf),
             _ => mf(vals, &name),

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -62,7 +62,7 @@ pub fn calculate(
     mf: impl Fn(&[Value], &Span) -> Result<Value, ShellError>,
 ) -> Result<Value, ShellError> {
     match values {
-        PipelineData::ListStream(s, ..) => helper_for_tables(&s.collect::<Vec<Value>>(), name, mf),
+        PipelineData::ListStream(s, ..) => helper_for_tables(&s.map(|(v, _)| v).collect::<Vec<Value>>(), name, mf),
         PipelineData::Value(Value::List { ref vals, .. }, ..) => match &vals[..] {
             [Value::Record { .. }, _end @ ..] => helper_for_tables(vals, name, mf),
             _ => mf(vals, &name),

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -70,7 +70,7 @@ impl Command for Complete {
                 }
 
                 if let Some(exit_code) = exit_code {
-                    let mut v: Vec<_> = exit_code.collect();
+                    let mut v: Vec<_> = exit_code.map(|(v, _)| v).collect();
 
                     if let Some(v) = v.pop() {
                         cols.push("exit_code".to_string());

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -90,7 +90,7 @@ prints out the list properly."#
             }
             PipelineData::ListStream(stream, ..) => {
                 // dbg!("value::stream");
-                let data = convert_to_list(stream, config, call.head);
+                let data = convert_to_list(stream.map(|(v, _)| v), config, call.head);
                 if let Some(items) = data {
                     Ok(create_grid_output(
                         items,

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -260,7 +260,7 @@ fn handle_row_stream(
             let ls_colors = get_ls_colors(ls_colors_env_str);
 
             ListStream::from_stream(
-                stream.map(move |mut x| match &mut x {
+                stream.map(move |(mut x, _)| match &mut x {
                     Value::Record { cols, vals, .. } => {
                         let mut idx = 0;
 
@@ -512,7 +512,11 @@ impl Iterator for PagingTableCreator {
         let mut idx = 0;
 
         // Pull from stream until time runs out or we have enough items
-        for item in self.stream.by_ref() {
+        for (mut item, formatter) in self.stream.by_ref() {
+            if let Some(formatter) = formatter {
+                item = formatter.format(item);
+            }
+
             batch.push(item);
             idx += 1;
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -248,7 +248,10 @@ fn eval_external(
         match exit_code {
             Some(exit_code_stream) => {
                 let ctrlc = exit_code_stream.ctrlc.clone();
-                let exit_code: Vec<Value> = exit_code_stream.into_iter().collect();
+                let exit_code: Vec<Value> = exit_code_stream
+                    .into_iter()
+                    .map(|(value, _)| value)
+                    .collect();
                 if let Some(Value::Int { val: code, .. }) = exit_code.last() {
                     // if exit_code is not 0, it indicates error occured, return back Err.
                     if *code != 0 {
@@ -775,7 +778,7 @@ pub fn eval_block(
                     };
 
                     if let Some(exit_code) = exit_code {
-                        let mut v: Vec<_> = exit_code.collect();
+                        let mut v: Vec<_> = exit_code.map(|(value, _)| value).collect();
 
                         if let Some(v) = v.pop() {
                             stack.add_env_var("LAST_EXIT_CODE".into(), v);

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -7,8 +7,8 @@ mod unit;
 
 use crate::ast::Operator;
 use crate::ast::{CellPath, PathMember};
-use crate::ShellError;
 use crate::{did_you_mean, BlockId, Config, Span, Spanned, Type, VarId};
+use crate::{ShellError, ValueFormatter};
 use byte_unit::ByteUnit;
 use chrono::{DateTime, Duration, FixedOffset};
 use chrono_humanize::HumanTime;
@@ -1124,6 +1124,12 @@ impl Default for Value {
         Value::Nothing {
             span: Span { start: 0, end: 0 },
         }
+    }
+}
+
+impl From<Value> for (Value, Option<ValueFormatter>) {
+    fn from(val: Value) -> Self {
+        (val, None)
     }
 }
 

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -171,23 +171,25 @@ impl Iterator for RawStream {
 /// Like other iterators in Rust, observing values from this stream will drain the items as you view them
 /// and the stream cannot be replayed.
 pub struct ListStream {
-    pub stream: Box<dyn Iterator<Item = Value> + Send + 'static>,
+    pub stream: Box<dyn Iterator<Item = (Value, Option<ValueFormatter>)> + Send + 'static>,
     pub ctrlc: Option<Arc<AtomicBool>>,
 }
 
 impl ListStream {
     pub fn into_string(self, separator: &str, config: &Config) -> String {
-        self.map(|x: Value| x.into_string(", ", config))
+        self.map(|(x, _): (Value, _)| x.into_string(", ", config))
             .collect::<Vec<String>>()
             .join(separator)
     }
 
     pub fn from_stream(
-        input: impl Iterator<Item = Value> + Send + 'static,
+        input: impl Iterator<Item = impl Into<(Value, Option<ValueFormatter>)> + 'static>
+            + Send
+            + 'static,
         ctrlc: Option<Arc<AtomicBool>>,
     ) -> ListStream {
         ListStream {
-            stream: Box::new(input),
+            stream: Box::new(input.map(Into::into)),
             ctrlc,
         }
     }
@@ -200,7 +202,7 @@ impl Debug for ListStream {
 }
 
 impl Iterator for ListStream {
-    type Item = Value;
+    type Item = (Value, Option<ValueFormatter>);
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(ctrlc) = &self.ctrlc {


### PR DESCRIPTION
# Description

Some commands like `ls` or `find` have the desire to show or highlight data in a certain way if shown to the user.
Currently there are two strategies to implement this:

- the `ls` way: metadata is set to signal to the `table` command to format the data a specific way. The logic for how to format the `ls` output is hardcoded into `table`. Adding other commands would require further polluting `table` with more code that is not relevant to `table`s core functionality.
- the `find` way: the data in the stream is modified to contain ansi escapes. This is flexible in that formatting logic stays encapsulated in the original command, but has the downside of making the data stream unusable for further processing.

This PR enables a third approach:
`ListStream` elements can now have an optional `ValueFormatter`. A `ValueFormatter` is at it's core just a glorified function `fn (Value) -> Value`. Its purpose is to be produced by commands like `ls`, `find`, or any other command that wishes a value to be presented to the user in a custom way. The intended consumer of `ValueFormatter`s is the `table` command and possibly other future commands that are intended to present data to the user. A command is always free to discard / ignore a `ValueFormatter` if it has no use for it, which applies to most commands.

This PR does **not** change any command to make use of `ValueFormatter` yet.

In the future this design could be naturally extendend to also work with `PipelineData` other than `ListStream`.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass (1 test already failed without changes)
