### PR TITLE
external echo won't show extra quote

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -602,6 +602,10 @@ impl ExternalCommand {
 
         process.arg("/c");
         process.arg(&self.name.item);
+        for arg in &self.args {
+            process.arg(&arg);
+        }
+        /*
         for (arg, arg_keep_raw) in self.args.iter().zip(self.arg_keep_raw.iter()) {
             // if arg is quoted, like "aa", 'aa', `aa`, or:
             // if arg is a variable or String interpolation, like: $variable_name, $"($variable_name)"
@@ -621,6 +625,7 @@ impl ExternalCommand {
             };
             process.arg(&arg);
         }
+        */
         process
     }
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -603,11 +603,6 @@ impl ExternalCommand {
         process.arg("/c");
         process.arg(&self.name.item);
         for (arg, arg_keep_raw) in self.args.iter().zip(self.arg_keep_raw.iter()) {
-            // Clean the args before we use them:
-            // https://stackoverflow.com/questions/1200235/how-to-pass-a-quoted-pipe-character-to-cmd-exe
-            // cmd.exe needs to have a caret to escape a pipe
-            let arg = arg.item.replace('|', "^|");
-
             // if arg is quoted, like "aa", 'aa', `aa`, or:
             // if arg is a variable or String interpolation, like: $variable_name, $"($variable_name)"
             // `as_a_whole` will be true, so nu won't remove the inner quotes.
@@ -616,6 +611,9 @@ impl ExternalCommand {
                 keep_raw = true;
             }
 
+            // Clean the args before we use them:
+            // https://stackoverflow.com/questions/1200235/how-to-pass-a-quoted-pipe-character-to-cmd-exe
+            // cmd.exe needs to have a caret to escape a pipe
             let mut arg = if keep_raw {
                 trimmed_args.replace('|', "^|")
             } else {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -606,7 +606,7 @@ impl ExternalCommand {
             // if arg is quoted, like "aa", 'aa', `aa`, or:
             // if arg is a variable or String interpolation, like: $variable_name, $"($variable_name)"
             // `as_a_whole` will be true, so nu won't remove the inner quotes.
-            let (trimmed_args, run_glob_expansion, mut keep_raw) = trim_enclosing_quotes(&arg.item);
+            let (trimmed_args, _, mut keep_raw) = trim_enclosing_quotes(&arg.item);
             if *arg_keep_raw {
                 keep_raw = true;
             }
@@ -614,7 +614,7 @@ impl ExternalCommand {
             // Clean the args before we use them:
             // https://stackoverflow.com/questions/1200235/how-to-pass-a-quoted-pipe-character-to-cmd-exe
             // cmd.exe needs to have a caret to escape a pipe
-            let mut arg = if keep_raw {
+            let arg = if keep_raw {
                 trimmed_args.replace('|', "^|")
             } else {
                 remove_quotes(trimmed_args).replace('|', "^|")

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -603,6 +603,10 @@ impl ExternalCommand {
         process.arg("/c");
         process.arg(&self.name.item);
         for arg in &self.args {
+            // Clean the args before we use them:
+            // https://stackoverflow.com/questions/1200235/how-to-pass-a-quoted-pipe-character-to-cmd-exe
+            // cmd.exe needs to have a caret to escape a pipe
+            let arg = arg.item.replace('|', "^|");
             process.arg(&arg);
         }
         /*

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -303,3 +303,18 @@ fn can_run_batch_files_without_bat_extension() {
         },
     );
 }
+
+#[cfg(windows)]
+#[test]
+fn external_echo_wont_pass_extra_quote() {
+    Playground::setup("external echo wont pass extra quote", |dirs, sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ^echo "X"
+            "#
+        ));
+
+        assert_eq!(actual.out, "X");
+    })
+}

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -307,7 +307,7 @@ fn can_run_batch_files_without_bat_extension() {
 #[cfg(windows)]
 #[test]
 fn external_echo_wont_pass_extra_quote() {
-    Playground::setup("external echo wont pass extra quote", |dirs, sandbox| {
+    Playground::setup("external echo wont pass extra quote", |dirs, _| {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"


### PR DESCRIPTION
# Description

Try fix #6465
(I don't have windows machine again, so borrow ci to check if the solution works..)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
