### PR TITLE
Feature cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,8 @@ Don't forget to add tests that cover your changes.
 Make sure you've run and fixed any issues with these commands:
 
 - `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
-- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
-- `cargo test --workspace --features=extra` to check that all tests pass
+- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
+- `cargo test --workspace` to check that all tests pass
 
 # After Submitting
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.1
         with:
           command: clippy
-          args: --features=extra --workspace --exclude nu_plugin_* -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+          args: --workspace --exclude nu_plugin_* -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
   nu-tests:
     env:
@@ -45,19 +45,6 @@ jobs:
       fail-fast: true
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        style: [extra, default]
-        rust:
-          - stable
-        include:
-          - style: extra
-            flags: "--features=extra"
-          - style: default
-            flags: ""
-        exclude:
-          - platform: windows-latest
-            style: default
-          - platform: macos-latest
-            style: default
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,20 @@ jobs:
       fail-fast: true
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
+        style: [default, dataframe]
+        rust:
+          - stable
+        include:
+          - style: default
+            flags: ""
+          - style: dataframe
+            flags: "--features=dataframe"
+        exclude:
+          # only test dataframes on Ubuntu (the fastest platform)
+          - platform: windows-latest
+            style: dataframe
+          - platform: macos-latest
+            style: dataframe
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -51,9 +51,9 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
 # ----------------------------------------------------------------------------
 if $os in ['windows-latest'] {
     if ($flags | str trim | is-empty) {
-        cargo build --release --all --target $target --features=extra
+        cargo build --release --all --target $target
     } else {
-        cargo build --release --all --target $target --features=extra $flags
+        cargo build --release --all --target $target $flags
     }
 }
 
@@ -138,9 +138,9 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
 
 def 'cargo-build-nu' [ options: string ] {
     if ($options | str trim | is-empty) {
-        cargo build --release --all --target $target --features=extra,static-link-openssl
+        cargo build --release --all --target $target --features=static-link-openssl
     } else {
-        cargo build --release --all --target $target --features=extra,static-link-openssl $options
+        cargo build --release --all --target $target --features=static-link-openssl $options
     }
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,21 +51,21 @@ The most comprehensive test suite we have is the `nu-test-support` crate. For te
   cargo run
   ```
 
-- Build and run with extra features. Currently extra features include dataframes and sqlite database support.
+- Build and run with dataframe support.
   ```shell
-  cargo run --features=extra
+  cargo run --features=dataframe
   ```
 
 - Run Clippy on Nushell:
 
   ```shell
-  cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+  cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
   ```
 
 - Run all tests:
 
   ```shell
-  cargo test --workspace --features=extra
+  cargo test --workspace
   ```
 
 - Run all tests for a specific command
