### PR TITLE
Fix `glob` error arrows

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -84,7 +84,7 @@ impl Command for Glob {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"For more glob pattern help please refer to https://github.com/olson-sean-k/wax"#
+        r#"For more glob pattern help, please refer to https://github.com/olson-sean-k/wax"#
     }
 
     fn run(
@@ -102,7 +102,7 @@ impl Command for Glob {
         if glob_pattern.item.is_empty() {
             return Err(ShellError::GenericError(
                 "glob pattern must not be empty".to_string(),
-                "".to_string(),
+                "glob pattern is empty".to_string(),
                 Some(glob_pattern.span),
                 Some("add characters to the glob pattern".to_string()),
                 Vec::new(),
@@ -120,9 +120,9 @@ impl Command for Glob {
             Err(e) => {
                 return Err(ShellError::GenericError(
                     "error with glob pattern".to_string(),
-                    "".to_string(),
+                    format!("{}", e),
+                    Some(glob_pattern.span),
                     None,
-                    Some(format!("{}", e)),
                     Vec::new(),
                 ))
             }


### PR DESCRIPTION
# Description
BEFORE:
```
〉glob ''
Error:
  × glob pattern must not be empty
   ╭─[entry #3:1:1]
 1 │ glob ''
   ·      ─┬
   ·       ╰── 
   ╰────
  help: add characters to the glob pattern

〉glob './/'
Error:
  × error with glob pattern
  help: malformed glob expression: adjacent component boundaries `/` or `**`
```
AFTER:
```
〉glob ''
Error:
  × glob pattern must not be empty
   ╭─[entry #1:1:1]
 1 │ glob ''
   ·      ─┬
   ·       ╰── glob pattern is empty
   ╰────
  help: add characters to the glob pattern

〉glob './/'
Error:
  × error with glob pattern
   ╭─[entry #4:1:1]
 1 │ glob './/'
   ·      ──┬──
   ·        ╰── malformed glob expression: adjacent component boundaries `/` or `**`
   ╰────
```
# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
