### PR TITLE
Move the config of complete rules to other place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "nu-color-config",
  "nu-command",
  "nu-engine",
+ "nu-glob",
  "nu-json",
  "nu-parser",
  "nu-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ nu-system = { path = "./crates/nu-system", version = "0.72.2" }
 nu-table = { path = "./crates/nu-table", version = "0.72.2"  }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.72.2"  }
 nu-utils = { path = "./crates/nu-utils", version = "0.72.2"  }
+nu-glob = { path="./crates/nu-glob", version = "0.72.2"  }
 reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 
 rayon = "1.5.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,6 +467,7 @@ fn setup_config(
 
     config_files::read_config_file(engine_state, stack, env_file, true);
     config_files::read_config_file(engine_state, stack, config_file, false);
+    config_files::read_complete_file(engine_state, stack);
 
     if is_login_shell {
         config_files::read_loginshell_file(engine_state, stack);


### PR DESCRIPTION
# Description

relate issue https://github.com/nushell/nushell/issues/7027,

I want nushell can load complete file from the path like zsh and fish

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
