### PR TITLE
Add did-you-mean suggestions for operators

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -72,6 +72,14 @@ pub enum ParseError {
     )]
     UnexpectedKeyword(String, #[label("unexpected {0}")] Span),
 
+    #[error("Unknown operator")]
+    #[diagnostic(code(nu::parser::unknown_operator), url(docsrs), help("{1}"))]
+    UnknownOperator(
+        &'static str,
+        &'static str,
+        #[label("Operator '{0}' not supported")] Span,
+    ),
+
     #[error("Statement used in pipeline.")]
     #[diagnostic(
         code(nu::parser::unexpected_keyword),
@@ -413,6 +421,7 @@ impl ParseError {
             ParseError::FileNotFound(_, s) => *s,
             ParseError::ReadingFile(_, s) => *s,
             ParseError::LabeledError(_, _, s) => *s,
+            ParseError::UnknownOperator(_, _, s) => *s,
         }
     }
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4543,6 +4543,16 @@ pub fn parse_operator(
                 )),
             );
         }
+        b"%" => {
+            return (
+                garbage(span),
+                Some(ParseError::UnknownOperator(
+                    "%",
+                    "Did you mean 'mod'?",
+                    span,
+                )),
+            );
+        }
         _ => {
             return (
                 garbage(span),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4504,6 +4504,45 @@ pub fn parse_operator(
         b"||" | b"or" => Operator::Boolean(Boolean::Or),
         b"xor" => Operator::Boolean(Boolean::Xor),
         b"**" => Operator::Math(Math::Pow),
+        // WARNING: not actual operators below! Error handling only
+        pow @ (b"^" | b"pow") => {
+            return (
+                garbage(span),
+                Some(ParseError::UnknownOperator(
+                    match pow {
+                        b"^" => "^",
+                        b"pow" => "pow",
+                        _ => unreachable!(),
+                    },
+                    "Use '**' for exponentiation",
+                    span,
+                )),
+            );
+        }
+        equality @ (b"is" | b"===") => {
+            return (
+                garbage(span),
+                Some(ParseError::UnknownOperator(
+                    match equality {
+                        b"is" => "is",
+                        b"===" => "===",
+                        _ => unreachable!(),
+                    },
+                    "Did you mean '=='?",
+                    span,
+                )),
+            );
+        }
+        b"contains" => {
+            return (
+                garbage(span),
+                Some(ParseError::UnknownOperator(
+                    "contains",
+                    "Did you mean '$string =~ $pattern' or '$element in $container'?",
+                    span,
+                )),
+            );
+        }
         _ => {
             return (
                 garbage(span),


### PR DESCRIPTION
# Description

Adds a `ParseError::UnkownOperator` and covers `^`,`pow`,`is`,`===`,`%`, and `contains` as likely operators based on other languages. Provides suggestion for the user to find the nu language feature they are looking for.  

![image](https://user-images.githubusercontent.com/15833959/204108373-d1165988-ad87-4a2e-bd81-b67a44072571.png)


# Tests + Formatting

(-)
