### PR TITLE
Wrap `open` parse errors from `from` commands

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -172,7 +172,7 @@ impl Command for Open {
                             let block = engine_state.get_block(block_id);
                             eval_block(engine_state, stack, block, output, false, false)
                         } else {
-                            decl.run(engine_state, stack, &Call::new(arg_span), output)
+                            decl.run(engine_state, stack, &Call::new(call_span), output)
                         }
                         .map_err(|inner| {
                             ShellError::GenericError(

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -179,7 +179,7 @@ impl Command for Open {
                                 format!("Error while parsing as {}", ext),
                                 format!("Could not parse '{}' with `from {}`", path.display(), ext),
                                 Some(arg_span),
-                                None,
+                                Some(format!("Check out `help from {}` or `help from` for more options or open raw data with `open --raw '{}'`", ext, path.display())),
                                 vec![inner],
                             )
                         })

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -174,6 +174,15 @@ impl Command for Open {
                         } else {
                             decl.run(engine_state, stack, &Call::new(arg_span), output)
                         }
+                        .map_err(|inner| {
+                            ShellError::GenericError(
+                                format!("Error while parsing as {}", ext),
+                                format!("Could not parse '{}' with `from {}`", path.display(), ext),
+                                Some(arg_span),
+                                None,
+                                vec![inner],
+                            )
+                        })
                     }
                     None => Ok(output),
                 }


### PR DESCRIPTION
# Description

Minimal fix for #6843

![grafik](https://user-images.githubusercontent.com/15833959/197416950-058a666b-147e-4b39-8989-89e59c8e0d45.png)


This propagates the underlying errors from the called `from` commands
and adds a top-level error with the full path and the understood file
extension and resulting called command.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
