### PR TITLE
Replace all instances of 'column path' in `help` messages with 'cell path'

### DIFF
--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -43,7 +43,7 @@ impl Command for BytesAdd {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally matches prefix of text by column paths",
+                "for a data structure input, add bytes to the data at the given cell paths",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -121,7 +121,7 @@ impl Command for BytesAt {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally get bytes by column paths",
+                "for a data structure input, get bytes from data at the given cell paths",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -33,7 +33,7 @@ impl Command for BytesEndsWith {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally matches prefix of text by column paths",
+                "for a data structure input, check if bytes at the given cell paths end with the pattern",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -41,7 +41,7 @@ impl Command for BytesIndexOf {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally returns index of pattern in string by column paths",
+                "for a data structure input, find the indexes at the given cell paths",
             )
             .switch("all", "returns all matched index", Some('a'))
             .switch("end", "search from the end of the binary", Some('e'))

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -21,7 +21,7 @@ impl Command for BytesLen {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally find length of binary by column paths",
+                "for a data structure input, find the length of data at the given cell paths",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -35,7 +35,7 @@ impl Command for BytesRemove {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally remove bytes by column paths",
+                "for a data structure input, remove bytes from data at the given cell paths",
             )
             .switch("end", "remove from end of binary", Some('e'))
             .switch("all", "remove occurrences of finding binary", Some('a'))

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -36,7 +36,7 @@ impl Command for BytesReplace {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally find and replace text by column paths",
+                "for a data structure input, replace bytes in data at the given cell paths",
             )
             .switch("all", "replace all occurrences of find binary", Some('a'))
             .category(Category::Bytes)

--- a/crates/nu-command/src/bytes/reverse.rs
+++ b/crates/nu-command/src/bytes/reverse.rs
@@ -21,13 +21,13 @@ impl Command for BytesReverse {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally matches prefix of text by column paths",
+                "for a data structure input, reverse data at the given cell paths",
             )
             .category(Category::Bytes)
     }
 
     fn usage(&self) -> &str {
-        "Reverse every bytes in the pipeline"
+        "Reverse the bytes in the pipeline"
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -33,7 +33,7 @@ impl Command for BytesStartsWith {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally matches prefix of text by column paths",
+                "for a data structure input, check if bytes at the given cell paths start with the pattern",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -30,7 +30,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "column paths to convert to binary (for table input)",
+                "for a data structure input, convert data at the given cell paths",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "column paths to convert to boolean (for table input)",
+                "for a data structure input, convert data at the given cell paths",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -94,7 +94,7 @@ impl Command for SubCommand {
             .rest(
             "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text into datetime by column paths",
+                "for a data structure input, convert data at the given cell paths",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text into decimal by column paths",
+                "for a data structure input, convert data at the given cell paths",
             )
     }
 

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -33,7 +33,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "column paths to convert to duration (for table input)",
+                "for a data structure input, convert data at the given cell paths",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -25,7 +25,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "column paths to convert to filesize (for table input)",
+                "for a data structure input, convert data at the given cell paths",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -43,7 +43,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "column paths to convert to int (for table input)",
+                "for a data structure input, convert data at the given cell paths",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -42,11 +42,10 @@ impl Command for SubCommand {
                 (Type::Date, Type::String),
             ])
             .allow_variants_without_examples(true) // https://github.com/nushell/nushell/issues/7032
-            // FIXME - need to support column paths
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "column paths to convert to string (for table input)",
+                "for a data structure input, convert data at the given cell paths",
             )
             .named(
                 "decimals",

--- a/crates/nu-command/src/input_handler.rs
+++ b/crates/nu-command/src/input_handler.rs
@@ -33,7 +33,7 @@ impl From<Vec<CellPath>> for CellPathOnlyArgs {
 ///
 /// In detail, for each elements, invoking relative `cmd` with `arg`.
 ///
-/// If `arg` tell us that it's column path is not None, only map over data under these columns.
+/// If `arg` tell us that its cell path is not None, only map over data under these columns.
 /// Else it will apply each column inside a table.
 ///
 /// The validation of input element should be handle by `cmd` itself.

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -375,8 +375,8 @@ second block if the expression is false.
 
 fn shorthand_tutor() -> &'static str {
     r#"
-You can access cells in a table using a shorthand notation sometimes called a
-"column path" or "cell path". These paths allow you to go from a table to
+You can access cells in a table using a shorthand notation called a "cell path",
+sometimes called a "column path". These paths allow you to go from a table to
 rows, columns, or cells inside of the table.
 
 Shorthand paths are made from rows numbers, column names, or both. You can use

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -313,9 +313,9 @@ tutor each
 
 fn each_tutor() -> &'static str {
     r#"
-The `each` command gives us a way of working with each individual row or
-element of a list one at a time. It reads these in from the pipeline and
-runs a block on each element. A block is a group of pipelines.
+The `each` command gives us a way of working with the individual elements
+(sometimes called 'rows') of a list one at a time. It reads these in from
+the pipeline and runs a block on each one. A block is a group of pipelines.
 ```
 echo 1 2 3 | each { |it| $it + 10}
 ```
@@ -375,9 +375,9 @@ second block if the expression is false.
 
 fn shorthand_tutor() -> &'static str {
     r#"
-You can access cells in a table using a shorthand notation called a "cell path",
-sometimes called a "column path". These paths allow you to go from a table to
-rows, columns, or cells inside of the table.
+You can access data in a structure via a shorthand notation called a "cell path",
+sometimes called a "column path". These paths allow you to go from a structure to
+rows, columns, or cells inside of the structure.
 
 Shorthand paths are made from rows numbers, column names, or both. You can use
 them on any variable or subexpression.
@@ -392,8 +392,8 @@ the shorthand path to retrieve only the cell data inside the "PWD" column.
 This will retrieve the cell data in the "name" column on the 5th row (note:
 row numbers are zero-based).
 
-Rows and columns don't need to come in any specific order. You can get the
-same value using:
+For tables, rows and columns don't need to come in any specific order. You can
+produce the same value using:
 ```
 (ls).4.name
 ```

--- a/crates/nu-command/src/path/basename.rs
+++ b/crates/nu-command/src/path/basename.rs
@@ -34,7 +34,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, convert strings in the given columns to their basename",
                 Some('c'),
             )
             .named(

--- a/crates/nu-command/src/path/dirname.rs
+++ b/crates/nu-command/src/path/dirname.rs
@@ -31,7 +31,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, convert strings at the given columns to their dirname",
                 Some('c'),
             )
             .named(

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -31,7 +31,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, check strings at the given columns, and replace with result",
                 Some('c'),
             )
     }

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -42,7 +42,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, expand strings at the given columns",
                 Some('c'),
             )
     }

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -40,7 +40,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, join strings at the given columns",
                 Some('c'),
             )
             .rest("append", SyntaxShape::String, "Path to append to the input")

