### PR TITLE
add some float operations with filesize

### DIFF
--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -283,6 +283,66 @@ fn modulo() {
 }
 
 #[test]
+fn unit_multiplication_math() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1mb * 2
+        "#
+    ));
+
+    assert_eq!(actual.out, "1.9 MiB");
+}
+
+#[test]
+fn unit_multiplication_float_math() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1mb * 1.2
+        "#
+    ));
+
+    assert_eq!(actual.out, "1.1 MiB");
+}
+
+#[test]
+fn unit_float_floor_division_math() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1mb // 3.0
+        "#
+    ));
+
+    assert_eq!(actual.out, "325.5 KiB");
+}
+
+#[test]
+fn unit_division_math() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1mb / 4
+        "#
+    ));
+
+    assert_eq!(actual.out, "244.1 KiB");
+}
+
+#[test]
+fn unit_float_division_math() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1mb / 3.1
+        "#
+    ));
+
+    assert_eq!(actual.out, "315.0 KiB");
+}
+
+#[test]
 fn duration_math() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -186,6 +186,7 @@ fn external_arg_with_variable_name() {
     })
 }
 
+#[cfg(not(windows))]
 #[test]
 fn external_command_escape_args() {
     Playground::setup("external failed command with semicolon", |dirs, _| {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -101,9 +101,10 @@ pub fn math_result_type(
                 (Type::Float, Type::Int) => (Type::Float, None),
                 (Type::Int, Type::Float) => (Type::Float, None),
                 (Type::Float, Type::Float) => (Type::Float, None),
-
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Int, Type::Filesize) => (Type::Filesize, None),
+                (Type::Filesize, Type::Float) => (Type::Filesize, None),
+                (Type::Float, Type::Filesize) => (Type::Filesize, None),
                 (Type::Duration, Type::Int) => (Type::Filesize, None),
                 (Type::Int, Type::Duration) => (Type::Filesize, None),
 
@@ -156,10 +157,10 @@ pub fn math_result_type(
                 (Type::Float, Type::Int) => (Type::Float, None),
                 (Type::Int, Type::Float) => (Type::Float, None),
                 (Type::Float, Type::Float) => (Type::Float, None),
-                (Type::Filesize, Type::Filesize) => (Type::Float, None),
-                (Type::Duration, Type::Duration) => (Type::Float, None),
-
+                (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
+                (Type::Filesize, Type::Float) => (Type::Filesize, None),
+                (Type::Duration, Type::Duration) => (Type::Float, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.to_string()), None),
@@ -186,10 +187,10 @@ pub fn math_result_type(
                 (Type::Float, Type::Int) => (Type::Int, None),
                 (Type::Int, Type::Float) => (Type::Int, None),
                 (Type::Float, Type::Float) => (Type::Int, None),
-                (Type::Filesize, Type::Filesize) => (Type::Int, None),
-                (Type::Duration, Type::Duration) => (Type::Int, None),
-
+                (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
+                (Type::Filesize, Type::Float) => (Type::Filesize, None),
+                (Type::Duration, Type::Duration) => (Type::Int, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
 
                 (Type::Any, _) => (Type::Any, None),

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -105,8 +105,9 @@ pub fn math_result_type(
                 (Type::Int, Type::Filesize) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
                 (Type::Float, Type::Filesize) => (Type::Filesize, None),
-                (Type::Duration, Type::Int) => (Type::Filesize, None),
-                (Type::Int, Type::Duration) => (Type::Filesize, None),
+                (Type::Duration, Type::Int) => (Type::Duration, None),
+                (Type::Int, Type::Duration) => (Type::Duration, None),
+                (Type::Duration, Type::Float) => (Type::Duration, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.to_string()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
@@ -160,8 +161,9 @@ pub fn math_result_type(
                 (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
-                (Type::Duration, Type::Duration) => (Type::Float, None),
+                (Type::Duration, Type::Duration) => (Type::Duration, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
+                (Type::Duration, Type::Float) => (Type::Duration, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.to_string()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
@@ -190,8 +192,9 @@ pub fn math_result_type(
                 (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
-                (Type::Duration, Type::Duration) => (Type::Int, None),
+                (Type::Duration, Type::Duration) => (Type::Duration, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
+                (Type::Duration, Type::Float) => (Type::Duration, None),
 
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -108,6 +108,7 @@ pub fn math_result_type(
                 (Type::Duration, Type::Int) => (Type::Duration, None),
                 (Type::Int, Type::Duration) => (Type::Duration, None),
                 (Type::Duration, Type::Float) => (Type::Duration, None),
+                (Type::Float, Type::Duration) => (Type::Duration, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.to_string()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -158,10 +158,10 @@ pub fn math_result_type(
                 (Type::Float, Type::Int) => (Type::Float, None),
                 (Type::Int, Type::Float) => (Type::Float, None),
                 (Type::Float, Type::Float) => (Type::Float, None),
-                (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
+                (Type::Filesize, Type::Filesize) => (Type::Float, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
-                (Type::Duration, Type::Duration) => (Type::Duration, None),
+                (Type::Duration, Type::Duration) => (Type::Float, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
                 (Type::Duration, Type::Float) => (Type::Duration, None),
 
@@ -192,7 +192,7 @@ pub fn math_result_type(
                 (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
-                (Type::Duration, Type::Duration) => (Type::Duration, None),
+                (Type::Duration, Type::Duration) => (Type::Int, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
                 (Type::Duration, Type::Float) => (Type::Duration, None),
 

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -189,7 +189,7 @@ pub fn math_result_type(
                 (Type::Float, Type::Int) => (Type::Int, None),
                 (Type::Int, Type::Float) => (Type::Int, None),
                 (Type::Float, Type::Float) => (Type::Int, None),
-                (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
+                (Type::Filesize, Type::Filesize) => (Type::Int, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
                 (Type::Duration, Type::Duration) => (Type::Int, None),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1822,6 +1822,12 @@ impl Value {
                     span,
                 })
             }
+            (Value::Float { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
+                Ok(Value::Duration {
+                    val: (*lhs * *rhs as f64) as i64,
+                    span,
+                })
+            }
             (Value::CustomValue { val: lhs, span }, rhs) => {
                 lhs.operation(*span, Operator::Multiply, op, rhs)
             }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1790,6 +1790,18 @@ impl Value {
                     span,
                 })
             }
+            (Value::Float { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
+                Ok(Value::Filesize {
+                    val: (*lhs * *rhs as f64) as i64,
+                    span,
+                })
+            }
+            (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
+                Ok(Value::Filesize {
+                    val: (*lhs as f64 * *rhs) as i64,
+                    span,
+                })
+            }
             (Value::Int { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 Ok(Value::Duration {
                     val: *lhs * *rhs,
@@ -1881,6 +1893,26 @@ impl Value {
                     Err(ShellError::DivisionByZero(op))
                 }
             }
+            (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if *rhs != 0 {
+                    Ok(Value::Filesize {
+                        val: lhs / rhs,
+                        span,
+                    })
+                } else {
+                    Err(ShellError::DivisionByZero(op))
+                }
+            }
+            (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
+                if *rhs != 0.0 {
+                    Ok(Value::Filesize {
+                        val: (*lhs as f64 / rhs) as i64,
+                        span,
+                    })
+                } else {
+                    Err(ShellError::DivisionByZero(op))
+                }
+            }
             (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 if *rhs != 0 {
                     if lhs % rhs == 0 {
@@ -1894,16 +1926,6 @@ impl Value {
                             span,
                         })
                     }
-                } else {
-                    Err(ShellError::DivisionByZero(op))
-                }
-            }
-            (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if *rhs != 0 {
-                    Ok(Value::Filesize {
-                        val: lhs / rhs,
-                        span,
-                    })
                 } else {
                     Err(ShellError::DivisionByZero(op))
                 }
@@ -1987,7 +2009,30 @@ impl Value {
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
                 if *rhs != 0 {
-                    Ok(Value::Int {
+                    Ok(Value::Filesize {
+                        val: (*lhs as f64 / *rhs as f64)
+                            .max(std::i64::MIN as f64)
+                            .min(std::i64::MAX as f64)
+                            .floor() as i64,
+                        span,
+                    })
+                } else {
+                    Err(ShellError::DivisionByZero(op))
+                }
+            }
+            (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if *rhs != 0 {
+                    Ok(Value::Filesize {
+                        val: lhs / rhs,
+                        span,
+                    })
+                } else {
+                    Err(ShellError::DivisionByZero(op))
+                }
+            }
+            (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
+                if *rhs != 0.0 {
+                    Ok(Value::Filesize {
                         val: (*lhs as f64 / *rhs as f64)
                             .max(std::i64::MIN as f64)
                             .min(std::i64::MAX as f64)
@@ -2005,16 +2050,6 @@ impl Value {
                             .max(std::i64::MIN as f64)
                             .min(std::i64::MAX as f64)
                             .floor() as i64,
-                        span,
-                    })
-                } else {
-                    Err(ShellError::DivisionByZero(op))
-                }
-            }
-            (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if *rhs != 0 {
-                    Ok(Value::Filesize {
-                        val: lhs / rhs,
                         span,
                     })
                 } else {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1888,13 +1888,13 @@ impl Value {
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
                 if *rhs != 0 {
                     if lhs % rhs == 0 {
-                        Ok(Value::Filesize {
+                        Ok(Value::Int {
                             val: lhs / rhs,
                             span,
                         })
                     } else {
-                        Ok(Value::Filesize {
-                            val: ((*lhs as f64) / (*rhs as f64)) as i64,
+                        Ok(Value::Float {
+                            val: (*lhs as f64) / (*rhs as f64),
                             span,
                         })
                     }
@@ -1925,13 +1925,13 @@ impl Value {
             (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 if *rhs != 0 {
                     if lhs % rhs == 0 {
-                        Ok(Value::Duration {
+                        Ok(Value::Int {
                             val: lhs / rhs,
                             span,
                         })
                     } else {
-                        Ok(Value::Duration {
-                            val: ((*lhs as f64) / (*rhs as f64)) as i64,
+                        Ok(Value::Float {
+                            val: (*lhs as f64) / (*rhs as f64),
                             span,
                         })
                     }
@@ -2029,7 +2029,7 @@ impl Value {
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
                 if *rhs != 0 {
-                    Ok(Value::Filesize {
+                    Ok(Value::Int {
                         val: (*lhs as f64 / *rhs as f64)
                             .max(std::i64::MIN as f64)
                             .min(std::i64::MAX as f64)
@@ -2068,7 +2068,7 @@ impl Value {
             }
             (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 if *rhs != 0 {
-                    Ok(Value::Duration {
+                    Ok(Value::Int {
                         val: (*lhs as f64 / *rhs as f64)
                             .max(std::i64::MIN as f64)
                             .min(std::i64::MAX as f64)


### PR DESCRIPTION
# Description

This PR adds some more math operations to file size.

- Filesize * Float = Filesize
- Float * Filesize = Filesize
- Filesize / Filesize = Int
- Filesize / Float = Filesize
- Filesize // Filesize = Int
- Filesize // Float = Filesize

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
