### PR TITLE
return Error if get meet nothing and without "i"

### DIFF
--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -74,7 +74,29 @@ impl Command for Get {
                     Err(_) => Ok(Value::Nothing { span: call.head }.into_pipeline_data()),
                 }
             } else {
-                output
+                match output {
+                    Ok(val) => {
+                        let val_check = val.into_value(span);
+                        match val_check {
+                            Value::List {
+                                ref vals,
+                                span: spanchild,
+                            } => {
+                                if vals.iter().any(|unit| unit.is_empty()) {
+                                    Err(nu_protocol::ShellError::CantFindColumn(
+                                        "Empty cell".to_string(),
+                                        spanchild,
+                                        span,
+                                    ))
+                                } else {
+                                    Ok(val_check.into_pipeline_data())
+                                }
+                            }
+                            val => Ok(val.into_pipeline_data()),
+                        }
+                    }
+                    Err(e) => Err(e),
+                }
             }
         } else {
             let mut output = vec![];
@@ -87,8 +109,18 @@ impl Command for Get {
                 let val = input.clone().follow_cell_path(&path.members, !sensitive);
 
                 if ignore_errors {
-                    if let Ok(val) = val {
-                        output.push(val);
+                    match val {
+                        Ok(Value::Nothing { span: spanchild }) => {
+                            return Err(nu_protocol::ShellError::CantFindColumn(
+                                "Nothing".to_string(),
+                                spanchild,
+                                span,
+                            ));
+                        }
+                        Ok(val) => {
+                            output.push(val);
+                        }
+                        Err(_) => {}
                     }
                 } else {
                     output.push(val?);

--- a/crates/nu-command/tests/commands/cal.rs
+++ b/crates/nu-command/tests/commands/cal.rs
@@ -71,7 +71,7 @@ fn cal_sees_pipeline_year() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        cal --full-year 1020 | get monday | first 4 | to json -r
+        cal --full-year 1020 | get -i monday | first 4 | to json -r
         "#
     ));
 

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -16,7 +16,7 @@ fn filters_by_unit_size_comparison() {
 fn filters_with_nothing_comparison() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r#"'[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from json | get foo | compact | where $it > 1 | math sum"#
+        r#"'[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from json | get -i foo | compact | where $it > 1 | math sum"#
     );
 
     assert_eq!(actual.out, "7");


### PR DESCRIPTION
# Description

relate issue https://github.com/nushell/nushell/issues/6969

before:
![image](https://user-images.githubusercontent.com/60290287/206604094-5eb78d2c-a798-49e4-ad42-8c8afb46ba3d.png)

after
![image](https://user-images.githubusercontent.com/60290287/206606443-39b1fab9-436d-48ba-8c2c-fb0237b1263a.png)


# Tests

Make sure you've done the following:

- [x] Add tests that cover your changes, either in the command examples, the crate/tests folder, or in the /tests folder.
- [x] Try to think about corner cases and various ways how your changes could break. Cover them with tests.
- [ ] If adding tests is not possible, please document in the PR body a minimal example with steps on how to reproduce so one can verify your change works.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace --features=extra` to check that all the tests pass

# Documentation

- [ ] If your PR touches a user-facing nushell feature then make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary.

