### PR TITLE
fix sys info mem usage

### DIFF
--- a/crates/nu-command/src/system/sys.rs
+++ b/crates/nu-command/src/system/sys.rs
@@ -276,43 +276,43 @@ pub fn mem(sys: &mut System, span: Span) -> Option<Value> {
 
     cols.push("total".into());
     vals.push(Value::Filesize {
-        val: total_mem as i64 * 1000,
+        val: total_mem as i64,
         span,
     });
 
     cols.push("free".into());
     vals.push(Value::Filesize {
-        val: free_mem as i64 * 1000,
+        val: free_mem as i64,
         span,
     });
 
     cols.push("used".into());
     vals.push(Value::Filesize {
-        val: used_mem as i64 * 1000,
+        val: used_mem as i64,
         span,
     });
 
     cols.push("available".into());
     vals.push(Value::Filesize {
-        val: avail_mem as i64 * 1000,
+        val: avail_mem as i64,
         span,
     });
 
     cols.push("swap total".into());
     vals.push(Value::Filesize {
-        val: total_swap as i64 * 1000,
+        val: total_swap as i64,
         span,
     });
 
     cols.push("swap free".into());
     vals.push(Value::Filesize {
-        val: free_swap as i64 * 1000,
+        val: free_swap as i64,
         span,
     });
 
     cols.push("swap used".into());
     vals.push(Value::Filesize {
-        val: used_swap as i64 * 1000,
+        val: used_swap as i64,
         span,
     });
 


### PR DESCRIPTION
# Description

Sysinfo's memory usage already returns size in bytes, we don't need to multiply them by 1000.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
