### PR TITLE
Change the `rm.always_trash` default in config.nu to `true` for safety

### DIFF
--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -114,7 +114,7 @@ impl Default for Config {
             keybindings: Vec::new(),
             menus: Vec::new(),
             hooks: Hooks::new(),
-            rm_always_trash: false,
+            rm_always_trash: true,
             shell_integration: false,
             buffer_editor: String::new(),
             table_index_mode: TableIndexMode::Always,

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -248,7 +248,7 @@ let-env config = {
     clickable_links: true # enable or disable clickable links. Your terminal has to support links.
   }
   rm: {
-    always_trash: false # always act as if -t was given. Can be overridden with -p
+    always_trash: true # always act as if -t was given. Can be overridden with -p
   }
   cd: {
     abbreviations: true # allows `cd s/o/f` to expand to `cd some/other/folder`


### PR DESCRIPTION
# Description

This was split from one of my recent PRs. I want to make this change because it A) seems to be a desirable default (based on anecdotal comments I've seen elsewhere) and B) corresponds with the recent trend towards safer defaults that resulted in `mv` defaulting to no-clobber (requiring `-f`).

# User-Facing Changes

When there is no `rm_always_trash` or `rm.always_trash` value in the user's config.nu, then it assumes `true` when formerly it assumed `false`.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
