### PR TITLE
Improve CantFindColumn and ColumnAlreadyExists errors

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -250,6 +250,7 @@ pub fn group(
                     move |_, row: &Value| match row.get_data_by_key(&column_name.item) {
                         Some(group_key) => Ok(group_key.as_string()?),
                         None => Err(ShellError::CantFindColumn(
+                            column_name.item.to_string(),
                             column_name.span,
                             row.span().unwrap_or(column_name.span),
                         )),

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -137,6 +137,7 @@ pub fn split_by(
             });
             Ok(split(&splitter, input, name)?)
         }
+        // This uses the same format as the 'requires a column name' error in sort_utils.rs
         None => Err(ShellError::GenericError(
             "expected name".into(),
             "requires a column name for splitting".into(),
@@ -165,6 +166,7 @@ pub fn split(
                     move |_, row: &Value| match row.get_data_by_key(&column_name.item) {
                         Some(group_key) => Ok(group_key.as_string()?),
                         None => Err(ShellError::CantFindColumn(
+                            column_name.item.to_string(),
                             column_name.span,
                             row.span().unwrap_or(column_name.span),
                         )),

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -1,5 +1,5 @@
 use alphanumeric_sort::compare_str;
-use nu_engine::column::column_does_not_exist;
+use nu_engine::column::nonexistent_column;
 use nu_protocol::{ShellError, Span, Value};
 use std::cmp::Ordering;
 
@@ -81,12 +81,18 @@ pub fn sort(
             ..
         } => {
             if sort_columns.is_empty() {
-                println!("sort-by requires a column name to sort table data");
-                return Err(ShellError::CantFindColumn(span, span));
+                // This uses the same format as the 'requires a column name' error in split_by.rs
+                return Err(ShellError::GenericError(
+                    "expected name".into(),
+                    "requires a column name to sort table data".into(),
+                    Some(span),
+                    None,
+                    Vec::new(),
+                ));
             }
 
-            if column_does_not_exist(sort_columns.clone(), cols.to_vec()) {
-                return Err(ShellError::CantFindColumn(span, span));
+            if let Some(nonexistent) = nonexistent_column(sort_columns.clone(), cols.to_vec()) {
+                return Err(ShellError::CantFindColumn(nonexistent, span, span));
             }
 
             // check to make sure each value in each column in the record

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -24,7 +24,9 @@ fn insert_the_column_conflict() {
         "#
     ));
 
-    assert!(actual.err.contains("column already exists"));
+    assert!(actual
+        .err
+        .contains("column 'pretty_assertions' already exists"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -95,3 +95,13 @@ fn update_past_end_list() {
 
     assert!(actual.err.contains("too large"));
 }
+
+#[test]
+fn update_nonexistent_column() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"{a:1} | update b 2"#
+    ));
+
+    assert!(actual.err.contains("cannot find column 'b'"));
+}

--- a/crates/nu-engine/src/column.rs
+++ b/crates/nu-engine/src/column.rs
@@ -19,22 +19,15 @@ pub fn get_columns<'a>(input: impl IntoIterator<Item = &'a Value>) -> Vec<String
     columns
 }
 
-/*
-*  Check to see if any of the columns inside the input
-*  does not exist in a vec of columns
-*/
-
-pub fn column_does_not_exist(inputs: Vec<String>, columns: Vec<String>) -> bool {
-    let mut set = HashSet::new();
-    for column in columns {
-        set.insert(column);
-    }
+// If a column doesn't exist in the input, return it.
+pub fn nonexistent_column(inputs: Vec<String>, columns: Vec<String>) -> Option<String> {
+    let set: HashSet<String> = HashSet::from_iter(columns.iter().cloned());
 
     for input in &inputs {
         if set.contains(input) {
             continue;
         }
-        return true;
+        return Some(input.clone());
     }
-    false
+    None
 }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -411,7 +411,8 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("Cannot find column")]
     #[diagnostic(code(nu::shell::column_not_found), url(docsrs))]
     CantFindColumn(
-        #[label = "cannot find column"] Span,
+        String,
+        #[label = "cannot find column '{0}'"] Span,
         #[label = "value originates here"] Span,
     ),
 
@@ -423,7 +424,8 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("Column already exists")]
     #[diagnostic(code(nu::shell::column_already_exists), url(docsrs))]
     ColumnAlreadyExists(
-        #[label = "column already exists"] Span,
+        String,
+        #[label = "column '{0}' already exists"] Span,
         #[label = "value originates here"] Span,
     ),
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -718,7 +718,11 @@ impl Value {
                                     return Err(ShellError::DidYouMean(suggestion, *origin_span));
                                 }
                             }
-                            return Err(ShellError::CantFindColumn(*origin_span, span));
+                            return Err(ShellError::CantFindColumn(
+                                column_name.to_string(),
+                                *origin_span,
+                                span,
+                            ));
                         }
                     }
                     Value::List { vals, span } => {
@@ -826,7 +830,13 @@ impl Value {
                                         }
                                     }
                                 }
-                                v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                                v => {
+                                    return Err(ShellError::CantFindColumn(
+                                        col_name.to_string(),
+                                        *span,
+                                        v.span()?,
+                                    ))
+                                }
                             }
                         }
                     }
@@ -856,7 +866,13 @@ impl Value {
                             }
                         }
                     }
