### PR TITLE
Clippy with the current stable toolchain

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -422,7 +422,7 @@ fn search_alias(input: &[u8], working_set: &StateWorkingSet) -> Option<MatchedAl
     }
     // Push the rest to names vector.
     if pos < input.len() {
-        vec_names.push((&input[pos..]).to_owned());
+        vec_names.push(input[pos..].to_owned());
     }
 
     for name in &vec_names {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -662,9 +662,7 @@ pub fn eval_string_with_input(
         (output, working_set.render())
     };
 
-    if let Err(err) = engine_state.merge_delta(delta) {
-        return Err(err);
-    }
+    engine_state.merge_delta(delta)?;
 
     let input_as_pipeline_data = match input {
         Some(input) => PipelineData::Value(input, None),

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -104,9 +104,7 @@ pub fn merge_input(
         (block, working_set.render())
     };
 
-    if let Err(err) = engine_state.merge_delta(delta) {
-        return Err(err);
-    }
+    engine_state.merge_delta(delta)?;
 
     assert!(eval_block(
         engine_state,

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -215,8 +215,8 @@ fn histogram_impl(
     const MAX_FREQ_COUNT: f64 = 100.0;
     for (val, count) in counter.into_iter() {
         let quantile = match calc_method {
-            PercentageCalcMethod::Normalize => (count as f64 / total_cnt as f64),
-            PercentageCalcMethod::Relative => (count as f64 / max_cnt as f64),
+            PercentageCalcMethod::Normalize => count as f64 / total_cnt as f64,
+            PercentageCalcMethod::Relative => count as f64 / max_cnt as f64,
         };
 
         let percentage = format!("{:.2}%", quantile * 100_f64);

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -110,7 +110,7 @@ fn with_env(
                 // primitive values([X Y W Z])
                 for row in table.chunks(2) {
                     if row.len() == 2 {
-                        env.insert(row[0].as_string()?, (&row[1]).clone());
+                        env.insert(row[0].as_string()?, row[1].clone());
                     }
                     // TODO: else error?
                 }

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -154,10 +154,7 @@ impl Command for Mv {
         }
 
         if let Some(Ok(_filename)) = some_if_source_is_destination {
-            sources = sources
-                .into_iter()
-                .filter(|f| matches!(f, Ok(f) if !destination.starts_with(f)))
-                .collect();
+            sources.retain(|f| matches!(f, Ok(f) if !destination.starts_with(f)));
         }
 
         let span = call.head;

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -110,7 +110,7 @@ fn fragment(input: Value, pretty: bool, config: &Config) -> String {
     let mut out = String::new();
 
     if headers.len() == 1 {
-        let markup = match (&headers[0]).to_ascii_lowercase().as_ref() {
+        let markup = match headers[0].to_ascii_lowercase().as_ref() {
             "h1" => "# ".to_string(),
             "h2" => "## ".to_string(),
             "h3" => "### ".to_string(),

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -427,7 +427,7 @@ fn helper(
                     // primitive values ([key1 val1 key2 val2])
                     for row in table.chunks(2) {
                         if row.len() == 2 {
-                            custom_headers.insert(row[0].as_string()?, (&row[1]).clone());
+                            custom_headers.insert(row[0].as_string()?, row[1].clone());
                         }
                     }
                 }

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -281,7 +281,7 @@ fn helper(
                     // primitive values ([key1 val1 key2 val2])
                     for row in table.chunks(2) {
                         if row.len() == 2 {
-                            custom_headers.insert(row[0].as_string()?, (&row[1]).clone());
+                            custom_headers.insert(row[0].as_string()?, row[1].clone());
                         }
                     }
                 }

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -357,10 +357,7 @@ fn convert_to_table(
 
         // The header with the INDEX is removed from the table headers since
         // it is added to the natural table index
-        headers = headers
-            .into_iter()
-            .filter(|header| header != INDEX_COLUMN_NAME)
-            .collect();
+        headers.retain(|header| header != INDEX_COLUMN_NAME);
 
         // Vec of Vec of String1, String2 where String1 is datatype and String2 is value
         let mut data: Vec<Vec<(String, String)>> = Vec::new();
@@ -408,7 +405,7 @@ fn convert_to_table(
 
                     match result {
                         Ok(value) => row.push((
-                            (&value.get_type()).to_string(),
+                            value.get_type().to_string(),
                             value.into_abbreviated_string(config),
                         )),
                         Err(_) => row.push(("empty".to_string(), "❎".into())),

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -199,9 +199,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> Result<Paths, PatternE
     }
 
     // make sure that the pattern is valid first, else early return with error
-    if let Err(err) = Pattern::new(pattern) {
-        return Err(err);
-    }
+    Pattern::new(pattern)?;
 
     let mut components = Path::new(pattern).components().peekable();
     while let Some(&Component::Prefix(..)) | Some(&Component::RootDir) = components.peek() {


### PR DESCRIPTION
# Description

Fix lints that are coming with rust 1.64

Passes with the earlier toolchain from `rust-toolchain.toml` as well.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
