### PR TITLE
avoid freeze for table print

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -424,7 +424,7 @@ impl PipelineData {
         stack: &mut Stack,
         no_newline: bool,
         to_stderr: bool,
-    ) -> Result<(), ShellError> {
+    ) -> Result<i64, ShellError> {
         // If the table function is in the declarations, then we can use it
         // to create the table value that will be printed in the terminal
 
@@ -452,10 +452,13 @@ impl PipelineData {
 
             // Make sure everything has finished
             if let Some(exit_code) = exit_code {
-                let _: Vec<_> = exit_code.into_iter().collect();
+                let mut exit_codes: Vec<_> = exit_code.into_iter().collect();
+                if let Some(Value::Int { val, .. }) = exit_codes.pop() {
+                    return Ok(val);
+                }
             }
 
-            return Ok(());
+            return Ok(0);
         }
 
         match engine_state.find_decl("table".as_bytes(), &[]) {
@@ -474,7 +477,7 @@ impl PipelineData {
             }
         };
 
-        Ok(())
+        Ok(0)
     }
 
     fn write_all_and_flush(
@@ -483,7 +486,7 @@ impl PipelineData {
         config: &Config,
         no_newline: bool,
         to_stderr: bool,
-    ) -> Result<(), ShellError> {
+    ) -> Result<i64, ShellError> {
         for item in self {
             let mut out = if let Value::Error { error } = item {
                 let working_set = StateWorkingSet::new(engine_state);
@@ -506,7 +509,7 @@ impl PipelineData {
             }
         }
 
-        Ok(())
+        Ok(0)
     }
 }
 


### PR DESCRIPTION
# Description

Fixes:  #6594 #6679

As @nibon7 point out, nushell is freeze because blocking channel sender is full, and exit code doesn't send through channel yet.

And while printing out pipeline, it tried to catch `exit_code` first, so everything hangged on.

This pr is going to solve this by removing exit_code consume logic from `eval_block` function, and so make `pipeline_data.print` method always consume stdout, then exit_code

For stderr relative example on https://github.com/nushell/nushell/issues/5625#issuecomment-1165173990, I'm trying to apply the same consuming logic, but it doesn't work, I need to think how to handle it properly.

# Tests

Make sure you've done the following:

- [] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
