### PR TITLE
fix the way lists are rendered in markdown

### DIFF
--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -169,7 +169,7 @@ fn table(input: PipelineData, pretty: bool, config: &Config) -> String {
                     let data = row.get_data_by_key(&headers[i]);
                     let value_string = data
                         .unwrap_or_else(|| Value::nothing(span))
-                        .into_string("|", config);
+                        .into_string(", ", config);
                     let new_column_width = value_string.len();
 
                     escaped_row.push(value_string);


### PR DESCRIPTION
# Description

This changes the way lists are rendered in markdown from `[fdncred|skelly]` which breaks because of the pipe to `[fdncred, skelly]`.

closes #6368

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
