### PR TITLE
Improve wording around `all` and `any`

### DIFF
--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -24,7 +24,7 @@ impl Command for All {
     }
 
     fn usage(&self) -> &str {
-        "Test if every element of the input fulfils a predicate expression."
+        "Test if every element of the input fulfills a predicate expression."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -18,17 +18,17 @@ impl Command for All {
             .required(
                 "predicate",
                 SyntaxShape::RowCondition,
-                "the predicate that must match",
+                "the predicate expression that must evaluate to a boolean",
             )
             .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {
-        "Test if every element of the input matches a predicate."
+        "Test if every element of the input fulfils a predicate expression."
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["every"]
+        vec!["every", "and"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -18,17 +18,17 @@ impl Command for Any {
             .required(
                 "predicate",
                 SyntaxShape::RowCondition,
-                "the predicate that must match",
+                "the predicate expression that should return a boolean",
             )
             .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {
-        "Tests if any element of the input matches a predicate."
+        "Tests if any element of the input fulfils a predicate expression."
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["some"]
+        vec!["some", "or"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -24,7 +24,7 @@ impl Command for Any {
     }
 
     fn usage(&self) -> &str {
-        "Tests if any element of the input fulfils a predicate expression."
+        "Tests if any element of the input fulfills a predicate expression."
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
# Description

The role of the `predicate` for `all` and `any` was not as clear.

See #6499

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
