### PR TITLE
Add pause and cls to cmd.exe exceptions

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -144,8 +144,9 @@ impl ExternalCommand {
 
                     // This has the full list of cmd.exe "internal" commands: https://ss64.com/nt/syntax-internal.html
                     // I (Reilly) went through the full list and whittled it down to ones that are potentially useful:
-                    const CMD_INTERNAL_COMMANDS: [&str; 8] = [
-                        "ASSOC", "DIR", "ECHO", "FTYPE", "MKLINK", "START", "VER", "VOL",
+                    const CMD_INTERNAL_COMMANDS: [&str; 10] = [
+                        "ASSOC", "CLS", "DIR", "ECHO", "FTYPE", "MKLINK", "PAUSE", "START", "VER",
+                        "VOL",
                     ];
                     let command_name_upper = self.name.item.to_uppercase();
                     let looks_like_cmd_internal = CMD_INTERNAL_COMMANDS


### PR DESCRIPTION
# Description

Related to https://github.com/nushell/nushell/issues/6359. This PR adds `cls` and `pause` to the list of known `cmd.exe` internals that we call if we can't find a command or executable on Windows, because some Windows users expect these to work.

This change brings Nu more in line with PowerShell, which makes `cls` and `pause` work using an alias and a function respectively.

# Tests

Manually tested `cls` and `pause`

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
