### PR TITLE
Error on negative argument to `last`

### DIFF
--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -78,3 +78,16 @@ fn gets_last_row_as_list_when_amount_given() {
 
     assert_eq!(actual.out, "list<int>");
 }
+
+#[test]
+fn last_errors_on_negative_index() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                [1, 2, 3]
+                | last -2
+            "#
+    ));
+
+    assert!(actual.err.contains("use a positive value"));
+}


### PR DESCRIPTION
# Description

- Error on negative argument to `last`
- Add test for negative value in last

Follow-up for #7178

# User-Facing Changes

Breaking change:

even before #7178 `last` returned an empty `list<any>` when given negative indices.
Now this is an [error](https://docs.rs/nu-protocol/latest/nu_protocol/enum.ShellError.html#variant.NeedsPositiveValue)

Note:
In #7136 we are considering supporting negative indexing

# Tests + Formatting

+ 1 failure test

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
