### PR TITLE
shell_integration: Report current working directory as OSC 7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,6 +2647,7 @@ dependencies = [
  "nu-protocol",
  "nu-test-support",
  "nu-utils",
+ "percent-encoding",
  "reedline",
  "rstest",
  "strip-ansi-escapes",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -30,6 +30,7 @@ is_executable = "1.0.1"
 lazy_static = "1.4.0"
 log = "0.4"
 miette = { version = "5.1.0", features = ["fancy"] }
+percent-encoding = "2"
 strip-ansi-escapes = "0.1.1"
 sysinfo = "0.25.2"
 thiserror = "1.0.31"

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -322,13 +322,14 @@ pub fn evaluate_repl(
 
         match input {
             Ok(Signal::Success(s)) => {
+                let hostname = sys.host_name();
                 let history_supports_meta =
                     matches!(config.history_file_format, HistoryFileFormat::Sqlite);
                 if history_supports_meta && !s.is_empty() {
                     line_editor
                         .update_last_command_context(&|mut c| {
                             c.start_timestamp = Some(chrono::Utc::now());
-                            c.hostname = sys.host_name();
+                            c.hostname = hostname.clone();
 
                             c.cwd = Some(StateWorkingSet::new(engine_state).get_cwd());
                             c
@@ -461,6 +462,21 @@ pub fn evaluate_repl(
                     run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
                     if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
                         let path = cwd.as_string()?;
+
+                        // Communicate the path as OSC 7 (often used for spawning new tabs in the same dir)
+                        run_ansi_sequence(&format!(
+                            "\x1b]7;file://{}{}{}\x1b\\",
+                            percent_encoding::utf8_percent_encode(
+                                &hostname.unwrap_or_else(|| "localhost".to_string()),
+                                percent_encoding::CONTROLS
+                            ),
+                            if path.starts_with('/') { "" } else { "/" },
+                            percent_encoding::utf8_percent_encode(
+                                &path,
+                                percent_encoding::CONTROLS
+                            )
+                        ))?;
+
                         // Try to abbreviate string for windows title
                         let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
                             path.replace(&p.as_path().display().to_string(), "~")


### PR DESCRIPTION
# Description

OSC 7 is a de-facto standard supported by many terminals, originally added to macOS Terminal.app, now also supported by libvte (GNOME), Konsole (KDE), [WezTerm](https://wezfurlong.org/wezterm/shell-integration.html#osc-7-escape-sequence-to-set-the-working-directory), and more.

Tested with WezTerm on unix only, not Windows… BTW, Windows users might be interested in also adding [OSC 9;9](https://github.com/microsoft/terminal/issues/8166), but I'm not testing on Windows.

To test on WezTerm: navigate to a directory, open a new tab, check that it opens in the same directory.

# Tests

Make sure you've done the following:

- :shrug: Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- :shrug: Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
