### PR TITLE
command `open` returns error when does not have parameters (#7048)

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -1,15 +1,17 @@
 use crate::filesystem::util::BufferedReader;
-use nu_engine::{eval_block, get_full_help, CallExt};
+use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError, Signature, Spanned,
-    SyntaxShape, Value,
+    Category, Example, PipelineData, RawStream, ShellError, Signature, Spanned, SyntaxShape, Value,
 };
 use std::io::BufReader;
 
 #[cfg(feature = "database")]
 use crate::database::SQLiteDatabase;
+
+#[cfg(feature = "database")]
+use nu_protocol::IntoPipelineData;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -67,29 +69,17 @@ impl Command for Open {
             // Collect a filename from the input
             match input {
                 PipelineData::Value(Value::Nothing { .. }, ..) => {
-                    return Ok(Value::String {
-                        val: get_full_help(
-                            &Open.signature(),
-                            &Open.examples(),
-                            engine_state,
-                            stack,
-                        ),
-                        span: call.head,
-                    }
-                    .into_pipeline_data())
+                    return Err(ShellError::MissingParameter(
+                        "needs filename".to_string(),
+                        call.head,
+                    ))
                 }
                 PipelineData::Value(val, ..) => val.as_spanned_string()?,
                 _ => {
-                    return Ok(Value::String {
-                        val: get_full_help(
-                            &Open.signature(),
-                            &Open.examples(),
-                            engine_state,
-                            stack,
-                        ),
-                        span: call.head,
-                    }
-                    .into_pipeline_data())
+                    return Err(ShellError::MissingParameter(
+                        "needs filename".to_string(),
+                        call.head,
+                    ));
                 }
             }
         };

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -299,3 +299,15 @@ fn open_ignore_ansi() {
         assert!(actual.err.is_empty());
     })
 }
+
+#[test]
+fn open_no_parameter() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        r#"
+            open
+        "#
+    );
+
+    assert!(actual.err.contains("needs filename"));
+}


### PR DESCRIPTION
# Description
When `open` command is invoked without a parameter, it returns a "Missing parameter" error instead of displaying the help. This makes `open` command behavior consistent with other commands like `mkdir`, and `rm`.

New error message: "needs filename"
![image](https://user-images.githubusercontent.com/3062698/200585643-b1a1d878-39b9-4019-ba66-2fca9acd0052.png)


# Tests + Formatting

Command that display the new error:

- `open`


