### PR TITLE
shows wrong item when each command runs to failed.

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -765,6 +765,12 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("Unexpected abbr component `{0}`.")]
     #[diagnostic(code(nu::shell::unexpected_path_abbreviateion), url(docsrs))]
     UnexpectedAbbrComponent(String),
+
+    // It should be only used by commands accepts block, and accept inputs from pipeline.
+    /// Failed to eval block with specific pipeline input.
+    #[error("Eval block failed with pipeline input")]
+    #[diagnostic(code(nu::shell::eval_block_with_input), url(docsrs))]
+    EvalBlockWithInput(#[label("Invalid item")] Span, #[related] Vec<ShellError>),
 }
 
 impl From<std::io::Error> for ShellError {

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -53,7 +53,7 @@ fn in_and_if_else() -> TestResult {
 
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
-    run_test(r#"each --help | lines | length"#, "37")
+    run_test(r#"each --help | lines | length"#, "32")
 }
 
 #[test]

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -53,7 +53,7 @@ fn in_and_if_else() -> TestResult {
 
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
-    run_test(r#"each --help | lines | length"#, "32")
+    run_test(r#"each --help | lines | length"#, "37")
 }
 
 #[test]


### PR DESCRIPTION
# Description

~As title: add `--wrong-item` for each command, it's useful for each block contains only one command~
As title: shows wrong item when each command runs to failed.
Closes: #6429 

## Screenshot


Current implementation:
<img width="696" alt="图片" src="https://user-images.githubusercontent.com/22256154/187063885-a3bffa6b-1e28-4886-b4c7-a13f83651804.png">

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
