### PR TITLE
Include exit code and command duration in left prompt

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -15,7 +15,7 @@ def create_left_prompt [] {
         }
     }
     let exit_code_segment = if ($env.LAST_EXIT_CODE == 0) {
-        $"(ansi green_bold)($env.LAST_EXIT_CODE) "
+        ""
     } else {
         $"(ansi red_bold)($env.LAST_EXIT_CODE) "
     }

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -15,7 +15,6 @@ def create_left_prompt [] {
     [$exit_code_segment, " ", $path_segment] | str join
 }
 
-
 def create_right_prompt [] {
     let time_segment = ([
         (date now | date format '%m/%d/%Y %r')

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -6,9 +6,15 @@ def create_left_prompt [] {
     } else {
         $"(ansi green_bold)($env.PWD)"
     }
+    let exit_code_segment = if ($env.LAST_EXIT_CODE == 0) {
+        $"(ansi green_bold)($env.LAST_EXIT_CODE)"
+    } else {
+        $"(ansi red_bold)($env.LAST_EXIT_CODE)"
+    }
 
-    $path_segment
+    [$exit_code_segment, " ", $path_segment] | str join
 }
+
 
 def create_right_prompt [] {
     let time_segment = ([

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -7,7 +7,7 @@ def create_left_prompt [] {
         $"(ansi green_bold)($env.PWD)"
     }
     let duration_segment = do {
-        let duration_secs = ($env.CMD_DURATION_MS | into int) / 1000;
+        let duration_secs = ($env.CMD_DURATION_MS | into int) / 1000
         if ($duration_secs >= 5) {
             $"(ansi yellow_bold)($duration_secs | math round | into string | append "sec" | str join | into duration) "
         } else {

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -6,13 +6,21 @@ def create_left_prompt [] {
     } else {
         $"(ansi green_bold)($env.PWD)"
     }
+    let duration_segment = do {
+        let duration_secs = ($env.CMD_DURATION_MS | into int) / 1000;
+        if ($duration_secs >= 5) {
+            $"(ansi yellow_bold)($duration_secs | math round | into string | append "sec" | str join | into duration) "
+        } else {
+            ""
+        }
+    }
     let exit_code_segment = if ($env.LAST_EXIT_CODE == 0) {
-        $"(ansi green_bold)($env.LAST_EXIT_CODE)"
+        $"(ansi green_bold)($env.LAST_EXIT_CODE) "
     } else {
-        $"(ansi red_bold)($env.LAST_EXIT_CODE)"
+        $"(ansi red_bold)($env.LAST_EXIT_CODE) "
     }
 
-    [$exit_code_segment, " ", $path_segment] | str join
+    [$duration_segment, $exit_code_segment, $path_segment] | str join
 }
 
 def create_right_prompt [] {


### PR DESCRIPTION
My old shell used to do this and I found it super valuable to quickly know if the last command failed.

Closes https://github.com/nushell/nushell/issues/6906