### PR TITLE
Start defining subtype relation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,6 +2743,8 @@ dependencies = [
  "num-format",
  "serde",
  "serde_json",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "sys-locale",
  "thiserror",
  "typetag",

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -22,6 +22,8 @@ miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 num-format = "0.4.3"
 serde = {version = "1.0.130", features = ["derive"]}
 serde_json = { version = "1.0", optional = true }
+strum = "0.24"
+strum_macros = "0.24"
 sys-locale = "0.2.0"
 thiserror = "1.0.31"
 typetag = "0.1.8"

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -39,6 +39,19 @@ impl Type {
             (Type::Int, Type::Number) => true,
             (_, Type::Any) => true,
             (Type::List(t), Type::List(u)) if t.is_subtype(u) => true, // List is covariant
+
+            // TODO: Currently Record types specify their field types. If we are
+            // going to continue to do that, then it might make sense to define
+            // a "structural subtyping" whereby r1 is a subtype of r2 is the
+            // fields of r1 are a "subset" of the fields of r2 (names are a
+            // subset and agree on types). However, if we do that, then we need
+            // a way to specify the supertype of all Records. For now, we define
+            // any Record to be a subtype of any other Record. This allows
+            // Record(vec![]) to be used as an ad-hoc supertype of all Records
+            // in command signatures. This comment applies to Tables also, with
+            // "columns" in place of "fields".
+            (Type::Record(_), Type::Record(_)) => true,
+            (Type::Table(_), Type::Table(_)) => true,
             _ => false,
         }
     }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
 
 use std::fmt::Display;
 
 use crate::SyntaxShape;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, EnumIter, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Type {
     Int,
     Float,
@@ -18,6 +19,7 @@ pub enum Type {
     Filesize,
     List(Box<Type>),
     Number,
+    #[default]
     Nothing,
     Record(Vec<(String, Type)>),
     Table(Vec<(String, Type)>),
@@ -30,6 +32,21 @@ pub enum Type {
 }
 
 impl Type {
+    pub fn is_subtype(&self, other: &Type) -> bool {
+        match (self, other) {
+            (t, u) if t == u => true,
+            (Type::Float, Type::Number) => true,
+            (Type::Int, Type::Number) => true,
+            (_, Type::Any) => true,
+            (Type::List(t), Type::List(u)) if t.is_subtype(u) => true, // List is covariant
+            _ => false,
+        }
+    }
+
+    pub fn is_numeric(&self) -> bool {
+        matches!(self, Type::Int | Type::Float | Type::Number)
+    }
+
     pub fn to_shape(&self) -> SyntaxShape {
         match self {
             Type::Int => SyntaxShape::Int,
@@ -97,6 +114,47 @@ impl Display for Type {
             Type::Binary => write!(f, "binary"),
             Type::Custom(custom) => write!(f, "{}", custom),
             Type::Signature => write!(f, "signature"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Type;
+    use strum::IntoEnumIterator;
+
+    mod subtype_relation {
+        use super::*;
+
+        #[test]
+        fn test_reflexivity() {
+            for ty in Type::iter() {
+                assert!(ty.is_subtype(&ty));
+            }
+        }
+
+        #[test]
+        fn test_any_is_top_type() {
+            for ty in Type::iter() {
+                assert!(ty.is_subtype(&Type::Any));
+            }
+        }
+
+        #[test]
+        fn test_number_supertype() {
+            assert!(Type::Int.is_subtype(&Type::Number));
+            assert!(Type::Float.is_subtype(&Type::Number));
+        }
+
+        #[test]
+        fn test_list_covariance() {
+            for ty1 in Type::iter() {
+                for ty2 in Type::iter() {
+                    let list_ty1 = Type::List(Box::new(ty1.clone()));
+                    let list_ty2 = Type::List(Box::new(ty2.clone()));
+                    assert_eq!(list_ty1.is_subtype(&list_ty2), ty1.is_subtype(&ty2));
+                }
+            }
         }
     }
 }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -399,7 +399,11 @@ impl Value {
                     match &ty {
                         Some(x) => {
                             if &val_ty != x {
-                                ty = Some(Type::Any)
+                                if x.is_numeric() && val_ty.is_numeric() {
+                                    ty = Some(Type::Number)
+                                } else {
+                                    ty = Some(Type::Any)
+                                }
                             }
                         }
                         None => ty = Some(val_ty),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3181,4 +3181,68 @@ mod tests {
             assert!(!one_column_with_empty_string_and_one_value_with_a_string.is_empty());
         }
     }
+
+    mod get_type {
+        use crate::Type;
+
+        use super::*;
+
+        #[test]
+        fn test_list() {
+            let list_of_ints = Value::List {
+                vals: vec![Value::Int {
+                    val: 0,
+                    span: Span::unknown(),
+                }],
+                span: Span::unknown(),
+            };
+            let list_of_floats = Value::List {
+                vals: vec![Value::Float {
+                    val: 0.0,
+                    span: Span::unknown(),
+                }],
+                span: Span::unknown(),
+            };
+            let list_of_ints_and_floats = Value::List {
+                vals: vec![
+                    Value::Int {
+                        val: 0,
+                        span: Span::unknown(),
+                    },
+                    Value::Float {
+                        val: 0.0,
+                        span: Span::unknown(),
+                    },
+                ],
+                span: Span::unknown(),
+            };
+            let list_of_ints_and_floats_and_bools = Value::List {
+                vals: vec![
+                    Value::Int {
+                        val: 0,
+                        span: Span::unknown(),
+                    },
+                    Value::Float {
+                        val: 0.0,
+                        span: Span::unknown(),
+                    },
+                    Value::Bool {
+                        val: false,
+                        span: Span::unknown(),
+                    },
+                ],
+                span: Span::unknown(),
+            };
+            assert_eq!(list_of_ints.get_type(), Type::List(Box::new(Type::Int)));
+            assert_eq!(list_of_floats.get_type(), Type::List(Box::new(Type::Float)));
+            assert_eq!(
+                list_of_ints_and_floats_and_bools.get_type(),
+                Type::List(Box::new(Type::Any))
+            );
+            assert_eq!(
+                list_of_ints_and_floats.get_type(),
+                Type::List(Box::new(Type::Number))
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR starts defining the subtype relation. The motivation is https://github.com/nushell/nushell/pull/6796. Specifically, this PR allows us in #6796 to do things like

- Declare `math avg` to have type `List<Number> => Number`, and have this work for lists of ints, lists of floats, or mixed lists of ints and floats.

- Require that the input type of a command observed when executing an example is a subtype of its declared input type (and same for observed output types)