### PR TITLE
add bs(block-source) command to get source code of block

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -163,6 +163,7 @@ pub fn create_default_context() -> EngineState {
             External,
             NuCheck,
             Sys,
+            BlockSource,
         };
 
         #[cfg(any(

--- a/crates/nu-command/src/system/block_source.rs
+++ b/crates/nu-command/src/system/block_source.rs
@@ -18,7 +18,7 @@ impl Command for BlockSource {
             .required(
                 "block",
                 SyntaxShape::BlockWithSource,
-                "block with source code",
+                "the input block to get source code",
             )
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/block_source.rs
+++ b/crates/nu-command/src/system/block_source.rs
@@ -48,7 +48,7 @@ impl Command for BlockSource {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Get source code from block { echo $x }",
+            description: "Get source code from block { echo 300 }",
             example: " bs { echo 300 } ",
             result: Some(Value::String {
                 val: " echo 300 ".to_string(),

--- a/crates/nu-command/src/system/block_source.rs
+++ b/crates/nu-command/src/system/block_source.rs
@@ -1,0 +1,71 @@
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::Call,
+    engine::{CaptureBlock, Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Value,
+};
+
+#[derive(Clone)]
+pub struct BlockSource;
+
+impl Command for BlockSource {
+    fn name(&self) -> &str {
+        "bs"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("bs")
+            .required(
+                "block",
+                SyntaxShape::BlockWithSource,
+                "block with source code",
+            )
+            .category(Category::System)
+    }
+
+    fn usage(&self) -> &str {
+        "return source code from given block"
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let block: CaptureBlock = call.req(engine_state, stack, 0)?;
+        let block_source = &engine_state.get_block(block.block_id).source;
+        Ok(match block_source {
+            None => Value::Nothing { span: call.head },
+            Some(code) => Value::String {
+                val: code.clone(),
+                span: call.head,
+            },
+        }
+        .into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get source code from block { echo $x }",
+            example: " bs { echo 300 } ",
+            result: Some(Value::String {
+                val: " echo 300 ".to_string(),
+                span: Span::test_data(),
+            }),
+        }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::BlockSource;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(BlockSource {})
+    }
+}

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,4 +1,5 @@
 mod benchmark;
+mod block_source;
 mod complete;
 mod exec;
 mod nu_check;
@@ -14,6 +15,7 @@ mod sys;
 mod which_;
 
 pub use benchmark::Benchmark;
+pub use block_source::BlockSource;
 pub use complete::Complete;
 pub use exec::Exec;
 pub use nu_check::NuCheck;

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -11,6 +11,7 @@ pub struct Block {
     pub captures: Vec<VarId>,
     pub redirect_env: bool,
     pub span: Option<Span>, // None option encodes no span to avoid using test_span()
+    pub source: Option<String>,
 }
 
 impl Block {
@@ -51,6 +52,7 @@ impl Block {
             captures: vec![],
             redirect_env: false,
             span: None,
+            source: None,
         }
     }
 }
@@ -66,6 +68,7 @@ where
             captures: vec![],
             redirect_env: false,
             span: None,
+            source: None,
         }
     }
 }

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -49,6 +49,9 @@ pub enum SyntaxShape {
     /// A block is allowed, eg `{start this thing}`
     Block(Option<Vec<SyntaxShape>>),
 
+    /// A block is allowed, and the relative block contains source code.
+    BlockWithSource,
+
     /// A table is allowed, eg `[[first, second]; [1, 2]]`
     Table,
 
@@ -104,6 +107,7 @@ impl SyntaxShape {
         match self {
             SyntaxShape::Any => Type::Any,
             SyntaxShape::Block(_) => Type::Block,
+            SyntaxShape::BlockWithSource => Type::Block,
             SyntaxShape::Binary => Type::Binary,
             SyntaxShape::CellPath => Type::Any,
             SyntaxShape::Custom(custom, _) => custom.to_type(),
@@ -157,6 +161,7 @@ impl Display for SyntaxShape {
             SyntaxShape::GlobPattern => write!(f, "glob"),
             SyntaxShape::ImportPattern => write!(f, "import"),
             SyntaxShape::Block(_) => write!(f, "block"),
+            SyntaxShape::BlockWithSource => write!(f, "block"),
             SyntaxShape::Binary => write!(f, "binary"),
             SyntaxShape::Table => write!(f, "table"),
             SyntaxShape::List(x) => write!(f, "list<{}>", x),


### PR DESCRIPTION
# Description

Add `bs` command to get source code of block

The reason I want this command is that I want nu to play well with [pueue](https://github.com/Nukesor/pueue), internally, when I get a block, I want to send the actual source code there.

Here is my script:
```
export def spawn [
    command: string   # the command to spawn
] {
    let config_path = $nu.config-path
    let env_path = $nu.env-path
    let job_id = (pueue add -p $"nu --config \"($config_path)\" --env-config \"($env_path)\" -c '($command)'")
    {"job_id": $job_id}
}
```

Invoke the `spawn` command with bare string would be easy to make wrong command, especially if the command comes with quoting.

But it'd be easy to invode the command with this new `bs` command.  Like the following: 
```
spawn (bs {let x = 3sec; sleep $x; echo xx | save gg.txt})
```

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
