### PR TITLE
fix plugin detection in help commands

### DIFF
--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -94,7 +94,7 @@ pub trait Command: Send + Sync + CommandClone {
             (true, true, false, false, false) => CommandType::Custom,
             (true, false, true, false, false) => CommandType::Keyword,
             (false, true, false, true, false) => CommandType::External,
-            (false, false, false, false, true) => CommandType::Plugin,
+            (true, false, false, false, true) => CommandType::Plugin,
             _ => CommandType::Other,
         }
     }


### PR DESCRIPTION
# Description

Fixes the problem where plugins are not detected properly in `help commands`.

Before - plugins were bucketed as "other"
![image](https://user-images.githubusercontent.com/343840/201214248-01f96a50-a37f-423e-bc04-c3e916890bda.png)

After
![image](https://user-images.githubusercontent.com/343840/201214296-60cec9f2-7e47-4446-937b-7e3687ab2edf.png)


# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
