### PR TITLE
fix description of build-string's second example

### DIFF
--- a/crates/nu-command/src/strings/build_string.rs
+++ b/crates/nu-command/src/strings/build_string.rs
@@ -40,7 +40,7 @@ impl Command for BuildString {
             },
             Example {
                 example: r#"build-string $"(1 + 2)" = one ' ' plus ' ' two"#,
-                description: "Builds a string from letters a b c",
+                description: "Builds a string from subexpression separating words with spaces",
                 result: Some(Value::String {
                     val: "3=one plus two".to_string(),
                     span: Span::test_data(),


### PR DESCRIPTION
# Description

Fixes description of `build-string`'s second example

Documentation PR: https://github.com/nushell/nushell.github.io/pull/649

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
