### PR TITLE
fix color_config crashing on nonstring data

### DIFF
--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -217,15 +217,10 @@ pub fn get_color_config(config: &Config) -> HashMap<String, Style> {
     hm.insert("hints".to_string(), Color::DarkGray.normal());
 
     for (key, value) in &config.color_config {
-        let value = value
-            .as_string()
-            .expect("the only values for config color must be strings");
-        update_hashmap(key, &value, &mut hm);
-
-        // eprintln!(
-        //     "config: {}:{}\t\t\thashmap: {}:{:?}",
-        //     &key, &value, &key, &hm[key]
-        // );
+        match value.as_string() {
+            Ok(value) => update_hashmap(key, &value, &mut hm),
+            Err(_) => continue,
+        }
     }
 
     hm


### PR DESCRIPTION
# Description
This PR closses issue #7155, where now providing a non valid color will just ignore it and use the default.

Making the same changes as the original issue just starts nushell without crashing.

I do have one comment. I thought it would be nice to provide some feedback to the user that the config value is invalid, rather than just ignore it, as someone might not know why is "not working properly". But I am guessing the current use case of just ignoring as its own reasons. Thanks :) 
# User-Facing Changes

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
