### PR TITLE
Filter out empty glob patterns to "glob" command

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -4,7 +4,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Spanned,
-    SyntaxShape, Value,
+    SyntaxShape, Value, Span,
 };
 use wax::{Glob as WaxGlob, WalkBehavior};
 
@@ -98,6 +98,8 @@ impl Command for Glob {
         let path = current_dir(engine_state, stack)?;
         let glob_pattern: Spanned<String> = call.req(engine_state, stack, 0)?;
         let depth = call.get_flag(engine_state, stack, "depth")?;
+
+        if glob_pattern.item.is_empty() { return Ok(PipelineData::new(Span::new(0, 0))); }
 
         let folder_depth = if let Some(depth) = depth {
             depth

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -3,8 +3,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Spanned,
-    SyntaxShape, Value, Span,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
+    Spanned, SyntaxShape, Value,
 };
 use wax::{Glob as WaxGlob, WalkBehavior};
 
@@ -99,7 +99,9 @@ impl Command for Glob {
         let glob_pattern: Spanned<String> = call.req(engine_state, stack, 0)?;
         let depth = call.get_flag(engine_state, stack, "depth")?;
 
-        if glob_pattern.item.is_empty() { return Ok(PipelineData::new(Span::new(0, 0))); }
+        if glob_pattern.item.is_empty() {
+            return Ok(PipelineData::new(Span::new(0, 0)));
+        }
 
         let folder_depth = if let Some(depth) = depth {
             depth

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -3,8 +3,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
-    Spanned, SyntaxShape, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Spanned,
+    SyntaxShape, Value,
 };
 use wax::{Glob as WaxGlob, WalkBehavior};
 
@@ -100,7 +100,13 @@ impl Command for Glob {
         let depth = call.get_flag(engine_state, stack, "depth")?;
 
         if glob_pattern.item.is_empty() {
-            return Ok(PipelineData::new(Span::new(0, 0)));
+            return Err(ShellError::GenericError(
+                "glob pattern must not be empty".to_string(),
+                "".to_string(),
+                Some(glob_pattern.span),
+                Some("add characters to the glob pattern".to_string()),
+                Vec::new(),
+            ));
         }
 
         let folder_depth = if let Some(depth) = depth {

--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -22,7 +22,7 @@ fn empty_glob_pattern_triggers_error() {
 
 #[test]
 fn nonempty_glob_lists_matching_paths() {
-    Playground::setup("glob_test_1", |dirs, sandbox| {
+    Playground::setup("glob_sanity_star", |dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("yehuda.txt"),
             EmptyFile("jonathan.txt"),

--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -1,0 +1,39 @@
+use nu_test_support::fs::Stub::EmptyFile;
+use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn empty_glob_pattern_triggers_error() {
+    Playground::setup("glob_test_1", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("yehuda.txt"),
+            EmptyFile("jonathan.txt"),
+            EmptyFile("andres.txt"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "glob ''",
+        );
+
+        assert!(actual.err.contains("must not be empty"));
+    })
+}
+
+#[test]
+fn nonempty_glob_lists_matching_paths() {
+    Playground::setup("glob_test_1", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("yehuda.txt"),
+            EmptyFile("jonathan.txt"),
+            EmptyFile("andres.txt"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            pipeline("glob '*' | length"),
+        );
+
+        assert_eq!(actual.out, "3");
+    })
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -24,6 +24,7 @@ mod flatten;
 mod format;
 mod g;
 mod get;
+mod glob;
 mod group_by;
 mod hash_;
 mod headers;


### PR DESCRIPTION
# Description

An empty argument to the "glob" command will now produce an empty result. Working towards nushell/nushell#6653, these changes only touch the `glob` command without changing globs used in cases like `rm ""`. Addressing `nu-glob` will be done in a follow-up PR.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
