### PR TITLE
Require input for `date format`

### DIFF
--- a/crates/nu-command/tests/commands/date/format.rs
+++ b/crates/nu-command/tests/commands/date/format.rs
@@ -5,12 +5,25 @@ fn formatter_not_valid() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        date format '%N'
+        date now | date format '%N'
         "#
         )
     );
 
     assert!(actual.err.contains("invalid format"));
+}
+
+#[test]
+fn fails_without_input() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        date format "%c"
+        "#
+        )
+    );
+
+    assert!(actual.err.contains("Unsupported input"));
 }
 
 #[test]


### PR DESCRIPTION
# Description

`date format` currently works even when not given a date; it automatically converts `Nothing` values to `Local::now()`. This feels like unexpected behaviour; I think `date format` should return an error when given `Nothing`.

### Before

![image](https://user-images.githubusercontent.com/26268125/200221245-2f4030a8-9d7f-4409-81ce-fe12dcede50d.png)

### After

![image](https://user-images.githubusercontent.com/26268125/200221188-f41a8588-2467-4e39-ac0b-ecce7c94b10e.png)

(thanks to Dan for noticing this)

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
