### PR TITLE
prevent error when `lines` reads bad bytes

### DIFF
--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -48,3 +48,16 @@ fn lines_multi_value_split() {
 
     assert_eq!(actual.out, "6");
 }
+
+#[test]
+fn does_not_error_with_invalid_utf8() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open non_valid_utf8.txt
+            | lines
+        "#
+    ));
+
+    assert!(actual.err.is_empty());
+}

--- a/tests/fixtures/formats/non_valid_utf8.txt
+++ b/tests/fixtures/formats/non_valid_utf8.txt
@@ -1,0 +1,1 @@
+The character ￾ cannot be properly displayed due to its illegal nature.


### PR DESCRIPTION
# Description

Fixes #6880.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
