### PR TITLE
Expose reedline EditCommand::Complete command

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -964,6 +964,7 @@ fn edit_from_record(
             let char = extract_char(value, config)?;
             EditCommand::MoveLeftBefore(char)
         }
+        "complete" => EditCommand::Complete,
         e => {
             return Err(ShellError::UnsupportedConfigValue(
                 "reedline EditCommand".to_string(),


### PR DESCRIPTION
This is a fixup which should have been done in #6802. It exposes the new Reedline command as `edit: complete` so that users can use it in their keybinding config.

Still TODO: Give users a coherent explanation of how to use config to select between common alternative "modes" of completion, such as tab-does-inline-completion-only vs the original behavior. 

So now, tab-does-inline-completion-only (as described in #6802) can be achieved by:

```diff
diff --git a/config.nu b/config.nu
index f70051a..5de4593 100644
--- a/config.nu
+++ b/config.nu
@@ -412,11 +412,11 @@ let-env config = {
       name: completion_menu
       modifier: none
       keycode: tab
       event: {
         until: [
           { send: menu name: completion_menu }
-          { send: menunext }
+          { edit: complete }
         ]
       }
     }
```

# Tests

No changes to tests

# Documentation

TODO