### PR TITLE
Mildly edited a small handful of help messages

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -50,7 +50,7 @@ pub fn evaluate_repl(
     if !atty::is(atty::Stream::Stdin) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "Nushell launched as interactive REPL but STDIN is not a TTY, either launch in a valid terminal or provide arguments to invoke a script!",
+            "Nushell launched as a REPL, but STDIN is not a TTY; either launch in a valid terminal or provide arguments to invoke a script!",
         ))
         .into_diagnostic();
     }

--- a/crates/nu-command/src/database/commands/group_by.rs
+++ b/crates/nu-command/src/database/commands/group_by.rs
@@ -19,7 +19,7 @@ impl Command for GroupByDb {
     }
 
     fn usage(&self) -> &str {
-        "Group by query"
+        "Group-by query"
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/sql_context.rs
+++ b/crates/nu-command/src/dataframe/eager/sql_context.rs
@@ -103,14 +103,14 @@ impl SQLContext {
                     let idx = match idx.parse::<usize>() {
                         Ok(0)| Err(_) => Err(
                         PolarsError::ComputeError(
-                            format!("Group By Error: Only positive number or expression are supported, got {idx}").into()
+                            format!("Group-By Error: Only positive number or expression are supported, got {idx}").into()
                         )),
                         Ok(idx) => Ok(idx)
                     }?;
                     Ok(projection[idx].clone())
                   }
                   SqlExpr::Value(_) => Err(
-                      PolarsError::ComputeError("Group By Error: Only positive number or expression are supported".into())
+                      PolarsError::ComputeError("Group-By Error: Only positive number or expression are supported".into())
                   ),
                   _ => parse_sql_expr(e)
                 }
