### PR TITLE
register-plugin.nu: refactor register plugin

### DIFF
--- a/register-plugins.nu
+++ b/register-plugins.nu
@@ -3,19 +3,24 @@ def match [input, matchers: record] {
     echo $matchers | get $input | do $in
 }
 
+# register plugin
+def register_plugin [encoding, plugin] {
+    print $"registering ($plugin)"
+    nu -c $'register -e ($encoding) ($plugin)'
+}
+
 # get list of all plugin files from their installed directory
 let plugin_location = ((which nu).path.0 | path dirname)
 
 # for each plugin file, print the name and launch another instance of nushell to register it
 for plugin in (ls $"($plugin_location)/nu_plugin_*") {
-    print $"registering ($plugin.name)"
     match ($plugin.name | path basename | str replace '\.exe$' '') {
-        nu_plugin_custom_values: { nu -c $'register -e msgpack ($plugin.name)' }
-        nu_plugin_example: { nu -c $'register -e msgpack ($plugin.name)' }
-        nu_plugin_from_parquet: { nu -c $'register -e json ($plugin.name)' }
-        nu_plugin_gstat: { nu -c $'register -e msgpack ($plugin.name)' }
-        nu_plugin_inc: { nu -c $'register -e json ($plugin.name)' }
-        nu_plugin_query: { nu -c $'register -e json ($plugin.name)' }
+        nu_plugin_custom_values: { register_plugin msgpack $plugin.name }
+        nu_plugin_example: { register_plugin msgpack $plugin.name }
+        nu_plugin_from_parquet: { register_plugin json $plugin.name }
+        nu_plugin_gstat: { register_plugin msgpack $plugin.name }
+        nu_plugin_inc: { register_plugin json $plugin.name }
+        nu_plugin_query: { register_plugin json $plugin.name }
     }
 }
 


### PR DESCRIPTION
# Description

This PR refactors register plugin, which moves printing and registering plugin into one custom command.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
