### PR TITLE
Fix `each while` behavior when printing and maybe in other situations by fusing the iterator

### DIFF
--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -36,21 +36,39 @@ impl Command for EachWhile {
     fn examples(&self) -> Vec<Example> {
         let stream_test_1 = vec![
             Value::Int {
-                val: 1,
+                val: 2,
                 span: Span::test_data(),
             },
             Value::Int {
-                val: 2,
+                val: 4,
+                span: Span::test_data(),
+            },
+        ];
+        let stream_test_2 = vec![
+            Value::String {
+                val: "Output: 1".into(),
+                span: Span::test_data(),
+            },
+            Value::String {
+                val: "Output: 2".into(),
                 span: Span::test_data(),
             },
         ];
 
         vec![
             Example {
-                example: "[1 2 3] | each while { |it| if $it < 3 { $it } else { null } }",
-                description: "Multiplies elements in list",
+                example: "[1 2 3] | each while { |it| if $it < 3 { $it * 2 } else { null } }",
+                description: "Multiplies elements below three by two",
                 result: Some(Value::List {
                     vals: stream_test_1,
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                example: r#"[1 2 stop 3 4] | each while { |it| if $it == 'stop' { null } else { $"Output: ($it)" } }"#,
+                description: "Output elements till reaching 'stop'",
+                result: Some(Value::List {
+                    vals: stream_test_2,
                     span: Span::test_data(),
                 }),
             },
@@ -140,6 +158,7 @@ impl Command for EachWhile {
                         Err(_) => None,
                     }
                 })
+                .fuse()
                 .into_pipeline_data(ctrlc)),
             PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::new(call.head)),
             PipelineData::ExternalStream {
@@ -198,6 +217,7 @@ impl Command for EachWhile {
                         Err(_) => None,
                     }
                 })
+                .fuse()
                 .into_pipeline_data(ctrlc)),
             PipelineData::Value(x, ..) => {
                 if let Some(var) = block.signature.get_positional(0) {


### PR DESCRIPTION
# Description

Fixes #6895

Warning: `Iterator::map_while` does not return a `FusedIterator`!
Depending on the consuming adaptor or code (e.g. for loop) the iteration
may be stopped but this is not guaranteed.

- Add test for fused iterator behavior, fix other

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