--- a/crates/nu-command/src/path/parse.rs
+++ b/crates/nu-command/src/path/parse.rs
@@ -33,7 +33,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, convert strings at the given columns",
                 Some('c'),
             )
             .named(

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -38,13 +38,13 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, convert strings at the given columns",
                 Some('c'),
             )
     }
 
     fn usage(&self) -> &str {
-        "Get a path as relative to another path."
+        "Express a path as relative to another path."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -31,7 +31,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, split strings at the given columns",
                 Some('c'),
             )
     }

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -31,7 +31,7 @@ impl Command for SubCommand {
             .named(
                 "columns",
                 SyntaxShape::Table,
-                "Optionally operate by column path",
+                "For a record or table input, check strings at the given columns, and replace with result",
                 Some('c'),
             )
     }

--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -39,15 +39,15 @@ impl Command for SubCommand {
                 Some('d'),
             )
             .rest(
-                "column path",
+                "cell path",
                 SyntaxShape::CellPath,
-                "optionally, draw gradients using text from column paths",
+                "for a data structure input, add a gradient to strings at the given cell paths",
             )
             .category(Category::Platform)
     }
 
     fn usage(&self) -> &str {
-        "Draw text with a provided start and end code making a gradient"
+        "Add a color gradient (using ANSI color codes) to the given string"
     }
 
     fn run(

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -16,9 +16,9 @@ impl Command for SubCommand {
         Signature::build("ansi strip")
             .input_output_types(vec![(Type::String, Type::String)])
             .rest(
-                "column path",
+                "cell path",
                 SyntaxShape::CellPath,
-                "optionally, remove ANSI sequences by column paths",
+                "for a data structure input, remove ANSI sequences from strings at the given cell paths",
             )
             .category(Category::Platform)
     }

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -34,7 +34,7 @@ impl Command for DecodeBase64 {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally base64 decode data by column paths",
+                "For a data structure input, decode data at the given cell paths",
             )
             .category(Category::Hash)
     }

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -26,7 +26,7 @@ impl Command for EncodeBase64 {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally base64 encode data by column paths",
+                "For a data structure input, encode data at the given cell paths",
             )
             .output_type(Type::String)
             .category(Category::Hash)

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -37,7 +37,7 @@ impl Command for FileSize {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "Optionally find and replace text by column paths",
+                "For a data structure input, format filesizes at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text to camelCase by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -20,7 +20,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally capitalize text by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -20,7 +20,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally downcase text by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text to kebab-case by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text to PascalCase by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text to SCREAMING_SNAKE_CASE by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text to snake_case by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally convert text to Title Case by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally upcase text by column paths",
+                "For a data structure input, convert strings at the given cell paths",
             )
     }
 

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -31,11 +31,11 @@ impl Command for SubCommand {
         Signature::build("str contains")
             .input_output_types(vec![(Type::String, Type::Bool)])
             .vectorizes_over_list(true)
-            .required("string", SyntaxShape::String, "the string to find")
+            .required("string", SyntaxShape::String, "the substring to find")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally check if input contains string by column paths",
+                "For a data structure input, check strings at the given cell paths, and replace with result",
             )
             .switch("insensitive", "search is case insensitive", Some('i'))
             .switch("not", "does not contain", Some('n'))
