### PR TITLE
Change parser cwd when running a file

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -29,6 +29,8 @@ pub fn evaluate_file(
 
     let file = std::fs::read(&path).into_diagnostic()?;
 
+    engine_state.start_in_file(Some(&path));
+
     let mut working_set = StateWorkingSet::new(engine_state);
     trace!("parsing file: {}", path);
 

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -3,6 +3,15 @@ use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
+fn source_file_relative_to_file() {
+    let actual = nu!(cwd: "tests/parsing/samples", r#"
+        nu source_file_relative.nu
+        "#);
+
+    assert_eq!(actual.out, "5");
+}
+
+#[test]
 fn run_nu_script_single_line() {
     let actual = nu!(cwd: "tests/parsing/samples", r#"
         nu single_line.nu

--- a/tests/parsing/samples/source_file_relative.nu
+++ b/tests/parsing/samples/source_file_relative.nu
@@ -1,0 +1,1 @@
+source single_line.nu


### PR DESCRIPTION
# Description

Previously, when running `nu spam.nu`, the currently parsed CWD was not set in the parser, so if the file included statements like `use mod.nu`, the `mod.nu` would not be looked up as file-relative. This PR fixes that.

# Major Changes

None

# Tests + Formatting

Make sure you've done the following, if applicable:

- Add tests that cover your changes (either in the command examples, the crate/tests folder, or in the /tests folder)
  - Try to think about corner cases and various ways how your changes could break. Cover those in the tests

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

* Help us keep the docs up to date: If your PR affects the user experience of Nushell (adding/removing a command, changing an input/output type, etc.), make sure the changes are reflected in the documentation (https://github.com/nushell/nushell.github.io) after the PR is merged.
