### PR TITLE
Fix `fetch`/`post` not erroring on 4xx and 5xx statuses

### DIFF
--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -450,7 +450,8 @@ fn helper(
         }
     }
 
-    match request.send() {
+    // Explicitly turn 4xx and 5xx statuses into errors.
+    match request.send().and_then(|r| r.error_for_status()) {
         Ok(resp) => match resp.headers().get("content-type") {
             Some(content_type) => {
                 let content_type = content_type.to_str().map_err(|e| {

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -304,7 +304,8 @@ fn helper(
         }
     }
 
-    match request.send() {
+    // Explicitly turn 4xx and 5xx statuses into errors.
+    match request.send().and_then(|r| r.error_for_status()) {
         Ok(resp) => match resp.headers().get("content-type") {
             Some(content_type) => {
                 let content_type = content_type.to_str().map_err(|e| {


### PR DESCRIPTION
# Description

Closes #6803.

You can look at the code and see this was always supposed to work this way, but was broken due to 1 line (per file).

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
