### PR TITLE
`cd` command returns MissingParameter error (#7048)

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -156,8 +156,10 @@ impl Command for Cd {
                 }
             }
             None => {
-                let path = nu_path::expand_tilde("~");
-                (path.to_string_lossy().to_string(), call.head)
+                return Err(ShellError::MissingParameter(
+                    "needs path".to_string(),
+                    call.head,
+                ));
             }
         };
 

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -4,6 +4,18 @@ use nu_test_support::playground::Playground;
 use std::path::PathBuf;
 
 #[test]
+fn cd_no_path() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+                cd
+            "#
+    );
+
+    assert!(actual.err.contains("needs path"));
+}
+
+#[test]
 fn cd_works_with_in_var() {
     Playground::setup("cd_test_1", |dirs, _| {
         let actual = nu!(


### PR DESCRIPTION
# Description

When `cd` command is invoked without a parameter, it returns a "Missing parameter" error instead of changing current directory to home directory (like `cd ~`). This makes open command behavior consistent with other commands like `mkdir`, and `rm`. 

New error message: "needs path"
![image](https://user-images.githubusercontent.com/3062698/200595330-aba71c32-75f7-40b7-b806-f9b071cd4c5a.png)


If we want to go to HOME we call `cd ~`.

# Tests + Formatting
Command that display the new error:

- `cd`
