### PR TITLE
Reinstate the `-a` short form of `save --append`

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -36,7 +36,7 @@ impl Command for Save {
         Signature::build("save")
             .required("filename", SyntaxShape::Filepath, "the filename to use")
             .switch("raw", "save file as raw binary", Some('r'))
-            .switch("append", "append input to the end of the file", None)
+            .switch("append", "append input to the end of the file", Some('a'))
             .category(Category::FileSystem)
     }
 


### PR DESCRIPTION
Present before engine-q merge (e.g. 265ee1281d810a569c7daddd02031f5c6991699e) but not included when --append was re-introduced at https://github.com/nushell/nushell/pull/4744.

# Description

Makes `save -a` work as `save --append`

# Tests

I just tested manually, with `echo hello | save -a /tmp/a`.

```
~ 〉save --help
Save a file.

Usage:
  > save {flags} <filename>

Flags:
  -h, --help - Display this help message
  -r, --raw - save file as raw binary
  -a, --append - append input to the end of the file
```

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
