### PR TITLE
Remove unnecessary clone in par-each

### DIFF
--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -106,7 +106,7 @@ impl Command for ParEach {
 
                     let val_span = x.span();
                     match eval_block(
-                        &engine_state,
+                        engine_state,
                         &mut stack,
                         block,
                         x.into_pipeline_data(),
@@ -158,7 +158,7 @@ impl Command for ParEach {
 
                     let val_span = x.span();
                     match eval_block(
-                        &engine_state,
+                        engine_state,
                         &mut stack,
                         block,
                         x.into_pipeline_data(),
@@ -209,7 +209,7 @@ impl Command for ParEach {
 
                     let val_span = x.span();
                     match eval_block(
-                        &engine_state,
+                        engine_state,
                         &mut stack,
                         block,
                         x.into_pipeline_data(),
@@ -268,7 +268,7 @@ impl Command for ParEach {
                     }
 
                     match eval_block(
-                        &engine_state,
+                        engine_state,
                         &mut stack,
                         block,
                         x.into_pipeline_data(),
@@ -293,7 +293,7 @@ impl Command for ParEach {
                 }
 
                 eval_block(
-                    &engine_state,
+                    engine_state,
                     &mut stack,
                     block,
                     x.into_pipeline_data(),

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -65,7 +65,6 @@ impl Command for ParEach {
         let numbered = call.has_flag("numbered");
         let metadata = input.metadata();
         let ctrlc = engine_state.ctrlc.clone();
-        let engine_state = engine_state.clone();
         let block_id = capture_block.block_id;
         let mut stack = stack.captures_to_stack(&capture_block.captures);
         let span = call.head;


### PR DESCRIPTION
# Description

Removes an unnecessary clone of the EngineState in `par-each`. I did see about a 5-7% performance increase for the benchmark I tried as a result.

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
