### PR TITLE
let path split keeps 'C:\' together

### DIFF
--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -109,11 +109,7 @@ fn split(path: &Path, span: Span, _: &Arguments) -> Value {
             .components()
             .filter_map(|comp| {
                 let comp = process_component(comp);
-                if let Some(s) = comp {
-                    Some(Value::string(s, span))
-                } else {
-                    None
-                }
+                comp.map(|s| Value::string(s, span))
             })
             .collect(),
         span,

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, Component};
 
 use nu_engine::CallExt;
 use nu_protocol::{engine::Command, Example, ShellError, Signature, Span, SyntaxShape, Value};
@@ -62,8 +62,7 @@ impl Command for SubCommand {
                 example: r"'C:\Users\viking\spam.txt' | path split",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::test_string("C:"),
-                        Value::test_string(r"\"),
+                        Value::test_string(r"C:\"),
                         Value::test_string("Users"),
                         Value::test_string("viking"),
                         Value::test_string("spam.txt"),
@@ -108,14 +107,38 @@ fn split(path: &Path, span: Span, _: &Arguments) -> Value {
     Value::List {
         vals: path
             .components()
-            .map(|comp| {
-                let s = comp.as_os_str().to_string_lossy();
-                Value::string(s, span)
+            .filter_map(|comp| {
+                let comp = process_component(comp);
+                if let Some(s) = comp {
+                    Some(Value::string(s, span))
+                }
+                else {
+                    None
+                }
             })
             .collect(),
         span,
     }
 }
+
+#[cfg(windows)]
+fn process_component(comp: Component) -> Option<String> {
+    match comp {
+        RootDir => None,
+        Prefix => {
+            let mut s = comp.as_os_str().to_string_lossy().to_string();
+            s.push('\\');
+            Some(s) 
+        }
+        comp => Some(comp.as_os_str().to_string_lossy().to_string())
+    }
+}
+
+#[cfg(not(windows))]
+fn process_component(comp: Component) -> Option<String> {
+    Some(comp.as_os_str().to_string_lossy().to_string())
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, Component};
+use std::path::{Component, Path};
 
 use nu_engine::CallExt;
 use nu_protocol::{engine::Command, Example, ShellError, Signature, Span, SyntaxShape, Value};
@@ -111,8 +111,7 @@ fn split(path: &Path, span: Span, _: &Arguments) -> Value {
                 let comp = process_component(comp);
                 if let Some(s) = comp {
                     Some(Value::string(s, span))
-                }
-                else {
+                } else {
                     None
                 }
             })
@@ -128,9 +127,9 @@ fn process_component(comp: Component) -> Option<String> {
         Prefix => {
             let mut s = comp.as_os_str().to_string_lossy().to_string();
             s.push('\\');
-            Some(s) 
+            Some(s)
         }
-        comp => Some(comp.as_os_str().to_string_lossy().to_string())
+        comp => Some(comp.as_os_str().to_string_lossy().to_string()),
     }
 }
 
@@ -138,7 +137,6 @@ fn process_component(comp: Component) -> Option<String> {
 fn process_component(comp: Component) -> Option<String> {
     Some(comp.as_os_str().to_string_lossy().to_string())
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -119,8 +119,8 @@ fn split(path: &Path, span: Span, _: &Arguments) -> Value {
 #[cfg(windows)]
 fn process_component(comp: Component) -> Option<String> {
     match comp {
-        RootDir => None,
-        Prefix => {
+        Component::RootDir => None,
+        Component::Prefix(_) => {
             let mut s = comp.as_os_str().to_string_lossy().to_string();
             s.push('\\');
             Some(s)


### PR DESCRIPTION
# Description

Fixes #6482. 

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
