### PR TITLE
Eval external command result immediately when using `do` command with `-c`

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -5,9 +5,45 @@ fn capture_errors_works() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        do -c {$env.use} | describe
+        do -c {$env.use}
         "#
     ));
 
-    assert_eq!(actual.out, "error");
+    assert!(actual.err.contains("column_not_found"));
+}
+
+#[test]
+fn capture_errors_works_for_external() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        do -c {nu --testbin fail}
+        "#
+    ));
+    assert!(actual.err.contains("External command runs to failed"));
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn capture_errors_works_for_external_with_pipeline() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        do -c {nu --testbin fail} | echo `text`
+        "#
+    ));
+    assert!(actual.err.contains("External command runs to failed"));
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn capture_errors_works_for_external_with_semicolon() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        do -c {nu --testbin fail}; echo `text`
+        "#
+    ));
+    assert!(actual.err.contains("External command runs to failed"));
+    assert_eq!(actual.out, "");
 }

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -173,18 +173,6 @@ fn from_nothing() {
 }
 
 #[test]
-fn from_error() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        do -c {$env.use} | into string
-        "#
-    ));
-
-    assert_eq!(actual.out, "nu::shell::column_not_found");
-}
-
-#[test]
 fn int_into_string() {
     let actual = nu!(
         cwd: ".", pipeline(


### PR DESCRIPTION
# Description

This pr is a companion to #6643, they both handle #6617 

**The reason to create a separate pr:** this pr handles different part of issue, and it just provide a workaround for use case.

## Background and Solution
For the user input cases:
``` 
# 1st case
> 1234 | node --eval `process.exit(1)` | `test`
test

# 2nd case
> 1234 | node --eval `process.exit(1)` | 1234; `test`
1234
test

# 3rd case
> (node --eval `process.exit(1)`); `test`
test
```
This is because the output of the external command is lazy by default, we have no way of knowing whether the external command succeeded or failed, we can only access the result in the command below, and we have no way to make it work directly.

But I think we can use `do -c` to provide eagly eval behavior for external commands' result, so it provides workaround for user cases.
```
# 1st case
> 1234 | do -c {node --eval `process.exit(1)`} | `test`
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #5:1:1]
 1 │ 1234 | do -c {node --eval `process.exit(1)`} | `test`
   ·               ──┬─
   ·                 ╰── External command runs to failed
   ╰────
  help:

# 2nd case
> 1234 | do -c {node --eval `process.exit(1)`} | 1234; `test`
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #6:1:1]
 1 │ 1234 | do -c {node --eval `process.exit(1)`} | 1234; `test`
   ·               ──┬─
   ·                 ╰── External command runs to failed
   ╰────
  help:


# 3rd case
> do -c { node --eval `process.exit(1)`}; `test`
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #7:1:1]
 1 │ do -c { node --eval `process.exit(1)`}; `test`
   ·         ──┬─
   ·           ╰── External command runs to failed
   ╰────
  help:
```

## About the change
1. when `capture_error` is enabled, if code block runs to failed, return `Err(ShellError)` instread of `Value::Error`, so we have an easy way to break our execution.
2. when `capture_error` is enabled, and if code block returns `PipelineData::ExternalStream`, we check the result immediately, so we can raise out error if **external command** runs to failed.

And... yeah, I think the new behavior is more like what the docs describe:
> -c, --capture-errors - capture errors as the block runs and return it

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
