### PR TITLE
Rename `all?`, `any?` and `empty?`

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -50,7 +50,7 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
 # Build for Windows without static-link-openssl feature
 # ----------------------------------------------------------------------------
 if $os in ['windows-latest'] {
-    if ($flags | str trim | empty?) {
+    if ($flags | str trim | is-empty) {
         cargo build --release --all --target $target --features=extra
     } else {
         cargo build --release --all --target $target --features=extra $flags
@@ -80,7 +80,7 @@ let ver = if $os == 'windows-latest' {
 } else {
     (do -i { ./output/nu -c 'version' }) | str collect
 }
-if ($ver | str trim | empty?) {
+if ($ver | str trim | is-empty) {
     $'(ansi r)Incompatible nu binary...(ansi reset)'
 } else { $ver }
 
@@ -124,14 +124,14 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
         7z a $archive *
         print $'archive: ---> ($archive)';
         let pkg = (ls -f $archive | get name)
-        if not ($pkg | empty?) {
+        if not ($pkg | is-empty) {
             echo $'::set-output name=archive::($pkg | get 0)'
         }
     }
 }
 
 def 'cargo-build-nu' [ options: string ] {
-    if ($options | str trim | empty?) {
+    if ($options | str trim | is-empty) {
         cargo build --release --all --target $target --features=extra,static-link-openssl
     } else {
         cargo build --release --all --target $target --features=extra,static-link-openssl $options

--- a/crates/nu-command/src/deprecated/deprecated_commands.rs
+++ b/crates/nu-command/src/deprecated/deprecated_commands.rs
@@ -5,11 +5,14 @@ use std::collections::HashMap;
 /// subcommands like `foo bar` where `foo` is still a valid command.
 /// For those, it's currently easiest to have a "stub" command that just returns an error.
 pub fn deprecated_commands() -> HashMap<String, String> {
-    let mut commands = HashMap::new();
-    commands.insert("keep".to_string(), "take".to_string());
-    commands.insert("match".to_string(), "find".to_string());
-    commands.insert("nth".to_string(), "select".to_string());
-    commands.insert("pivot".to_string(), "transpose".to_string());
-    commands.insert("unalias".to_string(), "hide".to_string());
-    commands
+    HashMap::from([
+        ("keep".to_string(), "take".to_string()),
+        ("match".to_string(), "find".to_string()),
+        ("nth".to_string(), "select".to_string()),
+        ("pivot".to_string(), "transpose".to_string()),
+        ("unalias".to_string(), "hide".to_string()),
+        ("all?".to_string(), "all".to_string()),
+        ("any?".to_string(), "any".to_string()),
+        ("empty?".to_string(), "is-empty".to_string()),
+    ])
 }

--- a/crates/nu-command/src/env/env_command.rs
+++ b/crates/nu-command/src/env/env_command.rs
@@ -75,7 +75,7 @@ impl Command for Env {
             },
             Example {
                 description: "Check whether the env variable `MY_ENV_ABC` exists",
-                example: r#"env | any? name == MY_ENV_ABC"#,
+                example: r#"env | any name == MY_ENV_ABC"#,
                 result: Some(Value::test_bool(false)),
             },
             Example {

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -10,7 +10,7 @@ pub struct All;
 
 impl Command for All {
     fn name(&self) -> &str {
-        "all?"
+        "all"
     }
 
     fn signature(&self) -> Signature {
@@ -35,12 +35,12 @@ impl Command for All {
         vec![
             Example {
                 description: "Find if services are running",
-                example: "echo [[status]; [UP] [UP]] | all? status == UP",
+                example: "echo [[status]; [UP] [UP]] | all status == UP",
                 result: Some(Value::test_bool(true)),
             },
             Example {
                 description: "Check that all values are even",
-                example: "echo [2 4 6 8] | all? ($it mod 2) == 0",
+                example: "echo [2 4 6 8] | all ($it mod 2) == 0",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -10,7 +10,7 @@ pub struct Any;
 
 impl Command for Any {
     fn name(&self) -> &str {
-        "any?"
+        "any"
     }
 
     fn signature(&self) -> Signature {
@@ -35,12 +35,12 @@ impl Command for Any {
         vec![
             Example {
                 description: "Find if a service is not running",
-                example: "echo [[status]; [UP] [DOWN] [UP]] | any? status == DOWN",
+                example: "echo [[status]; [UP] [DOWN] [UP]] | any status == DOWN",
                 result: Some(Value::test_bool(true)),
             },
             Example {
                 description: "Check if any of the values is odd",
-                example: "echo [2 4 1 6 8] | any? ($it mod 2) == 1",
+                example: "echo [2 4 1 6 8] | any ($it mod 2) == 1",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -10,11 +10,11 @@ pub struct Empty;
 
 impl Command for Empty {
     fn name(&self) -> &str {
-        "empty?"
+        "is-empty"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("empty?")
+        Signature::build("is-empty")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
@@ -41,7 +41,7 @@ impl Command for Empty {
         vec![
             Example {
                 description: "Check if a string is empty",
-                example: "'' | empty?",
+                example: "'' | is-empty",
                 result: Some(Value::Bool {
                     val: true,
                     span: Span::test_data(),
@@ -49,7 +49,7 @@ impl Command for Empty {
             },
             Example {
                 description: "Check if a list is empty",
-                example: "[] | empty?",
+                example: "[] | is-empty",
                 result: Some(Value::Bool {
                     val: true,
                     span: Span::test_data(),
@@ -58,7 +58,7 @@ impl Command for Empty {
             Example {
                 // TODO: revisit empty cell path semantics for a record.
                 description: "Check if more than one column are empty",
-                example: "[[meal size]; [arepa small] [taco '']] | empty? meal size",
+                example: "[[meal size]; [arepa small] [taco '']] | is-empty meal size",
                 result: Some(Value::Bool {
                     val: false,
                     span: Span::test_data(),

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -6,7 +6,7 @@ fn checks_all_rows_are_true() {
         cwd: ".", pipeline(
         r#"
                 echo  [ "Andrés", "Andrés", "Andrés" ]
-                | all? $it == "Andrés"
+                | all $it == "Andrés"
         "#
     ));
 
@@ -18,7 +18,7 @@ fn checks_all_rows_are_false_with_param() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-                [1, 2, 3, 4] | all? { |a| $a >= 5 }
+                [1, 2, 3, 4] | all { |a| $a >= 5 }
         "#
     ));
 
@@ -30,7 +30,7 @@ fn checks_all_rows_are_true_with_param() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-                [1, 2, 3, 4] | all? { |a| $a < 5 }
+                [1, 2, 3, 4] | all { |a| $a < 5 }
         "#
     ));
 
@@ -49,7 +49,7 @@ fn checks_all_columns_of_a_table_is_true() {
                         [      Darren, Schroeder, 10/11/2013,   1    ]
                         [      Yehuda,      Katz, 10/11/2013,   1    ]
                 ]
-                | all? likes > 0
+                | all likes > 0
         "#
     ));
 
@@ -61,7 +61,7 @@ fn checks_if_all_returns_error_with_invalid_command() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            [red orange yellow green blue purple] | all? ($it | st length) > 4
+            [red orange yellow green blue purple] | all ($it | st length) > 4
         "#
     ));
 

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -6,7 +6,7 @@ fn checks_any_row_is_true() {
         cwd: ".", pipeline(
         r#"
                 echo  [ "Ecuador", "USA", "New Zealand" ]
-                | any? $it == "New Zealand"
+                | any $it == "New Zealand"
         "#
     ));
 
@@ -25,7 +25,7 @@ fn checks_any_column_of_a_table_is_true() {
                         [      Darren, Schroeder, 10/11/2013,   1    ]
                         [      Yehuda,      Katz, 10/11/2013,   1    ]
                 ]
-                | any? rusty_at == 10/12/2013
+                | any rusty_at == 10/12/2013
         "#
     ));
 
@@ -37,7 +37,7 @@ fn checks_if_any_returns_error_with_invalid_command() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            [red orange yellow green blue purple] | any? ($it | st length) > 4
+            [red orange yellow green blue purple] | any ($it | st length) > 4
         "#
     ));
 

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -36,7 +36,7 @@ fn more_columns_than_table_has() {
               [3,  white]
               [8, yellow]
               [4,  white]
-            ] | drop column 3 | columns | empty?
+            ] | drop column 3 | columns | is-empty
         "#)
     );
 

--- a/crates/nu-command/tests/commands/empty.rs
+++ b/crates/nu-command/tests/commands/empty.rs
@@ -11,8 +11,8 @@ fn reports_emptiness() {
                      [([[check]; [{}] ])]
             ]
             | get are_empty
-            | all? {
-              empty? check
+            | all {
+              is-empty check
             }
         "#
     ));

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -373,7 +373,7 @@ fn parse_script_success_with_complex_internal_stream() {
                   #ls **/* | some_filter | grep-nu search
                   #open file.txt | grep-nu search
                 ] {
-                  if ($entrada | empty?) {
+                  if ($entrada | is-empty) {
                     if ($in | column? name) {
                       grep -ihHn $search ($in | get name)
                     } else {
@@ -422,7 +422,7 @@ fn parse_script_failure_with_complex_internal_stream() {
                   #ls **/* | some_filter | grep-nu search
                   #open file.txt | grep-nu search
                 ]
-                  if ($entrada | empty?) {
+                  if ($entrada | is-empty) {
                     if ($in | column? name) {
                       grep -ihHn $search ($in | get name)
                     } else {
@@ -471,7 +471,7 @@ fn parse_script_success_with_complex_external_stream() {
                   #ls **/* | some_filter | grep-nu search
                   #open file.txt | grep-nu search
                 ] {
-                  if ($entrada | empty?) {
+                  if ($entrada | is-empty) {
                     if ($in | column? name) {
                       grep -ihHn $search ($in | get name)
                     } else {
@@ -520,7 +520,7 @@ fn parse_module_success_with_complex_external_stream() {
                   #ls **/* | some_filter | grep-nu search
                   #open file.txt | grep-nu search
                 ] {
-                  if ($entrada | empty?) {
+                  if ($entrada | is-empty) {
                     if ($in | column? name) {
                       grep -ihHn $search ($in | get name)
                     } else {
@@ -569,7 +569,7 @@ fn parse_with_flag_all_success_for_complex_external_stream() {
                   #ls **/* | some_filter | grep-nu search
                   #open file.txt | grep-nu search
                 ] {
-                  if ($entrada | empty?) {
+                  if ($entrada | is-empty) {
                     if ($in | column? name) {
                       grep -ihHn $search ($in | get name)
                     } else {
@@ -618,7 +618,7 @@ fn parse_with_flag_all_failure_for_complex_external_stream() {
                   #ls **/* | some_filter | grep-nu search
                   #open file.txt | grep-nu search
                 ] {
-                  if ($entrada | empty?) {
+                  if ($entrada | is-empty) {
                     if ($in | column? name) {
                       grep -ihHn $search ($in | get name)
                     } else {
@@ -667,7 +667,7 @@ fn parse_with_flag_all_failure_for_complex_list_stream() {
                   #ls **/* | some_filter | grep-nu search
                   #open file.txt | grep-nu search
                 ] {
-                  if ($entrada | empty?) {
+                  if ($entrada | is-empty) {
                     if ($in | column? name) {
                       grep -ihHn $search ($in | get name)
                     } else {

--- a/crates/nu-command/tests/commands/zip.rs
+++ b/crates/nu-command/tests/commands/zip.rs
@@ -8,7 +8,7 @@ export def expect [
     --to-eq,
     right
 ] {
-    $left | zip $right | all? {|row|
+    $left | zip $right | all {|row|
         $row.name.0 == $row.name.1 && $row.commits.0 == $row.commits.1
     }
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -205,7 +205,7 @@ fn equals_separates_long_flag() -> TestResult {
 fn let_env_expressions() -> TestResult {
     let env = HashMap::from([("VENV_OLD_PATH", "Foobar"), ("Path", "Quux")]);
     run_test_with_env(
-        r#"let-env Path = if (env | any? name == VENV_OLD_PATH) { $env.VENV_OLD_PATH } else { $env.Path }; echo $env.Path"#,
+        r#"let-env Path = if (env | any name == VENV_OLD_PATH) { $env.VENV_OLD_PATH } else { $env.Path }; echo $env.Path"#,
         "Foobar",
         &env,
     )

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -191,7 +191,7 @@ fn run_custom_command_with_flag() {
     let actual = nu!(
         cwd: ".",
         r#"
-        def foo [--bar:number] { if ($bar | empty?) { echo "empty" } else { echo $bar } }; foo --bar 10
+        def foo [--bar:number] { if ($bar | is-empty) { echo "empty" } else { echo $bar } }; foo --bar 10
         "#
     );
 
@@ -203,7 +203,7 @@ fn run_custom_command_with_flag_missing() {
     let actual = nu!(
         cwd: ".",
         r#"
-        def foo [--bar:number] { if ($bar | empty?) { echo "empty" } else { echo $bar } }; foo
+        def foo [--bar:number] { if ($bar | is-empty) { echo "empty" } else { echo $bar } }; foo
         "#
     );
 


### PR DESCRIPTION
# Description
Rename `all?`, `any?` and `empty?` to `all`, `any` and `is-empty` for sake of simplicity and consistency.

- More understandable for newcomers, that these commands are no special to others.
- `?` syntax did not really aprove readability. For me it made it worse.
- We can reserve `?` syntax for any other nushell feature.

## Work to be done
If this we confirm this PR, we also should
- [x] Update deprecated commands 
- [x] Rename commands  in [nushell/nu_scripts](https://github.com/nushell/nu_scripts)
- [x] Update [nushell/nushell.github.io](https://github.com/nushell/nushell.github.io) / mention breaking changes
- [ ] Anything else ?

# Tests

Make sure you've done the following:

- [ ] ~~Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.~~
- [ ] ~~Try to think about corner cases and various ways how your changes could break. Cover them with tests.~~
- [ ] ~~If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.~~

Make sure you've run and fixed any issues with these commands:

- [ x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ x] `cargo test --workspace --features=extra` to check that all the tests pass
