### PR TITLE
reset stack size to 10mb vs 2gb

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.x86_64-pc-windows-msvc]
 # increase the default windows stack size
 # statically link the CRT so users don't have to install it
-rustflags = ["-C", "link-args=-stack:2147483648", "-C", "target-feature=+crt-static"]
+rustflags = ["-C", "link-args=-stack:10000000", "-C", "target-feature=+crt-static"]
 
 # keeping this but commentting out in case we need them in the future
 


### PR DESCRIPTION
# Description

This PR resets the stack size on Windows to 10MB vs 2GB.

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
