### PR TITLE
Add extended attributes (xattr) column to `ls -l` on supported platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,6 +2655,7 @@ dependencies = [
  "which",
  "windows 0.42.0",
  "winreg",
+ "xattr",
 ]
 
 [[package]]
@@ -5784,6 +5785,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -103,6 +103,9 @@ libc = "0.2"
 version = "2.1.3"
 optional = true
 
+[target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
+xattr = { version = "0.2.3", default-features = false }
+
 [dependencies.polars]
 version = "0.25.0"
 optional = true


### PR DESCRIPTION
# Description

(This might be solving #7106, but I'm unsure if I understood the ticket completely.)

I noticed that the nushell `ls` command was lacking the `-@` flag to show [extended attributes](https://en.wikipedia.org/wiki/Extended_file_attributes).
This flag exists in `ls` for systems supporting these attributes. Or at least I know it's part of the pre-installed `ls` on macOS, as well as on linux as described in #7106.

`man ls`
>     The following options are available:
>
>     -@      Display extended attribute keys and sizes in long (-l) output.



**Without** the flag some marker is shown as a suffix on the mode when extended attributes exist, e.g. `@` on macOS `ls`:
```
nushell ⟫ ^ls -l                                                                                                                                                                                                
...
drwxr-xr-x   9 remmy.cat.stock  staff     288 Nov 17 13:03 src
drwxr-xr-x@  6 remmy.cat.stock  staff     192 Nov 17 13:12 target
drwxr-xr-x  13 remmy.cat.stock  staff     416 Nov 17 13:03 
...
```

**With** the flag it looks like this
```
drwxr-xr-x   9 remmy.cat.stock  staff     288 Nov 17 13:03 src
drwxr-xr-x@  6 remmy.cat.stock  staff     192 Nov 17 13:12 target
	com.apple.metadata:com_apple_backup_excludeItem	    61 
drwxr-xr-x  13 remmy.cat.stock  staff     416 Nov 17 13:03 tests
```

The attributes are for example used by macOS to add a quarantine status to downloaded files using the `com.apple.quarantine` attribute.

# User-Facing Changes

I decided on adding a new column to `ls -l` called `extended_attributes` that contains a list of all attributes we can detect.
This is done using the [xattr crate](https://crates.io/crates/xattr).

<img width="2030" alt="Screenshot 2022-11-17 at 19 53 20" src="https://user-images.githubusercontent.com/3317423/202533435-04c15f71-2438-44d1-ac5e-2f84a764952f.png">

## Some points I feel unsure about:

1. Is `extended_attributes` too long as a column header? The table is already huge
    - A different name for these is `xattrs`, though I don't really like using abbreviations if we don't have to.
1. Where should the column be located?
    - For now I put it between `group` and `size`. I feel completely indifferent about any position after `type` though.
1. Is it enough to list only the attribute keys?
    - My thought process here was that the values are arbitrary binary data and are maybe not too useful as part of `ls`.
    - However, it seems "free"-ish to add the values (and change the list into a record or table), which would currently be the only way nushell users could access them without relying on external commands like `xattr`.
    - I do not know about potential edge cases here (e.g.: How huge can this data get)
1. Should I add documentation for this anywhere?
    - I thought briefly about adding an example to the list, but wasn't sure if it's so relevant as the other specific columns also don't have their own examples
1. Should the field be empty if there are no attributes set?
    - I felt like a uniform data type is probably the nicest for scripting, but I don't know if there is a reason why this is still discouraged