### PR TITLE
Allow "export-env" parsing in modules

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -17,8 +17,8 @@ use nu_protocol::{
 };
 
 use crate::parse_keywords::{
-    parse_alias, parse_def, parse_def_predecl, parse_export_in_block, parse_extern, parse_for, parse_hide, 
-    parse_let, parse_module, parse_overlay, parse_source, parse_use,
+    parse_alias, parse_def, parse_def_predecl, parse_export_in_block, parse_extern, parse_for,
+    parse_hide, parse_let, parse_module, parse_overlay, parse_source, parse_use,
 };
 
 use itertools::Itertools;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1,7 +1,6 @@
 use crate::{
     lex, lite_parse,
     lite_parse::LiteCommand,
-    parse_keywords::{parse_extern, parse_for, parse_source},
     type_check::{math_result_type, type_compatible},
     LiteBlock, ParseError, Token, TokenContents,
 };
@@ -18,8 +17,8 @@ use nu_protocol::{
 };
 
 use crate::parse_keywords::{
-    parse_alias, parse_def, parse_def_predecl, parse_hide, parse_let, parse_module, parse_overlay,
-    parse_use,
+    parse_alias, parse_def, parse_def_predecl, parse_extern, parse_for, parse_hide, parse_let,
+    parse_module, parse_overlay, parse_source, parse_use,
 };
 
 use itertools::Itertools;

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -345,3 +345,21 @@ fn module_nested_imports_in_dirs_prefixed() {
         assert_eq!(actual.out, "bar");
     })
 }
+
+#[test]
+fn module_eval_export_env() {
+    Playground::setup("module_eval_export_env", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "spam.nu",
+            r#"
+                export-env { let-env FOO = 'foo' }
+            "#,
+        )]);
+
+        let inp = &[r#"source spam.nu"#, r#"$env.FOO"#];
+
+        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+
+        assert_eq!(actual.out, "foo");
+    })
+}

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -151,3 +151,23 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_2() {
         assert!(actual.err.contains("File not found"));
     })
 }
+
+#[test]
+fn parse_export_env_in_module() {
+    let actual = nu!(cwd: "tests/parsing/samples",
+        r#"
+            module spam { export-env { } }
+        "#);
+
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn parse_export_env_missing_block() {
+    let actual = nu!(cwd: "tests/parsing/samples",
+        r#"
+            module spam { export-env }
+        "#);
+
+    assert!(actual.err.contains("missing block"));
+}


### PR DESCRIPTION
# Description

Allows defining `export-env { ... }` inside a module. Doesn't do anything, except not throwing an error. The true use is when you evaluate the module as a script, it will bring the environment inside the `{ ... }` block to the current scope.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
