### PR TITLE
create clickable links in ls output if configured

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -413,17 +413,6 @@ pub(crate) fn dir_entry_dict(
     let mut vals = vec![];
     let mut file_type = "unknown";
 
-    // uri's based on this https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
-
-    // cols.push("name".into());
-    // vals.push(Value::String {
-    //     val: format!(
-    //         "\x1b]8;;file://c:/users/dschroeder/source/repos/forks/nushell/{}\x1b\\{}\x1b]8;;\x1b\\",
-    //         display_name.to_string(),
-    //         display_name.to_string()
-    //     ),
-    //     span,
-    // });
     cols.push("name".into());
     vals.push(Value::String {
         val: display_name.to_string(),

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -413,6 +413,17 @@ pub(crate) fn dir_entry_dict(
     let mut vals = vec![];
     let mut file_type = "unknown";
 
+    // uri's based on this https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+
+    // cols.push("name".into());
+    // vals.push(Value::String {
+    //     val: format!(
+    //         "\x1b]8;;file://c:/users/dschroeder/source/repos/forks/nushell/{}\x1b\\{}\x1b]8;;\x1b\\",
+    //         display_name.to_string(),
+    //         display_name.to_string()
+    //     ),
+    //     span,
+    // });
     cols.push("name".into());
     vals.push(Value::String {
         val: display_name.to_string(),

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -371,6 +371,8 @@ fn make_clickable_link(
     link_name: Option<&str>,
     show_clickable_links: bool,
 ) -> String {
+    // uri's based on this https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+
     if show_clickable_links {
         format!(
             "\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\",

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -9,12 +9,14 @@ use nu_protocol::{
 };
 use nu_table::{Alignments, StyledString, TableTheme, TextStyle};
 use nu_utils::get_ls_colors;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+};
 use terminal_size::{Height, Width};
-
-//use super::lscolor_ansiterm::ToNuAnsiStyle;
+use url::Url;
 
 const STREAM_PAGE_SIZE: usize = 1000;
 const STREAM_TIMEOUT_CHECK_INTERVAL: usize = 100;
@@ -258,6 +260,7 @@ fn handle_row_stream(
                 None => None,
             };
             let ls_colors = get_ls_colors(ls_colors_env_str);
+            let show_clickable_links = config.show_clickable_links_in_ls;
 
             ListStream::from_stream(
                 stream.map(move |mut x| match &mut x {
@@ -279,9 +282,20 @@ fn handle_row_stream(
                                                 .unwrap_or_default();
                                             let use_ls_colors = config.use_ls_colors;
 
+                                            let full_path = PathBuf::from(path.clone())
+                                                .canonicalize()
+                                                .unwrap_or_else(|_| PathBuf::from(path));
+                                            let full_path_link = make_clickable_link(
+                                                full_path.display().to_string(),
+                                                Some(&path.clone()),
+                                                show_clickable_links,
+                                            );
+
                                             if use_ls_colors {
                                                 vals[idx] = Value::String {
-                                                    val: ansi_style.apply(path).to_string(),
+                                                    val: ansi_style
+                                                        .apply(full_path_link)
+                                                        .to_string(),
                                                     span: *span,
                                                 };
                                             }
@@ -294,9 +308,20 @@ fn handle_row_stream(
                                                 .unwrap_or_default();
                                             let use_ls_colors = config.use_ls_colors;
 
+                                            let full_path = PathBuf::from(path.clone())
+                                                .canonicalize()
+                                                .unwrap_or_else(|_| PathBuf::from(path));
+                                            let full_path_link = make_clickable_link(
+                                                full_path.display().to_string(),
+                                                Some(&path.clone()),
+                                                show_clickable_links,
+                                            );
+
                                             if use_ls_colors {
                                                 vals[idx] = Value::String {
-                                                    val: ansi_style.apply(path).to_string(),
+                                                    val: ansi_style
+                                                        .apply(full_path_link)
+                                                        .to_string(),
                                                     span: *span,
                                                 };
                                             }
@@ -339,6 +364,28 @@ fn handle_row_stream(
         span: head,
         metadata: None,
     })
+}
+
+fn make_clickable_link(
+    full_path: String,
+    link_name: Option<&str>,
+    show_clickable_links: bool,
+) -> String {
+    if show_clickable_links {
+        format!(
+            "\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\",
+            match Url::from_file_path(full_path.clone()) {
+                Ok(url) => url.to_string(),
+                Err(_) => full_path.clone(),
+            },
+            link_name.unwrap_or(full_path.as_str())
+        )
+    } else {
+        match link_name {
+            Some(link_name) => link_name.to_string(),
+            None => full_path,
+        }
+    }
 }
 
 fn convert_to_table(

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -82,6 +82,7 @@ pub struct Config {
     pub enable_external_completion: bool,
     pub trim_strategy: TrimStrategy,
     pub show_banner: bool,
+    pub show_clickable_links_in_ls: bool,
 }
 
 impl Default for Config {
@@ -117,6 +118,7 @@ impl Default for Config {
             enable_external_completion: true,
             trim_strategy: TRIM_STRATEGY_DEFAULT,
             show_banner: true,
+            show_clickable_links_in_ls: true,
         }
     }
 }
@@ -395,6 +397,13 @@ impl Value {
                             config.show_banner = b;
                         } else {
                             eprintln!("$config.show_banner is not a bool")
+                        }
+                    }
+                    "show_clickable_links_in_ls" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.show_clickable_links_in_ls = b;
+                        } else {
+                            eprintln!("$config.show_clickable_links_in_ls is not a bool")
                         }
                     }
                     x => {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -266,6 +266,7 @@ let-env config = {
     # truncating_suffix: "..."
   }
   show_banner: true # true or false to enable or disable the banner
+  show_clickable_links_in_ls: true # true or false to enable or disable clickable links in the ls listing. your terminal has to support links.
 
   hooks: {
     pre_prompt: [{


### PR DESCRIPTION
# Description

This PR introduces clickable links in the `ls` table output if your terminal supports it. I'm not really sure if we should have this or not, but there was a request for it (#6307) so I thought we could try it out.

![image](https://user-images.githubusercontent.com/343840/184687417-3379563c-0f58-4a6e-aaf5-ad3ad29e216f.png)

closes #6307 

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
