### PR TITLE
Allow parsing modules as scripts

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -622,7 +622,7 @@ pub fn parse_export_in_block(
     let full_name = if lite_command.parts.len() > 1 {
         let sub = working_set.get_span_contents(lite_command.parts[1]);
         match sub {
-            b"alias" | b"def" | b"def-env" | b"env" | b"extern" | b"use" => {
+            b"alias" | b"def" | b"def-env" | b"extern" | b"use" => {
                 [b"export ", sub].concat()
             }
             _ => b"export".to_vec(),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -232,30 +232,42 @@ pub fn check_name<'a>(
     working_set: &mut StateWorkingSet,
     spans: &'a [Span],
 ) -> Option<(&'a Span, ParseError)> {
+    let command_len = if spans.len() > 0 {
+        if working_set.get_span_contents(spans[0]) == b"export" {
+            2
+        } else {
+            1
+        }
+    } else {
+        return None;
+    };
+
     if spans.len() == 1 {
         None
-    } else if spans.len() < 4 {
-        if working_set.get_span_contents(spans[1]) == b"=" {
-            let name = String::from_utf8_lossy(working_set.get_span_contents(spans[0]));
+    } else if spans.len() < command_len + 3 {
+        if working_set.get_span_contents(spans[command_len]) == b"=" {
+            let name =
+                String::from_utf8_lossy(working_set.get_span_contents(span(&spans[..command_len])));
             Some((
-                &spans[1],
+                &spans[command_len],
                 ParseError::AssignmentMismatch(
                     format!("{} missing name", name),
                     "missing name".into(),
-                    spans[1],
+                    spans[command_len],
                 ),
             ))
         } else {
             None
         }
-    } else if working_set.get_span_contents(spans[2]) != b"=" {
-        let name = String::from_utf8_lossy(working_set.get_span_contents(spans[0]));
+    } else if working_set.get_span_contents(spans[command_len + 1]) != b"=" {
+        let name =
+            String::from_utf8_lossy(working_set.get_span_contents(span(&spans[..command_len])));
         Some((
-            &spans[2],
+            &spans[command_len + 1],
             ParseError::AssignmentMismatch(
                 format!("{} missing sign", name),
                 "missing equal sign".into(),
-                spans[2],
+                spans[command_len + 1],
             ),
         ))
     } else {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -232,7 +232,7 @@ pub fn check_name<'a>(
     working_set: &mut StateWorkingSet,
     spans: &'a [Span],
 ) -> Option<(&'a Span, ParseError)> {
-    let command_len = if spans.len() > 0 {
+    let command_len = if !spans.is_empty() {
         if working_set.get_span_contents(spans[0]) == b"export" {
             2
         } else {

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -183,7 +183,7 @@ fn run_script_that_looks_like_module() {
             r#"baz"#,
         ];
 
-        let actual= nu!(cwd: dirs.test(), inp_lines.join("; "));
+        let actual = nu!(cwd: dirs.test(), inp_lines.join("; "));
 
         assert_eq!(actual.out, "eggs");
     })

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -170,3 +170,21 @@ fn nu_lib_dirs_relative_script() {
         assert_eq!(actual_repl.out, "foo");
     })
 }
+
+#[test]
+fn run_script_that_looks_like_module() {
+    Playground::setup("run_script_that_looks_like_module", |dirs, _| {
+        let inp_lines = &[
+            r#"module spam { export def eggs [] { 'eggs' } }"#,
+            r#"export use spam eggs"#,
+            r#"export def foo [] { eggs }"#,
+            r#"export alias bar = foo"#,
+            r#"export def-env baz [] { bar }"#,
+            r#"baz"#,
+        ];
+
+        let actual= nu!(cwd: dirs.test(), inp_lines.join("; "));
+
+        assert_eq!(actual.out, "eggs");
+    })
+}

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -188,3 +188,14 @@ fn run_script_that_looks_like_module() {
         assert_eq!(actual.out, "eggs");
     })
 }
+
+#[test]
+fn run_export_extern() {
+    Playground::setup("run_script_that_looks_like_module", |dirs, _| {
+        let inp_lines = &[r#"export extern foo []"#, r#"help foo"#];
+
+        let actual = nu!(cwd: dirs.test(), inp_lines.join("; "));
+
+        assert!(actual.out.contains("Usage"));
+    })
+}


### PR DESCRIPTION
# Description

Any `export` encountered in a script will be ignored. So, for example, `export def` will be treated just like a regular `def`.

`export env` is not supported because it will be deleted anyway in favor of `export-env`.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
