### PR TITLE
Fix the span of "invalid time zone"

### DIFF
--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -126,7 +126,7 @@ fn _to_timezone(dt: DateTime<FixedOffset>, timezone: &Spanned<String>, span: Spa
     match datetime_in_timezone(&dt, timezone.item.as_str()) {
         Ok(dt) => Value::Date { val: dt, span },
         Err(_) => Value::Error {
-            error: ShellError::UnsupportedInput(String::from("invalid time zone"), span),
+            error: ShellError::UnsupportedInput(String::from("invalid time zone"), timezone.span),
         },
     }
 }


### PR DESCRIPTION
# Description

This PR fixes the span of "invalid time zone"

![Screenshot from 2022-08-25 17-48-47](https://user-images.githubusercontent.com/15247421/186638611-a85b01cf-8d7a-4cbc-b6a5-cdd5550d0bf5.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
