### PR TITLE
Make semicolon works better for internal commands

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -11,3 +11,15 @@ fn capture_errors_works() {
 
     assert_eq!(actual.out, "error");
 }
+
+#[test]
+fn do_with_semicolon_break_on_failed_external() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        do { nu --not_exist_flag }; `text`
+        "#
+    ));
+
+    assert_eq!(actual.out, "");
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -201,7 +201,7 @@ fn eval_external(
     input: PipelineData,
     redirect_stdout: bool,
     redirect_stderr: bool,
-) -> Result<(PipelineData, bool), ShellError> {
+) -> Result<PipelineData, ShellError> {
     let decl_id = engine_state
         .find_decl("run-external".as_bytes(), &[])
         .ok_or(ShellError::ExternalNotSupported(head.span))?;
@@ -238,54 +238,7 @@ fn eval_external(
         ))
     }
 
-    // when the external command doesn't redirect output, we eagerly check the result
-    // and find if the command runs to failed.
-    let mut runs_to_failed = false;
-    let result = command.run(engine_state, stack, &call, input)?;
-    if let PipelineData::ExternalStream {
-        stdout: None,
-        stderr,
-        mut exit_code,
-        span,
-        metadata,
-    } = result
-    {
-        let exit_code = exit_code.take();
-        match exit_code {
-            Some(exit_code_stream) => {
-                let ctrlc = exit_code_stream.ctrlc.clone();
-                let exit_code: Vec<Value> = exit_code_stream.into_iter().collect();
-                if let Some(Value::Int { val: code, .. }) = exit_code.last() {
-                    // if exit_code is not 0, it indicates error occured, return back Err.
-                    if *code != 0 {
-                        runs_to_failed = true;
-                    }
-                }
-                Ok((
-                    PipelineData::ExternalStream {
-                        stdout: None,
-                        stderr,
-                        exit_code: Some(ListStream::from_stream(exit_code.into_iter(), ctrlc)),
-                        span,
-                        metadata,
-                    },
-                    runs_to_failed,
-                ))
-            }
-            None => Ok((
-                PipelineData::ExternalStream {
-                    stdout: None,
-                    stderr,
-                    exit_code: None,
-                    span,
-                    metadata,
-                },
-                runs_to_failed,
-            )),
-        }
-    } else {
-        Ok((result, runs_to_failed))
-    }
+    command.run(engine_state, stack, &call, input)
 }
 
 pub fn eval_expression(
@@ -383,7 +336,6 @@ pub fn eval_expression(
                 false,
                 false,
             )?
-            .0
             .into_value(span))
         }
         Expr::DateTime(dt) => Ok(Value::Date {
@@ -682,7 +634,7 @@ pub fn eval_expression_with_input(
     redirect_stdout: bool,
     redirect_stderr: bool,
 ) -> Result<(PipelineData, bool), ShellError> {
-    let external_failed = match expr {
+    match expr {
         Expression {
             expr: Expr::Call(call),
             ..
@@ -696,15 +648,12 @@ pub fn eval_expression_with_input(
             } else {
                 input = eval_call(engine_state, stack, call, input)?;
             }
-            let res = might_consume_external_result(input);
-            input = res.0;
-            res.1
         }
         Expression {
             expr: Expr::ExternalCall(head, args),
             ..
         } => {
-            let external_result = eval_external(
+            input = eval_external(
                 engine_state,
                 stack,
                 head,
@@ -713,8 +662,6 @@ pub fn eval_expression_with_input(
                 redirect_stdout,
                 redirect_stderr,
             )?;
-            input = external_result.0;
-            external_result.1
         }
 
         Expression {
@@ -725,20 +672,14 @@ pub fn eval_expression_with_input(
 
             // FIXME: protect this collect with ctrl-c
             input = eval_subexpression(engine_state, stack, block, input)?;
-            let res = might_consume_external_result(input);
-            input = res.0;
-            res.1
         }
 
         elem => {
             input = eval_expression(engine_state, stack, elem)?.into_pipeline_data();
-            let res = might_consume_external_result(input);
-            input = res.0;
-            res.1
         }
     };
 
-    Ok((input, external_failed))
+    Ok(might_consume_external_result(input))
 }
 
 fn might_consume_external_result(input: PipelineData) -> (PipelineData, bool) {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -682,10 +682,13 @@ pub fn eval_expression_with_input(
     Ok(might_consume_external_result(input))
 }
 
+// if the result is ExternalStream without redirecting output.
+// that indicates we have no more commands to execute currently.
+// we can try to catch and detect if external command runs to failed.
+//
+// This is useful to commands with semicolon, we can detect errors early to avoid
+// commands after semicolon running.
 fn might_consume_external_result(input: PipelineData) -> (PipelineData, bool) {
-    // if the result is ExternalStream without redirecting output.
-    // that indicates we have no more commands to execute currently.
-    // we can try to catch and detect if external command runs to failed.
     let mut runs_to_failed = false;
     if let PipelineData::ExternalStream {
         stdout: None,


### PR DESCRIPTION
# Description

make semicolon works as expected when some internal commands runs with non-zero exit code.

Take the following mentioned by #6617 
```
do { node --eval `process.exit(1)` }; "test"
```

`"test"` should never be evaluated, because previous do runs to failed.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
