### PR TITLE
Update merge to also take single records (closes #5281)

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -40,7 +40,7 @@ impl Command for Update {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        upsert(engine_state, stack, call, input)
+        update(engine_state, stack, call, input)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -70,7 +70,7 @@ impl Command for Update {
     }
 }
 
-fn upsert(
+fn update(
     engine_state: &EngineState,
     stack: &mut Stack,
     call: &Call,

--- a/crates/nu-command/tests/commands/merge.rs
+++ b/crates/nu-command/tests/commands/merge.rs
@@ -38,5 +38,89 @@ fn row() {
         ));
 
         assert_eq!(actual.out, "2");
-    })
+    });
+}
+
+#[test]
+fn single_record_no_overwrite() {
+    assert_eq!(
+        nu!(
+            cwd: ".", pipeline(
+            r#"
+            {a: 1, b: 5} | merge {c: 2} | to nuon
+            "#
+        ))
+        .out,
+        "{a: 1, b: 5, c: 2}"
+    );
+}
+
+#[test]
+fn single_record_overwrite() {
+    assert_eq!(
+        nu!(
+            cwd: ".", pipeline(
+            r#"
+            {a: 1, b: 2} | merge {a: 2} | to nuon
+            "#
+        ))
+        .out,
+        "{a: 2, b: 2}"
+    );
+}
+
+#[test]
+fn single_row_table_overwrite() {
+    assert_eq!(
+        nu!(
+            cwd: ".", pipeline(
+            r#"
+            [[a b]; [1 4]] | merge [[a b]; [2 4]] | to nuon
+            "#
+        ))
+        .out,
+        "[[a, b]; [2, 4]]"
+    );
+}
+
+#[test]
+fn single_row_table_no_overwrite() {
+    assert_eq!(
+        nu!(
+            cwd: ".", pipeline(
+            r#"
+            [[a b]; [1 4]] | merge [[c d]; [2 4]] | to nuon
+            "#
+        ))
+        .out,
+        "[[a, b, c, d]; [1, 4, 2, 4]]"
+    );
+}
+
+#[test]
+fn multi_row_table_no_overwrite() {
+    assert_eq!(
+        nu!(
+            cwd: ".", pipeline(
+            r#"
+            [[a b]; [1 4] [8 9] [9 9]] | merge [[c d]; [2 4]]  | to nuon
+            "#
+        ))
+        .out,
+        "[{a: 1, b: 4, c: 2, d: 4}, {a: 8, b: 9}, {a: 9, b: 9}]"
+    );
+}
+
+#[test]
+fn multi_row_table_overwrite() {
+    assert_eq!(
+        nu!(
+            cwd: ".", pipeline(
+            r#"
+            [[a b]; [1 4] [8 9] [9 9]] | merge  [[a b]; [7 7]]  | to nuon
+            "#
+        ))
+        .out,
+        "[[a, b]; [7, 7], [8, 9], [9, 9]]"
+    );
 }


### PR DESCRIPTION
# Description

Closes #5281. Note that I don't actually know Rust, and mostly did this by studying and copying code structures from update.rs, which is another command that takes both values and blocks. I close to do this particular issue because it seemed to be one of the easiest for my skill level. All the tests pass and the error message arrows are still the same, but any edits that you think should be made are appreciated.

I'm not really happy with the current arbitrariness about whether commands can take blocks or not.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
