### PR TITLE
Fix invalid variable name in `input` command docs

### DIFF
--- a/crates/nu-command/src/platform/input.rs
+++ b/crates/nu-command/src/platform/input.rs
@@ -149,7 +149,7 @@ impl Command for Input {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Get input from the user, and assign to a variable",
-            example: "let user-input = (input)",
+            example: "let user_input = (input)",
             result: None,
         }]
     }


### PR DESCRIPTION
# Description

This PR fixes invalid syntax in the example of the `input` command. Previously, it contained a variable name `user-input`, which is not valid in nu 0.69.1. Related to nushell/nushell.github.io#635.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

I didn't change any code but ran the test suite anyway and got the following test failure. Seems like this test is not locale aware? :)

```
failures:

---- conversions::into::string::test::test_examples stdout ----
input: 5 | into string -d 3
result: String { val: "5,000", span: Span { start: 4, end: 15 } }
done: 757.9µs
thread 'conversions::into::string::test::test_examples' panicked at 'the example result is different to expected value: String { val: "5,000", span: Span { start: 4, end: 15 } } != String { val: "5.000", span: Span { start: 0, end: 0 } }', crates\nu-command\src\example_test.rs:140:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    conversions::into::string::test::test_examples
```
