### PR TITLE
fix: ls not show pattern error

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -165,8 +165,8 @@ impl Command for Ls {
         if paths_peek.peek().is_none() {
             return Err(ShellError::GenericError(
                 format!("No matches found for {}", &path.display().to_string()),
-                "".to_string(),
-                None,
+                "Pattern, file or folder not found".to_string(),
+                Some(p_tag),
                 Some("no matches found".to_string()),
                 Vec::new(),
             ));


### PR DESCRIPTION
Log: fix pattern error show in ls command


# Description

Relate Issue https://github.com/nushell/nushell/issues/7140

before
![image](https://user-images.githubusercontent.com/60290287/202071480-c4c3ace7-ac87-4a7a-810b-6d26bedb845f.png)
after
![image](https://user-images.githubusercontent.com/60290287/202071519-97628e53-1c00-48ec-8eef-dff947bd8b84.png)


# User-Facing Changes

Pattern error is not shown in ls command

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
