### PR TITLE
pin to a version of zstd that doesn't break dataframe compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,6 +2656,7 @@ dependencies = [
  "which",
  "windows 0.42.0",
  "winreg",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -91,6 +91,7 @@ reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0" }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
+zstd-sys = "=2.0.1+zstd.1.5.2"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"


### PR DESCRIPTION
# Description

The `zstd` team released a version that breaks dataframe compilation. This change pins to `zstd-sys = "=2.0.1+zstd.1.5.2"` in order to prevent the required `+nightly` build flag.

_(Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.)_

_(Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.)_

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
