### PR TITLE
Don't attempt to eval and trace if the repl line is empty

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -452,7 +452,7 @@ pub fn evaluate_repl(
                             span,
                         },
                     );
-                } else {
+                } else if !s.trim().is_empty() {
                     trace!("eval source: {}", s);
 
                     eval_source(


### PR DESCRIPTION
# Description

Fixes #6673.

Due to how `$env.LAST_EXIT_CODE` works, adding tests for this is impossible at the moment. 
1. Type in failing command (`cd non_existent`)
2. Type in `<enter>`, `<space>` then `<enter>`, etc.
3. `$env.LAST_EXIT_CODE` is still `1`.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
