### PR TITLE
Revert "register-plugin.nu: remove `.exe` extension match to simplify code"

### DIFF
--- a/register-plugins.nu
+++ b/register-plugins.nu
@@ -9,13 +9,21 @@ let plugin_location = ((which nu).path.0 | path dirname)
 # for each plugin file, print the name and launch another instance of nushell to register it
 for plugin in (ls $"($plugin_location)/nu_plugin_*") {
     print $"registering ($plugin.name)"
-    match ($plugin.name | path basename | str replace '\.exe$' '') {
+    match ($plugin.name | path basename) {
+        # MacOS/Linux
         nu_plugin_custom_values: { nu -c $'register -e msgpack ($plugin.name)' }
         nu_plugin_example: { nu -c $'register -e msgpack ($plugin.name)' }
         nu_plugin_from_parquet: { nu -c $'register -e json ($plugin.name)' }
         nu_plugin_gstat: { nu -c $'register -e msgpack ($plugin.name)' }
         nu_plugin_inc: { nu -c $'register -e json ($plugin.name)' }
         nu_plugin_query: { nu -c $'register -e json ($plugin.name)' }
+        # Windows
+        nu_plugin_custom_values.exe: { nu -c $'register -e msgpack ($plugin.name)' }
+        nu_plugin_example.exe: { nu -c $'register -e msgpack ($plugin.name)' }
+        nu_plugin_from_parquet.exe: { nu -c $'register -e json ($plugin.name)' }
+        nu_plugin_gstat.exe: { nu -c $'register -e msgpack ($plugin.name)' }
+        nu_plugin_inc.exe: { nu -c $'register -e json ($plugin.name)' }
+        nu_plugin_query.exe: { nu -c $'register -e json ($plugin.name)' }
     }
 }
 


### PR DESCRIPTION
Reverts nushell/nushell#6400

Let's just leave it like it was originally because this version doesn't work right in Windows.
```
~\source\repos\forks\nushell source register_plugins.nu   
registering C:\CarTar\debug\deps\nu_plugin_custom_values-4962dc32b7c35254.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-4962dc32b7c35254.exe
registering C:\CarTar\debug\deps\nu_plugin_custom_values-4962dc32b7c35254.pdb
registering C:\CarTar\debug\deps\nu_plugin_custom_values-6fb200ed30719f4d.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-6fb200ed30719f4d.exe
registering C:\CarTar\debug\deps\nu_plugin_custom_values-6fb200ed30719f4d.pdb
registering C:\CarTar\debug\deps\nu_plugin_custom_values-7421fd59d344c414.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-7b89837b87b80556.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-89937c3e9f70c1b6.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-8fc8f601ebfa904c.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-8fc8f601ebfa904c.exe
registering C:\CarTar\debug\deps\nu_plugin_custom_values-8fc8f601ebfa904c.pdb
registering C:\CarTar\debug\deps\nu_plugin_custom_values-9807feae9518bf4f.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-b9bd5010883f862b.d
registering C:\CarTar\debug\deps\nu_plugin_custom_values-ba37336922964977.d
```