### PR TITLE
Fix for escaping backslashes in interpolated strings (fixes #6737)

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1634,42 +1634,52 @@ pub fn parse_string_interpolation(
     let mut token_start = start;
     let mut delimiter_stack = vec![];
 
+    let mut consecutive_backslashes: usize = 0;
+
     let mut b = start;
 
     while b != end {
-        if contents[b - start] == b'('
-            && (if double_quote && (b - start) > 0 {
-                contents[b - start - 1] != b'\\'
+        let current_byte = contents[b - start];
+
+        if mode == InterpolationMode::String {
+            let preceding_consecutive_backslashes = consecutive_backslashes;
+
+            let is_backslash = current_byte == b'\\';
+            consecutive_backslashes = if is_backslash {
+                preceding_consecutive_backslashes + 1
             } else {
-                true
-            })
-            && mode == InterpolationMode::String
-        {
-            mode = InterpolationMode::Expression;
-            if token_start < b {
-                let span = Span::new(token_start, b);
-                let str_contents = working_set.get_span_contents(span);
+                0
+            };
 
-                let str_contents = if double_quote {
-                    let (str_contents, err) = unescape_string(str_contents, span);
-                    error = error.or(err);
+            if current_byte == b'(' && (!double_quote || preceding_consecutive_backslashes % 2 == 0)
+            {
+                mode = InterpolationMode::Expression;
+                if token_start < b {
+                    let span = Span::new(token_start, b);
+                    let str_contents = working_set.get_span_contents(span);
 
-                    str_contents
-                } else {
-                    str_contents.to_vec()
-                };
+                    let str_contents = if double_quote {
+                        let (str_contents, err) = unescape_string(str_contents, span);
+                        error = error.or(err);
 
-                output.push(Expression {
-                    expr: Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
-                    span,
-                    ty: Type::String,
-                    custom_completion: None,
-                });
-                token_start = b;
+                        str_contents
+                    } else {
+                        str_contents.to_vec()
+                    };
+
+                    output.push(Expression {
+                        expr: Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
+                        span,
+                        ty: Type::String,
+                        custom_completion: None,
+                    });
+                    token_start = b;
+                }
             }
         }
+
         if mode == InterpolationMode::Expression {
-            let byte = contents[b - start];
+            let byte = current_byte;
             if let Some(b'\'') = delimiter_stack.last() {
                 if byte == b'\'' {
                     delimiter_stack.pop();


### PR DESCRIPTION
# Description

(PR attempt #&#8203;2.)

When using a double-quoted interpolated string (`$"example"`), both escaped characters (e.g., `\n`, `\t`, `\\`) and interpolated expressions (e.g., `(1 + 2)`) are supported.

You can use these features independently or together.

| Expression | Resulting string |
|-|-|
| `$"\""` | `"` |
| `$"\\"` | `\` |
| `$"(1 + 3)"` | `4` |
| `$"\(1 + 3)"` | `(1 + 3)` |

However, there's a bug when you try to use them in sequence:

| Expression | Expected string | Actual string |
|-|-|-|
| `$"\\(1 + 3)"` | `\4` | `\(1 + 3)` |

The first backslash escapes the second, so the expression should not escaped, but the current implementation escapes both the second backslash and the expression (as described in #6737).  This PR addresses that issue.

# Difference from [previous PR](https://github.com/nushell/nushell/pull/7020)

In my previous PR, I changed (approximately)
```rs
if mode == InterpolationMode::String { ... }
if mode == InterpolationMode::Expression { ... }
```
into
```rs
match mode {
    InterpolationMode::String => { ... }
    InterpolationMode::Expression => { ... }
}
```

This introduced a bug, because `mode` can be set to `Expression` within the `String` `if` block, so the `if` blocks are not mutually exclusive.

I've added a new test, `string::interpolation::parse_nested_expressions`, which seems to cover this bug.

This issue was discovered by @fdncred due to errors in parsing [get-weather.nu](https://github.com/nushell/nu_scripts/blob/main/weather/get-weather.nu), so I've run that locally with these changes and it seems to be working.  @fdncred, if you wouldn't mind double-checking that these scripts are working as expected, I'd appreciate it!

# Major Changes

If you're considering making any major change to nushell, before starting work on it, seek feedback from regular contributors and get approval for the idea from the core team either on [Discord](https://discordapp.com/invite/NtAbbGn) or [GitHub issue](https://github.com/nushell/nushell/issues/new/choose).
Making sure we're all on board with the change saves everybody's time.
Thanks!

# Tests + Formatting

Make sure you've done the following, if applicable:

✅ Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

✅ `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
✅ `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
✅  `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
