### PR TITLE
Try not to use verbatim paths for UNC shares

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,12 +1047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,7 +2804,7 @@ name = "nu-path"
 version = "0.70.1"
 dependencies = [
  "dirs-next",
- "dunce",
+ "omnipath",
  "pwd",
 ]
 
@@ -3144,6 +3138,12 @@ checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "omnipath"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7461858c5ac9bde3fcdeedc17f58ed0469ec74f2d737b6369fc31c0b0ef576c"
 
 [[package]]
 name = "once_cell"

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.70.1"
 
 [dependencies]
 dirs-next = "2.0.0"
-dunce = "1.0.1"
+omnipath = "0.1.1"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 pwd = "1.3.1"

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -1,5 +1,7 @@
 use std::path::{is_separator, Component, Path, PathBuf};
 
+use super::helpers;
+
 const EXPAND_STR: &str = if cfg!(windows) { r"..\" } else { "../" };
 
 fn handle_dots_push(string: &mut String, count: u8) {
@@ -108,7 +110,7 @@ pub fn expand_dots(path: impl AsRef<Path>) -> PathBuf {
         _ => result.push(component),
     });
 
-    dunce::simplified(&result).to_path_buf()
+    helpers::simiplified(&result)
 }
 
 #[cfg(test)]

--- a/crates/nu-path/src/expansions.rs
+++ b/crates/nu-path/src/expansions.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use super::dots::{expand_dots, expand_ndots};
+use super::helpers;
 use super::tilde::expand_tilde;
 
 // Join a path relative to another path. Paths starting with tilde are considered as absolute.
@@ -30,7 +31,7 @@ fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
     let path = expand_tilde(path);
     let path = expand_ndots(path);
 
-    dunce::canonicalize(path)
+    helpers::canonicalize(&path)
 }
 
 /// Resolve all symbolic links and all components (tilde, ., .., ...+) and return the path in its

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -1,3 +1,5 @@
+#[cfg(windows)]
+use omnipath::WinPathExt;
 use std::path::PathBuf;
 
 pub fn home_dir() -> Option<PathBuf> {
@@ -6,4 +8,23 @@ pub fn home_dir() -> Option<PathBuf> {
 
 pub fn config_dir() -> Option<PathBuf> {
     dirs_next::config_dir()
+}
+
+#[cfg(windows)]
+pub fn canonicalize(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
+    path.canonicalize()?.to_winuser_path()
+}
+#[cfg(not(windows))]
+pub fn canonicalize(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
+    path.canonicalize()
+}
+
+#[cfg(windows)]
+pub fn simiplified(path: &std::path::Path) -> PathBuf {
+    path.to_winuser_path()
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+#[cfg(not(windows))]
+pub fn simiplified(path: &std::path::Path) -> PathBuf {
+    path.to_path_buf()
 }

--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -419,3 +419,14 @@ fn canonicalize_with_should_fail() {
 
     assert!(canonicalize_with(path, relative_to).is_err());
 }
+
+#[cfg(windows)]
+#[test]
+fn canonicalize_unc() {
+    // Ensure that canonicalizing UNC paths does not turn them verbatim.
+    // Assumes the C drive exists and that the `localhost` UNC path works.
+    let actual =
+        nu_path::canonicalize_with(r"\\localhost\c$", ".").expect("failed to canonicalize");
+    let expected = Path::new(r"\\localhost\c$");
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
# Description

On Windows when canonicalizing a UNC path (e.g. `\\server\share`) a verbatim path will be returned (e.g. `\\?\server\share`). This is unexpected by users and may not work with all tools. The crate `dunce` was previously used to remove verbatim prefixes. However, this does not work on UNC paths.

This PR replaces `dunce` with [`omnipath`](https://docs.rs/omnipath) which works on any kind of Windows path. I'm the author of `omnipath` and would be very amenable to fixing any issues that crop up. Note that I've currently limited the changes in this PR to being a drop-in replacement for dunce but I'd also point to [`omnipath::sys_absolute`](https://docs.rs/omnipath/latest/omnipath/fn.sys_absolute.html) as a potentially useful enhancement for when canonicalize fails or when it's simply the more appropriate option.

I'm not sure if the test will work in CI but hopefully it does.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
