### PR TITLE
New use_domterm_features config option. If set generate html table.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,8 +1930,7 @@ checksum = "47631885425c482fcf2dc4b182fc973c3c5b81a8f43a028055559bd24cccfa6e"
 [[package]]
 name = "json_to_table"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe97d58ab96691e90f26c10ecc1fc098a4c072714d2d126cc8a2234b89f3456"
+source = "git+https://github.com/zhiburt/tabled?rev=970ebc74c437f12ab520a107e617e0428cfea27c#970ebc74c437f12ab520a107e617e0428cfea27c"
 dependencies = [
  "serde_json",
  "tabled",
@@ -2886,6 +2885,7 @@ dependencies = [
  "nu-protocol",
  "serde_json",
  "strip-ansi-escapes",
+ "table_to_html",
  "tabled",
 ]
 
@@ -4958,10 +4958,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "table_to_html"
+version = "0.1.0"
+source = "git+https://github.com/zhiburt/tabled?rev=970ebc74c437f12ab520a107e617e0428cfea27c#970ebc74c437f12ab520a107e617e0428cfea27c"
+dependencies = [
+ "tabled",
+]
+
+[[package]]
 name = "tabled"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8a1ea336f84dc7dfae1025b73904551b3c6a42347f4243387e990f94325895"
+version = "0.9.0-fix.docs.rs.4"
+source = "git+https://github.com/zhiburt/tabled?rev=3d86a327267da9793c5ad9b48c5d6167bc9c9314#3d86a327267da9793c5ad9b48c5d6167bc9c9314"
 dependencies = [
  "ansi-str",
  "papergrid",

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -84,6 +84,7 @@ pub struct Config {
     pub trim_strategy: TrimStrategy,
     pub show_banner: bool,
     pub show_clickable_links_in_ls: bool,
+    pub use_domterm_features: bool,
 }
 
 impl Default for Config {
@@ -121,6 +122,7 @@ impl Default for Config {
             trim_strategy: TRIM_STRATEGY_DEFAULT,
             show_banner: true,
             show_clickable_links_in_ls: true,
+            use_domterm_features: false,
         }
     }
 }
@@ -429,6 +431,13 @@ impl Value {
                             config.show_clickable_links_in_ls = b;
                         } else {
                             eprintln!("$config.show_clickable_links_in_ls is not a bool")
+                        }
+                    }
+                    "use_domterm_features" => {
+                        if let Ok(b) = value.as_bool() {
+                            config.use_domterm_features = b;
+                        } else {
+                            eprintln!("$config.use_domterm_features")
                         }
                     }
                     x => {

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -496,10 +496,8 @@ impl PipelineData {
                 let working_set = StateWorkingSet::new(engine_state);
 
                 format_error(&working_set, &error)
-            } else if no_newline {
-                item.into_string("", config)
             } else {
-                item.into_string("\n", config)
+                item.into_string(if no_newline {""} else {"\n"}, config)
             };
 
             if !no_newline {

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -17,6 +17,8 @@ nu-ansi-term = "0.46.0"
 nu-protocol = { path = "../nu-protocol", version = "0.69.2" }
 strip-ansi-escapes = "0.1.1"
 atty = "0.2.14"
-tabled = { version = "0.9.0", features = ["color"], default-features = false }
-json_to_table = { version = "0.1.0", features = ["color"] }
+tabled = { git = "https://github.com/zhiburt/tabled", rev = "3d86a327267da9793c5ad9b48c5d6167bc9c9314", features = ["color"], default-features = false }
+json_to_table = { git = "https://github.com/zhiburt/tabled", rev = "970ebc74c437f12ab520a107e617e0428cfea27c", features = ["color"] }
+table_to_html = { git = "https://github.com/zhiburt/tabled", rev = "970ebc74c437f12ab520a107e617e0428cfea27c" }
+#table_to_html = { path = "../../../tabled/table_to_html" }
 serde_json = "*"

--- a/crates/nu-table/src/nu_protocol_table.rs
+++ b/crates/nu-table/src/nu_protocol_table.rs
@@ -5,9 +5,9 @@ use tabled::{color::Color, papergrid::records::Records, Table};
 
 use crate::{table::TrimStrategyModifier, TableTheme};
 
-/// NuTable has a recursive table representation of nu_prorocol::Value.
+/// NuTable has a recursive table representation of nu_protocol::Value.
 ///
-/// It doesn't support alignement and a proper width controll.
+/// It doesn't support alignment and a proper width control.
 pub struct NuTable {
     inner: tabled::Table,
 }


### PR DESCRIPTION
This is a work in progress.

# Description

This adds a new `use_domterm_features` config option to enable features of the [DomTerm](https://domterm.org) terminal emulator.
The first feature enabled is emitting tables as inline HTML tables. This uses the new `table_to_html` sub-package of the `named` crate. The table header is automatically fixed at the top of the window if any part (but not all) of the table is visible. See issue #1570.

There are a number of desirable improvements and tweaks:
* Set `use_domterm_features` automatically if the `$DOMTERM` environment variable is set.
* Make active link for filenames in `ls` output.
* More generally, customize output for table elements of different kinds of value. Partly that means adding `class` attributes. For example, a duration value could be output as `<span class="nu-duration">`.
* Similar, custom output for non-table values.
* Add horizonal scrollbar for wide tables. Remove width truncation.
* Eliminate padding and other styling generated by `table_to_html`. Styling should be by stylesheets. That way styling can be changed on-the-fly (even for old output), such as if switching from light to dark mode.
* Consider re-writing `nu-command/src/formats/to/html.rs` to using `table_to_html`.
* Somtimes the HTML output appears corrupted. I haven't looked into that yet.
* Other `use_domterm_features` such as shell integration.

Even in the current state, it looks pretty good on DomTerm and won't break other terminals.
