### PR TITLE
Require column name(s) in `sort-by`

### DIFF
--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -38,83 +38,17 @@ impl Command for SortBy {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[2 0 1] | sort-by",
-                description: "sort the list by increasing value",
-                result: Some(Value::List {
-                    vals: vec![Value::test_int(0), Value::test_int(1), Value::test_int(2)],
-                    span: Span::test_data(),
-                }),
+                description: "Sort files by modified date",
+                example: "ls | sort-by modified",
+                result: None,
             },
             Example {
-                example: "[2 0 1] | sort-by -r",
-                description: "sort the list by decreasing value",
-                result: Some(Value::List {
-                    vals: vec![Value::test_int(2), Value::test_int(1), Value::test_int(0)],
-                    span: Span::test_data(),
-                }),
+                description: "Sort files by name (case-insensitive)",
+                example: "ls | sort-by name -i",
+                result: None,
             },
             Example {
-                example: "[betty amy sarah] | sort-by",
-                description: "sort a list of strings",
-                result: Some(Value::List {
-                    vals: vec![
-                        Value::test_string("amy"),
-                        Value::test_string("betty"),
-                        Value::test_string("sarah"),
-                    ],
-                    span: Span::test_data(),
-                }),
-            },
-            Example {
-                example: "[betty amy sarah] | sort-by -r",
-                description: "sort a list of strings in reverse",
-                result: Some(Value::List {
-                    vals: vec![
-                        Value::test_string("sarah"),
-                        Value::test_string("betty"),
-                        Value::test_string("amy"),
-                    ],
-                    span: Span::test_data(),
-                }),
-            },
-            Example {
-                example: "[test1 test11 test2] | sort-by -n",
-                description: "sort a list of alphanumeric strings naturally",
-                result: Some(Value::List {
-                    vals: vec![
-                        Value::test_string("test1"),
-                        Value::test_string("test2"),
-                        Value::test_string("test11"),
-                    ],
-                    span: Span::test_data(),
-                }),
-            },
-            Example {
-                description: "Sort strings (case-insensitive)",
-                example: "echo [airplane Truck Car] | sort-by -i",
-                result: Some(Value::List {
-                    vals: vec![
-                        Value::test_string("airplane"),
-                        Value::test_string("Car"),
-                        Value::test_string("Truck"),
-                    ],
-                    span: Span::test_data(),
-                }),
-            },
-            Example {
-                description: "Sort strings (reversed case-insensitive)",
-                example: "echo [airplane Truck Car] | sort-by -i -r",
-                result: Some(Value::List {
-                    vals: vec![
-                        Value::test_string("Truck"),
-                        Value::test_string("Car"),
-                        Value::test_string("airplane"),
-                    ],
-                    span: Span::test_data(),
-                }),
-            },
-            Example {
-                description: "Sort a table by its column (reversed order)",
+                description: "Sort a table by a column (reversed order)",
                 example: "[[fruit count]; [apple 9] [pear 3] [orange 7]] | sort-by fruit -r",
                 result: Some(Value::List {
                     vals: vec![
@@ -150,6 +84,10 @@ impl Command for SortBy {
         let natural = call.has_flag("natural");
         let metadata = &input.metadata();
         let mut vec: Vec<_> = input.into_iter().collect();
+
+        if columns.is_empty() {
+            return Err(ShellError::MissingParameter("columns".into(), call.head));
+        }
 
         crate::sort(&mut vec, columns, call.head, insensitive, natural)?;
 

--- a/crates/nu-command/tests/commands/sort.rs
+++ b/crates/nu-command/tests/commands/sort.rs
@@ -1,0 +1,48 @@
+use nu_test_support::{nu, pipeline};
+
+
+#[test]
+fn by_invalid_types() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open cargo_sample.toml --raw
+            | echo ["foo" 1]
+            | sort
+            | to json -r
+        "#
+    ));
+
+    let json_output = r#"[1,"foo"]"#;
+    assert_eq!(actual.out, json_output);
+}
+
+#[test]
+fn sort_primitive_values() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open cargo_sample.toml --raw
+            | lines
+            | skip 1
+            | first 6
+            | sort
+            | first
+        "#
+    ));
+
+    assert_eq!(actual.out, "authors = [\"The Nushell Project Developers\"]");
+}
+
+#[test]
+fn sort_different_types() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [a, 1, b, 2, c, 3, [4, 5, 6], d, 4, [1, 2, 3]] | sort | to json --raw
+        "#
+    ));
+
+    let json_output = r#"[1,2,3,4,"a","b","c","d",[1,2,3],[4,5,6]]"#;
+    assert_eq!(actual.out, json_output);
+}

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -44,39 +44,6 @@ fn by_invalid_column() {
 }
 
 #[test]
-fn by_invalid_types() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            open cargo_sample.toml --raw
-            | echo ["foo" 1]
-            | sort-by
-            | to json -r
-        "#
-    ));
-
-    let json_output = r#"[1,"foo"]"#;
-    assert_eq!(actual.out, json_output);
-}
-
-#[test]
-fn sort_primitive_values() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            open cargo_sample.toml --raw
-            | lines
-            | skip 1
-            | first 6
-            | sort-by
-            | first
-        "#
-    ));
-
-    assert_eq!(actual.out, "authors = [\"The Nushell Project Developers\"]");
-}
-
-#[test]
 fn ls_sort_by_name_sensitive() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
@@ -142,14 +109,13 @@ fn ls_sort_by_type_name_insensitive() {
 }
 
 #[test]
-fn sort_different_types() {
+fn no_column_specified_fails() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            [a, 1, b, 2, c, 3, [4, 5, 6], d, 4, [1, 2, 3]] | sort-by | to json --raw
+            [2 0 1] | sort-by
         "#
     ));
 
-    let json_output = r#"[1,2,3,4,"a","b","c","d",[1,2,3],[4,5,6]]"#;
-    assert_eq!(actual.out, json_output);
+    assert!(actual.err.contains("missing parameter"));
 }

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -93,7 +93,7 @@ fn detect_newlines() -> TestResult {
 #[test]
 fn case_insensitive_sort() -> TestResult {
     run_test(
-        r#"[a, B, d, C, f] | sort-by -i | to json --raw"#,
+        r#"[a, B, d, C, f] | sort -i | to json --raw"#,
         "[\"a\",\"B\",\"C\",\"d\",\"f\"]",
     )
 }


### PR DESCRIPTION
# Description

Currently, `sort-by` does not require the user to specify a column name. The following 2 lines are equivalent:

```bash
[2 0 1] | sort-by # returns [0 1 2]
[2 0 1] | sort    # returns [0 1 2]
```

Weird, right? Given that we have `sort` for operating on data without specifying a column, I don't think `sort-by` should work this way. It's also surprising how the first 7 examples for `sort-by` are focused on using it without columns:

![image](https://user-images.githubusercontent.com/26268125/200213611-8379fb22-3c18-43de-bfd8-c9a8ea98dee3.png)


After this change, `sort-by` returns an error if not given column names:

![image](https://user-images.githubusercontent.com/26268125/200213310-c3b7bce8-060f-4280-baea-8dae70d68620.png)

`sort-by` examples look like this now:

![image](https://user-images.githubusercontent.com/26268125/200213370-e5ff051d-be4c-4b20-88ef-7d7e00fa16ca.png)

Thanks to @dandavison for pointing this out.

### Future work

I implemented this with a run-time check in `sort-by`. In the future, maybe we should extend rest parameters so they can be given a minimum number of elements?

This is a breaking change; I'll be sure to document it in the change notes if/when we merge it.