### PR TITLE
Prepend directory to the binary tarball

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -90,12 +90,16 @@ if ($ver | str trim | is-empty) {
 cd $dist; $'(char nl)Creating release archive...'; hr-line
 if $os in ['ubuntu-latest', 'macos-latest'] {
 
-    $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls
+    let files = (ls | get name)
+    let dest = $'($bin)-($version)-($target)'
+    let archive = $'($dist)/($dest).tar.gz'
 
-    let archive = $'($dist)/($bin)-($version)-($target).tar.gz'
-    let prefix = $'($bin)-($version)-($target)/'
-    let expr = $''s,^,($prefix),S''
-    tar --show-transformed-names --transform $expr -czvf $archive *
+    mkdir $dest
+    $files | each {|it| mv $it $dest } | ignore
+
+    $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls $dest
+
+    tar -czf $archive $dest
     print $'archive: ---> ($archive)'; ls $archive
     echo $'::set-output name=archive::($archive)'
 

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -93,7 +93,9 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
     $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls
 
     let archive = $'($dist)/($bin)-($version)-($target).tar.gz'
-    tar czf $archive *
+    let prefix = $'($bin)-($version)-($target)/'
+    let expr = $''s,^,($prefix),S''
+    tar --show-transformed-names --transform $expr -czvf $archive *
     print $'archive: ---> ($archive)'; ls $archive
     echo $'::set-output name=archive::($archive)'
 


### PR DESCRIPTION
# Description

~~According to https://www.gnu.org/software/tar/manual/html_section/transform.html, use `--transform` parameter to prepend directory to each file name.~~

GNU tar is not available on Mac by default, use a common way.

Closes #6676

![Screenshot from 2022-10-11 17-24-53](https://user-images.githubusercontent.com/15247421/195057143-641bff9c-377e-4fb5-ad5d-c22573de9d30.png)

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
