### PR TITLE
Table indexes

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -5,8 +5,8 @@ use nu_protocol::{
     ast::{Call, PathMember},
     engine::{Command, EngineState, Stack, StateWorkingSet},
     format_error, Category, Config, DataSource, Example, IntoPipelineData, ListStream,
-    PipelineData, PipelineMetadata, RawStream, ShellError, Signature, Span, SyntaxShape,
-    TableIndexes, Value,
+    PipelineData, PipelineMetadata, RawStream, ShellError, ShowTableIndexes, Signature, Span,
+    SyntaxShape, Value,
 };
 use nu_table::{Alignments, StyledString, TableTheme, TextStyle};
 use nu_utils::get_ls_colors;
@@ -349,10 +349,10 @@ fn convert_to_table(
     let mut input = input.iter().peekable();
     let color_hm = get_color_config(config);
     let float_precision = config.float_precision as usize;
-    let with_index = match config.table_indexes {
-        TableIndexes::Always => true,
-        TableIndexes::Never => false,
-        TableIndexes::Auto => headers.iter().any(|header| header == INDEX_COLUMN_NAME),
+    let with_index = match config.show_table_indexes {
+        ShowTableIndexes::Always => true,
+        ShowTableIndexes::Never => false,
+        ShowTableIndexes::Auto => headers.iter().any(|header| header == INDEX_COLUMN_NAME),
     };
 
     if input.peek().is_some() {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -5,8 +5,8 @@ use nu_protocol::{
     ast::{Call, PathMember},
     engine::{Command, EngineState, Stack, StateWorkingSet},
     format_error, Category, Config, DataSource, Example, IntoPipelineData, ListStream,
-    PipelineData, PipelineMetadata, RawStream, ShellError, ShowTableIndexes, Signature, Span,
-    SyntaxShape, Value,
+    PipelineData, PipelineMetadata, RawStream, ShellError, Signature, Span, SyntaxShape,
+    TableIndexMode, Value,
 };
 use nu_table::{Alignments, StyledString, TableTheme, TextStyle};
 use nu_utils::get_ls_colors;
@@ -349,10 +349,10 @@ fn convert_to_table(
     let mut input = input.iter().peekable();
     let color_hm = get_color_config(config);
     let float_precision = config.float_precision as usize;
-    let with_index = match config.show_table_indexes {
-        ShowTableIndexes::Always => true,
-        ShowTableIndexes::Never => false,
-        ShowTableIndexes::Auto => headers.iter().any(|header| header == INDEX_COLUMN_NAME),
+    let with_index = match config.table_index_mode {
+        TableIndexMode::Always => true,
+        TableIndexMode::Never => false,
+        TableIndexMode::Auto => headers.iter().any(|header| header == INDEX_COLUMN_NAME),
     };
 
     if input.peek().is_some() {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -5,7 +5,8 @@ use nu_protocol::{
     ast::{Call, PathMember},
     engine::{Command, EngineState, Stack, StateWorkingSet},
     format_error, Category, Config, DataSource, Example, IntoPipelineData, ListStream,
-    PipelineData, PipelineMetadata, RawStream, ShellError, Signature, Span, SyntaxShape, Value,
+    PipelineData, PipelineMetadata, RawStream, ShellError, Signature, Span, SyntaxShape,
+    TableIndexes, Value,
 };
 use nu_table::{Alignments, StyledString, TableTheme, TextStyle};
 use nu_utils::get_ls_colors;
@@ -348,10 +349,14 @@ fn convert_to_table(
     let mut input = input.iter().peekable();
     let color_hm = get_color_config(config);
     let float_precision = config.float_precision as usize;
-    let disable_index = config.disable_table_indexes;
+    let with_index = match config.table_indexes {
+        TableIndexes::Always => true,
+        TableIndexes::Never => false,
+        TableIndexes::Auto => headers.iter().any(|header| header == INDEX_COLUMN_NAME),
+    };
 
     if input.peek().is_some() {
-        if !headers.is_empty() && !disable_index {
+        if !headers.is_empty() && with_index {
             headers.insert(0, "#".into());
         }
 
@@ -373,7 +378,7 @@ fn convert_to_table(
             }
             // String1 = datatype, String2 = value as string
             let mut row: Vec<(String, String)> = vec![];
-            if !disable_index {
+            if with_index {
                 let row_val = match &item {
                     Value::Record { .. } => item
                         .get_data_by_key(INDEX_COLUMN_NAME)
@@ -390,7 +395,7 @@ fn convert_to_table(
                     item.into_abbreviated_string(config),
                 ));
             } else {
-                let skip_num = if !disable_index { 1 } else { 0 };
+                let skip_num = if with_index { 1 } else { 0 };
                 for header in headers.iter().skip(skip_num) {
                     let result = match item {
                         Value::Record { .. } => item.clone().follow_cell_path(
@@ -432,7 +437,7 @@ fn convert_to_table(
                     x.into_iter()
                         .enumerate()
                         .map(|(col, y)| {
-                            if col == 0 && !disable_index {
+                            if col == 0 && with_index {
                                 StyledString {
                                     contents: y.1,
                                     style: TextStyle {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -77,7 +77,7 @@ pub struct Config {
     pub rm_always_trash: bool,
     pub shell_integration: bool,
     pub buffer_editor: String,
-    pub show_table_indexes: ShowTableIndexes,
+    pub table_index_mode: TableIndexMode,
     pub cd_with_abbreviations: bool,
     pub case_sensitive_completions: bool,
     pub enable_external_completion: bool,
@@ -114,7 +114,7 @@ impl Default for Config {
             rm_always_trash: false,
             shell_integration: false,
             buffer_editor: String::new(),
-            show_table_indexes: ShowTableIndexes::Always,
+            table_index_mode: TableIndexMode::Always,
             cd_with_abbreviations: false,
             case_sensitive_completions: false,
             enable_external_completion: true,
@@ -146,7 +146,7 @@ pub enum HistoryFileFormat {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum ShowTableIndexes {
+pub enum TableIndexMode {
     /// Always show indexes
     Always,
     /// Never show indexes
@@ -380,19 +380,19 @@ impl Value {
                             eprintln!("$config.buffer_editor is not a string")
                         }
                     }
-                    "show_table_indexes" => {
+                    "table_index_mode" => {
                         if let Ok(b) = value.as_string() {
                             let val_str = b.to_lowercase();
                             match val_str.as_ref() {
-                                "always" => config.show_table_indexes = ShowTableIndexes::Always,
-                                "never" => config.show_table_indexes = ShowTableIndexes::Never,
-                                "auto" => config.show_table_indexes = ShowTableIndexes::Auto,
+                                "always" => config.table_index_mode = TableIndexMode::Always,
+                                "never" => config.table_index_mode = TableIndexMode::Never,
+                                "auto" => config.table_index_mode = TableIndexMode::Auto,
                                 _ => eprintln!(
-                                    "$config.show_table_indexes must be a never, always or auto"
+                                    "$config.table_index_mode must be a never, always or auto"
                                 ),
                             }
                         } else {
-                            eprintln!("$config.show_table_indexes is not a string")
+                            eprintln!("$config.table_index_mode is not a string")
                         }
                     }
                     "cd_with_abbreviations" => {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -77,7 +77,7 @@ pub struct Config {
     pub rm_always_trash: bool,
     pub shell_integration: bool,
     pub buffer_editor: String,
-    pub disable_table_indexes: bool,
+    pub table_indexes: TableIndexes,
     pub cd_with_abbreviations: bool,
     pub case_sensitive_completions: bool,
     pub enable_external_completion: bool,
@@ -114,7 +114,7 @@ impl Default for Config {
             rm_always_trash: false,
             shell_integration: false,
             buffer_editor: String::new(),
-            disable_table_indexes: false,
+            table_indexes: TableIndexes::Always,
             cd_with_abbreviations: false,
             case_sensitive_completions: false,
             enable_external_completion: true,
@@ -143,6 +143,16 @@ pub enum HistoryFileFormat {
     Sqlite,
     /// store history as a plain text file where every line is one command (without any context such as timestamps)
     PlainText,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum TableIndexes {
+    /// Always show indexes
+    Always,
+    /// Never show indexes
+    Never,
+    /// Show indexes when a table has "index" column
+    Auto,
 }
 
 /// A Table view configuration, for a situation where
@@ -370,11 +380,19 @@ impl Value {
                             eprintln!("$config.buffer_editor is not a string")
                         }
                     }
-                    "disable_table_indexes" => {
-                        if let Ok(b) = value.as_bool() {
-                            config.disable_table_indexes = b;
+                    "table_indexes" => {
+                        if let Ok(b) = value.as_string() {
+                            let val_str = b.to_lowercase();
+                            match val_str.as_ref() {
+                                "always" => config.table_indexes = TableIndexes::Always,
+                                "never" => config.table_indexes = TableIndexes::Never,
+                                "auto" => config.table_indexes = TableIndexes::Auto,
+                                _ => eprintln!(
+                                    "$config.table_indexes must be a never, always or auto"
+                                ),
+                            }
                         } else {
-                            eprintln!("$config.disable_table_indexes is not a bool")
+                            eprintln!("$config.table_indexes is not a string")
                         }
                     }
                     "cd_with_abbreviations" => {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -77,7 +77,7 @@ pub struct Config {
     pub rm_always_trash: bool,
     pub shell_integration: bool,
     pub buffer_editor: String,
-    pub table_indexes: TableIndexes,
+    pub show_table_indexes: ShowTableIndexes,
     pub cd_with_abbreviations: bool,
     pub case_sensitive_completions: bool,
     pub enable_external_completion: bool,
@@ -114,7 +114,7 @@ impl Default for Config {
             rm_always_trash: false,
             shell_integration: false,
             buffer_editor: String::new(),
-            table_indexes: TableIndexes::Always,
+            show_table_indexes: ShowTableIndexes::Always,
             cd_with_abbreviations: false,
             case_sensitive_completions: false,
             enable_external_completion: true,
@@ -146,7 +146,7 @@ pub enum HistoryFileFormat {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum TableIndexes {
+pub enum ShowTableIndexes {
     /// Always show indexes
     Always,
     /// Never show indexes
@@ -380,19 +380,19 @@ impl Value {
                             eprintln!("$config.buffer_editor is not a string")
                         }
                     }
-                    "table_indexes" => {
+                    "show_table_indexes" => {
                         if let Ok(b) = value.as_string() {
                             let val_str = b.to_lowercase();
                             match val_str.as_ref() {
-                                "always" => config.table_indexes = TableIndexes::Always,
-                                "never" => config.table_indexes = TableIndexes::Never,
-                                "auto" => config.table_indexes = TableIndexes::Auto,
+                                "always" => config.show_table_indexes = ShowTableIndexes::Always,
+                                "never" => config.show_table_indexes = ShowTableIndexes::Never,
+                                "auto" => config.show_table_indexes = ShowTableIndexes::Auto,
                                 _ => eprintln!(
-                                    "$config.table_indexes must be a never, always or auto"
+                                    "$config.show_table_indexes must be a never, always or auto"
                                 ),
                             }
                         } else {
-                            eprintln!("$config.table_indexes is not a string")
+                            eprintln!("$config.show_table_indexes is not a string")
                         }
                     }
                     "cd_with_abbreviations" => {

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use nu_ansi_term::Style;
-use nu_protocol::{Config, FooterMode, TrimStrategy};
+use nu_protocol::{Config, FooterMode, TableIndexes, TrimStrategy};
 use tabled::{
     builder::Builder,
     formatting_settings::AlignmentStrategy,
@@ -95,7 +95,15 @@ fn draw_table(
     let theme = &table.theme;
     let with_header = headers.is_some();
     let with_footer = with_header && need_footer(config, data.len() as u64);
-    let with_index = !config.disable_table_indexes;
+    let with_index = match config.table_indexes {
+        TableIndexes::Always => true,
+        TableIndexes::Never => false,
+        TableIndexes::Auto => table
+            .headers
+            .iter()
+            .flatten()
+            .any(|header| header.contents == "index"),
+    };
 
     let table = build_table(data, headers, with_footer);
     let table = load_theme(table, color_hm, theme, with_footer, with_header);

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use nu_ansi_term::Style;
-use nu_protocol::{Config, FooterMode, ShowTableIndexes, TrimStrategy};
+use nu_protocol::{Config, FooterMode, TableIndexMode, TrimStrategy};
 use tabled::{
     builder::Builder,
     formatting_settings::AlignmentStrategy,
@@ -95,10 +95,10 @@ fn draw_table(
     let theme = &table.theme;
     let with_header = headers.is_some();
     let with_footer = with_header && need_footer(config, data.len() as u64);
-    let with_index = match config.show_table_indexes {
-        ShowTableIndexes::Always => true,
-        ShowTableIndexes::Never => false,
-        ShowTableIndexes::Auto => table
+    let with_index = match config.table_index_mode {
+        TableIndexMode::Always => true,
+        TableIndexMode::Never => false,
+        TableIndexMode::Auto => table
             .headers
             .iter()
             .flatten()

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use nu_ansi_term::Style;
-use nu_protocol::{Config, FooterMode, TableIndexes, TrimStrategy};
+use nu_protocol::{Config, FooterMode, ShowTableIndexes, TrimStrategy};
 use tabled::{
     builder::Builder,
     formatting_settings::AlignmentStrategy,
@@ -95,10 +95,10 @@ fn draw_table(
     let theme = &table.theme;
     let with_header = headers.is_some();
     let with_footer = with_header && need_footer(config, data.len() as u64);
-    let with_index = match config.table_indexes {
-        TableIndexes::Always => true,
-        TableIndexes::Never => false,
-        TableIndexes::Auto => table
+    let with_index = match config.show_table_indexes {
+        ShowTableIndexes::Always => true,
+        ShowTableIndexes::Never => false,
+        ShowTableIndexes::Auto => table
             .headers
             .iter()
             .flatten()

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -259,7 +259,7 @@ let-env config = {
   sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
   history_file_format: "plaintext" # "sqlite" or "plaintext"
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
-  table_indexes: always # always, never, auto
+  show_table_indexes: auto # always, never, auto
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   case_sensitive_completions: false # set to true to enable case-sensitive completions
   enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -259,7 +259,7 @@ let-env config = {
   sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
   history_file_format: "plaintext" # "sqlite" or "plaintext"
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
-  show_table_indexes: auto # always, never, auto
+  table_index_mode: always # always, never, auto
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   case_sensitive_completions: false # set to true to enable case-sensitive completions
   enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -259,7 +259,7 @@ let-env config = {
   sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
   history_file_format: "plaintext" # "sqlite" or "plaintext"
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
-  disable_table_indexes: false # set to true to remove the index column from tables
+  table_indexes: always # always, never, auto
   cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
   case_sensitive_completions: false # set to true to enable case-sensitive completions
   enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow


### PR DESCRIPTION
# Description

This PR replaces `disable_table_indexes` with `table_indexes` in the config, which may be one of:
* `always` - always show indexes
* `never` - never show indexes
* `auto` - show indexes when a table has "index" column

This is a useful setting for those who use `disable_table_indexes: true`, but sometimes wants to index a table. If you set this to `auto`, then tables will not be indexed unless you explicitly want it to be.

# Example
With `table_indexes: auto` a table is displayed without indexes
```
 > ["foo", "bar"] | each { |r| { item: $r } }
╭──────╮
│ item │
├──────┤
│ foo  │
│ bar  │
╰──────╯
```

When you add an "index" column, it shows up
```
 > ["foo", "bar"] | each -n { |r| { item: $r.item, index: $r.index } }
╭───┬──────╮
│ # │ item │
├───┼──────┤
│ 0 │ foo  │
│ 1 │ bar  │
╰───┴──────╯
```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
