### PR TITLE
Add input-output types to $nu.scope.commands

### DIFF
--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -264,7 +264,7 @@ impl<'e, 's> ScopeData<'e, 's> {
     }
 
     fn collect_signatures(&self, signature: &Signature, span: Span) -> Value {
-        let (cols, vals) = signature
+        let mut sigs = signature
             .input_output_types
             .iter()
             // For most commands, input types are not repeated in
@@ -291,7 +291,9 @@ impl<'e, 's> ScopeData<'e, 's> {
                     },
                 )
             })
-            .unzip();
+            .collect::<Vec<(String, Value)>>();
+        sigs.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        let (cols, vals) = sigs.into_iter().unzip();
         Value::Record { cols, vals, span }
     }
 

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -378,7 +378,7 @@ impl<'e, 's> ScopeData<'e, 's> {
         // rest_positional
         if let Some(rest) = &signature.rest_positional {
             let sig_vals = vec![
-                Value::string(&rest.name, span),
+                Value::string(if rest.name == "rest" { "" } else { &rest.name }, span),
                 Value::string("rest", span),
                 Value::string(rest.shape.to_string(), span),
                 Value::boolean(true, span),

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -307,7 +307,6 @@ impl<'e, 's> ScopeData<'e, 's> {
         let mut sig_records = vec![];
 
         let sig_cols = vec![
-            "command".to_string(),
             "parameter_name".to_string(),
             "parameter_type".to_string(),
             "syntax_shape".to_string(),
@@ -321,7 +320,6 @@ impl<'e, 's> ScopeData<'e, 's> {
         sig_records.push(Value::Record {
             cols: sig_cols.clone(),
             vals: vec![
-                Value::string(&signature.name, span),
                 Value::nothing(span),
                 Value::string("input", span),
                 Value::string(input_type.to_shape().to_string(), span),
@@ -336,7 +334,6 @@ impl<'e, 's> ScopeData<'e, 's> {
         // required_positional
         for req in &signature.required_positional {
             let sig_vals = vec![
-                Value::string(&signature.name, span),
                 Value::string(&req.name, span),
                 Value::string("positional", span),
                 Value::string(req.shape.to_string(), span),
@@ -359,7 +356,6 @@ impl<'e, 's> ScopeData<'e, 's> {
         // optional_positional
         for opt in &signature.optional_positional {
             let sig_vals = vec![
-                Value::string(&signature.name, span),
                 Value::string(&opt.name, span),
                 Value::string("positional", span),
                 Value::string(opt.shape.to_string(), span),
@@ -382,7 +378,6 @@ impl<'e, 's> ScopeData<'e, 's> {
         // rest_positional
         if let Some(rest) = &signature.rest_positional {
             let sig_vals = vec![
-                Value::string(&signature.name, span),
                 Value::string(&rest.name, span),
                 Value::string("rest", span),
                 Value::string(rest.shape.to_string(), span),
@@ -429,7 +424,6 @@ impl<'e, 's> ScopeData<'e, 's> {
             };
 
             let sig_vals = vec![
-                Value::string(&signature.name, span),
                 Value::string(&named.long, span),
                 flag_type,
                 shape,
@@ -450,7 +444,6 @@ impl<'e, 's> ScopeData<'e, 's> {
         sig_records.push(Value::Record {
             cols: sig_cols,
             vals: vec![
-                Value::string(&signature.name, span),
                 Value::nothing(span),
                 Value::string("output", span),
                 Value::string(output_type.to_shape().to_string(), span),


### PR DESCRIPTION
This commit changes the schema: instead of

```
command.signature: table
```

we now have

```
command.signatures: list<table>
```

with one signature for every input-output type pair.

This is a breaking change of course so totally understandable if there's some discussion about it! I felt that this was the logical way to present the signatures of our commands, since they accept multiple input types 

<img width="1761" alt="image" src="https://user-images.githubusercontent.com/52205/201435907-a4f56cca-7782-4ecc-9a17-8e6929492f4a.png">

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/52205/201438921-5e499f0e-720c-474e-83a9-18e58198a0bc.png">


```
 〉$nu.scope.commands | each {|row| ($row.signatures | length) } | uniq -c
╭───────┬───────╮
│ value │ count │
├───────┼───────┤
│     0 │   175 │
│     1 │   174 │
│     2 │    42 │
│     3 │     6 │
│     7 │     2 │
│     5 │     2 │
│     4 │     2 │
╰───────┴───────╯
```

(The 0 counts are commands without examples which have not yet been given their types.)