### PR TITLE
make `take` behave like `first`

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -145,11 +145,20 @@ fn first_helper(
                         .set_metadata(metadata)),
                 }
             }
-            _ => Ok(input_peek
-                .into_iter()
-                .take(rows_desired)
-                .into_pipeline_data(ctrlc)
-                .set_metadata(metadata)),
+            _ => {
+                if rows_desired == 1 && rows.is_none() {
+                    match input_peek.next() {
+                        Some(val) => Ok(val.into_pipeline_data()),
+                        None => Err(ShellError::AccessBeyondEndOfStream(head)),
+                    }
+                } else {
+                    Ok(input_peek
+                        .into_iter()
+                        .take(rows_desired)
+                        .into_pipeline_data(ctrlc)
+                        .set_metadata(metadata))
+                }
+            }
         }
     } else {
         Ok(PipelineData::new(head).set_metadata(metadata))

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -145,20 +145,11 @@ fn first_helper(
                         .set_metadata(metadata)),
                 }
             }
-            _ => {
-                if rows_desired == 1 && rows.is_none() {
-                    match input_peek.next() {
-                        Some(val) => Ok(val.into_pipeline_data()),
-                        None => Err(ShellError::AccessBeyondEndOfStream(head)),
-                    }
-                } else {
-                    Ok(input_peek
-                        .into_iter()
-                        .take(rows_desired)
-                        .into_pipeline_data(ctrlc)
-                        .set_metadata(metadata))
-                }
-            }
+            _ => Ok(input_peek
+                .into_iter()
+                .take(rows_desired)
+                .into_pipeline_data(ctrlc)
+                .set_metadata(metadata)),
         }
     } else {
         Ok(PipelineData::new(head).set_metadata(metadata))

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -43,7 +43,10 @@ impl Command for Take {
             Example {
                 description: "Return the first item of a list/table",
                 example: "[1 2 3] | take",
-                result: Some(Value::test_int(1)),
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(1)],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Return the first 2 items of a list/table",
@@ -138,7 +141,7 @@ fn first_helper(
                 }
             }
             _ => {
-                if rows_desired == 1 {
+                if rows_desired == 1 && rows.is_none() {
                     match input_peek.next() {
                         Some(val) => Ok(val.into_pipeline_data()),
                         None => Err(ShellError::AccessBeyondEndOfStream(head)),

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -51,7 +51,10 @@ impl Command for Take {
             Example {
                 description: "Return the first item of a list/table",
                 example: "[1 2 3] | take",
-                result: Some(Value::test_int(1)),
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(1)],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 description: "Return the first 2 items of a list/table",

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -42,11 +42,16 @@ impl Command for Take {
         vec![
             Example {
                 description: "Return the first item of a list/table",
-                example: "[1 2 3] | take",
+                example: "[1 2 3] | take 1",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(1)],
                     span: Span::test_data(),
                 }),
+            },
+            Example {
+                description: "Return the first item of a list/table",
+                example: "[1 2 3] | take",
+                result: Some(Value::test_int(1)),
             },
             Example {
                 description: "Return the first 2 items of a list/table",

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -16,7 +16,7 @@ impl Command for Take {
 
     fn signature(&self) -> Signature {
         Signature::build("take")
-            .optional(
+            .required(
                 "n",
                 SyntaxShape::Int,
                 "starting from the front, the number of elements to return",
@@ -49,14 +49,6 @@ impl Command for Take {
                 }),
             },
             Example {
-                description: "Return the first item of a list/table",
-                example: "[1 2 3] | take",
-                result: Some(Value::List {
-                    vals: vec![Value::test_int(1)],
-                    span: Span::test_data(),
-                }),
-            },
-            Example {
                 description: "Return the first 2 items of a list/table",
                 example: "[1 2 3] | take 2",
                 result: Some(Value::List {
@@ -75,11 +67,7 @@ fn first_helper(
     input: PipelineData,
 ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
     let head = call.head;
-    let rows: Option<i64> = call.opt(engine_state, stack, 0)?;
-    let mut rows_desired: usize = match rows {
-        Some(x) => x as usize,
-        None => 1,
-    };
+    let mut rows_desired: usize = call.req(engine_state, stack, 0)?;
 
     let ctrlc = engine_state.ctrlc.clone();
     let metadata = input.metadata();

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -145,20 +145,11 @@ fn first_helper(
                         .set_metadata(metadata)),
                 }
             }
-            _ => {
-                if rows_desired == 1 && rows.is_none() {
-                    match input_peek.next() {
-                        Some(val) => Ok(val.into_pipeline_data()),
-                        None => Err(ShellError::AccessBeyondEndOfStream(head)),
-                    }
-                } else {
-                    Ok(input_peek
-                        .into_iter()
-                        .take(rows_desired)
-                        .into_pipeline_data(ctrlc)
-                        .set_metadata(metadata))
-                }
-            }
+            _ => Ok(input_peek
+                .into_iter()
+                .take(rows_desired)
+                .into_pipeline_data(ctrlc)
+                .set_metadata(metadata)),
         }
     } else {
         Err(ShellError::UnsupportedInput(

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -38,6 +38,6 @@ fn rows_with_no_arguments_should_lead_to_error() {
             r#"[1 2 3] | take"#
         ));
 
-        assert_eq!(actual.err, "missing_positional");
+        assert!(actual.err.contains("missing_positional"));
     })
 }

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -29,3 +29,15 @@ fn rows() {
         assert_eq!(actual.out, "4");
     })
 }
+
+#[test]
+fn rows_with_no_arguments_should_lead_to_error() {
+    Playground::setup("take_test_2", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"[1 2 3] | take"#
+        ));
+
+        assert_eq!(actual.err, "missing_positional");
+    })
+}


### PR DESCRIPTION
# Description

Fixes: #6890 
But I have a question: why `take` command exists, it seems that it does nearly the same to `first`.

# Tests

Make sure you've done the following:

- [X] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [X] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [X] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [N/A] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
