### PR TITLE
Make `cp` errors more specific+accurate

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -348,9 +348,22 @@ fn copy_file(src: PathBuf, dst: PathBuf, span: Span) -> Value {
             let msg = format!("copied {:} to {:}", src.display(), dst.display());
             Value::String { val: msg, span }
         }
-        Err(e) => Value::Error {
-            error: ShellError::FileNotFoundCustom(format!("copy file {src:?} failed: {e}"), span),
-        },
+        Err(e) => {
+            let message = format!("copy file {src:?} failed: {e}");
+
+            use std::io::ErrorKind;
+            let shell_error = match e.kind() {
+                ErrorKind::NotFound => ShellError::FileNotFoundCustom(message, span),
+                ErrorKind::PermissionDenied => ShellError::PermissionDeniedError(message, span),
+                ErrorKind::Interrupted => ShellError::IOInterrupted(message, span),
+                ErrorKind::OutOfMemory => ShellError::OutOfMemoryError(message, span),
+                // TODO: handle ExecutableFileBusy etc. when io_error_more is stabilized
+                // https://github.com/rust-lang/rust/issues/86442
+                _ => ShellError::IOErrorSpanned(message, span),
+            };
+
+            Value::Error { error: shell_error }
+        }
     }
 }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -478,7 +478,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// ## Resolution
     ///
-    /// This is a failry generic error. Refer to the specific error message for further details.
+    /// This is a fairly generic error. Refer to the specific error message for further details.
     #[error("Plugin failed to load: {0}")]
     #[diagnostic(code(nu::shell::plugin_failed_to_load), url(docsrs))]
     PluginFailedToLoad(String),
@@ -501,6 +501,15 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[diagnostic(code(nu::shell::plugin_failed_to_decode), url(docsrs))]
     PluginFailedToDecode(String),
 
+    /// I/O operation interrupted.
+    ///
+    /// ## Resolution
+    ///
+    /// This is a generic error. Refer to the specific error message for further details.
+    #[error("I/O interrupted")]
+    #[diagnostic(code(nu::shell::io_interrupted), url(docsrs))]
+    IOInterrupted(String, #[label("{0}")] Span),
+
     /// An I/O operation failed.
     ///
     /// ## Resolution
@@ -509,6 +518,33 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("I/O error")]
     #[diagnostic(code(nu::shell::io_error), url(docsrs), help("{0}"))]
     IOError(String),
+
+    /// An I/O operation failed.
+    ///
+    /// ## Resolution
+    ///
+    /// This is a generic error. Refer to the specific error message for further details.
+    #[error("I/O error")]
+    #[diagnostic(code(nu::shell::io_error), url(docsrs))]
+    IOErrorSpanned(String, #[label("{0}")] Span),
+
+    /// Permission for an operation was denied.
+    ///
+    /// ## Resolution
+    ///
+    /// This is a generic error. Refer to the specific error message for further details.
+    #[error("Permission Denied")]
+    #[diagnostic(code(nu::shell::permission_denied), url(docsrs))]
+    PermissionDeniedError(String, #[label("{0}")] Span),
+
+    /// Out of memory.
+    ///
+    /// ## Resolution
+    ///
+    /// This is a generic error. Refer to the specific error message for further details.
+    #[error("Out of memory")]
+    #[diagnostic(code(nu::shell::out_of_memory), url(docsrs))]
+    OutOfMemoryError(String, #[label("{0}")] Span),
 
     /// Tried to `cd` to a path that isn't a directory.
     ///


### PR DESCRIPTION
# Description

Small PR to improve error messages for `cp`. Previously every `cp` error was reported as "File not found":

![image](https://user-images.githubusercontent.com/26268125/186323283-a0dc39c6-ace2-4df8-8255-dcdbfa03ff76.png)

Now we have a handful of more specific error kinds, and "I/O error" is the generic fallback:
![image](https://user-images.githubusercontent.com/26268125/186324178-b3dc49cc-6446-4889-ba5f-df51287e467c.png)

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
