### PR TITLE
Grouped config commands better (closes #6911)

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -36,7 +36,7 @@ impl Command for Rm {
     }
 
     fn usage(&self) -> &str {
-        "Remove files and directories."
+        "Remove file(s)."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -53,17 +53,17 @@ impl Command for Rm {
         let sig = sig
             .switch(
                 "trash",
-                "move to the platform's trash instead of permanently deleting",
+                "use the platform's recycle bin instead of permanently deleting",
                 Some('t'),
             )
             .switch(
                 "permanent",
-                "delete permanently, ignoring the 'always_trash' config option",
+                "don't use recycle bin, delete permanently",
                 Some('p'),
             );
         sig.switch("recursive", "delete subdirectories recursively", Some('r'))
             .switch("force", "suppress error when no file", Some('f'))
-            .switch("verbose", "print names of deleted files", Some('v'))
+            .switch("verbose", "make rm to be verbose, showing files been deleted", Some('v'))
             .switch("interactive", "ask user to confirm action", Some('i'))
             .rest(
                 "rest",
@@ -97,7 +97,7 @@ impl Command for Rm {
         ))]
         examples.append(&mut vec![
             Example {
-                description: "Move a file to the trash",
+                description: "Move a file to the system trash",
                 example: "rm --trash file.txt",
                 result: None,
             },
@@ -109,7 +109,7 @@ impl Command for Rm {
             },
         ]);
         examples.push(Example {
-            description: "Delete a file, ignoring 'file not found' errors",
+            description: "Delete a file, and suppress errors if no file is found",
             example: "rm --force file.txt",
             result: None,
         });

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -36,7 +36,7 @@ impl Command for Rm {
     }
 
     fn usage(&self) -> &str {
-        "Remove file(s)."
+        "Remove files and directories."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -53,21 +53,17 @@ impl Command for Rm {
         let sig = sig
             .switch(
                 "trash",
-                "use the platform's recycle bin instead of permanently deleting",
+                "move to the platform's trash instead of permanently deleting",
                 Some('t'),
             )
             .switch(
                 "permanent",
-                "don't use recycle bin, delete permanently",
+                "delete permanently, ignoring the 'always_trash' config option",
                 Some('p'),
             );
         sig.switch("recursive", "delete subdirectories recursively", Some('r'))
             .switch("force", "suppress error when no file", Some('f'))
-            .switch(
-                "verbose",
-                "make rm to be verbose, showing files been deleted",
-                Some('v'),
-            )
+            .switch("verbose", "print names of deleted files", Some('v'))
             .switch("interactive", "ask user to confirm action", Some('i'))
             .rest(
                 "rest",
@@ -88,12 +84,12 @@ impl Command for Rm {
     }
 
     fn examples(&self) -> Vec<Example> {
-        let mut examples = vec![
-            Example {
-                description: "Delete or move a file to the system trash (depending on 'rm_always_trash' config option)",
-                example: "rm file.txt",
-                result: None,
-            }];
+        let mut examples = vec![Example {
+            description:
+                "Delete, or move a file to the trash (based on the 'always_trash' config option)",
+            example: "rm file.txt",
+            result: None,
+        }];
         #[cfg(all(
             feature = "trash-support",
             not(target_os = "android"),
@@ -101,19 +97,25 @@ impl Command for Rm {
         ))]
         examples.append(&mut vec![
             Example {
-                description: "Move a file to the system trash",
+                description: "Move a file to the trash",
                 example: "rm --trash file.txt",
                 result: None,
             },
             Example {
-                description: "Delete a file permanently",
+                description:
+                    "Delete a file permanently, even if the 'always_trash' config option is true",
                 example: "rm --permanent file.txt",
                 result: None,
             },
         ]);
         examples.push(Example {
-            description: "Delete a file, and suppress errors if no file is found",
+            description: "Delete a file, ignoring 'file not found' errors",
             example: "rm --force file.txt",
+            result: None,
+        });
+        examples.push(Example {
+            description: "Delete all 0KB files in the current directory",
+            example: "ls | where size == 0KB && type == file | each { rm $in.name } | null",
             result: None,
         });
         examples
@@ -164,7 +166,7 @@ fn rm(
         if rm_always_trash {
             return Err(ShellError::GenericError(
                 "Cannot execute `rm`; the current configuration specifies \
-                    `rm_always_trash = true`, but the current nu executable was not \
+                    `always_trash = true`, but the current nu executable was not \
                     built with feature `trash_support` or trash is not supported on \
                     your platform."
                     .into(),

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -63,7 +63,11 @@ impl Command for Rm {
             );
         sig.switch("recursive", "delete subdirectories recursively", Some('r'))
             .switch("force", "suppress error when no file", Some('f'))
-            .switch("verbose", "make rm to be verbose, showing files been deleted", Some('v'))
+            .switch(
+                "verbose",
+                "make rm to be verbose, showing files been deleted",
+                Some('v'),
+            )
             .switch("interactive", "ask user to confirm action", Some('i'))
             .rest(
                 "rest",

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -90,7 +90,7 @@ impl Command for Rm {
     fn examples(&self) -> Vec<Example> {
         let mut examples = vec![Example {
             description:
-                "Delete, or move a file to the trash (based on the 'always_trash' config option)",
+                "Delete or move a file to the trash (depending on 'always_trash' config option)",
             example: "rm file.txt",
             result: None,
         }];
@@ -106,8 +106,7 @@ impl Command for Rm {
                 result: None,
             },
             Example {
-                description:
-                    "Delete a file permanently, even if the 'always_trash' config option is true",
+                description: "Delete a file permanently",
                 example: "rm --permanent file.txt",
                 result: None,
             },
@@ -115,11 +114,6 @@ impl Command for Rm {
         examples.push(Example {
             description: "Delete a file, and suppress errors if no file is found",
             example: "rm --force file.txt",
-            result: None,
-        });
-        examples.push(Example {
-            description: "Delete all 0KB files in the current directory",
-            example: "ls | where size == 0KB && type == file | each { rm $in.name } | null",
             result: None,
         });
         examples

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -226,7 +226,7 @@ fn removes_multiple_files_with_asterisks() {
 
 #[test]
 fn removes_multiple_files_with_each() {
-    Playground::setup("rm_test_10", |dirs, sandbox| {
+    Playground::setup("rm_test_11b", |dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("a.txt"),
             EmptyFile("b.txt"),

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -225,27 +225,6 @@ fn removes_multiple_files_with_asterisks() {
 }
 
 #[test]
-fn removes_multiple_files_with_each() {
-    Playground::setup("rm_test_11b", |dirs, sandbox| {
-        sandbox.with_files(vec![
-            EmptyFile("a.txt"),
-            EmptyFile("b.txt"),
-            EmptyFile("c.txt"),
-        ]);
-
-        nu!(
-            cwd: dirs.test(),
-            "[[name]; [a.txt] [b.txt] [c.txt]] | each { rm $in.name }"
-        );
-
-        assert_eq!(
-            Playground::glob_vec(&format!("{}/*", dirs.test().display())),
-            Vec::<std::path::PathBuf>::new()
-        );
-    })
-}
-
-#[test]
 fn allows_doubly_specified_file() {
     Playground::setup("rm_test_12", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("yehuda.txt"), EmptyFile("jonathan.toml")]);

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -225,6 +225,27 @@ fn removes_multiple_files_with_asterisks() {
 }
 
 #[test]
+fn removes_multiple_files_with_each() {
+    Playground::setup("rm_test_10", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("a.txt"),
+            EmptyFile("b.txt"),
+            EmptyFile("c.txt"),
+        ]);
+
+        nu!(
+            cwd: dirs.test(),
+            "[[name]; [a.txt] [b.txt] [c.txt]] | each { rm $in.name }"
+        );
+
+        assert_eq!(
+            Playground::glob_vec(&format!("{}/*", dirs.test().display())),
+            Vec::<std::path::PathBuf>::new()
+        );
+    })
+}
+
+#[test]
 fn allows_doubly_specified_file() {
     Playground::setup("rm_test_12", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("yehuda.txt"), EmptyFile("jonathan.toml")]);

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -187,6 +187,8 @@ impl Value {
 
         let mut config = Config::default();
 
+        let mut legacy_options_used = false;
+
         if let Ok(v) = v {
             for (key, value) in v.0.iter().zip(v.1) {
                 let key = key.as_str();
@@ -625,6 +627,7 @@ impl Value {
                     }
                     // Legacy config options (deprecated as of 2022-11-02)
                     "use_ls_colors" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.use_ls_colors = b;
                         } else {
@@ -632,6 +635,7 @@ impl Value {
                         }
                     }
                     "rm_always_trash" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.rm_always_trash = b;
                         } else {
@@ -639,6 +643,7 @@ impl Value {
                         }
                     }
                     "history_file_format" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_string() {
                             let val_str = b.to_lowercase();
                             config.history_file_format = match val_str.as_ref() {
@@ -656,6 +661,7 @@ impl Value {
                         }
                     }
                     "sync_history_on_enter" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.sync_history_on_enter = b;
                         } else {
@@ -663,6 +669,7 @@ impl Value {
                         }
                     }
                     "max_history_size" => {
+                        legacy_options_used = true;
                         if let Ok(i) = value.as_i64() {
                             config.max_history_size = i;
                         } else {
@@ -670,6 +677,7 @@ impl Value {
                         }
                     }
                     "quick_completions" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.quick_completions = b;
                         } else {
@@ -677,6 +685,7 @@ impl Value {
                         }
                     }
                     "partial_completions" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.partial_completions = b;
                         } else {
@@ -684,6 +693,7 @@ impl Value {
                         }
                     }
                     "max_external_completion_results" => {
+                        legacy_options_used = true;
                         if let Ok(i) = value.as_integer() {
                             config.max_external_completion_results = i;
                         } else {
@@ -693,6 +703,7 @@ impl Value {
                         }
                     }
                     "completion_algorithm" => {
+                        legacy_options_used = true;
                         if let Ok(v) = value.as_string() {
                             let val_str = v.to_lowercase();
                             config.completion_algorithm = match val_str.as_ref() {
@@ -711,6 +722,7 @@ impl Value {
                         }
                     }
                     "case_sensitive_completions" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.case_sensitive_completions = b;
                         } else {
@@ -718,6 +730,7 @@ impl Value {
                         }
                     }
                     "enable_external_completion" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.enable_external_completion = b;
                         } else {
@@ -726,19 +739,25 @@ impl Value {
                     }
 
                     "external_completer" => {
+                        legacy_options_used = true;
                         if let Ok(v) = value.as_block() {
                             config.external_completer = Some(v)
                         }
                     }
                     "table_mode" => {
+                        legacy_options_used = true;
                         if let Ok(v) = value.as_string() {
                             config.table_mode = v;
                         } else {
                             eprintln!("$env.config.table_mode is not a string")
                         }
                     }
-                    "table_trim" => config.trim_strategy = try_parse_trim_strategy(value, &config)?,
+                    "table_trim" => {
+                        legacy_options_used = true;
+                        config.trim_strategy = try_parse_trim_strategy(value, &config)?
+                    }
                     "show_clickable_links_in_ls" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.show_clickable_links_in_ls = b;
                         } else {
@@ -746,6 +765,7 @@ impl Value {
                         }
                     }
                     "cd_with_abbreviations" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.cd_with_abbreviations = b;
                         } else {
@@ -753,6 +773,7 @@ impl Value {
                         }
                     }
                     "filesize_metric" => {
+                        legacy_options_used = true;
                         if let Ok(b) = value.as_bool() {
                             config.filesize_metric = b;
                         } else {
@@ -760,6 +781,7 @@ impl Value {
                         }
                     }
                     "filesize_format" => {
+                        legacy_options_used = true;
                         if let Ok(v) = value.as_string() {
                             config.filesize_format = v.to_lowercase();
                         } else {
@@ -774,6 +796,13 @@ impl Value {
             }
         } else {
             eprintln!("$env.config is not a record");
+        }
+
+        if legacy_options_used {
+            eprintln!(
+                r#"The format of $env.config has recently changed, and several options have been grouped into sub-records. You may need to update your config.nu file.
+Please consult https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html for details. Support for the old format will be removed in version 0.80."#
+            );
         }
 
         Ok(config)

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -574,14 +574,14 @@ impl Value {
                             eprintln!("$env.config.{} is not a string", key)
                         }
                     }
-                    "menus" => match create_menus(value, &config) {
+                    "menus" => match create_menus(value) {
                         Ok(map) => config.menus = map,
                         Err(e) => {
                             eprintln!("$env.config.{} is not a valid list of menus", key);
                             eprintln!("{:?}", e);
                         }
                     },
-                    "keybindings" => match create_keybindings(value, &config) {
+                    "keybindings" => match create_keybindings(value) {
                         Ok(keybindings) => config.keybindings = keybindings,
                         Err(e) => {
                             eprintln!("$env.config.{} is not a valid keybindings list", key);

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -112,7 +112,7 @@ impl Default for Config {
             keybindings: Vec::new(),
             menus: Vec::new(),
             hooks: Hooks::new(),
-            rm_always_trash: true,
+            rm_always_trash: false,
             shell_integration: false,
             buffer_editor: String::new(),
             table_index_mode: TableIndexMode::Always,

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -801,7 +801,7 @@ impl Value {
         if legacy_options_used {
             eprintln!(
                 r#"The format of $env.config has recently changed, and several options have been grouped into sub-records. You may need to update your config.nu file.
-Please consult https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html for details. Support for the old format will be removed in version 0.80."#
+Please consult https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html for details. Support for the old format will be removed in an upcoming Nu release."#
             );
         }
 

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -248,7 +248,7 @@ let-env config = {
     clickable_links: true # enable or disable clickable links. Your terminal has to support links.
   }
   rm: {
-    always_trash: true # always act as if -t was given. Can be overridden with -p
+    always_trash: false # always act as if -t was given. Can be overridden with -p
   }
   cd: {
     abbreviations: true # allows `cd s/o/f` to expand to `cd some/other/folder`

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -243,43 +243,55 @@ let light_theme = {
 
 # The default config record. This is where much of your global configuration is setup.
 let-env config = {
-  external_completer: null # check 'carapace_completer' above to as example
-  filesize_metric: false # true => (KB, MB, GB), false => (KiB, MiB, GiB)
-  table_mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-  use_ls_colors: true
-  rm_always_trash: false
+  ls: {
+    use_ls_colors: true # use the LS_COLORS environment variable to colorize output
+    clickable_links: true # enable or disable clickable links. Your terminal has to support links.
+  }
+  rm: {
+    always_trash: true # always act as if -t was given. Can be overridden with -p
+  }
+  cd: {
+    abbreviations: true # allows `cd s/o/f` to expand to `cd some/other/folder`
+  }
+  table: {
+    mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
+    index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
+    trim: {
+      methodology: wrapping # wrapping or truncating
+      wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
+      truncating_suffix: "..." # A suffix used by the 'truncating' methodology
+    }
+  }
+  history: {
+    max_size: 10000 # Session has to be reloaded for this to take effect
+    sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
+    file_format: "plaintext" # "sqlite" or "plaintext"
+  }
+  completions: {
+    case_sensitive: false # set to true to enable case-sensitive completions
+    quick: true  # set this to false to prevent auto-selecting completions when only one remains
+    partial: true  # set this to false to prevent partial filling of the prompt
+    algorithm: "prefix"  # prefix or fuzzy
+    external: {
+      enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
+      max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
+      completer: null # check 'carapace_completer' above as an example
+    }
+  }
+  filesize: {
+    metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
+    format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
+  }
   color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
   use_grid_icons: true
   footer_mode: "25" # always, never, number_of_rows, auto
-  quick_completions: true  # set this to false to prevent auto-selecting completions when only one remains
-  partial_completions: true  # set this to false to prevent partial filling of the prompt
-  completion_algorithm: "prefix"  # prefix, fuzzy
   float_precision: 2
   # buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
   use_ansi_coloring: true
-  filesize_format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
   edit_mode: emacs # emacs, vi
-  max_history_size: 10000 # Session has to be reloaded for this to take effect
-  sync_history_on_enter: true # Enable to share the history between multiple sessions, else you have to close the session to persist history to file
-  history_file_format: "plaintext" # "sqlite" or "plaintext"
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
-  table_index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
-  cd_with_abbreviations: false # set to true to allow you to do things like cd s/o/f and nushell expand it to cd some/other/folder
-  case_sensitive_completions: false # set to true to enable case-sensitive completions
-  enable_external_completion: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
-  max_external_completion_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
-  # A strategy of managing table view in case of limited space.
-  table_trim: {
-    methodology: wrapping, # truncating
-    # A strategy which will be used by 'wrapping' methodology
-    wrapping_try_keep_words: true,
-    # A suffix which will be used with 'truncating' methodology
-    # truncating_suffix: "..."
-  }
   show_banner: true # true or false to enable or disable the banner
-  show_clickable_links_in_ls: true # true or false to enable or disable clickable links in the ls listing. your terminal has to support links.
   render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
-
   hooks: {
     pre_prompt: [{
       $nothing  # replace with source code to run before the prompt is shown


### PR DESCRIPTION
# Description

 * Closes #6911. The new structure of the default config is this:
```
  ls: {
    use_ls_colors: true # use the LS_COLORS environment variable to colorize output
    clickable_links: true # enable or disable clickable links. Your terminal has to support links.
  }
  rm: {
    always_trash: true # always act as if -t was given. Can be overridden with -p
  }
  cd: {
    abbreviations: true # allows `cd s/o/f` to expand to `cd some/other/folder`
  }
  table: {
    mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
    index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
    trim: {
      methodology: wrapping # wrapping or truncating
      wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
      truncating_suffix: "..." # A suffix used by the 'truncating' methodology
    }
  }
  history: {
    max_size: 10000 # Session has to be reloaded for this to take effect
    sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
    file_format: "plaintext" # "sqlite" or "plaintext"
  }
  completions: {
    case_sensitive: false # set to true to enable case-sensitive completions
    quick: true  # set this to false to prevent auto-selecting completions when only one remains
    partial: true  # set this to false to prevent partial filling of the prompt
    algorithm: "prefix"  # prefix or fuzzy
    external: {
      enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
      max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
      completer: null # check 'carapace_completer' above as an example
    }
  }
  filesize: {
    metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
    format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
  }
```
All old options' positions continue to be read as usual, and there are currently no deprecation warnings given.

 * Changes the default `always_trash` option to `true` because I feel it's a safer default for basic usage. (negotiable)
 
 * Also tweaks the wording of `rm`'s help in a few places.

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
