### PR TITLE
change str distance to output value::int

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ debian/nu/
 # VSCode's IDE items
 .vscode/*
 
+# Visual Studio Extension SourceGear Rust items
+VSWorkspaceSettings.json
+unstable_cargo_features.txt
+
 # Helix configuration folder
 .helix/*
 .helix

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -87,12 +87,8 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     match &input {
         Value::String { val, .. } => {
             let distance = levenshtein_distance(val, compare_string);
-            Value::Record {
-                cols: vec!["distance".to_string()],
-                vals: vec![Value::Int {
-                    val: distance as i64,
-                    span: head,
-                }],
+            Value::Int {
+                val: distance as i64,
                 span: head,
             }
         }


### PR DESCRIPTION
# Description

This changes `str distance` to output a `Value::Int` instead of a `Value::Record`

closes #6955

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
