### PR TITLE
Add a 'commandline' command for manipulating the current buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,8 +4079,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5559b5ab4817b0da0c6fc6814edfae537209e01d955a2f3e7595606e3d039691"
+source = "git+https://github.com/nushell/reedline?branch=main#dc091e828590de6fd335af3f1d001ede851ac20a"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,3 +122,5 @@ debug = false
 name = "nu"
 path = "src/main.rs"
 
+[patch.crates-io]
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }

--- a/crates/nu-command/src/core_commands/commandline.rs
+++ b/crates/nu-command/src/core_commands/commandline.rs
@@ -1,0 +1,84 @@
+use nu_engine::CallExt;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::ReplOperation;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::Category;
+use nu_protocol::IntoPipelineData;
+use nu_protocol::{PipelineData, ShellError, Signature, SyntaxShape, Value};
+
+#[derive(Clone)]
+pub struct Commandline;
+
+impl Command for Commandline {
+    fn name(&self) -> &str {
+        "commandline"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("commandline")
+            .switch(
+                "append",
+                "appends the string to the end of the buffer",
+                Some('a'),
+            )
+            .switch(
+                "insert",
+                "inserts the string into the buffer at the cursor position",
+                Some('i'),
+            )
+            .switch(
+                "replace",
+                "replaces the current contents of the buffer (default)",
+                Some('r'),
+            )
+            .optional(
+                "cmd",
+                SyntaxShape::String,
+                "the string to perform the operation with",
+            )
+            .category(Category::Core)
+    }
+
+    fn usage(&self) -> &str {
+        "View or modify the current command line input buffer"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["repl", "interactive"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        if let Some(cmd) = call.opt::<Value>(engine_state, stack, 0)? {
+            let mut ops = engine_state
+                .repl_operation_queue
+                .lock()
+                .expect("repl op queue mutex");
+            ops.push_back(if call.has_flag("append") {
+                ReplOperation::Append(cmd.as_string()?)
+            } else if call.has_flag("insert") {
+                ReplOperation::Insert(cmd.as_string()?)
+            } else {
+                ReplOperation::Replace(cmd.as_string()?)
+            });
+            Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+        } else if let Some(ref cmd) = *engine_state
+            .repl_buffer_state
+            .lock()
+            .expect("repl buffer state mutex")
+        {
+            Ok(Value::String {
+                val: cmd.clone(),
+                span: call.head,
+            }
+            .into_pipeline_data())
+        } else {
+            Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+        }
+    }
+}

--- a/crates/nu-command/src/core_commands/mod.rs
+++ b/crates/nu-command/src/core_commands/mod.rs
@@ -1,5 +1,6 @@
 mod alias;
 mod ast;
+mod commandline;
 mod debug;
 mod def;
 mod def_env;
@@ -30,6 +31,7 @@ mod version;
 
 pub use alias::Alias;
 pub use ast::Ast;
+pub use commandline::Commandline;
 pub use debug::Debug;
 pub use def::Def;
 pub use def_env::DefEnv;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -30,6 +30,7 @@ pub fn create_default_context() -> EngineState {
         bind_command! {
             Alias,
             Ast,
+            Commandline,
             Debug,
             Def,
             DefEnv,


### PR DESCRIPTION
Depends on https://github.com/nushell/reedline/pull/472

Directions on making this better welcome; the mutex on the engine state was the best way of communicating between the REPL and a command I could come up with.

# Description

Add a command inspired by fish [`commandline`](https://fishshell.com/docs/current/cmds/commandline.html).

Should fix #1616 #6177 by allowing `executehostcommand` keybinds to do interesting things with the command buffer, like launching a fuzzy finder (even with the contents of the buffer as the initial query) and when it's done, replacing the contents of the buffer with its pick:

```nu
let-env config = {
  keybindings: [
    {
      name: fuzzy_history
      modifier: CONTROL
      keycode: Char_r
      mode: emacs
      event: {
        send: executehostcommand
        cmd: "commandline (history | each { |it| $it.command } | uniq | reverse | str collect (char nl) | sk --layout=reverse --height=40% -q (commandline) | decode utf-8 | str trim)"
      }
    }
  ]

}
```

https://user-images.githubusercontent.com/208340/188480285-d2438929-6fa9-4cec-b22f-8ab3fdc28ae4.mp4

# Tests

Make sure you've done the following:

- :shrug: Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- :shrug: Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
