### PR TITLE
Clean up keyword lines in help

### DIFF
--- a/crates/nu-command/src/core_commands/try_.rs
+++ b/crates/nu-command/src/core_commands/try_.rs
@@ -20,7 +20,7 @@ impl Command for Try {
             .input_output_types(vec![(Type::Any, Type::Any)])
             .required("try_block", SyntaxShape::Block, "block to run")
             .optional(
-                "else_expression",
+                "catch_block",
                 SyntaxShape::Keyword(
                     b"catch".to_vec(),
                     Box::new(SyntaxShape::Closure(Some(vec![SyntaxShape::Any]))),

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -57,7 +57,7 @@ fn test_cd_html_color_flag_dark_false() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display the help message for this command<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; <span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span><span style='color:#037979;'>~<span style='color:black;font-weight:normal;'><br><br>  Change to a directory via abbreviations<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>d/s/9<span style='color:black;font-weight:normal;'><br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>-<span style='color:black;font-weight:normal;'><br><br></body></html></span></span>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help<br>      Display the help message for this command<br><br>Parameters:<br>  (optional) path &lt;directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; <span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span><span style='color:#037979;'>~<span style='color:black;font-weight:normal;'><br><br>  Change to a directory via abbreviations<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>d/s/9<span style='color:black;font-weight:normal;'><br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>-<span style='color:black;font-weight:normal;'><br><br></body></html></span></span>"
     );
 }
 
@@ -72,7 +72,7 @@ fn test_no_color_flag() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help - Display the help message for this command<br><br>Parameters:<br>  (optional) path &lt;Directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; cd -<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help - Display the help message for this command<br><br>Parameters:<br>  (optional) path &lt;directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; cd -<br><br></body></html>"
     );
 }
 

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -116,27 +116,51 @@ fn get_documentation(
     {
         let _ = write!(long_desc, "\n{G}Parameters{RESET}:\n");
         for positional in &sig.required_positional {
-            let text = format!(
-                "  {C}{}{RESET} <{BB}{:?}{RESET}>: {}",
-                positional.name,
-                document_shape(positional.shape.clone()),
-                positional.desc
-            );
+            let text = match &positional.shape {
+                SyntaxShape::Keyword(kw, shape) => {
+                    format!(
+                        "  {C}\"{}\" + {RESET}<{BB}{}{RESET}>: {}",
+                        String::from_utf8_lossy(kw),
+                        document_shape(*shape.clone()),
+                        positional.desc
+                    )
+                }
+                _ => {
+                    format!(
+                        "  {C}{}{RESET} <{BB}{}{RESET}>: {}",
+                        positional.name,
+                        document_shape(positional.shape.clone()),
+                        positional.desc
+                    )
+                }
+            };
             let _ = writeln!(long_desc, "{}", text);
         }
         for positional in &sig.optional_positional {
-            let text = format!(
-                "  (optional) {C}{}{RESET} <{BB}{:?}{RESET}>: {}",
-                positional.name,
-                document_shape(positional.shape.clone()),
-                positional.desc
-            );
+            let text = match &positional.shape {
+                SyntaxShape::Keyword(kw, shape) => {
+                    format!(
+                        "  (optional) {C}\"{}\" + {RESET}<{BB}{}{RESET}>: {}",
+                        String::from_utf8_lossy(kw),
+                        document_shape(*shape.clone()),
+                        positional.desc
+                    )
+                }
+                _ => {
+                    format!(
+                        "  (optional) {C}{}{RESET} <{BB}{}{RESET}>: {}",
+                        positional.name,
+                        document_shape(positional.shape.clone()),
+                        positional.desc
+                    )
+                }
+            };
             let _ = writeln!(long_desc, "{}", text);
         }
 
         if let Some(rest_positional) = &sig.rest_positional {
             let text = format!(
-                "  ...{C}{}{RESET} <{BB}{:?}{RESET}>: {}",
+                "  ...{C}{}{RESET} <{BB}{}{RESET}>: {}",
                 rest_positional.name,
                 document_shape(rest_positional.shape.clone()),
                 rest_positional.desc

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -329,7 +329,7 @@ fn print_help(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                     .try_for_each(|positional| {
                         writeln!(
                             help,
-                            "  {} <{:?}>: {}",
+                            "  {} <{}>: {}",
                             positional.name, positional.shape, positional.desc
                         )
                     })
@@ -341,7 +341,7 @@ fn print_help(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                     .try_for_each(|positional| {
                         writeln!(
                             help,
-                            "  (optional) {} <{:?}>: {}",
+                            "  (optional) {} <{}>: {}",
                             positional.name, positional.shape, positional.desc
                         )
                     })
@@ -350,7 +350,7 @@ fn print_help(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                 if let Some(rest_positional) = &signature.rest_positional {
                     writeln!(
                         help,
-                        "  ...{} <{:?}>: {}",
+                        "  ...{} <{}>: {}",
                         rest_positional.name, rest_positional.shape, rest_positional.desc
                     )
                 } else {

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -165,7 +165,15 @@ impl Display for SyntaxShape {
             SyntaxShape::GlobPattern => write!(f, "glob"),
             SyntaxShape::ImportPattern => write!(f, "import"),
             SyntaxShape::Block => write!(f, "block"),
-            SyntaxShape::Closure(_) => write!(f, "closure"),
+            SyntaxShape::Closure(args) => {
+                if let Some(args) = args {
+                    let arg_vec: Vec<_> = args.iter().map(|x| x.to_string()).collect();
+                    let arg_string = arg_vec.join(", ");
+                    write!(f, "closure({})", arg_string)
+                } else {
+                    write!(f, "closure()")
+                }
+            }
             SyntaxShape::Binary => write!(f, "binary"),
             SyntaxShape::Table => write!(f, "table"),
             SyntaxShape::List(x) => write!(f, "list<{}>", x),


### PR DESCRIPTION
# Description

This makes the help messages cleaner for keyword-style arguments.

Before:
```
  (optional) else_expression <Keyword([101, 108, 115, 101], Expression)>: expression or block to run if check fails
```

Now:
```
  (optional) "else" + <expression>: expression or block to run if check fails
```


# User-Facing Changes

Changes how help is printed, so we use slightly different shape names

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
