### PR TITLE
Pass `TERM` environment var to clear

### DIFF
--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -32,7 +32,7 @@ impl Command for Clear {
             CommandSys::new("cmd")
                 .args(["/C", "cls"])
                 .status()
-                .expect("failed to execute process");
+                .map_err(|e| ShellError::IOError(e.to_string()))?;
         } else if cfg!(unix) {
             let mut cmd = CommandSys::new("/bin/sh");
 
@@ -42,7 +42,7 @@ impl Command for Clear {
 
             cmd.args(["-c", "clear"])
                 .status()
-                .expect("failed to execute process");
+                .map_err(|e| ShellError::IOError(e.to_string()))?;
         }
 
         Ok(Value::Nothing { span: call.head }.into_pipeline_data())

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -23,8 +23,8 @@ impl Command for Clear {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
@@ -34,8 +34,13 @@ impl Command for Clear {
                 .status()
                 .expect("failed to execute process");
         } else if cfg!(unix) {
-            CommandSys::new("/bin/sh")
-                .args(["-c", "clear"])
+            let mut cmd = CommandSys::new("/bin/sh");
+
+            if let Some(Value::String { val, .. }) = stack.get_env_var(engine_state, "TERM") {
+                cmd.env("TERM", val);
+            }
+
+            cmd.args(["-c", "clear"])
                 .status()
                 .expect("failed to execute process");
         }

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -28,11 +28,13 @@ impl Command for Clear {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let span = call.head;
+
         if cfg!(windows) {
             CommandSys::new("cmd")
                 .args(["/C", "cls"])
                 .status()
-                .map_err(|e| ShellError::IOError(e.to_string()))?;
+                .map_err(|e| ShellError::IOErrorSpanned(e.to_string(), span))?;
         } else if cfg!(unix) {
             let mut cmd = CommandSys::new("/bin/sh");
 
@@ -42,10 +44,10 @@ impl Command for Clear {
 
             cmd.args(["-c", "clear"])
                 .status()
-                .map_err(|e| ShellError::IOError(e.to_string()))?;
+                .map_err(|e| ShellError::IOErrorSpanned(e.to_string(), span))?;
         }
 
-        Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+        Ok(Value::Nothing { span }.into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
# Description
When running `nu` with invalid `TERM` environment variable, it seems that it can't clear the terminal screen with built-in `clear` command on linux.

![Screenshot from 2022-09-06 22-52-50](https://user-images.githubusercontent.com/15247421/188667208-dbe4ebdd-e602-4579-b9cb-126483a29621.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
