### PR TITLE
Highlight matching brackets / parentheses

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -1,6 +1,6 @@
 use log::trace;
 use nu_ansi_term::Style;
-use nu_color_config::get_shape_color;
+use nu_color_config::{get_matching_brackets_style, get_shape_color};
 use nu_parser::{flatten_block, parse, FlatShape};
 use nu_protocol::ast::{Argument, Block, Expr, Expression};
 use nu_protocol::engine::{EngineState, StateWorkingSet};
@@ -66,7 +66,7 @@ impl Highlighter for NuHighlighter {
                         let text = (&next_token[start..end]).to_string();
                         let mut style = get_shape_color($shape.to_string(), &self.config);
                         if *highlight {
-                            style = style.reverse();
+                            style = get_matching_brackets_style(style, &self.config);
                         }
                         output.push((style, text));
                     });

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -152,7 +152,7 @@ fn find_matching_bracket_in_block(
             }
         }
     }
-    return None;
+    None
 }
 
 fn find_matching_bracket_in_expr(
@@ -302,5 +302,5 @@ fn find_matching_bracket_in_expr(
             }
         };
     }
-    return None;
+    None
 }

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -2,6 +2,7 @@ use log::trace;
 use nu_ansi_term::Style;
 use nu_color_config::get_shape_color;
 use nu_parser::{flatten_block, parse, FlatShape};
+use nu_protocol::ast::{Argument, Block, Expr, Expression};
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 use nu_protocol::Config;
 use reedline::{Highlighter, StyledText};
