### PR TITLE
Stop panic when typing `module spam { export def-env`

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -896,7 +896,7 @@ pub fn parse_export_in_module(
                 let mut result = vec![];
 
                 let decl_name = match spans.get(2) {
-                    Some(span) => { working_set.get_span_contents(*span) },
+                    Some(span) => working_set.get_span_contents(*span),
                     None => &[],
                 };
                 let decl_name = trim_quotes(decl_name);
@@ -962,7 +962,7 @@ pub fn parse_export_in_module(
                 let mut result = vec![];
 
                 let decl_name = match spans.get(2) {
-                    Some(span) => { working_set.get_span_contents(*span) },
+                    Some(span) => working_set.get_span_contents(*span),
                     None => &[],
                 };
                 let decl_name = trim_quotes(decl_name);
@@ -1028,7 +1028,7 @@ pub fn parse_export_in_module(
                 let mut result = vec![];
 
                 let alias_name = match spans.get(2) {
-                    Some(span) => { working_set.get_span_contents(*span) },
+                    Some(span) => working_set.get_span_contents(*span),
                     None => &[],
                 };
                 let alias_name = trim_quotes(alias_name);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -895,7 +895,10 @@ pub fn parse_export_in_module(
 
                 let mut result = vec![];
 
-                let decl_name = working_set.get_span_contents(spans[2]);
+                let decl_name = match spans.get(2) {
+                    Some(span) => { working_set.get_span_contents(*span) },
+                    None => &[],
+                };
                 let decl_name = trim_quotes(decl_name);
 
                 if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Any) {
@@ -958,7 +961,10 @@ pub fn parse_export_in_module(
 
                 let mut result = vec![];
 
-                let decl_name = working_set.get_span_contents(spans[2]);
+                let decl_name = match spans.get(2) {
+                    Some(span) => { working_set.get_span_contents(*span) },
+                    None => &[],
+                };
                 let decl_name = trim_quotes(decl_name);
 
                 if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Any) {
@@ -1021,7 +1027,10 @@ pub fn parse_export_in_module(
 
                 let mut result = vec![];
 
-                let alias_name = working_set.get_span_contents(spans[2]);
+                let alias_name = match spans.get(2) {
+                    Some(span) => { working_set.get_span_contents(*span) },
+                    None => &[],
+                };
                 let alias_name = trim_quotes(alias_name);
 
                 if let Some(alias_id) = working_set.find_alias(alias_name) {


### PR DESCRIPTION
same goes for `export extern` and `export alias`

# Description

Fixes #6518. There might be a more elegant solution. The function `parse_export_in_module` (which is the "base" problematic function") is called here: https://github.com/merelymyself/nushell/blob/a9dfcc18f2b3a8f5f07254d4603d84dae2061f6e/crates/nu-parser/src/parse_keywords.rs#L1402 


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
