### PR TITLE
Add missing strip-ansi-escapes dependency to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,6 +2666,7 @@ dependencies = [
  "nu-path",
  "nu-protocol",
  "nu-utils",
+ "strip-ansi-escapes",
  "sysinfo",
 ]
 


### PR DESCRIPTION
Not sure where but `strip-ansi-escapes` seems to have been left out from Cargo.lock.