### PR TITLE
Try to make argument with quotes for external command better

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -639,10 +639,10 @@ fn shell_arg_escape(arg: &str) -> String {
     }
 }
 
-/// This function returns 3 tuple:
-/// 1st element: trimmed string.
-/// 2nd element: a boolean value indicate if it's ok to run glob expansion.
-/// 3rd element: a boolean value indicate if we need to make input as a whole.
+/// This function returns a tuple with 3 items:
+/// 1st item: trimmed string.
+/// 2nd item: a boolean value indicate if it's ok to run glob expansion.
+/// 3rd item: a boolean value indicate if we need to make input as a whole.
 fn trim_enclosing_quotes(input: &str) -> (String, bool, bool) {
     let mut chars = input.chars();
 

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -138,6 +138,36 @@ fn failed_command_with_semicolon_will_not_execute_following_cmds() {
     })
 }
 
+#[cfg(not(windows))]
+#[test]
+fn external_args_with_quoted() {
+    Playground::setup("external failed command with semicolon", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ^echo "foo=bar 'hi'"
+            "#
+        ));
+
+        assert_eq!(actual.out, "foo=bar 'hi'");
+    })
+}
+
+#[cfg(not(windows))]
+#[test]
+fn external_arg_with_long_flag_value_quoted() {
+    Playground::setup("external failed command with semicolon", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ^echo --foo='bar'
+            "#
+        ));
+
+        assert_eq!(actual.out, "--foo=bar");
+    })
+}
+
 #[cfg(windows)]
 #[test]
 fn explicit_glob_windows() {


### PR DESCRIPTION
# Description

Fixes:  #6399

## Detail
In general, if one external arg is quoted, `nu` won't remove inner extra quotes.

Else, if one external arg is not quoted, `nu` will try to remove inner extra quotes, which is implemented in #5846

Summarized:
1. `^echo --aa="bbbb"` ==> `--aa=bbbb`
2. `^echo "--aa='bbbb'"` ==> `--aa='bbbb'`
3. `^echo '--aa="bbb"'` ==> `--aa="bbb"`

For complex argument mentioned in https://github.com/nushell/nushell/issues/6399#issuecomment-1225596153:
```nu
let dump_command = "PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'"
```
If we want to use `$dump_command` as an argument, we can't use bare `$dump_command`, because it's intepreted as:

 `PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'`

We need to surrand $dump_command with ", and using them with String interpolation.

```
^echo $""($dump_command)""
```

Ok...have to admit it's a bit annoying

or just
```nu
^echo "PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'"
```

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
