### PR TITLE
fix issue 6602 (broken highlighting in find)

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -362,11 +362,16 @@ pub fn highlight_search_string(
             ));
         }
     };
+    // strip haystack to remove existing ansi style
+    let stripped_haystack: String = match strip_ansi_escapes::strip(haystack) {
+        Ok(i) => String::from_utf8(i).unwrap_or_else(|_| String::from(haystack)),
+        Err(_) => String::from(haystack)
+    };
     let mut last_match_end = 0;
     let style = Style::new().fg(White).on(Red);
     let mut highlighted = String::new();
 
-    for cap in regex.captures_iter(haystack) {
+    for cap in regex.captures_iter(stripped_haystack.as_str()) {
         match cap {
             Ok(capture) => {
                 let start = match capture.get(0) {
@@ -379,10 +384,10 @@ pub fn highlight_search_string(
                 };
                 highlighted.push_str(
                     &string_style
-                        .paint(&haystack[last_match_end..start])
+                        .paint(&stripped_haystack[last_match_end..start])
                         .to_string(),
                 );
-                highlighted.push_str(&style.paint(&haystack[start..end]).to_string());
+                highlighted.push_str(&style.paint(&stripped_haystack[start..end]).to_string());
                 last_match_end = end;
             }
             Err(e) => {
@@ -397,6 +402,6 @@ pub fn highlight_search_string(
         }
     }
 
-    highlighted.push_str(&string_style.paint(&haystack[last_match_end..]).to_string());
+    highlighted.push_str(&string_style.paint(&stripped_haystack[last_match_end..]).to_string());
     Ok(highlighted)
 }

--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -365,7 +365,7 @@ pub fn highlight_search_string(
     // strip haystack to remove existing ansi style
     let stripped_haystack: String = match strip_ansi_escapes::strip(haystack) {
         Ok(i) => String::from_utf8(i).unwrap_or_else(|_| String::from(haystack)),
-        Err(_) => String::from(haystack)
+        Err(_) => String::from(haystack),
     };
     let mut last_match_end = 0;
     let style = Style::new().fg(White).on(Red);
@@ -402,6 +402,10 @@ pub fn highlight_search_string(
         }
     }
 
-    highlighted.push_str(&string_style.paint(&stripped_haystack[last_match_end..]).to_string());
+    highlighted.push_str(
+        &string_style
+            .paint(&stripped_haystack[last_match_end..])
+            .to_string(),
+    );
     Ok(highlighted)
 }


### PR DESCRIPTION

# Description

Find uses highlight_search_string to see where the string was found. The problem was that the style would just "append" to the existing haystack (including the ANSI escape codes of LS_COLORS).

This first strips the ANSI escape codes out of the haystack before formatting the output string.

fixes #6602 

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
