### PR TITLE
Add export-env eval to use command

### DIFF
--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -1,4 +1,5 @@
-use nu_test_support::fs::{AbsolutePath, Stub::FileWithContent};
+use nu_test_support::fs::AbsolutePath;
+use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::nu;
 use nu_test_support::pipeline;
 use nu_test_support::playground::Playground;
@@ -61,5 +62,124 @@ fn use_keeps_doc_comments() {
 
         assert!(actual.out.contains("this is my foo command"));
         assert!(actual.out.contains("this is an x parameter"));
+    })
+}
+
+#[test]
+fn use_eval_export_env() {
+    Playground::setup("use_eval_export_env", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "spam.nu",
+            r#"
+                export-env { let-env FOO = 'foo' }
+            "#,
+        )]);
+
+        let inp = &[r#"use spam.nu"#, r#"$env.FOO"#];
+
+        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+
+        assert_eq!(actual.out, "foo");
+    })
+}
+
+#[test]
+fn use_eval_export_env_hide() {
+    Playground::setup("use_eval_export_env", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "spam.nu",
+            r#"
+                export-env { hide-env FOO }
+            "#,
+        )]);
+
+        let inp = &[r#"let-env FOO = 'foo'"#, r#"use spam.nu"#, r#"$env.FOO"#];
+
+        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+
+        assert!(actual.err.contains("did you mean"));
+    })
+}
+
+#[test]
+fn use_do_cd() {
+    Playground::setup("use_do_cd", |dirs, sandbox| {
+        sandbox
+            .mkdir("test1/test2")
+            .with_files(vec![FileWithContentToBeTrimmed(
+                "test1/test2/spam.nu",
+                r#"
+                    export-env { cd test1/test2 }
+                "#,
+            )]);
+
+        let inp = &[r#"use test1/test2/spam.nu"#, r#"$env.PWD | path basename"#];
+
+        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+
+        assert_eq!(actual.out, "test2");
+    })
+}
+
+#[test]
+fn use_do_cd_file_relative() {
+    Playground::setup("use_do_cd_file_relative", |dirs, sandbox| {
+        sandbox
+            .mkdir("test1/test2")
+            .with_files(vec![FileWithContentToBeTrimmed(
+                "test1/test2/spam.nu",
+                r#"
+                    export-env { cd ($env.FILE_PWD | path join '..') }
+                "#,
+            )]);
+
+        let inp = &[r#"use test1/test2/spam.nu"#, r#"$env.PWD | path basename"#];
+
+        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+
+        assert_eq!(actual.out, "test1");
+    })
+}
+
+#[test]
+fn use_dont_cd_overlay() {
+    Playground::setup("use_dont_cd_overlay", |dirs, sandbox| {
+        sandbox
+            .mkdir("test1/test2")
+            .with_files(vec![FileWithContentToBeTrimmed(
+                "test1/test2/spam.nu",
+                r#"
+                    export-env {
+                        overlay new spam
+                        cd test1/test2
+                        overlay hide spam
+                    }
+                "#,
+            )]);
+
+        let inp = &[r#"use test1/test2/spam.nu"#, r#"$env.PWD | path basename"#];
+
+        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+
+        assert_eq!(actual.out, "use_dont_cd_overlay");
+    })
+}
+
+#[test]
+fn use_export_env_combined() {
+    Playground::setup("use_is_scoped", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "spam.nu",
+            r#"
+                alias bar = foo
+                export-env { let-env FOO = bar }
+                def foo [] { 'foo' }
+            "#,
+        )]);
+
+        let inp = &[r#"use spam.nu"#, r#"$env.FOO"#];
+
+        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        assert_eq!(actual.out, "foo");
     })
 }


### PR DESCRIPTION
# Description

When `use` is called, it evaluates the `export-env` block, if there is one. This functionality was moved from the `source-env` command which will be removed.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
