### PR TITLE
avoid test failure caused by locale thousand separator

### DIFF
--- a/src/tests/test_math.rs
+++ b/src/tests/test_math.rs
@@ -107,5 +107,5 @@ fn precedence_of_or_groups() -> TestResult {
 
 #[test]
 fn test_filesize_op() -> TestResult {
-    run_test("-5kb + 4kb", "-1,000 B")
+    run_test("-5kb + 4.5kb", "-500 B")
 }


### PR DESCRIPTION
# Description

In machines where thousand separator is different than ',' the test `test_filesize_op` fails.
With this change, the test is still valid and we avoid that failure for some people.
