### PR TITLE
Allow for rejecting nested record cells

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -83,10 +83,16 @@ fn reject(
     _engine_state: &EngineState,
     span: Span,
     input: PipelineData,
-    columns: Vec<CellPath>,
+    cell_paths: Vec<CellPath>,
 ) -> Result<PipelineData, ShellError> {
     let val = input.into_value(span);
     let mut val = val;
+    let mut columns = vec![];
+    for c in cell_paths {
+        if !columns.contains(&c) {
+            columns.push(c);
+        }
+    }
     for cell_path in columns {
         val.remove_data_at_cell_path(&cell_path.members)?;
     }

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -2,8 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData,
-    ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Value,
 };
 
 #[derive(Clone)]
@@ -66,8 +66,11 @@ impl Command for Reject {
                     cols: vec!["a".into()],
                     vals: vec![Value::Record {
                         cols: vec!["c".into()],
-                        vals: vec![Value::Int { val: 5, span: Span::test_data() }],
-                        span: Span::test_data()
+                        vals: vec![Value::Int {
+                            val: 5,
+                            span: Span::test_data(),
+                        }],
+                        span: Span::test_data(),
                     }],
                     span: Span::test_data(),
                 }),

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, FromValue, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
+    Category, Example, IntoPipelineData, PipelineData,
     ShellError, Signature, Span, SyntaxShape, Value,
 };
 
