### PR TITLE
Turn off foreground processes on macOS

### DIFF
--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -79,7 +79,8 @@ impl Drop for ForegroundChild {
 }
 
 // It's a simpler version of fish shell's external process handling.
-#[cfg(target_family = "unix")]
+// Note: we exclude macos because the techniques below seem to have issues in macos 13 currently.
+#[cfg(all(target_family = "unix", not(target_os="macos")))]
 mod fg_process_setup {
     use nix::{
         sys::signal,
@@ -170,7 +171,7 @@ mod fg_process_setup {
     }
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(any(not(target_family = "unix"), target_os="macos"))]
 mod fg_process_setup {
     pub(super) fn prepare_to_foreground(_: &mut std::process::Command, _: u32) {}
 

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -80,7 +80,7 @@ impl Drop for ForegroundChild {
 
 // It's a simpler version of fish shell's external process handling.
 // Note: we exclude macos because the techniques below seem to have issues in macos 13 currently.
-#[cfg(all(target_family = "unix", not(target_os="macos")))]
+#[cfg(all(target_family = "unix", not(target_os = "macos")))]
 mod fg_process_setup {
     use nix::{
         sys::signal,
@@ -171,7 +171,7 @@ mod fg_process_setup {
     }
 }
 
-#[cfg(any(not(target_family = "unix"), target_os="macos"))]
+#[cfg(any(not(target_family = "unix"), target_os = "macos"))]
 mod fg_process_setup {
     pub(super) fn prepare_to_foreground(_: &mut std::process::Command, _: u32) {}
 


### PR DESCRIPTION
# Description

Looks like macOS 13 has issues with how we're currently handling foreground processes. For the time being, let's disable using those techniques on macOS until we have had a chance to investigate further.

This fix prevents a crash on macOS 13 when running `cargo test.

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
