### PR TITLE
Upgrade num-format to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,15 +118,6 @@ checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
@@ -1672,7 +1663,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.3",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -1713,7 +1704,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1902,9 +1893,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jobserver"
@@ -3053,12 +3044,12 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
 dependencies = [
- "arrayvec 0.4.12",
- "itoa 0.4.8",
+ "arrayvec 0.7.2",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -4556,7 +4547,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -4568,7 +4559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -4580,7 +4571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -5134,7 +5125,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "libc",
  "num_threads",
  "time-macros",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -25,7 +25,7 @@ nu-term-grid = { path = "../nu-term-grid", version = "0.69.2"  }
 nu-test-support = { path = "../nu-test-support", version = "0.69.2"  }
 nu-utils = { path = "../nu-utils", version = "0.69.2" }
 nu-ansi-term = "0.46.0"
-num-format = { version = "0.4.0" }
+num-format = { version = "0.4.3" }
 
 # Potential dependencies for extras
 alphanumeric-sort = "1.4.4"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -20,7 +20,7 @@ chrono-humanize = "0.2.1"
 fancy-regex = "0.10.0"
 indexmap = { version="1.7", features=["serde-1"] }
 miette = { version = "5.1.0", features = ["fancy"] }
-num-format = "0.4.0"
+num-format = "0.4.3"
 serde = {version = "1.0.130", features = ["derive"]}
 serde_json = { version = "1.0", optional = true }
 sys-locale = "0.2.0"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -15,7 +15,7 @@ nu-path = { path="../nu-path", version = "0.69.2"  }
 nu-glob = { path = "../nu-glob", version = "0.69.2" }
 nu-utils = { path="../nu-utils", version = "0.69.2"  }
 lazy_static = "1.4.0"
-num-format = "0.4.0"
+num-format = "0.4.3"
 
 getset = "0.1.1"
 num-bigint = { version="0.4.3", features=["serde"] }

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 lscolors = { version = "0.12.0", features = ["crossterm"]}
-num-format = { version = "0.4.0" }
+num-format = { version = "0.4.3" }
 sys-locale = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
# Description

I'm the author of `num-format`, one of `nushell`'s dependencies. Unfortunately I went a long time without maintaining the crate. But today I updated it. The public API hasn't changed, but I upgraded a number of `num-format`'s old dependencies, notably...

* arrayvec 0.4 -> 0.7.2
* itoa 0.4 -> 1.0.4

This PR updates your version of `num-format` to the latest release (`0.4.3`)

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
