### PR TITLE
Add auto-expanding table view to default config

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -305,7 +305,7 @@ let-env config = {
       }]
     }
     display_output: {
-      $nothing
+      if (term size).columns >= 100 { table -e } else { table }
     }
   }
   menus: [


### PR DESCRIPTION
# Description

Change the default hook to call `table -e` if the terminal width is >= 100. This should auto expand tables if we have the terminal space.

# User-Facing Changes

Will increase the amount of detail shown in tables if the terminal is wide enough.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
