### PR TITLE
tweak the banner message and make the time more accurate

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -578,7 +578,7 @@ fn get_banner(engine_state: &mut EngineState, stack: &mut Stack) -> String {
         engine_state,
         stack,
         None,
-        "(date now) - ('05/10/2019' | into datetime)",
+        "(date now) - ('2019-05-10 09:59:12-0700' | into datetime)",
     ) {
         Ok(Value::Duration { val, .. }) => format_duration(val),
         _ => "".to_string(),
@@ -595,7 +595,7 @@ Our {}GitHub{} repository is at {}https://github.com/nushell/nushell{}
 Our {}Documentation{} is located at {}http://nushell.sh{}
 {}Tweet{} us at {}@nu_shell{}
 
-{}Nushell{} has been around for:
+It's been this long since {}Nushell{}'s first commit:
 {}
 
 {}You can disable this banner using the {}config nu{}{} command


### PR DESCRIPTION
# Description

The changes the wording slightly in the banner and makes the duration more precise. (like it matters 🤣)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
