### PR TITLE
Adds progressbar for 'for' using '-b'.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
+dependencies = [
+ "console",
+ "number_prefix",
+ "unicode-width",
+]
+
+[[package]]
 name = "inotify"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2853,7 @@ dependencies = [
  "chrono-humanize",
  "fancy-regex",
  "indexmap",
+ "indicatif",
  "miette 5.3.0",
  "nu-json",
  "nu-path",
@@ -3121,6 +3133,12 @@ checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version="0.4.21", features=["serde"] }
 chrono-humanize = "0.2.1"
 fancy-regex = "0.10.0"
 indexmap = { version="1.7", features=["serde-1"] }
+indicatif = { version = "0.17"}
 miette = { version = "5.1.0", features = ["fancy"] }
 num-format = "0.4.3"
 serde = {version = "1.0.130", features = ["derive"]}

--- a/crates/nu-protocol/src/engine/mod.rs
+++ b/crates/nu-protocol/src/engine/mod.rs
@@ -3,6 +3,7 @@ mod capture_block;
 mod command;
 mod engine_state;
 mod overlay;
+mod progress_bar;
 mod stack;
 
 pub use call_info::*;
@@ -10,4 +11,5 @@ pub use capture_block::*;
 pub use command::*;
 pub use engine_state::*;
 pub use overlay::*;
+pub use progress_bar::*;
 pub use stack::*;

--- a/crates/nu-protocol/src/engine/progress_bar.rs
+++ b/crates/nu-protocol/src/engine/progress_bar.rs
@@ -1,0 +1,53 @@
+use crate::{ast::RangeInclusion, ShellError, Value};
+
+use indicatif::{HumanDuration, ProgressBar, ProgressState, ProgressStyle};
+use std::fmt::Write;
+
+pub fn get_progress_bar_from_value(value: &Value) -> Result<ProgressBar, ShellError> {
+    let progress_bar_length = {
+        match value {
+            Value::List { vals, .. } => vals.len() as u64,
+            Value::Range { val, .. } => {
+                let from = get_value_as_i64(&val.from)?;
+                let to = get_value_as_i64(&val.to)?;
+                let inclusive_range = if val.inclusion == RangeInclusion::Inclusive {
+                    1
+                } else {
+                    0
+                };
+                ((from - to).abs() as u64) + inclusive_range
+            }
+            _ => unreachable!(),
+        }
+    };
+    get_progress_bar(progress_bar_length)
+}
+
+pub fn get_progress_bar(len: u64) -> Result<ProgressBar, ShellError> {
+    let progress_bar = ProgressBar::new(len);
+    let style = get_default_style();
+    progress_bar.set_style(style);
+    Ok(progress_bar)
+}
+
+fn get_default_style() -> ProgressStyle {
+    let style = ProgressStyle::with_template(
+        "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] ({eta})",
+    )
+    .expect("to be a valid template string.")
+    .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
+        write!(w, "{:.1}", HumanDuration(state.eta())).expect("To have a valid eta")
+    })
+    .progress_chars("#>-");
+    style
+}
+
+fn get_value_as_i64(value: &Value) -> Result<i64, ShellError> {
+    let mut val = 0;
+    if let Ok(v) = value.as_i64() {
+        val = v;
+    } else if let Ok(v) = value.as_f64() {
+        val = v.floor() as i64;
+    }
+    Ok(val)
+}

--- a/crates/nu-protocol/src/engine/progress_bar.rs
+++ b/crates/nu-protocol/src/engine/progress_bar.rs
@@ -15,7 +15,7 @@ pub fn get_progress_bar_from_value(value: &Value) -> Result<ProgressBar, ShellEr
                 } else {
                     0
                 };
-                ((from - to).abs() as u64) + inclusive_range
+                (from - to).unsigned_abs() + inclusive_range
             }
             _ => unreachable!(),
         }
@@ -31,15 +31,14 @@ pub fn get_progress_bar(len: u64) -> Result<ProgressBar, ShellError> {
 }
 
 fn get_default_style() -> ProgressStyle {
-    let style = ProgressStyle::with_template(
+    ProgressStyle::with_template(
         "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] ({eta})",
     )
     .expect("to be a valid template string.")
     .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
         write!(w, "{:.1}", HumanDuration(state.eta())).expect("To have a valid eta")
     })
-    .progress_chars("#>-");
-    style
+    .progress_chars("#>-")
 }
 
 fn get_value_as_i64(value: &Value) -> Result<i64, ShellError> {


### PR DESCRIPTION
# Description

Adds support to run `for` with `-b` or `--bar` to add a progress bar tracking the elapsed progress.
This is initial work and I hope to test this out on other commands, eg `rm`, `fetch` `mv` etc.
This is my first major commit to Nushell, so please be nice 🙏.
This currently only works for Lists & Ranges as i am unsure how the third option in `for` works.

https://user-images.githubusercontent.com/17986183/197404072-6c743a43-357c-4f8d-ae31-5e7dbd441b8b.mp4

to test it out run:  
`for x in 1..100 -b { sleep 10ms }`
`for x in [1 2 3 4 5] -b { sleep 150ms }`

This is initial work on #5542
# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
