### PR TITLE
feat: Use Raw text to save if pipeline data is ExternalStream or String

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -121,6 +121,11 @@ impl Command for Save {
 
         let ext = if raw {
             None
+        // if is extern stream , in other words , not value
+        } else if let PipelineData::ExternalStream { .. } = input {
+            None
+        } else if let PipelineData::Value(Value::String { .. }, ..) = input {
+            None
         } else {
             path.extension()
                 .map(|name| name.to_string_lossy().to_string())

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -130,3 +130,22 @@ fn save_stderr_and_stdout_to_diff_file() {
         assert!(!actual.contains("bar"));
     })
 }
+
+#[test]
+fn save_string_and_stream_as_raw() {
+    Playground::setup("save_test_7", |dirs, sandbox| {
+        sandbox.with_files(vec![]);
+        let expected_file = dirs.test().join("temp.html");
+        nu!(
+            cwd: dirs.root(),
+            r#"
+            `<!DOCTYPE html><html><body><a href='http://example.org/'>Example</a></body></html>` | save save_test_7/temp.html
+            "#,
+        );
+        let actual = file_contents(expected_file);
+        assert_eq!(
+            actual,
+            r#"<!DOCTYPE html><html><body><a href='http://example.org/'>Example</a></body></html>"#
+        )
+    })
+}


### PR DESCRIPTION
if not value type in nushell, save will use raw type

# Description

Relate issue https://github.com/nushell/nushell/issues/7078, if the data is not value in nushell, I think we should save with raw text


# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
