### PR TITLE
add a new command to query the registry on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,7 @@ dependencies = [
  "wax",
  "which",
  "windows",
+ "winreg",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -90,9 +90,11 @@ uuid = { version = "1.1.2", features = ["v4"] }
 which = { version = "4.3.0", optional = true }
 reedline = { version = "0.12.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
-winreg = "0.10.1"
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
+
+[target.'cfg(windows)'.dependencies]
+winreg = "0.10.1"
 
 [target.'cfg(unix)'.dependencies]
 umask = "2.0.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -90,6 +90,7 @@ uuid = { version = "1.1.2", features = ["v4"] }
 which = { version = "4.3.0", optional = true }
 reedline = { version = "0.12.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
+winreg = "0.10.1"
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
 

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -158,12 +158,16 @@ pub fn create_default_context() -> EngineState {
         bind_command! {
             Benchmark,
             Complete,
-            Exec,
             External,
             NuCheck,
-            RegistryQuery,
             Sys,
         };
+
+        #[cfg(unix)]
+        bind_command! { Exec }
+
+        #[cfg(windows)]
+        bind_command! { RegistryQuery }
 
         #[cfg(any(
             target_os = "android",

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -161,6 +161,7 @@ pub fn create_default_context() -> EngineState {
             Exec,
             External,
             NuCheck,
+            RegistryQuery,
             Sys,
         };
 

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -1,8 +1,11 @@
+use super::run_external::ExternalCommand;
+use nu_engine::{current_dir, env_to_strings, CallExt};
 use nu_protocol::{
-    ast::Call,
+    ast::{Call, Expr},
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, SyntaxShape,
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
 };
+use std::os::unix::process::CommandExt;
 
 #[derive(Clone)]
 pub struct Exec;
@@ -57,19 +60,11 @@ impl Command for Exec {
     }
 }
 
-#[cfg(unix)]
 fn exec(
     engine_state: &EngineState,
     stack: &mut Stack,
     call: &Call,
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-    use std::os::unix::process::CommandExt;
-
-    use super::run_external::ExternalCommand;
-    use nu_engine::{current_dir, env_to_strings, CallExt};
-    use nu_protocol::ast::Expr;
-    use nu_protocol::Spanned;
-
     let name: Spanned<String> = call.req(engine_state, stack, 0)?;
     let name_span = name.span;
 
@@ -109,21 +104,6 @@ fn exec(
         "Error on exec".to_string(),
         err.to_string(),
         Some(name_span),
-        None,
-        Vec::new(),
-    ))
-}
-
-#[cfg(not(unix))]
-fn exec(
-    _engine_state: &EngineState,
-    _stack: &mut Stack,
-    call: &Call,
-) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-    Err(ShellError::GenericError(
-        "Error on exec".to_string(),
-        "exec is not supported on your platform".to_string(),
-        Some(call.head),
         None,
         Vec::new(),
     ))

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -9,6 +9,7 @@ mod nu_check;
     target_os = "windows"
 ))]
 mod ps;
+mod registry_query;
 mod run_external;
 mod sys;
 mod which_;
@@ -24,6 +25,7 @@ pub use nu_check::NuCheck;
     target_os = "windows"
 ))]
 pub use ps::Ps;
+pub use registry_query::RegistryQuery;
 pub use run_external::{External, ExternalCommand};
 pub use sys::Sys;
 pub use which_::Which;

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,5 +1,6 @@
 mod benchmark;
 mod complete;
+#[cfg(unix)]
 mod exec;
 mod nu_check;
 #[cfg(any(
@@ -9,6 +10,7 @@ mod nu_check;
     target_os = "windows"
 ))]
 mod ps;
+#[cfg(windows)]
 mod registry_query;
 mod run_external;
 mod sys;
@@ -16,6 +18,7 @@ mod which_;
 
 pub use benchmark::Benchmark;
 pub use complete::Complete;
+#[cfg(unix)]
 pub use exec::Exec;
 pub use nu_check::NuCheck;
 #[cfg(any(
@@ -25,6 +28,7 @@ pub use nu_check::NuCheck;
     target_os = "windows"
 ))]
 pub use ps::Ps;
