### PR TITLE
Add binstall metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ version = "0.71.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [workspace]
 members = [
 	"crates/nu-cli",


### PR DESCRIPTION
# Description

To make `cargo binstall nu` works out of the box, `Cargo.toml` needs to be slightly modified, likely because the URL to the download does not exactly match.

# User-Facing Changes

None

# Tests + Formatting

Tested by cherry-picking this commit on top of the 0.71.0 tag, running `cargo package --allow-dirty --no-verify`, then:

```
~
❯ cargo binstall --manifest-path ~/src/github/nushell/nushell/Cargo.toml nu --force
 INFO resolve: Resolving package: 'nu'
 WARN resolve: The package will be downloaded from github.com
 INFO resolve: This will install the following binaries:
 INFO resolve:   - nu (nu -> /home/michel/.cargo/bin/nu-v0.71.0)
 INFO resolve: And create (or update) the following symlinks:
 INFO resolve:   - nu (/home/michel/.cargo/bin/nu -> nu-v0.71.0)
Do you wish to continue? yes/[no]
? yes
 INFO install: Installing binaries...
 INFO Done in 8.538106765s
```

`--force` was needed because I've previously tried this to manually test the `pkg-url`:

```
cargo binstall \
        --pkg-url="{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }" \
        --pkg-fmt="tgz" nu
```

Fixes #7201.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>
