### PR TITLE
Fix issue 6596

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -169,9 +169,10 @@ impl NuCompleter {
                             }
                         };
 
-                        // Parses the prefix
+                        // Parses the prefix. Completion should look up to the cursor position, not after.
                         let mut prefix = working_set.get_span_contents(flat.0).to_vec();
-                        prefix.remove(pos - (flat.0.start - span_offset));
+                        let index = pos - (flat.0.start - span_offset);
+                        prefix.drain(index..);
 
                         // Variables completion
                         if prefix.starts_with(b"$") || most_left_var.is_some() {

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -123,7 +123,8 @@ impl NuCompleter {
         let offset = working_set.next_span_start();
         let (mut new_line, alias_offset) = try_find_alias(line.as_bytes(), &working_set);
         let initial_line = line.to_string();
-        new_line.push(b'a');
+        let alias_total_offset: usize = alias_offset.iter().sum();
+        new_line.insert(alias_total_offset + pos, b'a');
         let pos = offset + pos;
         let config = self.engine_state.get_config();
 

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -63,7 +63,7 @@ fn variables_single_dash_argument_with_flagcompletion(mut completer: NuCompleter
 
 #[rstest]
 fn variables_command_with_commandcompletion(mut completer_strings: NuCompleter) {
-    let suggestions = completer_strings.complete("my-command ", 9);
+    let suggestions = completer_strings.complete("my-c ", 4);
     let expected: Vec<String> = vec!["my-command".into()];
     match_suggestions(expected, suggestions);
 }
@@ -684,5 +684,19 @@ fn flagcompletion_triggers_after_cursor(mut completer: NuCompleter) {
 fn customcompletion_triggers_after_cursor(mut completer_strings: NuCompleter) {
     let suggestions = completer_strings.complete("my-command c", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn customcompletion_triggers_after_cursor_piped(mut completer_strings: NuCompleter) {
+    let suggestions = completer_strings.complete("my-command c | ls", 11);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn flagcompletion_triggers_after_cursor_piped(mut completer: NuCompleter) {
+    let suggestions = completer.complete("tst -h | ls", 5);
+    let expected: Vec<String> = vec!["--help".into(), "--mod".into(), "-h".into(), "-s".into()];
     match_suggestions(expected, suggestions);
 }

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -700,3 +700,24 @@ fn flagcompletion_triggers_after_cursor_piped(mut completer: NuCompleter) {
     let expected: Vec<String> = vec!["--help".into(), "--mod".into(), "-h".into(), "-s".into()];
     match_suggestions(expected, suggestions);
 }
+
+#[test]
+fn filecompletions_triggers_after_cursor() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+
+    let suggestions = completer.complete("cp   test_c", 3);
+
+    let expected_paths: Vec<String> = vec![
+        String::from("nushell"),
+        String::from("test_a/"),
+        String::from("test_b/"),
+        String::from("another/"),
+        String::from("custom_completion.nu"),
+        String::from(".hidden_file"),
+        String::from(".hidden_folder/"),
+    ];
+
+    match_suggestions(expected_paths, suggestions);
+}

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -672,3 +672,17 @@ fn unknown_command_completion() {
 
     match_suggestions(expected_paths, suggestions)
 }
+
+#[rstest]
+fn flagcompletion_triggers_after_cursor(mut completer: NuCompleter) {
+    let suggestions = completer.complete("tst -h", 5);
+    let expected: Vec<String> = vec!["--help".into(), "--mod".into(), "-h".into(), "-s".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn customcompletion_triggers_after_cursor(mut completer_strings: NuCompleter) {
+    let suggestions = completer_strings.complete("my-command c", 11);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -709,14 +709,25 @@ fn filecompletions_triggers_after_cursor() {
 
     let suggestions = completer.complete("cp   test_c", 3);
 
+    #[cfg(windows)]
     let expected_paths: Vec<String> = vec![
-        String::from("nushell"),
-        String::from("test_a/"),
-        String::from("test_b/"),
-        String::from("another/"),
-        String::from("custom_completion.nu"),
-        String::from(".hidden_file"),
-        String::from(".hidden_folder/"),
+        "nushell".to_string(),
+        "test_a\\".to_string(),
+        "test_b\\".to_string(),
+        "another\\".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder\\".to_string(),
+    ];
+    #[cfg(not(windows))]
+    let expected_paths: Vec<String> = vec![
+        "nushell".to_string(),
+        "test_a/".to_string(),
+        "test_b/".to_string(),
+        "another/".to_string(),
+        "custom_completion.nu".to_string(),
+        ".hidden_file".to_string(),
+        ".hidden_folder/".to_string(),
     ];
 
     match_suggestions(expected_paths, suggestions);


### PR DESCRIPTION
# Description

#6596, if there are something behind the cursor, the completion will ignore all after the cursor and try to run the completion


Demo

![Fix 6596](https://user-images.githubusercontent.com/85712372/191864140-9b639ad2-d86f-4f7d-8fed-342a9ae9c1b6.gif)


Extra checks to avoid previous regressions

## **Checklist**

- **Basic single alias**: `go` is an alias of `git`
    - [x]  `go [enter]`
    - [x]  `go [tab]` -> No crash
    
    ---
    
- **Alias + sub command**: `cg` is an alias of `cargo`
    - [x]  `cg [enter]`
    - [x]  `cg [tab]` -> No crash
    - [x]  `cg test [enter]`
    - [x]  `cg test [tab]` -> No crash
    - [x]  config export extern command "cargo test" : `cg test[tab]` - `cargo test`
    
    ---
    
- **Alias is command + flags**: `li` is an alias of `ll -ls`
    - [x]  `li [enter]`
    - [x]  `li [tab]` -> No crash
    - [x]  `li [first letter of folder name] [tab]` -> completion should work

---

- **Alias is command + flags - More test**: `rm` is an alias of `rm -iv`
    - [x]  `rm [enter]`
    - [x]  `rm [tab]` -> No crash
    - [x]  `rm [first letter of folder name] [tab]` -> completion -> `[Enter]` -> interactive confirm dialog

---

- **More than one alias**: `go` is an alias of `git`, and `co` is an alias of `checkout`
    - [x]  config export extern command "git checkout" : `go co[tab]` -> completion

---

- **Alias of an alias**

`alias ll = _ls -l --sort=time
alias _ls = exa --color=always --group-directories-first --icons`

- [x]  `ll [first letter of folder name] [tab]` -> completion should work
- [x]  `_ls [enter]`
- [x]  `_ls [tan]` -> No crash
- [x]  `_ls [first letter of folder name] [tab]` -> completion should work


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
