### PR TITLE
pin to rust v1.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,6 @@ dependencies = [
  "which",
  "windows 0.42.0",
  "winreg",
- "zstd-sys",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -91,7 +91,7 @@ reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0" }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
-zstd-sys = "=2.0.1+zstd.1.5.2"
+# zstd-sys = "=2.0.1+zstd.1.5.2"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -91,7 +91,6 @@ reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0" }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
-# zstd-sys = "=2.0.1+zstd.1.5.2"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -824,7 +824,7 @@ fn convert_to_table(
 
             row.push(value);
         } else {
-            let skip_num = if with_index { 1 } else { 0 };
+            let skip_num = usize::from(with_index);
             for header in data[0].iter().skip(skip_num) {
                 let value =
                     create_table2_entry_basic(item, header.as_ref(), head, config, color_hm);

--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -325,7 +325,7 @@ impl ProcessInfo {
     pub fn command(&self) -> String {
         if let Some(path) = &self.curr_path {
             if !path.cmd.is_empty() {
-                path.cmd.join(" ").replace('\n', " ").replace('\t', " ")
+                path.cmd.join(" ").replace(['\n', '\t'], " ")
             } else {
                 String::new()
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 3 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.63.0"
+channel = "1.65.0"


### PR DESCRIPTION
# Description

This fixes the compilation problems with `aarch64-apple-darwin` on rust 1.64 as well as the `zstd` problems. We recently found out that `zstd` pinned to 1.65.



# User-Facing Changes

N/A

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
