### PR TITLE
Remove unnecessary flags from `term size`

### DIFF
--- a/crates/nu-command/src/platform/term_size.rs
+++ b/crates/nu-command/src/platform/term_size.rs
@@ -12,35 +12,28 @@ impl Command for TermSize {
     }
 
     fn usage(&self) -> &str {
-        "Returns the terminal size"
+        "Returns a record containing the number of columns (width) and rows (height) of the terminal"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("term size")
-            .switch(
-                "columns",
-                "Report only the width of the terminal",
-                Some('c'),
-            )
-            .switch("rows", "Report only the height of the terminal", Some('r'))
-            .category(Category::Platform)
+        Signature::build("term size").category(Category::Platform)
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Return the width height of the terminal",
+                description: "Return the columns (width) and rows (height) of the terminal",
                 example: "term size",
                 result: None,
             },
             Example {
-                description: "Return the width (columns) of the terminal",
-                example: "term size -c",
+                description: "Return the columns (width) of the terminal",
+                example: "(term size).columns",
                 result: None,
             },
             Example {
-                description: "Return the height (rows) of the terminal",
-                example: "term size -r",
+                description: "Return the rows (height) of the terminal",
+                example: "(term size).rows",
                 result: None,
             },
         ]
@@ -54,60 +47,26 @@ impl Command for TermSize {
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let head = call.head;
-        let wide = call.has_flag("columns");
-        let tall = call.has_flag("rows");
 
         let (cols, rows) = match terminal_size() {
             Some((w, h)) => (Width(w.0), Height(h.0)),
             None => (Width(0), Height(0)),
         };
 
-        Ok((match (wide, tall) {
-            (true, false) => Value::Record {
-                cols: vec!["columns".into()],
-                vals: vec![Value::Int {
+        Ok(Value::Record {
+            cols: vec!["columns".into(), "rows".into()],
+            vals: vec![
+                Value::Int {
                     val: cols.0 as i64,
                     span: Span::test_data(),
-                }],
-                span: head,
-            },
-            (true, true) => Value::Record {
-                cols: vec!["columns".into(), "rows".into()],
-                vals: vec![
-                    Value::Int {
-                        val: cols.0 as i64,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: rows.0 as i64,
-                        span: Span::test_data(),
-                    },
-                ],
-                span: head,
-            },
-            (false, true) => Value::Record {
-                cols: vec!["rows".into()],
-                vals: vec![Value::Int {
+                },
+                Value::Int {
                     val: rows.0 as i64,
                     span: Span::test_data(),
-                }],
-                span: head,
-            },
-            (false, false) => Value::Record {
-                cols: vec!["columns".into(), "rows".into()],
-                vals: vec![
-                    Value::Int {
-                        val: cols.0 as i64,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: rows.0 as i64,
-                        span: Span::test_data(),
-                    },
-                ],
-                span: head,
-            },
-        })
+                },
+            ],
+            span: head,
+        }
         .into_pipeline_data())
     }
 }


### PR DESCRIPTION
This PR simplifies the `term size` command by removing the `-c` and `-r` flags. The columns and rows can be obtained individually using

```
(term size).columns
(term size).rows
```

and we should encourage this usage rather than providing flags that do the same thing. This sort of orthogonality is healthy for the language/project: if a user finds it inconvenient or non-obvious to extract fields from a record then that's a bug in the documentation, or a more profound problem.


# Tests

I've checked that the examples work.

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
