### PR TITLE
feat(nu-cli): use `cwd` to filter Hinter suggestions where available

### DIFF
--- a/crates/nu-cli/src/cwd_hinter.rs
+++ b/crates/nu-cli/src/cwd_hinter.rs
@@ -1,0 +1,71 @@
+use nu_ansi_term::{Color, Style};
+use nu_protocol::engine::EngineState;
+use reedline::{CommandLineSearch, Hinter, SearchDirection, SearchFilter, SearchQuery};
+
+struct CwdHinter {
+    style: Style,
+    current_hint: String,
+    min_chars: usize,
+    engine_state: Arc<EngineState>,
+}
+
+impl Hinter for CwdHinter {
+    fn handle(
+        &mut self,
+        line: &str,
+        pos: usize,
+        history: &dyn reedline::History,
+        use_ansi_coloring: bool,
+    ) -> String {
+        self.current_hint = if line.chars().count() >= self.min_chars {
+            let cwd = if let Some(d) = self.engine_state.get_env_var("PWD") {
+                match d.as_string() {
+                    Ok(s) => s,
+                    Err(_) => "".to_string(),
+                }
+            } else {
+                "".to_string()
+            };
+            
+            let mut search_filter = SearchFilter::anything();
+            search_filter.command_line = Some(CommandLineSearch::Prefix(line.to_string()));
+            search_filter.cwd_exact = Some(cwd);
+
+            history
+                .search(SearchQuery {
+                    direction: SearchDirection::Backward,
+                    start_time: None,
+                    end_time: None,
+                    start_id: None,
+                    end_id: None,
+                    limit: Some(1),
+                    filter: search_filter,
+                })
+                .expect("todo: error handling")
+                .get(0)
+                .map_or_else(String::new, |entry| {
+                    entry
+                        .command_line
+                        .get(line.len()..)
+                        .unwrap_or_default()
+                        .to_string()
+                })
+        } else {
+            String::new()
+        };
+
+        if use_ansi_coloring && !self.current_hint.is_empty() {
+            self.style.paint(&self.current_hint).to_string()
+        } else {
+            self.current_hint.clone()
+        }
+    }
+
+    fn complete_hint(&self) -> String {
+        todo!()
+    }
+
+    fn next_hint_token(&self) -> String {
+        todo!()
+    }
+}

--- a/crates/nu-cli/src/lib.rs
+++ b/crates/nu-cli/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod completions;
 mod config_files;
+mod cwd_hinter;
 mod eval_file;
 mod menus;
 mod nu_highlight;

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -222,7 +222,6 @@ pub fn evaluate_repl(
             .and_then(|d| d.as_string().ok());
         line_editor = if config.use_ansi_coloring {
             line_editor.with_hinter(Box::new(
-                // DefaultHinter::default().with_style(color_hm["hints"]),
                 CwdHinter::default().with_style(color_hm["hints"]).with_cwd(cwd)
             ))
         } else {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -3,7 +3,7 @@ use crate::{
     prompt_update,
     reedline_config::{add_menus, create_keybindings, KeybindingsMode},
     util::{eval_source, get_guaranteed_cwd, report_error, report_error_new},
-    NuHighlighter, NuValidator, NushellPrompt,
+    NuHighlighter, NuValidator, NushellPrompt, cwd_hinter::CwdHinter,
 };
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
@@ -217,9 +217,13 @@ pub fn evaluate_repl(
             .with_partial_completions(config.partial_completions)
             .with_ansi_colors(config.use_ansi_coloring);
 
+        let cwd = engine_state
+            .get_env_var("PWD")
+            .and_then(|d| d.as_string().ok());
         line_editor = if config.use_ansi_coloring {
             line_editor.with_hinter(Box::new(
-                DefaultHinter::default().with_style(color_hm["hints"]),
+                // DefaultHinter::default().with_style(color_hm["hints"]),
+                CwdHinter::default().with_style(color_hm["hints"]).with_cwd(cwd)
             ))
         } else {
             line_editor.disable_hints()


### PR DESCRIPTION
# Description

Resolves #5799. Implements a `reedline::Hinter` to suggest completions based on `cwd` (the current working directory), when where the `cwd` of command history is available. This matches the default `fish` shell behaviour. 

When it is not available, returns to the existing behaviour.

## TODOs
- [ ] basic tests (desired behavior)
- [ ] resiliency testing if there are no failures if the history is not supporting storing the cwd, errors from either reading the history or the current working directory should not crash the hinter.

## Example
Consider the following directory structure, where | is the current caret position:
```
foo/
bar/
├─ bacon.txt
├─ eggs.txt
├─ spam.txt
```

**Not filtered by `cwd`**
```
$ cd bar
$ cat bacon.txt
Lorem Ipsum
$ cd ..
$ cd bar
$ c|d bar
```

**Filtered by `cwd`**
```
$ cd bar
$ cat bacon.txt
Lorem Ipsum
$ cd ..
$ cd bar
$ c|at bacon.txt
```

### Some notes:
* Mostly ripped from the current reedline release's DefaultHinter implementation ([v0.11.0](https://github.com/nushell/reedline/releases/tag/v0.11.0))
* Next steps should involve colouring the output based on whether a file exists in the working directory or not. I will open a ticket and describe more fully

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
