### PR TITLE
Fix for escaping backslashes in interpolated strings (fixes #6737)

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1604,87 +1604,104 @@ pub fn parse_string_interpolation(
 
     let mut b = start;
 
+    let mut consecutive_backslashes: usize = 0;
+
     while b != end {
-        if contents[b - start] == b'('
-            && (if double_quote && (b - start) > 0 {
-                contents[b - start - 1] != b'\\'
-            } else {
-                true
-            })
-            && mode == InterpolationMode::String
-        {
-            mode = InterpolationMode::Expression;
-            if token_start < b {
-                let span = Span {
-                    start: token_start,
-                    end: b,
-                };
-                let str_contents = working_set.get_span_contents(span);
+        let current_byte = contents[b - start];
 
-                let str_contents = if double_quote {
-                    let (str_contents, err) = unescape_string(str_contents, span);
-                    error = error.or(err);
+        match mode {
+            InterpolationMode::String => {
+                let preceding_consecutive_backslashes = consecutive_backslashes;
 
-                    str_contents
+                let is_backslash = current_byte == b'\\';
+                consecutive_backslashes = if is_backslash {
+                    preceding_consecutive_backslashes + 1
                 } else {
-                    str_contents.to_vec()
+                    0
                 };
 
-                output.push(Expression {
-                    expr: Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
-                    span,
-                    ty: Type::String,
-                    custom_completion: None,
-                });
-                token_start = b;
-            }
-        }
-        if mode == InterpolationMode::Expression {
-            let byte = contents[b - start];
-            if let Some(b'\'') = delimiter_stack.last() {
-                if byte == b'\'' {
-                    delimiter_stack.pop();
-                }
-            } else if let Some(b'"') = delimiter_stack.last() {
-                if byte == b'"' {
-                    delimiter_stack.pop();
-                }
-            } else if let Some(b'`') = delimiter_stack.last() {
-                if byte == b'`' {
-                    delimiter_stack.pop();
-                }
-            } else if byte == b'\'' {
-                delimiter_stack.push(b'\'')
-            } else if byte == b'"' {
-                delimiter_stack.push(b'"');
-            } else if byte == b'`' {
-                delimiter_stack.push(b'`')
-            } else if byte == b'(' {
-                delimiter_stack.push(b')');
-            } else if byte == b')' {
-                if let Some(b')') = delimiter_stack.last() {
-                    delimiter_stack.pop();
-                }
-                if delimiter_stack.is_empty() {
-                    mode = InterpolationMode::String;
-
+                if current_byte == b'('
+                    && (!double_quote || preceding_consecutive_backslashes % 2 == 0)
+                {
+                    mode = InterpolationMode::Expression;
                     if token_start < b {
                         let span = Span {
                             start: token_start,
-                            end: b + 1,
+                            end: b,
+                        };
+                        let str_contents = working_set.get_span_contents(span);
+
+                        let str_contents = if double_quote {
+                            let (str_contents, err) = unescape_string(str_contents, span);
+                            error = error.or(err);
+
+                            str_contents
+                        } else {
+                            str_contents.to_vec()
                         };
 
-                        let (expr, err) =
-                            parse_full_cell_path(working_set, None, span, expand_aliases_denylist);
-                        error = error.or(err);
-                        output.push(expr);
+                        output.push(Expression {
+                            expr: Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
+                            span,
+                            ty: Type::String,
+                            custom_completion: None,
+                        });
+                        token_start = b;
                     }
+                }
+            }
+            InterpolationMode::Expression => {
+                let byte = current_byte;
+                if let Some(b'\'') = delimiter_stack.last() {
+                    if byte == b'\'' {
+                        delimiter_stack.pop();
+                    }
+                } else if let Some(b'"') = delimiter_stack.last() {
+                    if byte == b'"' {
+                        delimiter_stack.pop();
+                    }
+                } else if let Some(b'`') = delimiter_stack.last() {
+                    if byte == b'`' {
+                        delimiter_stack.pop();
+                    }
+                } else if byte == b'\'' {
+                    delimiter_stack.push(b'\'')
+                } else if byte == b'"' {
+                    delimiter_stack.push(b'"');
+                } else if byte == b'`' {
+                    delimiter_stack.push(b'`')
+                } else if byte == b'(' {
+                    delimiter_stack.push(b')');
+                } else if byte == b')' {
+                    if let Some(b')') = delimiter_stack.last() {
+                        delimiter_stack.pop();
+                    }
+                    if delimiter_stack.is_empty() {
+                        mode = InterpolationMode::String;
 
-                    token_start = b + 1;
-                    continue;
+                        if token_start < b {
+                            let span = Span {
+                                start: token_start,
+                                end: b + 1,
+                            };
+
+                            let (expr, err) = parse_full_cell_path(
+                                working_set,
+                                None,
+                                span,
+                                expand_aliases_denylist,
+                            );
+                            error = error.or(err);
+                            output.push(expr);
+                        }
+
+                        token_start = b + 1;
+                        continue;
+                    }
                 }
             }
         }
+
         b += 1;
     }
 


### PR DESCRIPTION
# Description

When using a double-quoted interpolated string (`$"example"`), both escaped characters (e.g., `\n`, `\t`, `\\`) and interpolated expressions (e.g., `(1 + 2)`) are supported.

You can use these features independently or together.

| Expression | Resulting string |
|-|-|
| `$"\""` | `"` |
| `$"\\"` | `\` |
| `$"(1 + 3)"` | `4` |
| `$"\(1 + 3)"` | `(1 + 3)` |

However, there's a bug when you try to use them in sequence:

| Expression | Expected string | Actual string |
|-|-|-|
| `$"\\(1 + 3)"` | `\4` | `\(1 + 3)` |

The first backslash escapes the second, so the expression should not escaped, but the current implementation escapes both the second backslash and the expression (as described in #6737).  This PR addresses that issue.

# Tests + Formatting

Make sure you've done the following, if applicable:

✅ Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)

Make sure you've run and fixed any issues with these commands:

✅ `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
✅ `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
✅ `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
