### PR TITLE
Tolerate more tty acquisition failures in non-interactive mode, fixes #6719

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,13 +97,17 @@ fn take_control(interactive: bool) {
             _ => {
                 // fish also has other heuristics than "too many attempts" for the orphan check, but they're optional
                 if signal::killpg(Pid::from_raw(-shell_pgid.as_raw()), Signal::SIGTTIN).is_err() {
+                    if !interactive {
+                        // that's fine
+                        return;
+                    }
                     eprintln!("ERROR: failed to SIGTTIN ourselves");
                     std::process::exit(1);
                 }
             }
         }
     }
-    if !success {
+    if !success && interactive {
         eprintln!("ERROR: failed take control of the terminal, we might be orphaned");
         std::process::exit(1);
     }


### PR DESCRIPTION
Sorry, this should've been here from the start. Hopefully this fixes #6719.