### PR TITLE
FIX: links to the "think in nu" page in help messages

### DIFF
--- a/crates/nu-command/src/core_commands/alias.rs
+++ b/crates/nu-command/src/core_commands/alias.rs
@@ -27,7 +27,7 @@ impl Command for Alias {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/def.rs
+++ b/crates/nu-command/src/core_commands/def.rs
@@ -28,7 +28,7 @@ impl Command for Def {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/def_env.rs
+++ b/crates/nu-command/src/core_commands/def_env.rs
@@ -28,7 +28,7 @@ impl Command for DefEnv {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html
+  https://www.nushell.sh/book/thinking_in_nu.html
 
 === EXTRA NOTE ===
 All blocks are scoped, including variable definition and environment variable changes.

--- a/crates/nu-command/src/core_commands/export.rs
+++ b/crates/nu-command/src/core_commands/export.rs
@@ -23,7 +23,7 @@ impl Command for ExportCommand {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_alias.rs
+++ b/crates/nu-command/src/core_commands/export_alias.rs
@@ -27,7 +27,7 @@ impl Command for ExportAlias {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_def.rs
+++ b/crates/nu-command/src/core_commands/export_def.rs
@@ -28,7 +28,7 @@ impl Command for ExportDef {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -28,7 +28,7 @@ impl Command for ExportDefEnv {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html
+  https://www.nushell.sh/book/thinking_in_nu.html
 
 === EXTRA NOTE ===
 All blocks are scoped, including variable definition and environment variable changes.

--- a/crates/nu-command/src/core_commands/export_env.rs
+++ b/crates/nu-command/src/core_commands/export_env.rs
@@ -31,7 +31,7 @@ impl Command for ExportEnv {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_extern.rs
+++ b/crates/nu-command/src/core_commands/export_extern.rs
@@ -23,7 +23,7 @@ impl Command for ExportExtern {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/export_use.rs
+++ b/crates/nu-command/src/core_commands/export_use.rs
@@ -22,7 +22,7 @@ impl Command for ExportUse {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/extern_.rs
+++ b/crates/nu-command/src/core_commands/extern_.rs
@@ -23,7 +23,7 @@ impl Command for Extern {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -46,7 +46,7 @@ impl Command for For {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/hide.rs
+++ b/crates/nu-command/src/core_commands/hide.rs
@@ -26,7 +26,7 @@ impl Command for Hide {
         r#"Definitions are hidden by priority: First aliases, then custom commands.
 
 This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/if_.rs
+++ b/crates/nu-command/src/core_commands/if_.rs
@@ -35,7 +35,7 @@ impl Command for If {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -28,7 +28,7 @@ impl Command for Let {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/module.rs
+++ b/crates/nu-command/src/core_commands/module.rs
@@ -27,7 +27,7 @@ impl Command for Module {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/overlay/add.rs
+++ b/crates/nu-command/src/core_commands/overlay/add.rs
@@ -39,7 +39,7 @@ impl Command for OverlayAdd {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/overlay/command.rs
+++ b/crates/nu-command/src/core_commands/overlay/command.rs
@@ -23,7 +23,7 @@ impl Command for Overlay {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/overlay/new.rs
+++ b/crates/nu-command/src/core_commands/overlay/new.rs
@@ -31,7 +31,7 @@ impl Command for OverlayNew {
         r#"The command will first create an empty module, then add it as an overlay.
 
 This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/overlay/remove.rs
+++ b/crates/nu-command/src/core_commands/overlay/remove.rs
@@ -34,7 +34,7 @@ impl Command for OverlayRemove {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/register.rs
+++ b/crates/nu-command/src/core_commands/register.rs
@@ -43,7 +43,7 @@ impl Command for Register {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/source.rs
+++ b/crates/nu-command/src/core_commands/source.rs
@@ -28,7 +28,7 @@ impl Command for Source {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -25,7 +25,7 @@ impl Command for Use {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nushell.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
     fn is_parser_keyword(&self) -> bool {


### PR DESCRIPTION
# Description

This PR fixes some broken links in the help messages of the built-in `nu` commands.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
