### PR TITLE
Revert "Return error early if seconds part of timestamp is invalid"

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -121,15 +121,7 @@ impl Command for Touch {
 
                 // Checks for the seconds stamp and removes the '.' delimiter if any
                 let (val, has_sec): (String, bool) = match stamp.split_once('.') {
-                    Some((dtime, sec)) => match sec.parse::<u8>() {
-                        Ok(sec) if sec < 60 => (format!("{}{}", dtime, sec), true),
-                        _ => {
-                            return Err(ShellError::UnsupportedInput(
-                                "input has an invalid timestamp".to_string(),
-                                span,
-                            ))
-                        }
-                    },
+                    Some((dtime, sec)) => (format!("{}{}", dtime, sec), true),
                     None => (stamp.to_string(), false),
                 };
 

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -180,34 +180,6 @@ fn errors_if_change_modified_time_of_file_with_invalid_timestamp() {
         );
 
         assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -t 082412.3012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -t 0824.123012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -t 08.24123012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -t 0.824123012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
     })
 }
 
@@ -426,34 +398,6 @@ fn errors_if_change_access_time_of_file_with_invalid_timestamp() {
         outcome = nu!(
             cwd: dirs.test(),
             "touch -a -t 01908241230 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -a -t 082412.3012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -a -t 0824.123012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -a -t 08.24123012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -a -t 0.824123012 file.txt"
         );
 
         assert!(outcome.err.contains("input has an invalid timestamp"));
@@ -687,34 +631,6 @@ fn errors_if_change_modified_and_access_time_of_file_with_invalid_timestamp() {
         outcome = nu!(
             cwd: dirs.test(),
             "touch -t 01908241230 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -a -t 082412.3012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -a -t 0824.123012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -a -t 08.24123012 file.txt"
-        );
-
-        assert!(outcome.err.contains("input has an invalid timestamp"));
-
-        outcome = nu!(
-            cwd: dirs.test(),
-            "touch -m -a -t 0.824123012 file.txt"
         );
 
         assert!(outcome.err.contains("input has an invalid timestamp"));


### PR DESCRIPTION
Reverts nushell/nushell#6193

testing to find a fix for the 0.69 test failures