### PR TITLE
Update `nix` crate to `0.25` and narrow features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
 dependencies = [
- "nix 0.25.0",
+ "nix",
  "winapi 0.3.9",
 ]
 
@@ -2410,18 +2410,6 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
@@ -2517,7 +2505,7 @@ dependencies = [
  "itertools",
  "log",
  "miette",
- "nix 0.24.2",
+ "nix",
  "nu-ansi-term",
  "nu-cli",
  "nu-color-config",
@@ -2811,7 +2799,7 @@ dependencies = [
  "libproc",
  "log",
  "mach2",
- "nix 0.24.2",
+ "nix",
  "ntapi 0.3.7",
  "once_cell",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ signal-hook = { version = "0.3.14", default-features = false }
 winres = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = "0.24"
+nix = { version = "0.25", default-features = false, features = ["signal", "process", "fs", "term"]}
 atty = "0.2"
 
 [dev-dependencies]

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2"
 log = "0.4"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = "0.24"
+nix = { version = "0.25", default-features = false, features = ["fs", "term", "process", "signal"]}
 atty = "0.2"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]


### PR DESCRIPTION
# Description

Avoids compiling the crate twice due to incompatible versions from dependencies. This avoids binary bloat before linking as well.
Narrow our feature selection to the used modules/functions to save compile time. On my machine reduces `nix` crate compile time from around 9 secs to 0.9 secs.

# Tests

Make sure you've done the following:

- [ ] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [ ] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
