### PR TITLE
Rename uniq `--ignore-case` long flag name to `--insensitive`

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -45,17 +45,17 @@ impl Command for Find {
             )
             .switch(
                 "insensitive",
-                "case-insensitive search for regex (?i)",
+                "case-insensitive regex mode; equivalent to (?i)",
                 Some('i'),
             )
             .switch(
                 "multiline",
-                "multi-line mode: ^ and $ match begin/end of line for regex (?m)",
+                "multi-line regex mode: ^ and $ match begin/end of line; equivalent to (?m)",
                 Some('m'),
             )
             .switch(
                 "dotall",
-                "dotall mode: allow a dot . to match newline character \\n for regex (?s)",
+                "dotall regex mode: allow a dot . to match newlines \\n; equivalent to (?s)",
                 Some('s'),
             )
             .switch("invert", "invert the match", Some('v'))

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -96,9 +96,9 @@ impl Command for Uniq {
             },
             Example {
                 description: "Ignore differences in case when comparing input values",
-                example: "['Hello' 'goodbye' 'HELLO'] | uniq -i",
+                example: "['hello' 'goodbye' 'Hello'] | uniq -i",
                 result: Some(Value::List {
-                    vals: vec![Value::test_string("Hello"), Value::test_string("goodbye")],
+                    vals: vec![Value::test_string("hello"), Value::test_string("goodbye")],
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -38,8 +38,8 @@ impl Command for Uniq {
                 Some('d'),
             )
             .switch(
-                "ignore-case",
-                "Ignore differences in case when comparing input values",
+                "insensitive",
+                "Compare input values case-insensitively",
                 Some('i'),
             )
             .switch(
@@ -96,9 +96,9 @@ impl Command for Uniq {
             },
             Example {
                 description: "Ignore differences in case when comparing input values",
-                example: "['hello' 'goodbye' 'Hello'] | uniq -i",
+                example: "['Hello' 'goodbye' 'HELLO'] | uniq -i",
                 result: Some(Value::List {
-                    vals: vec![Value::test_string("hello"), Value::test_string("goodbye")],
+                    vals: vec![Value::test_string("Hello"), Value::test_string("goodbye")],
                     span: Span::test_data(),
                 }),
             },
@@ -144,7 +144,7 @@ fn uniq(
     let head = call.head;
     let should_show_count = call.has_flag("count");
     let show_repeated = call.has_flag("repeated");
-    let ignore_case = call.has_flag("ignore-case");
+    let ignore_case = call.has_flag("insensitive");
     let only_uniques = call.has_flag("unique");
     let metadata = input.metadata();
 

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -230,3 +230,12 @@ fn uniq_simple_vals_strs() {
     print!("{}", expected.out);
     assert_eq!(actual.out, expected.out);
 }
+
+#[test]
+fn uniq_insensitive_long_flag() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        "[aaa aAa bbb BBB] | uniq --insensitive | to nuon"
+    ));
+    assert_eq!(actual.out, "[aaa Bbb]");
+}

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -230,12 +230,3 @@ fn uniq_simple_vals_strs() {
     print!("{}", expected.out);
     assert_eq!(actual.out, expected.out);
 }
-
-#[test]
-fn uniq_insensitive_long_flag() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        "[aaa aAa bbb BBB] | uniq --insensitive | to nuon"
-    ));
-    assert_eq!(actual.out, "[aaa Bbb]");
-}


### PR DESCRIPTION
# Description

`sort`, `sort-by`, `str contains` and `find` all have a -i flag that controls case-sensitivity. However, unlike `uniq`, the expanded version is called `--insensitive` for all of these commands. This changes `uniq` to use the same name. While this is a compat break, since long names aren't especially popular (existing primarily for self-documentation purposes), I consider this on the shallow end of the compat-break scale.

`uniq -i` remains exactly the same.

# User-Facing Changes

`uniq --ignore-case` → `uniq --insensitive` (compat break)

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
