### PR TITLE
Make run_external parameter required

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -34,7 +34,8 @@ impl Command for External {
         Signature::build(self.name())
             .switch("redirect-stdout", "redirect-stdout", None)
             .switch("redirect-stderr", "redirect-stderr", None)
-            .rest("rest", SyntaxShape::Any, "external command to run")
+            .required("command", SyntaxShape::Any, "external comamdn to run")
+            .rest("args", SyntaxShape::Any, "arguments for external command")
             .category(Category::System)
     }
 


### PR DESCRIPTION
# Description

This PR makes the command parameter required, if running `run-external` without parameters, the parser will check it and return proper error message.

![Screenshot from 2022-08-26 12-30-54](https://user-images.githubusercontent.com/15247421/186822586-fcb137f9-b7c4-4968-895c-0f3004f95926.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
