### PR TITLE
update register-plugins script to not use encoding

### DIFF
--- a/register-plugins.nu
+++ b/register-plugins.nu
@@ -4,9 +4,9 @@ def match [input, matchers: record] {
 }
 
 # register plugin
-def register_plugin [encoding, plugin] {
+def register_plugin [plugin] {
     print $"registering ($plugin)"
-    nu -c $'register -e ($encoding) ($plugin)'
+    nu -c $'register ($plugin)'
 }
 
 # get list of all plugin files from their installed directory
@@ -15,16 +15,14 @@ let plugin_location = ((which nu).path.0 | path dirname)
 # for each plugin file, print the name and launch another instance of nushell to register it
 for plugin in (ls $"($plugin_location)/nu_plugin_*") {
     match ($plugin.name | path basename | str replace '\.exe$' '') {
-        nu_plugin_custom_values: { register_plugin msgpack $plugin.name }
-        nu_plugin_example: { register_plugin msgpack $plugin.name }
-        nu_plugin_from_parquet: { register_plugin json $plugin.name }
-        nu_plugin_gstat: { register_plugin msgpack $plugin.name }
-        nu_plugin_inc: { register_plugin json $plugin.name }
-        nu_plugin_query: { register_plugin json $plugin.name }
+        nu_plugin_custom_values: { register_plugin $plugin.name }
+        nu_plugin_example: { register_plugin $plugin.name }
+        nu_plugin_from_parquet: { register_plugin $plugin.name }
+        nu_plugin_gstat: { register_plugin $plugin.name }
+        nu_plugin_inc: { register_plugin $plugin.name }
+        nu_plugin_query: { register_plugin $plugin.name }
     }
 }
 
+# print helpful message
 print "\nplugins registered, please restart nushell"
-
-# print "\nplugin commands registered"
-# version | get installed_plugins | split row ', '


### PR DESCRIPTION
# Description

The PR updates the register-plugins.nu script so that it doesn't specify the encoding after #6486 landed.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
