### PR TITLE
Use nt-api 4 on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,15 +2469,6 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ntapi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
@@ -2791,7 +2782,7 @@ dependencies = [
  "log",
  "mach2",
  "nix",
- "ntapi 0.3.7",
+ "ntapi",
  "once_cell",
  "procfs",
  "winapi 0.3.9",
@@ -4849,7 +4840,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
- "ntapi 0.4.0",
+ "ntapi",
  "once_cell",
  "rayon",
  "winapi 0.3.9",

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -32,5 +32,5 @@ mach2 = "0.4"
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["tlhelp32", "fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi", "std", "securitybaseapi"] }
 chrono = "0.4.21"
-ntapi = "0.3"
+ntapi = "0.4"
 once_cell = "1.0"


### PR DESCRIPTION
# Description

ntapi 0.3.7 trigger a warning about code being incompatible with future rust versions. This is resolved in 0.4
see [here](https://github.com/MSxDOS/ntapi/issues/11)

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

No tests added since just a dependency upgrade.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

Seeing the following test failure on Windows. 

Not sure how / if that is related
```
---- conversions::into::string::test::test_examples stdout ----
input: 5 | into string -d 3
result: String { val: "5,000", span: Span { start: 4, end: 15 } }
done: 605.9µs
thread 'conversions::into::string::test::test_examples' panicked at 'the example result is different to expected value: String { val: "5,000", span: Span { start: 4, end: 15 } } != String { val: "5.000", span: Span { start: 0, end: 0 } }', crates\nu-command\src\example_test.rs:140:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# User-Facing Changes

Does not apply

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
