### PR TITLE
Revert "Fix touch panics when using invalid timestamp"

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -148,24 +148,14 @@ impl Command for Touch {
                         10 => Some(AddYear::Full),
                         12 => Some(AddYear::FirstDigits),
                         14 => None,
-                        _ => {
-                            return Err(ShellError::UnsupportedInput(
-                                "input has an invalid timestamp".to_string(),
-                                span,
-                            ))
-                        }
+                        _ => unreachable!(), // This should never happen as the check above should catch it
                     }
                 } else {
                     match size {
                         8 => Some(AddYear::Full),
                         10 => Some(AddYear::FirstDigits),
                         12 => None,
-                        _ => {
-                            return Err(ShellError::UnsupportedInput(
-                                "input has an invalid timestamp".to_string(),
-                                span,
-                            ))
-                        }
+                        _ => unreachable!(), // This should never happen as the check above should catch it
                     }
                 };
 

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -850,20 +850,3 @@ fn not_create_file_if_it_not_exists() {
         assert!(!path.exists());
     })
 }
-
-#[test]
-fn test_invalid_timestamp() {
-    Playground::setup("test_invalid_timestamp", |dirs, _sandbox| {
-        let outcome = nu!(
-            cwd: dirs.test(),
-            r#"touch -t 20220729. file.txt"#
-        );
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        let outcome = nu!(
-            cwd: dirs.test(),
-            r#"touch -t 20220729120099 file.txt"#
-        );
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-    })
-}


### PR DESCRIPTION
Reverts nushell/nushell#6181

Hopefully this fixes the unit test failures on some Linux platforms