### PR TITLE
Add search terms for export commands

### DIFF
--- a/crates/nu-command/src/core_commands/export.rs
+++ b/crates/nu-command/src/core_commands/export.rs
@@ -59,4 +59,8 @@ impl Command for ExportCommand {
             }),
         }]
     }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["module"]
+    }
 }

--- a/crates/nu-command/src/core_commands/export_alias.rs
+++ b/crates/nu-command/src/core_commands/export_alias.rs
@@ -51,4 +51,8 @@ impl Command for ExportAlias {
             result: None,
         }]
     }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["aka", "abbr", "module"]
+    }
 }

--- a/crates/nu-command/src/core_commands/export_def.rs
+++ b/crates/nu-command/src/core_commands/export_def.rs
@@ -55,4 +55,8 @@ impl Command for ExportDef {
             }),
         }]
     }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["module"]
+    }
 }

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -81,4 +81,8 @@ export def-env cd_with_fallback [arg = ""] {
             }),
         }]
     }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["module"]
+    }
 }

--- a/crates/nu-command/src/core_commands/export_extern.rs
+++ b/crates/nu-command/src/core_commands/export_extern.rs
@@ -47,4 +47,8 @@ impl Command for ExportExtern {
             result: None,
         }]
     }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["signature", "module", "declare"]
+    }
 }

--- a/crates/nu-command/src/core_commands/export_use.rs
+++ b/crates/nu-command/src/core_commands/export_use.rs
@@ -53,4 +53,8 @@ impl Command for ExportUse {
             }),
         }]
     }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["reexport", "import", "module"]
+    }
 }


### PR DESCRIPTION


# Description

Adds search terms to export commands, contributes to https://github.com/nushell/nushell/issues/5093
This can be tested by opening the help menu, searching for "module". This should bring up the export commands. Other search terms are also added.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

Note that `tests::test_config_path::test_default_config_path` fails when running all the tests, but doesn't fail when run by itself. This is a known issue.
