### PR TITLE
Improve `par-each` to output values in the same order as `each`

### DIFF
--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -43,12 +43,13 @@ impl Command for ParEach {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[1 2 3] | par-each { 2 * $in }",
+                example: "[1 2 3 4 5 6 7 8 9] | par-each { 2 * $in }",
                 description:
                     "Multiplies each number.",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::test_int(2), Value::test_int(4), Value::test_int(6),
+                        Value::test_int(2), Value::test_int(4), Value::test_int(6), Value::test_int(8), Value::test_int(10),
+                        Value::test_int(12), Value::test_int(14), Value::test_int(16), Value::test_int(18),
                     ],
                     span: Span::test_data(),
                 }),

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -43,7 +43,7 @@ impl Command for ParEach {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[1 2 3 4 5 6 7 8 9] | par-each { 2 * $in }",
+                example: "[1 2 3 4 5 6 7 8 9] | par-each {|el| 2 * $el }",
                 description:
                     "Multiplies each number.",
                 result: Some(Value::List {


### PR DESCRIPTION
# Description

I noticed that the issue with `par-each`'s output ordering is because it uses `par_bridge()`. If it used more "native" Rayon methods, it'd preserve the order.

So, I changed it so that for each datatype that can't use `to_par_iter()` is collected to Vec first, so that it can. The performance impact, based on my tests, is below notice - for Ranges (`benchmark { 1..999 | par-each { $in } }`) it only increased from 4ms → 6ms. For Lists (`benchmark { 1..999 | each { $in } | par-each { $in / 2 } }`), performance improved from 41ms → 36ms (because it never needed `par_bridge()` in the first place). (However, I didn't test ListStreams or ExternalStreams because I don't know how exactly to do that.)

# User-Facing Changes

Ordering of `par-each` output is no longer arbitrary.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
