### PR TITLE
fix overflow on negative bytes

### DIFF
--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -74,3 +74,15 @@ fn into_filesize_filesize() {
 
     assert!(actual.out.contains("3.0 KiB"));
 }
+
+#[test]
+fn into_filesize_negative_filesize() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        -3kib | into filesize
+        "#
+    ));
+
+    assert!(actual.out.contains("-3.0 KiB"));
+}

--- a/src/tests/test_math.rs
+++ b/src/tests/test_math.rs
@@ -104,3 +104,8 @@ fn floating_add() -> TestResult {
 fn precedence_of_or_groups() -> TestResult {
     run_test(r#"4 mod 3 == 0 || 5 mod 5 == 0"#, "true")
 }
+
+#[test]
+fn test_filesize_op() -> TestResult {
+    run_test("-5kb + 4kb", "-1,000 B")
+}


### PR DESCRIPTION
# Description
Closes #7055 which caused overflow on negative bytes.

Now
```
〉-4kb                                                                                                                                                                          11/09/2022 09:11:35 PM
3.9 KiB
〉4kb                                                                                                                                                                           11/09/2022 09:11:37 PM
3.9 KiB
〉-4kb + 10kb                                                                                                                                                                   11/09/2022 09:11:39 PM
5.9 KiB
〉4kb + 10kb                                                                                                                                                                    11/09/2022 09:11:44 PM
13.7 KiB
```
So the math operations still check out, even tho the output is now always positive, which depending on the final use case of specifying negative bytes (.e.g -4kb), might or not be desirable. Before, specifying anything negative gave overflow, so improvement I would say regardless :) 
# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- [X] cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
