### PR TITLE
rename with_sql to query dfr

### DIFF
--- a/crates/nu-command/src/dataframe/eager/mod.rs
+++ b/crates/nu-command/src/dataframe/eager/mod.rs
@@ -13,6 +13,7 @@ mod last;
 mod list;
 mod melt;
 mod open;
+mod query_dfr;
 mod rename;
 mod sample;
 mod shape;
@@ -26,7 +27,6 @@ mod to_df;
 mod to_nu;
 mod to_parquet;
 mod with_column;
-mod with_sql;
 
 use nu_protocol::engine::StateWorkingSet;
 
@@ -45,6 +45,7 @@ pub use last::LastDF;
 pub use list::ListDF;
 pub use melt::MeltDF;
 pub use open::OpenDataFrame;
+pub use query_dfr::QueryDfr;
 pub use rename::RenameDF;
 pub use sample::SampleDF;
 pub use shape::ShapeDF;
@@ -58,7 +59,6 @@ pub use to_df::ToDataFrame;
 pub use to_nu::ToNu;
 pub use to_parquet::ToParquet;
 pub use with_column::WithColumn;
-pub use with_sql::WithSql;
 
 pub fn add_eager_decls(working_set: &mut StateWorkingSet) {
     macro_rules! bind_command {
@@ -87,6 +87,7 @@ pub fn add_eager_decls(working_set: &mut StateWorkingSet) {
         ListDF,
         MeltDF,
         OpenDataFrame,
+        QueryDfr,
         RenameDF,
         SampleDF,
         ShapeDF,
@@ -97,7 +98,6 @@ pub fn add_eager_decls(working_set: &mut StateWorkingSet) {
         ToDataFrame,
         ToNu,
         ToParquet,
-        WithColumn,
-        WithSql
+        WithColumn
     );
 }

--- a/crates/nu-command/src/dataframe/eager/query_dfr.rs
+++ b/crates/nu-command/src/dataframe/eager/query_dfr.rs
@@ -14,15 +14,15 @@ use nu_protocol::{
 // https://github.com/pola-rs/polars/tree/master/polars-sql
 
 #[derive(Clone)]
-pub struct WithSql;
+pub struct QueryDfr;
 
-impl Command for WithSql {
+impl Command for QueryDfr {
     fn name(&self) -> &str {
-        "with-sql"
+        "query dfr"
     }
 
     fn usage(&self) -> &str {
-        "Query dataframe using SQL. Note: The dataframe is always named df in your query."
+        "Query dataframe using SQL. Note: The dataframe is always named 'df' in your query's from clause."
     }
 
     fn signature(&self) -> Signature {
@@ -97,6 +97,6 @@ mod test {
 
     #[test]
     fn test_examples() {
-        test_dataframe(vec![Box::new(WithSql {})])
+        test_dataframe(vec![Box::new(QueryDfr {})])
     }
 }

--- a/crates/nu-command/src/dataframe/eager/query_dfr.rs
+++ b/crates/nu-command/src/dataframe/eager/query_dfr.rs
@@ -33,6 +33,10 @@ impl Command for QueryDfr {
             .category(Category::Custom("dataframe".into()))
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["dataframe", "sql", "search"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Query dataframe using SQL",

--- a/crates/nu-command/src/dataframe/eager/query_dfr.rs
+++ b/crates/nu-command/src/dataframe/eager/query_dfr.rs
@@ -40,7 +40,7 @@ impl Command for QueryDfr {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Query dataframe using SQL",
-            example: "[[a b]; [1 2] [3 4]] | into df | with-sql 'select a from df'",
+            example: "[[a b]; [1 2] [3 4]] | into df | query dfr 'select a from df'",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),


### PR DESCRIPTION
# Description

This PR renames the new command for dfrs `with_sql` to `query dfr` in hopes that it makes it easier to find and more intuitive.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
