### PR TITLE
Remove unnecessary clone in window

### DIFF
--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -155,7 +155,7 @@ impl Command for Window {
             group_size: group_size.item,
             input: Box::new(input.into_iter()),
             span: call.head,
-            previous: vec![],
+            previous: None,
             stride,
         };
 
@@ -169,7 +169,7 @@ struct EachWindowIterator {
     group_size: usize,
     input: Box<dyn Iterator<Item = Value> + Send>,
     span: Span,
-    previous: Vec<Value>,
+    previous: Option<Vec<Value>>,
     stride: usize,
 }
 
@@ -177,7 +177,7 @@ impl Iterator for EachWindowIterator {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut group = self.previous.clone();
+        let mut group = self.previous.take().unwrap_or_default();
         let mut current_count = 0;
 
         if group.is_empty() {
@@ -222,10 +222,11 @@ impl Iterator for EachWindowIterator {
             return None;
         }
 
-        self.previous = group.clone();
+        let return_group = group.clone();
+        self.previous = Some(group);
 
         Some(Value::List {
-            vals: group,
+            vals: return_group,
             span: self.span,
         })
     }


### PR DESCRIPTION
# Description
Window used to clone twice to preserve Self's memory integrity and again to return a `Value::List` at the end. I don't know how to get rid of the clone for the return value. I believe it might require taking ownership of the input stream or doing some unsafe things. But I did replace `this.previous` with an option, so we can now simply take its value and give it back at the end after creating the return clone. `mem::replace` could also be used, but I think using an option is clearer.

It's not a "savings approach infinity as stride grows" performance PR, but it is a nice 10-15% faster.

# Tests

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
