### PR TITLE
bump to 0.71, use 1.63 toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "assert_cmd",
  "atty",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "atty",
  "chrono",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "nu-ansi-term",
  "nu-json",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "Inflector",
  "alphanumeric-sort",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "chrono",
  "nu-glob",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "doc-comment",
  "tempdir",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "nu-json"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "fancy-regex",
  "lazy_static",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "atty",
  "chrono",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "atty",
  "json_to_table",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "getset",
  "hamcrest2",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "crossterm_winapi",
  "lscolors",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "git2",
  "nu-engine",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.70.1"
+version = "0.71.0"
 dependencies = [
  "gjson",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.70.1"
+version = "0.71.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -38,20 +38,20 @@ ctrlc = "3.2.1"
 log = "0.4"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 nu-ansi-term = "0.46.0"
-nu-cli = { path="./crates/nu-cli", version = "0.70.1"  }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.70.1"  }
-nu-command = { path="./crates/nu-command", version = "0.70.1"  }
-nu-engine = { path="./crates/nu-engine", version = "0.70.1"  }
-nu-json = { path="./crates/nu-json", version = "0.70.1"  }
-nu-parser = { path="./crates/nu-parser", version = "0.70.1"  }
-nu-path = { path="./crates/nu-path", version = "0.70.1"  }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.70.1"  }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.70.1"  }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.70.1"  }
-nu-system = { path = "./crates/nu-system", version = "0.70.1" }
-nu-table = { path = "./crates/nu-table", version = "0.70.1"  }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.70.1"  }
-nu-utils = { path = "./crates/nu-utils", version = "0.70.1"  }
+nu-cli = { path="./crates/nu-cli", version = "0.71.0"  }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.71.0"  }
+nu-command = { path="./crates/nu-command", version = "0.71.0"  }
+nu-engine = { path="./crates/nu-engine", version = "0.71.0"  }
+nu-json = { path="./crates/nu-json", version = "0.71.0"  }
+nu-parser = { path="./crates/nu-parser", version = "0.71.0"  }
+nu-path = { path="./crates/nu-path", version = "0.71.0"  }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.71.0"  }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.71.0"  }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.71.0"  }
+nu-system = { path = "./crates/nu-system", version = "0.71.0" }
+nu-table = { path = "./crates/nu-table", version = "0.71.0"  }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.71.0"  }
+nu-utils = { path = "./crates/nu-utils", version = "0.71.0"  }
 reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 
 rayon = "1.5.1"
