### PR TITLE
Revert "make `cd`, `cp`, `ls`, `mv`, `open` and `rm` automatically strip ansi codes (#6220)

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -41,20 +41,6 @@ impl Command for Cd {
         let config = engine_state.get_config();
         let use_abbrev = config.cd_with_abbreviations;
 
-        let path_val = {
-            if let Some(path) = path_val {
-                Some(Spanned {
-                    item: match strip_ansi_escapes::strip(&path.item) {
-                        Ok(item) => String::from_utf8(item).unwrap_or(path.item),
-                        Err(_) => path.item,
-                    },
-                    span: path.span,
-                })
-            } else {
-                path_val
-            }
-        };
-
         let (path, span) = match path_val {
             Some(v) => {
                 if v.item == "-" {

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -72,15 +72,6 @@ impl Command for Cp {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let src: Spanned<String> = call.req(engine_state, stack, 0)?;
-        let src = {
-            Spanned {
-                item: match strip_ansi_escapes::strip(&src.item) {
-                    Ok(item) => String::from_utf8(item).unwrap_or(src.item),
-                    Err(_) => src.item,
-                },
-                span: src.span,
-            }
-        };
         let dst: Spanned<String> = call.req(engine_state, stack, 1)?;
         let recursive = call.has_flag("recursive");
         let verbose = call.has_flag("verbose");

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -83,20 +83,6 @@ impl Command for Ls {
 
         let pattern_arg: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
 
-        let pattern_arg = {
-            if let Some(path) = pattern_arg {
-                Some(Spanned {
-                    item: match strip_ansi_escapes::strip(&path.item) {
-                        Ok(item) => String::from_utf8(item).unwrap_or(path.item),
-                        Err(_) => path.item,
-                    },
-                    span: path.span,
-                })
-            } else {
-                pattern_arg
-            }
-        };
-
         let (path, p_tag, absolute_path) = match pattern_arg {
             Some(p) => {
                 let p_tag = p.span;

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -65,15 +65,6 @@ impl Command for Mv {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         // TODO: handle invalid directory or insufficient permissions when moving
         let spanned_source: Spanned<String> = call.req(engine_state, stack, 0)?;
-        let spanned_source = {
-            Spanned {
-                item: match strip_ansi_escapes::strip(&spanned_source.item) {
-                    Ok(item) => String::from_utf8(item).unwrap_or(spanned_source.item),
-                    Err(_) => spanned_source.item,
-                },
-                span: spanned_source.span,
-            }
-        };
         let spanned_destination: Spanned<String> = call.req(engine_state, stack, 1)?;
         let verbose = call.has_flag("verbose");
         let interactive = call.has_flag("interactive");

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -50,20 +50,6 @@ impl Command for Open {
         let ctrlc = engine_state.ctrlc.clone();
         let path = call.opt::<Spanned<String>>(engine_state, stack, 0)?;
 
-        let path = {
-            if let Some(path_val) = path {
-                Some(Spanned {
-                    item: match strip_ansi_escapes::strip(&path_val.item) {
-                        Ok(item) => String::from_utf8(item).unwrap_or(path_val.item),
-                        Err(_) => path_val.item,
-                    },
-                    span: path_val.span,
-                })
-            } else {
-                path
-            }
-        };
-
         let path = if let Some(path) = path {
             path
         } else {

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -139,19 +139,7 @@ fn rm(
 
     let ctrlc = engine_state.ctrlc.clone();
 
-    let mut targets: Vec<Spanned<String>> = call.rest(engine_state, stack, 0)?;
-
-    for (idx, path) in targets.clone().into_iter().enumerate() {
-        let corrected_path = Spanned {
-            item: match strip_ansi_escapes::strip(&path.item) {
-                Ok(item) => String::from_utf8(item).unwrap_or(path.item),
-                Err(_) => path.item,
-            },
-            span: path.span,
-        };
-        let _ = std::mem::replace(&mut targets[idx], corrected_path);
-    }
-
+    let targets: Vec<Spanned<String>> = call.rest(engine_state, stack, 0)?;
     let span = call.head;
 
     let config = engine_state.get_config();

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -331,16 +331,3 @@ fn copy_identical_file() {
         assert!(actual.err.contains("Copy aborted"));
     });
 }
-
-#[test]
-fn copy_ignores_ansi() {
-    Playground::setup("cp_test_16", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
-
-        let actual = nu!(
-            cwd: sandbox.cwd(),
-            "ls | find test | get name | cp $in.0 success.txt; ls | find success | get name | ansi strip | get 0",
-        );
-        assert_eq!(actual.out, "success.txt");
-    });
-}

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -538,24 +538,3 @@ fn list_directory_contains_invalid_utf8() {
         },
     )
 }
-
-#[test]
-fn list_ignores_ansi() {
-    Playground::setup("ls_test_ansi", |dirs, sandbox| {
-        sandbox.with_files(vec![
-            EmptyFile("los.txt"),
-            EmptyFile("tres.txt"),
-            EmptyFile("amigos.txt"),
-            EmptyFile("arepas.clu"),
-        ]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                ls | find .txt | each { ls $in.name } 
-            "#
-        ));
-
-        assert!(actual.err.is_empty());
-    })
-}

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -362,21 +362,6 @@ fn does_not_error_when_some_file_is_moving_into_itself() {
 }
 
 #[test]
-fn mv_ignores_ansi() {
-    Playground::setup("mv_test_ansi", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
-        let actual = nu!(
-             cwd: sandbox.cwd(),
-            r#"
-                 ls | find test | mv $in.0.name success.txt; ls | $in.0.name
-            "#
-        );
-
-        assert_eq!(actual.out, "success.txt");
-    })
-}
-
-#[test]
 fn mv_directory_with_same_name() {
     Playground::setup("mv_test_directory_with_same_name", |_dirs, sandbox| {
         sandbox.mkdir("testdir");

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -267,19 +267,3 @@ fn test_open_block_command() {
 
     assert_eq!(actual.out, "abcd")
 }
-
-#[test]
-fn open_ignore_ansi() {
-    Playground::setup("open_test_ansi", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("nu.zion.txt")]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                ls | find nu.zion | get 0 | get name | open $in
-            "#
-        ));
-
-        assert!(actual.err.is_empty());
-    })
-}

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -324,16 +324,3 @@ fn removes_files_with_case_sensitive_glob_matches_by_default() {
         assert!(skipped_path.exists());
     })
 }
-
-#[test]
-fn remove_ignores_ansi() {
-    Playground::setup("rm_test_ansi", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
-
-        let actual = nu!(
-            cwd: sandbox.cwd(),
-            "ls | find test | get name | rm $in.0; ls",
-        );
-        assert!(actual.out.is_empty());
-    });
-}


### PR DESCRIPTION
# Description

This reverts commit 3b809b38e820eb06c6c8994568a3416a41262dda (#6220) .

Once #6356 and #6358 are merged, stripping of ansi codes is not necessary anymore.

This fixes #6315.

@merelymyself Sorry that I'm doing this, but please know that your effort was not wasted! Without your change I would not have investigated this new way of formatting values for presentation to the user 🙇. 

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
