### PR TITLE
Add search terms to roll commands

### DIFF
--- a/crates/nu-command/src/filters/roll/roll_.rs
+++ b/crates/nu-command/src/filters/roll/roll_.rs
@@ -11,6 +11,10 @@ impl Command for Roll {
         "roll"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["rotate", "shift", "move"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name()).category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/roll/roll_down.rs
+++ b/crates/nu-command/src/filters/roll/roll_down.rs
@@ -16,6 +16,10 @@ impl Command for RollDown {
         "roll down"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["rotate", "shift", "move", "row"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .named("by", SyntaxShape::Int, "Number of rows to roll", Some('b'))

--- a/crates/nu-command/src/filters/roll/roll_left.rs
+++ b/crates/nu-command/src/filters/roll/roll_left.rs
@@ -16,6 +16,10 @@ impl Command for RollLeft {
         "roll left"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["rotate", "shift", "move", "column"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .named(

--- a/crates/nu-command/src/filters/roll/roll_right.rs
+++ b/crates/nu-command/src/filters/roll/roll_right.rs
@@ -16,6 +16,10 @@ impl Command for RollRight {
         "roll right"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["rotate", "shift", "move", "column"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .named(

--- a/crates/nu-command/src/filters/roll/roll_up.rs
+++ b/crates/nu-command/src/filters/roll/roll_up.rs
@@ -16,6 +16,10 @@ impl Command for RollUp {
         "roll up"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["rotate", "shift", "move", "row"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .named("by", SyntaxShape::Int, "Number of rows to roll", Some('b'))


### PR DESCRIPTION
# Description
Added a couple of search terms for the following commands:
| Command | Search terms |
| :---:   | :---: |
| roll | rotate, shift, move |
| roll left | rotate, shift, move, column |
| roll right | rotate, shift, move, column |
| roll up | rotate, shift, move, row |
| roll down | rotate, shift, move, row |

Contributes to #5093.
# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