-                    v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                    v => {
+                        return Err(ShellError::CantFindColumn(
+                            col_name.to_string(),
+                            *span,
+                            v.span()?,
+                        ))
+                    }
                 },
                 PathMember::Int { val: row_num, span } => match self {
                     Value::List { vals, .. } => {
@@ -924,10 +940,20 @@ impl Value {
                                         }
                                     }
                                     if !found {
-                                        return Err(ShellError::CantFindColumn(*span, *v_span));
+                                        return Err(ShellError::CantFindColumn(
+                                            col_name.to_string(),
+                                            *span,
+                                            *v_span,
+                                        ));
                                     }
                                 }
-                                v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                                v => {
+                                    return Err(ShellError::CantFindColumn(
+                                        col_name.to_string(),
+                                        *span,
+                                        v.span()?,
+                                    ))
+                                }
                             }
                         }
                     }
@@ -947,10 +973,20 @@ impl Value {
                             }
                         }
                         if !found {
-                            return Err(ShellError::CantFindColumn(*span, *v_span));
+                            return Err(ShellError::CantFindColumn(
+                                col_name.to_string(),
+                                *span,
+                                *v_span,
+                            ));
                         }
                     }
-                    v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                    v => {
+                        return Err(ShellError::CantFindColumn(
+                            col_name.to_string(),
+                            *span,
+                            v.span()?,
+                        ))
+                    }
                 },
                 PathMember::Int { val: row_num, span } => match self {
                     Value::List { vals, .. } => {
@@ -999,10 +1035,20 @@ impl Value {
                                             }
                                         }
                                         if !found {
-                                            return Err(ShellError::CantFindColumn(*span, *v_span));
+                                            return Err(ShellError::CantFindColumn(
+                                                col_name.to_string(),
+                                                *span,
+                                                *v_span,
+                                            ));
                                         }
                                     }
-                                    v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                                    v => {
+                                        return Err(ShellError::CantFindColumn(
+                                            col_name.to_string(),
+                                            *span,
+                                            v.span()?,
+                                        ))
+                                    }
                                 }
                             }
                             Ok(())
@@ -1021,11 +1067,19 @@ impl Value {
                                 }
                             }
                             if !found {
-                                return Err(ShellError::CantFindColumn(*span, *v_span));
+                                return Err(ShellError::CantFindColumn(
+                                    col_name.to_string(),
+                                    *span,
+                                    *v_span,
+                                ));
                             }
                             Ok(())
                         }
-                        v => Err(ShellError::CantFindColumn(*span, v.span()?)),
+                        v => Err(ShellError::CantFindColumn(
+                            col_name.to_string(),
+                            *span,
+                            v.span()?,
+                        )),
                     },
                     PathMember::Int { val: row_num, span } => match self {
                         Value::List { vals, .. } => {
@@ -1065,10 +1119,20 @@ impl Value {
                                             }
                                         }
                                         if !found {
-                                            return Err(ShellError::CantFindColumn(*span, *v_span));
+                                            return Err(ShellError::CantFindColumn(
+                                                col_name.to_string(),
+                                                *span,
+                                                *v_span,
+                                            ));
                                         }
                                     }
-                                    v => return Err(ShellError::CantFindColumn(*span, v.span()?)),
+                                    v => {
+                                        return Err(ShellError::CantFindColumn(
+                                            col_name.to_string(),
+                                            *span,
+                                            v.span()?,
+                                        ))
+                                    }
                                 }
                             }
                             Ok(())
@@ -1088,11 +1152,19 @@ impl Value {
                                 }
                             }
                             if !found {
-                                return Err(ShellError::CantFindColumn(*span, *v_span));
+                                return Err(ShellError::CantFindColumn(
+                                    col_name.to_string(),
+                                    *span,
+                                    *v_span,
+                                ));
                             }
                             Ok(())
                         }
-                        v => Err(ShellError::CantFindColumn(*span, v.span()?)),
+                        v => Err(ShellError::CantFindColumn(
+                            col_name.to_string(),
+                            *span,
+                            v.span()?,
+                        )),
                     },
                     PathMember::Int { val: row_num, span } => match self {
                         Value::List { vals, .. } => {
@@ -1134,7 +1206,9 @@ impl Value {
                                         if col.0 == col_name {
                                             if cell_path.len() == 1 {
                                                 return Err(ShellError::ColumnAlreadyExists(
-                                                    *span, *v_span,
+                                                    col_name.to_string(),
+                                                    *span,
+                                                    *v_span,
                                                 ));
                                             } else {
                                                 return col.1.insert_data_at_cell_path(
@@ -1165,7 +1239,11 @@ impl Value {
                         for col in cols.iter().zip(vals.iter_mut()) {
                             if col.0 == col_name {
                                 if cell_path.len() == 1 {
-                                    return Err(ShellError::ColumnAlreadyExists(*span, *v_span));
+                                    return Err(ShellError::ColumnAlreadyExists(
+                                        col_name.to_string(),
+                                        *span,
+                                        *v_span,
+                                    ));
                                 } else {
                                     return col
                                         .1


### PR DESCRIPTION
# Description

* Changed all CantFindColumn errors to list the column name. This makes the following message more clear:
```
〉let b = 'c'
〉{a:1} | select $b
Error: nu::shell::column_not_found (link)

  × Cannot find column
   ╭─[entry #12:1:1]
 1 │ {a:1} | select $b
   · ──┬──          ─┬
   ·   │             ╰── cannot find column
   ·   ╰── value originates here
   ╰────

〉
```
The error is changed to:
```
  × Cannot find column
   ╭─[entry #11:1:1]
 1 │ {a:1} | select $b
   · ──┬──          ─┬
   ·   │             ╰── cannot find column 'c'
   ·   ╰── value originates here
   ╰────
```
* ColumnAlreadyExists errors are changed likewise.

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
