### PR TITLE
`to html --list` now returns a table

### DIFF
--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -86,6 +86,15 @@ impl Command for Metadata {
                                 span: head,
                             })
                         }
+                        PipelineMetadata {
+                            data_source: DataSource::HtmlThemes,
+                        } => {
+                            cols.push("source".into());
+                            vals.push(Value::String {
+                                val: "into html --list".into(),
+                                span: head,
+                            })
+                        }
                     }
                 }
 
@@ -145,6 +154,15 @@ fn build_metadata_record(arg: &Value, metadata: &Option<PipelineMetadata>, head:
                 cols.push("source".into());
                 vals.push(Value::String {
                     val: "ls".into(),
+                    span: head,
+                })
+            }
+            PipelineMetadata {
+                data_source: DataSource::HtmlThemes,
+            } => {
+                cols.push("source".into());
+                vals.push(Value::String {
+                    val: "into html --list".into(),
                     span: head,
                 })
             }

--- a/crates/nu-command/src/formats/to/html.rs
+++ b/crates/nu-command/src/formats/to/html.rs
@@ -147,6 +147,10 @@ impl Command for ToHtml {
         "Convert table into simple HTML"
     }
 
+    fn extra_usage(&self) -> &str {
+        "Screenshots of the themes can be browsed here: https://github.com/mbadolato/iTerm2-Color-Schemes"
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/formats/to/html.rs
+++ b/crates/nu-command/src/formats/to/html.rs
@@ -4,8 +4,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Config, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned,
-    SyntaxShape, Type, Value,
+    Category, Config, DataSource, Example, IntoPipelineData, PipelineData, PipelineMetadata,
+    ShellError, Signature, Spanned, SyntaxShape, Type, Value,
 };
 use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
@@ -109,7 +109,11 @@ impl Command for ToHtml {
                 "the name of the theme to use (github, blulocolight, ...)",
                 Some('t'),
             )
-            .switch("list", "list the names of all available themes", Some('l'))
+            .switch(
+                "list",
+                "produce a color table of all available themes",
+                Some('l'),
+            )
             .category(Category::Formats)
     }
 
@@ -223,12 +227,6 @@ fn get_html_themes(json_name: &str) -> Result<HtmlThemes, Box<dyn Error>> {
     }
 }
 
