### PR TITLE
allow tables in ++ operator

### DIFF
--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -509,3 +509,14 @@ fn adding_value_and_list() {
 
     assert_eq!(actual.out, "[1, 3, 5]");
 }
+
+#[test]
+fn adding_tables() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [[a b]; [1 2]] ++ [[4 5]; [10 11]] | to nuon
+        "#
+    ));
+    assert_eq!(actual.out, "[{a: 1, b: 2}, {4: 10, 5: 11}]");
+}

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -22,7 +22,6 @@ pub fn math_result_type(
     op: &mut Expression,
     rhs: &mut Expression,
 ) -> (Type, Option<ParseError>) {
-    //println!("checking: {:?} {:?} {:?}", lhs, op, rhs);
     match &op.expr {
         Expr::Operator(operator) => match operator {
             Operator::Plus => match (&lhs.ty, &rhs.ty) {
@@ -83,6 +82,7 @@ pub fn math_result_type(
                         (Type::List(Box::new(Type::Any)), None)
                     }
                 }
+                (Type::Table(a), Type::Table(_)) => (Type::Table(a.clone()), None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (


### PR DESCRIPTION
# Description
This PR closes #6916, which now allows table/table operations on the `++` operator.
```
[[a b]; [1 2]] ++ [[a b]; [1 3]]
╭───┬───┬───╮
│ # │ a │ b │
├───┼───┼───┤
│ 0 │ 1 │ 2 │
│ 1 │ 1 │ 3 │
╰───┴───┴───╯
```

# Tests + Formatting
- [X] Test added

Make sure you've run and fixed any issues with these commands:

- [X] cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] cargo test --workspace --features=extra` to check that all tests pass

# User-Facing Changes

If you're making changes that will affect the user experience of Nushell (ex: adding/removing a command, changing an input/output type, adding a new flag):

- Get another regular contributor to review the PR before merging
- Make sure that there is an entry in the documentation (https://github.com/nushell/nushell.github.io) for the feature, and update it if necessary
