### PR TITLE
Rename dataframe `describe` to `summary` so that the normal `describe` isn't overloaded

### DIFF
--- a/crates/nu-command/src/dataframe/eager/descriptives.rs
+++ b/crates/nu-command/src/dataframe/eager/descriptives.rs
@@ -15,15 +15,15 @@ use polars::{
 };
 
 #[derive(Clone)]
-pub struct DescribeDF;
+pub struct Descriptives;
 
-impl Command for DescribeDF {
+impl Command for Descriptives {
     fn name(&self) -> &str {
-        "describe"
+        "descriptives"
     }
 
     fn usage(&self) -> &str {
-        "Describes dataframes numeric columns"
+        "For a dataframe, produces descriptive statistics (descriptives) for its numeric columns."
     }
 
     fn signature(&self) -> Signature {
@@ -34,15 +34,15 @@ impl Command for DescribeDF {
             .named(
                 "quantiles",
                 SyntaxShape::Table,
-                "optional quantiles for describe",
+                "provide optional quantiles",
                 Some('q'),
             )
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "dataframe description",
-            example: "[[a b]; [1 1] [1 1]] | into df | describe",
+            description: "list dataframe descriptives",
+            example: "[[a b]; [1 1] [1 1]] | into df | descriptives",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(
@@ -266,6 +266,6 @@ mod test {
 
     #[test]
     fn test_examples() {
-        test_dataframe(vec![Box::new(DescribeDF {})])
+        test_dataframe(vec![Box::new(Descriptives {})])
     }
 }

--- a/crates/nu-command/src/dataframe/eager/mod.rs
+++ b/crates/nu-command/src/dataframe/eager/mod.rs
@@ -1,6 +1,5 @@
 mod append;
 mod columns;
-mod descriptives;
 mod drop;
 mod drop_duplicates;
 mod drop_nulls;
@@ -20,6 +19,7 @@ mod shape;
 mod slice;
 mod sql_context;
 mod sql_expr;
+mod summary;
 mod take;
 mod to_arrow;
 mod to_csv;
@@ -32,7 +32,6 @@ use nu_protocol::engine::StateWorkingSet;
 
 pub use append::AppendDF;
 pub use columns::ColumnsDF;
-pub use descriptives::Descriptives;
 pub use drop::DropDF;
 pub use drop_duplicates::DropDuplicates;
 pub use drop_nulls::DropNulls;
@@ -52,6 +51,7 @@ pub use shape::ShapeDF;
 pub use slice::SliceDF;
 pub use sql_context::SQLContext;
 pub use sql_expr::parse_sql_expr;
+pub use summary::Summary;
 pub use take::TakeDF;
 pub use to_arrow::ToArrow;
 pub use to_csv::ToCSV;
@@ -75,7 +75,7 @@ pub fn add_eager_decls(working_set: &mut StateWorkingSet) {
         AppendDF,
         ColumnsDF,
         DataTypes,
-        Descriptives,
+        Summary,
         DropDF,
         DropDuplicates,
         DropNulls,

--- a/crates/nu-command/src/dataframe/eager/mod.rs
+++ b/crates/nu-command/src/dataframe/eager/mod.rs
@@ -1,6 +1,6 @@
 mod append;
 mod columns;
-mod describe;
+mod descriptives;
 mod drop;
 mod drop_duplicates;
 mod drop_nulls;
@@ -32,7 +32,7 @@ use nu_protocol::engine::StateWorkingSet;
 
 pub use append::AppendDF;
 pub use columns::ColumnsDF;
-pub use describe::DescribeDF;
+pub use descriptives::Descriptives;
 pub use drop::DropDF;
 pub use drop_duplicates::DropDuplicates;
 pub use drop_nulls::DropNulls;
@@ -75,7 +75,7 @@ pub fn add_eager_decls(working_set: &mut StateWorkingSet) {
         AppendDF,
         ColumnsDF,
         DataTypes,
-        DescribeDF,
+        Descriptives,
         DropDF,
         DropDuplicates,
         DropNulls,

--- a/crates/nu-command/src/dataframe/eager/summary.rs
+++ b/crates/nu-command/src/dataframe/eager/summary.rs
@@ -15,15 +15,15 @@ use polars::{
 };
 
 #[derive(Clone)]
-pub struct Descriptives;
+pub struct Summary;
 
-impl Command for Descriptives {
+impl Command for Summary {
     fn name(&self) -> &str {
-        "descriptives"
+        "summary"
     }
 
     fn usage(&self) -> &str {
-        "For a dataframe, produces descriptive statistics (descriptives) for its numeric columns."
+        "For a dataframe, produces descriptive statistics (summary statistics) for its numeric columns."
     }
 
     fn signature(&self) -> Signature {
@@ -42,7 +42,7 @@ impl Command for Descriptives {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "list dataframe descriptives",
-            example: "[[a b]; [1 1] [1 1]] | into df | descriptives",
+            example: "[[a b]; [1 1] [1 1]] | into df | summary",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(
@@ -266,6 +266,6 @@ mod test {
 
     #[test]
     fn test_examples() {
-        test_dataframe(vec![Box::new(Descriptives {})])
+        test_dataframe(vec![Box::new(Summary {})])
     }
 }


### PR DESCRIPTION
# Description

This closes #6770.

First of all, **yes,** I understand that the df `describe` is supposed to map to [Pandas.DataFrame.describe()](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.describe.html)! However, I strongly feel that `describe` is fundamental to the Nushell language as the (current) only real type-checking facility, and must *NOT* be overridden by anything else. A user command which uses `describe` to check input data, and which assumes `describe` outputs a string, will break if `describe` is overridden to output some other data type, and said type is used with that command. I also think the need to make Nushell's dataframe API map one-to-one to Pandas's API is kind of a fool's errand anyway given how different Nushell's language is to Python.

~~I have chosen the name `descriptives` because:~~
* ~~"Descriptive statistics" (the very specific set of stats output by df `describe`) are sometimes shortened to "descriptives" in casual speech.~~
* ~~Name is close enough in root to "describe", the Pandas name.~~
* ~~Being plural, it suggests to the user that it outputs multiple values (i.e. a table).~~
* ~~While significantly longer, this command is not the sort that necessarily requires succinctness (compared to something like `get`).~~

# User-Facing Changes

Renames `describe` (the dataframe version only) to `summary`. Since dataframes are possibly going to be moved out of the default install entirely, this is a relatively minor change in comparison.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
