### PR TITLE
Get `$nu.config-path` and `$nu.env-path` from `EngineState`

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1298,9 +1298,7 @@ pub fn eval_variable(
             let mut output_cols = vec![];
             let mut output_vals = vec![];
 
-            let (nu_config_path, nu_env_config_path) = engine_state.get_config_path();
-
-            if let Some(path) = nu_config_path {
+            if let Some(path) = engine_state.get_config_path("config-path") {
                 output_cols.push("config-path".into());
                 output_vals.push(Value::String {
                     val: path.to_string_lossy().to_string(),
@@ -1308,7 +1306,7 @@ pub fn eval_variable(
                 });
             }
 
-            if let Some(path) = nu_env_config_path {
+            if let Some(path) = engine_state.get_config_path("env-path") {
                 output_cols.push("env-path".into());
                 output_vals.push(Value::String {
                     val: path.to_string_lossy().to_string(),
@@ -1339,7 +1337,7 @@ pub fn eval_variable(
                     span,
                 });
 
-                if nu_config_path.is_none() {
+                if engine_state.get_config_path("config-path").is_none() {
                     config_path.push("config.nu");
 
                     output_cols.push("config-path".into());
@@ -1349,7 +1347,7 @@ pub fn eval_variable(
                     });
                 }
 
-                if nu_env_config_path.is_none() {
+                if engine_state.get_config_path("env-path").is_none() {
                     env_config_path.push("env.nu");
 
                     output_cols.push("env-path".into());

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1298,6 +1298,24 @@ pub fn eval_variable(
             let mut output_cols = vec![];
             let mut output_vals = vec![];
 
+            let (nu_config_path, nu_env_config_path) = engine_state.get_config_path();
+
+            if let Some(path) = nu_config_path {
+                output_cols.push("config-path".into());
+                output_vals.push(Value::String {
+                    val: path.to_string_lossy().to_string(),
+                    span,
+                });
+            }
+
+            if let Some(path) = nu_env_config_path {
+                output_cols.push("env-path".into());
+                output_vals.push(Value::String {
+                    val: path.to_string_lossy().to_string(),
+                    span,
+                });
+            }
+
             if let Some(mut config_path) = nu_path::config_dir() {
                 config_path.push("nushell");
                 let mut env_config_path = config_path.clone();
@@ -1321,21 +1339,25 @@ pub fn eval_variable(
                     span,
                 });
 
-                config_path.push("config.nu");
+                if nu_config_path.is_none() {
+                    config_path.push("config.nu");
 
-                output_cols.push("config-path".into());
-                output_vals.push(Value::String {
-                    val: config_path.to_string_lossy().to_string(),
-                    span,
-                });
+                    output_cols.push("config-path".into());
+                    output_vals.push(Value::String {
+                        val: config_path.to_string_lossy().to_string(),
+                        span,
+                    });
+                }
 
-                env_config_path.push("env.nu");
+                if nu_env_config_path.is_none() {
+                    env_config_path.push("env.nu");
 
-                output_cols.push("env-path".into());
-                output_vals.push(Value::String {
-                    val: env_config_path.to_string_lossy().to_string(),
-                    span,
-                });
+                    output_cols.push("env-path".into());
+                    output_vals.push(Value::String {
+                        val: env_config_path.to_string_lossy().to_string(),
+                        span,
+                    });
+                }
 
                 loginshell_path.push("login.nu");
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -76,7 +76,7 @@ pub struct EngineState {
     pub plugin_signatures: Option<PathBuf>,
     #[cfg(not(windows))]
     sig_quit: Option<Arc<AtomicBool>>,
-    config_path: (Option<PathBuf>, Option<PathBuf>),
+    config_path: HashMap<String, PathBuf>,
 }
 
 pub const NU_VARIABLE_ID: usize = 0;
@@ -114,7 +114,7 @@ impl EngineState {
             plugin_signatures: None,
             #[cfg(not(windows))]
             sig_quit: None,
-            config_path: (None, None),
+            config_path: HashMap::new(),
         }
     }
 
@@ -756,16 +756,12 @@ impl EngineState {
         self.sig_quit = Some(sig_quit)
     }
 
-    pub fn set_config_path(
-        &mut self,
-        config_path: Option<PathBuf>,
-        env_config_path: Option<PathBuf>,
-    ) {
-        self.config_path = (config_path, env_config_path);
+    pub fn set_config_path(&mut self, key: &str, val: PathBuf) {
+        self.config_path.insert(key.to_string(), val);
     }
 
-    pub fn get_config_path(&self) -> (&Option<PathBuf>, &Option<PathBuf>) {
-        (&self.config_path.0, &self.config_path.1)
+    pub fn get_config_path(&self, key: &str) -> Option<&PathBuf> {
+        self.config_path.get(key)
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -76,6 +76,7 @@ pub struct EngineState {
     pub plugin_signatures: Option<PathBuf>,
     #[cfg(not(windows))]
     sig_quit: Option<Arc<AtomicBool>>,
+    config_path: (Option<PathBuf>, Option<PathBuf>),
 }
 
 pub const NU_VARIABLE_ID: usize = 0;
@@ -113,6 +114,7 @@ impl EngineState {
             plugin_signatures: None,
             #[cfg(not(windows))]
             sig_quit: None,
+            config_path: (None, None),
         }
     }
 
@@ -752,6 +754,18 @@ impl EngineState {
     #[cfg(not(windows))]
     pub fn set_sig_quit(&mut self, sig_quit: Arc<AtomicBool>) {
         self.sig_quit = Some(sig_quit)
+    }
+
+    pub fn set_config_path(
+        &mut self,
+        config_path: Option<PathBuf>,
+        env_config_path: Option<PathBuf>,
+    ) {
+        self.config_path = (config_path, env_config_path);
+    }
+
+    pub fn get_config_path(&self) -> (&Option<PathBuf>, &Option<PathBuf>) {
+        (&self.config_path.0, &self.config_path.1)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,16 @@ fn main() -> Result<()> {
         set_config_path(
             &mut engine_state,
             &init_cwd,
+            "config.nu",
+            "config-path",
             &args.config_file,
+        );
+
+        set_config_path(
+            &mut engine_state,
+            &init_cwd,
+            "env.nu",
+            "env-path",
             &args.env_file,
         );
     }
@@ -704,32 +713,20 @@ fn set_is_perf_value(value: bool) {
 fn set_config_path(
     engine_state: &mut EngineState,
     cwd: &Path,
+    default_config_name: &str,
+    key: &str,
     config_file: &Option<Spanned<String>>,
-    env_file: &Option<Spanned<String>>,
 ) {
     let config_path = match config_file {
         Some(s) => canonicalize_with(&s.item, cwd).ok(),
         None => nu_path::config_dir().map(|mut p| {
             p.push(config_files::NUSHELL_FOLDER);
-            p.push("config.nu");
+            p.push(default_config_name);
             p
         }),
     };
 
     if let Some(path) = config_path {
-        engine_state.set_config_path("config-path", path);
-    }
-
-    let env_path = match env_file {
-        Some(s) => canonicalize_with(&s.item, cwd).ok(),
-        None => nu_path::config_dir().map(|mut p| {
-            p.push(config_files::NUSHELL_FOLDER);
-            p.push("env.nu");
-            p
-        }),
-    };
-
-    if let Some(path) = env_path {
-        engine_state.set_config_path("env-path", path);
+        engine_state.set_config_path(key, path);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -716,7 +716,11 @@ fn set_config_path(
         }),
     };
 
-    let env_config_path = match env_file {
+    if let Some(path) = config_path {
+        engine_state.set_config_path("config-path", path);
+    }
+
+    let env_path = match env_file {
         Some(s) => canonicalize_with(&s.item, cwd).ok(),
         None => nu_path::config_dir().map(|mut p| {
             p.push(config_files::NUSHELL_FOLDER);
@@ -725,5 +729,7 @@ fn set_config_path(
         }),
     };
 
-    engine_state.set_config_path(config_path, env_config_path);
+    if let Some(path) = env_path {
+        engine_state.set_config_path("env-path", path);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use nu_cli::{
 use nu_command::{create_default_context, BufferedReader};
 use nu_engine::{get_full_help, CallExt};
 use nu_parser::{escape_for_script_arg, escape_quote_string, parse};
+use nu_path::canonicalize_with;
 use nu_protocol::{
     ast::{Call, Expr, Expression},
     engine::{Command, EngineState, Stack, StateWorkingSet},
@@ -25,7 +26,7 @@ use nu_protocol::{
     Spanned, SyntaxShape, Value,
 };
 use nu_utils::stdout_write_all_and_flush;
-use std::cell::RefCell;
+use std::{cell::RefCell, path::Path};
 use std::{
     io::BufReader,
     sync::{
@@ -140,6 +141,15 @@ fn main() -> Result<()> {
         // for this shell to manage its own process group / children / etc.
         nu_system::signal::block();
         nu_system::signal::set_terminal_leader()
+    }
+
+    if let Ok(ref args) = parsed_nu_cli_args {
+        set_config_path(
+            &mut engine_state,
+            &init_cwd,
+            &args.config_file,
+            &args.env_file,
+        );
     }
 
     match parsed_nu_cli_args {
@@ -689,4 +699,31 @@ fn set_is_perf_value(value: bool) {
     IS_PERF.with(|new_value| {
         *new_value.borrow_mut() = value;
     });
+}
+
+fn set_config_path(
+    engine_state: &mut EngineState,
+    cwd: &Path,
+    config_file: &Option<Spanned<String>>,
+    env_file: &Option<Spanned<String>>,
+) {
+    let config_path = match config_file {
+        Some(s) => canonicalize_with(&s.item, cwd).ok(),
+        None => nu_path::config_dir().map(|mut p| {
+            p.push(config_files::NUSHELL_FOLDER);
+            p.push("config.nu");
+            p
+        }),
+    };
+
+    let env_config_path = match env_file {
+        Some(s) => canonicalize_with(&s.item, cwd).ok(),
+        None => nu_path::config_dir().map(|mut p| {
+            p.push(config_files::NUSHELL_FOLDER);
+            p.push("env.nu");
+            p
+        }),
+    };
+
+    engine_state.set_config_path(config_path, env_config_path);
 }


### PR DESCRIPTION
# Description

Fixes #6344

![Screenshot from 2022-08-22 15-36-01](https://user-images.githubusercontent.com/15247421/185865585-aa31c162-5895-4ecd-a8cf-fa6156b4d06f.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
