### PR TITLE
Error on negative argument of `first`

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -97,6 +97,7 @@ fn first_helper(
     // the first N elements is covered by `take`
     let return_single_element = rows.is_none();
     let rows_desired: usize = match rows {
+        Some(i) if i < 0 => return Err(ShellError::NeedsPositiveValue(head)),
         Some(x) => x as usize,
         None => 1,
     };

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -92,3 +92,16 @@ fn works_with_binary_list() {
 
     assert_eq!(actual.out, "true");
 }
+
+#[test]
+fn errors_on_negative_rows() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                [1, 2, 3]
+                | first -10
+            "#
+    ));
+
+    assert!(actual.err.contains("use a positive value"));
+}


### PR DESCRIPTION
Fixes a two's complement underflow/overflow when given a negative arg.

Breaking change as it is throwing an error instead of most likely
returning most of the output.

Same behavior as #7184


# Tests + Formatting

+ 1 failure test

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
