### PR TITLE
Skip parsing named flags when not specified

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -794,8 +794,9 @@ pub fn parse_internal_call(
     // Starting at the first argument
     let mut spans_idx = 0;
 
-    // If there's no custom flag to parse, skip the flag parsing
-    let skip_named_flags = !signature.named.iter().any(|f| f.long != "help");
+    // If there's no custom flag to parse and rest_positional is in signature, skip the flag parsing
+    let skip_named_flags =
+        !signature.named.iter().any(|f| f.long != "help") && signature.rest_positional.is_some();
 
     while spans_idx < spans.len() {
         let arg_span = spans[spans_idx];

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -39,6 +39,14 @@ fn custom_rest_var() -> TestResult {
 }
 
 #[test]
+fn custom_rest_var_without_flags() -> TestResult {
+    run_test(
+        "def foo [...x] { echo $x }; foo --before value --after | str join ' '",
+        "--before value --after",
+    )
+}
+
+#[test]
 fn def_twice_should_fail() -> TestResult {
     fail_test(
         r#"def foo [] { "foo" }; def foo [] { "bar" }"#,

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -11,7 +11,7 @@ fn known_external_runs() -> TestResult {
 #[test]
 fn known_external_unknown_flag() -> TestResult {
     fail_test(
-        r#"extern "cargo version" []; cargo version --no-such-flag"#,
+        r#"extern "cargo version" [ --known-flag: string ]; cargo version --no-such-flag"#,
         "command doesn't have flag",
     )
 }


### PR DESCRIPTION
# Description

Skipped parsing process of named flags if it does not exist in signature and rest parameters were required in signature. Making option forwarding possible.

Fixes #3276

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
