### PR TITLE
A set of fixes for stderr redirect

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -74,6 +74,14 @@ pub fn print_table_or_error(
     // Change the engine_state config to use the passed in configuration
     engine_state.set_config(config);
 
+    if let PipelineData::Value(Value::Error { error }, ..) = &pipeline_data {
+        let working_set = StateWorkingSet::new(engine_state);
+
+        report_error(&working_set, error);
+
+        std::process::exit(1);
+    }
+
     match engine_state.find_decl("table".as_bytes(), &[]) {
         Some(decl_id) => {
             let command = engine_state.get_decl(decl_id);

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -528,7 +528,7 @@ pub fn evaluate_repl(
             Err(err) => {
                 let message = err.to_string();
                 if !message.contains("duration") {
-                    println!("Error: {:?}", err);
+                    eprintln!("Error: {:?}", err);
                     // TODO: Identify possible error cases where a hard failure is preferable
                     // Ignoring and reporting could hide bigger problems
                     // e.g. https://github.com/nushell/nushell/issues/6452

--- a/crates/nu-command/src/core_commands/do_.rs
+++ b/crates/nu-command/src/core_commands/do_.rs
@@ -168,6 +168,9 @@ impl Command for Do {
                 metadata,
                 trim_end_newline,
             }),
+            Ok(PipelineData::Value(Value::Error { .. }, ..)) if ignore_shell_errors => {
+                Ok(PipelineData::new(call.head))
+            }
             Err(_) if ignore_shell_errors => Ok(PipelineData::new(call.head)),
             r => r,
         }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -390,7 +390,7 @@ impl ExternalCommand {
                                 use std::os::unix::process::ExitStatusExt;
                                 if x.core_dumped() {
                                     let style = Style::new().bold().on(Color::Red);
-                                    println!(
+                                    eprintln!(
                                         "{}",
                                         style.paint(format!(
                                             "nushell: oops, process '{commandname}' core dumped"

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -9,6 +9,8 @@ fn capture_errors_works() {
         "#
     ));
 
+    eprintln!("actual.err: {:?}", actual.err);
+
     assert!(actual.err.contains("column_not_found"));
 }
 
@@ -65,7 +67,7 @@ fn ignore_shell_errors_works_for_external_with_semicolon() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        do -s { fail }; `text`
+        do -s { open asdfasdf.txt }; "text"
         "#
     ));
 

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -323,7 +323,7 @@ fn parse_string_as_script() {
             "#
         ));
 
-        println!("the out put is {}", actual.err);
+        println!("the output is {}", actual.err);
         assert!(actual.err.contains("Failed to parse content"));
     })
 }

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -20,10 +20,10 @@ fn redirect_err() {
     Playground::setup("redirect_err_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "dir missingapplication err> a; type a"
+            "dir missingapplication err> a; (open a | size).bytes >= 16"
         );
 
-        assert!(output.out.contains("Not Found"));
+        assert!(output.out.contains("true"));
     })
 }
 
@@ -46,10 +46,10 @@ fn redirect_outerr() {
     Playground::setup("redirect_outerr_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "dir missingapplication out+err> a; type a"
+            "dir missingapplication out+err> a; (open a | size).bytes >= 16"
         );
 
-        assert!(output.out.contains("Not Found"));
+        assert!(output.out.contains("true"));
     })
 }
 

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -20,10 +20,10 @@ fn redirect_err() {
     Playground::setup("redirect_err_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "type asdfasdfasdf.txt err> a; type a"
+            "missingapplication err> a; type a"
         );
 
-        assert!(output.out.contains("asdfasdfasdf.txt"));
+        assert!(output.out.contains("not found"));
     })
 }
 
@@ -46,10 +46,10 @@ fn redirect_outerr() {
     Playground::setup("redirect_outerr_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "type asdfasdfasdf.txt out+err> a; type a"
+            "missingapplication out+err> a; type a"
         );
 
-        assert!(output.err.contains("asdfasdfasdf.txt"));
+        assert!(output.out.contains("not found"));
     })
 }
 

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -7,10 +7,10 @@ fn redirect_err() {
     Playground::setup("redirect_err_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "cat asdfasdfasdf.txt err> a; cat a"
+            "cat asdfasdfasdf.txt err> a.txt; cat a.txt"
         );
 
-        assert!(output.err.contains("asdfasdfasdf.txt"));
+        assert!(output.out.contains("asdfasdfasdf.txt"));
     })
 }
 
@@ -23,7 +23,7 @@ fn redirect_err() {
             "type asdfasdfasdf.txt err> a; type a"
         );
 
-        assert!(output.err.contains("asdfasdfasdf.txt"));
+        assert!(output.out.contains("asdfasdfasdf.txt"));
     })
 }
 
@@ -36,7 +36,7 @@ fn redirect_outerr() {
             "cat asdfasdfasdf.txt out+err> a; cat a"
         );
 
-        assert!(output.err.contains("asdfasdfasdf.txt"));
+        assert!(output.out.contains("asdfasdfasdf.txt"));
     })
 }
 

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -20,10 +20,10 @@ fn redirect_err() {
     Playground::setup("redirect_err_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "missingapplication err> a; type a"
+            "dir missingapplication err> a; type a"
         );
 
-        assert!(output.out.contains("not found"));
+        assert!(output.out.contains("Not Found"));
     })
 }
 
@@ -46,10 +46,10 @@ fn redirect_outerr() {
     Playground::setup("redirect_outerr_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "missingapplication out+err> a; type a"
+            "dir missingapplication out+err> a; type a"
         );
 
-        assert!(output.out.contains("not found"));
+        assert!(output.out.contains("Not Found"));
     })
 }
 


### PR DESCRIPTION
# Description

This is a set of fixes to `err>` to make it work a bit more predictably.

I've also revised the tests, which accidentally tested the wrong thing for redirection, but should be more correct now.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
