### PR TITLE
avoid freeze when capturing external stderr

### DIFF
--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -37,22 +37,9 @@ impl Command for Complete {
                 let mut cols = vec![];
                 let mut vals = vec![];
 
-                if let Some(stdout) = stdout {
-                    cols.push("stdout".to_string());
-                    let stdout = stdout.into_bytes()?;
-                    if let Ok(st) = String::from_utf8(stdout.item.clone()) {
-                        vals.push(Value::String {
-                            val: st,
-                            span: stdout.span,
-                        })
-                    } else {
-                        vals.push(Value::Binary {
-                            val: stdout.item,
-                            span: stdout.span,
-                        })
-                    }
-                }
-
+                // the order is important, we need to read
+                // stderr, then stdout, then exit_code
+                // because run_external generate them in this order.
                 if let Some(stderr) = stderr {
                     cols.push("stderr".to_string());
                     let stderr = stderr.into_bytes()?;
@@ -67,6 +54,22 @@ impl Command for Complete {
                             span: stderr.span,
                         })
                     };
+                }
+
+                if let Some(stdout) = stdout {
+                    cols.push("stdout".to_string());
+                    let stdout = stdout.into_bytes()?;
+                    if let Ok(st) = String::from_utf8(stdout.item.clone()) {
+                        vals.push(Value::String {
+                            val: st,
+                            span: stdout.span,
+                        })
+                    } else {
+                        vals.push(Value::Binary {
+                            val: stdout.item,
+                            span: stdout.span,
+                        })
+                    }
                 }
 
                 if let Some(exit_code) = exit_code {

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -66,7 +66,7 @@ fn ignore_error_not_hang_nushell() {
     use nu_test_support::fs::Stub::FileWithContent;
     use nu_test_support::pipeline;
     use nu_test_support::playground::Playground;
-    Playground::setup("external with too much stderr", |dirs, sandbox| {
+    Playground::setup("external with many stderr message", |dirs, sandbox| {
         let bytes: usize = 81920;
         let mut large_file_body = String::with_capacity(bytes);
         for _ in 0..bytes {
@@ -87,10 +87,10 @@ fn ignore_error_not_hang_nushell() {
 
 #[test]
 #[cfg(not(windows))]
-fn ignore_error_with_both_stdout_stderr_not_hang_nushell() {
+fn ignore_error_with_both_stdout_stderr_messages_not_hang_nushell() {
     use nu_test_support::fs::Stub::FileWithContent;
     use nu_test_support::playground::Playground;
-    Playground::setup("external with too much stdout", |dirs, sandbox| {
+    Playground::setup("external with many stdout and stderr messages", |dirs, sandbox| {
         let script_body = r#"
         x=$(printf '=%.0s' {1..40960})
         echo $x

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -107,7 +107,7 @@ fn ignore_error_with_both_stdout_stderr_not_hang_nushell() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                do -i {sh test.sh} | complete | get stdout | str trim
+                do -i {bash test.sh} | complete | get stdout | str trim
             "#
         ));
         assert_eq!(actual.out, expect_body);
@@ -115,7 +115,7 @@ fn ignore_error_with_both_stdout_stderr_not_hang_nushell() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                do -i {sh test.sh} | complete | get stderr | str trim
+                do -i {bash test.sh} | complete | get stderr | str trim
             "#
         ));
         assert_eq!(actual.out, expect_body);

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -90,34 +90,37 @@ fn ignore_error_not_hang_nushell() {
 fn ignore_error_with_both_stdout_stderr_messages_not_hang_nushell() {
     use nu_test_support::fs::Stub::FileWithContent;
     use nu_test_support::playground::Playground;
-    Playground::setup("external with many stdout and stderr messages", |dirs, sandbox| {
-        let script_body = r#"
+    Playground::setup(
+        "external with many stdout and stderr messages",
+        |dirs, sandbox| {
+            let script_body = r#"
         x=$(printf '=%.0s' {1..40960})
         echo $x
         echo $x 1>&2
         "#;
-        let mut expect_body = String::new();
-        for _ in 0..40960 {
-            expect_body.push_str("=");
-        }
+            let mut expect_body = String::new();
+            for _ in 0..40960 {
+                expect_body.push_str("=");
+            }
 
-        sandbox.with_files(vec![FileWithContent("test.sh", &script_body)]);
+            sandbox.with_files(vec![FileWithContent("test.sh", &script_body)]);
 
-        // check for stdout
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
+            // check for stdout
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
                 do -i {bash test.sh} | complete | get stdout | str trim
             "#
-        ));
-        assert_eq!(actual.out, expect_body);
-        // check for stderr
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
+            ));
+            assert_eq!(actual.out, expect_body);
+            // check for stderr
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
                 do -i {bash test.sh} | complete | get stderr | str trim
             "#
-        ));
-        assert_eq!(actual.out, expect_body);
-    })
+            ));
+            assert_eq!(actual.out, expect_body);
+        },
+    )
 }

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -59,3 +59,65 @@ fn do_with_semicolon_break_on_failed_external() {
 
     assert_eq!(actual.out, "");
 }
+
+#[test]
+#[cfg(not(windows))]
+fn ignore_error_not_hang_nushell() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    use nu_test_support::pipeline;
+    use nu_test_support::playground::Playground;
+    Playground::setup("external with too much stderr", |dirs, sandbox| {
+        let bytes: usize = 81920;
+        let mut large_file_body = String::with_capacity(bytes);
+        for _ in 0..bytes {
+            large_file_body.push_str("a");
+        }
+        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                do -i {sh -c "cat a_large_file.txt 1>&2"} | complete | get stderr
+            "#
+        ));
+
+        assert_eq!(actual.out, large_file_body);
+    })
+}
+
+#[test]
+#[cfg(not(windows))]
+fn ignore_error_with_both_stdout_stderr_not_hang_nushell() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    use nu_test_support::playground::Playground;
+    Playground::setup("external with too much stdout", |dirs, sandbox| {
+        let script_body = r#"
+        x=$(printf '=%.0s' {1..40960})
+        echo $x
+        echo $x 1>&2
+        "#;
+        let mut expect_body = String::new();
+        for _ in 0..40960 {
+            expect_body.push_str("=");
+        }
+
+        sandbox.with_files(vec![FileWithContent("test.sh", &script_body)]);
+
+        // check for stdout
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                do -i {sh test.sh} | complete | get stdout | str trim
+            "#
+        ));
+        assert_eq!(actual.out, expect_body);
+        // check for stderr
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                do -i {sh test.sh} | complete | get stderr | str trim
+            "#
+        ));
+        assert_eq!(actual.out, expect_body);
+    })
+}

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -433,10 +433,14 @@ impl PipelineData {
 
         if let PipelineData::ExternalStream {
             stdout: stream,
+            stderr: stderr_stream,
             exit_code,
             ..
         } = self
         {
+            // NOTE: currently we don't need anything from stderr
+            // so directly consumes `stderr_stream` to make sure that everything is done.
+            let _ = stderr_stream.map(|x| x.into_bytes());
             if let Some(stream) = stream {
                 for s in stream {
                     let s_live = s?;


### PR DESCRIPTION
# Description

Fix #5156 
Relative #6219 and #5625 (I can't reproduce these relative issue, but I think this pr can resolve them)

The main issue is that when https://github.com/nushell/nushell/pull/4986 is landed, nushell doesn't handle external message properly.

In general, the thread which sends external result is sending stderr message, stdout message, exit code in order.  So the external result receiver must make sure that it receives relative message in the same order.  Or we'll likely to get a dead lock.

## About the test
I've done manually test which mentioned in https://github.com/nushell/nushell/issues/5625#issuecomment-1165173990, to make automation test code simpler, I use the following script to simulate the behavior:
```
# test.sh
x=$(printf '=%.0s' {1..40960})
echo $x
echo $x 1>&2
```
command:
```
do -i {bash test.sh} | complete
```


# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
