### PR TITLE
make `first` behave same way as `last`: always return list when with number argument

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -43,10 +43,7 @@ impl Command for First {
             Example {
                 description: "Return the first item of a list/table",
                 example: "[1 2 3] | first",
-                result: Some(Value::List {
-                    vals: vec![Value::test_int(1)],
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::test_int(1)),
             },
             Example {
                 description: "Return the first 2 items of a list/table",
@@ -148,11 +145,20 @@ fn first_helper(
                         .set_metadata(metadata)),
                 }
             }
-            _ => Ok(input_peek
-                .into_iter()
-                .take(rows_desired)
-                .into_pipeline_data(ctrlc)
-                .set_metadata(metadata)),
+            _ => {
+                if rows_desired == 1 && rows.is_none() {
+                    match input_peek.next() {
+                        Some(val) => Ok(val.into_pipeline_data()),
+                        None => Err(ShellError::AccessBeyondEndOfStream(head)),
+                    }
+                } else {
+                    Ok(input_peek
+                        .into_iter()
+                        .take(rows_desired)
+                        .into_pipeline_data(ctrlc)
+                        .set_metadata(metadata))
+                }
+            }
         }
     } else {
         Ok(PipelineData::new(head).set_metadata(metadata))

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -43,7 +43,10 @@ impl Command for First {
             Example {
                 description: "Return the first item of a list/table",
                 example: "[1 2 3] | first",
-                result: Some(Value::test_int(1)),
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(1)],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Return the first 2 items of a list/table",
@@ -145,20 +148,11 @@ fn first_helper(
                         .set_metadata(metadata)),
                 }
             }
-            _ => {
-                if rows_desired == 1 {
-                    match input_peek.next() {
-                        Some(val) => Ok(val.into_pipeline_data()),
-                        None => Err(ShellError::AccessBeyondEndOfStream(head)),
-                    }
-                } else {
-                    Ok(input_peek
-                        .into_iter()
-                        .take(rows_desired)
-                        .into_pipeline_data(ctrlc)
-                        .set_metadata(metadata))
-                }
-            }
+            _ => Ok(input_peek
+                .into_iter()
+                .take(rows_desired)
+                .into_pipeline_data(ctrlc)
+                .set_metadata(metadata)),
         }
     } else {
         Ok(PipelineData::new(head).set_metadata(metadata))

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -65,3 +65,17 @@ fn gets_first_row_when_no_amount_given() {
         assert_eq!(actual.out, "1");
     })
 }
+
+#[test]
+fn gets_first_row_as_list_when_amount_given() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                [1, 2, 3]
+                | first 1
+                | describe
+            "#
+    ));
+
+    assert_eq!(actual.out, "list<int>");
+}

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -64,3 +64,17 @@ fn requests_more_rows_than_table_has() {
 
     assert_eq!(actual.out, "1");
 }
+
+#[test]
+fn gets_last_row_as_list_when_amount_given() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                [1, 2, 3]
+                | last 1
+                | describe
+            "#
+    ));
+
+    assert_eq!(actual.out, "list<int>");
+}

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -9,7 +9,7 @@ fn lines() {
             | lines
             | skip while $it != "[dependencies]"
             | skip 1
-            | first 1
+            | first
             | split column "="
             | get column1.0
             | str trim

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -154,7 +154,7 @@ fn parses_tsv() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             open caco3_plastics.tsv
-            | first 1
+            | first
             | get origin
         "#
     ));
@@ -216,7 +216,7 @@ fn parses_arrow_ipc() {
         r#"
             open-df caco3_plastics.arrow
             | into nu
-            | first 1
+            | first
             | get origin
         "#
     ));

--- a/crates/nu-command/tests/commands/reverse.rs
+++ b/crates/nu-command/tests/commands/reverse.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu;
 fn can_get_reverse_first() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | sort-by name | reverse | first 1 | get name | str trim "
