### PR TITLE
add history session command

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -469,13 +469,12 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(10, suggestions.len());
+    assert_eq!(9, suggestions.len());
 
     let expected: Vec<String> = vec![
         "config-path".into(),
         "env-path".into(),
         "history-path".into(),
-        "history-session-id".into(),
         "home-path".into(),
         "loginshell-path".into(),
         "os-info".into(),
@@ -490,13 +489,9 @@ fn variables_completions() {
     // Test completions for $nu.h (filter)
     let suggestions = completer.complete("$nu.h", 5);
 
-    assert_eq!(3, suggestions.len());
+    assert_eq!(2, suggestions.len());
 
-    let expected: Vec<String> = vec![
-        "history-path".into(),
-        "history-session-id".into(),
-        "home-path".into(),
-    ];
+    let expected: Vec<String> = vec!["history-path".into(), "home-path".into()];
 
     // Match results
     match_suggestions(expected, suggestions);

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -138,6 +138,7 @@ pub fn create_default_context() -> EngineState {
         bind_command! {
             History,
             Tutor,
+            HistorySession,
         };
 
         // Path

--- a/crates/nu-command/src/misc/history_session.rs
+++ b/crates/nu-command/src/misc/history_session.rs
@@ -1,0 +1,43 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Value};
+
+#[derive(Clone)]
+pub struct HistorySession;
+
+impl Command for HistorySession {
+    fn name(&self) -> &str {
+        "history session"
+    }
+
+    fn usage(&self) -> &str {
+        "Get the command history session"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("history session").category(Category::Misc)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            example: "history session",
+            description: "Get current history session",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Ok(Value::Record {
+            cols: vec!["session-id".into()],
+            vals: vec![Value::int(engine_state.history_session_id, call.head)],
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+}

--- a/crates/nu-command/src/misc/mod.rs
+++ b/crates/nu-command/src/misc/mod.rs
@@ -1,5 +1,7 @@
 mod history;
+mod history_session;
 mod tutor;
 
 pub use history::History;
+pub use history_session::HistorySession;
 pub use tutor::Tutor;

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1434,9 +1434,6 @@ pub fn eval_variable(
             output_cols.push("os-info".into());
             output_vals.push(os_record);
 
-            output_cols.push("history-session-id".into());
-            output_vals.push(Value::int(engine_state.history_session_id, span));
-
             Ok(Value::Record {
                 cols: output_cols,
                 vals: output_vals,


### PR DESCRIPTION
# Description

This PR is here because I found out that the command below just doesn't work right with our architecture.
```
history | where session_id = $nu.history-session-id
```
It was taking me > 30 seconds in release mode to run this command with a history of ~5000 commands. It turns out that evaluating `$nu.history-session-id` on every row is super expensive. So, I removed the history-session-id variable in `$nu` and replaced it with a `history session` command, which takes about 62ms in debug mode with something like this:
```
history | where session_id == (history session).session-id
```

`history session` returns a record. Maybe it would be better to return just the int value but it's nushell so things should look nushelly.
![image](https://user-images.githubusercontent.com/343840/191096321-9142b124-cb0e-4f71-9c47-729e0618b7bb.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
