### PR TITLE
Rename column name from command to name for consistency

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -962,7 +962,7 @@ pub fn create_scope(
                 }
             }
 
-            cols.push("command".into());
+            cols.push("name".into());
             vals.push(Value::String {
                 val: String::from_utf8_lossy(command_name).to_string(),
                 span,


### PR DESCRIPTION
# Description
This PR should close issue #6922, which renames the column name of `$nu.scope.commands` from "commands" to "name". 

Now, both commands have the same column name which helps for consistency.
![image](https://user-images.githubusercontent.com/11776554/200075334-5f0f575a-596b-447c-ae3e-59ec41983b28.png)

# Tests + Formatting
- [X]cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
-[X] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
-[X] `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