+        "ls | sort-by name | reverse | first | get name | str trim "
     );
 
     assert_eq!(actual.out, "utf16.ini");

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -12,7 +12,7 @@ fn by_column() {
             | split column "="
             | sort-by column1
             | skip 1
-            | first 1
+            | first
             | get column1
             | str trim
         "#
@@ -33,7 +33,7 @@ fn by_invalid_column() {
             | split column "="
             | sort-by ColumnThatDoesNotExist
             | skip 1
-            | first 1
+            | first
             | get column1
             | str trim
         "#
@@ -69,7 +69,7 @@ fn sort_primitive_values() {
             | skip 1
             | first 6
             | sort-by
-            | first 1
+            | first
         "#
     ));
 

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -6,7 +6,7 @@ use nu_test_support::pipeline;
 fn filters_by_unit_size_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "ls | where size > 1kib | sort-by size | get name | first 1 | str trim"
+        "ls | where size > 1kib | sort-by size | get name | first | str trim"
     );
 
     assert_eq!(actual.out, "cargo_sample.toml");
@@ -103,7 +103,7 @@ fn binary_operator_comparisons() {
             open sample.db
             | get ints
             | where z != 1
-            | first 1
+            | first
             | get z
         "#
     ));

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -6,7 +6,7 @@ use nu_test_support::{nu, pipeline};
 fn table_to_csv_text_and_from_csv_text_back_into_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open caco3_plastics.csv | to csv | from csv | first 1 | get origin "
+        "open caco3_plastics.csv | to csv | from csv | first | get origin "
     );
 
     assert_eq!(actual.out, "SPAIN");

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -6,7 +6,7 @@ use nu_test_support::{nu, pipeline};
 fn table_to_tsv_text_and_from_tsv_text_back_into_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open caco3_plastics.tsv | to tsv | from tsv | first 1 | get origin"
+        "open caco3_plastics.tsv | to tsv | from tsv | first | get origin"
     );
 
     assert_eq!(actual.out, "SPAIN");
@@ -16,7 +16,7 @@ fn table_to_tsv_text_and_from_tsv_text_back_into_table() {
 fn table_to_tsv_text_and_from_tsv_text_back_into_table_using_csv_separator() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r"open caco3_plastics.tsv | to tsv | from csv --separator '\t' | first 1 | get origin"
+        r"open caco3_plastics.tsv | to tsv | from csv --separator '\t' | first | get origin"
     );
 
     assert_eq!(actual.out, "SPAIN");

--- a/tests/plugins/core_inc.rs
+++ b/tests/plugins/core_inc.rs
@@ -7,7 +7,7 @@ fn chooses_highest_increment_if_given_more_than_one() {
     let actual = nu_with_plugins!(
         cwd: "tests/fixtures/formats",
         plugin: ("nu_plugin_inc"),
-        "open cargo_sample.toml | first 1 | inc package.version --major --minor | get package.version"
+        "open cargo_sample.toml | first | inc package.version --major --minor | get package.version"
     );
 
     assert_eq!(actual.out, "1.0.0");
@@ -16,7 +16,7 @@ fn chooses_highest_increment_if_given_more_than_one() {
         cwd: "tests/fixtures/formats",
         plugin: ("nu_plugin_inc"),
         // Regardless of order of arguments
-        "open cargo_sample.toml | first 1 | inc package.version --minor --major | get package.version"
+        "open cargo_sample.toml | first | inc package.version --minor --major | get package.version"
     );
 
     assert_eq!(actual.out, "1.0.0");

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -232,7 +232,7 @@ mod stdin_evaluation {
                 | nu --testbin chop
                 | nu --testbin chop
                 | lines
-                | first 1 )
+                | first )
             "#
         ))
         .out;


### PR DESCRIPTION
# Description

Fixes #6611. This is a breaking change, but a necessary one; this brings `first` in line with `last`, where `first 1` returns a list as well.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
