### PR TITLE
Add accidentally missing tests of some command examples 

### DIFF
--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -13,7 +13,7 @@ use crate::To;
 
 #[cfg(test)]
 use super::{
-    Ansi, Date, From, If, Into, LetEnv, Math, Path, Random, Split, SplitColumn, SplitRow, Str,
+    Ansi, Date, From, If, Into, Let, LetEnv, Math, Path, Random, Split, SplitColumn, SplitRow, Str,
     StrJoin, StrLength, StrReplace, Url, Wrap,
 };
 
@@ -47,6 +47,7 @@ pub fn test_examples(cmd: impl Command + 'static) {
         working_set.add_decl(Box::new(Url));
         working_set.add_decl(Box::new(Ansi));
         working_set.add_decl(Box::new(Wrap));
+        working_set.add_decl(Box::new(Let));
         working_set.add_decl(Box::new(LetEnv));
 
         use super::Echo;

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -13,7 +13,7 @@ use crate::To;
 
 #[cfg(test)]
 use super::{
-    Ansi, Date, From, If, Into, Let, LetEnv, Math, Path, Random, Split, SplitColumn, SplitRow, Str,
+    Ansi, Date, From, If, Into, LetEnv, Math, Path, Random, Split, SplitColumn, SplitRow, Str,
     StrJoin, StrLength, StrReplace, Url, Wrap,
 };
 
@@ -47,7 +47,6 @@ pub fn test_examples(cmd: impl Command + 'static) {
         working_set.add_decl(Box::new(Url));
         working_set.add_decl(Box::new(Ansi));
         working_set.add_decl(Box::new(Wrap));
-        working_set.add_decl(Box::new(Let));
         working_set.add_decl(Box::new(LetEnv));
 
         use super::Echo;

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -122,3 +122,15 @@ fn getcol(
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(Length {})
+    }
+}

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -46,14 +46,14 @@ impl Command for Length {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Count the number of entries in a list",
-                example: "echo [1 2 3 4 5] | length",
+                description: "Count the number of items in a list",
+                example: "[1 2 3 4 5] | length",
                 result: Some(Value::test_int(5)),
             },
             Example {
-                description: "Count the number of columns in the calendar table",
-                example: "cal | length -c",
-                result: Some(Value::test_int(7)),
+                description: "Count the number of columns in a table",
+                example: "[{columnA: A0 columnB: B0}] | length -c",
+                result: Some(Value::test_int(2)),
             },
         ]
     }

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -252,3 +252,15 @@ impl RawStreamLinesAdapter {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(Lines {})
+    }
+}

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -129,7 +129,7 @@ impl Command for Lines {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Split multi-line string into lines",
-            example: "echo $'two(char nl)lines' | lines",
+            example: r#"echo $"two\nlines" | lines"#,
             result: Some(Value::List {
                 vals: vec![Value::test_string("two"), Value::test_string("lines")],
                 span: Span::test_data(),

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -258,3 +258,15 @@ impl Command for Where {
         ]
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(Where {})
+    }
+}

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -4,7 +4,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{CaptureBlock, Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, Span, SyntaxShape, Value,
+    Signature, SyntaxShape, Value,
 };
 
 #[derive(Clone)]
@@ -238,23 +238,25 @@ impl Command for Where {
                 example: "ls | where modified >= (date now) - 2wk",
                 result: None,
             },
-            Example {
-                description: "Get all numbers above 3 with an existing block condition",
-                example: "let a = {$in > 3}; [1, 2, 5, 6] | where -b $a",
-                result: Some(Value::List {
-                    vals: vec![
-                        Value::Int {
-                            val: 5,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 6,
-                            span: Span::test_data(),
-                        },
-                    ],
-                    span: Span::test_data(),
-                }),
-            },
+            // TODO: This should work but does not. (Note that `Let` must be present in the working_set in `example_test.rs`).
+            // See https://github.com/nushell/nushell/issues/7034
+            // Example {
+            //     description: "Get all numbers above 3 with an existing block condition",
+            //     example: "let a = {$in > 3}; [1, 2, 5, 6] | where -b $a",
+            //     result: Some(Value::List {
+            //         vals: vec![
+            //             Value::Int {
+            //                 val: 5,
+            //                 span: Span::test_data(),
+            //             },
+            //             Value::Int {
+            //                 val: 6,
+            //                 span: Span::test_data(),
+            //             },
+            //         ],
+            //         span: Span::test_data(),
+            //     }),
+            // },
         ]
     }
 }


### PR DESCRIPTION
# Description

Some commands were accidentally missing their examples. This PR adds the tests and makes necessary changes to make them pass.

One bug appears to be revealed: https://github.com/nushell/nushell/issues/7034
