### PR TITLE
no same did you mean

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -816,7 +816,6 @@ pub fn did_you_mean(possibilities: &[String], input: &str) -> Option<String> {
     let suggestion =
         crate::lev_distance::find_best_match_for_name_with_substrings(&possibilities, input, None)
             .map(|s| s.to_string());
-    println!("possibilities: {possibilities:?}, input: {input:?}, suggestion: {suggestion:?}");
 
     // Note: sometimes plugin or external command define's the same command
     // as user input, but the command doesn't match nu's requirements
@@ -825,12 +824,6 @@ pub fn did_you_mean(possibilities: &[String], input: &str) -> Option<String> {
     // will return `to-datetime`, but that's absolutely not what user want.
     // in that case, just return None.
     if let Some(suggestion) = &suggestion {
-        println!(
-            "suggestion lowercase: {}, input lowercase: {}, equal: {}",
-            suggestion.to_lowercase(),
-            input.to_lowercase(),
-            suggestion.to_lowercase() == input.to_lowercase()
-        );
         if (suggestion.len() == 1 && suggestion.to_lowercase() != input.to_lowercase())
             || (suggestion.len() > 1 && suggestion.to_lowercase() == input.to_lowercase())
         {

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -821,7 +821,7 @@ pub fn did_you_mean(possibilities: &[String], input: &str) -> Option<String> {
     // as user input, but the command doesn't match nu's requirements
     //
     // like [1 2] | to-datetime, `find_best_match_for_name_with_substrings`
-    // will return `to-datetime`, but that's absolutely not what user want.
+    // will return `to-datetime`, but is not compatible as it is a dataframe command.
     // in that case, just return None.
     if let Some(suggestion) = &suggestion {
         if (suggestion.len() == 1 && suggestion.to_lowercase() != input.to_lowercase())

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -816,8 +816,16 @@ pub fn did_you_mean(possibilities: &[String], input: &str) -> Option<String> {
     let suggestion =
         crate::lev_distance::find_best_match_for_name_with_substrings(&possibilities, input, None)
             .map(|s| s.to_string());
+    // Note: sometimes plugin or external command define's the same command
+    // as user input, but the command doesn't match nu's requirements
+    //
+    // like [1 2] | to-datetime, `find_best_match_for_name_with_substrings`
+    // will return `to-datetime`, but that's absolutely not what user want.
+    // in that case, just return None.
     if let Some(suggestion) = &suggestion {
-        if suggestion.len() == 1 && suggestion.to_lowercase() != input.to_lowercase() {
+        if (suggestion.len() == 1 && suggestion.to_lowercase() != input.to_lowercase())
+            || (suggestion.len() > 1 && suggestion.to_lowercase() == input.to_lowercase())
+        {
             return None;
         }
     }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -825,7 +825,7 @@ pub fn did_you_mean(possibilities: &[String], input: &str) -> Option<String> {
     // in that case, just return None.
     if let Some(suggestion) = &suggestion {
         if (suggestion.len() == 1 && suggestion.to_lowercase() != input.to_lowercase())
-            || (suggestion.len() > 1 && suggestion.to_lowercase() == input.to_lowercase())
+            || (suggestion.len() > 1 && suggestion == input)
         {
             return None;
         }
@@ -861,8 +861,8 @@ mod tests {
             (
                 vec!["OS", "PWD", "PWDPWDPWDPWD"],
                 vec![
-                    ("pwd", None, "The same item doesn't means match"),
-                    ("pwdpwdpwdpwd", None, "The same item doesn't means match"),
+                    ("pwd", Some("PWD"), "Exact case insensitive match yields a match"),
+                    ("pwdpwdpwdpwd", Some("PWDPWDPWDPWD"), "Exact case insensitive match yields a match"),
                     ("PWF", Some("PWD"), "One-letter typo yields a match"),
                     ("pwf", None, "Case difference plus typo yields no match"),
                     ("Xwdpwdpwdpwd", None, "Case difference plus typo yields no match"),
@@ -872,7 +872,8 @@ mod tests {
                 vec!["foo", "bar", "baz"],
                 vec![
                     ("fox", Some("foo"), ""),
-                    ("FOO", None, ""),
+                    ("foo", None, "It's special, the same item yields no match"),
+                    ("FOO", Some("foo"), ""),
                     ("FOX", None, ""),
                     (
                         "ccc",

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -816,6 +816,8 @@ pub fn did_you_mean(possibilities: &[String], input: &str) -> Option<String> {
     let suggestion =
         crate::lev_distance::find_best_match_for_name_with_substrings(&possibilities, input, None)
             .map(|s| s.to_string());
+    println!("possibilities: {possibilities:?}, input: {input:?}, suggestion: {suggestion:?}");
+
     // Note: sometimes plugin or external command define's the same command
     // as user input, but the command doesn't match nu's requirements
     //
@@ -823,6 +825,12 @@ pub fn did_you_mean(possibilities: &[String], input: &str) -> Option<String> {
     // will return `to-datetime`, but that's absolutely not what user want.
     // in that case, just return None.
     if let Some(suggestion) = &suggestion {
+        println!(
+            "suggestion lowercase: {}, input lowercase: {}, equal: {}",
+            suggestion.to_lowercase(),
+            input.to_lowercase(),
+            suggestion.to_lowercase() == input.to_lowercase()
+        );
         if (suggestion.len() == 1 && suggestion.to_lowercase() != input.to_lowercase())
             || (suggestion.len() > 1 && suggestion.to_lowercase() == input.to_lowercase())
         {
@@ -861,7 +869,7 @@ mod tests {
                 vec!["OS", "PWD", "PWDPWDPWDPWD"],
                 vec![
                     ("pwd", None, "The same item doesn't means match"),
-                    ("pwdpwdpwdpwd", Some("PWDPWDPWDPWD"), "The same item doesn't means match"),
+                    ("pwdpwdpwdpwd", None, "The same item doesn't means match"),
                     ("PWF", Some("PWD"), "One-letter typo yields a match"),
                     ("pwf", None, "Case difference plus typo yields no match"),
                     ("Xwdpwdpwdpwd", None, "Case difference plus typo yields no match"),

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -860,8 +860,8 @@ mod tests {
             (
                 vec!["OS", "PWD", "PWDPWDPWDPWD"],
                 vec![
-                    ("pwd", Some("PWD"), "Exact case insensitive match yields a match"),
-                    ("pwdpwdpwdpwd", Some("PWDPWDPWDPWD"), "Exact case insensitive match yields a match"),
+                    ("pwd", None, "The same item doesn't means match"),
+                    ("pwdpwdpwdpwd", Some("PWDPWDPWDPWD"), "The same item doesn't means match"),
                     ("PWF", Some("PWD"), "One-letter typo yields a match"),
                     ("pwf", None, "Case difference plus typo yields no match"),
                     ("Xwdpwdpwdpwd", None, "Case difference plus typo yields no match"),
@@ -871,7 +871,7 @@ mod tests {
                 vec!["foo", "bar", "baz"],
                 vec![
                     ("fox", Some("foo"), ""),
-                    ("FOO", Some("foo"), ""),
+                    ("FOO", None, ""),
                     ("FOX", None, ""),
                     (
                         "ccc",


### PR DESCRIPTION
# Description

Fixes:  #6780

It's a quick and a little dirty fix, because dataframe's command is never executed, but I think the error message is better than misleading message.  Current result:

```
❯ [1 2] | as-datetime
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #16:1:1]
 1 │ [1 2] | as-datetime
   ·         ─────┬─────
   ·              ╰── executable was not found
   ╰────
  help: No such file or directory (os error 2)
```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