@@ -18,7 +18,7 @@ impl Command for Reject {
         Signature::build("reject")
             .rest(
                 "rest",
-                SyntaxShape::String,
+                SyntaxShape::CellPath,
                 "the names of columns to remove from the table",
             )
             .category(Category::Filters)
@@ -35,7 +35,7 @@ impl Command for Reject {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let columns: Vec<String> = call.rest(engine_state, stack, 0)?;
+        let columns: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let span = call.head;
         reject(engine_state, span, input, columns)
     }
@@ -64,146 +64,17 @@ impl Command for Reject {
 }
 
 fn reject(
-    engine_state: &EngineState,
+    _engine_state: &EngineState,
     span: Span,
     input: PipelineData,
-    columns: Vec<String>,
+    columns: Vec<CellPath>,
 ) -> Result<PipelineData, ShellError> {
-    if columns.is_empty() {
-        return Err(ShellError::CantFindColumn(span, span));
+    let val = input.into_value(span);
+    let mut val = val;
+    for cell_path in columns {
+        val.remove_data_at_cell_path(&cell_path.members)?;
     }
-    let metadata = input.metadata();
-
-    let mut keep_columns = vec![];
-
-    match input {
-        PipelineData::Value(
-            Value::List {
-                vals: input_vals,
-                span,
-            },
-            ..,
-        ) => {
-            let mut output = vec![];
-            let input_cols = get_input_cols(input_vals.clone());
-            let kc = get_keep_columns(input_cols, columns);
-            keep_columns = get_cellpath_columns(kc, span);
-
-            for input_val in input_vals {
-                let mut cols = vec![];
-                let mut vals = vec![];
-
-                for path in &keep_columns {
-                    let fetcher = input_val.clone().follow_cell_path(&path.members, false);
-
-                    if let Ok(value) = fetcher {
-                        cols.push(path.into_string());
-                        vals.push(value);
-                    }
-                }
-                output.push(Value::Record { cols, vals, span })
-            }
-
-            Ok(output
-                .into_iter()
-                .into_pipeline_data(engine_state.ctrlc.clone()))
-        }
-        PipelineData::Value(
-            Value::Record {
-                mut cols,
-                mut vals,
-                span,
-            },
-            metadata,
-        ) => {
-            reject_record_columns(&mut cols, &mut vals, &columns);
-
-            let record = Value::Record { cols, vals, span };
-
-            Ok(PipelineData::Value(record, metadata))
-        }
-        PipelineData::ListStream(stream, ..) => {
-            let mut output = vec![];
-
-            let v: Vec<_> = stream.into_iter().collect();
-            let input_cols = get_input_cols(v.clone());
-            let kc = get_keep_columns(input_cols, columns);
-            keep_columns = get_cellpath_columns(kc, span);
-
-            for input_val in v {
-                let mut cols = vec![];
-                let mut vals = vec![];
-
-                for path in &keep_columns {
-                    let fetcher = input_val.clone().follow_cell_path(&path.members, false)?;
-                    cols.push(path.into_string());
-                    vals.push(fetcher);
-                }
-                output.push(Value::Record { cols, vals, span })
-            }
-
-            Ok(output
-                .into_iter()
-                .into_pipeline_data(engine_state.ctrlc.clone()))
-        }
-        PipelineData::Value(v, ..) => {
-            let mut cols = vec![];
-            let mut vals = vec![];
-
-            for cell_path in &keep_columns {
-                let result = v.clone().follow_cell_path(&cell_path.members, false)?;
-
-                cols.push(cell_path.into_string());
-                vals.push(result);
-            }
-
-            Ok(Value::Record { cols, vals, span }.into_pipeline_data())
-        }
-        x => Ok(x),
-    }
-    .map(|x| x.set_metadata(metadata))
-}
-
-fn get_input_cols(input: Vec<Value>) -> Vec<String> {
-    let rec = input.first();
-    match rec {
-        Some(Value::Record { cols, vals: _, .. }) => cols.to_vec(),
-        _ => vec!["".to_string()],
-    }
-}
-
-fn get_cellpath_columns(keep_cols: Vec<String>, span: Span) -> Vec<CellPath> {
-    let mut output = vec![];
-    for keep_col in keep_cols {
-        let val = Value::String {
-            val: keep_col,
-            span,
-        };
-        let cell_path = match CellPath::from_value(&val) {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-        output.push(cell_path);
-    }
-    output
-}
-
-fn get_keep_columns(mut input: Vec<String>, rejects: Vec<String>) -> Vec<String> {
-    for reject in rejects {
-        if let Some(index) = input.iter().position(|value| *value == reject) {
-            input.remove(index);
-        }
-    }
-    input
-}
-
-fn reject_record_columns(cols: &mut Vec<String>, vals: &mut Vec<Value>, rejects: &[String]) {
-    for reject in rejects {
-        if let Some(index) = cols.iter().position(|value| value == reject) {
-            cols.remove(index);
-            vals.remove(index);
-        }
-    }
+    Ok(val.into_pipeline_data())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -59,6 +59,19 @@ impl Command for Reject {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Reject a nested field in a record",
+                example: "echo {a: {b: 3,c: 5}} | reject a.b",
+                result: Some(Value::Record {
+                    cols: vec!["a".into()],
+                    vals: vec![Value::Record {
+                        cols: vec!["c".into()],
+                        vals: vec![Value::Int { val: 5, span: Span::test_data() }],
+                        span: Span::test_data()
+                    }],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -107,3 +107,16 @@ fn reject_table_from_raw_eval() {
 
     assert!(actual.out.contains("record 0 fields"));
 }
+
+#[test]
+fn reject_nested_field() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+            {a:{b:3,c:5}} | reject a.b | debug
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "{a: {c: 5}}");
+}

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -925,12 +925,9 @@ impl Value {
         }
         Ok(())
     }
-    
-    pub fn remove_data_at_cell_path(
-        &mut self,
-        cell_path: &[PathMember],
-    ) -> Result<(), ShellError> {
-    	if cell_path.len() > 1 {
+
+    pub fn remove_data_at_cell_path(&mut self, cell_path: &[PathMember]) -> Result<(), ShellError> {
+        if cell_path.len() > 1 {
             let path_member = cell_path.first().expect("there is a first");
             match path_member {
                 PathMember::String {
@@ -949,9 +946,7 @@ impl Value {
                                     for col in cols.iter().zip(vals.iter_mut()) {
                                         if col.0 == col_name {
                                             found = true;
-                                            col.1.remove_data_at_cell_path(
-                                                &cell_path[1..],
-                                            )?
+                                            col.1.remove_data_at_cell_path(&cell_path[1..])?
                                         }
                                     }
                                     if !found {
@@ -973,8 +968,7 @@ impl Value {
                             if col.0 == col_name {
                                 found = true;
 
-                                col.1
-                                    .remove_data_at_cell_path(&cell_path[1..])?
+                                col.1.remove_data_at_cell_path(&cell_path[1..])?
                             }
                         }
                         if !found {
@@ -1013,7 +1007,7 @@ impl Value {
                                         if col == col_name {
                                             cols.remove(i);
                                             vals.remove(i);
-                                            return Ok(())
+                                            return Ok(());
                                         }
                                     }
                                     return Err(ShellError::CantFindColumn(*span, *v_span));
@@ -1031,7 +1025,7 @@ impl Value {
                             if col == col_name {
                                 cols.remove(i);
                                 vals.remove(i);
-                                return Ok(())
+                                return Ok(());
                             }
                         }
                         return Err(ShellError::CantFindColumn(*span, *v_span));
@@ -1050,7 +1044,7 @@ impl Value {
                     v => return Err(ShellError::NotAList(*span, v.span()?)),
                 },
             }
-        } 
+        }
         Ok(())
     }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -925,6 +925,134 @@ impl Value {
         }
         Ok(())
     }
+    
+    pub fn remove_data_at_cell_path(
+        &mut self,
+        cell_path: &[PathMember],
+    ) -> Result<(), ShellError> {
+    	if cell_path.len() > 1 {
+            let path_member = cell_path.first().expect("there is a first");
+            match path_member {
+                PathMember::String {
+                    val: col_name,
+                    span,
+                } => match self {
+                    Value::List { vals, .. } => {
+                        for val in vals.iter_mut() {
+                            match val {
+                                Value::Record {
+                                    cols,
+                                    vals,
+                                    span: v_span,
+                                } => {
+                                    let mut found = false;
+                                    for col in cols.iter().zip(vals.iter_mut()) {
+                                        if col.0 == col_name {
+                                            found = true;
+                                            col.1.remove_data_at_cell_path(
+                                                &cell_path[1..],
+                                            )?
+                                        }
+                                    }
+                                    if !found {
+                                        return Err(ShellError::CantFindColumn(*span, *v_span));
+                                    }
+                                }
+                                v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                            }
+                        }
+                    }
+                    Value::Record {
+                        cols,
+                        vals,
+                        span: v_span,
+                    } => {
+                        let mut found = false;
+
+                        for col in cols.iter().zip(vals.iter_mut()) {
+                            if col.0 == col_name {
+                                found = true;
+
+                                col.1
+                                    .remove_data_at_cell_path(&cell_path[1..])?
+                            }
+                        }
+                        if !found {
+                            return Err(ShellError::CantFindColumn(*span, *v_span));
+                        }
+                    }
+                    v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                },
+                PathMember::Int { val: row_num, span } => match self {
+                    Value::List { vals, .. } => {
+                        if let Some(v) = vals.get_mut(*row_num) {
+                            v.remove_data_at_cell_path(&cell_path[1..])?
+                        } else {
+                            return Err(ShellError::AccessBeyondEnd(vals.len(), *span));
+                        }
+                    }
+                    v => return Err(ShellError::NotAList(*span, v.span()?)),
+                },
+            }
+        } else if cell_path.len() == 1 {
+            let path_member = cell_path.first().expect("there is a first");
+            match path_member {
+                PathMember::String {
+                    val: col_name,
+                    span,
+                } => match self {
+                    Value::List { vals, .. } => {
+                        for val in vals.iter_mut() {
+                            match val {
+                                Value::Record {
+                                    cols,
+                                    vals,
+                                    span: v_span,
+                                } => {
+                                    for (i, col) in cols.iter().enumerate() {
+                                        if col == col_name {
+                                            cols.remove(i);
+                                            vals.remove(i);
+                                            return Ok(())
+                                        }
+                                    }
+                                    return Err(ShellError::CantFindColumn(*span, *v_span));
+                                }
+                                v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                            }
+                        }
+                    }
+                    Value::Record {
+                        cols,
+                        vals,
+                        span: v_span,
+                    } => {
+                        for (i, col) in cols.iter().enumerate() {
+                            if col == col_name {
+                                cols.remove(i);
+                                vals.remove(i);
+                                return Ok(())
+                            }
+                        }
+                        return Err(ShellError::CantFindColumn(*span, *v_span));
+                    }
+                    v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                },
+                PathMember::Int { val: row_num, span } => match self {
+                    Value::List { vals, .. } => {
+                        if let Some(_) = vals.get_mut(*row_num) {
+                            vals.remove(*row_num);
+                            return Ok(());
+                        } else {
+                            return Err(ShellError::AccessBeyondEnd(vals.len(), *span));
+                        }
+                    }
+                    v => return Err(ShellError::NotAList(*span, v.span()?)),
+                },
+            }
+        } 
+        Ok(())
+    }
 
     pub fn insert_data_at_cell_path(
         &mut self,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1034,7 +1034,7 @@ impl Value {
                 },
                 PathMember::Int { val: row_num, span } => match self {
                     Value::List { vals, .. } => {
-                        if let Some(_) = vals.get_mut(*row_num) {
+                        if vals.get_mut(*row_num).is_some() {
                             vals.remove(*row_num);
                             return Ok(());
                         } else {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -959,7 +959,7 @@ impl Value {
                                     v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
                                 }
                             }
-                            return Ok(());
+                            Ok(())
                         }
                         Value::Record {
                             cols,
@@ -979,18 +979,18 @@ impl Value {
                             }
                             Ok(())
                         }
-                        v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                        v => Err(ShellError::CantFindColumn(*span, v.span()?)),
                     },
                     PathMember::Int { val: row_num, span } => match self {
                         Value::List { vals, .. } => {
                             if vals.get_mut(*row_num).is_some() {
                                 vals.remove(*row_num);
-                                return Ok(());
+                                Ok(())
                             } else {
-                                return Err(ShellError::AccessBeyondEnd(vals.len(), *span));
+                                Err(ShellError::AccessBeyondEnd(vals.len(), *span))
                             }
                         }
-                        v => return Err(ShellError::NotAList(*span, v.span()?)),
+                        v => Err(ShellError::NotAList(*span, v.span()?)),
                     },
                 }
             }
@@ -1023,7 +1023,7 @@ impl Value {
                                     v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
                                 }
                             }
-                            return Ok(());
+                            Ok(())
                         }
                         Value::Record {
                             cols,
@@ -1044,17 +1044,17 @@ impl Value {
                             }
                             Ok(())
                         }
-                        v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                        v => Err(ShellError::CantFindColumn(*span, v.span()?)),
                     },
                     PathMember::Int { val: row_num, span } => match self {
                         Value::List { vals, .. } => {
                             if let Some(v) = vals.get_mut(*row_num) {
                                 v.remove_data_at_cell_path(&cell_path[1..])
                             } else {
-                                return Err(ShellError::AccessBeyondEnd(vals.len(), *span));
+                                Err(ShellError::AccessBeyondEnd(vals.len(), *span))
                             }
                         }
-                        v => return Err(ShellError::NotAList(*span, v.span()?)),
+                        v => Err(ShellError::NotAList(*span, v.span()?)),
                     },
                 }
             }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1003,14 +1003,17 @@ impl Value {
                                     vals,
                                     span: v_span,
                                 } => {
-                                    for (i, col) in cols.iter().enumerate() {
+                                    let mut found = false;
+                                    for (i, col) in cols.clone().iter().enumerate() {
                                         if col == col_name {
                                             cols.remove(i);
                                             vals.remove(i);
-                                            return Ok(());
+                                            found = true;
                                         }
                                     }
-                                    return Err(ShellError::CantFindColumn(*span, *v_span));
+                                    if !found {
+                                        return Err(ShellError::CantFindColumn(*span, *v_span));
+                                    }
                                 }
                                 v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
                             }
@@ -1021,14 +1024,17 @@ impl Value {
                         vals,
                         span: v_span,
                     } => {
-                        for (i, col) in cols.iter().enumerate() {
+                        let mut found = false;
+                        for (i, col) in cols.clone().iter().enumerate() {
                             if col == col_name {
                                 cols.remove(i);
                                 vals.remove(i);
-                                return Ok(());
+                                found = true;
                             }
                         }
-                        return Err(ShellError::CantFindColumn(*span, *v_span));
+                        if !found {
+                            return Err(ShellError::CantFindColumn(*span, *v_span));
+                        }
                     }
                     v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
                 },


### PR DESCRIPTION
# Description

Title, Fixes #6410.
We now can `reject a.b`.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
