### PR TITLE
Bugfix: add table_index_mode check that was missing from #6983

### DIFF
--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -754,6 +754,22 @@ impl Value {
                             eprintln!("$env.config.table_mode is not a string")
                         }
                     }
+                    "table_index_mode" => {
+                        legacy_options_used = true;
+                        if let Ok(b) = value.as_string() {
+                            let val_str = b.to_lowercase();
+                            match val_str.as_ref() {
+                                "always" => config.table_index_mode = TableIndexMode::Always,
+                                "never" => config.table_index_mode = TableIndexMode::Never,
+                                "auto" => config.table_index_mode = TableIndexMode::Auto,
+                                _ => eprintln!(
+                                    "unrecognized $env.config.table_index_mode '{val_str}'; expected either 'never', 'always' or 'auto'"
+                                ),
+                            }
+                        } else {
+                            eprintln!("$env.config.table_index_mode is not a string")
+                        }
+                    }
                     "table_trim" => {
                         legacy_options_used = true;
                         config.trim_strategy = try_parse_trim_strategy(value, &config)?


### PR DESCRIPTION
# Description

Quick bugfix that re-adds legacy support for `$env.config.table_index_mode` (which was moved to `$env.config.table.index_mode` recently in #6983.)

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
