### PR TITLE
added some search-terms to the `platform` category

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -307,6 +307,10 @@ Format: #
         ]
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["text-color", "text-style", "colors"]
+    }
+
     fn run(
         &self,
         engine_state: &nu_protocol::engine::EngineState,

--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -50,6 +50,10 @@ impl Command for SubCommand {
         "Draw text with a provided start and end code making a gradient"
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["gradients"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -50,10 +50,6 @@ impl Command for SubCommand {
         "Draw text with a provided start and end code making a gradient"
     }
 
-    fn search_terms(&self) -> Vec<&str> {
-        vec!["gradients"]
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -43,6 +43,10 @@ impl Command for Kill {
         )
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["stop", "end", "close"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -31,6 +31,10 @@ impl Command for Sleep {
             .category(Category::Platform)
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["delay", "wait", "sleep", "timer"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -32,7 +32,7 @@ impl Command for Sleep {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["delay", "wait", "sleep", "timer"]
+        vec!["delay", "wait", "timer"]
     }
 
     fn run(


### PR DESCRIPTION
# Description

Add some search terms to the `platform` category
| command | search-terms(s) |
| :-- | :-- |
| kill | stop, end, close |
| sleep | delay, wait, ~~sleep~~, timer |
| ansi | text-color, text-style, colors |
| ~~ansi gradient~~ | ~~gradients~~ |

Contributes to issue #5093

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
