### PR TITLE
Improve `rm` error message when file not found

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -197,10 +197,24 @@ fn rm(
         ));
     }
 
+    let targets_span = Span {
+        start: targets
+            .iter()
+            .map(|x| x.span.start)
+            .min()
+            .expect("targets were empty"),
+        end: targets
+            .iter()
+            .map(|x| x.span.end)
+            .max()
+            .expect("targets were empty"),
+    };
+
     let path = current_dir(engine_state, stack)?;
 
     let (mut target_exists, mut empty_span) = (false, call.head);
     let mut all_targets: HashMap<PathBuf, Span> = HashMap::new();
+
     for target in targets {
         if path.to_string_lossy() == target.item
             || path.as_os_str().to_string_lossy().starts_with(&format!(
@@ -275,9 +289,9 @@ fn rm(
 
     if all_targets.is_empty() && !force {
         return Err(ShellError::GenericError(
-            "No valid paths".into(),
-            "no valid paths".into(),
-            Some(empty_span),
+            "File(s) not found".into(),
+            "File(s) not found".into(),
+            Some(targets_span),
             None,
             Vec::new(),
         ));


### PR DESCRIPTION
# Description

Closes #7091 by improving the error message when `rm` can't find the specified file(s). Also does a bit of work to ensure that the error span covers all the targets.

### Before:

![image](https://user-images.githubusercontent.com/26268125/201280033-5d698d54-699c-4359-ae5f-5b955c256eab.png)

### After:

![image](https://user-images.githubusercontent.com/26268125/201280166-1b309129-ae26-445b-9d96-ab49699076aa.png)