@@ -73,7 +73,7 @@ nix = { version = "0.25", default-features = false, features = ["signal", "proce
 atty = "0.2"
 
 [dev-dependencies]
-nu-test-support = { path="./crates/nu-test-support", version = "0.70.1"  }
+nu-test-support = { path="./crates/nu-test-support", version = "0.71.0"  }
 tempfile = "3.2.0"
 assert_cmd = "2.0.2"
 pretty_assertions = "1.0.0"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,21 +5,21 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.70.1"
+version = "0.71.0"
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.70.1"  }
-nu-command = { path = "../nu-command", version = "0.70.1" }
+nu-test-support = { path="../nu-test-support", version = "0.71.0"  }
+nu-command = { path = "../nu-command", version = "0.71.0" }
 rstest = {version = "0.15.0", default-features = false}
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.70.1"  }
-nu-path = { path = "../nu-path", version = "0.70.1"  }
-nu-parser = { path = "../nu-parser", version = "0.70.1"  }
-nu-protocol = { path = "../nu-protocol", version = "0.70.1"  }
-nu-utils = { path = "../nu-utils", version = "0.70.1"  }
+nu-engine = { path = "../nu-engine", version = "0.71.0"  }
+nu-path = { path = "../nu-path", version = "0.71.0"  }
+nu-parser = { path = "../nu-parser", version = "0.71.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.71.0"  }
+nu-utils = { path = "../nu-utils", version = "0.71.0"  }
 nu-ansi-term = "0.46.0"
-nu-color-config = { path = "../nu-color-config", version = "0.70.1"  }
+nu-color-config = { path = "../nu-color-config", version = "0.71.0"  }
 reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 
 atty = "0.2.14"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,11 +5,11 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.70.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.71.0"  }
 nu-ansi-term = "0.46.0"
-nu-json = { path = "../nu-json", version = "0.70.1"  }
-nu-table = { path = "../nu-table", version = "0.70.1"  }
+nu-json = { path = "../nu-json", version = "0.71.0"  }
+nu-table = { path = "../nu-table", version = "0.71.0"  }
 serde = { version="1.0.123", features=["derive"] }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -5,24 +5,24 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
 edition = "2021"
 license = "MIT"
 name = "nu-command"
-version = "0.70.1"
+version = "0.71.0"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-color-config = { path = "../nu-color-config", version = "0.70.1"  }
-nu-engine = { path = "../nu-engine", version = "0.70.1"  }
-nu-glob = { path = "../nu-glob", version = "0.70.1" }
-nu-json = { path = "../nu-json", version = "0.70.1"  }
-nu-parser = { path = "../nu-parser", version = "0.70.1"  }
-nu-path = { path = "../nu-path", version = "0.70.1"  }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.70.1"  }
-nu-protocol = { path = "../nu-protocol", version = "0.70.1"  }
-nu-system = { path = "../nu-system", version = "0.70.1"  }
-nu-table = { path = "../nu-table", version = "0.70.1"  }
-nu-term-grid = { path = "../nu-term-grid", version = "0.70.1"  }
-nu-utils = { path = "../nu-utils", version = "0.70.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.71.0"  }
+nu-engine = { path = "../nu-engine", version = "0.71.0"  }
+nu-glob = { path = "../nu-glob", version = "0.71.0" }
+nu-json = { path = "../nu-json", version = "0.71.0"  }
+nu-parser = { path = "../nu-parser", version = "0.71.0"  }
+nu-path = { path = "../nu-path", version = "0.71.0"  }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.71.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.71.0"  }
+nu-system = { path = "../nu-system", version = "0.71.0"  }
+nu-table = { path = "../nu-table", version = "0.71.0"  }
+nu-term-grid = { path = "../nu-term-grid", version = "0.71.0"  }
+nu-utils = { path = "../nu-utils", version = "0.71.0" }
 nu-ansi-term = "0.46.0"
 num-format = { version = "0.4.3" }
 
@@ -153,7 +153,7 @@ database = ["sqlparser", "rusqlite"]
 shadow-rs = { version = "0.16.1", default-features = false }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.70.1"  }
+nu-test-support = { path = "../nu-test-support", version = "0.71.0"  }
 
 hamcrest2 = "0.3.0"
 dirs-next = "2.0.0"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.70.1"  }
-nu-path = { path = "../nu-path", version = "0.70.1"  }
-nu-glob = { path = "../nu-glob", version = "0.70.1" }
-nu-utils = { path = "../nu-utils", version = "0.70.1"  }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.71.0"  }
+nu-path = { path = "../nu-path", version = "0.71.0"  }
+nu-glob = { path = "../nu-glob", version = "0.71.0" }
+nu-utils = { path = "../nu-utils", version = "0.71.0"  }
 
 chrono = { version="0.4.21", features=["serde"] }
 sysinfo = "0.26.2"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.70.1"
+version = "0.71.0"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.70.1"
+version = "0.71.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,5 +21,5 @@ num-traits = "0.2.14"
 serde = "1.0"
 
 [dev-dependencies]
-nu-path = { path="../nu-path", version = "0.70.1" }
+nu-path = { path="../nu-path", version = "0.71.0" }
 serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
 bytesize = "1.1.0"
@@ -14,10 +14,10 @@ itertools = "0.10"
 miette = {version = "5.1.0", features = ["fancy-no-backtrace"]}
 thiserror = "1.0.31"
 serde_json = "1.0"
-nu-path = {path = "../nu-path", version = "0.70.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.70.1" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.70.1"  }
-nu-engine = { path = "../nu-engine", version = "0.70.1" }
+nu-path = {path = "../nu-path", version = "0.71.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.71.0" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.71.0"  }
+nu-engine = { path = "../nu-engine", version = "0.71.0" }
 log = "0.4"
 
 [features]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
 dirs-next = "2.0.0"

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
 bincode = "1.3.3"
-nu-protocol = { path = "../nu-protocol", version = "0.70.1"  }
-nu-engine = { path = "../nu-engine", version = "0.70.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.71.0"  }
+nu-engine = { path = "../nu-engine", version = "0.71.0"  }
 serde = {version = "1.0.143", features = ["derive"]}
 serde_json = { version = "1.0"}
 rmp = "0.8.11"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.70.1"
+version = "0.71.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.70.1"  }
-nu-json = { path = "../nu-json", version = "0.70.1"  }
+nu-utils = { path = "../nu-utils", version = "0.71.0"  }
+nu-json = { path = "../nu-json", version = "0.71.0"  }
 
 byte-unit = "4.0.9"
 chrono = { version="0.4.21", features=["serde"] }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.70.1"
+version = "0.71.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
 nu-ansi-term = "0.46.0"
-nu-protocol = { path = "../nu-protocol", version = "0.70.1" }
-nu-utils = { path = "../nu-utils", version = "0.70.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.71.0" }
+nu-utils = { path = "../nu-utils", version = "0.71.0" }
 atty = "0.2.14"
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 json_to_table = { version = "0.2.0", features = ["color"] }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,9 +5,9 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
 unicode-width = "0.1.9"
 
-nu-utils = { path = "../nu-utils", version = "0.70.1"  }
+nu-utils = { path = "../nu-utils", version = "0.71.0"  }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,15 +5,15 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2018"
 license = "MIT"
 name = "nu-test-support"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-path = { path="../nu-path", version = "0.70.1"  }
-nu-glob = { path = "../nu-glob", version = "0.70.1" }
-nu-utils = { path="../nu-utils", version = "0.70.1"  }
+nu-path = { path="../nu-path", version = "0.71.0"  }
+nu-glob = { path = "../nu-glob", version = "0.71.0" }
+nu-utils = { path="../nu-utils", version = "0.71.0"  }
 lazy_static = "1.4.0"
 num-format = "0.4.3"
 

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
 edition = "2021"
 license = "MIT"
 name = "nu-utils"
-version = "0.70.1"
+version = "0.71.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.70.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.70.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.71.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.71.0", features = ["plugin"] }
 serde = { version = "1.0", features = ["derive"] }
 typetag = "0.1.8"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,8 +5,8 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.70.1"
+version = "0.71.0"
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0", features = ["plugin"]}

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,14 +5,14 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-engine = { path="../nu-engine", version = "0.70.1" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-engine = { path="../nu-engine", version = "0.71.0" }
 
 git2 = "0.15.0"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0", features = ["plugin"]}
 
 semver = "0.11.0"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,15 +5,15 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-engine = { path="../nu-engine", version = "0.70.1" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-engine = { path="../nu-engine", version = "0.71.0" }
 gjson = "0.8.0"
 scraper = "0.13.0"
 sxd-document = "0.3.2"

--- a/crates/old/nu_plugin_chart/Cargo.toml
+++ b/crates/old/nu_plugin_chart/Cargo.toml
@@ -4,18 +4,18 @@ description = "A plugin to display charts"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_chart"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-data = { path="../nu-data", version = "0.70.1" }
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
-nu-value-ext = { path="../nu-value-ext", version = "0.70.1" }
+nu-data = { path="../nu-data", version = "0.71.0" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
+nu-value-ext = { path="../nu-value-ext", version = "0.71.0" }
 
 crossterm = "0.19.0"
 tui = { version="0.15.0", default-features=false, features=["crossterm"] }

--- a/crates/old/nu_plugin_from_bson/Cargo.toml
+++ b/crates/old/nu_plugin_from_bson/Cargo.toml
@@ -4,7 +4,7 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_bson"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
@@ -12,9 +12,9 @@ doctest = false
 [dependencies]
 bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
 
 [build-dependencies]

--- a/crates/old/nu_plugin_from_mp4/Cargo.toml
+++ b/crates/old/nu_plugin_from_mp4/Cargo.toml
@@ -4,16 +4,16 @@ description = "A converter plugin to the mp4 format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_mp4"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
 tempfile = "3.2.0"
 mp4 = "0.9.0"
 

--- a/crates/old/nu_plugin_from_sqlite/Cargo.toml
+++ b/crates/old/nu_plugin_from_sqlite/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_sqlite"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
 bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
 tempfile = "3.2.0"
 
 [dependencies.rusqlite]

--- a/crates/old/nu_plugin_s3/Cargo.toml
+++ b/crates/old/nu_plugin_s3/Cargo.toml
@@ -4,17 +4,17 @@ description = "An S3 plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_s3"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
 futures = { version="0.3.12", features=["compat", "io-compat"] }
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
 s3handler = "0.7.5"
 
 [build-dependencies]

--- a/crates/old/nu_plugin_start/Cargo.toml
+++ b/crates/old/nu_plugin_start/Cargo.toml
@@ -4,17 +4,17 @@ description = "A plugin to open files/URLs directly from Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_start"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
 glob = "0.3.0"
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
 url = "2.2.0"
 webbrowser = "0.5.5"
 
@@ -22,5 +22,5 @@ webbrowser = "0.5.5"
 open = "1.4.0"
 
 [build-dependencies]
-nu-errors = { version = "0.70.1", path="../nu-errors" }
-nu-source = { version = "0.70.1", path="../nu-source" }
+nu-errors = { version = "0.71.0", path="../nu-errors" }
+nu-source = { version = "0.71.0", path="../nu-source" }

--- a/crates/old/nu_plugin_to_bson/Cargo.toml
+++ b/crates/old/nu_plugin_to_bson/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_bson"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
 bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
 num-traits = "0.2.14"
 
 [features]

--- a/crates/old/nu_plugin_to_sqlite/Cargo.toml
+++ b/crates/old/nu_plugin_to_sqlite/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the SQLite format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_sqlite"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
 hex = "0.4.2"
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
-nu-source = { path="../nu-source", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
+nu-source = { path="../nu-source", version = "0.71.0" }
 tempfile = "3.2.0"
 
 [dependencies.rusqlite]

--- a/crates/old/nu_plugin_tree/Cargo.toml
+++ b/crates/old/nu_plugin_tree/Cargo.toml
@@ -4,16 +4,16 @@ description = "Tree viewer plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_tree"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 doctest = false
 
 [dependencies]
 derive-new = "0.5.8"
-nu-errors = { path="../nu-errors", version = "0.70.1" }
-nu-plugin = { path="../nu-plugin", version = "0.70.1" }
-nu-protocol = { path="../nu-protocol", version = "0.70.1" }
+nu-errors = { path="../nu-errors", version = "0.71.0" }
+nu-plugin = { path="../nu-plugin", version = "0.71.0" }
+nu-protocol = { path="../nu-protocol", version = "0.71.0" }
 ptree = { version = "0.4.0", default-features = false }
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 3 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.64.0"
+channel = "1.63.0"

--- a/samples/wasm/Cargo.toml
+++ b/samples/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Nu authors"]
 edition = "2018"
 name = "wasm"
-version = "0.70.1"
+version = "0.71.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
# Description

Bump to 0.71 for release.
I had to revert the toolchain to 1.63 so it'd build on my mac (rustup issue, I believe).

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
