### PR TITLE
Allow captured stderr saving to file

### DIFF
--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -95,7 +95,7 @@ fn save_stderr_and_stdout_to_same_file() {
             r#"
             let-env FOO = "bar";
             let-env BAZ = "ZZZ";
-            nu -c 'do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save save_test_5/new-file.txt --stderr save_test_5/new-file.txt"#,
+            nu -c 'do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ} | save save_test_5/new-file.txt --stderr save_test_5/new-file.txt'"#,
         );
 
         let actual = file_contents(expected_file);
@@ -118,7 +118,7 @@ fn save_stderr_and_stdout_to_diff_file() {
             r#"
             let-env FOO = "bar";
             let-env BAZ = "ZZZ";
-            nu -c "do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ}" | save save_test_6/log.txt --stderr save_test_6/err.txt"#,
+            nu -c 'do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ}" | save save_test_6/log.txt --stderr save_test_6/err.txt'"#,
         );
 
         let actual = file_contents(expected_file);

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -95,12 +95,11 @@ fn save_stderr_and_stdout_to_same_file() {
             r#"
             let-env FOO = "bar";
             let-env BAZ = "ZZZ";
-            nu -c "nu --test-bin echo_env FOO; nu --test-bin echo_env_stderr BAZ" |
-            save save_test_5/new-file.txt --stderr save_test_5/new-file.txt"#,
+            nu -c 'do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save save_test_5/new-file.txt --stderr save_test_5/new-file.txt"#,
         );
 
         let actual = file_contents(expected_file);
-        println!("{}", actual);
+        println!("{}, {}", actual, actual.contains("ZZZ"));
         assert!(actual.contains("bar"));
         assert!(actual.contains("ZZZ"));
     })
@@ -119,8 +118,7 @@ fn save_stderr_and_stdout_to_diff_file() {
             r#"
             let-env FOO = "bar";
             let-env BAZ = "ZZZ";
-            nu -c "nu --test-bin echo_env FOO; nu --test-bin echo_env_stderr BAZ" |
-            save save_test_6/log.txt --stderr save_test_6/err.txt"#,
+            nu -c "do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ}" | save save_test_6/log.txt --stderr save_test_6/err.txt"#,
         );
 
         let actual = file_contents(expected_file);

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -95,7 +95,7 @@ fn save_stderr_and_stdout_to_same_file() {
             r#"
             let-env FOO = "bar";
             let-env BAZ = "ZZZ";
-            nu -c 'do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ} | save save_test_5/new-file.txt --stderr save_test_5/new-file.txt'"#,
+            do -i {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_5/new-file.txt --stderr save_test_5/new-file.txt"#,
         );
 
         let actual = file_contents(expected_file);
@@ -118,7 +118,7 @@ fn save_stderr_and_stdout_to_diff_file() {
             r#"
             let-env FOO = "bar";
             let-env BAZ = "ZZZ";
-            nu -c 'do -i {nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ}" | save save_test_6/log.txt --stderr save_test_6/err.txt'"#,
+            do -i {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_6/log.txt --stderr save_test_6/err.txt"#,
         );
 
         let actual = file_contents(expected_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,8 @@ fn main() -> Result<()> {
             if let Some(testbin) = &binary_args.testbin {
                 // Call out to the correct testbin
                 match testbin.item.as_str() {
-                    "echo_env" => test_bins::echo_env(),
+                    "echo_env" => test_bins::echo_env(true),
+                    "echo_env_stderr" => test_bins::echo_env(false),
                     "cococo" => test_bins::cococo(),
                     "meow" => test_bins::meow(),
                     "meowb" => test_bins::meowb(),

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -11,11 +11,15 @@ use nu_protocol::{CliError, PipelineData, Span, Value};
 /// Echo's value of env keys from args
 /// Example: nu --testbin env_echo FOO BAR
 /// If it it's not present echo's nothing
-pub fn echo_env() {
+pub fn echo_env(to_stdout: bool) {
     let args = args();
     for arg in args {
         if let Ok(v) = std::env::var(arg) {
-            println!("{}", v);
+            if to_stdout {
+                println!("{}", v);
+            } else {
+                eprintln!("{}", v);
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

Closes #6658

With this pr, user can do the following to redirect external commands' stdout/stderr to the same file:

```
do -i {external command} | save -r out.log --stderr err.log
```

Or

```
do -i {external command} | save -r out.log --stderr out.log
```

And no need to use `complete` to collect stderr data first, using `complete` to collect stderr data might results to high memory usage if the external command generates many messages.

## Why only works with -r flag
I think we need to consume these two(stdout/stderr) message as soon as possible.

And currently, if we're using `save` without `-r` flag, and file have an extension, it'll try to invoke `to xxx` command, which consumes external commands stdout stream.  Finally stderr stream will only be consumed when stdout is handled, which is not good.

The idle way would be using two threads, one for writing stdout, one for writing stderr, then writing these message as soon as possible, like `complete`, `table` command.

## Why only works with External Stream
Because nu's internal commands just return values, and there is no stdout/stderr property of that value.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [X] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
