### PR TITLE
touchup some clippy warnings in tests

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -114,7 +114,7 @@ fn external_completer_trailing_space() {
     let block = "let external_completer = {|spans| $spans}";
     let input = "gh alias ".to_string();
 
-    let suggestions = run_external_completion(&block, &input);
+    let suggestions = run_external_completion(block, &input);
     assert_eq!(3, suggestions.len());
     assert_eq!("gh", suggestions.get(0).unwrap().value);
     assert_eq!("alias", suggestions.get(1).unwrap().value);
@@ -126,7 +126,7 @@ fn external_completer_no_trailing_space() {
     let block = "let external_completer = {|spans| $spans}";
     let input = "gh alias".to_string();
 
-    let suggestions = run_external_completion(&block, &input);
+    let suggestions = run_external_completion(block, &input);
     assert_eq!(2, suggestions.len());
     assert_eq!("gh", suggestions.get(0).unwrap().value);
     assert_eq!("alias", suggestions.get(1).unwrap().value);
@@ -137,7 +137,7 @@ fn external_completer_pass_flags() {
     let block = "let external_completer = {|spans| $spans}";
     let input = "gh api --".to_string();
 
-    let suggestions = run_external_completion(&block, &input);
+    let suggestions = run_external_completion(block, &input);
     assert_eq!(3, suggestions.len());
     assert_eq!("gh", suggestions.get(0).unwrap().value);
     assert_eq!("api", suggestions.get(1).unwrap().value);
@@ -637,7 +637,7 @@ fn run_external_completion(block: &str, input: &str) -> Vec<Suggestion> {
     // Instatiate a new completer
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine_state), stack);
 
-    completer.complete(&input, input.len())
+    completer.complete(input, input.len())
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -149,7 +149,7 @@ fn can_source_dynamic_path() {
     Playground::setup("can_source_dynamic_path", |dirs, sandbox| {
         let foo_file = "foo.nu";
 
-        sandbox.with_files(vec![FileWithContent(&foo_file, "echo foo")]);
+        sandbox.with_files(vec![FileWithContent(foo_file, "echo foo")]);
 
         let cmd = format!("let file = `{}`; source-env $file", foo_file);
         let actual = nu!(cwd: dirs.test(), &cmd);

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -289,7 +289,7 @@ proptest! {
     }
     #[test]
     fn to_nuon_from_nuon_string(s: String) {
-        if s != "\\0" && s!= "" && !s.contains('\\') && !s.contains('"'){
+        if s != "\\0" && !s.is_empty() && !s.contains('\\') && !s.contains('"'){
         let actual = nu!(
             cwd: "tests/fixtures/formats", pipeline(
                 format!(r#"

--- a/crates/nu-plugin/benches/encoder_benchmark.rs
+++ b/crates/nu-plugin/benches/encoder_benchmark.rs
@@ -5,7 +5,7 @@ use nu_protocol::{Span, Value};
 // generate a new table data with `row_cnt` rows, `col_cnt` columns.
 fn new_test_data(row_cnt: usize, col_cnt: usize) -> Value {
     let columns: Vec<String> = (0..col_cnt).map(|x| format!("col_{x}")).collect();
-    let vals: Vec<Value> = (0..col_cnt as i64).map(|i| Value::test_int(i)).collect();
+    let vals: Vec<Value> = (0..col_cnt as i64).map(Value::test_int).collect();
 
     Value::List {
         vals: (0..row_cnt)

--- a/crates/nu-test-support/tests/get_system_locale.rs
+++ b/crates/nu-test-support/tests/get_system_locale.rs
@@ -4,7 +4,7 @@ use num_format::Grouping;
 
 #[test]
 fn test_get_system_locale_en() {
-    let locale = with_locale_override("en_US.UTF-8", || get_system_locale());
+    let locale = with_locale_override("en_US.UTF-8", get_system_locale);
 
     assert_eq!(locale.name(), "en");
     assert_eq!(locale.grouping(), Grouping::Standard)
@@ -12,7 +12,7 @@ fn test_get_system_locale_en() {
 
 #[test]
 fn test_get_system_locale_de() {
-    let locale = with_locale_override("de_DE.UTF-8", || get_system_locale());
+    let locale = with_locale_override("de_DE.UTF-8", get_system_locale);
 
     assert_eq!(locale.name(), "de");
     assert_eq!(locale.grouping(), Grouping::Standard)


### PR DESCRIPTION
# Description

(description of your pull request here)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
