### PR TITLE
Add test cases for $nu.config-path change

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 mod test_conditionals;
+mod test_config_path;
 mod test_converters;
 mod test_custom_commands;
 mod test_engine;

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -6,11 +6,11 @@ fn test_default_config_path() {
     let cwd = std::env::current_dir().expect("Could not get current working directory");
 
     let config_path = config_dir.join("nushell").join("config.nu");
-    let actual = nu!(cwd: &cwd, "nu -c '$nu.config-path'");
+    let actual = nu!(cwd: &cwd, "$nu.config-path");
     assert_eq!(actual.out, config_path.to_string_lossy().to_string());
 
     let env_path = config_dir.join("nushell").join("env.nu");
-    let actual = nu!(cwd: &cwd, "nu -c '$nu.env-path'");
+    let actual = nu!(cwd: &cwd, "$nu.env-path");
     assert_eq!(actual.out, env_path.to_string_lossy().to_string());
 }
 

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -1,0 +1,38 @@
+use nu_test_support::nu;
+
+#[test]
+fn test_default_config_path() {
+    let config_dir = nu_path::config_dir().expect("Could not get config directory");
+    let cwd = std::env::current_dir().expect("Could not get current working directory");
+
+    let config_path = config_dir.join("nushell").join("config.nu");
+    let actual = nu!(cwd: &cwd, "nu -c '$nu.config-path'");
+    assert_eq!(actual.out, config_path.to_string_lossy().to_string());
+
+    let env_path = config_dir.join("nushell").join("env.nu");
+    let actual = nu!(cwd: &cwd, "nu -c '$nu.env-path'");
+    assert_eq!(actual.out, env_path.to_string_lossy().to_string());
+}
+
+#[test]
+fn test_alternate_config_path() {
+    let config_file = "crates/nu-utils/src/sample_config/default_config.nu";
+    let env_file = "crates/nu-utils/src/sample_config/default_env.nu";
+
+    let cwd = std::env::current_dir().expect("Could not get current working directory");
+
+    let config_path =
+        nu_path::canonicalize_with(config_file, &cwd).expect("Could not get config path");
+    let actual = nu!(
+        cwd: &cwd,
+        format!("nu --config {:?} -c '$nu.config-path'", config_path)
+    );
+    assert_eq!(actual.out, config_path.to_string_lossy().to_string());
+
+    let env_path = nu_path::canonicalize_with(env_file, &cwd).expect("Could not get env path");
+    let actual = nu!(
+        cwd: &cwd,
+        format!("nu --env-config {:?} -c '$nu.env-path'", env_path)
+    );
+    assert_eq!(actual.out, env_path.to_string_lossy().to_string());
+}


### PR DESCRIPTION
# Description

This PR is part of #6366

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