@@ -43,7 +43,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Checks if input contains string"
+        "Checks if string input contains a substring"
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally check if string contains pattern by column paths",
+                "For a data structure input, check strings at the given cell paths, and replace with result",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -33,7 +33,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally matches suffix of text by cell paths",
+                "For a data structure input, check strings at the given cell paths, and replace with result",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -39,7 +39,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally returns index of string in input by column paths",
+                "For a data structure input, search strings at the given cell paths, and replace with result",
             )
             .named(
                 "range",

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -20,7 +20,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally find length of text by column paths",
+                "For a data structure input, replace strings at the given cell paths with their length",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/lpad.rs
+++ b/crates/nu-command/src/strings/str_/lpad.rs
@@ -40,7 +40,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally check if string contains pattern by column paths",
+                "For a data structure input, pad strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -40,7 +40,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally find and replace text by column paths",
+                "For a data structure input, operate on strings at the given cell paths",
             )
             .switch("all", "replace all occurrences of find string", Some('a'))
             .switch(

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally reverse text by column paths",
+                "For a data structure input, reverse strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/rpad.rs
+++ b/crates/nu-command/src/strings/str_/rpad.rs
@@ -40,7 +40,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally check if string contains pattern by column paths",
+                "For a data structure input, pad strings at the given cell paths",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally matches prefix of text by column paths",
+                "For a data structure input, check strings at the given cell paths, and replace with result",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -48,7 +48,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally substring text by column paths",
+                "For a data structure input, turn strings at the given cell paths into substrings",
             )
     }
 

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -44,8 +44,7 @@ impl Command for SubCommand {
         .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally trim text by column paths",
-            )
+                "For a data structure input, trim strings at the given cell paths",            )
             .named(
                 "char",
                 SyntaxShape::String,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -608,7 +608,7 @@ impl Value {
         Value::Nothing { span }
     }
 
-    /// Follow a given column path into the value: for example accessing select elements in a stream or list
+    /// Follow a given cell path into the value: for example accessing select elements in a stream or list
     pub fn follow_cell_path(
         self,
         cell_path: &[PathMember],
@@ -750,7 +750,7 @@ impl Value {
         Ok(current)
     }
 
-    /// Follow a given column path into the value: for example accessing select elements in a stream or list
+    /// Follow a given cell path into the value: for example accessing select elements in a stream or list
     pub fn upsert_cell_path(
         &mut self,
         cell_path: &[PathMember],
@@ -863,7 +863,7 @@ impl Value {
         Ok(())
     }
 
-    /// Follow a given column path into the value: for example accessing select elements in a stream or list
+    /// Follow a given cell path into the value: for example accessing select elements in a stream or list
     pub fn update_cell_path(
         &mut self,
         cell_path: &[PathMember],


### PR DESCRIPTION
# Description

Replaces all instances of 'column path' in `help` messages with 'cell path'

Reasons why:
* Cell path is already accepted terminology for this feature in [the Nushell docs](https://www.nushell.sh/book/types_of_data.html#cell-paths)
* Cell paths can also take row indexes (among complex paths like `a.0.b`)
* Cell paths can work on lists (by simply beginning with row indexes)
* "Column path" suggests it only works on tables and not records

This also (in passing) fixes a shocking number of help strings which until now were just flat-out incorrect. For example, `path` subcommands say they accept cell paths, but actually only operate on column names with no extra qualification.

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
