### PR TITLE
fix `ansi --osc` parameter adding extra semi-colon

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -381,8 +381,10 @@ Format: #
             format!("\x1b[{}", code_string)
         } else if osc && param_is_valid_string {
             // Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
-            // OCS's need to end with a bell '\x07' char
-            format!("\x1b]{};", code_string)
+            // OCS's need to end with either:
+            // bel '\x07' char
+            // string terminator aka st '\\' char
+            format!("\x1b]{}", code_string)
         } else if param_is_valid_string {
             // parse hex colors like #00FF00
             if code_string.starts_with('#') {


### PR DESCRIPTION
# Description

This PR fixes a bug where `ansi -o` was adding a semi-colon.

I discovered this by writing this command. Notice that the output we want to emulate requires `8;;` to work properly, previously you would just enter `8;` and nushell by itself would add the second `;`, which is incorrect. We shouldn't automatically pad a string with a semi-colon.

```
def 'str hyperlink' [text: string] {
  let url = $in
  # before fix
  # let osc8 = (ansi -o '8;')
  # after fix
  let osc8 = (ansi -o '8;;')
  let st = (ansi st)

  # This is what we want to emulate
  # "\e]8;;http://example.com\e\\This is a link\e]8;;\e\\\n"
  [$osc8 $url $st $text $osc8 $st] | str join
}
```

This is a bug, but theoretically also a breaking change

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
