### PR TITLE
better error handling for nu_command::env::conig::utils::get_editor

### DIFF
--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -58,7 +58,7 @@ impl Command for ConfigEnv {
         nu_config.push("env.nu");
 
         let name = Spanned {
-            item: get_editor(engine_state, stack),
+            item: get_editor(engine_state, stack)?,
             span: Span { start: 0, end: 0 },
         };
 

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -58,7 +58,7 @@ impl Command for ConfigNu {
         nu_config.push("config.nu");
 
         let name = Spanned {
-            item: get_editor(engine_state, stack),
+            item: get_editor(engine_state, stack)?,
             span: Span { start: 0, end: 0 },
         };
 

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -1,17 +1,20 @@
 use nu_protocol::engine::{EngineState, Stack};
 
-pub(crate) fn get_editor(engine_state: &EngineState, stack: &mut Stack) -> String {
+pub(crate) fn get_editor(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+) -> Result<String, nu_protocol::ShellError> {
     let config = engine_state.get_config();
     let env_vars = stack.get_env_vars(engine_state);
     if !config.buffer_editor.is_empty() {
-        config.buffer_editor.clone()
+        Ok(config.buffer_editor.clone())
     } else if let Some(value) = env_vars.get("EDITOR") {
-        value.as_string().expect("Unknown type")
+        value.as_string()
     } else if let Some(value) = env_vars.get("VISUAL") {
-        value.as_string().expect("Unknown type")
+        value.as_string()
     } else if cfg!(target_os = "windows") {
-        "notepad".to_string()
+        Ok("notepad".to_string())
     } else {
-        "nano".to_string()
+        Ok("nano".to_string())
     }
 }


### PR DESCRIPTION
# Description
If `$EDITOR` or `$VISUAL` are not strings, nushell panics.

~~~
〉let-env EDITOR = ["not a string"]
〉config env
thread 'main' panicked at 'Unknown type: CantConvert("string", "list<string>", Span { start: 3821, end: 3832 }, None)', crates/nu-command/src/env/config/utils.rs:9:27
~~~

After this change, a proper error message is shown.

~~~
〉let-env EDITOR = ["not a string"]
〉config env
Error: nu::shell::cant_convert (link)

  × Can't convert to string.
   ╭─[entry #2:1:1]
 1 │ let-env EDITOR = ["not a string"]
   ·                  ────────┬───────
   ·                          ╰── can't convert list<string> to string
   ╰────

~~~

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
