### PR TITLE
Allow iteration blocks to have an optional extra index parameter (alternative to `-n` flags)

### DIFF
--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -56,7 +56,7 @@ impl Command for All {
             },
             Example {
                 description: "Check that all values are equal to twice their index",
-                example: "[0 2 4 6] | all {|e i| $e == $i*2 }",
+                example: "[0 2 4 6] | all {|e i| $e == $i * 2 }",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -56,7 +56,7 @@ impl Command for All {
             },
             Example {
                 description: "Check that all values are equal to twice their index",
-                example: "[0 2 4 6] | all {|e i| $e == $i * 2 }",
+                example: "[0 2 4 6] | all {|el ind| $el == $ind * 2 }",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -55,7 +55,7 @@ impl Command for Any {
             },
             Example {
                 description: "Check if any value is equal to twice its own index",
-                example: "[9 8 7 6] | any {|e i| $e == $i*2 }",
+                example: "[9 8 7 6] | any {|e i| $e == $i * 2 }",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -55,7 +55,7 @@ impl Command for Any {
             },
             Example {
                 description: "Check if any value is equal to twice its own index",
-                example: "[9 8 7 6] | any {|e i| $e == $i * 2 }",
+                example: "[9 8 7 6] | any {|el ind| $el == $ind * 2 }",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -121,7 +121,7 @@ with 'transpose' first."#
                 }),
             },
             Example {
-                example: r#"[1 2 3] | each --keep-empty { if $in == 2 { echo "found 2!"} }"#,
+                example: r#"[1 2 3] | each --keep-empty {|e| if $e == 2 { echo "found 2!"} }"#,
                 description: "Iterate over each element, keeping all results",
                 result: Some(Value::List {
                     vals: stream_test_2,

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -84,7 +84,7 @@ with 'transpose' first."#
 
         vec![
             Example {
-                example: "[1 2 3] | each { 2 * $in }",
+                example: "[1 2 3] | each {|e| 2 * $e }",
                 description: "Multiplies elements in list",
                 result: Some(Value::List {
                     vals: stream_test_1,
@@ -92,7 +92,7 @@ with 'transpose' first."#
                 }),
             },
             Example {
-                example: r#"[1 2 3 2] | each { if $in == 2 { "two" } }"#,
+                example: r#"[1 2 3 2] | each {|e| if $e == 2 { "two" } }"#,
                 description: "Produce a list that has \"two\" for each 2 in the input",
                 result: Some(Value::List {
                     vals: vec![

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -155,8 +155,6 @@ with 'transpose' first."#
         let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
 
-        // Q: Does this have to use a match expression, as compared to
-        // other loop commands like `any` or `all`, which also operate on lists or single values?
         match input {
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
@@ -282,6 +280,8 @@ with 'transpose' first."#
                     }
                 })
                 .into_pipeline_data(ctrlc)),
+            // This match allows non-iterables to be accepted,
+            // which is currently considered undesirable (Nov 2022).
             PipelineData::Value(x, ..) => {
                 if let Some(var) = block.signature.get_positional(0) {
                     if let Some(var_id) = &var.var_id {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -109,7 +109,7 @@ with 'transpose' first."#
                 }),
             },
             Example {
-                example: r#"[1 2 3] | each {|e i| if $e == 2 { $"found 2 at ($i)!"} }"#,
+                example: r#"[1 2 3] | each {|el ind| if $el == 2 { $"found 2 at ($ind)!"} }"#,
                 description:
                     "Iterate over each element, producing a list showing indexes of any 2s",
                 result: Some(Value::List {

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -81,7 +81,7 @@ impl Command for EachWhile {
                 }),
             },
             Example {
-                example: r#"[1 2 3] | each while {|e i| if $e < 2 { $"value ($e) at ($i)!"} }"#,
+                example: r#"[1 2 3] | each while {|el ind| if $el < 2 { $"value ($el) at ($ind)!"} }"#,
                 description: "Iterate over each element, printing the matching value and its index",
                 result: Some(Value::List {
                     vals: vec![Value::String {
@@ -280,7 +280,7 @@ mod test {
     fn uses_optional_index_argument() {
         let actual = nu!(
             cwd: ".", pipeline(
-            r#"[7 8 9 10] | each while {|e i| $e + $i } | to nuon"#
+            r#"[7 8 9 10] | each while {|el ind| $e + $i } | to nuon"#
         ));
 
         assert_eq!(actual.out, "[7, 9, 11, 13]");

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -73,7 +73,7 @@ impl Command for EachWhile {
                 }),
             },
             Example {
-                example: r#"[1 2 stop 3 4] | each while { if $in != 'stop' { $"Output: ($in)" } }"#,
+                example: r#"[1 2 stop 3 4] | each while {|e| if $e != 'stop' { $"Output: ($e)" } }"#,
                 description: "Output elements until reaching 'stop'",
                 result: Some(Value::List {
                     vals: stream_test_2,

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -65,7 +65,7 @@ impl Command for EachWhile {
 
         vec![
             Example {
-                example: "[1 2 3 2 1] | each while { if $in < 3 { $in * 2 } }",
+                example: "[1 2 3 2 1] | each while {|e| if $e < 3 { $e * 2 } }",
                 description: "Produces a list of each element before the 3, doubled",
                 result: Some(Value::List {
                     vals: stream_test_1,
@@ -273,6 +273,7 @@ impl Command for EachWhile {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use nu_test_support::{nu, pipeline};
 
     #[test]
@@ -283,5 +284,11 @@ mod test {
         ));
 
         assert_eq!(actual.out, "[7, 9, 11, 13]");
+    }
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(EachWhile {})
     }
 }

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -280,7 +280,7 @@ mod test {
     fn uses_optional_index_argument() {
         let actual = nu!(
             cwd: ".", pipeline(
-            r#"[7 8 9 10] | each while {|el ind| $e + $i } | to nuon"#
+            r#"[7 8 9 10] | each while {|el ind| $el + $ind } | to nuon"#
         ));
 
         assert_eq!(actual.out, "[7, 9, 11, 13]");

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -15,7 +15,7 @@ impl Command for EachWhile {
     }
 
     fn usage(&self) -> &str {
-        "Run a block on each element of input until a null is found"
+        "Run a block on each row of the input list until a null is found, then create a new list with the results."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -30,10 +30,14 @@ impl Command for EachWhile {
             )])
             .required(
                 "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
                 "the closure to run",
             )
-            .switch("numbered", "iterate with an index", Some('n'))
+            .switch(
+                "numbered",
+                "iterate with an index (deprecated; use a two-parameter block instead)",
+                Some('n'),
+            )
             .category(Category::Filters)
     }
 
@@ -61,24 +65,24 @@ impl Command for EachWhile {
 
         vec![
             Example {
-                example: "[1 2 3] | each while { |it| if $it < 3 { $it * 2 } else { null } }",
-                description: "Multiplies elements below three by two",
+                example: "[1 2 3 2 1] | each while { if $in < 3 { $in * 2 } }",
+                description: "Produces a list of each element before the 3, doubled",
                 result: Some(Value::List {
                     vals: stream_test_1,
                     span: Span::test_data(),
                 }),
             },
             Example {
-                example: r#"[1 2 stop 3 4] | each while { |it| if $it == 'stop' { null } else { $"Output: ($it)" } }"#,
-                description: "Output elements till reaching 'stop'",
+                example: r#"[1 2 stop 3 4] | each while { if $in != 'stop' { $"Output: ($in)" } }"#,
+                description: "Output elements until reaching 'stop'",
                 result: Some(Value::List {
                     vals: stream_test_2,
                     span: Span::test_data(),
                 }),
             },
             Example {
-                example: r#"[1 2 3] | each while -n { |it| if $it.item < 2 { $"value ($it.item) at ($it.index)!"} else { null } }"#,
-                description: "Iterate over each element, print the matching value and its index",
+                example: r#"[1 2 3] | each while {|e i| if $e < 2 { $"value ($e) at ($i)!"} }"#,
+                description: "Iterate over each element, printing the matching value and its index",
                 result: Some(Value::List {
                     vals: vec![Value::String {
                         val: "value 1 at 0!".to_string(),
@@ -111,10 +115,15 @@ impl Command for EachWhile {
         let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
 
+        // Q: Does this have to use a match expression, as compared to
+        // other loop commands like `any` or `all`, which also operate on lists or single values?
         match input {
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::ListStream { .. } => Ok(input
+                // To enumerate over the input (for the index argument),
+                // it must be converted into an iterator using into_iter().
+                // TODO: Could this be changed to .into_interruptible_iter(ctrlc) ?
                 .into_iter()
                 .enumerate()
                 .map_while(move |(idx, x)| {
@@ -143,6 +152,18 @@ impl Command for EachWhile {
                             } else {
                                 stack.add_var(*var_id, x.clone());
                             }
+                        }
+                    }
+                    // Optional second index argument
+                    if let Some(var) = block.signature.get_positional(1) {
+                        if let Some(var_id) = &var.var_id {
+                            stack.add_var(
+                                *var_id,
+                                Value::Int {
+                                    val: idx as i64,
+                                    span,
+                                },
+                            );
                         }
                     }
 
@@ -252,12 +273,15 @@ impl Command for EachWhile {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use nu_test_support::{nu, pipeline};
 
     #[test]
-    fn test_examples() {
-        use crate::test_examples;
+    fn uses_optional_index_argument() {
+        let actual = nu!(
+            cwd: ".", pipeline(
+            r#"[7 8 9 10] | each while {|e i| $e + $i } | to nuon"#
+        ));
 
-        test_examples(EachWhile {})
+        assert_eq!(actual.out, "[7, 9, 11, 13]");
     }
 }

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -115,8 +115,6 @@ impl Command for EachWhile {
         let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
 
-        // Q: Does this have to use a match expression, as compared to
-        // other loop commands like `any` or `all`, which also operate on lists or single values?
         match input {
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
@@ -250,6 +248,8 @@ impl Command for EachWhile {
                 })
                 .fuse()
                 .into_pipeline_data(ctrlc)),
+            // This match allows non-iterables to be accepted,
+            // which is currently considered undesirable (Nov 2022).
             PipelineData::Value(x, ..) => {
                 if let Some(var) = block.signature.get_positional(0) {
                     if let Some(var_id) = &var.var_id {

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -70,7 +70,7 @@ impl Command for Insert {
             }),
         }, Example {
             description: "Insert a column with values equal to their row index, plus the value of 'foo' in each row",
-            example: "[[foo]; [7] [8] [9]] | insert bar {|e i| $e.foo + $i }",
+            example: "[[foo]; [7] [8] [9]] | insert bar {|el ind| $el.foo + $ind }",
             result: Some(Value::List {
                 vals: vec![Value::Record {
                     cols: vec!["foo".into(), "bar".into()],

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -71,13 +71,29 @@ impl Command for Insert {
         }, Example {
             description: "Insert a column with values equal to their row index, plus the value of 'foo' in each row",
             example: "[[foo]; [7] [8] [9]] | insert bar {|e i| $e.foo + $i }",
-            result: Some(Value::Record {
-                cols: vec!["foo".into(), "bar".into()],
-                vals: vec![
-                    Value::test_int(7),
-                    Value::test_int(9),
-                    Value::test_int(11),
-                ],
+            result: Some(Value::List {
+                vals: vec![Value::Record {
+                    cols: vec!["foo".into(), "bar".into()],
+                    vals: vec![
+                        Value::test_int(7),
+                        Value::test_int(7),
+                    ],
+                    span: Span::test_data(),
+                }, Value::Record {
+                    cols: vec!["foo".into(), "bar".into()],
+                    vals: vec![
+                        Value::test_int(8),
+                        Value::test_int(9),
+                    ],
+                    span: Span::test_data(),
+                }, Value::Record {
+                    cols: vec!["foo".into(), "bar".into()],
+                    vals: vec![
+                        Value::test_int(9),
+                        Value::test_int(11),
+                    ],
+                    span: Span::test_data(),
+                }],
                 span: Span::test_data(),
             }),
         }]

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -80,8 +80,6 @@ impl Command for ParEach {
         let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
 
-        // Q: Does this have to use a match expression, as compared to
-        // other loop commands like `any` or `all`, which also operate on lists or single values?
         match input {
             PipelineData::Value(Value::Range { val, .. }, ..) => Ok(val
                 .into_range_iter(ctrlc.clone())?
@@ -342,6 +340,8 @@ impl Command for ParEach {
                 .into_iter()
                 .flatten()
                 .into_pipeline_data(ctrlc)),
+            // This match allows non-iterables to be accepted,
+            // which is currently considered undesirable (Nov 2022).
             PipelineData::Value(x, ..) => {
                 let block = engine_state.get_block(block_id);
 

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -374,7 +374,7 @@ mod test {
     fn uses_optional_index_argument() {
         let actual = nu!(
             cwd: ".", pipeline(
-            r#"[7,8,9,10] | par-each {|e i| $i } | describe"#
+            r#"[7,8,9,10] | par-each {|el ind| $ind } | describe"#
         ));
 
         assert_eq!(actual.out, "list<int>");

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -373,9 +373,9 @@ mod test {
     fn uses_optional_index_argument() {
         let actual = nu!(
             cwd: ".", pipeline(
-            r#"[7,8,9,10] | par-each {|e i| $i } | sort | to nuon"#
+            r#"[7,8,9,10] | par-each {|e i| $i } | describe"#
         ));
 
-        assert_eq!(actual.out, "[0, 1, 2, 3]");
+        assert_eq!(actual.out, "list<int>");
     }
 }

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -367,6 +367,7 @@ impl Command for ParEach {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use nu_test_support::{nu, pipeline};
 
     #[test]
@@ -377,5 +378,12 @@ mod test {
         ));
 
         assert_eq!(actual.out, "list<int>");
+    }
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(ParEach {})
     }
 }

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -27,14 +27,22 @@ impl Command for Reduce {
             )
             .required(
                 "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Any])),
+                SyntaxShape::Closure(Some(vec![
+                    SyntaxShape::Any,
+                    SyntaxShape::Any,
+                    SyntaxShape::Int,
+                ])),
                 "reducing function",
             )
-            .switch("numbered", "iterate with an index", Some('n'))
+            .switch(
+                "numbered",
+                "iterate with an index (deprecated; use a 3-parameter block instead)",
+                Some('n'),
+            )
     }
 
     fn usage(&self) -> &str {
-        "Aggregate a list table to a single value using an accumulator block."
+        "Aggregate a list to a single value using an accumulator block."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -52,10 +60,10 @@ impl Command for Reduce {
                 }),
             },
             Example {
-                example: "[ 1 2 3 ] | reduce -n {|it, acc| $acc.item + $it.item }",
-                description: "Sum values of a list (same as 'math sum')",
+                example: "[ 8 7 6 ] | reduce {|it, acc, ind| $acc + $it + $ind }",
+                description: "Sum values of a list, plus their indexes",
                 result: Some(Value::Int {
-                    val: 6,
+                    val: 24,
                     span: Span::test_data(),
                 }),
             },
@@ -76,16 +84,27 @@ impl Command for Reduce {
                 }),
             },
             Example {
-                example: r#"[ one longest three bar ] | reduce -n { |it, acc|
-                    if ($it.item | str length) > ($acc.item | str length) {
-                        $it.item
-                    } else {
-                        $acc.item
-                    }
-                }"#,
-                description: "Find the longest string and its index",
-                result: Some(Value::String {
-                    val: "longest".to_string(),
+                example: r#"[ one longest three bar ] | reduce -f { len: -1, index: null } { |it, acc, ind|
+        let len = ($it | str length)
+        if $len > $acc.len {
+            { len: $len, index: $ind }
+        } else {
+            $acc
+        }
+    }"#,
+                description: "Find the length and index of the longest string",
+                result: Some(Value::Record {
+                    cols: vec!["len".to_string(), "index".to_string()],
+                    vals: vec![
+                        Value::Int {
+                            val: 7,
+                            span: Span::test_data(),
+                        },
+                        Value::Int {
+                            val: 1,
+                            span: Span::test_data(),
+                        },
+                    ],
                     span: Span::test_data(),
                 }),
             },
@@ -114,6 +133,8 @@ impl Command for Reduce {
         let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
 
+        // To enumerate over the input (for the index argument),
+        // it must be converted into an iterator using into_iter().
         let mut input_iter = input.into_iter();
 
         let (off, start_val) = if let Some(val) = fold {
@@ -170,12 +191,14 @@ impl Command for Reduce {
             // Hence, a 'cd' in the first loop won't affect the next loop.
             stack.with_env(&orig_env_vars, &orig_env_hidden);
 
+            // Element argument
             if let Some(var) = block.signature.get_positional(0) {
                 if let Some(var_id) = &var.var_id {
                     stack.add_var(*var_id, x);
                 }
             }
 
+            // Accumulator argument
             if let Some(var) = block.signature.get_positional(1) {
                 if let Some(var_id) = &var.var_id {
                     acc = if numbered {
@@ -199,6 +222,18 @@ impl Command for Reduce {
                     };
 
                     stack.add_var(*var_id, acc);
+                }
+            }
+            // Optional third index argument
+            if let Some(var) = block.signature.get_positional(2) {
+                if let Some(var_id) = &var.var_id {
+                    stack.add_var(
+                        *var_id,
+                        Value::Int {
+                            val: idx as i64,
+                            span,
+                        },
+                    );
                 }
             }
 

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -78,35 +78,13 @@ impl Command for Reduce {
             Example {
                 example: r#"[ i o t ] | reduce -f "Arthur, King of the Britons" {|it, acc| $acc | str replace -a $it "X" }"#,
                 description: "Replace selected characters in a string with 'X'",
-                result: Some(Value::String {
-                    val: "ArXhur, KXng Xf Xhe BrXXXns".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::test_string("ArXhur, KXng Xf Xhe BrXXXns")),
             },
             Example {
-                example: r#"[ one longest three bar ] | reduce -f { len: -1, index: null } { |it, acc, ind|
-        let len = ($it | str length)
-        if $len > $acc.len {
-            { len: $len, index: $ind }
-        } else {
-            $acc
-        }
-    }"#,
-                description: "Find the length and index of the longest string",
-                result: Some(Value::Record {
-                    cols: vec!["len".to_string(), "index".to_string()],
-                    vals: vec![
-                        Value::Int {
-                            val: 7,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 1,
-                            span: Span::test_data(),
-                        },
-                    ],
-                    span: Span::test_data(),
-                }),
+                example: r#"['foo.gz', 'bar.gz', 'baz.gz'] | reduce -f '' {|str all ind| $"($all)(if $ind != 0 {'; '})($ind + 1)-($str)" }"#,
+                description:
+                    "Add ascending numbers to each of the filenames, and join with semicolons.",
+                result: Some(Value::test_string("1-foo.gz; 2-bar.gz; 3-baz.gz")),
             },
         ]
     }

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -63,7 +63,7 @@ impl Command for Reduce {
                 example: "[ 8 7 6 ] | reduce {|it, acc, ind| $acc + $it + $ind }",
                 description: "Sum values of a list, plus their indexes",
                 result: Some(Value::Int {
-                    val: 24,
+                    val: 22,
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -48,7 +48,7 @@ impl Command for Update {
         vec![
             Example {
                 description: "Update a column value",
-                example: "echo {'name': 'nu', 'stars': 5} | update name 'Nushell'",
+                example: "{'name': 'nu', 'stars': 5} | update name 'Nushell'",
                 result: Some(Value::Record {
                     cols: vec!["name".into(), "stars".into()],
                     vals: vec![Value::test_string("Nushell"), Value::test_int(5)],
@@ -57,7 +57,7 @@ impl Command for Update {
             },
             Example {
                 description: "Use in block form for more involved updating logic",
-                example: "echo [[count fruit]; [1 'apple']] | update count {|row index| $row.fruit | str length + $index }",
+                example: "[[count fruit]; [1 'apple']] | update count {|row index| ($row.fruit | str length) + $index }",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["count".into(), "fruit".into()],

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -69,7 +69,7 @@ impl Command for Update {
             },
             Example {
                 description: "Alter each value in the 'authors' column to use a single string instead of a list",
-                example: "[[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors { $in.authors | str join ','}",
+                example: "[[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors {|row| $row.authors | str join ','}",
                 result: Some(Value::List { vals: vec![Value::Record { cols: vec!["project".into(), "authors".into()], vals: vec![Value::test_string("nu"), Value::test_string("Andrés,JT,Yehuda")], span: Span::test_data()}], span: Span::test_data()}),
             },
         ]

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -102,12 +102,11 @@ fn update(
         let orig_env_vars = stack.env_vars.clone();
         let orig_env_hidden = stack.env_hidden.clone();
 
-        // To enumerate over the input (for the optional index argument),
-        // it must be converted into an iterator using into_iter().
-        Ok(input
-            .into_iter()
-            .enumerate()
-            .map(move |(idx, mut input)| {
+        // enumerate() can't be used here because it converts records into tables
+        // when combined with into_pipeline_data(). Hence, the index is tracked manually like so.
+        let mut idx: i64 = 0;
+        input.map(
+            move |mut input| {
                 // with_env() is used here to ensure that each iteration uses
                 // a different set of environment variables.
                 // Hence, a 'cd' in the first loop won't affect the next loop.
@@ -121,14 +120,9 @@ fn update(
                 // Optional index argument
                 if let Some(var) = block.signature.get_positional(1) {
                     if let Some(var_id) = &var.var_id {
-                        stack.add_var(
-                            *var_id,
-                            Value::Int {
-                                val: idx as i64,
-                                span,
-                            },
-                        );
+                        stack.add_var(*var_id, Value::Int { val: idx, span });
                     }
+                    idx += 1;
                 }
 
                 let output = eval_block(
@@ -152,8 +146,9 @@ fn update(
                     }
                     Err(e) => Value::Error { error: e },
                 }
-            })
-            .into_pipeline_data(ctrlc))
+            },
+            ctrlc,
+        )
     } else {
         if let Some(PathMember::Int { val, span }) = cell_path.members.get(0) {
             let mut input = input.into_iter();

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -113,10 +113,11 @@ fn upsert(
         let orig_env_vars = stack.env_vars.clone();
         let orig_env_hidden = stack.env_hidden.clone();
 
-        Ok(input
-            .into_iter()
-            .enumerate()
-            .map(move |(idx, mut input)| {
+        // enumerate() can't be used here because it converts records into tables
+        // when combined with into_pipeline_data(). Hence, the index is tracked manually like so.
+        let mut idx: i64 = 0;
+        input.map(
+            move |mut input| {
                 // with_env() is used here to ensure that each iteration uses
                 // a different set of environment variables.
                 // Hence, a 'cd' in the first loop won't affect the next loop.
@@ -130,14 +131,9 @@ fn upsert(
                 // Optional index argument
                 if let Some(var) = block.signature.get_positional(1) {
                     if let Some(var_id) = &var.var_id {
-                        stack.add_var(
-                            *var_id,
-                            Value::Int {
-                                val: idx as i64,
-                                span,
-                            },
-                        );
+                        stack.add_var(*var_id, Value::Int { val: idx, span });
                     }
+                    idx += 1;
                 }
 
                 let output = eval_block(
@@ -161,8 +157,9 @@ fn upsert(
                     }
                     Err(e) => Value::Error { error: e },
                 }
-            })
-            .into_pipeline_data(ctrlc))
+            },
+            ctrlc,
+        )
     } else {
         if let Some(PathMember::Int { val, span }) = cell_path.members.get(0) {
             let mut input = input.into_iter();

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -59,7 +59,7 @@ impl Command for Upsert {
             result: Some(Value::Record { cols: vec!["name".into(), "stars".into(), "language".into()], vals: vec![Value::test_string("nu"), Value::test_int(5), Value::test_string("Rust")], span: Span::test_data()}),
         }, Example {
             description: "Use in closure form for more involved updating logic",
-            example: "[[count fruit]; [1 'apple']] | upsert count {|row index| $row.fruit | str length + $index }",
+            example: "[[count fruit]; [1 'apple']] | upsert count {|row index| ($row.fruit | str length) + $index }",
             result: Some(Value::List { vals: vec![Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(5), Value::test_string("apple")], span: Span::test_data()}], span: Span::test_data()}),
         },
         Example {

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -61,8 +61,6 @@ impl Command for Where {
             let redirect_stdout = call.redirect_stdout;
             let redirect_stderr = call.redirect_stderr;
 
-            // Q: Does this have to use a match expression, as compared to
-            // other loop commands like `any` or `all`, which also operate on lists or single values?
             match input {
                 PipelineData::Value(Value::Range { .. }, ..)
                 | PipelineData::Value(Value::List { .. }, ..)
@@ -175,6 +173,8 @@ impl Command for Where {
                         }
                     })
                     .into_pipeline_data(ctrlc)),
+                // This match allows non-iterables to be accepted,
+                // which is currently considered undesirable (Nov 2022).
                 PipelineData::Value(x, ..) => {
                     // see note above about with_env()
                     stack.with_env(&orig_env_vars, &orig_env_hidden);

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -125,7 +125,8 @@ impl Command for Where {
                     ..
                 } => Ok(stream
                     .into_iter()
-                    .filter_map(move |x| {
+                    .enumerate()
+                    .filter_map(move |(idx, x)| {
                         // see note above about with_env()
                         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
@@ -137,6 +138,18 @@ impl Command for Where {
                         if let Some(var) = block.signature.get_positional(0) {
                             if let Some(var_id) = &var.var_id {
                                 stack.add_var(*var_id, x.clone());
+                            }
+                        }
+                        // Optional index argument
+                        if let Some(var) = block.signature.get_positional(1) {
+                            if let Some(var_id) = &var.var_id {
+                                stack.add_var(
+                                    *var_id,
+                                    Value::Int {
+                                        val: idx as i64,
+                                        span,
+                                    },
+                                );
                             }
                         }
 
@@ -212,14 +225,26 @@ impl Command for Where {
 
                 let redirect_stdout = call.redirect_stdout;
                 let redirect_stderr = call.redirect_stderr;
-                Ok(input
-                    .into_iter()
-                    .filter_map(move |value| {
+                Ok(input.into_iter()
+                    .enumerate()
+                    .filter_map(move |(idx, value)| {
                         stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                         if let Some(var) = block.signature.get_positional(0) {
                             if let Some(var_id) = &var.var_id {
                                 stack.add_var(*var_id, value.clone());
+                            }
+                        }
+                        // Optional index argument
+                        if let Some(var) = block.signature.get_positional(1) {
+                            if let Some(var_id) = &var.var_id {
+                                stack.add_var(
+                                    *var_id,
+                                    Value::Int {
+                                        val: idx as i64,
+                                        span,
+                                    },
+                                );
                             }
                         }
                         let result = eval_block(

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -225,7 +225,8 @@ impl Command for Where {
 
                 let redirect_stdout = call.redirect_stdout;
                 let redirect_stderr = call.redirect_stderr;
-                Ok(input.into_iter()
+                Ok(input
+                    .into_iter()
                     .enumerate()
                     .filter_map(move |(idx, value)| {
                         stack.with_env(&orig_env_vars, &orig_env_hidden);

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -109,6 +109,16 @@ fn early_exits_with_0_param_blocks() {
 }
 
 #[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9] | all {|e i| print $i | true }"#
+    ));
+
+    assert_eq!(actual.out, "012true");
+}
+
+#[test]
 fn unique_env_each_iteration() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -112,7 +112,7 @@ fn early_exits_with_0_param_blocks() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[7 8 9] | all {|e i| print $i | true }"#
+        r#"[7 8 9] | all {|el ind| print $ind | true }"#
     ));
 
     assert_eq!(actual.out, "012true");

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -85,6 +85,16 @@ fn early_exits_with_0_param_blocks() {
 }
 
 #[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9] | any {|e i| print $i | false }"#
+    ));
+
+    assert_eq!(actual.out, "012false");
+}
+
+#[test]
 fn unique_env_each_iteration() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -88,7 +88,7 @@ fn early_exits_with_0_param_blocks() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[7 8 9] | any {|e i| print $i | false }"#
+        r#"[7 8 9] | any {|el ind| print $ind | false }"#
     ));
 
     assert_eq!(actual.out, "012false");

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -76,7 +76,7 @@ fn each_implicit_it_in_block() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[7 8 9 10] | each {|e i| $i } | to nuon"#
+        r#"[7 8 9 10] | each {|el ind| $ind } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[0, 1, 2, 3]");
@@ -86,7 +86,7 @@ fn uses_optional_index_argument() {
 fn each_while_uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[7 8 9 10] | each while {|e i| $i } | to nuon"#
+        r#"[7 8 9 10] | each while {|el ind| $ind } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[0, 1, 2, 3]");
@@ -96,7 +96,7 @@ fn each_while_uses_optional_index_argument() {
 fn par_each_uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[7 8 9 10] | par-each {|e i| $i } | to nuon"#
+        r#"[7 8 9 10] | par-each {|el ind| $ind } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[0, 1, 2, 3]");

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -71,3 +71,33 @@ fn each_implicit_it_in_block() {
 
     assert_eq!(actual.out, "ace");
 }
+
+#[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9 10] | each {|e i| $i } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[0, 1, 2, 3]");
+}
+
+#[test]
+fn each_while_uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9 10] | each while {|e i| $i } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[0, 1, 2, 3]");
+}
+
+#[test]
+fn par_each_uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9 10] | par-each {|e i| $i } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[0, 1, 2, 3]");
+}

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -90,7 +90,7 @@ fn insert_past_end_list() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | insert b {|e i| $i + 1 + $e.a } | to nuon"#
+        r#"[[a]; [7] [6]] | insert b {|el ind| $ind + 1 + $el.a } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -76,3 +76,13 @@ fn insert_past_end_list() {
 
     assert_eq!(actual.out, r#"[1,2,3,null,null,"abc"]"#);
 }
+
+#[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | insert b {|e i| $i + 1 + $e.a } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");
+}

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -15,6 +15,15 @@ fn insert_the_column() {
 }
 
 #[test]
+fn doesnt_convert_record_to_table() {
+    let actual = nu!(
+        cwd: ".", r#"{a:1} | insert b 2 | to nuon"#
+    );
+
+    assert_eq!(actual.out, "{a: 1, b: 2}");
+}
+
+#[test]
 fn insert_the_column_conflict() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -124,7 +124,7 @@ fn error_reduce_empty() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[18 19 20] | reduce -f 0 {|e a i| $a + $i } | to nuon"#
+        r#"[18 19 20] | reduce -f 0 {|elem accum index| $accum + $index } | to nuon"#
     ));
 
     assert_eq!(actual.out, "3");

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -119,3 +119,13 @@ fn error_reduce_empty() {
 
     assert!(actual.err.contains("needs input"));
 }
+
+#[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[18 19 20] | reduce -f 0 {|e a i| $a + $i } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "3");
+}

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -105,3 +105,13 @@ fn update_nonexistent_column() {
 
     assert!(actual.err.contains("cannot find column 'b'"));
 }
+
+#[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | update a {|e i| $i + 1 + $e.a } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[a]; [8], [8]]");
+}

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -119,7 +119,7 @@ fn update_nonexistent_column() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | update a {|e i| $i + 1 + $e.a } | to nuon"#
+        r#"[[a]; [7] [6]] | update a {|el ind| $ind + 1 + $el.a } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[[a]; [8], [8]]");

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -14,6 +14,15 @@ fn sets_the_column() {
     assert_eq!(actual.out, "0.7.0");
 }
 
+#[test]
+fn doesnt_convert_record_to_table() {
+    let actual = nu!(
+        cwd: ".", r#"{a:1} | update a 2 | to nuon"#
+    );
+
+    assert_eq!(actual.out, "{a: 2}");
+}
+
 #[cfg(features = "inc")]
 #[test]
 fn sets_the_column_from_a_block_run_output() {

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -69,11 +69,21 @@ fn sets_the_column_from_a_subexpression() {
 }
 
 #[test]
-fn uses_optional_index_argument() {
+fn uses_optional_index_argument_inserting() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"[[a]; [7] [6]] | upsert b {|el ind| $ind + 1 + $el.a } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");
+}
+
+#[test]
+fn uses_optional_index_argument_updating() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | upsert a {|el ind| $ind + 1 + $el.a } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[a]; [8], [8]]");
 }

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -72,7 +72,7 @@ fn sets_the_column_from_a_subexpression() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | upsert b {|e i| $i + 1 + $e.a } | to nuon"#
+        r#"[[a]; [7] [6]] | upsert b {|el ind| $ind + 1 + $el.a } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -14,6 +14,15 @@ fn sets_the_column() {
     assert_eq!(actual.out, "0.7.0");
 }
 
+#[test]
+fn doesnt_convert_record_to_table() {
+    let actual = nu!(
+        cwd: ".", r#"{a:1} | upsert a 2 | to nuon"#
+    );
+
+    assert_eq!(actual.out, "{a: 2}");
+}
+
 #[cfg(features = "inc")]
 #[test]
 fn sets_the_column_from_a_block_run_output() {

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -58,3 +58,13 @@ fn sets_the_column_from_a_subexpression() {
 
     assert_eq!(actual.out, "true");
 }
+
+#[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | upsert b {|e i| $i + 1 + $e.a } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");
+}

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -168,3 +168,13 @@ fn contains_operator() {
 
     assert_eq!(actual.out, "2");
 }
+
+#[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9 10] | where {|e i| $i < 2 } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[7, 8]");
+}

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -72,6 +72,16 @@ fn where_not_in_table() {
     assert_eq!(actual.out, "4");
 }
 
+#[test]
+fn uses_optional_index_argument() {
+    let actual = nu!(
+        cwd: ".",
+        r#"[7 8 9 10] | where {|e i| $i < 2 } | to nuon"#
+    );
+
+    assert_eq!(actual.out, "[7, 8]");
+}
+
 #[cfg(feature = "database")]
 #[test]
 fn binary_operator_comparisons() {
@@ -167,14 +177,4 @@ fn contains_operator() {
     ));
 
     assert_eq!(actual.out, "2");
-}
-
-#[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9 10] | where {|e i| $i < 2 } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[7, 8]");
 }

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -76,7 +76,7 @@ fn where_not_in_table() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".",
-        r#"[7 8 9 10] | where {|e i| $i < 2 } | to nuon"#
+        r#"[7 8 9 10] | where {|el ind| $ind < 2 } | to nuon"#
     );
 
     assert_eq!(actual.out, "[7, 8]");

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -349,7 +349,7 @@ fn proper_missing_param() -> TestResult {
 
 #[test]
 fn block_arity_check1() -> TestResult {
-    fail_test(r#"ls | each { |x, y| 1}"#, "expected 1 block parameter")
+    fail_test(r#"ls | each { |x, y, z| 1}"#, "expected 2 block parameters")
 }
 
 #[test]


### PR DESCRIPTION
# Description

This implements my solution to https://github.com/nushell/nushell/issues/4605#issuecomment-1296243929. Alters `all`, `any`, `each while`, `each`, `insert`, `par-each`, `reduce`, `update`, `upsert` and `where` so that their blocks take an optional extra parameter containing the index. This is meant to be a replacement for `-n` (which is agreed to be unnecessarily verbose by me and the issue creator) for those commands that support it (only `each while`, `each`, `par-each` and `where`) and adds this index-accessing functionality to the others.

`reduce`, as a result, may take 3 parameters (element, accumulator, index) as well as 2, 1 or 0. The others now may take 2 parameters, 1 or 0.

I did NOT change `for`, even though it also uses `-n`, because I ran into some difficulties (involving duplicate `var_id`s) and decided to leave it to the experts.

This also adjusts various help strings and adds examples for the new functionality.

`-n` is now listed as deprecated in the help for the aforementioned commands (negotiable).

NO FUNCTIONALITY HAS BEEN REMOVED YET.

Any remarks or recommendations for coding/implementation are welcome.

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
