### PR TITLE
use path.try_exist() to fix silent errors

### DIFF
--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -103,7 +103,10 @@ If you need to distinguish dirs and files, please use `path type`."#
 fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
     let path = expand_path_with(path, &args.pwd);
     Value::Bool {
-        val: path.exists(),
+        val: match path.try_exists() {
+            Ok(exists) => exists,
+            Err(err) => return Value::Error { error: err.into() },
+        },
         span,
     }
 }


### PR DESCRIPTION
# Description

This should close #7065 

This uses `path.try_exists()` in order to not silently fail. Thanks @ChrisDenton for the tip.

This is how I tested.
1. `mkdir c:\tmp\banned`
2. `cd c:\tmp\banned`
3. `touch foo`
4. `icacls foo /deny BUILTIN\Administrators:F`
5. `'c:\tmp\banned\foo' | path exists` <-- returns a permission denied error now (screenshot below)
6. `'c:\tmp\banned\foo2' | path exists` <-- returns false
7. `'c:\tmp\banned' | path exists` <-- turns true
8. `touch foo2`
9. `'c:\tmp\banned\foo2 | path exists` <-- returns true
10. cleanup now - `icacls foo /grant BUILTIN\Administrators:F`


![image](https://user-images.githubusercontent.com/343840/200915557-0c3af68b-7dc9-46fa-a4dd-1b674a7f1c0a.png)

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