@@ -91,11 +91,11 @@ The most comprehensive test suite we have is the `nu-test-support` crate. For te
 - To view verbose logs when developing, enable the `trace` log level.
 
   ```shell
-  cargo run --release --features=extra -- --log-level trace
+  cargo run --release -- --log-level trace
   ```
 
 - To redirect trace logs to a file, enable the `--log-target file` switch.
   ```shell
-  cargo run --release --features=extra -- --log-level trace --log-target file
+  cargo run --release -- --log-level trace --log-target file
   open $"($nu.temp-path)/nu-($nu.pid).log"
   ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,9 @@ rstest = {version = "0.15.0", default-features = false}
 itertools = "0.10.3"
 
 [features]
-plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin", "database"]
+plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
 extra = ["default"]
-default = ["plugin", "which-support", "trash-support"]
+default = ["plugin", "which-support", "trash-support", "sqlite"]
 stable = ["default"]
 wasi = []
 
@@ -101,8 +101,8 @@ trash-support = ["nu-command/trash-support"]
 # Dataframe feature for nushell
 dataframe = ["nu-command/dataframe"]
 
-# Database commands for nushell
-database = ["nu-command/database"]
+# SQLite commands for nushell
+sqlite = ["nu-command/sqlite"]
 
 [profile.release]
 opt-level = "s" # Optimize for size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ itertools = "0.10.3"
 
 [features]
 plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
+# extra used to be more useful but now it's the same as default. Leaving it in for backcompat with existing build scripts
 extra = ["default"]
 default = ["plugin", "which-support", "trash-support", "sqlite"]
 stable = ["default"]

--- a/build-all-maclin.sh
+++ b/build-all-maclin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "---------------------------------------------------------------"
-echo "Building nushell (nu) with all the plugins"
+echo "Building nushell (nu) with dataframes and all the plugins"
 echo "---------------------------------------------------------------"
 echo ""
 
@@ -14,7 +14,7 @@ NU_PLUGINS=(
 )
 
 echo "Building nushell"
-cargo build
+cargo build --features=dataframe
 for plugin in "${NU_PLUGINS[@]}"
 do
     echo '' && cd crates/$plugin

--- a/build-all-maclin.sh
+++ b/build-all-maclin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "---------------------------------------------------------------"
-echo "Building nushell (nu) with --features=extra and all the plugins"
+echo "Building nushell (nu) with all the plugins"
 echo "---------------------------------------------------------------"
 echo ""
 
@@ -14,7 +14,7 @@ NU_PLUGINS=(
 )
 
 echo "Building nushell"
-cargo build --features=extra
+cargo build
 for plugin in "${NU_PLUGINS[@]}"
 do
     echo '' && cd crates/$plugin

--- a/build-all-windows.cmd
+++ b/build-all-windows.cmd
@@ -1,11 +1,11 @@
 @echo off
 @echo -------------------------------------------------------------------
-@echo Building nushell (nu.exe) with all the plugins
+@echo Building nushell (nu.exe) with dataframes and all the plugins
 @echo -------------------------------------------------------------------
 @echo.
 
 echo Building nushell.exe
-cargo build
+cargo build cargo build --features=dataframe
 @echo.
 
 @cd crates\nu_plugin_example

--- a/build-all-windows.cmd
+++ b/build-all-windows.cmd
@@ -1,11 +1,11 @@
 @echo off
 @echo -------------------------------------------------------------------
-@echo Building nushell (nu.exe) with --features=extra and all the plugins
+@echo Building nushell (nu.exe) with all the plugins
 @echo -------------------------------------------------------------------
 @echo.
 
 echo Building nushell.exe
-cargo build --features=extra
+cargo build
 @echo.
 
 @cd crates\nu_plugin_example

--- a/build-all.nu
+++ b/build-all.nu
@@ -1,10 +1,10 @@
 echo '-------------------------------------------------------------------'
-echo 'Building nushell (nu) with --features=extra and all the plugins'
+echo 'Building nushell (nu) with and all the plugins'
 echo '-------------------------------------------------------------------'
 
 echo $'(char nl)Building nushell'
 echo '----------------------------'
-cargo build --features=extra
+cargo build
 
 let plugins = [
     nu_plugin_inc,

--- a/build-all.nu
+++ b/build-all.nu
@@ -1,10 +1,10 @@
 echo '-------------------------------------------------------------------'
-echo 'Building nushell (nu) with and all the plugins'
+echo 'Building nushell (nu) with dataframes and all the plugins'
 echo '-------------------------------------------------------------------'
 
 echo $'(char nl)Building nushell'
 echo '----------------------------'
-cargo build
+cargo build --features=dataframe
 
 let plugins = [
     nu_plugin_inc,

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -148,7 +148,7 @@ trash-support = ["trash"]
 which-support = ["which"]
 plugin = ["nu-parser/plugin"]
 dataframe = ["polars", "num", "sqlparser"]
-database = ["rusqlite"] # TODO: given that rusqlite is included in reedline, should we just always include it?
+sqlite = ["rusqlite"] # TODO: given that rusqlite is included in reedline, should we just always include it?
 
 [build-dependencies]
 shadow-rs = { version = "0.16.1", default-features = false }

--- a/crates/nu-command/src/core_commands/version.rs
+++ b/crates/nu-command/src/core_commands/version.rs
@@ -193,7 +193,7 @@ fn features_enabled() -> Vec<String> {
         names.push("trash".to_string());
     }
 
-    #[cfg(feature = "database")]
+    #[cfg(feature = "sqlite")]
     {
         names.push("database".to_string());
     }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -23,7 +23,7 @@ pub fn create_default_context() -> EngineState {
 
         // Database-related
         // Adds all related commands to query databases
-        #[cfg(feature = "database")]
+        #[cfg(feature = "sqlite")]
         add_database_decls(&mut working_set);
 
         // Core

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -7,10 +7,10 @@ use nu_protocol::{
 };
 use std::io::BufReader;
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 use crate::database::SQLiteDatabase;
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 use nu_protocol::IntoPipelineData;
 
 #[cfg(unix)]
@@ -107,7 +107,7 @@ impl Command for Open {
                 Vec::new(),
             ))
         } else {
-            #[cfg(feature = "database")]
+            #[cfg(feature = "sqlite")]
             if !raw {
                 let res = SQLiteDatabase::try_from_path(path, arg_span)
                     .map(|db| db.into_value(call.head).into_pipeline_data());

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -62,8 +62,8 @@ mod dataframe;
 #[cfg(feature = "dataframe")]
 pub use dataframe::*;
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 mod database;
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 pub use database::*;

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -53,7 +53,7 @@ mod path;
 mod platform;
 mod prepend;
 mod print;
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 mod query;
 mod random;
 mod range;

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -108,7 +108,7 @@ fn parses_more_bson_complexity() {
 // │ 4 │      │
 // ╰───┴──────╯
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn parses_sqlite() {
     let actual = nu!(
@@ -123,7 +123,7 @@ fn parses_sqlite() {
     assert_eq!(actual.out, "3");
 }
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn parses_sqlite_get_column_name() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/query/db.rs
+++ b/crates/nu-command/tests/commands/query/db.rs
@@ -1,6 +1,6 @@
 use nu_test_support::{nu, pipeline};
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn can_query_single_table() {
     let actual = nu!(
@@ -16,7 +16,7 @@ fn can_query_single_table() {
     assert_eq!(actual.out, "4");
 }
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn invalid_sql_fails() {
     let actual = nu!(
@@ -30,7 +30,7 @@ fn invalid_sql_fails() {
     assert!(actual.err.contains("syntax error"));
 }
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn invalid_input_fails() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -1,5 +1,5 @@
 use nu_test_support::nu;
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 use nu_test_support::pipeline;
 
 #[test]
@@ -82,7 +82,7 @@ fn uses_optional_index_argument() {
     assert_eq!(actual.out, "[7, 8]");
 }
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn binary_operator_comparisons() {
     let actual = nu!(
@@ -151,7 +151,7 @@ fn binary_operator_comparisons() {
     assert_eq!(actual.out, "42");
 }
 
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn contains_operator() {
     let actual = nu!(

--- a/install-all.ps1
+++ b/install-all.ps1
@@ -2,13 +2,13 @@
 # Usage: Just run `powershell install-all.ps1` in nushell root directory
 
 Write-Output "-----------------------------------------------------------------"
-Write-Output "Installing nushell (nu) with --features=extra and all the plugins"
+Write-Output "Installing nushell (nu) with all the plugins"
 Write-Output "-----------------------------------------------------------------"
 Write-Output ""
 
 Write-Output "Install nushell from local..."
 Write-Output "----------------------------------------------"
-cargo install --path . --features=extra
+cargo install --path .
 
 $NU_PLUGINS = @(
     'nu_plugin_example',

--- a/install-all.ps1
+++ b/install-all.ps1
@@ -2,13 +2,13 @@
 # Usage: Just run `powershell install-all.ps1` in nushell root directory
 
 Write-Output "-----------------------------------------------------------------"
-Write-Output "Installing nushell (nu) with all the plugins"
+Write-Output "Installing nushell (nu) with dataframes and all the plugins"
 Write-Output "-----------------------------------------------------------------"
 Write-Output ""
 
 Write-Output "Install nushell from local..."
 Write-Output "----------------------------------------------"
-cargo install --path .
+cargo install --path . --features=dataframe
 
 $NU_PLUGINS = @(
     'nu_plugin_example',

--- a/install-all.sh
+++ b/install-all.sh
@@ -3,13 +3,13 @@
 # Usage: Just run `sh install-all.sh` in nushell root directory
 
 echo "-----------------------------------------------------------------"
-echo "Installing nushell (nu) with --features=extra and all the plugins"
+echo "Installing nushell (nu) with all the plugins"
 echo "-----------------------------------------------------------------"
 echo ""
 
 echo "Install nushell from local..."
 echo "----------------------------------------------"
-cargo install --path . --features=extra
+cargo install --path .
 
 NU_PLUGINS=(
     'nu_plugin_inc'

--- a/install-all.sh
+++ b/install-all.sh
@@ -3,13 +3,13 @@
 # Usage: Just run `sh install-all.sh` in nushell root directory
 
 echo "-----------------------------------------------------------------"
-echo "Installing nushell (nu) with all the plugins"
+echo "Installing nushell (nu) with dataframes and all the plugins"
 echo "-----------------------------------------------------------------"
 echo ""
 
 echo "Install nushell from local..."
 echo "----------------------------------------------"
-cargo install --path .
+cargo install --path . --features=dataframe
 
 NU_PLUGINS=(
     'nu_plugin_inc'

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -53,7 +53,7 @@ fn can_get_describe_plugin_custom_values() {
 // There are currently no custom values defined by the engine that aren't hidden behind an extra
 // feature, both database and dataframes are hidden behind --features=extra so we need to guard
 // this test
-#[cfg(feature = "database")]
+#[cfg(feature = "sqlite")]
 #[test]
 fn fails_if_passing_engine_custom_values_to_plugins() {
     let actual = nu_with_plugins!(


### PR DESCRIPTION
Following up on #7180 with some feature cleanup:

- Move the `database` feature from `plugin` to `default`
- Rename the `database` feature to `sqlite`
- Remove `--features=extra` from a lot of scripts etc. 
    - No need to specify this, the `extra` feature is now the same as the default feature set
- Remove the now-redundant 2nd Ubuntu test run