### PR TITLE
Don't compute 'did you mean' suggestions unless showing them to user

### DIFF
--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -336,7 +336,7 @@ fn get_converted_value(
             val: block_id,
             span: from_span,
             ..
-        }) = env_conversions.follow_cell_path(path_members, false)
+        }) = env_conversions.follow_cell_path_not_from_user_input(path_members, false)
         {
             let block = engine_state.get_block(block_id);
 


### PR DESCRIPTION
The levenshtein edit distance calculations for "did you mean" suggestions are done inside [`Value::follow_cell_path`]( https://github.com/nushell/nushell/blob/4926865c4ecc5cf3a7024dad57aea478bb16f690/crates/nu-protocol/src/value/mod.rs#L608). This means that we do them when [looking up](https://github.com/nushell/nushell/blob/4926865c4ecc5cf3a7024dad57aea478bb16f690/crates/nu-engine/src/env.rs#L303) user-registered env var conversions, for all user env vars, every time we run an external process. We don't need to do that, since the suggestions computed will not be shown to the user.

The output below shows the edit distance calculations being done on every user command at the REPL. I haven't done real benchmarking, but I believe that this could cause noticeable performance degradation (e.g. in scripts making many external process calls, or for users with many env vars, or with env vars that are long strings, or on old/slow hardware), so this PR changes things to that we don't do edit distance calculations during env var conversion lookups.

I think that the ideal code change would be to do the edit distance calculations lazily: i.e. only if and when we actually render the Miette error diagnostic. That would prevent us from ever introducing future code paths that do unnecessary edit distance calculations. However, I haven't quite got that working... I'll bring it up in Discord. So this PR does something simpler and just addresses the current code path.

# Tests

- [ ] _Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder._

I'd like to add a test like the one below. However, that doesn't quite work currently, because [`ConversionResult::CellPathError`](https://github.com/nushell/nushell/blob/4926865c4ecc5cf3a7024dad57aea478bb16f690/crates/nu-engine/src/env.rs#L369) does not include the underlying `ShellError`, so we can't make assertions about it. It may make sense to change the release code paths to make this testable, but I haven't done that yet (lmk if you have a view).

```rust
// crates/nu-engine/src/env.rs
#[cfg(test)]
mod test {
    use super::*;

    #[test]
    fn test_env_to_string_lookup_failure_does_not_compute_suggestions() {
        let engine_state = EngineState::new();
        let mut stack = Stack::new();
        let fake_span = Span::test_data();
        let converter = Value::Record {
            cols: vec!["from_string".to_string(), "to_string".to_string()],
            vals: vec![],
            span: fake_span,
        };
        stack.add_env_var(
            "ENV_CONVERSIONS".to_string(),
            Value::Record {
                cols: vec!["PATH".to_string(), "Path".to_string()],
                vals: vec![converter.clone(), converter],
                span: fake_span,
            },
        );
        let err = env_to_string(
            "ENV_VAR_WITHOUT_CONVERTER",
            &Value::Int {
                val: 7,
                span: fake_span,
            },
            &engine_state,
            &stack,
        );
        assert!(matches!(err, Err(ShellError::CantFindColumn(_, _))));
    }
}
```

- [x] _Try to think about corner cases and various ways how your changes could break. Cover them with tests._

The change here is that an internal code path returns a different error class. But this error was, and continues to be, ignored. I believe this change is safe.

- [x] _If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works._


- [x] _`cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)_
- [x] _`cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style_
- [x] _`cargo test --workspace --features=extra` to check that all the tests pass_


# Details

For every env var that we try to convert to string, we compute edit distance against every env var for which we have a registered conversion (by default that's `PATH` and `Path`).

Without any user config, if the user displays the prompt without invoking an external command then we only compute a couple of edit  distances (`PWD` against `PATH` and `Path`):

```
〉ls /tmp/nu-*.txt | each { |it| let name = ($it | get name); {name: $name, lines: ($name | open | lines | length) } }                                               09/11/2022 09:27:12 AM
╭───┬────────────────────────────────────┬───────╮
│ # │                name                │ lines │
├───┼────────────────────────────────────┼───────┤
│ 0 │ /tmp/nu-did-you-mean-calls.txt     │     8 │
│ 1 │ /tmp/nu-levenshtein-inner-loop.txt │   240 │
╰───┴────────────────────────────────────┴───────╯
```

But things get a bit worse if the user invokes an external process since we compute edit distances for all env vars that they happen to have set:
```
〉^ls | save /dev/null; ls /tmp/nu-*.txt | each { |it| let name = ($it | get name); {name: $name, lines: ($name | open | lines | length) } }                         09/11/2022 09:30:56 AM
╭───┬────────────────────────────────────┬───────╮
│ # │                name                │ lines │
├───┼────────────────────────────────────┼───────┤
│ 0 │ /tmp/nu-did-you-mean-calls.txt     │    69 │
│ 1 │ /tmp/nu-levenshtein-inner-loop.txt │  5776 │
╰───┴────────────────────────────────────┴───────╯
```

There we're doing comparisons like

```
ALTERNATE_EDITOR: ["PATH", "Path"]
ALACRITTY_LOG: ["PATH", "Path"]
USER: ["PATH", "Path"]
JAVA_HOME: ["PATH", "Path"]
...
```

If I activate my personal nu config, then I'm doing some git calls for my prompt, and it's a bit worse still:

```
 〉ls /tmp/nu-*.txt | each { |it| let name = ($it | get name); {name: $name, lines: ($name | open | lines | length) } }
╭────────────────────────────────────┬───────╮
│                name                │ lines │
├────────────────────────────────────┼───────┤
│ /tmp/nu-did-you-mean-calls.txt     │   311 │
│ /tmp/nu-levenshtein-inner-loop.txt │ 27872 │
╰────────────────────────────────────┴───────╯
```

And if a user runs a complex nu script that makes a lot of external process calls, then it can end up doing thousands of unnecessary edit distance calculations.

Double-check we do still get the suggestions on this branch:

```
〉let r = {abcdef: 1}
〉echo $r.abcde
Error: nu::shell::name_not_found (link)

  × Name not found
   ╭─[entry #2:1:1]
 1 │ echo $r.abcde
   ·         ──┬──
   ·           ╰── did you mean 'abcdef'?
   ╰────
```

```
 〉$env.PATHX
Error: nu::shell::name_not_found (link)

  × Name not found
   ╭─[entry #2:1:1]
 1 │ $env.PATHX
   ·      ──┬──
   ·        ╰── did you mean 'PATH'?
   ╰────
```

