### PR TITLE
Print command help in base from+to commands

### DIFF
--- a/crates/nu-command/src/formats/from/command.rs
+++ b/crates/nu-command/src/formats/from/command.rs
@@ -1,6 +1,7 @@
+use nu_engine::get_full_help;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Value};
 
 #[derive(Clone)]
 pub struct From;
@@ -20,11 +21,15 @@ impl Command for From {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
-        Ok(PipelineData::new(call.head))
+        Ok(Value::String {
+            val: get_full_help(&From.signature(), &From.examples(), engine_state, stack),
+            span: call.head,
+        }
+        .into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/formats/to/command.rs
+++ b/crates/nu-command/src/formats/to/command.rs
@@ -1,6 +1,7 @@
+use nu_engine::get_full_help;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Value};
 
 #[derive(Clone)]
 pub struct To;
@@ -20,11 +21,15 @@ impl Command for To {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
-        Ok(PipelineData::new(call.head))
+        Ok(Value::String {
+            val: get_full_help(&To.signature(), &To.examples(), engine_state, stack),
+            span: call.head,
+        }
+        .into_pipeline_data())
     }
 }


### PR DESCRIPTION
# Description

Partial fix for #6844. Previously, running `from` or `to` with no subcommands returned no useful info:

```
〉from
〉to
```

Now we return the help text, same as `config`:
```
〉from
Usage:
  > from

Subcommands:
  from csv - Parse text as .csv and create table.
  from eml - Parse text as .eml and create table.
  from ics - Parse text as .ics and create table.
  from ini - Parse text as .ini and create table
  from json - Convert from json to structured data
  from nuon - Convert from nuon to structured data
  from ods - Parse OpenDocument Spreadsheet(.ods) data and create table.
  from ssv - Parse text as space-separated values and create a table. The default minimum number of spaces counted as a separator is 2.
  from toml - Parse text as .toml and create table.
  from tsv - Parse text as .tsv and create table.
  from url - Parse url-encoded string as a table.
  from vcf - Parse text as .vcf and create table.
  from xlsx - Parse binary Excel(.xlsx) data and create table.
  from xml - Parse text as .xml and create table.
  from yaml - Parse text as .yaml/.yml and create table.
  from yml - Parse text as .yaml/.yml and create table.

Flags:
  -h, --help - Display this help message


〉to
Usage:
  > to

Subcommands:
  to csv - Convert table into .csv text
  to html - Convert table into simple HTML
  to json - Converts table data into JSON text.
  to md - Convert table into simple Markdown
  to nuon - Converts table data into Nuon (Nushell Object Notation) text.
  to text - Converts data into simple text.
  to toml - Convert table into .toml text
  to tsv - Convert table into .tsv text
  to url - Convert table into url-encoded text
  to xml - Convert table into .xml text
  to yaml - Convert table into .yaml/.yml text

Flags:
  -h, --help - Display this help message

```

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [N/A] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
  - Not a big enough feature to document