### PR TITLE
Diagnostics logging streamlining+tweaks

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -15,7 +15,6 @@ pub fn evaluate_commands(
     engine_state: &mut EngineState,
     stack: &mut Stack,
     input: PipelineData,
-    is_perf_true: bool,
     table_mode: Option<Value>,
 ) -> Result<Option<i64>> {
     // Translate environment variables from Strings to Values
@@ -68,9 +67,7 @@ pub fn evaluate_commands(
         }
     };
 
-    if is_perf_true {
-        info!("evaluate {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("evaluate {}:{}:{}", file!(), line!(), column!());
 
     Ok(exit_code)
 }

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -23,7 +23,6 @@ pub fn read_plugin_file(
     stack: &mut Stack,
     plugin_file: Option<Spanned<String>>,
     storage_path: &str,
-    is_perf_true: bool,
 ) {
     // Reading signatures from signature file
     // The plugin.nu file stores the parsed signature collected from each registered plugin
@@ -44,9 +43,7 @@ pub fn read_plugin_file(
         }
     }
 
-    if is_perf_true {
-        info!("read_plugin_file {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("read_plugin_file {}:{}:{}", file!(), line!(), column!());
 }
 
 #[cfg(feature = "plugin")]

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -19,7 +19,6 @@ pub fn evaluate_file(
     engine_state: &mut EngineState,
     stack: &mut Stack,
     input: PipelineData,
-    is_perf_true: bool,
 ) -> Result<()> {
     // Translate environment variables from Strings to Values
     if let Some(e) = convert_env_values(engine_state, stack) {
@@ -54,9 +53,7 @@ pub fn evaluate_file(
         std::process::exit(1);
     }
 
-    if is_perf_true {
-        info!("evaluate {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("evaluate {}:{}:{}", file!(), line!(), column!());
 
     Ok(())
 }

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -25,7 +25,6 @@ fn get_prompt_string(
     config: &Config,
     engine_state: &EngineState,
     stack: &mut Stack,
-    is_perf_true: bool,
 ) -> Option<String> {
     stack
         .get_env_var(engine_state, prompt)
@@ -44,14 +43,12 @@ fn get_prompt_string(
                     block,
                     PipelineData::new(Span::new(0, 0)), // Don't try this at home, 0 span is ignored
                 );
-                if is_perf_true {
-                    info!(
-                        "get_prompt_string (block) {}:{}:{}",
-                        file!(),
-                        line!(),
-                        column!()
-                    );
-                }
+                info!(
+                    "get_prompt_string (block) {}:{}:{}",
+                    file!(),
+                    line!(),
+                    column!()
+                );
 
                 match ret_val {
                     Ok(ret_val) => Some(ret_val),
@@ -90,17 +87,10 @@ pub(crate) fn update_prompt<'prompt>(
     engine_state: &EngineState,
     stack: &Stack,
     nu_prompt: &'prompt mut NushellPrompt,
-    is_perf_true: bool,
 ) -> &'prompt dyn Prompt {
     let mut stack = stack.clone();
 
-    let left_prompt_string = get_prompt_string(
-        PROMPT_COMMAND,
-        config,
-        engine_state,
-        &mut stack,
-        is_perf_true,
-    );
+    let left_prompt_string = get_prompt_string(PROMPT_COMMAND, config, engine_state, &mut stack);
 
     // Now that we have the prompt string lets ansify it.
     // <133 A><prompt><133 B><command><133 C><command output>
@@ -116,45 +106,20 @@ pub(crate) fn update_prompt<'prompt>(
         left_prompt_string
     };
 
-    let right_prompt_string = get_prompt_string(
-        PROMPT_COMMAND_RIGHT,
-        config,
-        engine_state,
-        &mut stack,
-        is_perf_true,
-    );
+    let right_prompt_string =
+        get_prompt_string(PROMPT_COMMAND_RIGHT, config, engine_state, &mut stack);
 
-    let prompt_indicator_string = get_prompt_string(
-        PROMPT_INDICATOR,
-        config,
-        engine_state,
-        &mut stack,
-        is_perf_true,
-    );
+    let prompt_indicator_string =
+        get_prompt_string(PROMPT_INDICATOR, config, engine_state, &mut stack);
 
-    let prompt_multiline_string = get_prompt_string(
-        PROMPT_MULTILINE_INDICATOR,
-        config,
-        engine_state,
-        &mut stack,
-        is_perf_true,
-    );
+    let prompt_multiline_string =
+        get_prompt_string(PROMPT_MULTILINE_INDICATOR, config, engine_state, &mut stack);
 
-    let prompt_vi_insert_string = get_prompt_string(
-        PROMPT_INDICATOR_VI_INSERT,
-        config,
-        engine_state,
-        &mut stack,
-        is_perf_true,
-    );
+    let prompt_vi_insert_string =
+        get_prompt_string(PROMPT_INDICATOR_VI_INSERT, config, engine_state, &mut stack);
 
-    let prompt_vi_normal_string = get_prompt_string(
-        PROMPT_INDICATOR_VI_NORMAL,
-        config,
-        engine_state,
-        &mut stack,
-        is_perf_true,
-    );
+    let prompt_vi_normal_string =
+        get_prompt_string(PROMPT_INDICATOR_VI_NORMAL, config, engine_state, &mut stack);
 
     // apply the other indicators
     nu_prompt.update_all_prompt_strings(
@@ -166,9 +131,7 @@ pub(crate) fn update_prompt<'prompt>(
     );
 
     let ret_val = nu_prompt as &dyn Prompt;
-    if is_perf_true {
-        info!("update_prompt {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("update_prompt {}:{}:{}", file!(), line!(), column!());
 
     ret_val
 }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -41,7 +41,6 @@ pub fn evaluate_repl(
     engine_state: &mut EngineState,
     stack: &mut Stack,
     nushell_path: &str,
-    is_perf_true: bool,
     prerun_command: Option<Spanned<String>>,
 ) -> Result<()> {
     use reedline::{FileBackedHistory, Reedline, Signal};
@@ -60,14 +59,12 @@ pub fn evaluate_repl(
 
     let mut nu_prompt = NushellPrompt::new();
 
-    if is_perf_true {
-        info!(
-            "translate environment vars {}:{}:{}",
-            file!(),
-            line!(),
-            column!()
-        );
-    }
+    info!(
+        "translate environment vars {}:{}:{}",
+        file!(),
+        line!(),
+        column!()
+    );
 
     // Translate environment variables from Strings to Values
     if let Some(e) = convert_env_values(engine_state, stack) {
@@ -92,18 +89,14 @@ pub fn evaluate_repl(
         },
     );
 
-    if is_perf_true {
-        info!(
-            "load config initially {}:{}:{}",
-            file!(),
-            line!(),
-            column!()
-        );
-    }
+    info!(
+        "load config initially {}:{}:{}",
+        file!(),
+        line!(),
+        column!()
+    );
 
-    if is_perf_true {
-        info!("setup reedline {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("setup reedline {}:{}:{}", file!(), line!(), column!());
 
     let mut line_editor = Reedline::create();
 
@@ -121,9 +114,7 @@ pub fn evaluate_repl(
         engine_state.config.history_file_format,
     );
     if let Some(history_path) = history_path.as_deref() {
-        if is_perf_true {
-            info!("setup history {}:{}:{}", file!(), line!(), column!());
-        }
+        info!("setup history {}:{}:{}", file!(), line!(), column!());
 
         let history: Box<dyn reedline::History> = match engine_state.config.history_file_format {
             HistoryFileFormat::PlainText => Box::new(
@@ -173,14 +164,12 @@ pub fn evaluate_repl(
     }
 
     loop {
-        if is_perf_true {
-            info!(
-                "load config each loop {}:{}:{}",
-                file!(),
-                line!(),
-                column!()
-            );
-        }
+        info!(
+            "load config each loop {}:{}:{}",
+            file!(),
+            line!(),
+            column!()
+        );
 
         let cwd = get_guaranteed_cwd(engine_state, stack);
 
@@ -201,15 +190,11 @@ pub fn evaluate_repl(
 
         let config = engine_state.get_config();
 
-        if is_perf_true {
-            info!("setup colors {}:{}:{}", file!(), line!(), column!());
-        }
+        info!("setup colors {}:{}:{}", file!(), line!(), column!());
 
         let color_hm = get_color_config(config);
 
-        if is_perf_true {
-            info!("update reedline {}:{}:{}", file!(), line!(), column!());
-        }
+        info!("update reedline {}:{}:{}", file!(), line!(), column!());
         let engine_reference = std::sync::Arc::new(engine_state.clone());
         line_editor = line_editor
             .with_highlighter(Box::new(NuHighlighter {
@@ -266,18 +251,14 @@ pub fn evaluate_repl(
         };
 
         if config.sync_history_on_enter {
-            if is_perf_true {
-                info!("sync history {}:{}:{}", file!(), line!(), column!());
-            }
+            info!("sync history {}:{}:{}", file!(), line!(), column!());
 
             if let Err(e) = line_editor.sync_history() {
                 warn!("Failed to sync history: {}", e);
             }
         }
 
-        if is_perf_true {
-            info!("setup keybindings {}:{}:{}", file!(), line!(), column!());
-        }
+        info!("setup keybindings {}:{}:{}", file!(), line!(), column!());
 
         // Changing the line editor based on the found keybindings
         line_editor = match create_keybindings(config) {
@@ -301,9 +282,7 @@ pub fn evaluate_repl(
             }
         };
 
-        if is_perf_true {
-            info!("prompt_update {}:{}:{}", file!(), line!(), column!());
-        }
+        info!("prompt_update {}:{}:{}", file!(), line!(), column!());
 
         // Right before we start our prompt and take input from the user,
         // fire the "pre_prompt" hook
@@ -323,19 +302,16 @@ pub fn evaluate_repl(
         }
 
         let config = engine_state.get_config();
-        let prompt =
-            prompt_update::update_prompt(config, engine_state, stack, &mut nu_prompt, is_perf_true);
+        let prompt = prompt_update::update_prompt(config, engine_state, stack, &mut nu_prompt);
 
         entry_num += 1;
 
-        if is_perf_true {
-            info!(
-                "finished setup, starting repl {}:{}:{}",
-                file!(),
-                line!(),
-                column!()
-            );
-        }
+        info!(
+            "finished setup, starting repl {}:{}:{}",
+            file!(),
+            line!(),
+            column!()
+        );
 
         let input = line_editor.read_line(prompt);
         let shell_integration = config.shell_integration;

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -17,7 +17,6 @@ pub(crate) fn read_config_file(
     engine_state: &mut EngineState,
     stack: &mut Stack,
     config_file: Option<Spanned<String>>,
-    is_perf_true: bool,
     is_env_config: bool,
 ) {
     // Load config startup file
@@ -105,16 +104,10 @@ pub(crate) fn read_config_file(
         eval_config_contents(config_path, engine_state, stack);
     }
 
-    if is_perf_true {
-        info!("read_config_file {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("read_config_file {}:{}:{}", file!(), line!(), column!());
 }
 
-pub(crate) fn read_loginshell_file(
-    engine_state: &mut EngineState,
-    stack: &mut Stack,
-    is_perf_true: bool,
-) {
+pub(crate) fn read_loginshell_file(engine_state: &mut EngineState, stack: &mut Stack) {
     // read and execute loginshell file if exists
     if let Some(mut config_path) = nu_path::config_dir() {
         config_path.push(NUSHELL_FOLDER);
@@ -125,16 +118,10 @@ pub(crate) fn read_loginshell_file(
         }
     }
 
-    if is_perf_true {
-        info!("read_loginshell_file {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("read_loginshell_file {}:{}:{}", file!(), line!(), column!());
 }
 
-pub(crate) fn read_default_env_file(
-    engine_state: &mut EngineState,
-    stack: &mut Stack,
-    is_perf_true: bool,
-) {
+pub(crate) fn read_default_env_file(engine_state: &mut EngineState, stack: &mut Stack) {
     let config_file = get_default_env();
     eval_source(
         engine_state,
@@ -144,9 +131,7 @@ pub(crate) fn read_default_env_file(
         PipelineData::new(Span::new(0, 0)),
     );
 
-    if is_perf_true {
-        info!("read_config_file {}:{}:{}", file!(), line!(), column!());
-    }
+    info!("read_config_file {}:{}:{}", file!(), line!(), column!());
     // Merge the environment in case env vars changed in the config
     match nu_engine::env::current_dir(engine_state, stack) {
         Ok(cwd) => {


### PR DESCRIPTION
# What?

We currently have 2 separate flags on `nu` that control logging:

```
  -p, --perf - start and print performance metrics during startup
  --log-level <String> - log level for performance logs
```

This PR removes the `--perf` flag and documents `--log-level` behaviour better:

```
  --log-level <String> - log level for diagnostic logs (error, warn, info, debug, trace). Off by default
```

It also changes behaviour when the user specifies an invalid log level. Previously Nu silently fell back to `warn`, now it falls back to `info` with an error:

```
> nu --log-level=infoz
ERROR: log library did not recognize log level 'infoz', using default 'info'
2022-10-21 01:08:05.637 AM [INFO ] nu: start logging src/main.rs:287:67
...
```

# Why?

I've needed to confirm+refresh my understanding of Nu logging multiple times now. Some points I've found unintuitive:
- not obvious what counts as performance logging
- the way that `--perf` interacts with log levels is not obvious and can only be understood by looking at the code
- why is `--log-level` labelled as "performance logs" when it seems to be a more general logging mechanism?
- `--log-level` docs did not list possible input values, and silently fell back to `warn` when an invalid level was specified
- `--perf` docs say "startup" but it controls a bunch of logging on every prompt

I believe this PR addresses all those issues. The log statements that were previously controlled by `--perf` can still be viewed with `--log-level=info` or higher.

# Tests

Make sure you've done the following:

- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
  - No docs needed but I'll make sure to get another dev's approval before merging
