### PR TITLE
add the ability to convert durations

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -142,18 +142,20 @@ fn into_duration(
     let head = call.head;
     let convert_to_unit: Option<Spanned<String>> = call.get_flag(engine_state, stack, "convert")?;
     let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+    let config = engine_state.get_config();
+    let float_precision = config.float_precision as usize;
 
     input.map(
         move |v| {
             if column_paths.is_empty() {
-                action(&v, &convert_to_unit, head)
+                action(&v, &convert_to_unit, float_precision, head)
             } else {
                 let mut ret = v;
                 for path in &column_paths {
                     let d = convert_to_unit.clone();
                     let r = ret.update_cell_path(
                         &path.members,
-                        Box::new(move |old| action(old, &d, head)),
+                        Box::new(move |old| action(old, &d, float_precision, head)),
                     );
                     if let Err(error) = r {
                         return Value::Error { error };
@@ -173,127 +175,129 @@ fn convert_str_from_unit_to_unit(
     to_unit: &str,
     span: Span,
     value_span: Span,
-) -> Result<i64, ShellError> {
+) -> Result<f64, ShellError> {
     match (from_unit, to_unit) {
-        ("ns", "ns") => Ok(val),
-        ("ns", "us") => Ok(val / 1000),
-        ("ns", "ms") => Ok(val / 1000 / 1000),
-        ("ns", "sec") => Ok(val / 1000 / 1000 / 1000),
-        ("ns", "min") => Ok(val / 1000 / 1000 / 1000 / 60),
-        ("ns", "hr") => Ok(val / 1000 / 1000 / 1000 / 60 / 60),
-        ("ns", "day") => Ok(val / 1000 / 1000 / 1000 / 60 / 60 / 24),
-        ("ns", "wk") => Ok(val / 1000 / 1000 / 1000 / 60 / 60 / 24 / 7),
-        ("ns", "month") => Ok(val / 1000 / 1000 / 1000 / 60 / 60 / 24 / 30),
-        ("ns", "yr") => Ok(val / 1000 / 1000 / 1000 / 60 / 60 / 24 / 365),
-        ("ns", "dec") => Ok(val / 10 / 1000 / 1000 / 1000 / 60 / 60 / 24 / 365),
+        ("ns", "ns") => Ok(val as f64),
+        ("ns", "us") => Ok(val as f64 / 1000.0),
+        ("ns", "ms") => Ok(val as f64 / 1000.0 / 1000.0),
+        ("ns", "sec") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0),
+        ("ns", "min") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0),
+        ("ns", "hr") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0),
+        ("ns", "day") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0),
+        ("ns", "wk") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
+        ("ns", "month") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
+        ("ns", "yr") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
+        ("ns", "dec") => {
+            Ok(val as f64 / 10.0 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0)
+        }
 
-        ("us", "ns") => Ok(val * 1000),
-        ("us", "us") => Ok(val),
-        ("us", "ms") => Ok(val / 1000),
-        ("us", "sec") => Ok(val / 1000 / 1000),
-        ("us", "min") => Ok(val / 1000 / 1000 / 60),
-        ("us", "hr") => Ok(val / 1000 / 1000 / 60 / 60),
-        ("us", "day") => Ok(val / 1000 / 1000 / 60 / 60 / 24),
-        ("us", "wk") => Ok(val / 1000 / 1000 / 60 / 60 / 24 / 7),
-        ("us", "month") => Ok(val / 1000 / 1000 / 60 / 60 / 24 / 30),
-        ("us", "yr") => Ok(val / 1000 / 1000 / 60 / 60 / 24 / 365),
-        ("us", "dec") => Ok(val / 10 / 1000 / 1000 / 60 / 60 / 24 / 365),
+        ("us", "ns") => Ok(val as f64 * 1000.0),
+        ("us", "us") => Ok(val as f64),
+        ("us", "ms") => Ok(val as f64 / 1000.0),
+        ("us", "sec") => Ok(val as f64 / 1000.0 / 1000.0),
+        ("us", "min") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0),
+        ("us", "hr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0),
+        ("us", "day") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0),
+        ("us", "wk") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
+        ("us", "month") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
+        ("us", "yr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
+        ("us", "dec") => Ok(val as f64 / 10.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
-        ("ms", "ns") => Ok(val * 1000 * 1000),
-        ("ms", "us") => Ok(val * 1000),
-        ("ms", "ms") => Ok(val),
-        ("ms", "sec") => Ok(val / 1000),
-        ("ms", "min") => Ok(val / 1000 / 60),
-        ("ms", "hr") => Ok(val / 1000 / 60 / 60),
-        ("ms", "day") => Ok(val / 1000 / 60 / 60 / 24),
-        ("ms", "wk") => Ok(val / 1000 / 60 / 60 / 24 / 7),
-        ("ms", "month") => Ok(val / 1000 / 60 / 60 / 24 / 30),
-        ("ms", "yr") => Ok(val / 1000 / 60 / 60 / 24 / 365),
-        ("ms", "dec") => Ok(val / 10 / 1000 / 60 / 60 / 24 / 365),
+        ("ms", "ns") => Ok(val as f64 * 1000.0 * 1000.0),
+        ("ms", "us") => Ok(val as f64 * 1000.0),
+        ("ms", "ms") => Ok(val as f64),
+        ("ms", "sec") => Ok(val as f64 / 1000.0),
+        ("ms", "min") => Ok(val as f64 / 1000.0 / 60.0),
+        ("ms", "hr") => Ok(val as f64 / 1000.0 / 60.0 / 60.0),
+        ("ms", "day") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0),
+        ("ms", "wk") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
+        ("ms", "month") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
+        ("ms", "yr") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
+        ("ms", "dec") => Ok(val as f64 / 10.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
-        ("sec", "ns") => Ok(val * 1000 * 1000 * 1000),
-        ("sec", "us") => Ok(val * 1000 * 1000),
-        ("sec", "ms") => Ok(val * 1000),
-        ("sec", "sec") => Ok(val),
-        ("sec", "min") => Ok(val / 60),
-        ("sec", "hr") => Ok(val / 60 / 60),
-        ("sec", "day") => Ok(val / 60 / 60 / 24),
-        ("sec", "wk") => Ok(val / 60 / 60 / 24 / 7),
-        ("sec", "month") => Ok(val / 60 / 60 / 24 / 30),
-        ("sec", "yr") => Ok(val / 60 / 60 / 24 / 365),
-        ("sec", "dec") => Ok(val / 10 / 60 / 60 / 24 / 365),
+        ("sec", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0),
+        ("sec", "us") => Ok(val as f64 * 1000.0 * 1000.0),
+        ("sec", "ms") => Ok(val as f64 * 1000.0),
+        ("sec", "sec") => Ok(val as f64),
+        ("sec", "min") => Ok(val as f64 / 60.0),
+        ("sec", "hr") => Ok(val as f64 / 60.0 / 60.0),
+        ("sec", "day") => Ok(val as f64 / 60.0 / 60.0 / 24.0),
+        ("sec", "wk") => Ok(val as f64 / 60.0 / 60.0 / 24.0 / 7.0),
+        ("sec", "month") => Ok(val as f64 / 60.0 / 60.0 / 24.0 / 30.0),
+        ("sec", "yr") => Ok(val as f64 / 60.0 / 60.0 / 24.0 / 365.0),
+        ("sec", "dec") => Ok(val as f64 / 10.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
-        ("min", "ns") => Ok(val * 1000 * 1000 * 1000 * 60),
-        ("min", "us") => Ok(val * 1000 * 1000 * 60),
-        ("min", "ms") => Ok(val * 1000 * 60),
-        ("min", "sec") => Ok(val * 60),
-        ("min", "min") => Ok(val),
-        ("min", "hr") => Ok(val / 60),
-        ("min", "day") => Ok(val / 60 / 24),
-        ("min", "wk") => Ok(val / 60 / 24 / 7),
-        ("min", "month") => Ok(val / 60 / 24 / 30),
-        ("min", "yr") => Ok(val / 60 / 24 / 365),
-        ("min", "dec") => Ok(val / 10 / 60 / 24 / 365),
+        ("min", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0),
+        ("min", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0),
+        ("min", "ms") => Ok(val as f64 * 1000.0 * 60.0),
+        ("min", "sec") => Ok(val as f64 * 60.0),
+        ("min", "min") => Ok(val as f64),
+        ("min", "hr") => Ok(val as f64 / 60.0),
+        ("min", "day") => Ok(val as f64 / 60.0 / 24.0),
+        ("min", "wk") => Ok(val as f64 / 60.0 / 24.0 / 7.0),
+        ("min", "month") => Ok(val as f64 / 60.0 / 24.0 / 30.0),
+        ("min", "yr") => Ok(val as f64 / 60.0 / 24.0 / 365.0),
+        ("min", "dec") => Ok(val as f64 / 10.0 / 60.0 / 24.0 / 365.0),
 
-        ("hr", "ns") => Ok(val * 1000 * 1000 * 1000 * 60 * 60),
-        ("hr", "us") => Ok(val * 1000 * 1000 * 60 * 60),
-        ("hr", "ms") => Ok(val * 1000 * 60 * 60),
-        ("hr", "sec") => Ok(val * 60 * 60),
-        ("hr", "min") => Ok(val * 60),
-        ("hr", "hr") => Ok(val),
-        ("hr", "day") => Ok(val / 24),
-        ("hr", "wk") => Ok(val / 24 / 7),
-        ("hr", "month") => Ok(val / 24 / 30),
-        ("hr", "yr") => Ok(val / 24 / 365),
-        ("hr", "dec") => Ok(val / 10 / 24 / 365),
+        ("hr", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0),
+        ("hr", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0),
+        ("hr", "ms") => Ok(val as f64 * 1000.0 * 60.0 * 60.0),
+        ("hr", "sec") => Ok(val as f64 * 60.0 * 60.0),
+        ("hr", "min") => Ok(val as f64 * 60.0),
+        ("hr", "hr") => Ok(val as f64),
+        ("hr", "day") => Ok(val as f64 / 24.0),
+        ("hr", "wk") => Ok(val as f64 / 24.0 / 7.0),
+        ("hr", "month") => Ok(val as f64 / 24.0 / 30.0),
+        ("hr", "yr") => Ok(val as f64 / 24.0 / 365.0),
+        ("hr", "dec") => Ok(val as f64 / 10.0 / 24.0 / 365.0),
 
-        ("day", "ns") => Ok(val * 1000 * 1000 * 1000 * 60 * 60 * 24),
-        ("day", "us") => Ok(val * 1000 * 1000 * 60 * 60 * 24),
-        ("day", "ms") => Ok(val * 1000 * 60 * 60 * 24),
-        ("day", "sec") => Ok(val * 60 * 60 * 24),
-        ("day", "min") => Ok(val * 60 * 24),
-        ("day", "hr") => Ok(val * 24),
-        ("day", "day") => Ok(val),
-        ("day", "wk") => Ok(val / 7),
-        ("day", "month") => Ok(val / 30),
-        ("day", "yr") => Ok(val / 365),
-        ("day", "dec") => Ok(val / 10 / 365),
+        ("day", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0),
+        ("day", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0),
+        ("day", "ms") => Ok(val as f64 * 1000.0 * 60.0 * 60.0 * 24.0),
+        ("day", "sec") => Ok(val as f64 * 60.0 * 60.0 * 24.0),
+        ("day", "min") => Ok(val as f64 * 60.0 * 24.0),
+        ("day", "hr") => Ok(val as f64 * 24.0),
+        ("day", "day") => Ok(val as f64),
+        ("day", "wk") => Ok(val as f64 / 7.0),
+        ("day", "month") => Ok(val as f64 / 30.0),
+        ("day", "yr") => Ok(val as f64 / 365.0),
+        ("day", "dec") => Ok(val as f64 / 10.0 / 365.0),
 
-        ("wk", "ns") => Ok(val * 1000 * 1000 * 1000 * 60 * 60 * 24 * 7),
-        ("wk", "us") => Ok(val * 1000 * 1000 * 60 * 60 * 24 * 7),
-        ("wk", "ms") => Ok(val * 1000 * 60 * 60 * 24 * 7),
-        ("wk", "sec") => Ok(val * 60 * 60 * 24 * 7),
-        ("wk", "min") => Ok(val * 60 * 24 * 7),
-        ("wk", "hr") => Ok(val * 24 * 7),
-        ("wk", "day") => Ok(val * 7),
-        ("wk", "wk") => Ok(val),
-        ("wk", "month") => Ok(val / 4),
-        ("wk", "yr") => Ok(val / 52),
-        ("wk", "dec") => Ok(val / 10 / 52),
+        ("wk", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 7.0),
+        ("wk", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 7.0),
+        ("wk", "ms") => Ok(val as f64 * 1000.0 * 60.0 * 60.0 * 24.0 * 7.0),
+        ("wk", "sec") => Ok(val as f64 * 60.0 * 60.0 * 24.0 * 7.0),
+        ("wk", "min") => Ok(val as f64 * 60.0 * 24.0 * 7.0),
+        ("wk", "hr") => Ok(val as f64 * 24.0 * 7.0),
+        ("wk", "day") => Ok(val as f64 * 7.0),
+        ("wk", "wk") => Ok(val as f64),
+        ("wk", "month") => Ok(val as f64 / 4.0),
+        ("wk", "yr") => Ok(val as f64 / 52.0),
+        ("wk", "dec") => Ok(val as f64 / 10.0 / 52.0),
 
-        ("month", "ns") => Ok(val * 1000 * 1000 * 1000 * 60 * 60 * 24 * 30),
-        ("month", "us") => Ok(val * 1000 * 1000 * 60 * 60 * 24 * 30),
-        ("month", "ms") => Ok(val * 1000 * 60 * 60 * 24 * 30),
-        ("month", "sec") => Ok(val * 60 * 60 * 24 * 30),
-        ("month", "min") => Ok(val * 60 * 24 * 30),
-        ("month", "hr") => Ok(val * 24 * 30),
-        ("month", "day") => Ok(val * 30),
-        ("month", "wk") => Ok(val * 4),
-        ("month", "month") => Ok(val),
-        ("month", "yr") => Ok(val / 12),
-        ("month", "dec") => Ok(val / 10 / 12),
+        ("month", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0),
+        ("month", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0),
+        ("month", "ms") => Ok(val as f64 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0),
+        ("month", "sec") => Ok(val as f64 * 60.0 * 60.0 * 24.0 * 30.0),
+        ("month", "min") => Ok(val as f64 * 60.0 * 24.0 * 30.0),
+        ("month", "hr") => Ok(val as f64 * 24.0 * 30.0),
+        ("month", "day") => Ok(val as f64 * 30.0),
+        ("month", "wk") => Ok(val as f64 * 4.0),
+        ("month", "month") => Ok(val as f64),
+        ("month", "yr") => Ok(val as f64 / 12.0),
+        ("month", "dec") => Ok(val as f64 / 10.0 / 12.0),
 
-        ("yr", "ns") => Ok(val * 1000 * 1000 * 1000 * 60 * 60 * 24 * 365),
-        ("yr", "us") => Ok(val * 1000 * 1000 * 60 * 60 * 24 * 365),
-        ("yr", "ms") => Ok(val * 1000 * 60 * 60 * 24 * 365),
-        ("yr", "sec") => Ok(val * 60 * 60 * 24 * 365),
-        ("yr", "min") => Ok(val * 60 * 24 * 365),
-        ("yr", "hr") => Ok(val * 24 * 365),
-        ("yr", "day") => Ok(val * 365),
-        ("yr", "wk") => Ok(val * 52),
-        ("yr", "month") => Ok(val * 12),
-        ("yr", "yr") => Ok(val),
-        ("yr", "dec") => Ok(val / 10),
+        ("yr", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0),
+        ("yr", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0),
+        ("yr", "ms") => Ok(val as f64 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0),
+        ("yr", "sec") => Ok(val as f64 * 60.0 * 60.0 * 24.0 * 365.0),
+        ("yr", "min") => Ok(val as f64 * 60.0 * 24.0 * 365.0),
+        ("yr", "hr") => Ok(val as f64 * 24.0 * 365.0),
+        ("yr", "day") => Ok(val as f64 * 365.0),
+        ("yr", "wk") => Ok(val as f64 * 52.0),
+        ("yr", "month") => Ok(val as f64 * 12.0),
+        ("yr", "yr") => Ok(val as f64),
+        ("yr", "dec") => Ok(val as f64 / 10.0),
 
         _ => Err(ShellError::CantConvertWithValue(
             "string duration".to_string(),
@@ -376,7 +380,12 @@ fn string_to_unit_duration(
     ))
 }
 
-fn action(input: &Value, convert_to_unit: &Option<Spanned<String>>, span: Span) -> Value {
+fn action(
+    input: &Value,
+    convert_to_unit: &Option<Spanned<String>>,
+    float_precision: usize,
+    span: Span,
+) -> Value {
     match input {
         Value::Duration {
             val: val_num,
@@ -392,10 +401,19 @@ fn action(input: &Value, convert_to_unit: &Option<Spanned<String>>, span: Span) 
                     span,
                     *value_span,
                 ) {
-                    Ok(d) => Value::String {
-                        val: format!("{} {}", d, &to_unit.item),
-                        span: *value_span,
-                    },
+                    Ok(d) => {
+                        if d.fract() == 0.0 {
+                            Value::String {
+                                val: format!("{} {}", d, &to_unit.item),
+                                span: *value_span,
+                            }
+                        } else {
+                            Value::String {
+                                val: format!("{:.float_precision$} {}", d, &to_unit.item),
+                                span: *value_span,
+                            }
+                        }
+                    }
                     Err(e) => Value::Error { error: e },
                 }
             } else {
@@ -417,10 +435,19 @@ fn action(input: &Value, convert_to_unit: &Option<Spanned<String>>, span: Span) 
                         span,
                         *value_span,
                     ) {
-                        Ok(d) => Value::String {
-                            val: format!("{} {}", d, &to_unit.item),
-                            span: *value_span,
-                        },
+                        Ok(d) => {
+                            if d.fract() == 0.0 {
+                                Value::String {
+                                    val: format!("{} {}", d, &to_unit.item),
+                                    span: *value_span,
+                                }
+                            } else {
+                                Value::String {
+                                    val: format!("{:.float_precision$} {}", d, &to_unit.item),
+                                    span: *value_span,
+                                }
+                            }
+                        }
                         Err(e) => Value::Error { error: e },
                     }
                 } else {
@@ -465,7 +492,7 @@ mod test {
         let expected = Value::Duration { val: 3, span };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 
@@ -479,7 +506,7 @@ mod test {
         };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 
@@ -493,7 +520,7 @@ mod test {
         };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 
@@ -507,7 +534,7 @@ mod test {
         };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 
@@ -521,7 +548,7 @@ mod test {
         };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 
@@ -535,7 +562,7 @@ mod test {
         };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 
@@ -549,7 +576,7 @@ mod test {
         };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 
@@ -563,7 +590,7 @@ mod test {
         };
         let convert_duration = None;
 
-        let actual = action(&word, &convert_duration, span);
+        let actual = action(&word, &convert_duration, 2, span);
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
# Description

This PR allows you to convert a duration into another duration and output a string. If we convert one duration to another duration you won't be able to tell what it's doing since durations always get formatted a certain way. So, this is why I chose to output it as a string.
![image](https://user-images.githubusercontent.com/343840/195884572-87796785-5198-45f8-91a1-0da5246c815b.png)

But wait, that's not all. It also converts to float and it uses the `float_precision` config point to determine how many decimal places to use.
![image](https://user-images.githubusercontent.com/343840/195898526-d62d8813-4e27-4793-9c6c-e564dbc65f21.png)

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
