### PR TITLE
Fix `mv` error message issues (arrows, Windows paths)

### DIFF
--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -403,7 +403,7 @@ fn mv_directory_with_same_name() {
             "#
         );
 
-        assert!(actual.err.contains("Directory not empty"));
+        assert!(actual.err.contains("is not empty"));
     })
 }
 


### PR DESCRIPTION
# Description

BEFORE (notice Windows paths look wrong):
```
〉mv 8 9
Error:
  × Destination file already exists
   ╭─[entry #22:1:1]
 1 │ mv 8 9
   ·      ┬
   ·      ╰── you can use -f, --force to force overwriting the destination
   ╰────

〉mv d1 tmp
Error:
  × Can't move "C:\\Users\\Leon\\TODO\\d1" to "C:\\Users\\Leon\\TODO\\tmp\\d1"
   ╭─[entry #19:1:1]
 1 │ mv d1 tmp
   ·       ─┬─
   ·        ╰── Directory not empty
   ╰────

```
AFTER (full paths are now included in the arrows' messages to make lines like `mv $foo` entirely unambiguous):
```
〉mv 8 9
Error:
  × Destination file already exists
   ╭─[entry #4:1:1]
 1 │ mv 8 9
   ·      ┬
   ·      ╰── Destination file 'C:\Users\Leon\TODO\tmp\9' already exists
   ╰────
  help: you can use -f, --force to force overwriting the destination

〉mv d1 tmp
Error:
  × Can't move 'C:\Users\Leon\TODO\d1' to 'C:\Users\Leon\TODO\tmp\d1'
   ╭─[entry #3:1:1]
 1 │ mv d1 tmp
   ·       ─┬─
   ·        ╰── Directory 'C:\Users\Leon\TODO\tmp' is not empty
   ╰────

```
# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
