### PR TITLE
Add additional assignment operators

### DIFF
--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -47,3 +47,51 @@ fn mut_a_field() {
 
     assert_eq!(actual.out, "456");
 }
+
+#[test]
+fn mut_add_assign() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        mut y = 3; $y += 2; $y
+        "#
+    ));
+
+    assert_eq!(actual.out, "5");
+}
+
+#[test]
+fn mut_minus_assign() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        mut y = 3; $y -= 2; $y
+        "#
+    ));
+
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn mut_multiply_assign() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        mut y = 3; $y *= 2; $y
+        "#
+    ));
+
+    assert_eq!(actual.out, "6");
+}
+
+#[test]
+fn mut_divide_assign() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        mut y = 8; $y /= 2; $y
+        "#
+    ));
+
+    assert_eq!(actual.out, "4");
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -434,8 +434,28 @@ pub fn eval_expression(
                         Bits::ShiftRight => lhs.bit_shr(op_span, &rhs, expr.span),
                     }
                 }
-                Operator::Assignment(Assignment::Assign) => {
+                Operator::Assignment(assignment) => {
                     let rhs = eval_expression(engine_state, stack, rhs)?;
+
+                    let rhs = match assignment {
+                        Assignment::Assign => rhs,
+                        Assignment::PlusAssign => {
+                            let lhs = eval_expression(engine_state, stack, lhs)?;
+                            lhs.add(op_span, &rhs, op_span)?
+                        }
+                        Assignment::MinusAssign => {
+                            let lhs = eval_expression(engine_state, stack, lhs)?;
+                            lhs.sub(op_span, &rhs, op_span)?
+                        }
+                        Assignment::MultiplyAssign => {
+                            let lhs = eval_expression(engine_state, stack, lhs)?;
+                            lhs.mul(op_span, &rhs, op_span)?
+                        }
+                        Assignment::DivideAssign => {
+                            let lhs = eval_expression(engine_state, stack, lhs)?;
+                            lhs.div(op_span, &rhs, op_span)?
+                        }
+                    };
 
                     match &lhs.expr {
                         Expr::Var(var_id) | Expr::VarDecl(var_id) => {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4420,6 +4420,10 @@ pub fn parse_operator(
 
     let operator = match contents {
         b"=" => Operator::Assignment(Assignment::Assign),
+        b"+=" => Operator::Assignment(Assignment::PlusAssign),
+        b"-=" => Operator::Assignment(Assignment::MinusAssign),
+        b"*=" => Operator::Assignment(Assignment::MultiplyAssign),
+        b"/=" => Operator::Assignment(Assignment::DivideAssign),
         b"==" => Operator::Comparison(Comparison::Equal),
         b"!=" => Operator::Comparison(Comparison::NotEqual),
         b"<" => Operator::Comparison(Comparison::LessThan),

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -1,6 +1,6 @@
 use crate::ParseError;
 use nu_protocol::{
-    ast::{Assignment, Bits, Boolean, Comparison, Expr, Expression, Math, Operator},
+    ast::{Bits, Boolean, Comparison, Expr, Expression, Math, Operator},
     engine::StateWorkingSet,
     Type,
 };
@@ -555,7 +555,7 @@ pub fn math_result_type(
                     )
                 }
             },
-            Operator::Assignment(Assignment::Assign) => match (&lhs.ty, &rhs.ty) {
+            Operator::Assignment(_) => match (&lhs.ty, &rhs.ty) {
                 (x, y) if x == y => (Type::Nothing, None),
                 (Type::Any, _) => (Type::Nothing, None),
                 (_, Type::Any) => (Type::Nothing, None),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -55,7 +55,7 @@ impl Expression {
                     Operator::Bits(Bits::BitOr) => 60,
                     Operator::Boolean(Boolean::And) => 50,
                     Operator::Boolean(Boolean::Or) => 40,
-                    Operator::Assignment(Assignment::Assign) => 10,
+                    Operator::Assignment(_) => 10,
                 }
             }
             _ => 0,

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -49,6 +49,10 @@ pub enum Bits {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Assignment {
     Assign,
+    PlusAssign,
+    MinusAssign,
+    MultiplyAssign,
+    DivideAssign,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -64,6 +68,10 @@ impl Display for Operator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Operator::Assignment(Assignment::Assign) => write!(f, "="),
+            Operator::Assignment(Assignment::PlusAssign) => write!(f, "+="),
+            Operator::Assignment(Assignment::MinusAssign) => write!(f, "-="),
+            Operator::Assignment(Assignment::MultiplyAssign) => write!(f, "*="),
+            Operator::Assignment(Assignment::DivideAssign) => write!(f, "/="),
             Operator::Comparison(Comparison::Equal) => write!(f, "=="),
             Operator::Comparison(Comparison::NotEqual) => write!(f, "!="),
             Operator::Comparison(Comparison::LessThan) => write!(f, "<"),


### PR DESCRIPTION
# Description

This adds support for `+=`, `-=`, `*=`, and `/=`.

cc @fdncred 

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
