### PR TITLE
preserve space by letting `to nuon` only add quotes when necessary

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -191,7 +191,16 @@ fn to_nuon(call: &Call, input: PipelineData) -> Result<String, ShellError> {
 }
 
 fn needs_quotes(string: &str) -> bool {
-    string.contains(' ') || string.contains(',') || string.contains(':')
+    string.contains(' ')
+        || string.contains(',')
+        || string.contains(':')
+        || string.contains(';')
+        || string.contains('(')
+        || string.contains(')')
+        || string.contains('[')
+        || string.contains(']')
+        || string.contains('{')
+        || string.contains('}')
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -155,7 +155,11 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
             let mut collection = vec![];
             for (col, val) in cols.iter().zip(vals) {
                 collection.push(if needs_quotes(col) {
-                    format!("\"{}\": {}", col, value_to_string_without_quotes(val, span)?)
+                    format!(
+                        "\"{}\": {}",
+                        col,
+                        value_to_string_without_quotes(val, span)?
+                    )
                 } else {
                     format!("{}: {}", col, value_to_string_without_quotes(val, span)?)
                 });
@@ -187,9 +191,7 @@ fn to_nuon(call: &Call, input: PipelineData) -> Result<String, ShellError> {
 }
 
 fn needs_quotes(string: &str) -> bool {
-    string.contains(' ') 
-        || string.contains(',') 
-        || string.contains(':')
+    string.contains(' ') || string.contains(',') || string.contains(':')
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -249,3 +249,21 @@ fn to_nuon_converts_columns_with_spaces() {
     ));
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn to_nuon_does_not_quote_unnecessarily() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+        let test = [["a", "b", "c d"]; [1 2 3] [4 5 6]]; $test | to nuon
+    "#
+    ));
+    assert_eq!(actual.out, "[[a, b, \"c d\"]; [1, 2, 3], [4, 5, 6]]");
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+         let a = {"ro name": "sam" rank: 10}; $a | to nuon
+    "#
+    ));
+    assert_eq!(actual.out, "{\"ro name\": sam, rank: 10}");
+}


### PR DESCRIPTION
# Description

Related: #6376 (comments), #6283

Quotes are now only used when absolutely needed, i.e. there is a space or comma in the name.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
