### PR TITLE
Improve `run-external`'s "Cannot convert argument to string" message

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -64,7 +64,7 @@ impl Command for External {
                 .map(|item| Spanned { item, span })
                 .map_err(|_| {
                     ShellError::ExternalCommand(
-                        "Cannot convert argument to a string".into(),
+                        format!("Cannot convert {} to a string", value.get_type()),
                         "All arguments to an external command need to be string-compatible".into(),
                         span,
                     )
@@ -267,7 +267,7 @@ impl ExternalCommand {
                             Some(s) => {
                                 if reconfirm_command_name {
                                     format!(
-                                        "'{}' was not found, did you mean '{s}'?",
+                                        "'{}' was not found; did you mean '{s}'?",
                                         self.name.item
                                     )
                                 } else if self.name.item == s {


### PR DESCRIPTION
# Description

Improved this error message so that it now includes the input value's type.
Example:
```
〉ls | ^file $in
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #2:1:1]
 1 │ ls | ^file $in
   · ─┬
   ·  ╰── Cannot convert record<name: string, type: string, size: filesize, modified: date> to a string
   ╰────
  help: All arguments to an external command need to be string-compatible
```

Also fixed punctuation in a different unrelated message.

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