-fn get_list_of_theme_names() -> Vec<String> {
-    // If asset doesn't work, make sure to return the default theme
-    let html_themes = get_html_themes("228_themes.json").unwrap_or_default();
-    html_themes.themes.into_iter().map(|n| n.name).collect()
-}
-
 fn to_html(
     input: PipelineData,
     call: &Call,
@@ -251,17 +249,76 @@ fn to_html(
     let mut output_string = String::new();
     let mut regex_hm: HashMap<u32, (&str, String)> = HashMap::with_capacity(17);
 
+    // Being essentially a 'help' option, this can afford to be relatively unoptimised
     if list {
-        // Get the list of theme names
-        let theme_names = get_list_of_theme_names();
+        // If asset doesn't work, make sure to return the default theme
+        let html_themes = get_html_themes("228_themes.json").unwrap_or_default();
 
-        // Put that list into the output string
-        for s in &theme_names {
-            writeln!(&mut output_string, "{}", s).unwrap();
+        let cols = vec![
+            "name".into(),
+            "black".into(),
+            "red".into(),
+            "green".into(),
+            "yellow".into(),
+            "blue".into(),
+            "purple".into(),
+            "cyan".into(),
+            "white".into(),
+            "brightBlack".into(),
+            "brightRed".into(),
+            "brightGreen".into(),
+            "brightYellow".into(),
+            "brightBlue".into(),
+            "brightPurple".into(),
+            "brightCyan".into(),
+            "brightWhite".into(),
+            "background".into(),
+            "foreground".into(),
+        ];
+
+        let result: Vec<Value> = html_themes
+            .themes
+            .into_iter()
+            .map(|n| {
+                let vals = vec![
+                    n.name,
+                    n.black,
+                    n.red,
+                    n.green,
+                    n.yellow,
+                    n.blue,
+                    n.purple,
+                    n.cyan,
+                    n.white,
+                    n.brightBlack,
+                    n.brightRed,
+                    n.brightGreen,
+                    n.brightYellow,
+                    n.brightBlue,
+                    n.brightPurple,
+                    n.brightCyan,
+                    n.brightWhite,
+                    n.background,
+                    n.foreground,
+                ]
+                .into_iter()
+                .map(|val| Value::String { val, span: head })
+                .collect();
+
+                Value::Record {
+                    cols: cols.clone(),
+                    vals,
+                    span: head,
+                }
+            })
+            .collect();
+        return Ok(Value::List {
+            vals: result,
+            span: head,
         }
-
-        output_string.push_str("\nScreenshots of themes can be found here:\n");
-        output_string.push_str("https://github.com/mbadolato/iTerm2-Color-Schemes\n");
+        .into_pipeline_data_with_metadata(PipelineMetadata {
+            data_source: DataSource::HtmlThemes,
+        }));
     } else {
         let theme_span = match &theme {
             Some(v) => v.span,

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -75,3 +75,15 @@ fn test_no_color_flag() {
         r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help - Display the help message for this command<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; cd -<br><br></body></html>"
     );
 }
+
+#[test]
+fn test_list() {
+    let actual = nu!(
+        cwd: ".",
+        r#"to html --list | where name == C64 | get 0 | to nuon"#
+    );
+    assert_eq!(
+        actual.out,
+        r##"{name: C64, black: "#090300", red: "#883932", green: "#55a049", yellow: "#bfce72", blue: "#40318d", purple: "#8b3f96", cyan: "#67b6bd", white: "#ffffff", brightBlack: "#000000", brightRed: "#883932", brightGreen: "#55a049", brightYellow: "#bfce72", brightBlue: "#40318d", brightPurple: "#8b3f96", brightCyan: "#67b6bd", brightWhite: "#f7f7f7", background: "#40318d", foreground: "#7869c4"}"##
+    );
+}

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -56,6 +56,7 @@ pub struct PipelineMetadata {
 #[derive(Debug, Clone)]
 pub enum DataSource {
     Ls,
+    HtmlThemes,
 }
 
 impl PipelineData {
@@ -586,6 +587,7 @@ impl Iterator for PipelineIterator {
 
 pub trait IntoPipelineData {
     fn into_pipeline_data(self) -> PipelineData;
+    fn into_pipeline_data_with_metadata(self, metadata: PipelineMetadata) -> PipelineData;
 }
 
 impl<V> IntoPipelineData for V
@@ -594,6 +596,9 @@ where
 {
     fn into_pipeline_data(self) -> PipelineData {
         PipelineData::Value(self.into(), None)
+    }
+    fn into_pipeline_data_with_metadata(self, metadata: PipelineMetadata) -> PipelineData {
+        PipelineData::Value(self.into(), Some(metadata))
     }
 }
 


### PR DESCRIPTION
# Description

I noticed that `to html --list` produced the bare minimum output, so I decided it needed to give structured data.

Note: I am aware `to html`'s themes don't actually work at all. If this is accepted, I plan to do a PR afterward to improve its output a tad.

P.S: The message `Screenshots of themes can be found here: https://github.com/mbadolato/iTerm2-Color-Schemes` has been moved to the `help` message.

# Example output (edit: colours removed for use in a forthcoming PR)
![image](https://user-images.githubusercontent.com/83939/201096172-5128e8b9-03aa-4c43-8e6a-d895b78b1806.png)

I'm aware this is only particularly useful on wide screens, but then again, there isn't really a more compact way to render all of this. And, there's always `| get name` when you just want the names.

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
