### PR TITLE
Use stripped path for lscolors to get style

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -591,10 +591,10 @@ fn render_path_name(
 
     let (style, has_metadata) = match std::fs::symlink_metadata(&stripped_path) {
         Ok(metadata) => (
-            ls_colors.style_for_path_with_metadata(path, Some(&metadata)),
+            ls_colors.style_for_path_with_metadata(&stripped_path, Some(&metadata)),
             true,
         ),
-        Err(_) => (ls_colors.style_for_path(path), false),
+        Err(_) => (ls_colors.style_for_path(&stripped_path), false),
     };
 
     // clickable links don't work in remote SSH sessions


### PR DESCRIPTION
# Description

This PR fixes b159bf2c28a2979d91e059938c2d739e740de040, a stripped path should pass to `LsColors::style_for_path_with_metadata` and `LsColors::style_for_path`.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
