### PR TITLE
Terminate REPL if not connected to tty input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ dependencies = [
 name = "nu-cli"
 version = "0.67.1"
 dependencies = [
+ "atty",
  "chrono",
  "crossterm 0.24.0",
  "fancy-regex",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -22,6 +22,7 @@ nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.67.1"  }
 reedline = { version = "0.10.0", features = ["bashisms", "sqlite"]}
 
+atty = "0.2.14"
 chrono = "0.4.21"
 crossterm = "0.24.0"
 fancy-regex = "0.10.0"

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -48,7 +48,7 @@ pub fn evaluate_repl(
     if !atty::is(atty::Stream::Stdin) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "STDIN is not a TTY",
+            "Nushell launched as interactive REPL but STDIN is not a TTY, either launch in a valid terminal or provide arguments to invoke a script!",
         ))
         .into_diagnostic();
     }
@@ -509,7 +509,7 @@ pub fn evaluate_repl(
                     // TODO: Identify possible error cases where a hard failure is preferable
                     // Ignoring and reporting could hide bigger problems
                     // e.g. https://github.com/nushell/nushell/issues/6452
-                    // Alternatively only allow expected failures to let the REPL to loop
+                    // Alternatively only allow that expected failures let the REPL loop
                 }
                 if shell_integration {
                     run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -43,6 +43,16 @@ pub fn evaluate_repl(
 ) -> Result<()> {
     use reedline::{FileBackedHistory, Reedline, Signal};
 
+    // Guard against invocation without a connected terminal.
+    // reedline / crossterm event polling will fail without a connected tty
+    if !atty::is(atty::Stream::Stdin) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "STDIN is not a TTY",
+        ))
+        .into_diagnostic();
+    }
+
     let mut entry_num = 0;
 
     let mut nu_prompt = NushellPrompt::new();
@@ -496,6 +506,10 @@ pub fn evaluate_repl(
                 let message = err.to_string();
                 if !message.contains("duration") {
                     println!("Error: {:?}", err);
+                    // TODO: Identify possible error cases where a hard failure is preferable
+                    // Ignoring and reporting could hide bigger problems
+                    // e.g. https://github.com/nushell/nushell/issues/6452
+                    // Alternatively only allow expected failures to let the REPL to loop
                 }
                 if shell_integration {
                     run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;


### PR DESCRIPTION
# Description

If the standard input stream is not a TTY abort the REPL execution.

Solves a problem as the current REPL tries to be I/O fault tolerant and
would indefinetely fail when crossterm tries to handle the STDIN.

Fixes nushell/nushell#6452

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
