### PR TITLE
fix `do -i` breaking execution when the block contains external commands

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -13,6 +13,15 @@ fn capture_errors_works() {
 }
 
 #[test]
+fn ignore_error_should_work_for_external_command() {
+    let actual = nu!(cwd: ".", pipeline(
+        r#"do -i {nu --testbin fail asdf}; echo post"#
+    ));
+
+    assert!(actual.out.contains("post"));
+}
+
+#[test]
 fn capture_errors_works_for_external() {
     let actual = nu!(
         cwd: ".", pipeline(


### PR DESCRIPTION
# Description

Fixes: #7076
Fixes: #6956

It's a regression introduced by #6643.

Before this pr(outputs nothing):
```
❯ do -i {nu --testbin fail asdf}; echo post
```

After this pr:
```
❯ do -i {nu --testbin fail asdf}; echo post
post
```

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
