### PR TITLE
To nuon escapes

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -209,6 +209,7 @@ fn needs_quotes(string: &str) -> bool {
         || string.contains('\t')
         || string.contains('\n')
         || string.contains('\r')
+        || string.contains('\"')
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -173,12 +173,11 @@ fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
 fn value_to_string_without_quotes(v: &Value, span: Span) -> Result<String, ShellError> {
     match v {
         Value::String { val, .. } => Ok({
-            let mut quoted = escape_quote_string(val);
-            if !needs_quotes(val) {
-                quoted.remove(0);
-                quoted.pop();
+            if needs_quotes(val) {
+                escape_quote_string(val)
+            } else {
+                val.clone()
             }
-            quoted
         }),
         _ => value_to_string(v, span),
     }

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -104,6 +104,51 @@ fn to_nuon_escaping2() {
 }
 
 #[test]
+fn to_nuon_escaping3() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            ["hello\\world"]
+            | to nuon
+            | from nuon
+            | $in == [hello\world]
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn to_nuon_escaping4() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            ["hello\"world"]
+            | to nuon
+            | from nuon
+            | $in == ["hello\"world"]
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn to_nuon_escaping5() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            {s: "hello\"world"}
+            | to nuon
+            | from nuon
+            | $in == {s: "hello\"world"}
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
 fn to_nuon_negative_int() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(


### PR DESCRIPTION
# Description
Fix issue described in #6650
In this PR i added some tests that cover the faulty conversion of backslashes and double quotes in non-quoted strings in tables and records (try out `[qwe\qwe] | to nuon | from nuon`) and added a fix for these issues.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
