### PR TITLE
window --remainder

### DIFF
--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -23,6 +23,11 @@ impl Command for Window {
                 "the number of rows to slide over between windows",
                 Some('s'),
             )
+            .switch(
+                "remainder",
+                "yield last chunks even if they have fewer elements than size",
+                Some('r'),
+            )
             .category(Category::Filters)
     }
 
@@ -115,6 +120,39 @@ impl Command for Window {
             },
         ];
 
+        let stream_test_3 = vec![
+            Value::List {
+                vals: vec![
+                    Value::Int {
+                        val: 1,
+                        span: Span::test_data(),
+                    },
+                    Value::Int {
+                        val: 2,
+                        span: Span::test_data(),
+                    },
+                    Value::Int {
+                        val: 3,
+                        span: Span::test_data(),
+                    },
+                ],
+                span: Span::test_data(),
+            },
+            Value::List {
+                vals: vec![
+                    Value::Int {
+                        val: 4,
+                        span: Span::test_data(),
+                    },
+                    Value::Int {
+                        val: 5,
+                        span: Span::test_data(),
+                    },
+                ],
+                span: Span::test_data(),
+            },
+        ];
+
         vec![
             Example {
                 example: "echo [1 2 3 4] | window 2",
@@ -132,6 +170,14 @@ impl Command for Window {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                example: "[1, 2, 3, 4, 5] | window 3 --stride 3 --remainder",
+                description: "A sliding window of equal stride that includes remainder. Equivalent to chunking",
+                result: Some(Value::List {
+                    vals: stream_test_3,
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 
@@ -146,6 +192,7 @@ impl Command for Window {
         let ctrlc = engine_state.ctrlc.clone();
         let metadata = input.metadata();
         let stride: Option<usize> = call.get_flag(engine_state, stack, "stride")?;
+        let remainder = call.has_flag("remainder");
 
         let stride = stride.unwrap_or(1);
 
@@ -157,6 +204,7 @@ impl Command for Window {
             span: call.head,
             previous: None,
             stride,
+            remainder,
         };
 
         Ok(each_group_iterator
@@ -171,13 +219,18 @@ struct EachWindowIterator {
     span: Span,
     previous: Option<Vec<Value>>,
     stride: usize,
+    remainder: bool,
 }
 
 impl Iterator for EachWindowIterator {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut group = self.previous.take().unwrap_or_default();
+        // We default to a Vec of capacity size + stride as striding pushes n extra elements to the end
+        let mut group = self
+            .previous
+            .take()
+            .unwrap_or_else(|| Vec::with_capacity(self.group_size + self.stride));
         let mut current_count = 0;
 
         if group.is_empty() {
@@ -193,7 +246,13 @@ impl Iterator for EachWindowIterator {
                             break;
                         }
                     }
-                    None => return None,
+                    None => {
+                        if self.remainder {
+                            break;
+                        } else {
+                            return None;
+                        }
+                    }
                 }
             }
         } else {
@@ -211,14 +270,23 @@ impl Iterator for EachWindowIterator {
                             break;
                         }
                     }
-                    None => return None,
+                    None => {
+                        if self.remainder {
+                            break;
+                        } else {
+                            return None;
+                        }
+                    }
                 }
             }
 
-            group = group[current_count..].to_vec();
+            // We now have elements + stride in our group, and need to
+            // drop the skipped elements. Drain to preserve allocation and capacity
+            // Dropping this iterator consumes it.
+            group.drain(..self.stride.min(group.len()));
         }
 
-        if group.is_empty() || current_count == 0 {
+        if group.is_empty() {
             return None;
         }
 

--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -226,11 +226,14 @@ impl Iterator for EachWindowIterator {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // We default to a Vec of capacity size + stride as striding pushes n extra elements to the end
-        let mut group = self
-            .previous
-            .take()
-            .unwrap_or_else(|| Vec::with_capacity(self.group_size + self.stride));
+        let mut group = self.previous.take().unwrap_or_else(|| {
+            let mut vec = Vec::new();
+
+            // We default to a Vec of capacity size + stride as striding pushes n extra elements to the end
+            vec.try_reserve(self.group_size + self.stride).ok();
+
+            vec
+        });
         let mut current_count = 0;
 
         if group.is_empty() {


### PR DESCRIPTION
# Description
In this PR I Implemented a --remainder (-r) flag for `window`. This flag makes it so it doesn't early-return when the internal iterator stops yielding elements; instead, it breaks the loop, and yields the remaining items in the group if it is not empty (after performing the stride).

I added an example to the command to show how to implement the common "chunking" operation with it, but here's how --remainder works in practice:
```py
# Chunking by 3
> [1, 2, 3, 4, 5] | window 3 -s 3 -r
[1, 2, 3]
[4, 5]

# Sliding window of 3 with remainder
> [1, 2, 3, 4, 5] | window 3 -r
[ 1, 2, 3 ]
[ 2, 3, 4 ]
[ 3, 4, 5 ]
[ 4, 5 ]
[ 5 ]

# Larger chunk
> [1, 2] | window 10 -s 10 -r
[1, 2]

# Larger window
> [1, 2] | window 10 -r
[1, 2]
[2]
```

I believe this is the only way a remainder flag would make sense and be consistent, but tell me if you have any concerns about the results above.

I also saved a few allocations by not cloning the Vec (via `.to_vec()`), as cloning tightens the Vec's capacity to its length, so the next push will need a resize. I did this by allocating capacity + stride at the beginning, and draining the vector of `stride` elements instead of slicing. This brings another 10-20% speed improvements 😜 (and this might be pathologic, but I've seen 2x faster for our csv test when not using --raw)

Some open questions:
- Should `window` print remainders by default? I personally think it should, but this is not the default behavior of the actual windows method in Itertools. So I'm a little torn on whether it should be `--remainder` or `--exact`. I stuck to `-r` in this PR to not bring any breaking changes
- Should the remainder flag be called like that? I could also see `incomplete`, `rest`, `partial`, or other names working. I didn't overthink it, but I'll change it if someone has a better name
- **Allocating the vector with capacity can fail.** This is trivially reproducible: `[] | window 1000000000`. I solved this by calling `try_reserve()` instead, but there may be open considerations about large allocations.
- ~~I personally dislike the way cargo fmt formatted the `self.previous.take()`, but what can ya do~~ It made it nice after I changed it to fallible allocations 😃 

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Fun
By the way, if you have a little free time and a lot of RAM, try reverting the .drain() line back to .to_vec(), and try to separate a large file with remainder. ;)