### PR TITLE
Fix scoped `overlay use` not finding a module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "77e9c9abb82613923ec78d7a461595d52491ba7240f3c64c0bbe0e6d98e0fce0"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
 dependencies = [
  "libc",
 ]
@@ -1769,14 +1769,13 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
@@ -3149,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "77e9c9abb82613923ec78d7a461595d52491ba7240f3c64c0bbe0e6d98e0fce0"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -1769,13 +1769,14 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
@@ -3148,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "oorandom"

--- a/crates/nu-command/src/core_commands/overlay/list.rs
+++ b/crates/nu-command/src/core_commands/overlay/list.rs
@@ -4,8 +4,6 @@ use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
 };
 
-use log::trace;
-
 #[derive(Clone)]
 pub struct OverlayList;
 
@@ -28,40 +26,16 @@ impl Command for OverlayList {
 
     fn run(
         &self,
-        engine_state: &EngineState,
+        _engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let active_overlays_parser: Vec<Value> = engine_state
-            .active_overlay_names(&[])
-            .iter()
-            .map(|s| Value::string(String::from_utf8_lossy(s), call.head))
-            .collect();
-
         let active_overlays_engine: Vec<Value> = stack
             .active_overlays
             .iter()
             .map(|s| Value::string(s, call.head))
             .collect();
-
-        // Check if the overlays in the engine match the overlays in the parser
-        if (active_overlays_parser.len() != active_overlays_engine.len())
-            || active_overlays_parser
-                .iter()
-                .zip(active_overlays_engine.iter())
-                .any(|(op, oe)| op != oe)
-        {
-            trace!("parser overlays: {:?}", active_overlays_parser);
-            trace!("engine overlays: {:?}", active_overlays_engine);
-
-            return Err(ShellError::NushellFailedSpannedHelp(
-                "Overlay mismatch".into(),
-                "Active overlays do not match between the engine and the parser.".into(),
-                call.head,
-                "Run Nushell with --log-level=trace to see what went wrong.".into(),
-            ));
-        }
 
         Ok(Value::List {
             vals: active_overlays_engine,

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -265,6 +265,12 @@ fn convert_to_value(
             "imports not supported in nuon".into(),
             expr.span,
         )),
+        Expr::Overlay(..) => Err(ShellError::OutsideSpannedLabeledError(
+            original_text.to_string(),
+            "Error when loading".into(),
+            "overlays not supported in nuon".into(),
+            expr.span,
+        )),
         Expr::Int(val) => Ok(Value::Int { val, span }),
         Expr::Keyword(kw, ..) => Err(ShellError::OutsideSpannedLabeledError(
             original_text.to_string(),

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -141,3 +141,17 @@ fn sources_unicode_file_in_unicode_dir_with_spaces_2() {
 fn sources_unicode_file_in_non_utf8_dir() {
     // How do I create non-UTF-8 path???
 }
+
+#[test]
+fn can_source_dynamic_path() {
+    Playground::setup("can_source_dynamic_path", |dirs, sandbox| {
+        let foo_file = "foo.nu";
+
+        sandbox.with_files(vec![FileWithContent(&foo_file, "echo foo")]);
+
+        let cmd = format!("let file = `{}`; source-env $file", foo_file);
+        let actual = nu!(cwd: dirs.test(), &cmd);
+
+        assert_eq!(actual.out, "foo");
+    });
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -355,6 +355,15 @@ pub fn eval_expression(
             value.follow_cell_path(&cell_path.tail, false)
         }
         Expr::ImportPattern(_) => Ok(Value::Nothing { span: expr.span }),
+        Expr::Overlay(_) => {
+            let name =
+                String::from_utf8_lossy(engine_state.get_span_contents(&expr.span)).to_string();
+
+            Ok(Value::String {
+                val: name,
+                span: expr.span,
+            })
+        }
         Expr::Call(call) => {
             // FIXME: protect this collect with ctrl-c
             Ok(

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -260,6 +260,9 @@ pub fn flatten_expression(
 
             output
         }
+        Expr::Overlay(_) => {
+            vec![(expr.span, FlatShape::String)]
+        }
         Expr::Range(from, next, to, op) => {
             let mut output = vec![];
             if let Some(f) = from {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5221,6 +5221,7 @@ pub fn discover_captures_in_expr(
             output.extend(&result);
         }
         Expr::ImportPattern(_) => {}
+        Expr::Overlay(_) => {}
         Expr::Garbage => {}
         Expr::Nothing => {}
         Expr::GlobPattern(_) => {}

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -82,6 +82,10 @@ impl Call {
         self.positional_iter().nth(i)
     }
 
+    pub fn positional_nth_mut(&mut self, i: usize) -> Option<&mut Expression> {
+        self.positional_iter_mut().nth(i)
+    }
+
     pub fn positional_len(&self) -> usize {
         self.positional_iter().count()
     }

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -39,6 +39,7 @@ pub enum Expr {
     CellPath(CellPath),
     FullCellPath(Box<FullCellPath>),
     ImportPattern(ImportPattern),
+    Overlay(Option<BlockId>), // block ID of the overlay's origin module
     Signature(Box<Signature>),
     StringInterpolation(Vec<Expression>),
     Nothing,

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -169,6 +169,7 @@ impl Expression {
                 false
             }
             Expr::ImportPattern(_) => false,
+            Expr::Overlay(_) => false,
             Expr::Filepath(_) => false,
             Expr::Directory(_) => false,
             Expr::Float(_) => false,
@@ -337,6 +338,7 @@ impl Expression {
                     .replace_in_variable(working_set, new_var_id);
             }
             Expr::ImportPattern(_) => {}
+            Expr::Overlay(_) => {}
             Expr::Garbage => {}
             Expr::Nothing => {}
             Expr::GlobPattern(_) => {}
@@ -485,6 +487,7 @@ impl Expression {
                     .replace_span(working_set, replaced, new_span);
             }
             Expr::ImportPattern(_) => {}
+            Expr::Overlay(_) => {}
             Expr::Garbage => {}
             Expr::Nothing => {}
             Expr::GlobPattern(_) => {}

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -874,9 +874,7 @@ fn overlay_use_find_scoped_module() {
             "#;
 
         let actual = nu!(cwd: dirs.test(), inp);
-        // let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
         assert_eq!(actual.out, "spam");
-        // assert_eq!(actual_repl.out, "foo");
     })
 }

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -239,6 +239,24 @@ fn update_overlay_from_module_env() {
 }
 
 #[test]
+fn overlay_use_do_not_eval_twice() {
+    let inp = &[
+        r#"module spam { export env FOO { "foo" } }"#,
+        r#"overlay use spam"#,
+        r#"let-env FOO = "bar""#,
+        r#"overlay hide spam"#,
+        r#"overlay use spam"#,
+        r#"$env.FOO"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert_eq!(actual.out, "bar");
+    assert_eq!(actual_repl.out, "bar");
+}
+
+#[test]
 fn remove_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
@@ -843,23 +861,22 @@ fn overlay_use_dont_cd_overlay() {
     })
 }
 
-#[ignore]
 #[test]
-fn overlay_use_find_module_scoped() {
+fn overlay_use_find_scoped_module() {
     Playground::setup("overlay_use_find_module_scoped", |dirs, _| {
-        let inp = &[r#"
+        let inp = r#"
                 do {
-                    module spam { export def foo [] { 'foo' } }
+                    module spam { }
 
                     overlay use spam
-                    foo
+                    overlay list | last
                 }
-            "#];
+            "#;
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
-        let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+        let actual = nu!(cwd: dirs.test(), inp);
+        // let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
-        assert_eq!(actual.out, "foo");
-        assert_eq!(actual_repl.out, "foo");
+        assert_eq!(actual.out, "spam");
+        // assert_eq!(actual_repl.out, "foo");
     })
 }


### PR DESCRIPTION
# Description

```
do {
    module spam { }

    overlay use spam
}
```
would fail because the command code would check the engine state for the existence of the `spam` overlay. However, it is already out of scope because the parsing is over at that point.

The solution is to communicate which overlay to use in the `overlay use` command by passing it via the parsed call. To do that, it was necessary to add a new `Expr::Overlay` that contains the ID of the "origin module" so checking the engine state is not necessary anymore.

Also adds one sanity check for the new `source-env`.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
