### PR TITLE
update sql-parser crate and all the files it touches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,9 +4774,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.16.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9a527b68048eb95495a1508f6c8395c8defcff5ecdbe8ad4106d08a2ef2a3c"
+checksum = "0beb13adabbdda01b63d595f38c8bfd19a361e697fd94ce0098a634077bc5b25"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ winres = "0.1"
 [features]
 plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
 extra = ["default", "dataframe", "database"]
-default = ["extra", "plugin", "which-support", "trash-support"]
+default = ["plugin", "which-support", "trash-support"]
 stable = ["default"]
 wasi = []
 # Enable to statically link OpenSSL; otherwise the system version will be used. Not enabled by default because it takes a while to build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,9 +79,9 @@ winres = "0.1"
 
 [features]
 plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
-default = ["plugin", "which-support", "trash-support"]
-stable = ["default"]
 extra = ["default", "dataframe", "database"]
+default = ["extra", "plugin", "which-support", "trash-support"]
+stable = ["default"]
 wasi = []
 # Enable to statically link OpenSSL; otherwise the system version will be used. Not enabled by default because it takes a while to build
 static-link-openssl = ["dep:openssl"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -90,7 +90,7 @@ which = { version = "4.3.0", optional = true }
 reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
-sqlparser = { version = "0.16.0", features = ["serde"], optional = true }
+sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 umask = "2.0.0"

--- a/crates/nu-command/src/database/commands/and.rs
+++ b/crates/nu-command/src/database/commands/and.rs
@@ -125,7 +125,7 @@ impl Command for AndDb {
 }
 
 fn modify_query(query: &mut Box<Query>, expression: Expr, span: Span) -> Result<(), ShellError> {
-    match query.body {
+    match *query.body {
         SetExpr::Select(ref mut select) => modify_select(select, expression, span)?,
         _ => {
             return Err(ShellError::GenericError(

--- a/crates/nu-command/src/database/commands/as_.rs
+++ b/crates/nu-command/src/database/commands/as_.rs
@@ -113,7 +113,7 @@ fn alias_db(
             Vec::new(),
         )),
         Some(statement) => match statement {
-            Statement::Query(query) => match &mut query.body {
+            Statement::Query(query) => match &mut *query.body {
                 SetExpr::Select(select) => {
                     select.as_mut().from.iter_mut().for_each(|table| {
                         let new_alias = Some(TableAlias {

--- a/crates/nu-command/src/database/commands/conversions.rs
+++ b/crates/nu-command/src/database/commands/conversions.rs
@@ -17,7 +17,7 @@ pub fn value_into_table_factor(
             Ok(TableFactor::Table {
                 name: ObjectName(vec![ident]),
                 alias,
-                args: Vec::new(),
+                args: None,
                 with_hints: Vec::new(),
             })
         }

--- a/crates/nu-command/src/database/commands/from_table.rs
+++ b/crates/nu-command/src/database/commands/from_table.rs
@@ -96,12 +96,12 @@ fn create_statement(
 ) -> Result<Statement, ShellError> {
     let query = Query {
         with: None,
-        body: SetExpr::Select(Box::new(create_select(
+        body: Box::new(SetExpr::Select(Box::new(create_select(
             connection,
             engine_state,
             stack,
             call,
-        )?)),
+        )?))),
         order_by: Vec::new(),
         limit: None,
         offset: None,
@@ -121,18 +121,18 @@ fn modify_statement(
 ) -> Result<Statement, ShellError> {
     match statement {
         Statement::Query(ref mut query) => {
-            match query.body {
+            match *query.body {
                 SetExpr::Select(ref mut select) => {
                     let table = create_table(connection, engine_state, stack, call)?;
                     select.from.push(table);
                 }
                 _ => {
-                    query.as_mut().body = SetExpr::Select(Box::new(create_select(
+                    query.as_mut().body = Box::new(SetExpr::Select(Box::new(create_select(
                         connection,
                         engine_state,
                         stack,
                         call,
-                    )?));
+                    )?)));
                 }
             };
 
@@ -167,6 +167,7 @@ fn create_select(
         distribute_by: Vec::new(),
         sort_by: Vec::new(),
         having: None,
+        qualify: None,
     })
 }
 

--- a/crates/nu-command/src/database/commands/group_by.rs
+++ b/crates/nu-command/src/database/commands/group_by.rs
@@ -104,7 +104,7 @@ impl Command for GroupByDb {
         let mut db = SQLiteDatabase::try_from_pipeline(input, call.head)?;
         match db.statement.as_mut() {
             Some(statement) => match statement {
-                Statement::Query(ref mut query) => match &mut query.body {
+                Statement::Query(ref mut query) => match &mut *query.body {
                     SetExpr::Select(ref mut select) => select.group_by = expressions,
                     s => {
                         return Err(ShellError::GenericError(

--- a/crates/nu-command/src/database/commands/join.rs
+++ b/crates/nu-command/src/database/commands/join.rs
@@ -146,7 +146,7 @@ fn modify_statement(
 ) -> Result<Statement, ShellError> {
     match statement {
         Statement::Query(ref mut query) => {
-            match &mut query.body {
+            match &mut *query.body {
                 SetExpr::Select(ref mut select) => {
                     modify_from(connection, select, engine_state, stack, call)?
                 }

--- a/crates/nu-command/src/database/commands/or.rs
+++ b/crates/nu-command/src/database/commands/or.rs
@@ -125,7 +125,7 @@ impl Command for OrDb {
 }
 
 fn modify_query(query: &mut Box<Query>, expression: Expr, span: Span) -> Result<(), ShellError> {
-    match query.body {
+    match *query.body {
         SetExpr::Select(ref mut select) => modify_select(select, expression, span)?,
         _ => {
             return Err(ShellError::GenericError(

--- a/crates/nu-command/src/database/commands/select.rs
+++ b/crates/nu-command/src/database/commands/select.rs
@@ -108,7 +108,7 @@ impl Command for ProjectionDb {
 fn create_statement(expressions: Vec<SelectItem>) -> Statement {
     let query = Query {
         with: None,
-        body: SetExpr::Select(Box::new(create_select(expressions))),
+        body: Box::new(SetExpr::Select(Box::new(create_select(expressions)))),
         order_by: Vec::new(),
         limit: None,
         offset: None,
@@ -126,10 +126,11 @@ fn modify_statement(
 ) -> Result<Statement, ShellError> {
     match statement {
         Statement::Query(ref mut query) => {
-            match query.body {
+            match *query.body {
                 SetExpr::Select(ref mut select) => select.as_mut().projection = expressions,
                 _ => {
-                    query.as_mut().body = SetExpr::Select(Box::new(create_select(expressions)));
+                    query.as_mut().body =
+                        Box::new(SetExpr::Select(Box::new(create_select(expressions))));
                 }
             };
 
@@ -159,6 +160,7 @@ fn create_select(projection: Vec<SelectItem>) -> Select {
         distribute_by: Vec::new(),
         sort_by: Vec::new(),
         having: None,
+        qualify: None,
     }
 }
 

--- a/crates/nu-command/src/database/commands/where_.rs
+++ b/crates/nu-command/src/database/commands/where_.rs
@@ -99,10 +99,10 @@ impl Command for WhereDb {
 }
 
 fn modify_query(query: &mut Box<Query>, expression: Expr) {
-    match query.body {
+    match *query.body {
         SetExpr::Select(ref mut select) => modify_select(select, expression),
         _ => {
-            query.as_mut().body = SetExpr::Select(Box::new(create_select(expression)));
+            query.as_mut().body = Box::new(SetExpr::Select(Box::new(create_select(expression))));
         }
     };
 }
@@ -125,6 +125,7 @@ fn create_select(expression: Expr) -> Select {
         distribute_by: Vec::new(),
         sort_by: Vec::new(),
         having: None,
+        qualify: None,
     }
 }
 

--- a/crates/nu-command/src/database/expressions/function.rs
+++ b/crates/nu-command/src/database/expressions/function.rs
@@ -132,6 +132,7 @@ impl Command for FunctionExpr {
             args,
             over: None,
             distinct: call.has_flag("distinct"),
+            special: false,
         })
         .into();
 

--- a/crates/nu-command/src/database/values/dsl/expression.rs
+++ b/crates/nu-command/src/database/values/dsl/expression.rs
@@ -249,7 +249,7 @@ impl ExtractedExpr {
 
 impl ExprDb {
     pub fn expr_to_value(expr: &Expr, span: Span) -> Value {
-        match expr {
+        match &*expr {
             Expr::Identifier(ident) => {
                 let cols = vec!["value".into(), "quoted_style".into()];
                 let val = Value::String {
@@ -339,7 +339,7 @@ impl ExprDb {
             Expr::TypedString { .. } => todo!(),
             Expr::MapAccess { .. } => todo!(),
             Expr::Case { .. } => todo!(),
-            Expr::Exists(_) => todo!(),
+            Expr::Exists { .. } => todo!(),
             Expr::Subquery(_) => todo!(),
             Expr::ListAgg(_) => todo!(),
             Expr::GroupingSets(_) => todo!(),
@@ -348,6 +348,25 @@ impl ExprDb {
             Expr::Tuple(_) => todo!(),
             Expr::ArrayIndex { .. } => todo!(),
             Expr::Array(_) => todo!(),
+            Expr::JsonAccess { .. } => todo!(),
+            Expr::CompositeAccess { .. } => todo!(),
+            Expr::IsFalse(_) => todo!(),
+            Expr::IsNotFalse(_) => todo!(),
+            Expr::IsTrue(_) => todo!(),
+            Expr::IsNotTrue(_) => todo!(),
+            Expr::IsUnknown(_) => todo!(),
+            Expr::IsNotUnknown(_) => todo!(),
+            Expr::Like { .. } => todo!(),
+            Expr::ILike { .. } => todo!(),
+            Expr::SimilarTo { .. } => todo!(),
+            Expr::AnyOp(_) => todo!(),
+            Expr::AllOp(_) => todo!(),
+            Expr::SafeCast { .. } => todo!(),
+            Expr::AtTimeZone { .. } => todo!(),
+            Expr::Position { .. } => todo!(),
+            Expr::Overlay { .. } => todo!(),
+            Expr::AggregateExpressionWithFilter { .. } => todo!(),
+            Expr::ArraySubquery(_) => todo!(),
         }
     }
 }

--- a/crates/nu-command/src/dataframe/eager/sql_context.rs
+++ b/crates/nu-command/src/dataframe/eager/sql_context.rs
@@ -184,7 +184,7 @@ impl SQLContext {
                 .ok_or_else(|| PolarsError::NotFound("No statement found".to_string()))?;
             Ok(match ast {
                 Statement::Query(query) => {
-                    let rs = match &query.body {
+                    let rs = match &*query.body {
                         SetExpr::Select(select_stmt) => self.execute_select(&*select_stmt)?,
                         _ => {
                             return Err(PolarsError::ComputeError(


### PR DESCRIPTION
# Description

Wow, what a mess. This PR updates the sql-parser crate from v16 to v23. That part was easy. The rest wasn't as easy but it seems to still work ok so far. :)
There are quite a few `todo!()`s since the entire sql syntax isn't currently support in nushell. It would be nice to impelement all that seem reasonable.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
