### PR TITLE
Change all `--insensitive` flags to `--ignore-case`

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -44,18 +44,18 @@ impl Command for Find {
                 Some('r'),
             )
             .switch(
-                "insensitive",
-                "case-insensitive search for regex (?i)",
+                "ignore-case",
+                "case-insensitive regex mode; equivalent to (?i)",
                 Some('i'),
             )
             .switch(
                 "multiline",
-                "multi-line mode: ^ and $ match begin/end of line for regex (?m)",
+                "multi-line regex mode: ^ and $ match begin/end of line; equivalent to (?m)",
                 Some('m'),
             )
             .switch(
                 "dotall",
-                "dotall mode: allow a dot . to match newline character \\n for regex (?s)",
+                "dotall regex mode: allow a dot . to match newlines \\n; equivalent to (?s)",
                 Some('s'),
             )
             .switch("invert", "invert the match", Some('v'))
@@ -166,7 +166,7 @@ fn find_with_regex(
     let ctrlc = engine_state.ctrlc.clone();
     let config = engine_state.get_config().clone();
 
-    let insensitive = call.has_flag("insensitive");
+    let insensitive = call.has_flag("ignore-case");
     let multiline = call.has_flag("multiline");
     let dotall = call.has_flag("dotall");
     let invert = call.has_flag("invert");

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -22,7 +22,7 @@ impl Command for Sort {
         ), (Type::Record(vec![]), Type::Record(vec![])),])
     .switch("reverse", "Sort in reverse order", Some('r'))
             .switch(
-                "insensitive",
+                "ignore-case",
                 "Sort string-based columns case-insensitively",
                 Some('i'),
             )
@@ -133,7 +133,7 @@ impl Command for Sort {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let reverse = call.has_flag("reverse");
-        let insensitive = call.has_flag("insensitive");
+        let insensitive = call.has_flag("ignore-case");
         let metadata = &input.metadata();
 
         match input {

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -20,7 +20,7 @@ impl Command for SortBy {
             .rest("columns", SyntaxShape::Any, "the column(s) to sort by")
             .switch("reverse", "Sort in reverse order", Some('r'))
             .switch(
-                "insensitive",
+                "ignore-case",
                 "Sort string-based columns case-insensitively",
                 Some('i'),
             )
@@ -81,7 +81,7 @@ impl Command for SortBy {
     ) -> Result<PipelineData, ShellError> {
         let columns: Vec<String> = call.rest(engine_state, stack, 0)?;
         let reverse = call.has_flag("reverse");
-        let insensitive = call.has_flag("insensitive");
+        let insensitive = call.has_flag("ignore-case");
         let natural = call.has_flag("natural");
         let metadata = &input.metadata();
         let mut vec: Vec<_> = input.into_iter().collect();

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -39,7 +39,7 @@ impl Command for Uniq {
             )
             .switch(
                 "ignore-case",
-                "Ignore differences in case when comparing input values",
+                "Compare input values case-insensitively",
                 Some('i'),
             )
             .switch(

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "For a data structure input, check strings at the given cell paths, and replace with result",
             )
-            .switch("insensitive", "search is case insensitive", Some('i'))
+            .switch("ignore-case", "search is case insensitive", Some('i'))
             .switch("not", "does not contain", Some('n'))
             .category(Category::Strings)
     }
@@ -62,7 +62,7 @@ impl Command for SubCommand {
         let args = Arguments {
             substring: call.req::<String>(engine_state, stack, 0)?,
             cell_paths,
-            case_insensitive: call.has_flag("insensitive"),
+            case_insensitive: call.has_flag("ignore-case"),
             not_contain: call.has_flag("not"),
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())


### PR DESCRIPTION
# Description

Support for this breaking change was raised in #7191. This affects `sort`, `sort-by`, `str contains` and `find`. `--ignore-case` is used by a few POSIX programs such as `less` and `grep`, as well as a few other popular utils like `tree` and `wget`. Since long names aren't especially popular (existing primarily for self-documentation purposes), I consider this on the shallow end of the compat-break scale.

Note that the `-i` short flag is not affected.
 
# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace --features=extra` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
