### PR TITLE
shows wrong item when some commands runs to failed.

### DIFF
--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -1,9 +1,10 @@
+use super::utils::chain_error_with_input;
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, Span, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
+    Span, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -172,7 +173,7 @@ impl Command for Each {
                     ) {
                         Ok(v) => v.into_value(span),
                         Err(error) => {
-                            let error = each_cmd_error(error, input_span);
+                            let error = chain_error_with_input(error, input_span);
                             Value::Error { error }
                         }
                     }
@@ -227,7 +228,7 @@ impl Command for Each {
                     ) {
                         Ok(v) => v.into_value(span),
                         Err(error) => {
-                            let error = each_cmd_error(error, input_span);
+                            let error = chain_error_with_input(error, input_span);
                             Value::Error { error }
                         }
                     }
@@ -258,13 +259,6 @@ impl Command for Each {
         })
         .map(|x| x.set_metadata(metadata))
     }
-}
-
-fn each_cmd_error(error_source: ShellError, input_span: Result<Span, ShellError>) -> ShellError {
-    if let Ok(span) = input_span {
-        return ShellError::EvalBlockWithInput(span, vec![error_source]);
-    }
-    error_source
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/mod.rs
+++ b/crates/nu-command/src/filters/mod.rs
@@ -44,6 +44,7 @@ mod uniq;
 mod update;
 mod update_cells;
 mod upsert;
+mod utils;
 mod where_;
 mod window;
 mod wrap;

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -7,6 +7,8 @@ use nu_protocol::{
 };
 use rayon::prelude::*;
 
+use super::utils::chain_error_with_input;
+
 #[derive(Clone)]
 pub struct ParEach;
 
@@ -103,6 +105,7 @@ impl Command for ParEach {
                         }
                     }
 
+                    let val_span = x.span();
                     match eval_block(
                         &engine_state,
                         &mut stack,
@@ -112,7 +115,10 @@ impl Command for ParEach {
                         redirect_stderr,
                     ) {
                         Ok(v) => v,
-                        Err(error) => Value::Error { error }.into_pipeline_data(),
+                        Err(error) => Value::Error {
+                            error: chain_error_with_input(error, val_span),
+                        }
+                        .into_pipeline_data(),
                     }
                 })
                 .collect::<Vec<_>>()
@@ -151,6 +157,7 @@ impl Command for ParEach {
                         }
                     }
 
+                    let val_span = x.span();
                     match eval_block(
                         &engine_state,
                         &mut stack,
@@ -160,7 +167,10 @@ impl Command for ParEach {
                         redirect_stderr,
                     ) {
                         Ok(v) => v,
-                        Err(error) => Value::Error { error }.into_pipeline_data(),
+                        Err(error) => Value::Error {
+                            error: chain_error_with_input(error, val_span),
+                        }
+                        .into_pipeline_data(),
                     }
                 })
                 .collect::<Vec<_>>()
@@ -198,6 +208,7 @@ impl Command for ParEach {
                         }
                     }
 
+                    let val_span = x.span();
                     match eval_block(
                         &engine_state,
                         &mut stack,
@@ -207,7 +218,10 @@ impl Command for ParEach {
                         redirect_stderr,
                     ) {
                         Ok(v) => v,
-                        Err(error) => Value::Error { error }.into_pipeline_data(),
+                        Err(error) => Value::Error {
+                            error: chain_error_with_input(error, val_span),
+                        }
+                        .into_pipeline_data(),
                     }
                 })
                 .collect::<Vec<_>>()

--- a/crates/nu-command/src/filters/utils.rs
+++ b/crates/nu-command/src/filters/utils.rs
@@ -1,0 +1,11 @@
+use nu_protocol::{ShellError, Span};
+
+pub fn chain_error_with_input(
+    error_source: ShellError,
+    input_span: Result<Span, ShellError>,
+) -> ShellError {
+    if let Ok(span) = input_span {
+        return ShellError::EvalBlockWithInput(span, vec![error_source]);
+    }
+    error_source
+}

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -1,3 +1,4 @@
+use super::utils::chain_error_with_input;
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
@@ -83,7 +84,9 @@ impl Command for Where {
                                     None
                                 }
                             }
