### PR TITLE
Support interpolation in backtick strings

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1698,7 +1698,7 @@ pub fn parse_string_interpolation(
                 0
             };
 
-            if current_byte == b'(' && (escaped_string || preceding_consecutive_backslashes % 2 == 0)
+            if current_byte == b'(' && (!escaped_string || preceding_consecutive_backslashes % 2 == 0)
             {
                 mode = InterpolationMode::Expression;
                 if token_start < b {

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -235,6 +235,31 @@ fn string_interpolation_escaping() -> TestResult {
 }
 
 #[test]
+fn string_interpolation_paren_escaping() -> TestResult {
+    run_test(r#"$"A\(3)B(4 + 4)C""#, "A(3)B8C")
+}
+
+#[test]
+fn string_interpolation_single_tick() -> TestResult {
+    run_test(r#"$'A(3 + 4)B'"#, "A7B")
+}
+
+#[test]
+fn string_interpolation_backtick() -> TestResult {
+    run_test(r#"$`A(3 + 4)B`"#, "A7B")
+}
+
+#[test]
+fn string_interpolation_nested() -> TestResult {
+    run_test(r#"$`A($`A(3 + 4)B`)B`"#, "AA7BB")
+}
+
+#[test]
+fn string_interpolation_null() -> TestResult {
+    run_test(r#"$`A(null)B`"#, "AB")
+}
+
+#[test]
 fn capture_multiple_commands() -> TestResult {
     run_test(
         r#"

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -245,8 +245,18 @@ fn string_interpolation_single_tick() -> TestResult {
 }
 
 #[test]
+fn string_interpolation_single_tick_no_escaping() -> TestResult {
+    run_test(r#"$'A\nt'"#, "A\\nt")
+}
+
+#[test]
 fn string_interpolation_backtick() -> TestResult {
     run_test(r#"$`A(3 + 4)B`"#, "A7B")
+}
+
+#[test]
+fn string_interpolation_backtick_no_escaping() -> TestResult {
+    run_test(r#"$`A\nt`"#, "A\\nt")
 }
 
 #[test]

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -47,11 +47,6 @@ fn string_in_valuestream() -> TestResult {
 }
 
 #[test]
-fn single_tick_interpolation() -> TestResult {
-    run_test(r#"$'(3 + 4)'"#, "7")
-}
-
-#[test]
 fn detect_newlines() -> TestResult {
     run_test("'hello\r\nworld' | lines | get 0 | str length", "5")
 }


### PR DESCRIPTION
# Description

Support interpolation in backtick strings:
```
$`( "gray" | str title-case )'s Anatomy`
```

Also moved all the string interpolation tests into one file (were separated unnecessarily).

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
