### PR TITLE
Move dataframe out of extra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,11 +83,12 @@ rstest = {version = "0.15.0", default-features = false}
 itertools = "0.10.3"
 
 [features]
-plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
-extra = ["default", "dataframe", "database"]
+plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin", "database"]
+extra = ["default"]
 default = ["plugin", "which-support", "trash-support"]
 stable = ["default"]
 wasi = []
+
 # Enable to statically link OpenSSL; otherwise the system version will be used. Not enabled by default because it takes a while to build
 static-link-openssl = ["dep:openssl"]
 


### PR DESCRIPTION
# Description

This moves `dataframe` out of extra and `database` into default. This means dataframe commands are considered experimental and sqlite commands are considered part of the core format support.

# User-Facing Changes

Unless you explicitly install with the dataframe feature enabled, you will not get dataframe support.

This also removes dataframe commands from the binaries that are built for each release.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