-                            Err(error) => Some(Value::Error { error }),
+                            Err(error) => Some(Value::Error {
+                                error: chain_error_with_input(error, x.span()),
+                            }),
                         }
                     })
                     .into_pipeline_data(ctrlc)),
@@ -124,7 +127,9 @@ impl Command for Where {
                                     None
                                 }
                             }
-                            Err(error) => Some(Value::Error { error }),
+                            Err(error) => Some(Value::Error {
+                                error: chain_error_with_input(error, x.span()),
+                            }),
                         }
                     })
                     .into_pipeline_data(ctrlc)),
@@ -149,7 +154,9 @@ impl Command for Where {
                                 None
                             }
                         }
-                        Err(error) => Some(Value::Error { error }),
+                        Err(error) => Some(Value::Error {
+                            error: chain_error_with_input(error, x.span()),
+                        }),
                     }
                     .into_pipeline_data(ctrlc))
                 }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -770,7 +770,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     /// Failed to eval block with specific pipeline input.
     #[error("Eval block failed with pipeline input")]
     #[diagnostic(code(nu::shell::eval_block_with_input), url(docsrs))]
-    EvalBlockWithInput(#[label("Invalid item")] Span, #[related] Vec<ShellError>),
+    EvalBlockWithInput(#[label("source value")] Span, #[related] Vec<ShellError>),
 }
 
 impl From<std::io::Error> for ShellError {


### PR DESCRIPTION
# Description

Take the idea from #6429, make more commands show wrong item when relative block runs to failed

## par-each
### Before
```
❯ [1 2 3] | par-each -n { |it| if $it.item > "asodfjaos" { echo $"found 2 at ($it.index)!"} }
Error: nu::shell::type_mismatch (link)

  × Type mismatch
   ╭─[entry #1:1:1]
 1 │ [1 2 3] | par-each -n { |it| if $it.item > "asodfjaos" { echo $"found 2 at ($it.index)!"} }
   ·                                          ┬
   ·                                          ╰── needs compatible type
   ╰────

```

### After
```
❯ [1 2 3] | par-each -n { |it| if $it.item > "asodfjaos" { echo $"found 2 at ($it.index)!"} }
Error: nu::shell::eval_block_with_input (link)

  × Eval block failed with pipeline input
   ╭─[entry #20:1:1]
 1 │ [1 2 3] | par-each -n { |it| if $it.item > "asodfjaos" { echo $"found 2 at ($it.index)!"} }
   ·  ┬
   ·  ╰── Invalid item
   ╰────

Error: nu::shell::type_mismatch (link)

  × Type mismatch
   ╭─[entry #20:1:1]
 1 │ [1 2 3] | par-each -n { |it| if $it.item > "asodfjaos" { echo $"found 2 at ($it.index)!"} }
   ·                                          ┬
   ·                                          ╰── needs compatible type
   ╰────

```

## where with `-b`
```
let a = {($in | get 2) > 3}
```
### Before
```
Error: nu::shell::access_beyond_end (link)

  × Row number too large (max: 2).
   ╭─[entry #3:1:1]
 1 │ let a = {($in | get 2) > 3}
   ·                     ┬
   ·                     ╰── index too large (max: 2)
   ╰────

```
### After
```
❯ [[1 2] [1 2 3] 4 5] | where -b $a
Error: nu::shell::eval_block_with_input (link)

  × Eval block failed with pipeline input
   ╭─[entry #36:1:1]
 1 │ [[1 2] [1 2 3] 4 5] | where -b $a
   ·  ──┬──
   ·    ╰── Invalid item
   ╰────

Error: nu::shell::access_beyond_end (link)

  × Row number too large (max: 2).
   ╭─[entry #35:1:1]
 1 │ let a = {($in | get 2) > 3}
   ·                     ┬
   ·                     ╰── index too large (max: 2)
   ╰────

```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
