### PR TITLE
add support for '.' in keybindings

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -667,6 +667,7 @@ fn add_parsed_keybinding(
             KeyCode::Char(char)
         }
         "space" => KeyCode::Char(' '),
+        "dot" => KeyCode::Char('.'),
         "down" => KeyCode::Down,
         "up" => KeyCode::Up,
         "left" => KeyCode::Left,


### PR DESCRIPTION
# Description
I would like to allow configuration of keybindings with the '.' (dot) character.
For example, `bash` has the `alt+.` keybinding to cycle through previous last tokens and I got used to it to insert the last token of the previous command.

This PR allows to configure a (close enough for me) reimplementation of said keybinding:
```
{
  name: insert_last_token
  modifier: alt
  keycode: dot
  mode: emacs
  event:
  [
    { edit: InsertString, value: " !$" }
    { send: Enter }
  ]
}
```
This is also my test for this PR:
- Add this entry to the keybindings list in `config.nu`
- Source `config.nu`
- Hit `alt+.`
- The last token should be inserted on the line (with a space before it) on each hit


(If there is a way to actually cycle through last tokens, please let me know!)

There will also be a PR for reedline to update `keybindings list` with the new keycode.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
