### PR TITLE
Remove erroneous test introduced in #6994

### DIFF
--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -91,13 +91,3 @@ fn each_while_uses_optional_index_argument() {
 
     assert_eq!(actual.out, "[0, 1, 2, 3]");
 }
-
-#[test]
-fn par_each_uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9 10] | par-each {|el ind| $ind } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[0, 1, 2, 3]");
-}


### PR DESCRIPTION
# Description

#6994 accidentally included two versions of a new test. One of them accidentally assumes `par-each` guarantees order (it doesn't) and this PR removes it.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
