### PR TITLE
Test command names and search terms for redundancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,18 +4362,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -49,7 +49,7 @@ impl Command for BytesIndexOf {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["pattern", "match", "find", "search", "index"]
+        vec!["pattern", "match", "find", "search"]
     }
 
     fn run(

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -39,7 +39,7 @@ impl Command for BytesLen {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["len", "size", "count"]
+        vec!["size", "count"]
     }
 
     fn run(

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "binary", "bytes", "bin"]
+        vec!["convert", "bytes"]
     }
 
     fn run(

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -103,7 +103,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "date", "time", "timezone", "UTC"]
+        vec!["convert", "timezone", "UTC"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "number", "size", "bytes"]
+        vec!["convert", "number", "bytes"]
     }
 
     fn run(

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -38,7 +38,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "str", "text"]
+        vec!["convert", "text"]
     }
 
     fn run(

--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -29,7 +29,7 @@ impl Command for ErrorMake {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["err", "panic", "crash", "throw"]
+        vec!["panic", "crash", "throw"]
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/collect.rs
+++ b/crates/nu-command/src/database/commands/collect.rs
@@ -34,7 +34,7 @@ impl Command for CollectDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "collect"]
+        vec!["database"]
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/describe.rs
+++ b/crates/nu-command/src/database/commands/describe.rs
@@ -47,7 +47,7 @@ impl Command for DescribeDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "SQLite", "describe"]
+        vec!["database", "SQLite"]
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/from.rs
+++ b/crates/nu-command/src/database/commands/from.rs
@@ -41,7 +41,7 @@ impl Command for FromDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "from"]
+        vec!["database"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -49,7 +49,7 @@ impl Command for IntoSqliteDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "sqlite", "database"]
+        vec!["convert", "database"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/join.rs
+++ b/crates/nu-command/src/database/commands/join.rs
@@ -47,7 +47,7 @@ impl Command for JoinDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "join"]
+        vec!["database"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/limit.rs
+++ b/crates/nu-command/src/database/commands/limit.rs
@@ -34,7 +34,7 @@ impl Command for LimitDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "limit"]
+        vec!["database", "head", "tail"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/open.rs
+++ b/crates/nu-command/src/database/commands/open.rs
@@ -29,7 +29,7 @@ impl Command for OpenDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "open"]
+        vec!["database"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/order_by.rs
+++ b/crates/nu-command/src/database/commands/order_by.rs
@@ -37,7 +37,7 @@ impl Command for OrderByDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "order-by"]
+        vec!["database"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -34,7 +34,7 @@ impl Command for SchemaDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "info", "SQLite", "schema"]
+        vec!["database", "info", "SQLite"]
     }
 
     fn run(

--- a/crates/nu-command/src/database/commands/select.rs
+++ b/crates/nu-command/src/database/commands/select.rs
@@ -33,7 +33,7 @@ impl Command for ProjectionDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "select"]
+        vec!["database"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/to_db.rs
+++ b/crates/nu-command/src/database/commands/to_db.rs
@@ -30,7 +30,7 @@ impl Command for ToDataBase {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "into", "db"]
+        vec!["database", "convert"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/commands/where_.rs
+++ b/crates/nu-command/src/database/commands/where_.rs
@@ -31,7 +31,7 @@ impl Command for WhereDb {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "where"]
+        vec!["database"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/expressions/and.rs
+++ b/crates/nu-command/src/database/expressions/and.rs
@@ -30,7 +30,7 @@ impl Command for AndExpr {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "and", "expression"]
+        vec!["database", "expression"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/expressions/or.rs
+++ b/crates/nu-command/src/database/expressions/or.rs
@@ -30,7 +30,7 @@ impl Command for OrExpr {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "or", "expression"]
+        vec!["database", "expression"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/database/expressions/over.rs
+++ b/crates/nu-command/src/database/expressions/over.rs
@@ -92,7 +92,7 @@ impl Command for OverExpr {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["database", "over", "expression"]
+        vec!["database", "expression"]
     }
 
     fn run(

--- a/crates/nu-command/src/date/date_.rs
+++ b/crates/nu-command/src/date/date_.rs
@@ -23,7 +23,6 @@ impl Command for Date {
 
     fn search_terms(&self) -> Vec<&str> {
         vec![
-            "date",
             "time",
             "now",
             "today",

--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["date", "format", "strftime"]
+        vec!["fmt", "strftime"]
     }
 
     fn run(

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -22,8 +22,6 @@ impl Command for SubCommand {
 
     fn search_terms(&self) -> Vec<&str> {
         vec![
-            "date",
-            "humanize",
             "relative",
             "now",
             "today",

--- a/crates/nu-command/src/date/list_timezone.rs
+++ b/crates/nu-command/src/date/list_timezone.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["UTC", "GMT", "timezone", "list", "list-timezone"]
+        vec!["UTC", "GMT", "tz"]
     }
 
     fn run(

--- a/crates/nu-command/src/date/now.rs
+++ b/crates/nu-command/src/date/now.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["date", "now", "present", "current-time"]
+        vec!["present", "current-time"]
     }
 
     fn run(

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["date", "to", "record", "structured", "table"]
+        vec!["structured", "table"]
     }
 
     fn run(

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["date", "to", "record", "structured", "table"]
+        vec!["structured"]
     }
 
     fn run(

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -34,9 +34,7 @@ impl Command for SubCommand {
 
     fn search_terms(&self) -> Vec<&str> {
         vec![
-            "date",
-            "to",
-            "timezone",
+            "tz",
             "transform",
             "convert",
             "UTC",

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -20,7 +20,7 @@ impl Command for IsAdmin {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["root", "admin", "administrator", "superuser", "supervisor"]
+        vec!["root", "administrator", "superuser", "supervisor"]
     }
 
     fn run(

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -20,7 +20,7 @@ impl Command for Cd {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["cd", "change", "directory", "dir", "folder", "switch"]
+        vec!["change", "directory", "dir", "folder", "switch"]
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -36,7 +36,7 @@ impl Command for Cp {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["cp", "copy", "file", "files"]
+        vec!["copy", "file", "files"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -33,7 +33,7 @@ impl Command for Glob {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["glob", "files", "folders", "list", "ls"]
+        vec!["pattern", "files", "folders", "list", "ls"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -34,12 +34,9 @@ impl Command for Mkdir {
 
     fn search_terms(&self) -> Vec<&str> {
         vec![
-            "mkdir",
-            "make",
             "directory",
-            "dir",
             "folder",
-            "make_dir",
+            "create",
             "make_dirs",
         ]
     }

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -33,12 +33,7 @@ impl Command for Mkdir {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec![
-            "directory",
-            "folder",
-            "create",
-            "make_dirs",
-        ]
+        vec!["directory", "folder", "create", "make_dirs"]
     }
 
     fn run(

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -31,7 +31,7 @@ impl Command for Mv {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["mv", "move"]
+        vec!["move"]
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -28,7 +28,7 @@ impl Command for Open {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["open", "load", "read", "load_file", "read_file"]
+        vec!["load", "read", "load_file", "read_file"]
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -40,7 +40,7 @@ impl Command for Rm {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["rm", "remove"]
+        vec!["delete", "remove"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -25,7 +25,7 @@ impl Command for Touch {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["touch"]
+        vec!["create", "file"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -19,7 +19,7 @@ impl Command for EachWhile {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["for", "loop", "iterate", "while"]
+        vec!["for", "loop", "iterate"]
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -25,7 +25,7 @@ impl Command for Length {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["count", "len", "size", "wc"]
+        vec!["count", "size", "wc"]
     }
 
     fn run(

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -68,7 +68,7 @@ impl Command for ToText {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["text", "convert"]
+        vec!["convert"]
     }
 }
 

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["average", "mean"]
+        vec!["average", "mean", "statistics"]
     }
 
     fn run(

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["ceiling"]
+        vec!["ceiling", "round up", "rounding", "integer"]
     }
 
     fn run(

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["floor"]
+        vec!["round down", "rounding", "integer"]
     }
 
     fn run(

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["middle", "median"]
+        vec!["middle", "statistics"]
     }
 
     fn run(

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -23,7 +23,14 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["SD", "standard", "deviation", "dispersion", "variation", "statistics"]
+        vec![
+            "SD",
+            "standard",
+            "deviation",
+            "dispersion",
+            "variation",
+            "statistics",
+        ]
     }
 
     fn run(

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["SD", "standard", "deviation", "dispersion", "variation"]
+        vec!["SD", "standard", "deviation", "dispersion", "variation", "statistics"]
     }
 
     fn run(

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["deviation", "dispersion", "variance", "variation"]
+        vec!["deviation", "dispersion", "variation", "statistics"]
     }
 
     fn run(

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -94,7 +94,7 @@ impl Command for SubCommand {
 
     fn search_terms(&self) -> Vec<&str> {
         vec![
-            "network", "fetch", "get", "pull", "request", "http", "download", "curl", "wget",
+            "network", "get", "pull", "request", "http", "download", "curl", "wget",
         ]
     }
 

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -32,7 +32,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["network", "http", "port"]
+        vec!["network", "http"]
     }
 
     fn run(

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -80,7 +80,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["network", "post", "send", "push", "http"]
+        vec!["network", "send", "push", "http"]
     }
 
     fn run(

--- a/crates/nu-command/src/network/url/host.rs
+++ b/crates/nu-command/src/network/url/host.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["url", "host", "hostname"]
+        vec!["hostname"]
     }
 
     fn run(

--- a/crates/nu-command/src/network/url/path.rs
+++ b/crates/nu-command/src/network/url/path.rs
@@ -25,10 +25,6 @@ impl Command for SubCommand {
         "Get the path of a URL"
     }
 
-    fn search_terms(&self) -> Vec<&str> {
-        vec!["url", "path"]
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/network/url/query.rs
+++ b/crates/nu-command/src/network/url/query.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["url", "query", "parameter"]
+        vec!["parameter"]
     }
 
     fn run(

--- a/crates/nu-command/src/network/url/scheme.rs
+++ b/crates/nu-command/src/network/url/scheme.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["url", "scheme", "protocol"]
+        vec!["protocol"]
     }
 
     fn run(

--- a/crates/nu-command/src/network/url/url_.rs
+++ b/crates/nu-command/src/network/url/url_.rs
@@ -22,7 +22,7 @@ impl Command for Url {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["url", "network", "parse"]
+        vec!["network", "parse"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -35,7 +35,7 @@ impl Command for FileSize {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "display", "pattern", "file", "size"]
+        vec!["convert", "display", "pattern", "human readable"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -34,7 +34,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["column", "separate", "divide"]
+        vec!["separate", "divide"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["list", "separate", "divide"]
+        vec!["separate", "divide"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -34,7 +34,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["row", "separate", "divide"]
+        vec!["separate", "divide"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/split/words.rs
+++ b/crates/nu-command/src/strings/split/words.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["word", "separate", "divide"]
+        vec!["separate", "divide"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "style", "snake", "underscore", "convention"]
+        vec!["convert", "style", "underscore", "convention"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -29,13 +29,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec![
-            "convert",
-            "style",
-            "underscore",
-            "lower",
-            "convention",
-        ]
+        vec!["convert", "style", "underscore", "lower", "convention"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -32,7 +32,6 @@ impl Command for SubCommand {
         vec![
             "convert",
             "style",
-            "snake",
             "underscore",
             "lower",
             "convention",

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -30,7 +30,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "style", "title", "convention"]
+        vec!["convert", "style", "convention"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -52,7 +52,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["pattern", "match", "find", "search", "index"]
+        vec!["pattern", "match", "find", "search"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["len", "size", "count"]
+        vec!["size", "count"]
     }
 
     fn run(

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -23,3 +23,55 @@ fn quickcheck_parse(data: String) -> bool {
     }
     true
 }
+
+#[test]
+fn signature_name_matches_command_name() {
+    let ctx = crate::create_default_context();
+    let decls = ctx.get_decl_ids_sorted(true);
+    let mut failures = Vec::new();
+
+    for decl_id in decls {
+        let cmd = ctx.get_decl(decl_id);
+        let cmd_name = cmd.name();
+        let sig_name = cmd.signature().name;
+        let category = cmd.signature().category;
+
+        if cmd_name != sig_name {
+            failures.push(format!(
+                "{cmd_name} ({category:?}): Signature name \"{sig_name}\" is not equal to the command name \"{cmd_name}\""
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Name mismatch:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn no_search_term_duplicates() {
+    let ctx = crate::create_default_context();
+    let decls = ctx.get_decl_ids_sorted(true);
+    let mut failures = Vec::new();
+
+    for decl_id in decls {
+        let cmd = ctx.get_decl(decl_id);
+        let cmd_name = cmd.name();
+        let search_terms = cmd.search_terms();
+        let category = cmd.signature().category;
+
+        for search_term in search_terms {
+            if cmd_name.contains(search_term) {
+                failures.push(format!("{cmd_name} ({category:?}): Search term \"{search_term}\" is substring of command name \"{cmd_name}\""));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Duplication in search terms:\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
# Description

- Ensure that the command name is equal to the signature name (Unsure if there exists an orthogonal test already)

- Avoid duplicating the command name in the search terms as this does not help with `help --find` or `F1` interactive search that consult the command name as well as the usage on top of the `search_terms`.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