@@ -124,7 +124,7 @@ impl SQLContext {
             // Return error on wild card, shouldn't process this
             if contain_wildcard {
                 return Err(PolarsError::ComputeError(
-                    "Group By Error: Can't processed wildcard in groupby".into(),
+                    "Group-By Error: Can't process wildcard in group-by".into(),
                 ));
             }
             // Default polars group by will have group by columns at the front

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -15,7 +15,7 @@ impl Command for ToDataFrame {
     }
 
     fn usage(&self) -> &str {
-        "Converts a List, Table or Dictionary into a dataframe"
+        "Converts a list, table or record into a dataframe"
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
@@ -243,7 +243,7 @@ expr_command!(
     "max",
     "Creates a max expression",
     vec![Example {
-        description: "Max aggregation for a group by",
+        description: "Max aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | into df
     | group-by a
@@ -274,7 +274,7 @@ expr_command!(
     "min",
     "Creates a min expression",
     vec![Example {
-        description: "Min aggregation for a group by",
+        description: "Min aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | into df
     | group-by a
@@ -305,7 +305,7 @@ expr_command!(
     "sum",
     "Creates a sum expression for an aggregation",
     vec![Example {
-        description: "Sum aggregation for a group by",
+        description: "Sum aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | into df
     | group-by a
@@ -336,7 +336,7 @@ expr_command!(
     "mean",
     "Creates a mean expression for an aggregation",
     vec![Example {
-        description: "Mean aggregation for a group by",
+        description: "Mean aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | into df
     | group-by a
@@ -367,7 +367,7 @@ expr_command!(
     "median",
     "Creates a median expression for an aggregation",
     vec![Example {
-        description: "Median aggregation for a group by",
+        description: "Median aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | into df
     | group-by a
@@ -398,7 +398,7 @@ expr_command!(
     "std",
     "Creates a std expression for an aggregation",
     vec![Example {
-        description: "Std aggregation for a group by",
+        description: "Std aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
     | into df
     | group-by a
@@ -429,7 +429,7 @@ expr_command!(
     "var",
     "Create a var expression for an aggregation",
     vec![Example {
-        description: "Var aggregation for a group by",
+        description: "Var aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
     | into df
     | group-by a

--- a/crates/nu-command/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-command/src/dataframe/expressions/quantile.rs
@@ -33,7 +33,7 @@ impl Command for ExprQuantile {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Quantile aggregation for a group by",
+            description: "Quantile aggregation for a group-by",
             example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | into df
     | group-by a

--- a/crates/nu-command/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-command/src/dataframe/lazy/aggregate.rs
@@ -17,13 +17,13 @@ impl Command for LazyAggregate {
     }
 
     fn usage(&self) -> &str {
-        "Performs a series of aggregations from a group by"
+        "Performs a series of aggregations from a group-by"
     }
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .rest(
-                "Group by expressions",
+                "Group-by expressions",
                 SyntaxShape::Any,
                 "Expression(s) that define the aggregations to be applied",
             )

--- a/crates/nu-command/src/dataframe/lazy/groupby.rs
+++ b/crates/nu-command/src/dataframe/lazy/groupby.rs
@@ -16,15 +16,15 @@ impl Command for ToLazyGroupBy {
     }
 
     fn usage(&self) -> &str {
-        "Creates a groupby object that can be used for other aggregations"
+        "Creates a group-by object that can be used for other aggregations"
     }
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .rest(
-                "Group by expressions",
+                "Group-by expressions",
                 SyntaxShape::Any,
-                "Expression(s) that define the lazy group by",
+                "Expression(s) that define the lazy group-by",
             )
             .input_type(Type::Custom("dataframe".into()))
             .output_type(Type::Custom("dataframe".into()))

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -274,45 +274,45 @@ impl Command for Ls {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "List all files in the current directory",
+                description: "List visible files in the current directory",
                 example: "ls",
                 result: None,
             },
             Example {
-                description: "List all files in a subdirectory",
+                description: "List visible files in a subdirectory",
                 example: "ls subdir",
                 result: None,
             },
             Example {
-                description: "List all files with full path in the parent directory",
+                description: "List visible files with full path in the parent directory",
                 example: "ls -f ..",
                 result: None,
             },
             Example {
-                description: "List all rust files",
+                description: "List Rust files",
                 example: "ls *.rs",
                 result: None,
             },
             Example {
-                description: "List all files and directories whose name do not contain 'bar'",
+                description: "List files and directories whose name do not contain 'bar'",
                 example: "ls -s | where name !~ bar",
                 result: None,
             },
             Example {
                 description: "List all dirs in your home directory",
-                example: "ls ~ | where type == dir",
+                example: "ls -a ~ | where type == dir",
                 result: None,
             },
             Example {
                 description:
                     "List all dirs in your home directory which have not been modified in 7 days",
-                example: "ls -s ~ | where type == dir && modified < ((date now) - 7day)",
+                example: "ls -as ~ | where type == dir && modified < ((date now) - 7day)",
                 result: None,
             },
             Example {
-                description: "List given paths, show directories themselves",
+                description: "List given paths and show directories themselves",
                 example:
-                    "['/path/to/directory' '/path/to/file'] | each { |it| ls -D $it } | flatten",
+                    "['/path/to/directory' '/path/to/file'] | each { ls -D $in } | flatten",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -311,8 +311,7 @@ impl Command for Ls {
             },
             Example {
                 description: "List given paths and show directories themselves",
-                example:
-                    "['/path/to/directory' '/path/to/file'] | each { ls -D $in } | flatten",
+                example: "['/path/to/directory' '/path/to/file'] | each { ls -D $in } | flatten",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -26,7 +26,7 @@ impl Command for Drop {
     }
 
     fn usage(&self) -> &str {
-        "Remove the last number of rows or columns."
+        "Remove the last several rows of the input. Counterpart of 'skip'. Opposite of 'last'."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -25,7 +25,7 @@ impl Command for First {
     }
 
     fn usage(&self) -> &str {
-        "Show only the first number of rows."
+        "Return only the first several rows of the input. Counterpart of 'last'. Opposite of 'skip'."
     }
 
     fn run(

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -25,7 +25,7 @@ impl Command for GroupBy {
     }
 
     fn usage(&self) -> &str {
-        "Create a new table grouped."
+        "Split a table into groups based on one column's values, and return a record with those groups."
     }
 
     fn run(
@@ -42,12 +42,12 @@ impl Command for GroupBy {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "group items by column named \"type\"",
+                description: "Group items by the \"type\" column's values",
                 example: r#"ls | group-by type"#,
                 result: None,
             },
             Example {
-                description: "you can also group by raw values by leaving out the argument",
+                description: "You can also group by raw values by leaving out the argument",
                 example: "echo ['1' '3' '1' '3' '2' '1' '1'] | group-by",
                 result: Some(Value::Record {
                     cols: vec!["1".to_string(), "3".to_string(), "2".to_string()],

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -26,7 +26,7 @@ impl Command for Last {
     }
 
     fn usage(&self) -> &str {
-        "Show only the last number of rows."
+        "Return only the last several rows of the input. Counterpart of 'first'. Opposite of 'drop'."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -23,7 +23,11 @@ impl Command for Skip {
     }
 
     fn usage(&self) -> &str {
-        "Skip the first n elements of the input."
+        "Skip the first several rows of the input. Counterpart of 'drop'. Opposite of 'first'."
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"To skip specific numbered rows, try 'drop nth'. To skip specific named columns, try 'reject'."#
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -33,7 +33,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Split a path into parts by a separator."
+        "Split a path into a list based on the system's path separator."
     }
 
     fn run(

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -159,7 +159,7 @@ impl Command for Table {
         let span = Span::test_data();
         vec![
             Example {
-                description: "List the files in current directory with index number start from 1.",
+                description: "List the files in current directory, with indexes starting from 1.",
                 example: r#"ls | table -n 1"#,
                 result: None,
             },


### PR DESCRIPTION
# Description

* Closes #6753
* `group-by` is now consistently spelled "group-by" instead of either "group by" or "groupby" in usage strings.
* `first`, `last`, `skip` and `drop`'s usage strings now mention how they relate to some of the others, so that it's clear that they fit together as a set.
* Fixed capitalisation/punctuation/grammar in a few more lines.

If this is acceptable then I'll make another PR for nushell.github.io which updates the messages there. (Unless you want me to do it first?)
Also I might do a more thorough proofread of more help messages later.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
