### PR TITLE
Rename `query dfr` -> `query df`

### DIFF
--- a/crates/nu-command/src/dataframe/eager/mod.rs
+++ b/crates/nu-command/src/dataframe/eager/mod.rs
@@ -13,7 +13,7 @@ mod last;
 mod list;
 mod melt;
 mod open;
-mod query_dfr;
+mod query_df;
 mod rename;
 mod sample;
 mod shape;
@@ -45,7 +45,7 @@ pub use last::LastDF;
 pub use list::ListDF;
 pub use melt::MeltDF;
 pub use open::OpenDataFrame;
-pub use query_dfr::QueryDfr;
+pub use query_df::QueryDf;
 pub use rename::RenameDF;
 pub use sample::SampleDF;
 pub use shape::ShapeDF;
@@ -87,7 +87,7 @@ pub fn add_eager_decls(working_set: &mut StateWorkingSet) {
         ListDF,
         MeltDF,
         OpenDataFrame,
-        QueryDfr,
+        QueryDf,
         RenameDF,
         SampleDF,
         ShapeDF,

--- a/crates/nu-command/src/dataframe/eager/query_df.rs
+++ b/crates/nu-command/src/dataframe/eager/query_df.rs
@@ -14,11 +14,11 @@ use nu_protocol::{
 // https://github.com/pola-rs/polars/tree/master/polars-sql
 
 #[derive(Clone)]
-pub struct QueryDfr;
+pub struct QueryDf;
 
-impl Command for QueryDfr {
+impl Command for QueryDf {
     fn name(&self) -> &str {
-        "query dfr"
+        "query df"
     }
 
     fn usage(&self) -> &str {
@@ -40,7 +40,7 @@ impl Command for QueryDfr {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Query dataframe using SQL",
-            example: "[[a b]; [1 2] [3 4]] | into df | query dfr 'select a from df'",
+            example: "[[a b]; [1 2] [3 4]] | into df | query df 'select a from df'",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),
@@ -101,6 +101,6 @@ mod test {
 
     #[test]
     fn test_examples() {
-        test_dataframe(vec![Box::new(QueryDfr {})])
+        test_dataframe(vec![Box::new(QueryDf {})])
     }
 }


### PR DESCRIPTION
# Description

Rename `query dfr` to `query df`.

`query df` is clearly the appropriate name here: `df` is already widely used in various contexts in nushell to refer to dataframe, including in the command `into df`, whereas "dfr" is no longer used anywhere else. (I understand that [previously](https://www.nushell.sh/blog/2022-06-14-nushell_0_64.html#input-overloading-elferherrera) dataframe commands were prefixed with `dfr` but the string `dfr` doesn't occur anywhere in the codebase after this change). The help text of the command states

```
Query dataframe using SQL. Note: The dataframe is always named 'df' in your query's from clause.
```

making it even more clear that the command should use the abbreviation `df`.

# Tests

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.

I believe that the relevant content is automatically generated and so will be updated automatically in due course: https://www.nushell.sh/book/commands/query_dfr.html#frontmatter-title-for-dataframe
