### PR TITLE
version: show built time git branch

### DIFF
--- a/crates/nu-command/src/core_commands/version.rs
+++ b/crates/nu-command/src/core_commands/version.rs
@@ -59,7 +59,7 @@ pub fn version(
 
     cols.push("branch".to_string());
     vals.push(Value::String {
-        val: shadow_rs::branch(),
+        val: shadow::BRANCH.to_string(),
         span: call.head,
     });
 


### PR DESCRIPTION
# Description
This PR fixes incorrect branch name of `version | get branch`.

![Screenshot from 2022-09-24 19-00-25](https://user-images.githubusercontent.com/15247421/192094802-c076749b-abcc-4e33-9ec4-bade93de7366.png)


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
