### PR TITLE
Fix `$in` in blocks given to `any` and `all`

### DIFF
--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -34,7 +34,7 @@ impl Command for All {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Check if each rows' status is the string 'UP'",
+                description: "Check if each row's status is the string 'UP'",
                 example: "[[status]; [UP] [UP]] | all status == UP",
                 result: Some(Value::test_bool(true)),
             },

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -39,13 +39,13 @@ impl Command for All {
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description: "Check that all values are even, using the built-in $it variable",
+                description: "Check that all of the values are even, using the built-in $it variable",
                 example: "[2 4 6 8] | all ($it mod 2) == 0",
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description: "Check that all values are even, using a block",
-                example: "[2 4 6 8] | all { $in mod 2 == 0 }",
+                description: "Check that all of the values are even, using a block",
+                example: "[2 4 6 8] | all {|e| $e mod 2 == 0 }",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -39,7 +39,8 @@ impl Command for All {
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description: "Check that all of the values are even, using the built-in $it variable",
+                description:
+                    "Check that all of the values are even, using the built-in $it variable",
                 example: "[2 4 6 8] | all ($it mod 2) == 0",
                 result: Some(Value::test_bool(true)),
             },

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -45,7 +45,7 @@ impl Command for Any {
             },
             Example {
                 description: "Check if any of the values are odd, using a block",
-                example: "[2 4 6 8] | any { $in mod 2 == 1 }",
+                example: "[2 4 1 6 8] | any {|e| $e mod 2 == 1 }",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -34,7 +34,7 @@ impl Command for Any {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Check if any rows' status is the string 'DOWN'",
+                description: "Check if any row's status is the string 'DOWN'",
                 example: "[[status]; [UP] [DOWN] [UP]] | any status == DOWN",
                 result: Some(Value::test_bool(true)),
             },

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -67,3 +67,43 @@ fn checks_if_all_returns_error_with_invalid_command() {
 
     assert!(actual.err.contains("can't run executable") || actual.err.contains("did you mean"));
 }
+
+#[test]
+fn works_with_1_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | all {|e| print $e | true }"#
+    ));
+
+    assert_eq!(actual.out, "123true");
+}
+
+#[test]
+fn works_with_0_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | all { print $in | true }"#
+    ));
+
+    assert_eq!(actual.out, "123true");
+}
+
+#[test]
+fn early_exits_with_1_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | all {|e| print $e | false }"#
+    ));
+
+    assert_eq!(actual.out, "1false");
+}
+
+#[test]
+fn early_exits_with_0_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | all { print $in | false }"#
+    ));
+
+    assert_eq!(actual.out, "1false");
+}

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -43,3 +43,43 @@ fn checks_if_any_returns_error_with_invalid_command() {
 
     assert!(actual.err.contains("can't run executable") || actual.err.contains("did you mean"));
 }
+
+#[test]
+fn works_with_1_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | any {|e| print $e | false }"#
+    ));
+
+    assert_eq!(actual.out, "123false");
+}
+
+#[test]
+fn works_with_0_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | any { print $in | false }"#
+    ));
+
+    assert_eq!(actual.out, "123false");
+}
+
+#[test]
+fn early_exits_with_1_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | any {|e| print $e | true }"#
+    ));
+
+    assert_eq!(actual.out, "1true");
+}
+
+#[test]
+fn early_exits_with_0_param_blocks() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1 2 3] | any { print $in | true }"#
+    ));
+
+    assert_eq!(actual.out, "1true");
+}

--- a/crates/nu-command/tests/commands/empty.rs
+++ b/crates/nu-command/tests/commands/empty.rs
@@ -5,17 +5,57 @@ fn reports_emptiness() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            echo [[are_empty];
-                     [([[check]; [[]]      ])]
-                     [([[check]; [""]      ])]
-                     [([[check]; [{}] ])]
-            ]
-            | get are_empty
+            [[] '' {} null]
             | all {
-              is-empty check
+              is-empty
             }
         "#
     ));
 
     assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn reports_nonemptiness() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            [[1] ' ' {a:1} 0]
+            | any {
+              is-empty
+            }
+        "#
+    ));
+
+    assert_eq!(actual.out, "false");
+}
+
+#[test]
+fn reports_emptiness_by_columns() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            [{a:1 b:null c:null} {a:2 b:null c:null}]
+            | any {
+              is-empty b c
+            }
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn reports_nonemptiness_by_columns() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            [{a:1 b:null c:3} {a:null b:5 c:2}]
+            | any {
+              is-empty a b
+            }
+        "#
+    ));
+
+    assert_eq!(actual.out, "false");
 }


### PR DESCRIPTION
# Description

Closes #6917. A fix of a couple of lines.

# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [x] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [x] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.
