### PR TITLE
Update reedline to improved undo-system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.9.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#a406bfc6621f01805a0a80cd520ac59c128aec23"
+source = "git+https://github.com/nushell/reedline.git?branch=main#174255535dccb0fea5e2d0e055fc5884830df898"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -814,7 +814,6 @@ fn event_from_record(
 ) -> Result<ReedlineEvent, ShellError> {
     let event = match name {
         "none" => ReedlineEvent::None,
-        "actionhandler" => ReedlineEvent::ActionHandler,
         "clearscreen" => ReedlineEvent::ClearScreen,
         "clearscrollback" => ReedlineEvent::ClearScrollback,
         "historyhintcomplete" => ReedlineEvent::HistoryHintComplete,


### PR DESCRIPTION

# Description

@bnprks fixed inadequacies of our previous undo system, now better coalescing of combinable events of user keypresses (typing, deleting, history navigation). Plus better interface for the outside world (e.g. implemented custom completion menus)

- Update after Reedline API update
- Update reedline

(Reedline bump also includes improvements to keybindings)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
