### PR TITLE
Move nu-test-support into dev deps on nu-command

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -22,7 +22,6 @@ nu-protocol = { path = "../nu-protocol", version = "0.70.1"  }
 nu-system = { path = "../nu-system", version = "0.70.1"  }
 nu-table = { path = "../nu-table", version = "0.70.1"  }
 nu-term-grid = { path = "../nu-term-grid", version = "0.70.1"  }
-nu-test-support = { path = "../nu-test-support", version = "0.70.1"  }
 nu-utils = { path = "../nu-utils", version = "0.70.1" }
 nu-ansi-term = "0.46.0"
 num-format = { version = "0.4.3" }
@@ -154,6 +153,8 @@ database = ["sqlparser", "rusqlite"]
 shadow-rs = { version = "0.16.1", default-features = false }
 
 [dev-dependencies]
+nu-test-support = { path = "../nu-test-support", version = "0.70.1"  }
+
 hamcrest2 = "0.3.0"
 dirs-next = "2.0.0"
 proptest = "1.0.0"


### PR DESCRIPTION
# Description

This reduces the number of dependencies to build for `cargo build` or
`cargo run` by around 19.

Will not speed up CI as we need to `cargo test` but should help for
`cargo install` or users just building from source.
Time saved on my machine ~0.8 secs so likely unnoticable in noise.

Larger future goal is reducing longer dependency chains to allow more
parallel compilation.

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