@@ -15,16 +16,26 @@ impl Highlighter for NuHighlighter {
     fn highlight(&self, line: &str, _cursor: usize) -> StyledText {
         trace!("highlighting: {}", line);
 
-        let (shapes, global_span_offset) = {
-            let mut working_set = StateWorkingSet::new(&self.engine_state);
+        let mut working_set = StateWorkingSet::new(&self.engine_state);
+        let block = {
             let (block, _) = parse(&mut working_set, None, line.as_bytes(), false, &[]);
-
+            block
+        };
+        let (shapes, global_span_offset) = {
             let shapes = flatten_block(&working_set, &block);
             (shapes, self.engine_state.next_span_start())
         };
 
         let mut output = StyledText::default();
         let mut last_seen_span = global_span_offset;
+
+        let global_cursor_offset = _cursor + global_span_offset;
+        let matching_bracket_pos =
+            find_matching_bracket_in_block(&working_set, &block, global_cursor_offset);
+        println!(
+            "Cursor: {:?}, match: {:?}",
+            global_cursor_offset, matching_bracket_pos
+        ); // FIXME:
 
         for shape in &shapes {
             if shape.0.end <= last_seen_span
@@ -44,166 +55,90 @@ impl Highlighter for NuHighlighter {
             let next_token = line
                 [(shape.0.start - global_span_offset)..(shape.0.end - global_span_offset)]
                 .to_string();
+
+            macro_rules! add_colored_token {
+                ($shape:ident) => {
+                    output.push((
+                        get_shape_color($shape.1.to_string(), &self.config),
+                        next_token,
+                    ))
+                };
+            }
+
             match shape.1 {
-                FlatShape::Garbage => output.push((
-                    // nushell Garbage
-                    get_shape_color(shape.1.to_string(), &self.config),
+                FlatShape::Garbage => add_colored_token!(shape),
+                FlatShape::Nothing => add_colored_token!(shape),
+                FlatShape::Binary => add_colored_token!(shape),
+                FlatShape::Bool => add_colored_token!(shape),
+                FlatShape::Int => add_colored_token!(shape),
+                FlatShape::Float => add_colored_token!(shape),
+                FlatShape::Range => add_colored_token!(shape),
+                FlatShape::InternalCall => add_colored_token!(shape),
+                FlatShape::External => add_colored_token!(shape),
+                FlatShape::ExternalArg => add_colored_token!(shape),
+                FlatShape::Literal => add_colored_token!(shape),
+                FlatShape::Operator => add_colored_token!(shape),
+                FlatShape::Signature => add_colored_token!(shape),
+                FlatShape::String => add_colored_token!(shape),
+                FlatShape::StringInterpolation => add_colored_token!(shape),
+                FlatShape::DateTime => add_colored_token!(shape),
+                FlatShape::List => output.push((
+                    if let Some(pos) = matching_bracket_pos {
+                        if shape.0.contains(pos) {
+                            get_shape_color(shape.1.to_string(), &self.config).reverse()
+                        } else {
+                            get_shape_color(shape.1.to_string(), &self.config)
+                        }
+                    } else {
+                        get_shape_color(shape.1.to_string(), &self.config)
+                    },
                     next_token,
                 )),
-                FlatShape::Nothing => output.push((
-                    // nushell Nothing
-                    get_shape_color(shape.1.to_string(), &self.config),
+                FlatShape::Table => output.push((
+                    if let Some(pos) = matching_bracket_pos {
+                        if shape.0.contains(pos) {
+                            get_shape_color(shape.1.to_string(), &self.config).reverse()
+                        } else {
+                            get_shape_color(shape.1.to_string(), &self.config)
+                        }
+                    } else {
+                        get_shape_color(shape.1.to_string(), &self.config)
+                    },
                     next_token,
                 )),
-                FlatShape::Binary => {
-                    // nushell ?
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Bool => {
-                    // nushell ?
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Int => {
-                    // nushell Int
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Float => {
-                    // nushell Decimal
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Range => output.push((
-                    // nushell DotDot ?
-                    get_shape_color(shape.1.to_string(), &self.config),
+                FlatShape::Record => output.push((
+                    if let Some(pos) = matching_bracket_pos {
+                        if shape.0.contains(pos) {
+                            get_shape_color(shape.1.to_string(), &self.config).reverse()
+                        } else {
+                            get_shape_color(shape.1.to_string(), &self.config)
+                        }
+                    } else {
+                        get_shape_color(shape.1.to_string(), &self.config)
+                    },
                     next_token,
                 )),
-                FlatShape::InternalCall => output.push((
-                    // nushell InternalCommand
-                    get_shape_color(shape.1.to_string(), &self.config),
+
+                // FIXME: highlight only matching_bracket_pos
+                FlatShape::Block => output.push((
+                    if let Some(pos) = matching_bracket_pos {
+                        if shape.0.contains(pos) {
+                            get_shape_color(shape.1.to_string(), &self.config).reverse()
+                        } else {
+                            get_shape_color(shape.1.to_string(), &self.config)
+                        }
+                    } else {
+                        get_shape_color(shape.1.to_string(), &self.config)
+                    },
                     next_token,
                 )),
-                FlatShape::External => {
-                    // nushell ExternalCommand
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::ExternalArg => {
-                    // nushell ExternalWord
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Literal => {
-                    // nushell ?
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Operator => output.push((
-                    // nushell Operator
-                    get_shape_color(shape.1.to_string(), &self.config),
-                    next_token,
-                )),
-                FlatShape::Signature => output.push((
-                    // nushell ?
-                    get_shape_color(shape.1.to_string(), &self.config),
-                    next_token,
-                )),
-                FlatShape::String => {
-                    // nushell String
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::StringInterpolation => {
-                    // nushell ???
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::DateTime => {
-                    // nushell ???
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::List => {
-                    // nushell ???
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Table => {
-                    // nushell ???
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Record => {
-                    // nushell ???
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Block => {
-                    // nushell ???
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Filepath => output.push((
-                    // nushell Path
-                    get_shape_color(shape.1.to_string(), &self.config),
-                    next_token,
-                )),
-                FlatShape::Directory => output.push((
-                    // nushell Directory
-                    get_shape_color(shape.1.to_string(), &self.config),
-                    next_token,
-                )),
-                FlatShape::GlobPattern => output.push((
-                    // nushell GlobPattern
-                    get_shape_color(shape.1.to_string(), &self.config),
-                    next_token,
-                )),
-                FlatShape::Variable => output.push((
-                    // nushell Variable
-                    get_shape_color(shape.1.to_string(), &self.config),
-                    next_token,
-                )),
-                FlatShape::Flag => {
-                    // nushell Flag
-                    output.push((
-                        get_shape_color(shape.1.to_string(), &self.config),
-                        next_token,
-                    ))
-                }
-                FlatShape::Custom(..) => output.push((
-                    get_shape_color(shape.1.to_string(), &self.config),
-                    next_token,
-                )),
+
+                FlatShape::Filepath => add_colored_token!(shape),
+                FlatShape::Directory => add_colored_token!(shape),
+                FlatShape::GlobPattern => add_colored_token!(shape),
+                FlatShape::Variable => add_colored_token!(shape),
+                FlatShape::Flag => add_colored_token!(shape),
+                FlatShape::Custom(..) => add_colored_token!(shape),
             }
             last_seen_span = shape.0.end;
         }
@@ -215,4 +150,174 @@ impl Highlighter for NuHighlighter {
 
         output
     }
+}
+
+fn find_matching_bracket_in_block(
+    working_set: &StateWorkingSet,
+    block: &Block,
+    global_cursor_offset: usize,
+) -> Option<usize> {
+    println!("Block: {:?}", block);
+    for p in &block.pipelines {
+        for e in &p.expressions {
+            if e.span.contains(global_cursor_offset) {
+                if let Some(pos) =
+                    find_matching_bracket_in_expr(working_set, e, global_cursor_offset)
+                {
+                    return Some(pos);
+                }
+            }
+        }
+    }
+    return None;
+}
+
+fn find_matching_bracket_in_expr(
+    working_set: &StateWorkingSet,
+    expression: &Expression,
+    global_cursor_offset: usize,
+) -> Option<usize> {
+    macro_rules! find_in_expr_or_continue {
+        ($inner_expr:ident) => {
+            if let Some(pos) =
+                find_matching_bracket_in_expr(working_set, $inner_expr, global_cursor_offset)
+            {
+                return Some(pos);
+            }
+        };
+    }
+
+    if expression.span.contains(global_cursor_offset) {
+        let expr_first = expression.span.start;
+        let expr_last = expression.span.end - 1;
+
+        return match &expression.expr {
+            Expr::Bool(_) => None,
+            Expr::Int(_) => None,
+            Expr::Float(_) => None,
+            Expr::Binary(_) => None,
+            Expr::Range(..) => None,
+            Expr::Var(_) => None,
+            Expr::VarDecl(_) => None,
+            Expr::ExternalCall(..) => None,
+            Expr::Operator(_) => None,
+            Expr::UnaryNot(_) => None,
+            Expr::Keyword(..) => None,
+            Expr::ValueWithUnit(..) => None,
+            Expr::DateTime(_) => None,
+            Expr::Filepath(_) => None,
+            Expr::Directory(_) => None,
+            Expr::GlobPattern(_) => None,
+            Expr::String(_) => None,
+            Expr::CellPath(_) => None,
+            Expr::ImportPattern(_) => None,
+            Expr::Overlay(_) => None,
+            Expr::Signature(_) => None,
+            Expr::Nothing => None,
+            Expr::Garbage => None,
+
+            Expr::Table(hdr, rows) => {
+                if expr_last == global_cursor_offset {
+                    // cursor is at table end
+                    Some(expr_first)
+                } else if expr_first == global_cursor_offset {
+                    // cursor is at table start
+                    Some(expr_last)
+                } else {
+                    // cursor is inside table
+                    for inner_expr in hdr {
+                        find_in_expr_or_continue!(inner_expr);
+                    }
+                    for row in rows {
+                        for inner_expr in row {
+                            find_in_expr_or_continue!(inner_expr);
+                        }
+                    }
+                    None
+                }
+            }
+
+            Expr::Record(exprs) => {
+                if expr_last == global_cursor_offset {
+                    // cursor is at record end
+                    Some(expr_first)
+                } else if expr_first == global_cursor_offset {
+                    // cursor is at record start
+                    Some(expr_last)
+                } else {
+                    // cursor is inside record
+                    for (k, v) in exprs {
+                        find_in_expr_or_continue!(k);
+                        find_in_expr_or_continue!(v);
+                    }
+                    None
+                }
+            }
+
+            Expr::Call(call) => {
+                for arg in &call.arguments {
+                    let opt_expr = match arg {
+                        Argument::Named((_, _, opt_expr)) => opt_expr.as_ref(),
+                        Argument::Positional(inner_expr) => Some(inner_expr),
+                    };
+
+                    if let Some(inner_expr) = opt_expr {
+                        find_in_expr_or_continue!(inner_expr);
+                    }
+                }
+                None
+            }
+
+            Expr::FullCellPath(b) => {
+                find_matching_bracket_in_expr(working_set, &b.head, global_cursor_offset)
+            }
+
+            Expr::BinaryOp(lhs, op, rhs) => {
+                find_in_expr_or_continue!(lhs);
+                find_in_expr_or_continue!(op);
+                find_in_expr_or_continue!(rhs);
+                None
+            }
+
+            Expr::Block(block_id)
+            | Expr::RowCondition(block_id)
+            | Expr::Subexpression(block_id) => {
+                if expr_last == global_cursor_offset {
+                    // cursor is at block end
+                    Some(expr_first)
+                } else if expr_first == global_cursor_offset {
+                    // cursor is at block start
+                    Some(expr_last)
+                } else {
+                    // cursor is inside block
+                    let nested_block = working_set.get_block(*block_id);
+                    find_matching_bracket_in_block(working_set, nested_block, global_cursor_offset)
+                }
+            }
+
+            Expr::StringInterpolation(inner_expr) => {
+                for inner_expr in inner_expr {
+                    find_in_expr_or_continue!(inner_expr);
+                }
+                None
+            }
+
+            Expr::List(inner_expr) => {
+                if expr_last == global_cursor_offset {
+                    // cursor is at list end
+                    Some(expr_first)
+                } else if expr_first == global_cursor_offset {
+                    // cursor is at list start
+                    Some(expr_last)
+                } else {
+                    // cursor is inside list
+                    for inner_expr in inner_expr {
+                        find_in_expr_or_continue!(inner_expr);
+                    }
+                    None
+                }
+            }
+        };
+    }
+    return None;
 }

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -201,7 +201,7 @@ fn find_matching_brackets(
             };
         }
     }
-    return Vec::new();
+    Vec::new()
 }
 
 fn find_matching_block_end_in_block(

--- a/crates/nu-color-config/src/lib.rs
+++ b/crates/nu-color-config/src/lib.rs
@@ -1,7 +1,9 @@
 mod color_config;
+mod matching_brackets_style;
 mod nu_style;
 mod shape_color;
 
 pub use color_config::*;
+pub use matching_brackets_style::*;
 pub use nu_style::*;
 pub use shape_color::*;

--- a/crates/nu-color-config/src/matching_brackets_style.rs
+++ b/crates/nu-color-config/src/matching_brackets_style.rs
@@ -1,0 +1,30 @@
+use crate::color_config::lookup_ansi_color_style;
+use nu_ansi_term::Style;
+use nu_protocol::Config;
+
+const MATCHING_BRACKETS_CONFIG_KEY: &str = "shape_matching_brackets";
+
+pub fn get_matching_brackets_style(default_style: Style, conf: &Config) -> Style {
+    match conf.color_config.get(MATCHING_BRACKETS_CONFIG_KEY) {
+        Some(int_color) => match int_color.as_string() {
+            Ok(int_color) => merge_styles(default_style, lookup_ansi_color_style(&int_color)),
+            Err(_) => default_style,
+        },
+        None => default_style,
+    }
+}
+
+fn merge_styles(base: Style, extra: Style) -> Style {
+    Style {
+        foreground: extra.foreground.or(base.foreground),
+        background: extra.background.or(base.background),
+        is_bold: extra.is_bold || base.is_bold,
+        is_dimmed: extra.is_dimmed || base.is_dimmed,
+        is_italic: extra.is_italic || base.is_italic,
+        is_underline: extra.is_underline || base.is_underline,
+        is_blink: extra.is_blink || base.is_blink,
+        is_reverse: extra.is_reverse || base.is_reverse,
+        is_hidden: extra.is_hidden || base.is_hidden,
+        is_strikethrough: extra.is_strikethrough || base.is_strikethrough,
+    }
+}

--- a/crates/nu-color-config/src/matching_brackets_style.rs
+++ b/crates/nu-color-config/src/matching_brackets_style.rs
@@ -2,9 +2,9 @@ use crate::color_config::lookup_ansi_color_style;
 use nu_ansi_term::Style;
 use nu_protocol::Config;
 
-const MATCHING_BRACKETS_CONFIG_KEY: &str = "shape_matching_brackets";
-
 pub fn get_matching_brackets_style(default_style: Style, conf: &Config) -> Style {
+    const MATCHING_BRACKETS_CONFIG_KEY: &str = "shape_matching_brackets";
+
     match conf.color_config.get(MATCHING_BRACKETS_CONFIG_KEY) {
         Some(int_color) => match int_color.as_string() {
             Ok(int_color) => merge_styles(default_style, lookup_ansi_color_style(&int_color)),

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -178,6 +178,7 @@ let dark_theme = {
     shape_flag: blue_bold
     shape_custom: green
     shape_nothing: light_cyan
+    shape_matching_brackets: { attr: u }
 }
 
 let light_theme = {
@@ -229,6 +230,7 @@ let light_theme = {
     shape_flag: blue_bold
     shape_custom: green
     shape_nothing: light_cyan
+    shape_matching_brackets: { attr: u }
 }
 
 # External completer example


### PR DESCRIPTION
# Description

In this PR I propose a solution for matching bracket highlighting based on the AST. Thus, given the current cursor position we find the token to which it belongs and if the cursor is at the start/end of a specific token (a record, a list, a block, etc.) the other end of the token will be highlighted.

I decided it was a not a good idea to simply find a matching bracket without using ATS. The reason is, in some cases, like in case of `[\[]]` (where the `\[]` is a string), this would contradict the ATS.

This approach has some downsides:
1. Currently in tables only the outer brackets are matched.
2. If an expression is isolated with brackets in order for matching to work, the expression should be processed correctly in the `find_matching_bracket_in_expr` function.

Please, provide me the feedback on this solution. I will adjust the logic if necessary and cover the functionality with tests.

Fixes #4325.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
