### PR TITLE
add more helpful error for calling a decl that exists in a module

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -273,9 +273,9 @@ impl ExternalCommand {
                                     let sugg = engine_state.which_module_has_decl(s.as_bytes());
                                     if let Some(sugg) = sugg {
                                         let sugg = String::from_utf8_lossy(sugg);
-                                        format!("did you mean '{sugg} {s}'?")
+                                        format!("command '{s}' was not found but it exists in module '{sugg}'")
                                     } else {
-                                        format!("did you mean '<module> {s}'?")
+                                        format!("did you mean '{s}'?")
                                     }
                                 } else {
                                     format!("did you mean '{s}'?")

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -273,7 +273,7 @@ impl ExternalCommand {
                                     let sugg = engine_state.which_module_has_decl(s.as_bytes());
                                     if let Some(sugg) = sugg {
                                         let sugg = String::from_utf8_lossy(sugg);
-                                        format!("command '{s}' was not found but it exists in module '{sugg}'")
+                                        format!("command '{s}' was not found but it exists in module '{sugg}'; try using `{sugg} {s}`")
                                     } else {
                                         format!("did you mean '{s}'?")
                                     }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -269,6 +269,14 @@ impl ExternalCommand {
                                         "'{}' was not found, did you mean '{s}'?",
                                         self.name.item
                                     )
+                                } else if self.name.item == s {
+                                    let sugg = engine_state.which_module_has_decl(s.as_bytes());
+                                    if let Some(sugg) = sugg {
+                                        let sugg = String::from_utf8_lossy(sugg);
+                                        format!("did you mean '{sugg} {s}'?")
+                                    } else {
+                                        format!("did you mean '<module> {s}'?")
+                                    }
                                 } else {
                                     format!("did you mean '{s}'?")
                                 }

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -183,3 +183,15 @@ fn use_export_env_combined() {
         assert_eq!(actual.out, "foo");
     })
 }
+
+#[test]
+fn use_module_creates_accurate_did_you_mean() {
+    let actual = nu!(
+    cwd: ".", pipeline(
+        r#"
+                module spam { export def foo [] { "foo" } }; use spam; foo
+            "#
+        )
+    );
+    assert!(actual.err.contains("did you mean 'spam foo'?"));
+}

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -193,5 +193,7 @@ fn use_module_creates_accurate_did_you_mean() {
             "#
         )
     );
-    assert!(actual.err.contains("did you mean 'spam foo'?"));
+    assert!(actual
+        .err
+        .contains("command 'foo' was not found but it exists in module 'spam'"));
 }

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -193,7 +193,7 @@ fn use_module_creates_accurate_did_you_mean() {
             "#
         )
     );
-    assert!(actual
-        .err
-        .contains("command 'foo' was not found but it exists in module 'spam'"));
+    assert!(actual.err.contains(
+        "command 'foo' was not found but it exists in module 'spam'; try using `spam foo`"
+    ));
 }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -546,6 +546,26 @@ impl EngineState {
         None
     }
 
+    pub fn which_module_has_decl(&self, name: &[u8]) -> Option<&[u8]> {
+        for (module_id, m) in self.modules.iter().enumerate() {
+            if m.has_decl(name) {
+                for overlay_frame in self.active_overlays(&[]).iter() {
+                    let module_name = overlay_frame.modules.iter().find_map(|(key, &val)| {
+                        if val == module_id {
+                            Some(key)
+                        } else {
+                            None
+                        }
+                    });
+                    if let Some(final_name) = module_name {
+                        return Some(&final_name[..]);
+                    }
+                }
+            }
+        }
+        None
+    }
+
     pub fn find_overlay(&self, name: &[u8]) -> Option<OverlayId> {
         self.scope.find_overlay(name)
     }


### PR DESCRIPTION
# Description

Fixes #6750.
New error:
```
~/CodingProjects/nushell〉module spam { export def foo [] { "foo" } }; use spam; foo
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #1:1:1]
 1 │ module spam { export def foo [] { "foo" } }; use spam; foo
   ·                                                        ─┬─
   ·                                                         ╰── command 'foo' was not found but it exists in module 'spam'
   ╰────
  help: No such file or directory (os error 2)
```

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass
