### PR TITLE
Completer: Fix fetch for CommandCompletions

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -170,7 +170,7 @@ impl Completer for CommandCompletion {
             .flattened
             .iter()
             .rev()
-            .skip_while(|x| x.0.end > pos)
+            .skip_while(|x| x.0.start >= pos)
             .take_while(|x| {
                 matches!(
                     x.1,
@@ -185,12 +185,10 @@ impl Completer for CommandCompletion {
 
         // The last item here would be the earliest shape that could possible by part of this subcommand
         let subcommands = if let Some(last) = last {
+            let last_span = Span::new(last.0.start, pos);
             self.complete_commands(
                 working_set,
-                Span {
-                    start: last.0.start,
-                    end: pos,
-                },
+                last_span,
                 offset,
                 false,
                 options.match_algorithm,

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -184,7 +184,7 @@ impl Completer for CommandCompletion {
             .last();
 
         // The last item here would be the earliest shape that could possible by part of this subcommand
-        let subcommands = if let Some(last) = last {
+        if let Some(subcommands) = last.map(|last| {
             let last_span = Span::new(last.0.start, pos);
             self.complete_commands(
                 working_set,
@@ -193,18 +193,15 @@ impl Completer for CommandCompletion {
                 false,
                 options.match_algorithm,
             )
-        } else {
-            vec![]
-        };
-
-        if !subcommands.is_empty() {
+        }) {
             return subcommands;
         }
 
         let config = working_set.get_config();
-        let commands = if matches!(self.flat_shape, nu_parser::FlatShape::External)
-            || matches!(self.flat_shape, nu_parser::FlatShape::InternalCall)
-            || ((span.end - span.start) == 0)
+        let commands = if matches!(
+            self.flat_shape,
+            nu_parser::FlatShape::External | nu_parser::FlatShape::InternalCall
+        ) || ((span.end - span.start) == 0)
         {
             // we're in a gap or at a command
             if working_set.get_span_contents(span).is_empty() && !self.force_completion_after_space
@@ -222,10 +219,7 @@ impl Completer for CommandCompletion {
             vec![]
         };
 
-        subcommands
-            .into_iter()
-            .chain(commands.into_iter())
-            .collect::<Vec<_>>()
+        commands
     }
 
     fn get_sort_by(&self) -> SortBy {

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -28,6 +28,10 @@ impl From<Span> for SourceSpan {
 
 impl Span {
     pub fn new(start: usize, end: usize) -> Span {
+        debug_assert!(
+            start <= end,
+            "a span must reflect a valid slice (begin <= end)"
+        );
         Span { start, end }
     }
 

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -28,10 +28,6 @@ impl From<Span> for SourceSpan {
 
 impl Span {
     pub fn new(start: usize, end: usize) -> Span {
-        debug_assert!(
-            start <= end,
-            "a span must reflect a valid slice (begin <= end)"
-        );
         Span { start, end }
     }
 


### PR DESCRIPTION
# Description

Nushell crashes with panic due to invalid slicing into span content when completing with a pipeline.

1. ls -la | sele<Tab>
2. delete N chars (backspace)
3. Panic

Somewhere down the line as current line characters shrinks towards zero we see a crash with invalid slice indexing.

Last commit in this MR can be removed and discussed further in another MR.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
