### PR TITLE
Fix mv data loss when changing folder case (step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "rstest",
  "rusqlite",
  "rust-embed",
+ "same-file",
  "serde",
  "serde_ini",
  "serde_urlencoded",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -70,6 +70,7 @@ rayon = "1.5.1"
 reqwest = {version = "0.11", features = ["blocking", "json"] }
 roxmltree = "0.14.0"
 rust-embed = "6.3.0"
+same-file = "1.0.6"
 serde = { version="1.0.123", features=["derive"] }
 serde_ini = "0.2.0"
 serde_urlencoded = "0.7.0"

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -253,8 +253,12 @@ fn move_file(
         return Err(ShellError::DirectoryNotFound(to_span, None));
     }
 
+    // This can happen when changing case on a case-insensitive filesystem (ex: changing foo to Foo on Windows)
+    // When it does, we want to do a plain rename instead of moving `from` into `to`
+    let from_to_are_same_file = same_file::is_same_file(&from, &to).unwrap_or(false);
+
     let mut to = to;
-    if !from.is_dir() && to.is_dir() {
+    if !from_to_are_same_file && to.is_dir() {
         let from_file_name = match from.file_name() {
             Some(name) => name,
             None => return Err(ShellError::DirectoryNotFound(to_span, None)),

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -254,7 +254,7 @@ fn move_file(
     }
 
     let mut to = to;
-    if to.is_dir() {
+    if !from.is_dir() && to.is_dir() {
         let from_file_name = match from.file_name() {
             Some(name) => name,
             None => return Err(ShellError::DirectoryNotFound(to_span, None)),


### PR DESCRIPTION
# Description

Related to #6583, which is a really ugly bug where `mv` can delete folders on Windows. The `mv` code works like this:

1. Try to rename a directory with `std::fs::rename()`
2. If that failed, fall back to `fs_extra::dir::move_dir()`

We had a bug that was causing directory renames to _always_ fall back to `fs_extra`, which has a bug on case-insensitive filesystems. I've fixed our bug and have added tests to catch folder deletion when using `mv`.

The author of `fs_extra` is also working on a fix and I'll update our dependency when that's ready.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
