### PR TITLE
Plugin: make friendly error message when python is not found

### DIFF
--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -7,7 +7,7 @@ use crate::protocol::{CallInput, LabeledError, PluginCall, PluginData, PluginRes
 use crate::EncodingType;
 use std::env;
 use std::fmt::Write;
-use std::io::{BufReader, Read, Write as WriteTrait};
+use std::io::{BufReader, ErrorKind, Read, Write as WriteTrait};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdout, Command as CommandSys, Stdio};
 
@@ -120,10 +120,25 @@ pub fn get_signature(
     current_envs: &HashMap<String, String>,
 ) -> Result<Vec<Signature>, ShellError> {
     let mut plugin_cmd = create_command(path, shell);
+    let program_name = plugin_cmd.get_program().to_os_string().into_string();
 
     plugin_cmd.envs(current_envs);
     let mut child = plugin_cmd.spawn().map_err(|err| {
-        ShellError::PluginFailedToLoad(format!("Error spawning child process: {}", err))
+        let error_msg = match err.kind() {
+            ErrorKind::NotFound => match program_name {
+                Ok(prog_name) => {
+                    format!("Can't find {prog_name}, please make sure that {prog_name} is in PATH.")
+                }
+                _ => {
+                    format!("Error spawning child process: {}", err)
+                }
+            },
+            _ => {
+                format!("Error spawning child process: {}", err)
+            }
+        };
+
+        ShellError::PluginFailedToLoad(error_msg)
     })?;
 
     let mut stdin_writer = child


### PR DESCRIPTION
# Description

Closes: #7150
Closes: https://github.com/nushell/nushell/issues/7014

# User-Facing Changes

![图片](https://user-images.githubusercontent.com/22256154/202829670-10b35b81-5b9d-454f-8028-035139454e7e.png)

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
