### PR TITLE
Fixed json parsing

### DIFF
--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -100,9 +100,11 @@ fn table_to_json_text() {
 }
 
 #[test]
-fn top_level_values_to_json() {
-    for value in ["null", "true", "false"] {
+fn top_level_values_from_json() {
+    for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
         let actual = nu!(r#""{}" | from json | to json"#, value);
         assert_eq!(actual.out, value);
+        let actual = nu!(r#""{}" | from json | describe"#, value);
+        assert_eq!(actual.out, type_name);
     }
 }

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -98,3 +98,11 @@ fn table_to_json_text() {
         assert_eq!(actual.out, "JonAndrehudaTZ");
     })
 }
+
+#[test]
+fn top_level_values_to_json() {
+    for value in ["null", "true", "false"] {
+        let actual = nu!(r#""{}" | from json | to json"#, value);
+        assert_eq!(actual.out, value);
+    }
+}

--- a/crates/nu-json/src/util.rs
+++ b/crates/nu-json/src/util.rs
@@ -44,7 +44,8 @@ where
     }
 
     pub fn eof(&mut self) -> Result<bool> {
-        Ok(self.peek()?.is_none())
+        let ch = self.peek()?;
+        Ok(matches!(ch, None | Some(b'\x00')))
     }
 
     pub fn peek_next(&mut self, idx: usize) -> Result<Option<u8>> {


### PR DESCRIPTION
# Description

I noticed that some json values are not parsed at the top level, for example: `null`, `true`, `false`. Although this is a valid json.
```
> "null" | from json
Error:
  × Error while parsing JSON text
   ╭─[entry #12:1:1]
 1 │ "null" | from json
   ·          ────┬────
   ·              ╰── error parsing JSON text
   ╰────

Error:
  × Error while parsing JSON text
   ╭────
 1 │ null
   ╰────
```

I tried to fix it and it seems to work fine.

# User-Facing Changes

It should give fewer errors.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
