### PR TITLE
add history session id to $nu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.11.0"
-source = "git+https://github.com/nushell/reedline?branch=main#dc091e828590de6fd335af3f1d001ede851ac20a"
+source = "git+http://github.com/nushell/reedline?rev=9a6fdd7#9a6fdd78dcf2fc472040748b5c9dc0b0f0ee31f6"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,9 @@ nu-system = { path = "./crates/nu-system", version = "0.68.2" }
 nu-table = { path = "./crates/nu-table", version = "0.68.2"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.68.2"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.68.2"  }
-reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
+# reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
+reedline = { git = "http://github.com/nushell/reedline", rev = "9a6fdd7", features = ["bashisms", "sqlite"]}
+
 rayon = "1.5.1"
 is_executable = "1.0.1"
 simplelog = "0.12.0"
@@ -122,5 +124,5 @@ debug = false
 name = "nu"
 path = "src/main.rs"
 
-[patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+# [patch.crates-io]
+# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -20,7 +20,8 @@ nu-protocol = { path = "../nu-protocol", version = "0.68.2"  }
 nu-utils = { path = "../nu-utils", version = "0.68.2"  }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.68.2"  }
-reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
+# reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
+reedline = { git = "http://github.com/nushell/reedline", rev = "9a6fdd7", features = ["bashisms", "sqlite"]}
 
 atty = "0.2.14"
 chrono = "0.4.21"

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -19,8 +19,11 @@ use nu_protocol::{
     Spanned, Type, Value, VarId,
 };
 use reedline::{DefaultHinter, EditCommand, Emacs, SqliteBackedHistory, Vi};
-use std::io::{self, Write};
-use std::{sync::atomic::Ordering, time::Instant};
+use std::{
+    io::{self, Write},
+    sync::atomic::Ordering,
+    time::Instant,
+};
 use strip_ansi_escapes::strip;
 use sysinfo::SystemExt;
 
@@ -98,14 +101,21 @@ pub fn evaluate_repl(
         );
     }
 
-    // Get the config once for the history `max_history_size`
-    // Updating that will not be possible in one session
-    let config = engine_state.get_config();
-
     if is_perf_true {
         info!("setup reedline {}:{}:{}", file!(), line!(), column!());
     }
+
     let mut line_editor = Reedline::create();
+
+    // Now that reedline is created, get the history session id and store it in engine_state
+    let hist_sesh = match line_editor.get_history_session_id() {
+        Some(id) => i64::from(id),
+        None => 0,
+    };
+    engine_state.history_session_id = hist_sesh;
+
+    let config = engine_state.get_config();
+
     let history_path = crate::config_files::get_history_path(
         nushell_path,
         engine_state.config.history_file_format,

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -469,12 +469,13 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(9, suggestions.len());
+    assert_eq!(10, suggestions.len());
 
     let expected: Vec<String> = vec![
         "config-path".into(),
         "env-path".into(),
         "history-path".into(),
+        "history-session-id".into(),
         "home-path".into(),
         "loginshell-path".into(),
         "os-info".into(),
@@ -489,9 +490,13 @@ fn variables_completions() {
     // Test completions for $nu.h (filter)
     let suggestions = completer.complete("$nu.h", 5);
 
-    assert_eq!(2, suggestions.len());
+    assert_eq!(3, suggestions.len());
 
-    let expected: Vec<String> = vec!["history-path".into(), "home-path".into()];
+    let expected: Vec<String> = vec![
+        "history-path".into(),
+        "history-session-id".into(),
+        "home-path".into(),
+    ];
 
     // Match results
     match_suggestions(expected, suggestions);

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -87,7 +87,8 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "1.1.2", features = ["v4"] }
 which = { version = "4.3.0", optional = true }
-reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
+# reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
+reedline = { git = "http://github.com/nushell/reedline", rev = "9a6fdd7", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1434,6 +1434,9 @@ pub fn eval_variable(
             output_cols.push("os-info".into());
             output_vals.push(os_record);
 
+            output_cols.push("history-session-id".into());
+            output_vals.push(Value::int(engine_state.history_session_id, span));
+
             Ok(Value::Record {
                 cols: output_cols,
                 vals: output_vals,

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -87,6 +87,7 @@ pub struct EngineState {
     #[cfg(not(windows))]
     sig_quit: Option<Arc<AtomicBool>>,
     config_path: HashMap<String, PathBuf>,
+    pub history_session_id: i64,
 }
 
 pub const NU_VARIABLE_ID: usize = 0;
@@ -127,6 +128,7 @@ impl EngineState {
             #[cfg(not(windows))]
             sig_quit: None,
             config_path: HashMap::new(),
+            history_session_id: 0,
         }
     }
 


### PR DESCRIPTION
# Description

This PR adds the reedline history session id to the `$nu` variable. When using the sqlite history db, this should make it easier to query history records by history session. A new history session is created with every new instance of reedline, so every new instance of nushell.

<img width="480" alt="Screen Shot 2022-09-18 at 9 18 39 PM" src="https://user-images.githubusercontent.com/343840/190940156-94ab9783-1df5-4645-9a24-80ff0d97e5a5.png">

The history session id is stored at time since UNIX_EPOCH in nanoseconds but is not intended to be used as any type of a timing mechanism. It's just meant to try and have a mostly unique history session id, that fits within the datatype. If we have to move to a ulid, we'll have to change the data type, which we don't really want to do.

This PR is dependent on https://github.com/nushell/reedline/pull/485 so, I'll make this a draft until the reedline PR is landed.

Note: I couldn't get ci to see the right main branch in reedline without specifically pointing it out. Not sure if it was cached or what.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
