### PR TITLE
Add an expected result to date format test

### DIFF
--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -87,7 +87,10 @@ impl Command for SubCommand {
             Example {
                 description: "Format a given date using a given format string.",
                 example: r#""2021-10-22 20:00:12 +01:00" | date format "%Y-%m-%d""#,
-                result: None,
+                result: Some(Value::String {
+                    val: "2021-10-22".to_string(),
+                    span: Span::test_data(),
+                }),
             },
         ]
     }


### PR DESCRIPTION
# Description

Adds an expected result to a test.

This came up in the course of debugging https://github.com/nushell/nushell/pull/6796, which revealed a bug in nushell `main` branch: if you change this example to

```
"2021-10-22 20:00:12 +01:00" | into datetime | date format "%Y-%m-%d"
```

then that works fine at the REPL, but is a parse error in `example_test`:


```
thread 'date::format::test::test_examples' panicked at
'test parse error in
`"2021-10-22 20:00:12 +01:00" | into datetime | date format "%Y-%m-%d"`:
ExtraPositional("into ", Span { start: 78, end: 86 })',
crates/nu-command/src/example_test.rs:99:17
```

I can create an Issue for this after landing this PR.