### PR TITLE
Improve erroring of `config nu` and `config env`

### DIFF
--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -37,7 +37,7 @@ impl Command for ConfigEnv {
         &self,
         engine_state: &EngineState,
         stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let env_vars_str = env_to_strings(engine_state, stack)?;
@@ -59,7 +59,7 @@ impl Command for ConfigEnv {
 
         let name = Spanned {
             item: get_editor(engine_state, stack)?,
-            span: Span { start: 0, end: 0 },
+            span: call.head,
         };
 
         let args = vec![Spanned {
@@ -76,6 +76,6 @@ impl Command for ConfigEnv {
             env_vars: env_vars_str,
         };
 
-        command.run_with_input(engine_state, stack, input)
+        command.run_with_input(engine_state, stack, input, true)
     }
 }

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -37,7 +37,7 @@ impl Command for ConfigNu {
         &self,
         engine_state: &EngineState,
         stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let env_vars_str = env_to_strings(engine_state, stack)?;
@@ -59,7 +59,7 @@ impl Command for ConfigNu {
 
         let name = Spanned {
             item: get_editor(engine_state, stack)?,
-            span: Span { start: 0, end: 0 },
+            span: call.head,
         };
 
         let args = vec![Spanned {
@@ -76,6 +76,6 @@ impl Command for ConfigNu {
             env_vars: env_vars_str,
         };
 
-        command.run_with_input(engine_state, stack, input)
+        command.run_with_input(engine_state, stack, input, true)
     }
 }

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -284,12 +284,12 @@ fn source_env_is_scoped() {
 
         let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
 
-        assert!(actual.err.contains("can't run executable"));
+        assert!(actual.err.contains("executable was not found"));
 
         let inp = &[r#"source-env spam.nu"#, r#"nor-similar-to-this"#];
 
         let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
 
-        assert!(actual.err.contains("can't run executable"));
+        assert!(actual.err.contains("executable was not found"));
     })
 }


### PR DESCRIPTION
# Description

Related: #6646. Edited for clarity.

Error after change:
```
~/CodingProjects/nushell〉config nu           
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #1:1:1]
 1 │ config nu
   · ────┬────
   ·     ╰── executable 'notepad' was not found
   ╰────
  help: No such file or directory (os error 2)

~/CodingProjects/nushell〉config env       
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #2:1:1]
 1 │ config env
   · ─────┬────
   ·      ╰── executable 'notepad' was not found
   ╰────
  help: No such file or directory (os error 2)
```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
