### PR TITLE
make `let` throw error when name is number

### DIFF
--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -13,3 +13,17 @@ fn let_parse_error() {
         .err
         .contains("'in' is the name of a builtin Nushell variable"));
 }
+
+#[test]
+fn let_parse_error_when_name_is_number() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        let 123 = 3
+        "#
+    ));
+
+    assert!(actual
+        .err
+        .contains("variable name can't contain spaces or quotes or be a number"));
+}

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -110,7 +110,7 @@ pub enum ParseError {
 
     #[error("Variable name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
-    VariableNotValid(#[label = "variable name can't contain spaces or quotes"] Span),
+    VariableNotValid(#[label = "variable name can't contain spaces or quotes or be a number"] Span),
 
     #[error("Module not found.")]
     #[diagnostic(

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2922,6 +2922,13 @@ pub fn parse_var_with_opt_type(
         );
     }
 
+    if String::from_utf8_lossy(&bytes).parse::<f64>().is_ok() || String::from_utf8_lossy(&bytes).parse::<i64>().is_ok() {
+        return (
+            garbage(spans[*spans_idx]),
+            Some(ParseError::VariableNotValid(spans[*spans_idx])),
+        );
+    }
+
     if bytes.ends_with(b":") {
         // We end with colon, so the next span should be the type
         if *spans_idx + 1 < spans.len() {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2915,14 +2915,9 @@ pub fn parse_var_with_opt_type(
         || bytes.contains(&b'"')
         || bytes.contains(&b'\'')
         || bytes.contains(&b'`')
+        || String::from_utf8_lossy(&bytes).parse::<f64>().is_ok()
+        || String::from_utf8_lossy(&bytes).parse::<i64>().is_ok()
     {
-        return (
-            garbage(spans[*spans_idx]),
-            Some(ParseError::VariableNotValid(spans[*spans_idx])),
-        );
-    }
-
-    if String::from_utf8_lossy(&bytes).parse::<f64>().is_ok() || String::from_utf8_lossy(&bytes).parse::<i64>().is_ok() {
         return (
             garbage(spans[*spans_idx]),
             Some(ParseError::VariableNotValid(spans[*spans_idx])),


### PR DESCRIPTION
# Description

In these instances, the variable cannot be called. A parser error should be thrown.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
