### PR TITLE
Add `help` warnings for `path exists` and `path type` regarding usage

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
     }
 
     fn extra_usage(&self) -> &str {
-        "into duration does not take leap years into account and every month is calculated with 30 days"
+        "This command does not take leap years into account, and every month is assumed to have 30 days (4 weeks)."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
     }
 
     fn extra_usage(&self) -> &str {
-        "This command does not take leap years into account, and every month is assumed to have 30 days (4 weeks)."
+        "This command does not take leap years into account, and every month is assumed to have 30 days."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -38,6 +38,11 @@ impl Command for SubCommand {
         "Check whether a path exists"
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This only checks if it is possible to either `open` or `cd` to the given path.
+If you need to distinguish dirs and files, please use `path type`."#
+    }
+
     fn run(
         &self,
         engine_state: &nu_protocol::engine::EngineState,

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -36,6 +36,11 @@ impl Command for SubCommand {
         "Get the type of the object a path refers to (e.g., file, dir, symlink)"
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This checks the file system to confirm the path's object type.
+If nothing is found, an empty string will be returned."#
+    }
+
     fn run(
         &self,
         engine_state: &nu_protocol::engine::EngineState,


### PR DESCRIPTION
# Description

Adds 'extra usage' sections to the commands `path exists` and `path type` which advise on how they can be used to check the filesystem, and what happens if nothing is found.

Also tweaked `into duration`'s message for a little clarity.

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
