### PR TITLE
ensure external signatures do not enforce type checking

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -498,6 +498,7 @@ pub fn parse_extern(
 
                 signature.name = name.clone();
                 signature.usage = usage.clone();
+                signature.external_completion = true;
 
                 let decl = KnownExternal {
                     name: name.to_string(),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -773,6 +773,7 @@ pub fn parse_internal_call(
 
     let decl = working_set.get_decl(decl_id);
     let signature = decl.signature();
+    let is_external_completion = signature.external_completion;
     let output = signature.output_type.clone();
 
     working_set.type_scope.add_type(output.clone());
@@ -967,6 +968,10 @@ pub fn parse_internal_call(
 
     if signature.creates_scope {
         working_set.exit_scope();
+    }
+
+    if is_external_completion {
+        error = None;
     }
 
     ParsedInternalCall {

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -117,6 +117,7 @@ pub struct Signature {
     pub creates_scope: bool,
     // Signature category used to classify commands stored in the list of declarations
     pub category: Category,
+    pub external_completion: bool,
 }
 
 impl PartialEq for Signature {
@@ -148,6 +149,7 @@ impl Signature {
             is_filter: false,
             creates_scope: false,
             category: Category::Default,
+            external_completion: false,
         }
     }
 


### PR DESCRIPTION
# Description

Title. Fixes #4659. Fixes #6020. Kind of Fixes #5103. Fixes #5294. Fixes #6124. Try typing `git fetch -a`; I have no clue how to add tests for this.

This prevents all parse errors for export extern; in other words, now the exported extern is only used for completions.

Related to the discussion in #6020, I'm wondering if the hard check should be a configurable option, turned off by default. Thoughts? 

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
