### PR TITLE
category tweak

### DIFF
--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -7,7 +7,7 @@ impl Plugin for GStat {
         vec![Signature::build("gstat")
             .usage("Get the git status of a repo")
             .optional("path", SyntaxShape::Filepath, "path to repo")
-            .category(Category::Custom("Prompt".to_string()))]
+            .category(Category::Custom("prompt".to_string()))]
     }
 
     fn run(


### PR DESCRIPTION
# Description

Updates the `gstat` category from `Prompt` to `prompt`.

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
