### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Additionally, commands can output structured data (you can think of this as a th
 Commands that work in the pipeline fit into one of three categories:
 
 -   Commands that produce a stream (e.g., `ls`)
--   Commands that filter a stream (eg, `where type == "dir"`)
+-   Commands that filter a stream (e.g., `where type == "dir"`)
 -   Commands that consume the output of the pipeline (e.g., `table`)
 
 Commands are separated by the pipe symbol (`|`) to denote a pipeline flowing left to right.


### PR DESCRIPTION
Fixed a very small inconsistency.

# Description

Just fixed a small inconsistency, two "e.g." were written with dots in between, and one "eg" without.

# Tests
# Documentation

This just edits the README, so i dont think tests are necessary here.