### PR TITLE
Collapse some `help commands` columns into a single column

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -134,21 +134,9 @@ fn help(
                     span: head,
                 });
 
-                cols.push("is_plugin".into());
-                vals.push(Value::Bool {
-                    val: decl.is_plugin().is_some(),
-                    span: head,
-                });
-
-                cols.push("is_custom".into());
-                vals.push(Value::Bool {
-                    val: decl.is_custom_command(),
-                    span: head,
-                });
-
-                cols.push("is_keyword".into());
-                vals.push(Value::Bool {
-                    val: decl.is_parser_keyword(),
+                cols.push("command_type".into());
+                vals.push(Value::String {
+                    val: format!("{:?}", decl.command_type()).to_lowercase(),
                     span: head,
                 });
 
@@ -235,21 +223,9 @@ fn help(
                     span: head,
                 });
 
-                cols.push("is_plugin".into());
-                vals.push(Value::Bool {
-                    val: decl.is_plugin().is_some(),
-                    span: head,
-                });
-
-                cols.push("is_custom".into());
-                vals.push(Value::Bool {
-                    val: decl.is_custom_command(),
-                    span: head,
-                });
-
-                cols.push("is_keyword".into());
-                vals.push(Value::Bool {
-                    val: decl.is_parser_keyword(),
+                cols.push("command_type".into());
+                vals.push(Value::String {
+                    val: format!("{:?}", decl.command_type()).to_lowercase(),
                     span: head,
                 });
 

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -4,6 +4,15 @@ use crate::{ast::Call, BlockId, Example, PipelineData, ShellError, Signature};
 
 use super::{EngineState, Stack};
 
+#[derive(Debug)]
+pub enum CommandType {
+    Builtin,
+    Custom,
+    Keyword,
+    Plugin,
+    Other,
+}
+
 pub trait Command: Send + Sync + CommandClone {
     fn name(&self) -> &str;
 
@@ -70,6 +79,21 @@ pub trait Command: Send + Sync + CommandClone {
     // Related terms to help with command search
     fn search_terms(&self) -> Vec<&str> {
         vec![]
+    }
+
+    fn command_type(&self) -> CommandType {
+        match (
+            self.is_builtin(),
+            self.is_custom_command(),
+            self.is_parser_keyword(),
+            self.is_plugin().is_some(),
+        ) {
+            (true, false, false, false) => CommandType::Builtin,
+            (false, true, false, false) => CommandType::Custom,
+            (_, false, true, false) => CommandType::Keyword,
+            (false, false, false, true) => CommandType::Plugin,
+            _ => CommandType::Other,
+        }
     }
 }
 


### PR DESCRIPTION
This PR collapses the `is_plugin`, `is_custom`, `is_keyword` boolean columns down to a single column taking values in `{plugin, custom, keyword, other}`. The motivation is that it makes the table easier to visually digest (and arguably easier to query?).

#### Before
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/52205/200457098-5eb2b21b-67fd-437d-b39f-1f12d0e2f179.png">

#### After
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/52205/200462152-8f976d93-2505-41ed-a7fd-f7f42e737893.png">