### PR TITLE
Fix double cache read in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Rust toolchain
+      - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
-        # makes ci use rust-toolchain.toml
-        # with:
-        #   profile: minimal
-        #   toolchain: ${{ matrix.rust }}
-        #   override: true
-        #   components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2.0.1
-        with:
-          key: "v2" # increment this to bust the cache if needed
 
       - name: Rustfmt
         uses: actions-rs/cargo@v1.0.1
@@ -74,17 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Rust toolchain
+      - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
-        # makes ci use rust-toolchain.toml
-        # with:
-        #   profile: minimal
-        #   toolchain: ${{ matrix.rust }}
-        #   override: true
-
-      - uses: Swatinem/rust-cache@v2.0.1
-        with:
-          key: ${{ matrix.style }}v3 # increment this to bust the cache if needed
 
       - name: Tests
         uses: actions-rs/cargo@v1.0.1
@@ -110,17 +91,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Rust toolchain
+      - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
-        # makes ci use rust-toolchain.toml
-        # with:
-        #   profile: minimal
-        #   toolchain: ${{ matrix.rust }}
-        #   override: true
-
-      - uses: Swatinem/rust-cache@v2.0.1
-        with:
-          key: "2" # increment this to bust the cache if needed
 
       - name: Install Nushell
         uses: actions-rs/cargo@v1.0.1
@@ -161,13 +133,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Rust toolchain
+      - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
-        # makes ci use rust-toolchain.toml
-        # with:
-        #   profile: minimal
-        #   toolchain: ${{ matrix.rust }}
-        #   override: true
 
       - name: Clippy
         uses: actions-rs/cargo@v1.0.1


### PR DESCRIPTION
I noticed that our CI actions were reading from [the cache](https://github.com/Swatinem/rust-cache) twice:

![image](https://user-images.githubusercontent.com/26268125/198863416-d7630127-60e9-42dd-a094-1e12241df308.png)

It looks like [the new (ish) action we use for setting up our Rust toolchain](https://github.com/actions-rust-lang/setup-rust-toolchain) includes `rust-cache` by default, so we don't need a separate `rust-cache` step anymore.