### PR TITLE
make default config and default_env works more like module

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -232,281 +232,283 @@ let light_theme = {
 }
 
 # External completer example
-# let carapace_completer = {|spans| 
+# let carapace_completer = {|spans|
 #     carapace $spans.0 nushell $spans | from json
 # }
 
 
 # The default config record. This is where much of your global configuration is setup.
-let-env config = {
-  external_completer: $nothing # check 'carapace_completer' above to as example
-  filesize_metric: false
-  table_mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-  use_ls_colors: true
-  rm_always_trash: false
-  color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
-  use_grid_icons: true
-  footer_mode: "25" # always, never, number_of_rows, auto
-  quick_completions: true  # set this to false to prevent auto-selecting completions when only one remains
-  partial_completions: true  # set this to false to prevent partial filling of the prompt
-  completion_algorithm: "prefix"  # prefix, fuzzy
-  float_precision: 2
-  # buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
-  use_ansi_coloring: true
-  filesize_format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
-  edit_mode: emacs # emacs, vi
-  max_history_size: 10000 # Session has to be reloaded for this to take effect
-  sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
-  history_file_format: "plaintext" # "sqlite" or "plaintext"
-  shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
-  disable_table_indexes: false # set to true to remove the index column from tables
-  cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
-  case_sensitive_completions: false # set to true to enable case-sensitive completions
-  enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
-  max_external_completion_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
-  # A strategy of managing table view in case of limited space.
-  table_trim: {
-    methodology: wrapping, # truncating
-    # A strategy which will be used by 'wrapping' methodology
-    wrapping_try_keep_words: true,
-    # A suffix which will be used with 'truncating' methodology
-    # truncating_suffix: "..."
-  }
-  show_banner: true # true or false to enable or disable the banner
-  show_clickable_links_in_ls: true # true or false to enable or disable clickable links in the ls listing. your terminal has to support links.
+export-env {
+    let-env config = {
+        external_completer: $nothing # check 'carapace_completer' above to as example
+        filesize_metric: false
+        table_mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
+        use_ls_colors: true
+        rm_always_trash: false
+        color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
+        use_grid_icons: true
+        footer_mode: "25" # always, never, number_of_rows, auto
+        quick_completions: true  # set this to false to prevent auto-selecting completions when only one remains
+        partial_completions: true  # set this to false to prevent partial filling of the prompt
+        completion_algorithm: "prefix"  # prefix, fuzzy
+        float_precision: 2
+        # buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
+        use_ansi_coloring: true
+        filesize_format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
+        edit_mode: emacs # emacs, vi
+        max_history_size: 10000 # Session has to be reloaded for this to take effect
+        sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
+        history_file_format: "plaintext" # "sqlite" or "plaintext"
+        shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
+        disable_table_indexes: false # set to true to remove the index column from tables
+        cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
+        case_sensitive_completions: false # set to true to enable case-sensitive completions
+        enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
+        max_external_completion_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
+        # A strategy of managing table view in case of limited space.
+        table_trim: {
+            methodology: wrapping, # truncating
+            # A strategy which will be used by 'wrapping' methodology
+            wrapping_try_keep_words: true,
+            # A suffix which will be used with 'truncating' methodology
+            # truncating_suffix: "..."
+        }
+        show_banner: true # true or false to enable or disable the banner
+        show_clickable_links_in_ls: true # true or false to enable or disable clickable links in the ls listing. your terminal has to support links.
 
-  hooks: {
-    pre_prompt: [{
-      $nothing  # replace with source code to run before the prompt is shown
-    }]
-    pre_execution: [{
-      $nothing  # replace with source code to run before the repl input is run
-    }]
-    env_change: {
-      PWD: [{|before, after|
-        $nothing  # replace with source code to run if the PWD environment is different since the last repl input
-      }]
-    }
-  }
-  menus: [
-      # Configuration for default nushell menus
-      # Note the lack of souce parameter
-      {
-        name: completion_menu
-        only_buffer_difference: false
-        marker: "| "
-        type: {
-            layout: columnar
-            columns: 4
-            col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-            col_padding: 2
+        hooks: {
+            pre_prompt: [{
+                $nothing  # replace with source code to run before the prompt is shown
+            }]
+            pre_execution: [{
+                $nothing  # replace with source code to run before the repl input is run
+            }]
+            env_change: {
+                PWD: [{|before, after|
+                    $nothing  # replace with source code to run if the PWD environment is different since the last repl input
+                }]
+            }
         }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-      }
-      {
-        name: history_menu
-        only_buffer_difference: true
-        marker: "? "
-        type: {
-            layout: list
-            page_size: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-      }
-      {
-        name: help_menu
-        only_buffer_difference: true
-        marker: "? "
-        type: {
-            layout: description
-            columns: 4
-            col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-            col_padding: 2
-            selection_rows: 4
-            description_rows: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-      }
-      # Example of extra menus created using a nushell source
-      # Use the source field to create a list of records that populates
-      # the menu
-      {
-        name: commands_menu
-        only_buffer_difference: false
-        marker: "# "
-        type: {
-            layout: columnar
-            columns: 4
-            col_width: 20
-            col_padding: 2
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-        source: { |buffer, position|
-            $nu.scope.commands
-            | where command =~ $buffer
-            | each { |it| {value: $it.command description: $it.usage} }
-        }
-      }
-      {
-        name: vars_menu
-        only_buffer_difference: true
-        marker: "# "
-        type: {
-            layout: list
-            page_size: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-        source: { |buffer, position|
-            $nu.scope.vars
-            | where name =~ $buffer
-            | sort-by name
-            | each { |it| {value: $it.name description: $it.type} }
-        }
-      }
-      {
-        name: commands_with_description
-        only_buffer_difference: true
-        marker: "# "
-        type: {
-            layout: description
-            columns: 4
-            col_width: 20
-            col_padding: 2
-            selection_rows: 4
-            description_rows: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-        source: { |buffer, position|
-            $nu.scope.commands
-            | where command =~ $buffer
-            | each { |it| {value: $it.command description: $it.usage} }
-        }
-      }
-  ]
-  keybindings: [
-    {
-      name: completion_menu
-      modifier: none
-      keycode: tab
-      mode: emacs # Options: emacs vi_normal vi_insert
-      event: {
-        until: [
-          { send: menu name: completion_menu }
-          { send: menunext }
+        menus: [
+            # Configuration for default nushell menus
+            # Note the lack of souce parameter
+            {
+                name: completion_menu
+                only_buffer_difference: false
+                marker: "| "
+                type: {
+                    layout: columnar
+                    columns: 4
+                    col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+                    col_padding: 2
+                }
+                style: {
+                    text: green
+                    selected_text: green_reverse
+                    description_text: yellow
+                }
+            }
+            {
+                name: history_menu
+                only_buffer_difference: true
+                marker: "? "
+                type: {
+                    layout: list
+                    page_size: 10
+                }
+                style: {
+                    text: green
+                    selected_text: green_reverse
+                    description_text: yellow
+                }
+            }
+            {
+                name: help_menu
+                only_buffer_difference: true
+                marker: "? "
+                type: {
+                    layout: description
+                    columns: 4
+                    col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+                    col_padding: 2
+                    selection_rows: 4
+                    description_rows: 10
+                }
+                style: {
+                    text: green
+                    selected_text: green_reverse
+                    description_text: yellow
+                }
+            }
+            # Example of extra menus created using a nushell source
+            # Use the source field to create a list of records that populates
+            # the menu
+            {
+                name: commands_menu
+                only_buffer_difference: false
+                marker: "# "
+                type: {
+                    layout: columnar
+                    columns: 4
+                    col_width: 20
+                    col_padding: 2
+                }
+                style: {
+                    text: green
+                    selected_text: green_reverse
+                    description_text: yellow
+                }
+                source: { |buffer, position|
+                    $nu.scope.commands
+                    | where command =~ $buffer
+                    | each { |it| {value: $it.command description: $it.usage} }
+                }
+            }
+            {
+                name: vars_menu
+                only_buffer_difference: true
+                marker: "# "
+                type: {
+                    layout: list
+                    page_size: 10
+                }
+                style: {
+                    text: green
+                    selected_text: green_reverse
+                    description_text: yellow
+                }
+                source: { |buffer, position|
+                    $nu.scope.vars
+                    | where name =~ $buffer
+                    | sort-by name
+                    | each { |it| {value: $it.name description: $it.type} }
+                }
+            }
+            {
+                name: commands_with_description
+                only_buffer_difference: true
+                marker: "# "
+                type: {
+                    layout: description
+                    columns: 4
+                    col_width: 20
+                    col_padding: 2
+                    selection_rows: 4
+                    description_rows: 10
+                }
+                style: {
+                    text: green
+                    selected_text: green_reverse
+                    description_text: yellow
+                }
+                source: { |buffer, position|
+                    $nu.scope.commands
+                    | where command =~ $buffer
+                    | each { |it| {value: $it.command description: $it.usage} }
+                }
+            }
         ]
-      }
+        keybindings: [
+            {
+                name: completion_menu
+                modifier: none
+                keycode: tab
+                mode: emacs # Options: emacs vi_normal vi_insert
+                event: {
+                    until: [
+                        { send: menu name: completion_menu }
+                        { send: menunext }
+                    ]
+                }
+            }
+            {
+                name: completion_previous
+                modifier: shift
+                keycode: backtab
+                mode: [emacs, vi_normal, vi_insert] # Note: You can add the same keybinding to all modes by using a list
+                event: { send: menuprevious }
+            }
+            {
+                name: history_menu
+                modifier: control
+                keycode: char_r
+                mode: emacs
+                event: { send: menu name: history_menu }
+            }
+            {
+                name: next_page
+                modifier: control
+                keycode: char_x
+                mode: emacs
+                event: { send: menupagenext }
+            }
+            {
+                name: undo_or_previous_page
+                modifier: control
+                keycode: char_z
+                mode: emacs
+                event: {
+                    until: [
+                        { send: menupageprevious }
+                        { edit: undo }
+                    ]
+                }
+            }
+            {
+                name: yank
+                modifier: control
+                keycode: char_y
+                mode: emacs
+                event: {
+                    until: [
+                        {edit: pastecutbufferafter}
+                    ]
+                }
+            }
+            {
+                name: unix-line-discard
+                modifier: control
+                keycode: char_u
+                mode: [emacs, vi_normal, vi_insert]
+                event: {
+                    until: [
+                        {edit: cutfromlinestart}
+                    ]
+                }
+            }
+            {
+                name: kill-line
+                modifier: control
+                keycode: char_k
+                mode: [emacs, vi_normal, vi_insert]
+                event: {
+                    until: [
+                        {edit: cuttolineend}
+                    ]
+                }
+            }
+            # Keybindings used to trigger the user defined menus
+            {
+                name: commands_menu
+                modifier: control
+                keycode: char_t
+                mode: [emacs, vi_normal, vi_insert]
+                event: { send: menu name: commands_menu }
+            }
+            {
+                name: vars_menu
+                modifier: alt
+                keycode: char_o
+                mode: [emacs, vi_normal, vi_insert]
+                event: { send: menu name: vars_menu }
+            }
+            {
+                name: commands_with_description
+                modifier: control
+                keycode: char_s
+                mode: [emacs, vi_normal, vi_insert]
+                event: { send: menu name: commands_with_description }
+            }
+       ]
     }
-    {
-      name: completion_previous
-      modifier: shift
-      keycode: backtab
-      mode: [emacs, vi_normal, vi_insert] # Note: You can add the same keybinding to all modes by using a list
-      event: { send: menuprevious }
-    }
-    {
-      name: history_menu
-      modifier: control
-      keycode: char_r
-      mode: emacs
-      event: { send: menu name: history_menu }
-    }
-    {
-      name: next_page
-      modifier: control
-      keycode: char_x
-      mode: emacs
-      event: { send: menupagenext }
-    }
-    {
-      name: undo_or_previous_page
-      modifier: control
-      keycode: char_z
-      mode: emacs
-      event: {
-        until: [
-          { send: menupageprevious }
-          { edit: undo }
-        ]
-       }
-    }
-    {
-      name: yank
-      modifier: control
-      keycode: char_y
-      mode: emacs
-      event: {
-        until: [
-          {edit: pastecutbufferafter}
-        ]
-      }
-    }
-    {
-      name: unix-line-discard
-      modifier: control
-      keycode: char_u
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {edit: cutfromlinestart}
-        ]
-      }
-    }
-    {
-      name: kill-line
-      modifier: control
-      keycode: char_k
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {edit: cuttolineend}
-        ]
-      }
-    }
-    # Keybindings used to trigger the user defined menus
-    {
-      name: commands_menu
-      modifier: control
-      keycode: char_t
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: menu name: commands_menu }
-    }
-    {
-      name: vars_menu
-      modifier: alt
-      keycode: char_o
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: menu name: vars_menu }
-    }
-    {
-      name: commands_with_description
-      modifier: control
-      keycode: char_s
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: menu name: commands_with_description }
-    }
-  ]
 }

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -18,45 +18,47 @@ def create_right_prompt [] {
     $time_segment
 }
 
-# Use nushell functions to define your right and left prompt
-let-env PROMPT_COMMAND = { create_left_prompt }
-let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
+export-env {
+    # Use nushell functions to define your right and left prompt
+    let-env PROMPT_COMMAND = { create_left_prompt }
+    let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
 
-# The prompt indicators are environmental variables that represent
-# the state of the prompt
-let-env PROMPT_INDICATOR = { "〉" }
-let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
-let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
-let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
+    # The prompt indicators are environmental variables that represent
+    # the state of the prompt
+    let-env PROMPT_INDICATOR = { "〉" }
+    let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
+    let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
+    let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
 
-# Specifies how environment variables are:
-# - converted from a string to a value on Nushell startup (from_string)
-# - converted from a value back to a string when running external commands (to_string)
-# Note: The conversions happen *after* config.nu is loaded
-let-env ENV_CONVERSIONS = {
-  "PATH": {
-    from_string: { |s| $s | split row (char esep) | path expand -n }
-    to_string: { |v| $v | path expand -n | str join (char esep) }
-  }
-  "Path": {
-    from_string: { |s| $s | split row (char esep) | path expand -n }
-    to_string: { |v| $v | path expand -n | str join (char esep) }
-  }
+    # Specifies how environment variables are:
+    # - converted from a string to a value on Nushell startup (from_string)
+    # - converted from a value back to a string when running external commands (to_string)
+    # Note: The conversions happen *after* config.nu is loaded
+    let-env ENV_CONVERSIONS = {
+        "PATH": {
+            from_string: { |s| $s | split row (char esep) | path expand -n }
+            to_string: { |v| $v | path expand -n | str join (char esep) }
+        }
+        "Path": {
+            from_string: { |s| $s | split row (char esep) | path expand -n }
+            to_string: { |v| $v | path expand -n | str join (char esep) }
+        }
+    }
+
+    # Directories to search for scripts when calling source or use
+    #
+    # By default, <nushell-config-dir>/scripts is added
+    let-env NU_LIB_DIRS = [
+        ($nu.config-path | path dirname | path join 'scripts')
+    ]
+
+    # Directories to search for plugin binaries when calling register
+    #
+    # By default, <nushell-config-dir>/plugins is added
+    let-env NU_PLUGIN_DIRS = [
+        ($nu.config-path | path dirname | path join 'plugins')
+    ]
+
+    # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
+    # let-env PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
 }
-
-# Directories to search for scripts when calling source or use
-#
-# By default, <nushell-config-dir>/scripts is added
-let-env NU_LIB_DIRS = [
-    ($nu.config-path | path dirname | path join 'scripts')
-]
-
-# Directories to search for plugin binaries when calling register
-#
-# By default, <nushell-config-dir>/plugins is added
-let-env NU_PLUGIN_DIRS = [
-    ($nu.config-path | path dirname | path join 'plugins')
-]
-
-# To add entries to PATH (on Windows you might use Path), you can use the following pattern:
-# let-env PATH = ($env.PATH | split row (char esep) | prepend '/some/path')


### PR DESCRIPTION
# Description

Doing this by wrapping `export-env` around several `let-env` definition

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
