### PR TITLE
Add support to render right prompt on last line of the prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.13.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#30713abe8708020052eb4623a641449c8eee9f3a"
+source = "git+https://github.com/nibon7/reedline.git?branch=fix_indicator_line#ae461a92f68619b50aea1ab79e7234a599009256"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.13.0"
-source = "git+https://github.com/dandavison/reedline.git?branch=tab-inline-completion#5211f420e803ad8ea0479084155576b6d13ca40f"
+source = "git+https://github.com/nushell/reedline.git?branch=main#30713abe8708020052eb4623a641449c8eee9f3a"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.13.0"
-source = "git+https://github.com/nibon7/reedline.git?branch=fix_indicator_line#ae461a92f68619b50aea1ab79e7234a599009256"
+source = "git+https://github.com/nushell/reedline.git?branch=main#39e6bc8eb3324b560479d097c7ab42d1ba45ec90"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,5 +130,4 @@ path = "src/main.rs"
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-#reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
-reedline = { git = "https://github.com/nibon7/reedline.git", branch = "fix_indicator_line" }
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,4 +130,5 @@ path = "src/main.rs"
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+#reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+reedline = { git = "https://github.com/nibon7/reedline.git", branch = "fix_indicator_line" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ nu-system = { path = "./crates/nu-system", version = "0.70.1" }
 nu-table = { path = "./crates/nu-table", version = "0.70.1"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.70.1"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.70.1"  }
-reedline = { git = "https://github.com/dandavison/reedline.git", branch="tab-inline-completion", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.13.0", features = ["bashisms", "sqlite"]}
 
 rayon = "1.5.1"
 is_executable = "1.0.1"
@@ -130,4 +130,4 @@ path = "src/main.rs"
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -20,7 +20,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.70.1"  }
 nu-utils = { path = "../nu-utils", version = "0.70.1"  }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.70.1"  }
-reedline = { git = "https://github.com/dandavison/reedline.git", branch="tab-inline-completion", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.13.0", features = ["bashisms", "sqlite"]}
 
 atty = "0.2.14"
 chrono = "0.4.21"

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -17,6 +17,7 @@ pub struct NushellPrompt {
     default_vi_insert_prompt_indicator: Option<String>,
     default_vi_normal_prompt_indicator: Option<String>,
     default_multiline_indicator: Option<String>,
+    render_right_prompt_on_last_line: bool,
 }
 
 impl Default for NushellPrompt {
@@ -34,6 +35,7 @@ impl NushellPrompt {
             default_vi_insert_prompt_indicator: None,
             default_vi_normal_prompt_indicator: None,
             default_multiline_indicator: None,
+            render_right_prompt_on_last_line: false,
         }
     }
 
@@ -41,8 +43,13 @@ impl NushellPrompt {
         self.left_prompt_string = prompt_string;
     }
 
-    pub fn update_prompt_right(&mut self, prompt_string: Option<String>) {
+    pub fn update_prompt_right(
+        &mut self,
+        prompt_string: Option<String>,
+        render_right_prompt_on_last_line: bool,
+    ) {
         self.right_prompt_string = prompt_string;
+        self.render_right_prompt_on_last_line = render_right_prompt_on_last_line;
     }
 
     pub fn update_prompt_indicator(&mut self, prompt_indicator_string: Option<String>) {
@@ -68,6 +75,7 @@ impl NushellPrompt {
         prompt_indicator_string: Option<String>,
         prompt_multiline_indicator_string: Option<String>,
         prompt_vi: (Option<String>, Option<String>),
+        render_right_prompt_on_last_line: bool,
     ) {
         let (prompt_vi_insert_string, prompt_vi_normal_string) = prompt_vi;
 
@@ -78,6 +86,8 @@ impl NushellPrompt {
 
         self.default_vi_insert_prompt_indicator = prompt_vi_insert_string;
         self.default_vi_normal_prompt_indicator = prompt_vi_normal_string;
+
+        self.render_right_prompt_on_last_line = render_right_prompt_on_last_line;
     }
 
     fn default_wrapped_custom_string(&self, str: String) -> String {
@@ -161,5 +171,9 @@ impl Prompt for NushellPrompt {
             "({}reverse-search: {})",
             prefix, history_search.term
         ))
+    }
+
+    fn right_prompt_on_last_line(&self) -> bool {
+        self.render_right_prompt_on_last_line
     }
 }

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -128,6 +128,7 @@ pub(crate) fn update_prompt<'prompt>(
         prompt_indicator_string,
         prompt_multiline_string,
         (prompt_vi_insert_string, prompt_vi_normal_string),
+        config.render_right_prompt_on_last_line,
     );
 
     let ret_val = nu_prompt as &dyn Prompt;

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -88,7 +88,7 @@ unicode-segmentation = "1.8.0"
 url = "2.2.1"
 uuid = { version = "1.1.2", features = ["v4"] }
 which = { version = "4.3.0", optional = true }
-reedline = { git = "https://github.com/dandavison/reedline.git", branch="tab-inline-completion", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.13.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0", features = ["diagnostics"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -84,6 +84,7 @@ pub struct Config {
     pub trim_strategy: TrimStrategy,
     pub show_banner: bool,
     pub show_clickable_links_in_ls: bool,
+    pub render_right_prompt_on_last_line: bool,
 }
 
 impl Default for Config {
@@ -121,6 +122,7 @@ impl Default for Config {
             trim_strategy: TRIM_STRATEGY_DEFAULT,
             show_banner: true,
             show_clickable_links_in_ls: true,
+            render_right_prompt_on_last_line: false,
         }
     }
 }
@@ -429,6 +431,13 @@ impl Value {
                             config.show_clickable_links_in_ls = b;
                         } else {
                             eprintln!("$config.show_clickable_links_in_ls is not a bool")
+                        }
+                    }
+                    "render_right_prompt_on_last_line" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.render_right_prompt_on_last_line = b;
+                        } else {
+                            eprintln!("$config.render_right_prompt_on_last_line is not a bool")
                         }
                     }
                     x => {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -278,6 +278,7 @@ let-env config = {
   }
   show_banner: true # true or false to enable or disable the banner
   show_clickable_links_in_ls: true # true or false to enable or disable clickable links in the ls listing. your terminal has to support links.
+  render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
 
   hooks: {
     pre_prompt: [{


### PR DESCRIPTION
# Description

Depends on nushell/reedline#492

* `new_line` `line_break`
![Screenshot from 2022-10-18 15-56-15](https://user-images.githubusercontent.com/15247421/197098534-0f454d98-74d6-4639-a772-790f3e66a527.png)

* `new_line`  ~~`line_break`~~
![Screenshot from 2022-10-18 16-00-28](https://user-images.githubusercontent.com/15247421/197098530-4b574ffe-c4d6-42f5-a4d3-537a7dd0c866.png)

* ~~`new_line`~~  `line_break`
![Screenshot from 2022-10-18 15-55-51](https://user-images.githubusercontent.com/15247421/197098539-48071c59-9e1e-48b1-8d14-f117ed99413a.png)

* ~~`new_line`~~ ~~`line_break`~~
![Screenshot from 2022-10-18 15-55-27](https://user-images.githubusercontent.com/15247421/197098541-1825dff6-ca90-41de-9e0f-c79c80ed2fda.png)


# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
