### PR TITLE
return value::int instead of value::record in `history session`

### DIFF
--- a/crates/nu-command/src/misc/history_session.rs
+++ b/crates/nu-command/src/misc/history_session.rs
@@ -1,9 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
-    Value,
-};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Value};
 
 #[derive(Clone)]
 pub struct HistorySession;

--- a/crates/nu-command/src/misc/history_session.rs
+++ b/crates/nu-command/src/misc/history_session.rs
@@ -1,6 +1,9 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Value};
+use nu_protocol::{
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
+    Value,
+};
 
 #[derive(Clone)]
 pub struct HistorySession;
@@ -33,11 +36,6 @@ impl Command for HistorySession {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        Ok(Value::Record {
-            cols: vec!["session-id".into()],
-            vals: vec![Value::int(engine_state.history_session_id, call.head)],
-            span: call.head,
-        }
-        .into_pipeline_data())
+        Ok(Value::int(engine_state.history_session_id, call.head).into_pipeline_data())
     }
 }


### PR DESCRIPTION
# Description

This follows previous changes by changing the return from a Value::Record to a Value::Int. It just seemed like a record wasn't necessary.

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
