### PR TITLE
fix typo

### DIFF
--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -30,7 +30,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "compare to strings and return the edit distance/levenshtein distance"
+        "compare two strings and return the edit distance/levenshtein distance"
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
# Description

Fix typo in usage documentation of new str distance command

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
