### PR TITLE
Avoid update_last_command_context "No command run" error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,8 +4078,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84e8704e9eb141e73ac426c72af95eb195d4c3221a11ea92d5709f4a025adb5"
+source = "git+https://github.com/nushell/reedline?branch=main#fe889ae5c4b4fa7492cf6f138ccd4274b0f682cf"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,3 +121,6 @@ debug = false
 [[bin]]
 name = "nu"
 path = "src/main.rs"
+
+[patch.crates-io]
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -324,7 +324,8 @@ pub fn evaluate_repl(
             Ok(Signal::Success(s)) => {
                 let history_supports_meta =
                     matches!(config.history_file_format, HistoryFileFormat::Sqlite);
-                if history_supports_meta && !s.is_empty() {
+                if history_supports_meta && !s.is_empty() && line_editor.has_last_command_context()
+                {
                     line_editor
                         .update_last_command_context(&|mut c| {
                             c.start_timestamp = Some(chrono::Utc::now());
@@ -445,7 +446,8 @@ pub fn evaluate_repl(
                     },
                 );
 
-                if history_supports_meta && !s.is_empty() {
+                if history_supports_meta && !s.is_empty() && line_editor.has_last_command_context()
+                {
                     line_editor
                         .update_last_command_context(&|mut c| {
                             c.duration = Some(cmd_duration);


### PR DESCRIPTION
WAITING ON https://github.com/nushell/reedline/pull/470

# Description

When using `executehostcommand` bindings without having run actual user input commands yet, `update_last_command_context` is guaranteed to fail.

# Tests

Make sure you've done the following:

- :shrug: Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- :shrug: Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
