### PR TITLE
Fix quadratic time complexity with large strides

### DIFF
--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -215,9 +215,7 @@ impl Iterator for EachWindowIterator {
                 }
             }
 
-            for _ in 0..current_count {
-                let _ = group.remove(0);
-            }
+            group = group[current_count..].to_vec();
         }
 
         if group.is_empty() || current_count == 0 {


### PR DESCRIPTION
# Description
`window` becomes unbearably slow when input size, and especially stride, becomes large.

Compare `benchmark { for i in 0..100000 { echo [a, b] } | window 10000 -s 10000 }` in nushell v0.69 (nice) and this PR. Then increase the numbers by one order of magnitude.

Fixes #6725 

# Tests
Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Other comments
No tests because I have no idea how to test performance regressions.