### PR TITLE
Don't redirect stdout when only redirecting stderr

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -938,7 +938,14 @@ pub fn eval_block(
                 stack,
                 &pipeline.elements[i],
                 input,
-                redirect_stdout || (i != pipeline.elements.len() - 1),
+                redirect_stdout
+                    || (i != pipeline.elements.len() - 1)
+                        && (matches!(
+                            pipeline.elements[i + 1],
+                            PipelineElement::Redirection(_, Redirection::Stdout, _)
+                                | PipelineElement::Redirection(_, Redirection::StdoutAndStderr, _)
+                                | PipelineElement::Expression(..)
+                        )),
                 redirect_stderr
                     || ((i < pipeline.elements.len() - 1)
                         && (matches!(


### PR DESCRIPTION
# Description

Spotted by @WindSoilder - don't redirect stdout if the user requests `err>`.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
