### PR TITLE
Fixes for `ps` on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "errno",
  "libc",
  "libproc",
+ "log",
  "mach2",
  "nix 0.24.2",
  "ntapi 0.3.7",

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 libc = "0.2"
+log = "0.4"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = "0.24"

--- a/crates/nu-system/src/linux.rs
+++ b/crates/nu-system/src/linux.rs
@@ -1,7 +1,6 @@
 use log::info;
-use procfs::process::{FDInfo, Io, Process, Stat, Status, TasksIter};
+use procfs::process::{FDInfo, Io, Process, Stat, Status};
 use procfs::{ProcError, ProcessCgroup};
-use std::collections::HashMap;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -74,34 +73,33 @@ pub struct ProcessInfo {
     pub pid: i32,
     pub ppid: i32,
     pub curr_proc: ProcessTask,
-    pub prev_proc: ProcessTask,
     pub curr_io: Option<Io>,
     pub prev_io: Option<Io>,
+    pub curr_stat: Option<Stat>,
+    pub prev_stat: Option<Stat>,
     pub curr_status: Option<Status>,
     pub interval: Duration,
 }
 
-pub fn collect_proc(interval: Duration, with_thread: bool) -> Vec<ProcessInfo> {
+pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
-    let mut base_tasks = HashMap::new();
     let mut ret = Vec::new();
 
+    // Take an initial snapshot of process I/O and CPU info, so we can calculate changes over time
     if let Ok(all_proc) = procfs::process::all_processes() {
         for proc in all_proc.flatten() {
             let io = proc.io().ok();
+            let stat = proc.stat().ok();
             let time = Instant::now();
-            if with_thread {
-                if let Ok(iter) = proc.tasks() {
-                    collect_task(iter, &mut base_tasks);
-                }
-            }
-            base_procs.push((proc.pid(), proc, io, time));
+            base_procs.push((proc.pid(), io, stat, time));
         }
     }
 
+    // wait a bit...
     thread::sleep(interval);
 
-    for (pid, prev_proc, prev_io, prev_time) in base_procs {
+    // now get process info again, build up results
+    for (pid, prev_io, prev_stat, prev_time) in base_procs {
         let curr_proc_pid = pid;
         let curr_proc = if let Ok(p) = Process::new(curr_proc_pid) {
             p
@@ -111,6 +109,7 @@ pub fn collect_proc(interval: Duration, with_thread: bool) -> Vec<ProcessInfo> {
         };
 
         let curr_io = curr_proc.io().ok();
+        let curr_stat = curr_proc.stat().ok();
         let curr_status = curr_proc.status().ok();
         let curr_time = Instant::now();
         let interval = curr_time - prev_time;
@@ -118,76 +117,24 @@ pub fn collect_proc(interval: Duration, with_thread: bool) -> Vec<ProcessInfo> {
             Ok(p) => p.ppid,
             Err(_) => 0,
         };
-        let owner = curr_proc.uid().unwrap_or(0);
-
-        let mut curr_tasks = HashMap::new();
-        if with_thread {
-            if let Ok(iter) = curr_proc.tasks() {
-                collect_task(iter, &mut curr_tasks);
-            }
-        }
-
         let curr_proc = ProcessTask::Process(curr_proc);
-        let prev_proc = ProcessTask::Process(prev_proc);
 
         let proc = ProcessInfo {
             pid,
             ppid,
             curr_proc,
-            prev_proc,
             curr_io,
             prev_io,
+            curr_stat,
+            prev_stat,
             curr_status,
             interval,
         };
 
         ret.push(proc);
-
-        for (tid, (pid, curr_stat, curr_status, curr_io)) in curr_tasks {
-            if let Some((_, prev_stat, _, prev_io)) = base_tasks.remove(&tid) {
-                let proc = ProcessInfo {
-                    pid: tid,
-                    ppid: pid,
-                    curr_proc: ProcessTask::Task {
-                        stat: Box::new(curr_stat),
-                        owner,
-                    },
-                    prev_proc: ProcessTask::Task {
-                        stat: Box::new(prev_stat),
-                        owner,
-                    },
-                    curr_io,
-                    prev_io,
-                    curr_status,
-                    interval,
-                };
-                ret.push(proc);
-            }
-        }
     }
 
     ret
-}
-
-#[allow(clippy::type_complexity)]
-fn collect_task(iter: TasksIter, map: &mut HashMap<i32, (i32, Stat, Option<Status>, Option<Io>)>) {
-    for task in iter {
-        let task = if let Ok(x) = task {
-            x
-        } else {
-            continue;
-        };
-        if task.tid != task.pid {
-            let stat = if let Ok(x) = task.stat() {
-                x
-            } else {
-                continue;
-            };
-            let status = task.status().ok();
-            let io = task.io().ok();
-            map.insert(task.tid, (task.pid, stat, status, io));
-        }
-    }
 }
 
 impl ProcessInfo {
@@ -246,24 +193,24 @@ impl ProcessInfo {
         }
     }
 
-    // FIXME: I think these calculations are totally broken and cpu_usage will always return zero.
-    // As I understand it, the underlying procfs::process::Process is more like a handle to a process
-    // than a snapshot in time. So we're trying to get the delta in CPU time over 100ms, but we're actually
-    // getting the delta over a few nanoseconds (which is almost always zero)
     /// CPU usage as a percent of total
     pub fn cpu_usage(&self) -> f64 {
-        let curr_time = match self.curr_proc.stat() {
-            Ok(c) => c.utime + c.stime,
-            Err(_) => 0,
-        };
-        let prev_time = match self.prev_proc.stat() {
-            Ok(c) => c.utime + c.stime,
-            Err(_) => 0,
-        };
-        let usage_ms =
-            (curr_time - prev_time) * 1000 / procfs::ticks_per_second().unwrap_or(100) as u64;
-        let interval_ms = self.interval.as_secs() * 1000 + u64::from(self.interval.subsec_millis());
-        usage_ms as f64 * 100.0 / interval_ms as f64
+        if let Some(cs) = &self.curr_stat {
+            if let Some(ps) = &self.prev_stat {
+                let curr_time = cs.utime + cs.stime;
+                let prev_time = ps.utime + ps.stime;
+
+                let usage_ms = (curr_time - prev_time) * 1000
+                    / procfs::ticks_per_second().unwrap_or(100) as u64;
+                let interval_ms =
+                    self.interval.as_secs() * 1000 + u64::from(self.interval.subsec_millis());
+                usage_ms as f64 * 100.0 / interval_ms as f64
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        }
     }
 
     /// Memory size in number of bytes


### PR DESCRIPTION
# Description

Fixes #6829, and another newly discovered bug where CPU usage was always reported as zero on Linux.

# Bug 1

Previously, `ps` would sometimes return an empty list on Linux. The easiest way to see this is to run `ps` in a loop:

```
/home/pi〉1..100 | each { ps | describe }
╭────┬─────────────────────────────────────────────────────────────────────────────────────────────╮
│  0 │ table<pid: int, name: string, status: string, cpu: float, mem: filesize, virtual: filesize> │
│  1 │ table<pid: int, name: string, status: string, cpu: float, mem: filesize, virtual: filesize> │
│  2 │ list<any>                                                                                   │
│  3 │ table<pid: int, name: string, status: string, cpu: float, mem: filesize, virtual: filesize> │
│  4 │ table<pid: int, name: string, status: string, cpu: float, mem: filesize, virtual: filesize> │
...
```

This line was the culprit: https://github.com/nushell/nushell/blob/5cc6505512bd9b92a1251a14539742441db2d8f3/crates/nu-system/src/linux.rs#L121

`ps` works by taking 2 snapshots of process activity, and then comparing them to get an idea of process activity over time. It's a reasonable approach, but we weren't handling the situation where a process dies between the 2 snapshots well.

The fix: skip over just the process that died instead of skipping over _all_ processes.

# Bug 2

Another problem: I noticed that the `cpu` field in `ps` results was always returning zero. Even when compiling Rust code on all cores, `ps` was saying that every process was using zero CPU.

When I took a closer look, the problem seemed to be that we were using [`procfs::process::Process`](https://docs.rs/procfs/latest/procfs/process/struct.Process.html) as if it were a snapshot of process activity, when in reality it's more like a handle to a process:

https://github.com/nushell/nushell/blob/5cc6505512bd9b92a1251a14539742441db2d8f3/crates/nu-system/src/linux.rs#L265-L275

The calls to `curr_proc.stat()` and `prev_proc.stat()` are not retrieving previously taken snapshots of `stat` data ; they are taking _new_ snapshots. And so the intended 100ms delay between snapshots was effectively 0ms.

To fix this, I tweaked the `ps` code to take snapshots of `stat` data like we already do for I/O data.

# Tests

I did a bunch of manual testing, but this is an area that's somewhat difficult to write automated tests for. If anyone has ideas, I'm all ears.

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass


