### PR TITLE
Return error when `kill` didn't terminate successfully 

### DIFF
--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -48,6 +48,7 @@ mod open;
 mod p;
 mod parse;
 mod path;
+mod platform;
 mod prepend;
 mod print;
 #[cfg(feature = "database")]

--- a/crates/nu-command/tests/commands/platform/kill.rs
+++ b/crates/nu-command/tests/commands/platform/kill.rs
@@ -1,0 +1,9 @@
+use nu_test_support::nu;
+
+#[test]
+fn test_kill_invalid_pid() {
+    let pid = i32::MAX;
+    let actual = nu!(format!("kill {}", pid));
+
+    assert!(actual.err.contains("process didn't terminate successfully"));
+}

--- a/crates/nu-command/tests/commands/platform/mod.rs
+++ b/crates/nu-command/tests/commands/platform/mod.rs
@@ -1,0 +1,1 @@
+mod kill;


### PR DESCRIPTION
# Description

This PR returns error when `kill` didn't terminate successfully.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
