### PR TITLE
Fixed $in in `where` blocks

### DIFF
--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -92,6 +92,9 @@ impl Command for For {
                 Ok(ListStream::from_stream(vals.into_iter(), ctrlc.clone())
                     .enumerate()
                     .map(move |(idx, x)| {
+                        // with_env() is used here to ensure that each iteration uses
+                        // a different set of environment variables.
+                        // Hence, a 'cd' in the first loop won't affect the next loop.
                         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                         stack.add_var(
@@ -133,6 +136,9 @@ impl Command for For {
                 .into_range_iter(ctrlc.clone())?
                 .enumerate()
                 .map(move |(idx, x)| {
+                    // with_env() is used here to ensure that each iteration uses
+                    // a different set of environment variables.
+                    // Hence, a 'cd' in the first loop won't affect the next loop.
                     stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     stack.add_var(

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -77,6 +77,9 @@ impl Command for All {
         let engine_state = engine_state.clone();
 
         for value in input.into_interruptible_iter(ctrlc) {
+            // with_env() is used here to ensure that each iteration uses
+            // a different set of environment variables.
+            // Hence, a 'cd' in the first loop won't affect the next loop.
             stack.with_env(&orig_env_vars, &orig_env_hidden);
 
             if let Some(var_id) = var_id {

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -76,6 +76,9 @@ impl Command for Any {
         let engine_state = engine_state.clone();
 
         for value in input.into_interruptible_iter(ctrlc) {
+            // with_env() is used here to ensure that each iteration uses
+            // a different set of environment variables.
+            // Hence, a 'cd' in the first loop won't affect the next loop.
             stack.with_env(&orig_env_vars, &orig_env_hidden);
 
             if let Some(var_id) = var_id {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -147,6 +147,9 @@ with 'transpose' first."#
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
+                    // with_env() is used here to ensure that each iteration uses
+                    // a different set of environment variables.
+                    // Hence, a 'cd' in the first loop won't affect the next loop.
                     stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     if let Some(var) = block.signature.get_positional(0) {
@@ -197,6 +200,9 @@ with 'transpose' first."#
                 .into_iter()
                 .enumerate()
                 .map(move |(idx, x)| {
+                    // with_env() is used here to ensure that each iteration uses
+                    // a different set of environment variables.
+                    // Hence, a 'cd' in the first loop won't affect the next loop.
                     stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     let x = match x {

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -114,6 +114,9 @@ impl Command for EachWhile {
                 .into_iter()
                 .enumerate()
                 .map_while(move |(idx, x)| {
+                    // with_env() is used here to ensure that each iteration uses
+                    // a different set of environment variables.
+                    // Hence, a 'cd' in the first loop won't affect the next loop.
                     stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     if let Some(var) = block.signature.get_positional(0) {
@@ -168,6 +171,9 @@ impl Command for EachWhile {
                 .into_iter()
                 .enumerate()
                 .map_while(move |(idx, x)| {
+                    // with_env() is used here to ensure that each iteration uses
+                    // a different set of environment variables.
+                    // Hence, a 'cd' in the first loop won't affect the next loop.
                     stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                     let x = match x {

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -92,6 +92,9 @@ fn insert(
 
         input.map(
             move |mut input| {
+                // with_env() is used here to ensure that each iteration uses
+                // a different set of environment variables.
+                // Hence, a 'cd' in the first loop won't affect the next loop.
                 stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                 if let Some(var) = block.signature.get_positional(0) {

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -164,6 +164,9 @@ impl Command for Reduce {
             .peekable();
 
         while let Some((idx, x)) = input_iter.next() {
+            // with_env() is used here to ensure that each iteration uses
+            // a different set of environment variables.
+            // Hence, a 'cd' in the first loop won't affect the next loop.
             stack.with_env(&orig_env_vars, &orig_env_hidden);
 
             if let Some(var) = block.signature.get_positional(0) {

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -98,6 +98,9 @@ fn update(
 
         input.map(
             move |mut input| {
+                // with_env() is used here to ensure that each iteration uses
+                // a different set of environment variables.
+                // Hence, a 'cd' in the first loop won't affect the next loop.
                 stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                 if let Some(var) = block.signature.get_positional(0) {

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -118,6 +118,9 @@ fn upsert(
 
         input.map(
             move |mut input| {
+                // with_env() is used here to ensure that each iteration uses
+                // a different set of environment variables.
+                // Hence, a 'cd' in the first loop won't affect the next loop.
                 stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                 if let Some(var) = block.signature.get_positional(0) {

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -61,6 +61,9 @@ impl Command for Where {
                 | PipelineData::ListStream { .. } => Ok(input
                     .into_iter()
                     .filter_map(move |x| {
+                        // with_env() is used here to ensure that each iteration uses
+                        // a different set of environment variables.
+                        // Hence, a 'cd' in the first loop won't affect the next loop.
                         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                         if let Some(var) = block.signature.get_positional(0) {
@@ -73,6 +76,7 @@ impl Command for Where {
                             &engine_state,
                             &mut stack,
                             &block,
+                            // clone() is used here because x is given to Ok() below.
                             x.clone().into_pipeline_data(),
                             redirect_stdout,
                             redirect_stderr,
@@ -99,6 +103,7 @@ impl Command for Where {
                 } => Ok(stream
                     .into_iter()
                     .filter_map(move |x| {
+                        // see note above about with_env()
                         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                         let x = match x {
@@ -116,6 +121,7 @@ impl Command for Where {
                             &engine_state,
                             &mut stack,
                             &block,
+                            // clone() is used here because x is given to Ok() below.
                             x.clone().into_pipeline_data(),
                             redirect_stdout,
                             redirect_stderr,
@@ -134,6 +140,9 @@ impl Command for Where {
                     })
                     .into_pipeline_data(ctrlc)),
                 PipelineData::Value(x, ..) => {
+                    // see note above about with_env()
+                    stack.with_env(&orig_env_vars, &orig_env_hidden);
+
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
                             stack.add_var(*var_id, x.clone());
@@ -143,6 +152,7 @@ impl Command for Where {
                         &engine_state,
                         &mut stack,
                         &block,
+                        // clone() is used here because x is given to Ok() below.
                         x.clone().into_pipeline_data(),
                         redirect_stdout,
                         redirect_stderr,
@@ -171,6 +181,9 @@ impl Command for Where {
                 let mut stack = stack.captures_to_stack(&block.captures);
                 let block = engine_state.get_block(block.block_id).clone();
 
+                let orig_env_vars = stack.env_vars.clone();
+                let orig_env_hidden = stack.env_hidden.clone();
+
                 let ctrlc = engine_state.ctrlc.clone();
                 let engine_state = engine_state.clone();
 
@@ -179,6 +192,8 @@ impl Command for Where {
                 Ok(input
                     .into_iter()
                     .filter_map(move |value| {
+                        stack.with_env(&orig_env_vars, &orig_env_hidden);
+
                         if let Some(var) = block.signature.get_positional(0) {
                             if let Some(var_id) = &var.var_id {
                                 stack.add_var(*var_id, value.clone());
@@ -188,7 +203,8 @@ impl Command for Where {
                             &engine_state,
                             &mut stack,
                             &block,
-                            PipelineData::new(span),
+                            // clone() is used here because x is given to Ok() below.
+                            value.clone().into_pipeline_data(),
                             redirect_stdout,
                             redirect_stderr,
                         );

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -107,3 +107,13 @@ fn early_exits_with_0_param_blocks() {
 
     assert_eq!(actual.out, "1false");
 }
+
+#[test]
+fn unique_env_each_iteration() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "[1 2] | all { print ($env.PWD | str ends-with 'formats') | cd '/' | true } | to nuon"
+    );
+
+    assert_eq!(actual.out, "truetruetrue");
+}

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -83,3 +83,13 @@ fn early_exits_with_0_param_blocks() {
 
     assert_eq!(actual.out, "1true");
 }
+
+#[test]
+fn unique_env_each_iteration() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "[1 2] | any { print ($env.PWD | str ends-with 'formats') | cd '/' | false } | to nuon"
+    );
+
+    assert_eq!(actual.out, "truetruefalse");
+}

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -23,6 +23,36 @@ fn filters_with_nothing_comparison() {
 }
 
 #[test]
+fn filters_with_0_arity_block() {
+    let actual = nu!(
+        cwd: ".",
+        "[1 2 3 4] | where { $in < 3 } | to nuon"
+    );
+
+    assert_eq!(actual.out, "[1, 2]");
+}
+
+#[test]
+fn filters_with_1_arity_block() {
+    let actual = nu!(
+        cwd: ".",
+        "[1 2 3 6 7 8] | where {|e| $e < 5 } | to nuon"
+    );
+
+    assert_eq!(actual.out, "[1, 2, 3]");
+}
+
+#[test]
+fn unique_env_each_iteration() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "[1 2] | where { print ($env.PWD | str ends-with 'formats') | cd '/' | true } | to nuon"
+    );
+
+    assert_eq!(actual.out, "truetrue[1, 2]");
+}
+
+#[test]
 fn where_in_table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",


### PR DESCRIPTION
# Description

Closes #6967. Added tests for $in usage in `all`, `any` and `where`.

Also adds comments to most instances of `stack.with_env(&orig_env_vars, &orig_env_hidden);`, because that line isn't actually self-explanatory.

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
