### PR TITLE
`uniq -i` does not convert to lowercase (#7192)

### DIFF
--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -232,11 +232,11 @@ fn uniq_simple_vals_strs() {
 }
 
 #[test]
-fn with_table() {
+fn table() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            [[fruit day]; [apple monday] [apple friday] [apple monday] [pear monday] [orange tuesday]]
+            [[fruit day]; [apple monday] [apple friday] [Apple friday] [apple monday] [pear monday] [orange tuesday]]
             | uniq
         "#
     ));
@@ -244,10 +244,59 @@ fn with_table() {
     let expected = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-        echo [[fruit day]; [apple monday] [apple friday] [pear monday] [orange tuesday]]
+        echo [[fruit day]; [apple monday] [apple friday] [Apple friday] [pear monday] [orange tuesday]]
         "#
     ));
     print!("{}", actual.out);
     print!("{}", expected.out);
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn table_with_ignore_case() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [[origin, people];
+                [World, (
+                    [[name, meal];
+                        ['Geremias', {plate: 'bitoque', carbs: 100}]
+                    ]
+                )],
+                [World, (
+                    [[name, meal];
+                        ['Martin', {plate: 'bitoque', carbs: 100}]
+                    ]
+                )],
+                [World, (
+                    [[name, meal];
+                        ['Geremias', {plate: 'Bitoque', carbs: 100}]
+                    ]
+                )],
+            ] | uniq -i
+        "#
+    ));
+
+    let expected = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        echo [[origin, people];
+                [World, (
+                    [[name, meal];
+                        ['Geremias', {plate: 'bitoque', carbs: 100}]
+                    ]
+                )],
+                [World, (
+                    [[name, meal];
+                        ['Martin', {plate: 'bitoque', carbs: 100}]
+                    ]
+                )],
+            ]
+        "#
+    ));
+
+    print!("{}", actual.out);
+    print!("{}", expected.out);
+    assert_eq!(actual.out, expected.out);
     assert_eq!(actual.out, expected.out);
 }


### PR DESCRIPTION
# Description
`uniq -i` does not convert output strings to lowercase.

Also, `uniq -i` did not ignore case in strings below the first level of Tables and Records. Now all strings case are ignored for all children Values for tables, Records, and List.

Fixes https://github.com/nushell/nushell/issues/7192


# Tests + Formatting
About the issue https://github.com/nushell/nushell/issues/7192, the output will be:
```
〉[AAA BBB CCC] | uniq -i
╭───┬─────╮
│ 0 │ AAA │
│ 1 │ BBB │
│ 2 │ CCC │
╰───┴─────╯
```

About ignoring case for all children string, I expect this to be true:
```
([[origin, people];
    [World, (
        [[name, meal];
            ['Geremias', {plate: 'bitoque', carbs: 100}]
        ]
    )],
    [World, (
        [[name, meal];
            ['Martin', {plate: 'bitoque', carbs: 100}]
        ]
    )],
    [World, (
        [[name, meal];
            ['Geremias', {plate: 'Bitoque', carbs: 100}]
        ]
    )],
] | uniq -i
) == ([[origin, people];
    [World, (
        [[name, meal];
            ['Geremias', {plate: 'bitoque', carbs: 100}]
        ]
    )],
    [World, (
        [[name, meal];
            ['Martin', {plate: 'bitoque', carbs: 100}]
        ]
    )]
])
```

