### PR TITLE
Always report errors in `cp`

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -50,7 +50,7 @@ impl Command for Cp {
             )
             .switch(
                 "verbose",
-                "do copy in verbose mode (default:false)",
+                "show successful copies in addition to failed copies (default:false)",
                 Some('v'),
             )
             // TODO: add back in additional features
@@ -285,7 +285,11 @@ impl Command for Cp {
         if verbose {
             Ok(result.into_iter().into_pipeline_data(ctrlc))
         } else {
-            Ok(PipelineData::new(span))
+            // filter to only errors
+            Ok(result
+                .into_iter()
+                .filter(|v| matches!(v, Value::Error { .. }))
+                .into_pipeline_data(ctrlc))
         }
     }
 


### PR DESCRIPTION
# Description

Closes #6393. Previously, `cp` errors were only displayed to the user if the `--verbose` flag was specified. After this PR, errors are always displayed and `--verbose` controls whether to show successful results to the user.

#### Before:
![image](https://user-images.githubusercontent.com/26268125/186475122-96cabc43-5dcf-4016-a1ac-c75b8f8c2f37.png)

#### After:
![image](https://user-images.githubusercontent.com/26268125/186475003-6a0976c4-64bf-4c42-a289-981f37d67cfd.png)



# Future Work

`cp` still does not set `LAST_EXIT_CODE` correctly when there is an error. I spent some time looking into how to fix this, but it's a little tricky.

It would be good to have more tests that exercise error handling in filesystem-related commands, but I'm not sure how to do that without mocking the entire filesystem. Some research needed here.

I took a quick look at `rm` and `mv`, I believe they are not affected by this issue but [fdncred said otherwise](https://github.com/nushell/nushell/issues/6393#issuecomment-1224380666). Double-check that later.

# Tests

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
