### PR TITLE
Update to reedline 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,8 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.9.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#174255535dccb0fea5e2d0e055fc5884830df898"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84e8704e9eb141e73ac426c72af95eb195d4c3221a11ea92d5709f4a025adb5"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ nu-system = { path = "./crates/nu-system", version = "0.66.4" }
 nu-table = { path = "./crates/nu-table", version = "0.66.4"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.66.4"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.66.4"  }
-reedline = { version = "0.9.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.10.0", features = ["bashisms", "sqlite"]}
 rayon = "1.5.1"
 is_executable = "1.0.1"
 simplelog = "0.12.0"
@@ -121,6 +121,3 @@ debug = false
 [[bin]]
 name = "nu"
 path = "src/main.rs"
-
-[patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -20,7 +20,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.66.4"  }
 nu-utils = { path = "../nu-utils", version = "0.66.4"  }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.66.4"  }
-reedline = { version = "0.9.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.10.0", features = ["bashisms", "sqlite"]}
 
 chrono = "0.4.21"
 crossterm = "0.24.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -87,7 +87,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "1.1.2", features = ["v4"] }
 which = { version = "4.2.2", optional = true }
-reedline = { version = "0.9.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.10.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.16.0", features = ["serde"], optional = true }


### PR DESCRIPTION
# Description

Changes to reedline:

- Move vi support 
- Ctrl-h as edit binding
- Overhaul of the undo system

https://github.com/nushell/reedline/releases/tag/v0.10.0

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
