### PR TITLE
Bring in module's environment when activating overlay

### DIFF
--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -11,6 +11,7 @@ pub struct Module {
     pub decls: IndexMap<Vec<u8>, DeclId>,
     pub aliases: IndexMap<Vec<u8>, AliasId>,
     pub env_vars: IndexMap<Vec<u8>, BlockId>,
+    pub env_block: Option<BlockId>,
     pub span: Option<Span>,
 }
 
@@ -20,6 +21,7 @@ impl Module {
             decls: IndexMap::new(),
             aliases: IndexMap::new(),
             env_vars: IndexMap::new(),
+            env_block: None,
             span: None,
         }
     }
@@ -29,6 +31,7 @@ impl Module {
             decls: IndexMap::new(),
             aliases: IndexMap::new(),
             env_vars: IndexMap::new(),
+            env_block: None,
             span: Some(span),
         }
     }
@@ -43,6 +46,10 @@ impl Module {
 
     pub fn add_env_var(&mut self, name: Vec<u8>, block_id: BlockId) -> Option<BlockId> {
         self.env_vars.insert(name, block_id)
+    }
+
+    pub fn add_env_block(&mut self, block_id: BlockId) {
+        self.env_block = Some(block_id);
     }
 
     pub fn extend(&mut self, other: &Module) {

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -736,3 +736,34 @@ fn overlay_remove_and_add_renamed_overlay() {
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
 }
+
+#[test]
+fn overlay_use_export_env() {
+    let inp = &[
+        r#"module spam { export-env { let-env FOO = 'foo' } }"#,
+        r#"overlay use spam"#,
+        r#"$env.FOO"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert_eq!(actual.out, "foo");
+    assert_eq!(actual_repl.out, "foo");
+}
+
+#[test]
+fn overlay_use_export_env_hide() {
+    let inp = &[
+        r#"let-env FOO = 'foo'"#,
+        r#"module spam { export-env { hide-env FOO } }"#,
+        r#"overlay use spam"#,
+        r#"$env.FOO"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert!(actual.err.contains("did you mean"));
+    assert!(actual_repl.err.contains("did you mean"));
+}


### PR DESCRIPTION
# Description

If present, `overlay use` will evaluate the `export-env { }` block and preserve its environment.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
