### PR TITLE
allow for `$in` to affect environment

### DIFF
--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, CallExt, redirect_env};
+use nu_engine::{eval_block, redirect_env, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{

--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -46,7 +46,7 @@ impl Command for Collect {
 
         let metadata = input.metadata();
         let input: Value = input.into_value(call.head);
-        
+
         let mut saved_positional = None;
         if let Some(var) = block.signature.get_positional(0) {
             if let Some(var_id) = &var.var_id {
@@ -66,10 +66,10 @@ impl Command for Collect {
         .map(|x| x.set_metadata(metadata));
         if call.has_flag("affect-env") {
             for var_id in capture_block.captures.keys() {
-                stack_captures.vars.remove(var_id); 
+                stack_captures.vars.remove(var_id);
             }
             if let Some(u) = saved_positional {
-                stack_captures.vars.remove(&u); 
+                stack_captures.vars.remove(&u);
             }
             stack.vars = stack_captures.vars;
             stack.env_vars = stack_captures.env_vars;

--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -71,7 +71,7 @@ impl Command for Collect {
             if let Some(u) = saved_positional {
                 stack_captures.vars.remove(&u);
             }
-            stack.vars = stack_captures.vars;
+            stack.vars.extend(stack_captures.vars);
             stack.env_vars = stack_captures.env_vars;
             stack.active_overlays = stack_captures.active_overlays;
             stack.env_hidden.extend(stack_captures.env_hidden);

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -3,6 +3,20 @@ use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use std::path::PathBuf;
 
+#[test]
+fn cd_works_with_in_var() {
+    Playground::setup("cd_test_1", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.root(),
+            r#"
+                "cd_test_1" | cd $in; $env.PWD | path split | last
+            "#
+        );
+
+        assert_eq!("cd_test_1", actual.out);
+    })
+}
+
 // FIXME: jt: needs more work
 #[ignore]
 #[test]

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5367,6 +5367,15 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
             custom_completion: None,
         }));
 
+        output.push(Argument::Named((
+            Spanned {
+                item: "affect-env".to_string(),
+                span: Span::new(0, 0),
+            },
+            None,
+            None,
+        )));
+
         // The containing, synthetic call to `collect`.
         // We don't want to have a real span as it will confuse flattening
         // The args are where we'll get the real info

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5369,7 +5369,7 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
 
         output.push(Argument::Named((
             Spanned {
-                item: "affect-env".to_string(),
+                item: "keep-env".to_string(),
                 span: Span::new(0, 0),
             },
             None,


### PR DESCRIPTION
# Description

Fixes #6081. Try `"target_dir" | cd $in`, it works now.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works. 

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
