### PR TITLE
Support ranges in `str substring`

### DIFF
--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -65,12 +65,18 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Get a substring \"nushell\" from the text \"good nushell\"",
+                description:
+                    "Get a substring \"nushell\" from the text \"good nushell\" using a range",
+                example: " 'good nushell' | str substring 5..12",
+                result: Some(Value::test_string("nushell")),
+            },
+            Example {
+                description: "Alternately, you can pass in a list",
                 example: " 'good nushell' | str substring [5 12]",
                 result: Some(Value::test_string("nushell")),
             },
             Example {
-                description: "Alternatively, you can use the form",
+                description: "Or a simple comma-separated string",
                 example: " 'good nushell' | str substring '5,12'",
                 result: Some(Value::test_string("nushell")),
             },
@@ -199,6 +205,11 @@ fn action(input: &Value, options: &Substring, head: Span) -> Value {
 
 fn process_arguments(options: &Arguments, head: Span) -> Result<(isize, isize), ShellError> {
     let search = match &options.range {
+        Value::Range { val, .. } => {
+            let start = val.from()?;
+            let end = val.to()?;
+            Ok(SubstringText(start.to_string(), end.to_string()))
+        }
         Value::List { vals, .. } => {
             if vals.len() > 2 {
                 Err(ShellError::UnsupportedInput(

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -122,6 +122,19 @@ impl Range {
         matches!(self.inclusion, RangeInclusion::Inclusive)
     }
 
+    pub fn from(&self) -> Result<i64, ShellError> {
+        self.from.as_integer()
+    }
+
+    pub fn to(&self) -> Result<i64, ShellError> {
+        let to = self.to.as_integer()?;
+        if self.is_end_inclusive() {
+            Ok(to)
+        } else {
+            Ok(to - 1)
+        }
+    }
+
     pub fn contains(&self, item: &Value) -> bool {
         match (item.partial_cmp(&self.from), item.partial_cmp(&self.to)) {
             (Some(Ordering::Greater | Ordering::Equal), Some(Ordering::Less)) => self.moves_up(),


### PR DESCRIPTION
# Description

Fixes #6861 by making `str substring` accept ranges:

![image](https://user-images.githubusercontent.com/26268125/197370549-2e7c0a88-e7af-4dc6-9831-35cf064901be.png)

Surprisingly, `Range` didn't have an easy way to get at the start+end values. Fixed that.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
  - Is user-facing, but the example will get picked up next time the script runs