### PR TITLE
Minor cleanup: simplify and reduce allocations in pipeline data loop

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -185,29 +185,17 @@ impl PipelineData {
             PipelineData::ExternalStream {
                 stdout: Some(s), ..
             } => {
-                let mut items = vec![];
+                let mut output = String::new();
 
                 for val in s {
                     match val {
-                        Ok(val) => {
-                            items.push(val);
-                        }
-                        Err(e) => {
-                            return Err(e);
-                        }
+                        Ok(val) => match val.as_string() {
+                            Ok(s) => output.push_str(&s),
+                            Err(err) => return Err(err),
+                        },
+                        Err(e) => return Err(e),
                     }
                 }
-
-                let mut output = String::new();
-                for item in items {
-                    match item.as_string() {
-                        Ok(s) => output.push_str(&s),
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
-                }
-
                 Ok(output)
             }
         }


### PR DESCRIPTION
# Description

This is a minor cleanup of something I happened to notice. It eliminates an allocation and a little bit of CPU activity and makes the code more compact.

# Tests

Covered by existing tests.

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
N/A
