### PR TITLE
Suggest using float on `Value::Int` overflow

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -34,8 +34,8 @@ pub enum ShellError {
     /// Check the inputs to the operation and add guards for their sizes.
     /// Integers are generally of size i64, floats are generally f64.
     #[error("Operator overflow.")]
-    #[diagnostic(code(nu::shell::operator_overflow), url(docsrs))]
-    OperatorOverflow(String, #[label = "{0}"] Span),
+    #[diagnostic(code(nu::shell::operator_overflow), url(docsrs), help("{2}"))]
+    OperatorOverflow(String, #[label = "{0}"] Span, String),
 
     /// The pipelined input into a command was not of the expected type. For example, it might
     /// expect a string input, but received a table instead.

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1762,6 +1762,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "add operation overflowed".into(),
                         span,
+                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
                     ))
                 }
             }
@@ -1787,6 +1788,7 @@ impl Value {
                     _ => Err(ShellError::OperatorOverflow(
                         "addition operation overflowed".into(),
                         span,
+                        "".into(),
                     )),
                 }
             }
@@ -1797,6 +1799,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "add operation overflowed".into(),
                         span,
+                        "".into(),
                     ))
                 }
             }
@@ -1807,6 +1810,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "add operation overflowed".into(),
                         span,
+                        "".into(),
                     ))
                 }
             }
@@ -1862,6 +1866,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "subtraction operation overflowed".into(),
                         span,
+                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
                     ))
                 }
             }
@@ -1885,6 +1890,7 @@ impl Value {
                     None => Err(ShellError::OperatorOverflow(
                         "subtraction operation overflowed".into(),
                         span,
+                        "".into(),
                     )),
                 }
             }
@@ -1894,6 +1900,7 @@ impl Value {
                     _ => Err(ShellError::OperatorOverflow(
                         "subtraction operation overflowed".into(),
                         span,
+                        "".into(),
                     )),
                 }
             }
@@ -1904,6 +1911,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "subtraction operation overflowed".into(),
                         span,
+                        "".into(),
                     ))
                 }
             }
@@ -1914,6 +1922,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "add operation overflowed".into(),
                         span,
+                        "".into(),
                     ))
                 }
             }
@@ -1941,6 +1950,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "multiply operation overflowed".into(),
                         span,
+                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
                     ))
                 }
             }
@@ -2893,6 +2903,7 @@ impl Value {
                     Err(ShellError::OperatorOverflow(
                         "pow operation overflowed".into(),
                         span,
+                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
                     ))
                 }
             }


### PR DESCRIPTION
# Description

Suggest that floats support a larger range of values but warn about the
loss in precision.

![image](https://user-images.githubusercontent.com/15833959/204114339-c987cd47-f035-4c01-853f-e9a00441bf49.png)


(Doesn't apply to the types with associated units)

# Tests + Formatting

(-)
