### PR TITLE
Add search terms to arg dataframe commands

### DIFF
--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -19,6 +19,10 @@ impl Command for ArgMax {
         "Return index for max value in series"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["argmax", "max", "maximum", "most", "largest", "greatest"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_type(Type::Custom("dataframe".into()))

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -20,7 +20,7 @@ impl Command for ArgMax {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["argmax", "max", "maximum", "most", "largest", "greatest"]
+        vec!["argmax", "maximum", "most", "largest", "greatest"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -20,7 +20,7 @@ impl Command for ArgMin {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["argmin", "min", "minimum", "least", "smallest", "lowest"]
+        vec!["argmin", "minimum", "least", "smallest", "lowest"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -19,6 +19,10 @@ impl Command for ArgMin {
         "Return index for min value in series"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["argmin", "min", "minimum", "least", "smallest", "lowest"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_type(Type::Custom("dataframe".into()))

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -20,7 +20,7 @@ impl Command for ArgSort {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["argsort", "order", "sort", "arrange"]
+        vec!["argsort", "order", "arrange"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -19,6 +19,10 @@ impl Command for ArgSort {
         "Returns indexes for a sorted series"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["argsort", "order", "sort", "arrange"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .switch("reverse", "reverse order", Some('r'))

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -20,7 +20,7 @@ impl Command for ArgTrue {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["argtrue", "true", "truth", "boolean-true"]
+        vec!["argtrue", "truth", "boolean-true"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -19,6 +19,10 @@ impl Command for ArgTrue {
         "Returns indexes where values are true"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["argtrue", "true", "truth", "boolean-true"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_type(Type::Custom("dataframe".into()))

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -20,13 +20,7 @@ impl Command for ArgUnique {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec![
-            "argunique",
-            "unique",
-            "distinct",
-            "noduplicate",
-            "unrepeated",
-        ]
+        vec!["argunique", "distinct", "noduplicate", "unrepeated"]
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -19,6 +19,16 @@ impl Command for ArgUnique {
         "Returns indexes for unique values"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec![
+            "argunique",
+            "unique",
+            "distinct",
+            "noduplicate",
+            "unrepeated",
+        ]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_type(Type::Custom("dataframe".into()))


### PR DESCRIPTION
# Description

Added a couple of search terms for the following commands https://github.com/nushell/nushell/issues/5093

Command | Search terms added
-- | --
arg-sort | argsort, order, arrange
arg-true | argtrue, truth, boolean-true
arg-unique | argunique, distinct, noduplicate, unrepeated
arg-max | argmax, maximum, most, largest, greatest
arg-min | argmin, minimum, least, smallest, lowest


# Tests


Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass 


















