### PR TITLE
avoid freeze when external command generates too much stdout output 

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -62,7 +62,7 @@ fn do_with_semicolon_break_on_failed_external() {
 
 #[test]
 #[cfg(not(windows))]
-fn ignore_error_not_hang_nushell() {
+fn ignore_error_with_too_much_stderr_not_hang_nushell() {
     use nu_test_support::fs::Stub::FileWithContent;
     use nu_test_support::pipeline;
     use nu_test_support::playground::Playground;
@@ -78,6 +78,31 @@ fn ignore_error_not_hang_nushell() {
             cwd: dirs.test(), pipeline(
             r#"
                 do -i {sh -c "cat a_large_file.txt 1>&2"} | complete | get stderr
+            "#
+        ));
+
+        assert_eq!(actual.out, large_file_body);
+    })
+}
+
+#[test]
+#[cfg(not(windows))]
+fn ignore_error_with_too_much_stdout_not_hang_nushell() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    use nu_test_support::pipeline;
+    use nu_test_support::playground::Playground;
+    Playground::setup("external with many stdout message", |dirs, sandbox| {
+        let bytes: usize = 81920;
+        let mut large_file_body = String::with_capacity(bytes);
+        for _ in 0..bytes {
+            large_file_body.push_str("a");
+        }
+        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                do -i {sh -c "cat a_large_file.txt"} | complete | get stdout
             "#
         ));
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -440,7 +440,7 @@ impl PipelineData {
         {
             // NOTE: currently we don't need anything from stderr
             // so directly consumes `stderr_stream` to make sure that everything is done.
-            let _ = stderr_stream.map(|x| x.into_bytes());
+            std::thread::spawn(move || stderr_stream.map(|x| x.into_bytes()));
             if let Some(stream) = stream {
                 for s in stream {
                     let s_live = s?;


### PR DESCRIPTION
# Description

Fix the problem mentioned here: https://github.com/nushell/nushell/issues/5625#issuecomment-1276269684
```shell
do -i { dmesg } | complete
``` 
makes nushell hangged.

## the cause of the problem
The problem happened because `dmesg` writes `> 65535 bytes` to stdout.   Then bad thing happened:
1. **Producer side in run_external**: it's trying to read stderr from child process first, then stdout.  But `dmesg` writes too much data to stdout pipe, so `dmesg` hangged, producer hangged(so, I think this issue exists for a long time).

`dmesg` hangged because of pipe capacity mentioned here: https://man7.org/linux/man-pages/man7/pipe.7.html
> Pipe capacity
       A pipe has a limited capacity.  If the pipe is full, then a [write(2)](https://man7.org/linux/man-pages/man2/write.2.html) will block or fail, depending on whether the O_NONBLOCK flag is set (see below).  Different implementations have different limits for the pipe capacity.  Applications should not rely on a particular capacity: an application should be designed so that a reading process consumes data as soon as it is available, so that a writing process does not remain blocked.

2 . **Consumer side in complete/table command**: Because producer don't have a chance to read stderr message, so it hangged either.

## Solution
My solution is composed with the following parts:
1. **Producer side in run_external** read stderr, stdout in different threads, if child process `dmesg` writes too much data to stdout pipe, the data in pipe still can be read.
2. **Consumer side in complete/table command**: read stderr, stdout in different threads.  

It uses two more threads than before to handle stderr message, which uses more resources, but I think that's ok.  Because it solves the problem, and it makes https://github.com/nushell/nushell/issues/6658 possible.  So we can have a change to redirect external commands' stdout and stderr to a file without using too much memory.

Another solution would be using something like [mio](https://github.com/tokio-rs/mio) to detect if `stdout/stderr` is `readable/writable`, but It's hard to me, and I don't think it's necessary to introduce one new dependency.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass
