### PR TITLE
Remove month and year duration constants

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -315,9 +315,6 @@ fn string_to_duration(s: &str, span: Span, value_span: Span) -> Result<i64, Shel
                     Unit::Hour => return Ok(x * 60 * 60 * 1000 * 1000 * 1000),
                     Unit::Day => return Ok(x * 24 * 60 * 60 * 1000 * 1000 * 1000),
                     Unit::Week => return Ok(x * 7 * 24 * 60 * 60 * 1000 * 1000 * 1000),
-                    Unit::Month => return Ok(x * 30 * 24 * 60 * 60 * 1000 * 1000 * 1000), //30 days to a month
-                    Unit::Year => return Ok(x * 365 * 24 * 60 * 60 * 1000 * 1000 * 1000), //365 days to a year
-                    Unit::Decade => return Ok(x * 10 * 365 * 24 * 60 * 60 * 1000 * 1000 * 1000), //365 days to a year
                     _ => {}
                 }
             }
@@ -353,9 +350,6 @@ fn string_to_unit_duration(
                     Unit::Hour => return Ok(("hr", x)),
                     Unit::Day => return Ok(("day", x)),
                     Unit::Week => return Ok(("wk", x)),
-                    Unit::Month => return Ok(("month", x)), //30 days to a month
-                    Unit::Year => return Ok(("yr", x)),     //365 days to a year
-                    Unit::Decade => return Ok(("dec", x)),  //365 days to a year
 
                     _ => return Ok(("ns", 0)),
                 }

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -526,35 +526,6 @@ fn convert_to_value(
                         expr.span,
                     )),
                 },
-                Unit::Month => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 30) {
-                    Some(val) => Ok(Value::Duration { val, span }),
-                    None => Err(ShellError::OutsideSpannedLabeledError(
-                        original_text.to_string(),
-                        "month duration too large".into(),
-                        "month duration too large".into(),
-                        expr.span,
-                    )),
-                },
-                Unit::Year => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 365) {
-                    Some(val) => Ok(Value::Duration { val, span }),
-                    None => Err(ShellError::OutsideSpannedLabeledError(
-                        original_text.to_string(),
-                        "year duration too large".into(),
-                        "year duration too large".into(),
-                        expr.span,
-                    )),
-                },
-                Unit::Decade => {
-                    match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 365 * 10) {
-                        Some(val) => Ok(Value::Duration { val, span }),
-                        None => Err(ShellError::OutsideSpannedLabeledError(
-                            original_text.to_string(),
-                            "decade duration too large".into(),
-                            "decade duration too large".into(),
-                            expr.span,
-                        )),
-                    }
-                }
             }
         }
         Expr::Var(..) => Err(ShellError::OutsideSpannedLabeledError(

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -335,13 +335,13 @@ fn duration_decimal_math_with_all_units() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            5dec + 3yr + 2month + 1wk + 3day + 8hr + 10min + 16sec + 121ms + 11us + 12ns
+            1wk + 3day + 8hr + 10min + 16sec + 121ms + 11us + 12ns
         "#
     ));
 
     assert_eq!(
         actual.out,
-        "53yr 2month 1wk 3day 8hr 10min 16sec 121ms 11µs 12ns"
+        "1wk 3day 8hr 10min 16sec 121ms 11µs 12ns"
     );
 }
 

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -339,10 +339,7 @@ fn duration_decimal_math_with_all_units() {
         "#
     ));
 
-    assert_eq!(
-        actual.out,
-        "1wk 3day 8hr 10min 16sec 121ms 11µs 12ns"
-    );
+    assert_eq!(actual.out, "1wk 3day 8hr 10min 16sec 121ms 11µs 12ns");
 }
 
 #[test]

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1570,41 +1570,5 @@ fn compute(size: i64, unit: Unit, span: Span) -> Value {
                 ),
             },
         },
-        Unit::Month => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 30) {
-            Some(val) => Value::Duration { val, span },
-            None => Value::Error {
-                error: ShellError::GenericError(
-                    "month duration too large".into(),
-                    "month duration too large".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                ),
-            },
-        },
-        Unit::Year => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 365) {
-            Some(val) => Value::Duration { val, span },
-            None => Value::Error {
-                error: ShellError::GenericError(
-                    "year duration too large".into(),
-                    "year duration too large".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                ),
-            },
-        },
-        Unit::Decade => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 365 * 10) {
-            Some(val) => Value::Duration { val, span },
-            None => Value::Error {
-                error: ShellError::GenericError(
-                    "decade duration too large".into(),
-                    "decade duration too large".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                ),
-            },
-        },
     }
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2201,9 +2201,6 @@ pub fn parse_duration_bytes(bytes: &[u8], span: Span) -> Option<Expression> {
         (Unit::Hour, "HR", Some((Unit::Minute, 60))),
         (Unit::Day, "DAY", Some((Unit::Minute, 1440))),
         (Unit::Week, "WK", Some((Unit::Day, 7))),
-        (Unit::Month, "MONTH", Some((Unit::Day, 30))), //30 day month
-        (Unit::Year, "YR", Some((Unit::Day, 365))),    //365 day year
-        (Unit::Decade, "DEC", Some((Unit::Year, 10))), //365 day years
     ];
     if let Some(unit) = unit_groups.iter().find(|&x| upper.ends_with(x.1)) {
         let mut lhs = token;

--- a/crates/nu-protocol/src/value/unit.rs
+++ b/crates/nu-protocol/src/value/unit.rs
@@ -30,7 +30,4 @@ pub enum Unit {
     Hour,
     Day,
     Week,
-    Month,
-    Year,
-    Decade,
 }


### PR DESCRIPTION
# Description

Some of the humanize logic got mixed into the parsing and duration models, so this removes those but keeps the humanized print. With it, we'll no longer support `1yr` or `1month`, or any duration above `1wk` as the former do not have fixed values.

This should help people create more predictable duration constants.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
