### PR TITLE
fix(#7097): let-env should not be able to set PWD

### DIFF
--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -1,4 +1,4 @@
-use nu_engine::{current_dir, eval_expression_with_input, CallExt};
+use nu_engine::{eval_expression_with_input, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -49,24 +49,11 @@ impl Command for LetEnv {
                 .0
                 .into_value(call.head);
 
-        if env_var.item == "FILE_PWD" {
+        if env_var.item == "FILE_PWD" || env_var.item == "PWD" {
             return Err(ShellError::AutomaticEnvVarSetManually(
                 env_var.item,
                 env_var.span,
             ));
-        }
-
-        if env_var.item == "PWD" {
-            let cwd = current_dir(engine_state, stack)?;
-            let rhs = rhs.as_string()?;
-            let rhs = nu_path::expand_path_with(rhs, cwd);
-            stack.add_env_var(
-                env_var.item,
-                Value::String {
-                    val: rhs.to_string_lossy().to_string(),
-                    span: call.head,
-                },
-            );
         } else {
             stack.add_env_var(env_var.item, rhs);
         }


### PR DESCRIPTION
# Description

the path of directory should be changed by cd, and should not be set by let-env, cd already can handle the let-env PWD , and can report error , use let-env to set it is useless
Fixes #7097

# Major Changes

PWD should also not be set manully

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
