### PR TITLE
nu-command/filters: drop column check positive value

### DIFF
--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -49,6 +49,13 @@ impl Command for DropColumn {
             1
         };
 
+        // Make columns to drop is positive
+        if columns_to_drop < 0 {
+            if let Some(expr) = call.positional_nth(0) {
+                return Err(ShellError::NeedsPositiveValue(expr.span));
+            }
+        }
+
         dropcol(engine_state, span, input, columns_to_drop)
     }
 

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -17,6 +17,17 @@ fn columns() {
 }
 
 #[test]
+fn drop_columns_positive_value() {
+    let actual = nu!(
+    cwd: ".", pipeline(r#"
+            echo [[a, b];[1,2]] | drop column -1
+            "#)
+    );
+
+    assert!(actual.err.contains("use a positive value"));
+}
+
+#[test]
 fn more_columns_than_table_has() {
     let actual = nu!(
         cwd: ".", pipeline(r#"


### PR DESCRIPTION
# Description

This PR adds a check for positive values in the command `drop column`.
I was parsing Google countries csv and found the command to drop column. I tried using different values to see what happens, then decided to try a negative value (I was thinking it should drop from the left instead of right), but then Nu panicked.

Command I ran:
```
$ curl https://raw.githubusercontent.com/google/dspl/master/samples/google/canonical/countries.csv | from csv | drop column -1 |  to json
```

Before this PR:
<img width="1135" alt="Screen Shot 2022-08-25 at 1 48 51 PM" src="https://user-images.githubusercontent.com/3419441/186656548-d768be17-7aea-4e1c-9587-28f7347124de.png">

After this PR:
<img width="1509" alt="Screen Shot 2022-08-25 at 1 49 23 PM" src="https://user-images.githubusercontent.com/3419441/186656653-e491a973-108c-4ad0-bd9c-5f5c96aab71d.png">


# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
