### PR TITLE
let `to nuon` convert column names with spaces

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -102,6 +102,10 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
             let headers = get_columns(vals);
             if !headers.is_empty() && vals.iter().all(|x| x.columns() == headers) {
                 // Table output
+                let headers: Vec<String> = headers
+                    .iter()
+                    .map(|string| format!("\"{}\"", string))
+                    .collect();
                 let headers_output = headers.join(", ");
 
                 let mut table_output = vec![];

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -244,7 +244,7 @@ fn to_nuon_converts_columns_with_spaces() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
             r#"
-    [[a, b, "c d"]; [1 2 3] [4 5 6]] | to nuon | from nuon
+    let test = [[a, b, "c d"]; [1 2 3] [4 5 6]]; $test | to nuon | from nuon
     "#
     ));
     assert!(actual.err.is_empty());

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -238,3 +238,14 @@ fn float_nan_parsed_properly() {
 
     assert_eq!(actual.out, "NaN")
 }
+
+#[test]
+fn to_nuon_converts_columns_with_spaces() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+    [[a, b, "c d"]; [1 2 3] [4 5 6]] | to nuon | from nuon
+    "#
+    ));
+    assert!(actual.err.is_empty());
+}


### PR DESCRIPTION
# Description

Fixes #6283.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
