### PR TITLE
Enhanced shell integration for prompts

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -106,16 +106,18 @@ pub(crate) fn update_prompt<'prompt>(
 
     let prompt_vi_normal_string =
         get_prompt_string(PROMPT_INDICATOR_VI_NORMAL, config, engine_state, &mut stack);
-    let wrap_left_prompt =
-        if let Some((s1, s2)) = &config.wrap_left_prompt {
-            Some((s1.clone(), s2.clone()))
-        } else if config.shell_integration {
-            // Now that we have the prompt string lets ansify it.
-            // <133 A><prompt><133 B><command><133 C><command output>
-            Some((PRE_PROMPT_MARKER.to_string(), POST_PROMPT_MARKER.to_string()))
-        } else {
-            None
-        };
+    let wrap_left_prompt = if let Some((s1, s2)) = &config.wrap_left_prompt {
+        Some((s1.clone(), s2.clone()))
+    } else if config.shell_integration {
+        // Now that we have the prompt string lets ansify it.
+        // <133 A><prompt><133 B><command><133 C><command output>
+        Some((
+            PRE_PROMPT_MARKER.to_string(),
+            POST_PROMPT_MARKER.to_string(),
+        ))
+    } else {
+        None
+    };
 
     // apply the other indicators
     nu_prompt.update_all_prompt_strings(

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -92,20 +92,6 @@ pub(crate) fn update_prompt<'prompt>(
 
     let left_prompt_string = get_prompt_string(PROMPT_COMMAND, config, engine_state, &mut stack);
 
-    // Now that we have the prompt string lets ansify it.
-    // <133 A><prompt><133 B><command><133 C><command output>
-    let left_prompt_string = if config.shell_integration {
-        match left_prompt_string {
-            Some(prompt_string) => Some(format!(
-                "{}{}{}",
-                PRE_PROMPT_MARKER, prompt_string, POST_PROMPT_MARKER
-            )),
-            None => left_prompt_string,
-        }
-    } else {
-        left_prompt_string
-    };
-
     let right_prompt_string =
         get_prompt_string(PROMPT_COMMAND_RIGHT, config, engine_state, &mut stack);
 
@@ -120,6 +106,16 @@ pub(crate) fn update_prompt<'prompt>(
 
     let prompt_vi_normal_string =
         get_prompt_string(PROMPT_INDICATOR_VI_NORMAL, config, engine_state, &mut stack);
+    let wrap_left_prompt =
+        if let Some((s1, s2)) = &config.wrap_left_prompt {
+            Some((s1.clone(), s2.clone()))
+        } else if config.shell_integration {
+            // Now that we have the prompt string lets ansify it.
+            // <133 A><prompt><133 B><command><133 C><command output>
+            Some((PRE_PROMPT_MARKER.to_string(), POST_PROMPT_MARKER.to_string()))
+        } else {
+            None
+        };
 
     // apply the other indicators
     nu_prompt.update_all_prompt_strings(
@@ -129,6 +125,11 @@ pub(crate) fn update_prompt<'prompt>(
         prompt_multiline_string,
         (prompt_vi_insert_string, prompt_vi_normal_string),
         config.render_right_prompt_on_last_line,
+        wrap_left_prompt,
+        config.wrap_right_prompt.clone(),
+        config.wrap_history_search_prompt.clone(),
+        config.wrap_indicator_prompt.clone(),
+        config.wrap_multiline_prompt.clone(),
     );
 
     let ret_val = nu_prompt as &dyn Prompt;

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -87,11 +87,11 @@ pub struct Config {
     pub show_banner: bool,
     pub show_clickable_links_in_ls: bool,
     pub render_right_prompt_on_last_line: bool,
-    pub wrap_left_prompt: Option<(String,String)>,
-    pub wrap_right_prompt: Option<(String,String)>,
-    pub wrap_history_search_prompt: Option<(String,String)>,
-    pub wrap_indicator_prompt: Option<(String,String)>,
-    pub wrap_multiline_prompt: Option<(String,String)>,
+    pub wrap_left_prompt: Option<(String, String)>,
+    pub wrap_right_prompt: Option<(String, String)>,
+    pub wrap_history_search_prompt: Option<(String, String)>,
+    pub wrap_indicator_prompt: Option<(String, String)>,
+    pub wrap_multiline_prompt: Option<(String, String)>,
 }
 
 impl Default for Config {
@@ -452,25 +452,29 @@ impl Value {
                             eprintln!("$config.render_right_prompt_on_last_line is not a bool")
                         }
                     }
-                    "wrap_left_prompt" | "wrap_right_prompt" | "wrap_history_search_prompt" | "wrap_indicator_prompt" | "wrap_multiline_prompt" => {
+                    "wrap_left_prompt"
+                    | "wrap_right_prompt"
+                    | "wrap_history_search_prompt"
+                    | "wrap_indicator_prompt"
+                    | "wrap_multiline_prompt" => {
                         let mut wraps = None;
                         match value {
                             Value::Nothing { .. } => {
                                 wraps = None;
                             }
-                            Value::List { vals, .. } => {
-                                match &vals[..] {
-                                    [Value::String { val: v1, .. },
-                                     Value::String { val: v2, .. }] => {
-                                        wraps = Some((v1.to_string(), v2.to_string()));
-                                    }
-                                    _ => {
-                                        eprintln!("$config.{} is neither a 2-string list or null", key)
-                                    }
+                            Value::List { vals, .. } => match &vals[..] {
+                                [Value::String { val: v1, .. }, Value::String { val: v2, .. }] => {
+                                    wraps = Some((v1.to_string(), v2.to_string()));
                                 }
-                            }
+                                _ => {
+                                    eprintln!("$config.{} is neither a 2-string list or null", key)
+                                }
+                            },
                             _ => {
-                                eprintln!("$config.{}_right_prompt is neither 2-string list or null", key)
+                                eprintln!(
+                                    "$config.{}_right_prompt is neither 2-string list or null",
+                                    key
+                                )
                             }
                         }
                         match key.as_str() {
@@ -489,8 +493,7 @@ impl Value {
                             "wrap_multiline_prompt" => {
                                 config.wrap_multiline_prompt = wraps;
                             }
-                            _ => {
-                            }
+                            _ => {}
                         }
                     }
                     x => {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -87,6 +87,11 @@ pub struct Config {
     pub show_banner: bool,
     pub show_clickable_links_in_ls: bool,
     pub render_right_prompt_on_last_line: bool,
+    pub wrap_left_prompt: Option<(String,String)>,
+    pub wrap_right_prompt: Option<(String,String)>,
+    pub wrap_history_search_prompt: Option<(String,String)>,
+    pub wrap_indicator_prompt: Option<(String,String)>,
+    pub wrap_multiline_prompt: Option<(String,String)>,
 }
 
 impl Default for Config {
@@ -125,6 +130,11 @@ impl Default for Config {
             show_banner: true,
             show_clickable_links_in_ls: true,
             render_right_prompt_on_last_line: false,
+            wrap_left_prompt: None,
+            wrap_right_prompt: None,
+            wrap_history_search_prompt: None,
+            wrap_indicator_prompt: None,
+            wrap_multiline_prompt: None,
         }
     }
 }
@@ -440,6 +450,47 @@ impl Value {
                             config.render_right_prompt_on_last_line = b;
                         } else {
                             eprintln!("$config.render_right_prompt_on_last_line is not a bool")
+                        }
+                    }
+                    "wrap_left_prompt" | "wrap_right_prompt" | "wrap_history_search_prompt" | "wrap_indicator_prompt" | "wrap_multiline_prompt" => {
+                        let mut wraps = None;
+                        match value {
+                            Value::Nothing { .. } => {
+                                wraps = None;
+                            }
+                            Value::List { vals, .. } => {
+                                match &vals[..] {
+                                    [Value::String { val: v1, .. },
+                                     Value::String { val: v2, .. }] => {
+                                        wraps = Some((v1.to_string(), v2.to_string()));
+                                    }
+                                    _ => {
+                                        eprintln!("$config.{} is neither a 2-string list or null", key)
+                                    }
+                                }
+                            }
+                            _ => {
+                                eprintln!("$config.{}_right_prompt is neither 2-string list or null", key)
+                            }
+                        }
+                        match key.as_str() {
+                            "wrap_left_prompt" => {
+                                config.wrap_left_prompt = wraps;
+                            }
+                            "wrap_right_prompt" => {
+                                config.wrap_right_prompt = wraps;
+                            }
+                            "wrap_history_search_prompt" => {
+                                config.wrap_history_search_prompt = wraps;
+                            }
+                            "wrap_indicator_prompt" => {
+                                config.wrap_indicator_prompt = wraps;
+                            }
+                            "wrap_multiline_prompt" => {
+                                config.wrap_multiline_prompt = wraps;
+                            }
+                            _ => {
+                            }
                         }
                     }
                     x => {


### PR DESCRIPTION
# Description

This provides more flexibility in support different or [expanded shell integration protocols](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md).

On DomTerm, the  `config.nu` shown below enables the following features:
* Move cursor by clicking mouse.  This is simulated by the terminal sending Left/Right arrow keys.
* Command errors are indicated with a small red circle.  Hovering over it displays the error code.
* If you change the window width, it automatically adjusts the position of right prompts in the scroll-back buffer.  The prompt is hidden if there isn't enough space on the line. _Note_: While reedline adjusts the right-prompt position in the _current_ command, for previous commends this had to be handled by the terminal.
* "Folding": Little triangles that when clicked show or hide the output of a command.
* Right prompt and indicators are distinguished internally and visibly.

See [this old blog article](http://per.bothner.com/blog/2019/shell-integration-proposal/) for more about these features, with (non-Nu) screenshots.

This is the `config.nu` addition I use:

    let-env config = if "DOMTERM" in (env).name { $env.config
      | upsert hooks {
        pre_prompt: { print --no-newline "\u001b]133;A;cl=m\u0007" }
        display_output: { to html --partial --no-color | domterm hcat } }
      | upsert wrap_left_prompt ["\u001b]133;P;k=i\u0007", "\u001b]133;B\u0007"]
      | upsert wrap_right_prompt ["\u001b]133;P;k=r\u0007", "\u001b]133;B\u0007"]
      | upsert wrap_multiline_prompt ["\u001b]133;P;k=c\u0007", "\u001b]133;B\u0007"]
      | upsert wrap_indicator_prompt ["\u001b]133;P\u0007", "\u001b]133;B\u0007"]
      | upsert wrap_history_search_prompt ["\u001b]133;P;k=i\u0007", "\u001b]133;B\u0007"]
      } else { $env.config }


# Tests + Formatting

Make sure you've run and fixed any issues with these commands:

[X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
[-] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style

> This causes one problem: `update_all_prompt_strings` causes `error: this function has too many arguments (12/7)`. I will discuss my recommended fix in a follow-up comment.

   
[X] `cargo test --workspace --features=extra` to check that all tests pass
