### PR TITLE
[Experiment] Reenable CI build cache for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,9 @@ jobs:
         #   toolchain: ${{ matrix.rust }}
         #   override: true
 
-      # Temporarily disabled; the cache was getting huge (2.6GB compressed) on Windows and causing issues.
-      # TODO: investigate why the cache was so big
-      # - uses: Swatinem/rust-cache@v1
-      #   with:
-      #     key: ${{ matrix.style }}v3 # increment this to bust the cache if needed
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.style }}v3 # increment this to bust the cache if needed
 
       - name: Tests
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Let's see if we can again use `cargo-cache` for the tests after #6389 reduced the number of test binaries to build.
They are quite large due as they statically link copies of the same engine.
This might be one of the reasons why the tests on windows exceeded the allotted disk space.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
