### PR TITLE
Remove And and Or pipeline elements

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1422,9 +1422,7 @@ pub fn parse_module_block(
 
                         pipeline
                     }
-                    LiteElement::Or(_, command)
-                    | LiteElement::And(_, command)
-                    | LiteElement::Redirection(_, _, command) => garbage_pipeline(&command.parts),
+                    LiteElement::Redirection(_, _, command) => garbage_pipeline(&command.parts),
                 }
             } else {
                 error = Some(ParseError::Expected("not a pipeline".into(), span));

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3837,10 +3837,7 @@ pub fn parse_table_expression(
         }
         _ => {
             match &output.block[0].commands[0] {
-                LiteElement::Command(_, command)
-                | LiteElement::Redirection(_, _, command)
-                | LiteElement::And(_, command)
-                | LiteElement::Or(_, command) => {
+                LiteElement::Command(_, command) | LiteElement::Redirection(_, _, command) => {
                     let mut table_headers = vec![];
 
                     let (headers, err) = parse_value(
@@ -3861,9 +3858,7 @@ pub fn parse_table_expression(
 
                     match &output.block[1].commands[0] {
                         LiteElement::Command(_, command)
-                        | LiteElement::Redirection(_, _, command)
-                        | LiteElement::And(_, command)
-                        | LiteElement::Or(_, command) => {
+                        | LiteElement::Redirection(_, _, command) => {
                             let mut rows = vec![];
                             for part in &command.parts {
                                 let (values, err) = parse_value(
@@ -5228,10 +5223,7 @@ pub fn parse_block(
     for pipeline in &lite_block.block {
         if pipeline.commands.len() == 1 {
             match &pipeline.commands[0] {
-                LiteElement::Command(_, command)
-                | LiteElement::Redirection(_, _, command)
-                | LiteElement::And(_, command)
-                | LiteElement::Or(_, command) => {
+                LiteElement::Command(_, command) | LiteElement::Redirection(_, _, command) => {
                     if let Some(err) =
                         parse_def_predecl(working_set, &command.parts, expand_aliases_denylist)
                     {
@@ -5282,38 +5274,6 @@ pub fn parse_block(
 
                             PipelineElement::Redirection(*span, redirection.clone(), expr)
                         }
-                        LiteElement::And(span, command) => {
-                            let (expr, err) = parse_expression(
-                                working_set,
-                                &command.parts,
-                                expand_aliases_denylist,
-                                is_subexpression,
-                            );
-
-                            working_set.type_scope.add_type(expr.ty.clone());
-
-                            if error.is_none() {
-                                error = err;
-                            }
-
-                            PipelineElement::And(*span, expr)
-                        }
-                        LiteElement::Or(span, command) => {
-                            let (expr, err) = parse_expression(
-                                working_set,
-                                &command.parts,
-                                expand_aliases_denylist,
-                                is_subexpression,
-                            );
-
-                            working_set.type_scope.add_type(expr.ty.clone());
-
-                            if error.is_none() {
-                                error = err;
-                            }
-
-                            PipelineElement::Or(*span, expr)
-                        }
                     })
                     .collect::<Vec<PipelineElement>>();
 
@@ -5334,10 +5294,7 @@ pub fn parse_block(
                 Pipeline { elements: output }
             } else {
                 match &pipeline.commands[0] {
-                    LiteElement::Command(_, command)
-                    | LiteElement::Redirection(_, _, command)
-                    | LiteElement::And(_, command)
-                    | LiteElement::Or(_, command) => {
+                    LiteElement::Command(_, command) | LiteElement::Redirection(_, _, command) => {
                         let (mut pipeline, err) = parse_builtin_commands(
                             working_set,
                             command,
@@ -5843,8 +5800,6 @@ impl LiteCommand {
 pub enum LiteElement {
     Command(Option<Span>, LiteCommand),
     Redirection(Span, Redirection, LiteCommand),
-    And(Span, LiteCommand),
-    Or(Span, LiteCommand),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
# Description

Since we're not implementing `&&` or `||`, let's remove their pipeline elements.

# User-Facing Changes

Nothing user facing. These were not yet implemented.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
