### PR TITLE
Add support for while loops

### DIFF
--- a/crates/nu-command/src/core_commands/mod.rs
+++ b/crates/nu-command/src/core_commands/mod.rs
@@ -28,6 +28,7 @@ mod mut_;
 pub(crate) mod overlay;
 mod use_;
 mod version;
+mod while_;
 
 pub use alias::Alias;
 pub use ast::Ast;
@@ -59,6 +60,7 @@ pub use mut_::Mut;
 pub use overlay::*;
 pub use use_::Use;
 pub use version::Version;
+pub use while_::While;
 #[cfg(feature = "plugin")]
 mod register;
 

--- a/crates/nu-command/src/core_commands/while_.rs
+++ b/crates/nu-command/src/core_commands/while_.rs
@@ -1,0 +1,99 @@
+use nu_engine::{eval_block, eval_expression, CallExt};
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Block, Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
+
+#[derive(Clone)]
+pub struct While;
+
+impl Command for While {
+    fn name(&self) -> &str {
+        "while"
+    }
+
+    fn usage(&self) -> &str {
+        "Conditionally run a block in a loop."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("while")
+            .required("cond", SyntaxShape::Expression, "condition to check")
+            .required(
+                "block",
+                SyntaxShape::Block,
+                "block to loop if check succeeds",
+            )
+            .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let cond = call.positional_nth(0).expect("checked through parser");
+        let block: Block = call.req(engine_state, stack, 1)?;
+
+        loop {
+            let result = eval_expression(engine_state, stack, cond)?;
+            match &result {
+                Value::Bool { val, .. } => {
+                    if *val {
+                        let block = engine_state.get_block(block.block_id);
+                        eval_block(
+                            engine_state,
+                            stack,
+                            block,
+                            PipelineData::new(call.head),
+                            call.redirect_stdout,
+                            call.redirect_stderr,
+                        )?
+                        .into_value(call.head);
+                    } else {
+                        break;
+                    }
+                }
+                x => {
+                    return Err(ShellError::CantConvert(
+                        "bool".into(),
+                        x.get_type().to_string(),
+                        result.span()?,
+                        None,
+                    ))
+                }
+            }
+        }
+        Ok(PipelineData::new(call.head))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Loop while a condition is true",
+            example: "mut x = 0; while $x < 10 { $x = $x + 1 }",
+            result: None,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(While {})
+    }
+}

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -62,6 +62,7 @@ pub fn create_default_context() -> EngineState {
             Mut,
             Use,
             Version,
+            While,
         };
 
         // Charts

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -88,6 +88,7 @@ mod use_;
 mod where_;
 #[cfg(feature = "which-support")]
 mod which;
+mod while_;
 mod with_env;
 mod wrap;
 mod zip;

--- a/crates/nu-command/tests/commands/while_.rs
+++ b/crates/nu-command/tests/commands/while_.rs
@@ -1,0 +1,11 @@
+use nu_test_support::nu;
+
+#[test]
+fn while_sum() {
+    let actual = nu!(
+        cwd: ".",
+        "mut total = 0; mut x = 0; while $x <= 10 { $total = $total + $x; $x = $x + 1 }; $total"
+    );
+
+    assert_eq!(actual.out, "55");
+}

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -968,7 +968,6 @@ mod input_types {
             working_set.add_decl(Box::new(GroupBy));
             working_set.add_decl(Box::new(LsTest));
             working_set.add_decl(Box::new(ToCustom));
-            working_set.add_decl(Box::new(Let));
             working_set.add_decl(Box::new(AggMin));
             working_set.add_decl(Box::new(Collect));
             working_set.add_decl(Box::new(WithColumn));


### PR DESCRIPTION
# Description

This adds basic support for `while` loops:

```
mut i = 0
while $i < 10 {
  print $i
  $i = $i + 1
}
```

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
