### PR TITLE
enable ability to upsert into a list like update

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -66,6 +66,16 @@ impl Command for Update {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Upsert a value int a list, updating an existing value",
+                example: "[1 2 3] | upsert 0 2",
+                result: None,
+            },
+            Example {
+                description: "Upsert a value int a list, inserting a new value",
+                example: "[1 2 3] | upsert 3 4",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -66,16 +66,6 @@ impl Command for Update {
                     span: Span::test_data(),
                 }),
             },
-            Example {
-                description: "Upsert a value int a list, updating an existing value",
-                example: "[1 2 3] | upsert 0 2",
-                result: None,
-            },
-            Example {
-                description: "Upsert a value int a list, inserting a new value",
-                example: "[1 2 3] | upsert 3 4",
-                result: None,
-            },
         ]
     }
 }

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -64,7 +64,29 @@ impl Command for Upsert {
             description: "Use in block form for more involved updating logic",
             example: "echo [[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | upsert authors {|a| $a.authors | str join ','}",
             result: Some(Value::List { vals: vec![Value::Record { cols: vec!["project".into(), "authors".into()], vals: vec![Value::test_string("nu"), Value::test_string("Andrés,JT,Yehuda")], span: Span::test_data()}], span: Span::test_data()}),
-        }]
+        },
+        Example {
+            description: "Upsert a value int a list, updating an existing value",
+            example: "[1 2 3] | upsert 0 2",
+            result: Some(Value::List {
+                vals: vec![Value::test_int(2), Value::test_int(2), Value::test_int(3)],
+                span: Span::test_data(),
+            }),
+        },
+        Example {
+            description: "Upsert a value int a list, inserting a new value",
+            example: "[1 2 3] | upsert 3 4",
+            result: Some(Value::List {
+                vals: vec![
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(4),
+                ],
+                span: Span::test_data(),
+            }),
+        },
+        ]
     }
 }
 


### PR DESCRIPTION
# Description

Fixes this scenario reported in #6926.
```
> [1 2 3] | upsert 0 2
╭───┬───╮
│ 0 │ 2 │
│ 1 │ 2 │
│ 2 │ 3 │
╰───┴───╯
> [1 2 3] | upsert 3 4
╭───┬───╮
│ 0 │ 1 │
│ 1 │ 2 │
│ 2 │ 3 │
│ 3 │ 4 │
╰───┴───╯
```
closed #6926

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
