### PR TITLE
Use try_exist to handle the permission in cd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,6 @@ dependencies = [
  "is-root",
  "itertools",
  "lazy_static",
- "libc",
  "log",
  "lscolors",
  "md-5",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -97,7 +97,6 @@ winreg = "0.10.1"
 [target.'cfg(unix)'.dependencies]
 umask = "2.0.0"
 users = "0.11.0"
-libc = "0.2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
 version = "2.1.3"


### PR DESCRIPTION
Permission is complex, I do not know there is a tenth bit permission on unix system, and the handle of permission on windows is bad, I have found the founction of try_exist, but nightly, so maybe we can use this one

# Description
relate issue https://github.com/nushell/nushell/issues/7106

Sometimes there are `tenth permission` on unix system, it is called extended permission, I try to handle it in cd command, but I know little about it , and seems it have a lot of other attributes..

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
