### PR TITLE
add edit distance/levenshtein command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -190,6 +190,7 @@ pub fn create_default_context() -> EngineState {
             StrCapitalize,
             StrCollect,
             StrContains,
+            StrDistance,
             StrDowncase,
             StrEndswith,
             StrReplace,

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -51,8 +51,12 @@ impl Command for SubCommand {
         vec![Example {
             description: "get the edit distance between two strings",
             example: "'nushell' | str distance 'nutshell'",
-            result: Some(Value::Int {
-                val: 1,
+            result: Some(Value::Record {
+                cols: vec!["distance".to_string()],
+                vals: vec![Value::Int {
+                    val: 1,
+                    span: Span::test_data(),
+                }],
                 span: Span::test_data(),
             }),
         }]

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -96,8 +96,12 @@ fn action(input: &Value, compare_string: &str, head: Span) -> Value {
     match &input {
         Value::String { val, .. } => {
             let distance = levenshtein_distance(val, compare_string);
-            Value::Int {
-                val: distance as i64,
+            Value::Record {
+                cols: vec!["distance".to_string()],
+                vals: vec![Value::Int {
+                    val: distance as i64,
+                    span: head,
+                }],
                 span: head,
             }
         }

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -1,0 +1,126 @@
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::{Call, CellPath},
+    engine::{Command, EngineState, Stack},
+    levenshtein_distance, Category, Example, PipelineData, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Value,
+};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "str distance"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("str distance")
+            .required(
+                "compare-string",
+                SyntaxShape::String,
+                "the first string to compare",
+            )
+            .rest(
+                "rest",
+                SyntaxShape::CellPath,
+                "optionally check if string contains pattern by column paths",
+            )
+            .category(Category::Strings)
+    }
+
+    fn usage(&self) -> &str {
+        "compare to strings and return the edit distance/levenshtein distance"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["edit", "distance", "levenshtein"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        operate(engine_state, stack, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "get the edit distance between two strings",
+            example: "'nushell' | str distance 'nutshell'",
+            result: Some(Value::Int {
+                val: 1,
+                span: Span::test_data(),
+            }),
+        }]
+    }
+}
+
+fn operate(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+) -> Result<PipelineData, ShellError> {
+    let head = call.head;
+    let compare_string: Spanned<String> = call.req(engine_state, stack, 0)?;
+    let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
+
+    input.map(
+        move |v| {
+            if column_paths.is_empty() {
+                action(&v, &compare_string.item, head)
+            } else {
+                let mut ret = v;
+                for path in &column_paths {
+                    let c = compare_string.item.clone();
+                    let r = ret.update_cell_path(
+                        &path.members,
+                        Box::new(move |old| action(old, &c, head)),
+                    );
+                    if let Err(error) = r {
+                        return Value::Error { error };
+                    }
+                }
+                ret
+            }
+        },
+        engine_state.ctrlc.clone(),
+    )
+}
+
+fn action(input: &Value, compare_string: &str, head: Span) -> Value {
+    match &input {
+        Value::String { val, .. } => {
+            let distance = levenshtein_distance(val, compare_string);
+            Value::Int {
+                val: distance as i64,
+                span: head,
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Input's type is {}. This command only works with strings.",
+                    other.get_type()
+                ),
+                head,
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/strings/str_/mod.rs
+++ b/crates/nu-command/src/strings/str_/mod.rs
@@ -1,6 +1,7 @@
 mod case;
 mod collect;
 mod contains;
+mod distance;
 mod ends_with;
 mod index_of;
 mod length;
@@ -15,6 +16,7 @@ mod trim;
 pub use case::*;
 pub use collect::*;
 pub use contains::SubCommand as StrContains;
+pub use distance::SubCommand as StrDistance;
 pub use ends_with::SubCommand as StrEndswith;
 pub use index_of::SubCommand as StrIndexOf;
 pub use length::SubCommand as StrLength;


### PR DESCRIPTION
# Description

This command adds our built in Levenshtein algorithm as a command. I was doing some work today with OCR results and desparately needed nushell to understand Levenshtein.

![image](https://user-images.githubusercontent.com/343840/186168523-5037faf7-5385-452e-a995-2218c8e51481.png)

If we end up adding more algorithms, maybe the record key could name the algorithm.


I'd like to see this grow to support other edit distance algorithms like:
- Damerau Levenshtein - wanting this one too because it works better with transposed letters
- Hamming - total mismatches between strings
- Longest Common Subsequence
- Jaro
- etc

[This crate](https://github.com/Daniel-Liu-c0deb0t/triple_accel) seems interesting since it supports simd in comparisons.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
