### PR TITLE
keep raw for variable inputed argument

### DIFF
--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -70,6 +70,7 @@ impl Command for ConfigEnv {
         let command = ExternalCommand {
             name,
             args,
+            arg_keep_raw: vec![false],
             redirect_stdout: false,
             redirect_stderr: false,
             env_vars: env_vars_str,

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -70,6 +70,7 @@ impl Command for ConfigNu {
         let command = ExternalCommand {
             name,
             args,
+            arg_keep_raw: vec![false],
             redirect_stdout: false,
             redirect_stderr: false,
             env_vars: env_vars_str,

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    ast::{Call, Expr},
+    ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, PipelineData, ShellError, Signature, SyntaxShape,
 };
@@ -65,10 +65,10 @@ fn exec(
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
     use std::os::unix::process::CommandExt;
 
-    use nu_engine::{current_dir, env_to_strings, CallExt};
-    use nu_protocol::Spanned;
-
     use super::run_external::ExternalCommand;
+    use nu_engine::{current_dir, env_to_strings, CallExt};
+    use nu_protocol::ast::Expr;
+    use nu_protocol::Spanned;
 
     let name: Spanned<String> = call.req(engine_state, stack, 0)?;
     let name_span = name.span;

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -168,7 +168,6 @@ fn external_arg_with_long_flag_value_quoted() {
     })
 }
 
-#[cfg(not(windows))]
 #[test]
 fn external_arg_with_variable_name() {
     Playground::setup("external failed command with semicolon", |dirs, _| {
@@ -176,7 +175,7 @@ fn external_arg_with_variable_name() {
             cwd: dirs.test(), pipeline(
             r#"
                 let dump_command = "PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'";
-                ^echo $dump_command
+                nu --testbin nonu $dump_command
             "#
         ));
 

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -168,6 +168,25 @@ fn external_arg_with_long_flag_value_quoted() {
     })
 }
 
+#[cfg(not(windows))]
+#[test]
+fn external_arg_with_variable_name() {
+    Playground::setup("external failed command with semicolon", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                let dump_command = "PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'";
+                ^echo $dump_command
+            "#
+        ));
+
+        assert_eq!(
+            actual.out,
+            r#"PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'"#
+        );
+    })
+}
+
 #[cfg(windows)]
 #[test]
 fn explicit_glob_windows() {


### PR DESCRIPTION
# Description

It's a further and user friendly improvement after #6420
Reiative issue: #6399

With this pr, users no longer need to quote variable as arguments which passed to external string.

Before:
```
let dump_command = "PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'"
^echo $""($dump_command)""
```

After:
```
let dump_command = "PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'"
# no need any quotes, if we pass variable as echo's argument, the inner quote will keep the same.
^echo $dump_command
```

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
