### PR TITLE
Make `seq` return a `ListStream` where possible.

### DIFF
--- a/crates/nu-command/src/generators/seq.rs
+++ b/crates/nu-command/src/generators/seq.rs
@@ -135,12 +135,12 @@ fn seq(
                 span: val.span().unwrap_or_else(|_| Span::unknown()),
             }),
             Err(_) => match val.as_i64() {
-            Ok(int) => rest_nums.push(Spanned {
-                item: int as f64,
-                span: val.span().unwrap_or_else(|_| Span::unknown()),
-            }),
-            Err(e) => return Err(e),
-            }
+                Ok(int) => rest_nums.push(Spanned {
+                    item: int as f64,
+                    span: val.span().unwrap_or_else(|_| Span::unknown()),
+                }),
+                Err(e) => return Err(e),
+            },
         }
     }
 

--- a/crates/nu-command/tests/commands/seq.rs
+++ b/crates/nu-command/tests/commands/seq.rs
@@ -1,0 +1,37 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn float_in_seq_leads_to_lists_of_floats1() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        seq 1.0 5 6 | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "list<float>");
+}
+
+#[test]
+fn float_in_seq_leads_to_lists_of_floats1() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        seq -10 5.0 6 | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "list<float>");
+}
+
+#[test]
+fn float_in_seq_leads_to_lists_of_floats1() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        seq 1 5 6.0 | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "list<float>");
+}


### PR DESCRIPTION
# Description

Significant perf improvements as well: try something like `seq 1 100000000000` and observe how it is streaming correctly.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
