### PR TITLE
when execute external command, escape args if possible

### DIFF
--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -186,6 +186,20 @@ fn external_arg_with_variable_name() {
     })
 }
 
+#[test]
+fn external_command_escape_args() {
+    Playground::setup("external failed command with semicolon", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                ^echo "\"abcd"
+            "#
+        ));
+
+        assert_eq!(actual.out, r#""abcd"#);
+    })
+}
+
 #[cfg(windows)]
 #[test]
 fn explicit_glob_windows() {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -331,7 +331,13 @@ pub fn parse_external_call(
             args.push(arg);
         } else {
             // Eval stage trims the quotes, so we don't have to do the same thing when parsing.
-            let contents = String::from_utf8_lossy(contents).to_string();
+            let contents = if contents.starts_with(b"\"") {
+                let (contents, err) = unescape_string(contents, *span);
+                error = error.or(err);
+                String::from_utf8_lossy(&contents).to_string()
+            } else {
+                String::from_utf8_lossy(contents).to_string()
+            };
 
             args.push(Expression {
                 expr: Expr::String(contents),


### PR DESCRIPTION
# Description

Fixes: #6559

When passing argument to external command, try escape it.

Relative history:
https://github.com/nushell/nushell/pull/6014, in this change, we move `trim quote logic` into `run_external` eval stage, but `escape logic` is also removed.

This pr is going to keep `escape logic` when parsing arguments.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
