### PR TITLE
Make `$` on variable names optional

### DIFF
--- a/crates/nu-command/src/dataframe/eager/append.rs
+++ b/crates/nu-command/src/dataframe/eager/append.rs
@@ -32,7 +32,7 @@ impl Command for AppendDF {
         vec![
             Example {
                 description: "Appends a dataframe as new columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | into df);
+                example: r#"let a = ([['a' 'b']; [1 2] [3 4]] | into df);
     $a | append $a"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -59,7 +59,7 @@ impl Command for AppendDF {
             },
             Example {
                 description: "Appends a dataframe merging at the end of columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | into df);
+                example: r#"let a = ([['a' 'b']; [1 2] [3 4]] | into df);
     $a | append $a --col"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -36,9 +36,9 @@ impl Command for DropNulls {
         vec![
             Example {
                 description: "drop null values in dataframe",
-                example: r#"let df = ([[a b]; [1 2] [3 0] [1 2]] | into df);
-    let res = ($df.b / $df.b);
-    let a = ($df | with-column $res --name res);
+                example: r#"let my_df = ([[a b]; [1 2] [3 0] [1 2]] | into df);
+    let res = ($my_df.b / $my_df.b);
+    let a = ($my_df | with-column $res --name 'res');
     $a | drop-nulls"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -38,9 +38,9 @@ impl Command for TakeDF {
         vec![
             Example {
                 description: "Takes selected rows from dataframe",
-                example: r#"let df = ([[a b]; [4 1] [5 2] [4 3]] | into df);
+                example: r#"let my_df = ([[a b]; [4 1] [5 2] [4 3]] | into df);
     let indices = ([0 2] | into df);
-    $df | take $indices"#,
+    $my_df | take $indices"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4017,6 +4017,23 @@ pub fn parse_value(
         return parse_variable_expr(working_set, span);
     }
 
+    let parsed_variable = parse_variable(working_set, span);
+    if parsed_variable.0.is_some() && parsed_variable.1.is_none() {
+        let var_id = parsed_variable
+            .0
+            .expect("internal error: already checked var id exists");
+        return (
+            Expression {
+                expr: Expr::Var(var_id),
+                span,
+                custom_completion: None,
+                ty: working_set.get_variable(var_id).ty.clone(),
+            },
+            None,
+        );
+    }
+    let bytes = working_set.get_span_contents(span);
+
     // Check for reserved keyword values
     match bytes {
         b"true" => {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4235,7 +4235,6 @@ pub fn parse_value(
                     SyntaxShape::Duration,
                     SyntaxShape::Record,
                     SyntaxShape::Block(None),
-                    SyntaxShape::Variable,
                     SyntaxShape::String,
                 ];
                 for shape in shapes.iter() {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -74,6 +74,10 @@ pub fn is_math_expression_like(
         return true;
     }
 
+    if bytes == b"nu" {
+        return false;
+    }
+
     let b = bytes[0];
 
     if b == b'('
@@ -112,6 +116,11 @@ pub fn is_math_expression_like(
         .1
         .is_none()
     {
+        return true;
+    }
+
+    let parsed_variable = parse_variable(working_set, span);
+    if parsed_variable.0.is_some() && parsed_variable.1.is_none() {
         return true;
     }
 
@@ -4209,6 +4218,7 @@ pub fn parse_value(
                     SyntaxShape::Duration,
                     SyntaxShape::Record,
                     SyntaxShape::Block(None),
+                    SyntaxShape::Variable,
                     SyntaxShape::String,
                 ];
                 for shape in shapes.iter() {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1508,13 +1508,21 @@ impl<'a> StateWorkingSet<'a> {
     pub fn find_variable(&self, name: &[u8]) -> Option<VarId> {
         let mut removed_overlays = vec![];
 
+        let name = if name.starts_with(&[b'$']) {
+            name.to_vec()
+        } else {
+            let mut new_name = name.to_vec();
+            new_name.insert(0, b'$');
+            new_name
+        };
+
         for scope_frame in self.delta.scope.iter().rev() {
             for overlay_frame in scope_frame
                 .active_overlays(&mut removed_overlays)
                 .iter()
                 .rev()
             {
-                if let Some(var_id) = overlay_frame.vars.get(name) {
+                if let Some(var_id) = overlay_frame.vars.get(&name) {
                     return Some(*var_id);
                 }
             }
@@ -1526,7 +1534,7 @@ impl<'a> StateWorkingSet<'a> {
             .iter()
             .rev()
         {
-            if let Some(var_id) = overlay_frame.vars.get(name) {
+            if let Some(var_id) = overlay_frame.vars.get(&name) {
                 return Some(*var_id);
             }
         }


### PR DESCRIPTION
# Description

This makes the dollar sign optional for vars (except in the case of an external):

```
> let x = 10
> x + 5
15
```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
