### PR TITLE
Edit `rm` help messages

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -199,10 +199,24 @@ fn rm(
         ));
     }
 
+    let targets_span = Span {
+        start: targets
+            .iter()
+            .map(|x| x.span.start)
+            .min()
+            .expect("targets were empty"),
+        end: targets
+            .iter()
+            .map(|x| x.span.end)
+            .max()
+            .expect("targets were empty"),
+    };
+
     let path = current_dir(engine_state, stack)?;
 
     let (mut target_exists, mut empty_span) = (false, call.head);
     let mut all_targets: HashMap<PathBuf, Span> = HashMap::new();
+
     for target in targets {
         if path.to_string_lossy() == target.item
             || path.as_os_str().to_string_lossy().starts_with(&format!(
@@ -277,9 +291,9 @@ fn rm(
 
     if all_targets.is_empty() && !force {
         return Err(ShellError::GenericError(
-            "No valid paths".into(),
-            "no valid paths".into(),
-            Some(empty_span),
+            "File(s) not found".into(),
+            "File(s) not found".into(),
+            Some(targets_span),
             None,
             Vec::new(),
         ));

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -36,7 +36,7 @@ impl Command for Rm {
     }
 
     fn usage(&self) -> &str {
-        "Remove file(s)."
+        "Remove files and directories."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -53,21 +53,17 @@ impl Command for Rm {
         let sig = sig
             .switch(
                 "trash",
-                "use the platform's recycle bin instead of permanently deleting",
+                "move to the platform's trash instead of permanently deleting",
                 Some('t'),
             )
             .switch(
                 "permanent",
-                "don't use recycle bin, delete permanently",
+                "delete permanently, ignoring the 'always_trash' config option",
                 Some('p'),
             );
         sig.switch("recursive", "delete subdirectories recursively", Some('r'))
             .switch("force", "suppress error when no file", Some('f'))
-            .switch(
-                "verbose",
-                "make rm to be verbose, showing files been deleted",
-                Some('v'),
-            )
+            .switch("verbose", "print names of deleted files", Some('v'))
             .switch("interactive", "ask user to confirm action", Some('i'))
             .rest(
                 "rest",
@@ -90,7 +86,7 @@ impl Command for Rm {
     fn examples(&self) -> Vec<Example> {
         let mut examples = vec![Example {
             description:
-                "Delete or move a file to the trash (depending on 'always_trash' config option)",
+                "Delete, or move a file to the trash (based on the 'always_trash' config option)",
             example: "rm file.txt",
             result: None,
         }];
@@ -101,19 +97,25 @@ impl Command for Rm {
         ))]
         examples.append(&mut vec![
             Example {
-                description: "Move a file to the system trash",
+                description: "Move a file to the trash",
                 example: "rm --trash file.txt",
                 result: None,
             },
             Example {
-                description: "Delete a file permanently",
+                description:
+                    "Delete a file permanently, even if the 'always_trash' config option is true",
                 example: "rm --permanent file.txt",
                 result: None,
             },
         ]);
         examples.push(Example {
-            description: "Delete a file, and suppress errors if no file is found",
+            description: "Delete a file, ignoring 'file not found' errors",
             example: "rm --force file.txt",
+            result: None,
+        });
+        examples.push(Example {
+            description: "Delete all 0KB files in the current directory",
+            example: "ls | where size == 0KB && type == file | each { rm $in.name } | null",
             result: None,
         });
         examples
@@ -197,24 +199,10 @@ fn rm(
         ));
     }
 
-    let targets_span = Span {
-        start: targets
-            .iter()
-            .map(|x| x.span.start)
-            .min()
-            .expect("targets were empty"),
-        end: targets
-            .iter()
-            .map(|x| x.span.end)
-            .max()
-            .expect("targets were empty"),
-    };
-
     let path = current_dir(engine_state, stack)?;
 
     let (mut target_exists, mut empty_span) = (false, call.head);
     let mut all_targets: HashMap<PathBuf, Span> = HashMap::new();
-
     for target in targets {
         if path.to_string_lossy() == target.item
             || path.as_os_str().to_string_lossy().starts_with(&format!(
@@ -289,9 +277,9 @@ fn rm(
 
     if all_targets.is_empty() && !force {
         return Err(ShellError::GenericError(
-            "File(s) not found".into(),
-            "File(s) not found".into(),
-            Some(targets_span),
+            "No valid paths".into(),
+            "no valid paths".into(),
+            Some(empty_span),
             None,
             Vec::new(),
         ));


### PR DESCRIPTION
# Description

Splitoff from #6983. This tweaks `rm`'s `help` messages for grammar and readability.

Also, this adds a test showing a slightly more complex `rm` use-case.

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
