### PR TITLE
feat: coredump

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -445,9 +445,12 @@ impl PipelineData {
             // Make sure everything has finished
             if let Some(exit_code) = exit_code {
                 let mut exit_codes: Vec<_> = exit_code.into_iter().collect();
-                if let Some(Value::Int { val, .. }) = exit_codes.pop() {
-                    return Ok(val);
-                }
+                return match exit_codes.pop() {
+                    #[cfg(unix)]
+                    Some(Value::Error { error }) => Err(error),
+                    Some(Value::Int { val, .. }) => Ok(val),
+                    _ => Ok(0),
+                };
             }
 
             return Ok(0);


### PR DESCRIPTION
Finally

# Description

Coredump , try to fix again, here I just print the message, without use channels, so timers or timeout is not need, and all coredump messages will be print on the screen

https://github.com/nushell/nushell/issues/5903

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
