### PR TITLE
Add history menu for commands in current working directory

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -257,7 +257,7 @@ let-env config = {
   edit_mode: emacs # emacs, vi
   max_history_size: 10000 # Session has to be reloaded for this to take effect
   sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
-  history_file_format: "plaintext" # "sqlite" or "plaintext"
+  history_file_format: "sqlite" # "sqlite" or "plaintext"
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
   disable_table_indexes: false # set to true to remove the index column from tables
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
@@ -319,6 +319,30 @@ let-env config = {
             text: green
             selected_text: green_reverse
             description_text: yellow
+        }
+      }
+      {
+        name: history_menu_pwd
+        only_buffer_difference: true
+        marker: "? "
+        type: {
+            layout: list
+            page_size: 10
+        }
+        style: {
+            text: green
+            selected_text: green_reverse
+            description_text: yellow
+        }
+        source: { |buffer, position|
+            history
+            | select command exit_status cwd
+            | where exit_status != 1
+            | where cwd == $env.PWD
+            | where command =~ $buffer
+            | each { |it| {value: $it.command } }
+            | reverse
+            | uniq
         }
       }
       {
@@ -433,6 +457,13 @@ let-env config = {
       keycode: char_r
       mode: emacs
       event: { send: menu name: history_menu }
+    }
+    {
+      name: history_menu_pwd
+      modifier: control
+      keycode: char_h
+      mode: emacs
+      event: { send: menu name: history_menu_pwd }
     }
     {
       name: next_page


### PR DESCRIPTION
# Description

Add history menu for commands in current working directory

# Tests

Make sure you've done the following:

- [-] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [-] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [-] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [-] `cargo test --workspace --features=extra` to check that all the tests pass
