### PR TITLE
Upgrade `which` dependency to fix case on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5638,13 +5638,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -86,7 +86,7 @@ toml = "0.5.8"
 unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "1.1.2", features = ["v4"] }
-which = { version = "4.2.2", optional = true }
+which = { version = "4.3.0", optional = true }
 reedline = { version = "0.10.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }


### PR DESCRIPTION
# Description

Closes #6208. Just bumping our `which` dependency to fix an issue where the file extensions of `which` results was displayed incorrectly on Windows - previously they were always displayed in uppercase regardless of the case actually used on disk.

Details in [this `which` issue](https://github.com/harryfei/which-rs/issues/54).

### Before

![image](https://user-images.githubusercontent.com/26268125/187729523-cd7dae83-c9ac-4731-af7b-fb447e61d1c0.png)

### After

![image](https://user-images.githubusercontent.com/26268125/187729684-8b02e217-ded2-4570-a587-4d964f404667.png)

# Tests

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
