### PR TITLE
fix freeze for do -c

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -187,3 +187,93 @@ fn ignore_error_with_both_stdout_stderr_messages_not_hang_nushell() {
         },
     )
 }
+
+#[test]
+#[cfg(not(windows))]
+fn capture_error_with_too_much_stderr_not_hang_nushell() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    use nu_test_support::pipeline;
+    use nu_test_support::playground::Playground;
+    Playground::setup("external with many stderr message", |dirs, sandbox| {
+        let bytes: usize = 81920;
+        let mut large_file_body = String::with_capacity(bytes);
+        for _ in 0..bytes {
+            large_file_body.push('a');
+        }
+        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                do -c {sh -c "cat a_large_file.txt 1>&2"} | complete | get stderr
+            "#
+        ));
+
+        assert_eq!(actual.out, large_file_body);
+    })
+}
+
+#[test]
+#[cfg(not(windows))]
+fn capture_error_with_too_much_stdout_not_hang_nushell() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    use nu_test_support::pipeline;
+    use nu_test_support::playground::Playground;
+    Playground::setup("external with many stdout message", |dirs, sandbox| {
+        let bytes: usize = 81920;
+        let mut large_file_body = String::with_capacity(bytes);
+        for _ in 0..bytes {
+            large_file_body.push('a');
+        }
+        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                do -c {sh -c "cat a_large_file.txt"} | complete | get stdout
+            "#
+        ));
+
+        assert_eq!(actual.out, large_file_body);
+    })
+}
+
+#[test]
+#[cfg(not(windows))]
+fn capture_error_with_both_stdout_stderr_messages_not_hang_nushell() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    use nu_test_support::playground::Playground;
+    Playground::setup(
+        "external with many stdout and stderr messages",
+        |dirs, sandbox| {
+            let script_body = r#"
+        x=$(printf '=%.0s' {1..40960})
+        echo $x
+        echo $x 1>&2
+        "#;
+            let mut expect_body = String::new();
+            for _ in 0..40960 {
+                expect_body.push('=');
+            }
+
+            sandbox.with_files(vec![FileWithContent("test.sh", script_body)]);
+
+            // check for stdout
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                do -c {bash test.sh} | complete | get stdout | str trim
+            "#
+            ));
+            assert_eq!(actual.out, expect_body);
+            // check for stderr
+            let actual = nu!(
+                cwd: dirs.test(), pipeline(
+                r#"
+                do -c {bash test.sh} | complete | get stderr | str trim
+            "#
+            ));
+            assert_eq!(actual.out, expect_body);
+        },
+    )
+}


### PR DESCRIPTION
# Description

Fixes #7205

Apply the same pattern for external result consuming in `do -c`

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
