### PR TITLE
prevent alias name from being filesize or number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,6 +2800,7 @@ dependencies = [
 name = "nu-parser"
 version = "0.68.2"
 dependencies = [
+ "bytesize",
  "chrono",
  "itertools",
  "log",

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -49,12 +49,16 @@ fn alias_fails_with_invalid_name() {
             alias 1234 = echo "test"   
         "#
     ));
-    assert!(actual.err.contains("alias name can't be a number or a filesize"));
+    assert!(actual
+        .err
+        .contains("alias name can't be a number or a filesize"));
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             alias 5gib = echo "test"   
         "#
     ));
-    assert!(actual.err.contains("alias name can't be a number or a filesize"));
+    assert!(actual
+        .err
+        .contains("alias name can't be a number or a filesize"));
 }

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -40,3 +40,21 @@ fn alias_hiding_2() {
 
     assert_eq!(actual.out, "0");
 }
+
+#[test]
+fn alias_fails_with_invalid_name() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            alias 1234 = echo "test"   
+        "#
+    ));
+    assert!(actual.err.contains("alias name can't be a number or a filesize"));
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            alias 5gib = echo "test"   
+        "#
+    ));
+    assert!(actual.err.contains("alias name can't be a number or a filesize"));
+}

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -8,6 +8,7 @@ name = "nu-parser"
 version = "0.68.2"
 
 [dependencies]
+bytesize = "1.1.0"
 chrono = "0.4.21"
 itertools = "0.10"
 miette = "5.1.0"

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -112,6 +112,10 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
     VariableNotValid(#[label = "variable name can't contain spaces or quotes"] Span),
 
+    #[error("Alias name not supported.")]
+    #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
+    AliasNotValid(#[label = "alias name can't be a number or a filesize"] Span),
+
     #[error("Module not found.")]
     #[diagnostic(
         code(nu::parser::module_not_found),
@@ -344,6 +348,7 @@ impl ParseError {
             ParseError::MultipleRestParams(s) => *s,
             ParseError::VariableNotFound(s) => *s,
             ParseError::VariableNotValid(s) => *s,
+            ParseError::AliasNotValid(s) => *s,
             ParseError::ModuleNotFound(s) => *s,
             ParseError::CyclicalModuleImport(_, s) => *s,
             ParseError::ModuleOrOverlayNotFound(s) => *s,


### PR DESCRIPTION
# Description

NB: The parsing has to be done like that as some commands exist (e.g. 7zip) that start with a number. It's filesizes and numbers that specifically can't be called.
`bytesize` isn't a new dependency, it's used in `nu-command` as well.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
