### PR TITLE
Add "space" key to bind in vi normal mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.11.0"
-source = "git+http://github.com/nushell/reedline?rev=9a6fdd7#9a6fdd78dcf2fc472040748b5c9dc0b0f0ee31f6"
+source = "git+https://github.com/nushell/reedline?branch=main#710393a0375860709e368d0ba8c5883a6e44e673"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,7 @@ nu-system = { path = "./crates/nu-system", version = "0.68.2" }
 nu-table = { path = "./crates/nu-table", version = "0.68.2"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.68.2"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.68.2"  }
-# reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
-reedline = { git = "http://github.com/nushell/reedline", rev = "9a6fdd7", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
 
 rayon = "1.5.1"
 is_executable = "1.0.1"
@@ -124,5 +123,5 @@ debug = false
 name = "nu"
 path = "src/main.rs"
 
-# [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+[patch.crates-io]
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -20,8 +20,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.68.2"  }
 nu-utils = { path = "../nu-utils", version = "0.68.2"  }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.68.2"  }
-# reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
-reedline = { git = "http://github.com/nushell/reedline", rev = "9a6fdd7", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
 
 atty = "0.2.14"
 chrono = "0.4.21"

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -666,6 +666,7 @@ fn add_parsed_keybinding(
 
             KeyCode::Char(char)
         }
+        "space" => KeyCode::Char(' '),
         "down" => KeyCode::Down,
         "up" => KeyCode::Up,
         "left" => KeyCode::Left,

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -87,8 +87,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "1.1.2", features = ["v4"] }
 which = { version = "4.3.0", optional = true }
-# reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
-reedline = { git = "http://github.com/nushell/reedline", rev = "9a6fdd7", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.11.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }


### PR DESCRIPTION
# Description

Implements #6586

No special logic to prevent you from binding it in other modes!
Needs a separate change to reedline to make it available in the default listing of `keybindings list`.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
