### PR TITLE
Improve error message for `get 0` on non-collection types

### DIFF
--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -176,12 +176,7 @@ fn errors_fetching_by_column_using_a_number() {
             "#
         ));
 
-        assert!(actual
-            .err
-            .contains("Data cannot be accessed with a cell path"),);
-        assert!(actual
-            .err
-            .contains("record<0: string> doesn't support cell paths"),);
+        assert!(actual.err.contains("Type mismatch"),);
     })
 }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -60,6 +60,19 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::type_mismatch), url(docsrs))]
     TypeMismatch(String, #[label = "needs {0}"] Span),
 
+    /// A command received an argument of the wrong type.
+    ///
+    /// ## Resolution
+    ///
+    /// Convert the argument type before passing it in, or change the command to accept the type.
+    #[error("Type mismatch")]
+    #[diagnostic(code(nu::shell::type_mismatch), url(docsrs))]
+    TypeMismatchGenericMessage {
+        err_message: String,
+        #[label = "{err_message}"]
+        span: Span,
+    },
+
     /// This value cannot be used with this operator.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -666,10 +666,9 @@ impl Value {
                             current = val.follow_path_int(*count, *origin_span)?;
                         }
                         x => {
-                            return Err(ShellError::IncompatiblePathAccess(
-                                format!("{}", x.get_type()),
-                                *origin_span,
-                            ))
+                            return Err(ShellError::TypeMismatchGenericMessage {
+                                err_message: format!("Can't access {} values with a row index. Try specifying a column name instead", x.get_type().to_shape()),
+                                span: *origin_span, })
                         }
                     }
                 }


### PR DESCRIPTION
Closes #6874.

## Before
![image](https://user-images.githubusercontent.com/26268125/197653670-bc59bccf-b4dc-4bf9-be93-75490e7eca60.png)

## After
![image](https://user-images.githubusercontent.com/26268125/197653595-f860b614-c02e-459b-9876-4741a692f7e5.png)

# Tests

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [N/A] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
