### PR TITLE
Make clickable links smarter

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -587,10 +587,10 @@ fn render_path_name(
 
     let (style, has_metadata) = match std::fs::symlink_metadata(&stripped_path) {
         Ok(metadata) => (
-            ls_colors.style_for_path_with_metadata(path.clone(), Some(&metadata)),
+            ls_colors.style_for_path_with_metadata(path, Some(&metadata)),
             true,
         ),
-        Err(_) => (ls_colors.style_for_path(path.clone()), false),
+        Err(_) => (ls_colors.style_for_path(path), false),
     };
 
     // clickable links don't work in remote SSH sessions
@@ -603,13 +603,13 @@ fn render_path_name(
         .unwrap_or_default();
     let use_ls_colors = config.use_ls_colors;
 
-    let full_path = PathBuf::from(stripped_path.clone())
+    let full_path = PathBuf::from(&stripped_path)
         .canonicalize()
         .unwrap_or_else(|_| PathBuf::from(&stripped_path));
 
     let full_path_link = make_clickable_link(
         full_path.display().to_string(),
-        Some(&path.clone()),
+        Some(path),
         show_clickable_links,
     );
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -317,7 +317,7 @@ fn handle_row_stream(
                                             let full_path_link = make_clickable_link(
                                                 full_path.display().to_string(),
                                                 Some(&path.clone()),
-                                                show_clickable_links,
+                                                false,
                                             );
 
                                             if use_ls_colors {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1,4 +1,4 @@
-use lscolors::Style;
+use lscolors::{LsColors, Style};
 use nu_color_config::{get_color_config, style_primitive};
 use nu_engine::{column::get_columns, env_to_string, CallExt};
 use nu_protocol::{
@@ -261,10 +261,6 @@ fn handle_row_stream(
             };
             let ls_colors = get_ls_colors(ls_colors_env_str);
 
-            // clickable links don't work in remote SSH sessions
-            let in_ssh_session = std::env::var("SSH_CLIENT").is_ok();
-            let show_clickable_links = config.show_clickable_links_in_ls && !in_ssh_session;
-
             ListStream::from_stream(
                 stream.map(move |mut x| match &mut x {
                     Value::Record { cols, vals, .. } => {
@@ -273,62 +269,10 @@ fn handle_row_stream(
                         while idx < cols.len() {
                             if cols[idx] == "name" {
                                 if let Some(Value::String { val: path, span }) = vals.get(idx) {
-                                    match std::fs::symlink_metadata(&path) {
-                                        Ok(metadata) => {
-                                            let style = ls_colors.style_for_path_with_metadata(
-                                                path.clone(),
-                                                Some(&metadata),
-                                            );
-                                            let ansi_style = style
-                                                .map(Style::to_crossterm_style)
-                                                // .map(ToNuAnsiStyle::to_nu_ansi_style)
-                                                .unwrap_or_default();
-                                            let use_ls_colors = config.use_ls_colors;
-
-                                            let full_path = PathBuf::from(path.clone())
-                                                .canonicalize()
-                                                .unwrap_or_else(|_| PathBuf::from(path));
-                                            let full_path_link = make_clickable_link(
-                                                full_path.display().to_string(),
-                                                Some(&path.clone()),
-                                                show_clickable_links,
-                                            );
-
-                                            if use_ls_colors {
-                                                vals[idx] = Value::String {
-                                                    val: ansi_style
-                                                        .apply(full_path_link)
-                                                        .to_string(),
-                                                    span: *span,
-                                                };
-                                            }
-                                        }
-                                        Err(_) => {
-                                            let style = ls_colors.style_for_path(path.clone());
-                                            let ansi_style = style
-                                                .map(Style::to_crossterm_style)
-                                                // .map(ToNuAnsiStyle::to_nu_ansi_style)
-                                                .unwrap_or_default();
-                                            let use_ls_colors = config.use_ls_colors;
-
-                                            let full_path = PathBuf::from(path.clone())
-                                                .canonicalize()
-                                                .unwrap_or_else(|_| PathBuf::from(path));
-                                            let full_path_link = make_clickable_link(
-                                                full_path.display().to_string(),
-                                                Some(&path.clone()),
-                                                false,
-                                            );
-
-                                            if use_ls_colors {
-                                                vals[idx] = Value::String {
-                                                    val: ansi_style
-                                                        .apply(full_path_link)
-                                                        .to_string(),
-                                                    span: *span,
-                                                };
-                                            }
-                                        }
+                                    if let Some(val) =
+                                        render_path_name(path, &config, &ls_colors, *span)
+                                    {
+                                        vals[idx] = val;
                                     }
                                 }
                             }
@@ -627,5 +571,47 @@ fn load_theme_from_config(config: &Config) -> TableTheme {
         "heavy" => nu_table::TableTheme::heavy(),
         "none" => nu_table::TableTheme::none(),
         _ => nu_table::TableTheme::rounded(),
+    }
+}
+
+fn render_path_name(
+    path: &String,
+    config: &Config,
+    ls_colors: &LsColors,
+    span: Span,
+) -> Option<Value> {
+    let (style, has_metadata) = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => (
+            ls_colors.style_for_path_with_metadata(path.clone(), Some(&metadata)),
+            true,
+        ),
+        Err(_) => (ls_colors.style_for_path(path.clone()), false),
+    };
+
+    // clickable links don't work in remote SSH sessions
+    let in_ssh_session = std::env::var("SSH_CLIENT").is_ok();
+    let show_clickable_links = config.show_clickable_links_in_ls && !in_ssh_session && has_metadata;
+
+    let ansi_style = style
+        .map(Style::to_crossterm_style)
+        // .map(ToNuAnsiStyle::to_nu_ansi_style)
+        .unwrap_or_default();
+    let use_ls_colors = config.use_ls_colors;
+
+    let full_path = PathBuf::from(path.clone())
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(path));
+
+    let full_path_link = make_clickable_link(
+        full_path.display().to_string(),
+        Some(&path.clone()),
+        show_clickable_links,
+    );
+
+    if use_ls_colors {
+        let val = ansi_style.apply(full_path_link).to_string();
+        Some(Value::String { val, span })
+    } else {
+        None
     }
 }

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -580,6 +580,10 @@ fn render_path_name(
     ls_colors: &LsColors,
     span: Span,
 ) -> Option<Value> {
+    if !config.use_ls_colors {
+        return None;
+    }
+
     let stripped_path = match strip_ansi_escapes::strip(path) {
         Ok(v) => String::from_utf8(v).unwrap_or_else(|_| path.to_owned()),
         Err(_) => path.to_owned(),
@@ -601,7 +605,6 @@ fn render_path_name(
         .map(Style::to_crossterm_style)
         // .map(ToNuAnsiStyle::to_nu_ansi_style)
         .unwrap_or_default();
-    let use_ls_colors = config.use_ls_colors;
 
     let full_path = PathBuf::from(&stripped_path)
         .canonicalize()
@@ -613,10 +616,6 @@ fn render_path_name(
         show_clickable_links,
     );
 
-    if use_ls_colors {
-        let val = ansi_style.apply(full_path_link).to_string();
-        Some(Value::String { val, span })
-    } else {
-        None
-    }
+    let val = ansi_style.apply(full_path_link).to_string();
+    Some(Value::String { val, span })
 }


### PR DESCRIPTION
# Description

Fixes #6498, when running `ls Cargo.* | find Cargo`,  `find` highlights filename with ANSI escape sequence , and the filename will be something like `"\e[37m\e[0m\e[41;37mCargo\e[0m\e[37m.lock\e[0m"`, which is not a valid path. Then we render the filename with table, and `make_clickable_link` change the filename to  `"\e]8;;\e[37m\e[0m\e[41;37mCargo\e[0m\e[37m.lock\e[0m\e\\\e[37m\e[0m\e[41;37mCargo\e[0m\e[37m.lock\e[0m\e]8;;\e\\"`, which doubles the output in the 'name' column.

[Screencast from 09-14-2022 06:15:31 PM.webm](https://user-images.githubusercontent.com/15247421/190128330-6bfbc76b-1d80-48de-80ef-86bcf73796e4.webm)


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
