### PR TITLE
Apply clippy fix for rust 1.63.0

### DIFF
--- a/crates/nu-command/src/database/values/dsl/expression.rs
+++ b/crates/nu-command/src/database/values/dsl/expression.rs
@@ -249,7 +249,7 @@ impl ExtractedExpr {
 
 impl ExprDb {
     pub fn expr_to_value(expr: &Expr, span: Span) -> Value {
-        match &*expr {
+        match expr {
             Expr::Identifier(ident) => {
                 let cols = vec!["value".into(), "quoted_style".into()];
                 let val = Value::String {

--- a/crates/nu-command/src/dataframe/eager/sql_context.rs
+++ b/crates/nu-command/src/dataframe/eager/sql_context.rs
@@ -185,7 +185,7 @@ impl SQLContext {
             Ok(match ast {
                 Statement::Query(query) => {
                     let rs = match &*query.body {
-                        SetExpr::Select(select_stmt) => self.execute_select(&*select_stmt)?,
+                        SetExpr::Select(select_stmt) => self.execute_select(select_stmt)?,
                         _ => {
                             return Err(PolarsError::ComputeError(
                                 "INSERT, UPDATE is not supported for polars".into(),

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -79,7 +79,7 @@ fn get_documentation(
     let _ = write!(long_desc, "{}", text);
 
     if !subcommands.is_empty() {
-        long_desc.push_str(&format!("\n{G}Subcommands{RESET}:\n"));
+        let _ = write!(long_desc, "\n{G}Subcommands{RESET}:\n");
         subcommands.sort();
         long_desc.push_str(&subcommands.join("\n"));
         long_desc.push('\n');
@@ -93,7 +93,7 @@ fn get_documentation(
         || !sig.optional_positional.is_empty()
         || sig.rest_positional.is_some()
     {
-        long_desc.push_str(&format!("\n{G}Parameters{RESET}:\n"));
+        let _ = write!(long_desc, "\n{G}Parameters{RESET}:\n");
         for positional in &sig.required_positional {
             let text = format!(
                 "  {C}{}{RESET} <{BB}{:?}{RESET}>: {}",
@@ -125,7 +125,7 @@ fn get_documentation(
     }
 
     if !examples.is_empty() {
-        long_desc.push_str(&format!("\n{}Examples{}:", G, RESET));
+        let _ = write!(long_desc, "\n{}Examples{}:", G, RESET);
     }
 
     for example in examples {
@@ -199,7 +199,7 @@ pub fn get_flags_section(signature: &Signature) -> String {
     const D: &str = "\x1b[39m"; // default
 
     let mut long_desc = String::new();
-    long_desc.push_str(&format!("\n{}Flags{}:\n", G, RESET));
+    let _ = write!(long_desc, "\n{}Flags{}:\n", G, RESET);
     for flag in &signature.named {
         let msg = if let Some(arg) = &flag.arg {
             if let Some(short) = flag.short {


### PR DESCRIPTION
# Description
When running clippy with rust-1.63.0, there are two types of warnings:
```
error: `format!(..)` appended to existing `String`
  --> crates/nu-engine/src/documentation.rs:82:9
   |
82 |         long_desc.push_str(&format!("\n{G}Subcommands{RESET}:\n"));
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D clippy::format-push-string` implied by `-D warnings`
   = help: consider using `write!` to avoid the extra allocation
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string

error: `format!(..)` appended to existing `String`
  --> crates/nu-engine/src/documentation.rs:96:9
   |
96 |         long_desc.push_str(&format!("\n{G}Parameters{RESET}:\n"));
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider using `write!` to avoid the extra allocation
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string

error: `format!(..)` appended to existing `String`
   --> crates/nu-engine/src/documentation.rs:128:9
    |
128 |         long_desc.push_str(&format!("\n{}Examples{}:", G, RESET));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using `write!` to avoid the extra allocation
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string

error: `format!(..)` appended to existing `String`
   --> crates/nu-engine/src/documentation.rs:202:5
    |
202 |     long_desc.push_str(&format!("\n{}Flags{}:\n", G, RESET));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using `write!` to avoid the extra allocation
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string

error: could not compile `nu-engine` due to 4 previous errors
```

```
error: deref on an immutable reference
   --> crates/nu-command/src/dataframe/eager/sql_context.rs:188:77
    |
188 |                         SetExpr::Select(select_stmt) => self.execute_select(&*select_stmt)?,
    |                                                                             ^^^^^^^^^^^^^
    |
    = note: `-D clippy::borrow-deref-ref` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
help: if you would like to reborrow, try removing `&*`
    |
188 |                         SetExpr::Select(select_stmt) => self.execute_select(select_stmt)?,
    |                                                                             ~~~~~~~~~~~
help: if you would like to deref, try using `&**`
    |
188 |                         SetExpr::Select(select_stmt) => self.execute_select(&**select_stmt)?,
    |                                                                             ~~~~~~~~~~~~~~

error: deref on an immutable reference
   --> crates/nu-command/src/database/values/dsl/expression.rs:252:15
    |
252 |         match &*expr {
    |               ^^^^^^ help: if you would like to reborrow, try removing `&*`: `expr`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref

error: could not compile `nu-command` due to 2 previous errors
```


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
