### PR TITLE
`table -e` align key to 2nd line

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -439,6 +439,7 @@ fn build_expanded_table(
         }
 
         let is_limited = matches!(expand_limit, Some(0));
+        let mut is_expanded = false;
         let value = if is_limited {
             value_to_styled_string(&value, 0, config, &color_hm).0
         } else {
@@ -469,6 +470,7 @@ fn build_expanded_table(
 
                     let result =
                         table.draw_table(config, &color_hm, alignments, &theme, remaining_width);
+                    is_expanded = true;
                     match result {
                         Some(result) => result,
                         None => return Ok(None),
@@ -481,6 +483,14 @@ fn build_expanded_table(
                 }
             }
         };
+
+        // we want to have a key being aligned to 2nd line,
+        // we could use Padding for it but,
+        // the easiest way to do so is just push a new_line char before
+        let mut key = key;
+        if !key.is_empty() && is_expanded && theme.has_top_line() {
+            key.insert(0, '\n');
+        }
 
         let key = Value::String {
             val: key,

--- a/crates/nu-table/src/table_theme.rs
+++ b/crates/nu-table/src/table_theme.rs
@@ -114,4 +114,11 @@ impl TableTheme {
             theme: Style::blank().into(),
         }
     }
+
+    pub fn has_top_line(&self) -> bool {
+        self.theme.get_top().is_some()
+            || self.theme.get_top_intersection().is_some()
+            || self.theme.get_top_left().is_some()
+            || self.theme.get_top_right().is_some()
+    }
 }


### PR DESCRIPTION
close #6821 

![image](https://user-images.githubusercontent.com/20165848/197132393-96c85e09-e271-4364-b350-47029addc02d.png)

Notice that it works only in case of records but not lists.

![image](https://user-images.githubusercontent.com/20165848/197131983-6b52b861-c770-4397-b5ad-d646478b3c0a.png)
![image](https://user-images.githubusercontent.com/20165848/197131909-2492f596-1445-4d3a-8517-344184779e50.png)
