### PR TITLE
Port `find` find to the new list stream formatting

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -1,14 +1,16 @@
+use std::borrow::Cow;
+
 use crate::help::highlight_search_string;
 use fancy_regex::Regex;
-use lscolors::Style as LsColors_Style;
+use lscolors::{LsColors, Style as LsColors_Style};
 use nu_ansi_term::{Color::Default, Style};
 use nu_color_config::get_color_config;
 use nu_engine::{env_to_string, eval_block, CallExt};
 use nu_protocol::{
     ast::Call,
     engine::{CaptureBlock, Command, EngineState, Stack},
-    Category, Example, IntoInterruptiblePipelineData, ListStream, PipelineData, ShellError,
-    Signature, Span, SyntaxShape, Value,
+    Category, Config, Example, IntoInterruptiblePipelineData, ListStream, PipelineData, ShellError,
+    Signature, Span, SyntaxShape, Value, ValueFormatter,
 };
 use nu_utils::get_ls_colors;
 
@@ -313,6 +315,7 @@ fn find_with_rest_and_highlight(
         None => None,
     };
     let ls_colors = get_ls_colors(ls_colors_env_str);
+    let record_formatter = terms_record_formatter(terms, config.clone(), ls_colors, string_style);
 
     match input {
         PipelineData::Value(_, _) => input.filter(
@@ -344,10 +347,8 @@ fn find_with_rest_and_highlight(
                         .map_or(false, |val| val.is_true()),
                     Value::Record { vals, .. } => vals.iter().any(|val| {
                         if let Ok(span) = val.span() {
-                            let lower_val = Value::string(
-                                val.into_string("", &config).to_lowercase(),
-                                Span::test_data(),
-                            );
+                            let lower_val =
+                                Value::string(val.into_string("", &config).to_lowercase(), span);
 
                             term.r#in(span, &lower_val, span)
                                 .map_or(false, |aval| aval.is_true())
@@ -362,124 +363,76 @@ fn find_with_rest_and_highlight(
             ctrlc,
         ),
         PipelineData::ListStream(stream, meta) => {
-            Ok(ListStream::from_stream(
-                stream
-                    .map(move |(mut x, _)| match &mut x {
-                        Value::Record { cols, vals, span } => {
-                            let mut output = vec![];
-                            for val in vals {
-                                let val_str = val.into_string("", &config);
-                                let lower_val = val.into_string("", &config).to_lowercase();
-                                let mut term_added_to_output = false;
-                                for term in terms.clone() {
-                                    let term_str = term.into_string("", &config);
-                                    let lower_term = term.into_string("", &config).to_lowercase();
-                                    if lower_val.contains(&lower_term) {
-                                        if config.use_ls_colors {
-                                            // Get the original LS_COLORS color
-                                            let style = ls_colors.style_for_path(val_str.clone());
-                                            let ansi_style = style
-                                                .map(LsColors_Style::to_crossterm_style)
-                                                .unwrap_or_default();
+            let stream = stream.filter_map(move |(value, _)| {
+                let lower_value = if let Ok(span) = value.span() {
+                    Value::string(value.into_string("", &filter_config).to_lowercase(), span)
+                } else {
+                    value.clone()
+                };
 
-                                            let ls_colored_val =
-                                                ansi_style.apply(&val_str).to_string();
-                                            let hi = match highlight_search_string(
-                                                &ls_colored_val,
-                                                &term_str,
-                                                &string_style,
-                                            ) {
-                                                Ok(hi) => hi,
-                                                Err(_) => string_style
-                                                    .paint(term_str.to_string())
-                                                    .to_string(),
-                                            };
-                                            output.push(Value::String {
-                                                val: hi,
-                                                span: *span,
-                                            });
-                                            term_added_to_output = true;
-                                        } else {
-                                            // No LS_COLORS support, so just use the original value
-                                            let hi = match highlight_search_string(
-                                                &val_str,
-                                                &term_str,
-                                                &string_style,
-                                            ) {
-                                                Ok(hi) => hi,
-                                                Err(_) => string_style
-                                                    .paint(term_str.to_string())
-                                                    .to_string(),
-                                            };
-                                            output.push(Value::String {
-                                                val: hi,
-                                                span: *span,
-                                            });
-                                        }
-                                    }
-                                }
-                                if !term_added_to_output {
-                                    output.push(val.clone());
-                                }
-                            }
-                            Value::Record {
-                                cols: cols.to_vec(),
-                                vals: output,
-                                span: *span,
-                            }
-                        }
-                        _ => x,
-                    })
-                    .filter(move |value| {
-                        let lower_value = if let Ok(span) = value.span() {
-                            Value::string(
-                                value.into_string("", &filter_config).to_lowercase(),
-                                span,
-                            )
-                        } else {
-                            value.clone()
-                        };
+                let (matched, formatter) = match &value {
+                    Value::Bool { .. }
+                    | Value::Int { .. }
+                    | Value::Filesize { .. }
+                    | Value::Duration { .. }
+                    | Value::Date { .. }
+                    | Value::Range { .. }
+                    | Value::Float { .. }
+                    | Value::Block { .. }
+                    | Value::Nothing { .. }
+                    | Value::Error { .. } => {
+                        let matched = lower_terms.iter().any(|lower_term| {
+                            lower_value
+                                .eq(span, lower_term, span)
+                                .map_or(false, |value| value.is_true())
+                        });
 
-                        lower_terms.iter().any(|term| match value {
-                            Value::Bool { .. }
-                            | Value::Int { .. }
-                            | Value::Filesize { .. }
-                            | Value::Duration { .. }
-                            | Value::Date { .. }
-                            | Value::Range { .. }
-                            | Value::Float { .. }
-                            | Value::Block { .. }
-                            | Value::Nothing { .. }
-                            | Value::Error { .. } => lower_value
-                                .eq(span, term, span)
-                                .map_or(false, |value| value.is_true()),
-                            Value::String { .. }
-                            | Value::List { .. }
-                            | Value::CellPath { .. }
-                            | Value::CustomValue { .. } => term
+                        (matched, None)
+                    }
+                    Value::String { .. }
+                    | Value::List { .. }
+                    | Value::CellPath { .. }
+                    | Value::CustomValue { .. } => {
+                        let matched = lower_terms.iter().any(|lower_term| {
+                            lower_term
                                 .r#in(span, &lower_value, span)
-                                .map_or(false, |value| value.is_true()),
-                            Value::Record { vals, .. } => vals.iter().any(|val| {
-                                if let Ok(span) = val.span() {
-                                    let lower_val = Value::string(
-                                        val.into_string("", &filter_config).to_lowercase(),
-                                        Span::test_data(),
-                                    );
+                                .map_or(false, |value| value.is_true())
+                        });
 
-                                    term.r#in(span, &lower_val, span)
-                                        .map_or(false, |value| value.is_true())
-                                } else {
-                                    term.r#in(span, val, span)
-                                        .map_or(false, |value| value.is_true())
-                                }
-                            }),
-                            Value::Binary { .. } => false,
-                        }) != invert
-                    }),
-                ctrlc.clone(),
-            )
-            .into_pipeline_data(ctrlc)
-            .set_metadata(meta))
+                        (matched, None)
+                    }
+                    Value::Record { vals, .. } => {
+                        let matched = lower_terms.iter().any(|lower_term| {
+                            vals.iter().any(|val| {
+                                let lower_val = match val.span() {
+                                    Ok(_) => Cow::Owned(Value::string(
+                                        val.into_string("", &filter_config).to_lowercase(),
+                                        span,
+                                    )),
+                                    Err(_) => Cow::Borrowed(val),
+                                };
+
+                                lower_term
+                                    .r#in(span, &lower_val, span)
+                                    .map_or(false, |value| value.is_true())
+                            })
+                        });
+
+                        (matched, Some(record_formatter.clone()))
+                    }
+                    Value::Binary { .. } => (false, None),
+                };
+
+                if matched != invert {
+                    Some((value, formatter))
+                } else {
+                    None
+                }
+            });
+
+            Ok(ListStream::from_stream(stream, ctrlc.clone())
+                .into_pipeline_data(ctrlc)
+                .set_metadata(meta))
         }
         PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(span)),
         PipelineData::ExternalStream {
@@ -533,6 +486,59 @@ fn find_with_rest_and_highlight(
             Ok(output.into_pipeline_data(ctrlc))
         }
     }
+}
+
+fn terms_record_formatter(
+    terms: Vec<Value>,
+    config: Config,
+    ls_colors: LsColors,
+    string_style: Style,
+) -> ValueFormatter {
+    ValueFormatter::from_fn(move |value| {
+        let (cols, mut vals, span) = match value {
+            Value::Record { cols, vals, span } => (cols, vals, span),
+            _ => return value,
+        };
+
+        'vals: for val in &mut vals {
+            let val_str = val.into_string("", &config);
+            let lower_val = val.into_string("", &config).to_lowercase();
+
+            for term in terms.iter() {
+                let term_str = term.into_string("", &config);
+                let lower_term = term.into_string("", &config).to_lowercase();
+
+                if lower_val.contains(&lower_term) {
+                    let val_str = if config.use_ls_colors {
+                        // Get the original LS_COLORS color
+                        let style = ls_colors.style_for_path(val_str.clone());
+                        let ansi_style = style
+                            .map(LsColors_Style::to_crossterm_style)
+                            .unwrap_or_default();
+                        let val_str = ansi_style.apply(&val_str).to_string();
+
+                        Cow::Owned(val_str)
+                    } else {
+                        // No LS_COLORS support, so just use the original value
+                        Cow::Borrowed(&val_str)
+                    };
+
+                    let highlighted =
+                        match highlight_search_string(&val_str, &term_str, &string_style) {
+                            Ok(highlighted) => highlighted,
+                            Err(_) => string_style.paint(term_str.to_string()).to_string(),
+                        };
+
+                    *val = Value::string(highlighted, span);
+
+                    // only highlight the first found match of a val
+                    continue 'vals;
+                }
+            }
+        }
+
+        Value::Record { cols, vals, span }
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

This change ports `find` to use the new list stream formatting that was introduced in https://github.com/nushell/nushell/pull/6325.
Previously the formatting code was intermingled with the filtering code and has now been separated.

Minor alterations have been done to fix some of the bugs I raised [here](https://github.com/nushell/nushell/issues/6315#issuecomment-1214371993):
- find works correctly independent of `use_ls_colors` now [[bug demo]](https://user-images.githubusercontent.com/628445/184538362-8ed16e55-7a39-4e14-924d-b23aacddcd55.png)
- multiple search terms don't break the results anymore [[bug demo]](https://user-images.githubusercontent.com/628445/184540952-febf4ed3-035f-4aaf-b55e-522e6a3f6ca8.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