+#[cfg(windows)]
 pub use registry_query::RegistryQuery;
 pub use run_external::{External, ExternalCommand};
 pub use sys::Sys;

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -1,0 +1,230 @@
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
+};
+#[cfg(windows)]
+use winreg::RegKey;
+
+#[derive(Clone)]
+pub struct RegistryQuery;
+
+struct RegistryQueryArgs {
+    hkcr: bool,
+    hkcu: bool,
+    hklm: bool,
+    hku: bool,
+    hkpd: bool,
+    hkpt: bool,
+    hkpnls: bool,
+    hkcc: bool,
+    hkdd: bool,
+    hkculs: bool,
+    key: String,
+}
+
+impl Command for RegistryQuery {
+    fn name(&self) -> &str {
+        "registry query"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("registry query")
+            .switch("hkcr", "query the hkey_classes_root hive", None)
+            .switch("hkcu", "query the hkey_current_user hive", None)
+            .switch("hklm", "query the hkey_local_machine hive", None)
+            .switch("hku", "query the hkey_users hive", None)
+            .switch("hkpd", "query the hkey_performance_data hive", None)
+            .switch("hkpt", "query the hkey_performance_text hive", None)
+            .switch("hkpnls", "query the hkey_performance_nls_text hive", None)
+            .switch("hkcc", "query the hkey_current_config hive", None)
+            .switch("hkdd", "query the hkey_dyn_data hive", None)
+            .switch(
+                "hkculs",
+                "query the hkey_current_user_local_settings hive",
+                None,
+            )
+            .required("key", SyntaxShape::String, "registry key to query")
+            .optional(
+                "value",
+                SyntaxShape::String,
+                "optionally supply a registry value to query",
+            )
+            .category(Category::System)
+    }
+
+    fn usage(&self) -> &str {
+        "Query the Windows registry."
+    }
+
+    fn extra_usage(&self) -> &str {
+        "Currently supported only on Windows systems."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        registry_query(engine_state, stack, call)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Query the HKEY_CURRENT_USER hive",
+                example: "registry query --hkcu environment",
+                result: None,
+            },
+            Example {
+                description: "Query the HKEY_LOCAL_MACHINE hive",
+                example: r"registry query --hklm 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment'",
+                result: None,
+            },
+        ]
+    }
+}
+
+#[cfg(windows)]
+fn registry_query(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+    use nu_engine::CallExt;
+    use nu_protocol::{IntoInterruptiblePipelineData, IntoPipelineData, Span, Value};
+
+    let registry_key: Spanned<String> = call.req(engine_state, stack, 0)?;
+    let registry_key_span = &registry_key.clone().span;
+    let registry_value: Option<Spanned<String>> = call.opt(engine_state, stack, 1)?;
+
+    let reg_params = RegistryQueryArgs {
+        hkcr: call.has_flag("hkcr"),
+        hkcu: call.has_flag("hkcu"),
+        hklm: call.has_flag("hklm"),
+        hku: call.has_flag("hku"),
+        hkpd: call.has_flag("hkpd"),
+        hkpt: call.has_flag("hkpt"),
+        hkpnls: call.has_flag("hkpnls"),
+        hkcc: call.has_flag("hkcc"),
+        hkdd: call.has_flag("hkdd"),
+        hkculs: call.has_flag("hkculs"),
+        key: registry_key.item,
+    };
+
+    let reg_key = get_reg_key(reg_params)?;
+
+    if registry_value.is_none() {
+        let mut reg_values = vec![];
+        for (name, val) in reg_key.enum_values().flatten() {
+            reg_values.push(Value::Record {
+                cols: vec!["name".to_string(), "value".to_string(), "type".to_string()],
+                vals: vec![
+                    Value::string(name, Span::test_data()),
+                    Value::string(val.to_string(), Span::test_data()),
+                    Value::string(format!("{:?}", val.vtype), Span::test_data()),
+                ],
+                span: *registry_key_span,
+            })
+        }
+        Ok(reg_values.into_pipeline_data(engine_state.ctrlc.clone()))
+    } else {
+        match registry_value {
+            Some(value) => {
+                let reg_value = reg_key.get_raw_value(value.item.as_str());
+                match reg_value {
+                    Ok(val) => Ok(Value::Record {
+                        cols: vec!["name".to_string(), "value".to_string(), "type".to_string()],
+                        vals: vec![
+                            Value::string(value.item, Span::test_data()),
+                            Value::string(val.to_string(), Span::test_data()),
+                            Value::string(format!("{:?}", val.vtype), Span::test_data()),
+                        ],
+                        span: value.span,
+                    }
+                    .into_pipeline_data()),
+                    Err(_) => Ok(Value::Error {
+                        error: ShellError::GenericError(
+                            "Unable to find registry key/value".to_string(),
+                            format!("Registry value: {} was not found", value.item),
+                            Some(value.span),
+                            None,
+                            Vec::new(),
+                        ),
+                    }
+                    .into_pipeline_data()),
+                }
+            }
+            None => Ok(Value::nothing(Span::test_data()).into_pipeline_data()),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn get_reg_key(reg_params: RegistryQueryArgs) -> Result<RegKey, ShellError> {
+    use nu_protocol::Span;
+    use winreg::enums::*;
+
+    let mut key_count = 0;
+    let registry_key = if reg_params.hkcr {
+        key_count += 1;
+        RegKey::predef(HKEY_CLASSES_ROOT).open_subkey(reg_params.key)?
+    } else if reg_params.hkcu {
+        key_count += 1;
+        RegKey::predef(HKEY_CURRENT_USER).open_subkey(reg_params.key)?
+    } else if reg_params.hklm {
+        key_count += 1;
+        RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey(reg_params.key)?
+    } else if reg_params.hku {
+        key_count += 1;
+        RegKey::predef(HKEY_USERS).open_subkey(reg_params.key)?
+    } else if reg_params.hkpd {
+        key_count += 1;
+        RegKey::predef(HKEY_PERFORMANCE_DATA).open_subkey(reg_params.key)?
+    } else if reg_params.hkpt {
+        key_count += 1;
+        RegKey::predef(HKEY_PERFORMANCE_TEXT).open_subkey(reg_params.key)?
+    } else if reg_params.hkpnls {
+        key_count += 1;
+        RegKey::predef(HKEY_PERFORMANCE_NLSTEXT).open_subkey(reg_params.key)?
+    } else if reg_params.hkcc {
+        key_count += 1;
+        RegKey::predef(HKEY_CURRENT_CONFIG).open_subkey(reg_params.key)?
+    } else if reg_params.hkdd {
+        key_count += 1;
+        RegKey::predef(HKEY_DYN_DATA).open_subkey(reg_params.key)?
+    } else if reg_params.hkculs {
+        key_count += 1;
+        RegKey::predef(HKEY_CURRENT_USER_LOCAL_SETTINGS).open_subkey(reg_params.key)?
+    } else {
+        RegKey::predef(HKEY_CURRENT_USER).open_subkey(reg_params.key)?
+    };
+
+    if key_count > 1 {
+        return Err(ShellError::GenericError(
+            "Only one registry key can be specified".into(),
+            "Only one registry key can be specified".into(),
+            Some(Span::test_data()),
+            None,
+            Vec::new(),
+        ));
+    }
+    Ok(registry_key)
+}
+
+#[cfg(not(windows))]
+fn registry_query(
+    _engine_state: &EngineState,
+    _stack: &mut Stack,
+    call: &Call,
+) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+    Err(ShellError::GenericError(
+        "Error on registry query".to_string(),
+        "registry is not supported on your platform".to_string(),
+        Some(call.head),
+        None,
+        Vec::new(),
+    ))
+}

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -1,14 +1,16 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape,
 };
+
 #[cfg(windows)]
 use winreg::RegKey;
 
 #[derive(Clone)]
 pub struct RegistryQuery;
 
+#[cfg(windows)]
 struct RegistryQueryArgs {
     hkcr: bool,
     hkcu: bool,
@@ -94,7 +96,7 @@ fn registry_query(
     call: &Call,
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
     use nu_engine::CallExt;
-    use nu_protocol::{IntoInterruptiblePipelineData, IntoPipelineData, Span, Value};
+    use nu_protocol::{IntoInterruptiblePipelineData, IntoPipelineData, Span, Spanned, Value};
 
     let registry_key: Spanned<String> = call.req(engine_state, stack, 0)?;
     let registry_key_span = &registry_key.clone().span;


### PR DESCRIPTION
# Description

This command is for Windows only and adds the ability to query the registry and get tabular nushell output.

![image](https://user-images.githubusercontent.com/343840/194429154-59e5a9a5-2d84-4833-9425-79d20d2a2667.png)

![image](https://user-images.githubusercontent.com/343840/194429190-b72c41cc-e348-4ba4-955d-6b08f3bc22df.png)

Tweaked the code to return nushell datatypes
![image](https://user-images.githubusercontent.com/343840/194616122-41f401be-3010-4f61-924c-afffcdeb05f7.png)

As a "might as well do it now" part of this PR. I've changed the visibility of `exec` to only be visible in "unix" environments and `registry` should only be visible in Windows environments.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
