### PR TITLE
Add overlay use usage for 'as'

### DIFF
--- a/crates/nu-command/src/core_commands/overlay/use_.rs
+++ b/crates/nu-command/src/core_commands/overlay/use_.rs
@@ -195,6 +195,13 @@ impl Command for OverlayUse {
                 result: None,
             },
             Example {
+                description: "Create an overlay from a module and rename it",
+                example: r#"module spam { export def foo [] { "foo" } }
+    overlay use spam as spam_new
+    foo"#,
+                result: None,
+            },
+            Example {
                 description: "Create an overlay with a prefix",
                 example: r#"echo 'export def foo { "foo" }'
     overlay use --prefix spam

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -18,6 +18,21 @@ fn add_overlay() {
 }
 
 #[test]
+fn add_overlay_as_new_name() {
+    let inp = &[
+        r#"module spam { export def foo [] { "foo" } }"#,
+        r#"overlay use spam as spam_new"#,
+        r#"foo"#,
+    ];
+
+    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+
+    assert_eq!(actual.out, "foo");
+    assert_eq!(actual_repl.out, "foo");
+}
+
+#[test]
 fn add_overlay_twice() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,


### PR DESCRIPTION
# Description

Overlay use supports an optional arg `as`, but the help usage does not have it

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
