### PR TITLE
Remove --separator from `seq date`

### DIFF
--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -24,12 +24,6 @@ impl Command for SeqDate {
         Signature::build("seq date")
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::String)))])
             .named(
-                "separator",
-                SyntaxShape::String,
-                "separator character (defaults to \\n)",
-                Some('s'),
-            )
-            .named(
                 "output-format",
                 SyntaxShape::String,
                 "prints dates in this format (defaults to %Y-%m-%d)",
@@ -133,7 +127,6 @@ impl Command for SeqDate {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        let separator: Option<Spanned<String>> = call.get_flag(engine_state, stack, "separator")?;
         let output_format: Option<Spanned<String>> =
             call.get_flag(engine_state, stack, "output-format")?;
         let input_format: Option<Spanned<String>> =
@@ -144,31 +137,6 @@ impl Command for SeqDate {
         let increment: Option<Spanned<i64>> = call.get_flag(engine_state, stack, "increment")?;
         let days: Option<Spanned<i64>> = call.get_flag(engine_state, stack, "days")?;
         let reverse = call.has_flag("reverse");
-
-        let sep: String = match separator {
-            Some(s) => {
-                if s.item == r"\t" {
-                    '\t'.to_string()
-                } else if s.item == r"\n" {
-                    '\n'.to_string()
-                } else if s.item == r"\r" {
-                    '\r'.to_string()
-                } else {
-                    let vec_s: Vec<char> = s.item.chars().collect();
-                    if vec_s.is_empty() {
-                        return Err(ShellError::GenericError(
-                            "Expected a single separator char from --separator".to_string(),
-                            "requires a single character string input".to_string(),
-                            Some(s.span),
-                            None,
-                            Vec::new(),
-                        ));
-                    };
-                    vec_s.iter().collect()
-                }
-            }
-            _ => '\n'.to_string(),
-        };
 
         let outformat = match output_format {
             Some(s) => Some(Value::string(s.item, s.span)),
@@ -203,7 +171,7 @@ impl Command for SeqDate {
         }
 
         Ok(
-            run_seq_dates(sep, outformat, informat, begin, end, inc, day_count, rev)?
+            run_seq_dates(outformat, informat, begin, end, inc, day_count, rev)?
                 .into_pipeline_data(),
         )
     }
@@ -219,7 +187,6 @@ pub fn parse_date_string(s: &str, format: &str) -> Result<NaiveDate, &'static st
 
 #[allow(clippy::too_many_arguments)]
 pub fn run_seq_dates(
-    separator: String,
     output_format: Option<Value>,
     input_format: Option<Value>,
     beginning_date: Option<String>,
@@ -353,25 +320,19 @@ pub fn run_seq_dates(
         ));
     }
 
-    let mut ret_str = String::from("");
+    let mut ret = vec![];
     loop {
-        ret_str.push_str(&next.format(&out_format).to_string());
+        let date_string = &next.format(&out_format).to_string();
+        ret.push(Value::string(date_string, Span::test_data()));
         next += Duration::days(step_size);
 
         if is_out_of_range(next) {
             break;
         }
-
-        ret_str.push_str(&separator);
     }
 
-    let rows: Vec<Value> = ret_str
-        .lines()
-        .map(|v| Value::string(v, Span::test_data()))
-        .collect();
-
     Ok(Value::List {
-        vals: rows,
+        vals: ret,
         span: Span::test_data(),
     })
 }


### PR DESCRIPTION
# Description

This PR removes the `--separator` flag from `seq date`, so that `seq date` always returns a `list<string>` and never a `string`.

This brings `seq date` in line with `seq` (#7045) and `seq char` (#7054). I probably should have done all 3 at once, my bad.

# Future Work

It's weird that `seq date` operates on strings instead of `Value::Date`s. We should change that someday. I was hoping to tackle that in this PR, but quickly got bogged down in reasoning about times and time zone offsets. I think that someday we need to sit down and do a larger review of our date+time functionality.