### PR TITLE
Fix command_type classification

### DIFF
--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -99,6 +99,8 @@ impl Command for Let {
 
 #[cfg(test)]
 mod test {
+    use nu_protocol::engine::CommandType;
+
     use super::*;
 
     #[test]
@@ -106,5 +108,10 @@ mod test {
         use crate::test_examples;
 
         test_examples(Let {})
+    }
+
+    #[test]
+    fn test_command_type() {
+        assert!(matches!(Let.command_type(), CommandType::Keyword));
     }
 }

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -292,6 +292,9 @@ pub fn process(
 
 #[cfg(test)]
 mod test {
+
+    use nu_protocol::engine::CommandType;
+
     use super::*;
 
     #[test]
@@ -299,5 +302,10 @@ mod test {
         use crate::test_examples;
 
         test_examples(Sort {})
+    }
+
+    #[test]
+    fn test_command_type() {
+        assert!(matches!(Sort.command_type(), CommandType::Builtin));
     }
 }

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -9,6 +9,7 @@ pub enum CommandType {
     Builtin,
     Custom,
     Keyword,
+    External,
     Plugin,
     Other,
 }
@@ -86,12 +87,14 @@ pub trait Command: Send + Sync + CommandClone {
             self.is_builtin(),
             self.is_custom_command(),
             self.is_parser_keyword(),
+            self.is_known_external(),
             self.is_plugin().is_some(),
         ) {
-            (true, false, false, false) => CommandType::Builtin,
-            (false, true, false, false) => CommandType::Custom,
-            (_, false, true, false) => CommandType::Keyword,
-            (false, false, false, true) => CommandType::Plugin,
+            (true, false, false, false, false) => CommandType::Builtin,
+            (true, true, false, false, false) => CommandType::Custom,
+            (true, false, true, false, false) => CommandType::Keyword,
+            (false, true, false, true, false) => CommandType::External,
+            (false, false, false, false, true) => CommandType::Plugin,
             _ => CommandType::Other,
         }
     }


### PR DESCRIPTION
This PR fixes a bug in #7052, adds an `external` command type, and adds a couple of tests.

Specifically the bug was:

- Custom commands are `true` for builtin as well as custom, but #7052 was missing that

For example, in my personal Nushell, I get

```
 〉help commands | get command_type | uniq -c
╭──────────┬───────╮
│  value   │ count │
├──────────┼───────┤
│ custom   │    84 │
│ keyword  │    22 │
│ builtin  │   293 │
│ external │     3 │
╰──────────┴───────╯
```