### PR TITLE
Update reedline to fix history search filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.13.0"
-source = "git+https://github.com/dandavison/reedline.git?branch=tab-inline-completion#2a8e6c7c3ae610e15c91ad24d45c5b2ad0a1615b"
+source = "git+https://github.com/dandavison/reedline.git?branch=tab-inline-completion#5211f420e803ad8ea0479084155576b6d13ca40f"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",


### PR DESCRIPTION
Update nushell's reedline to pull in a fix for history search filtering which was broken by #6802.

The reedline PR (to which nushell reedline is currently pointing) is https://github.com/nushell/reedline/pull/498 (see last commit in that PR).

# Tests

I haven't tried to add tests for this.

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.

We should document how tab completion works and the relevant options.