### PR TITLE
Implement more math commands (e.g. trig, ln)

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -405,6 +405,9 @@ pub fn create_default_context() -> EngineState {
             MathStddev,
             MathSum,
             MathVariance,
+            MathSin,
+            MathCos,
+            MathTan,
             MathPi,
             MathEuler,
         };

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -408,6 +408,9 @@ pub fn create_default_context() -> EngineState {
             MathSin,
             MathCos,
             MathTan,
+            MathSinH,
+            MathCosH,
+            MathTanH,
             MathPi,
             MathEuler,
         };

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -411,6 +411,9 @@ pub fn create_default_context() -> EngineState {
             MathSinH,
             MathCosH,
             MathTanH,
+            MathArcSin,
+            MathArcCos,
+            MathArcTan,
             MathPi,
             MathEuler,
         };

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -405,6 +405,8 @@ pub fn create_default_context() -> EngineState {
             MathStddev,
             MathSum,
             MathVariance,
+            MathPi,
+            MathEuler,
         };
 
         // Network

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -414,6 +414,9 @@ pub fn create_default_context() -> EngineState {
             MathArcSin,
             MathArcCos,
             MathArcTan,
+            MathArcSinH,
+            MathArcCosH,
+            MathArcTanH,
             MathPi,
             MathEuler,
         };

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -419,6 +419,7 @@ pub fn create_default_context() -> EngineState {
             MathArcTanH,
             MathPi,
             MathEuler,
+            MathLn,
         };
 
         // Network

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -9,8 +9,8 @@ pub fn test_examples(cmd: impl Command + 'static) {
 #[cfg(test)]
 mod test_examples {
     use super::super::{
-        Ansi, Date, Echo, From, If, Into, LetEnv, Math, Path, Random, Split, SplitColumn, SplitRow,
-        Str, StrJoin, StrLength, StrReplace, Url, Wrap,
+        Ansi, Date, Echo, From, If, Into, LetEnv, Math, MathEuler, MathPi, MathRound, Path, Random,
+        Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace, Url, Wrap,
     };
     use crate::{Break, Mut, To};
     use itertools::Itertools;
@@ -82,6 +82,9 @@ mod test_examples {
             working_set.add_decl(Box::new(Echo));
             working_set.add_decl(Box::new(Break));
             working_set.add_decl(Box::new(Mut));
+            working_set.add_decl(Box::new(MathEuler));
+            working_set.add_decl(Box::new(MathPi));
+            working_set.add_decl(Box::new(MathRound));
             // Adding the command that is being tested to the working set
             working_set.add_decl(cmd);
 

--- a/crates/nu-command/src/math/arccos.rs
+++ b/crates/nu-command/src/math/arccos.rs
@@ -1,0 +1,105 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math arccos"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math arccos")
+            .switch("degrees", "Return degrees instead of radians", Some('d'))
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the arccosine of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "inverse"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let use_degrees = call.has_flag("degrees");
+        input.map(
+            move |value| operate(value, head, use_degrees),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Get the arccosine of 1",
+                example: "1 | math arccos",
+                result: Some(Value::test_float(0.0f64)),
+            },
+            Example {
+                description: "Get the arccosine of -1 in degrees",
+                example: "-1 | math arccos -d",
+                result: Some(Value::test_float(180.0)),
+            },
+        ]
+    }
+}
+
+fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            if (-1.0..=1.0).contains(&val) {
+                let val = val.acos();
+                let val = if use_degrees { val.to_degrees() } else { val };
+
+                Value::Float { val, span }
+            } else {
+                Value::Error {
+                    error: ShellError::UnsupportedInput(
+                        "'arccos' undefined for values outside the closed interval [-1, 1].".into(),
+                        span,
+                    ),
+                }
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/arccosh.rs
+++ b/crates/nu-command/src/math/arccosh.rs
@@ -1,0 +1,95 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math arccosh"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math arccosh")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the inverse of the hyperbolic cosine function."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "inverse", "hyperbolic"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get the arccosh of 1",
+            example: "1 | math arccosh",
+            result: Some(Value::test_float(0.0f64)),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            if (1.0..).contains(&val) {
+                let val = val.acosh();
+
+                Value::Float { val, span }
+            } else {
+                Value::Error {
+                    error: ShellError::UnsupportedInput(
+                        "'arccosh' undefined for values below 1.".into(),
+                        span,
+                    ),
+                }
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/arcsin.rs
+++ b/crates/nu-command/src/math/arcsin.rs
@@ -1,0 +1,106 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math arcsin"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math arcsin")
+            .switch("degrees", "Return degrees instead of radians", Some('d'))
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the arcsine of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "inverse"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let use_degrees = call.has_flag("degrees");
+        input.map(
+            move |value| operate(value, head, use_degrees),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        let pi = std::f64::consts::PI;
+        vec![
+            Example {
+                description: "Get the arcsine of 1",
+                example: "1 | math arcsin",
+                result: Some(Value::test_float(pi / 2.0)),
+            },
+            Example {
+                description: "Get the arcsine of 1 in degrees",
+                example: "1 | math arcsin -d",
+                result: Some(Value::test_float(90.0)),
+            },
+        ]
+    }
+}
+
+fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            if (-1.0..=1.0).contains(&val) {
+                let val = val.asin();
+                let val = if use_degrees { val.to_degrees() } else { val };
+
+                Value::Float { val, span }
+            } else {
+                Value::Error {
+                    error: ShellError::UnsupportedInput(
+                        "'arcsin' undefined for values outside the closed interval [-1, 1].".into(),
+                        span,
+                    ),
+                }
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/arcsinh.rs
+++ b/crates/nu-command/src/math/arcsinh.rs
@@ -1,0 +1,86 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math arcsinh"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math arcsinh")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the inverse of the hyperbolic sine function."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "inverse", "hyperbolic"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get the arcsinh of 0",
+            example: "0 | math arcsinh",
+            result: Some(Value::test_float(0.0f64)),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            let val = val.asinh();
+
+            Value::Float { val, span }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/arctan.rs
+++ b/crates/nu-command/src/math/arctan.rs
@@ -1,0 +1,97 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math arctan"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math arctan")
+            .switch("degrees", "Return degrees instead of radians", Some('d'))
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the arctangent of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "inverse"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let use_degrees = call.has_flag("degrees");
+        input.map(
+            move |value| operate(value, head, use_degrees),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        let pi = std::f64::consts::PI;
+        vec![
+            Example {
+                description: "Get the arctangent of 1",
+                example: "1 | math arctan",
+                result: Some(Value::test_float(pi / 4.0f64)),
+            },
+            Example {
+                description: "Get the arctangent of -1 in degrees",
+                example: "-1 | math arctan -d",
+                result: Some(Value::test_float(-45.0)),
+            },
+        ]
+    }
+}
+
+fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            let val = val.atan();
+            let val = if use_degrees { val.to_degrees() } else { val };
+
+            Value::Float { val, span }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/arctanh.rs
+++ b/crates/nu-command/src/math/arctanh.rs
@@ -1,0 +1,95 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math arctanh"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math arctanh")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the inverse of the hyperbolic tangent function."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "inverse", "hyperbolic"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get the arctanh of 1",
+            example: "1 | math arctanh",
+            result: Some(Value::test_float(f64::INFINITY)),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            if (-1.0..=1.0).contains(&val) {
+                let val = val.atanh();
+
+                Value::Float { val, span }
+            } else {
+                Value::Error {
+                    error: ShellError::UnsupportedInput(
+                        "'arctanh' undefined for values outside the open interval (-1, 1).".into(),
+                        span,
+                    ),
+                }
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/cos.rs
+++ b/crates/nu-command/src/math/cos.rs
@@ -1,0 +1,107 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math cos"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math cos")
+            .switch("degrees", "Use degrees instead of radians", Some('d'))
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the cosine of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let use_degrees = call.has_flag("degrees");
+        input.map(
+            move |value| operate(value, head, use_degrees),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Apply the cosine to pi",
+                example: "math pi | math cos",
+                result: Some(Value::test_float(-1f64)),
+            },
+            Example {
+                description: "Apply the cosine to a list of angles in degrees",
+                example: "[0 90 180 270 360] | math cos -d",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_float(1f64),
+                        Value::test_float(0f64),
+                        Value::test_float(-1f64),
+                        Value::test_float(0f64),
+                        Value::test_float(1f64),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            let val = if use_degrees { val.to_radians() } else { val };
+
+            Value::Float {
+                val: val.cos(),
+                span,
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/cosh.rs
+++ b/crates/nu-command/src/math/cosh.rs
@@ -1,0 +1,88 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math cosh"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math cosh")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the hyperbolic cosine of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "hyperbolic"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        let e = std::f64::consts::E;
+        vec![Example {
+            description: "Apply the hyperpolic cosine to 1",
+            example: "1 | math cosh",
+            result: Some(Value::test_float(((e * e) + 1.0) / (2.0 * e))),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            Value::Float {
+                val: val.cosh(),
+                span,
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/euler.rs
+++ b/crates/nu-command/src/math/euler.rs
@@ -1,0 +1,61 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math e"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math e")
+            .input_output_types(vec![(Type::Any, Type::Float)])
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the mathematical constant π."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["euler", "constant"]
+    }
+
+    #[allow(clippy::approx_constant)]
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            example: "math e | math round --precision 3",
+            description: "Get the first three decimal digits of e",
+            result: Some(Value::test_float(2.718)),
+        }]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Ok(Value::Float {
+            val: std::f64::consts::E,
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/ln.rs
+++ b/crates/nu-command/src/math/ln.rs
@@ -1,0 +1,95 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math ln"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math ln")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the natural logarithm. Base: (math e)"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["natural", "logarithm", "inverse", "euler"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get the natural logarithm of e",
+            example: "math e | math ln",
+            result: Some(Value::test_float(1.0f64)),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            if val > 0.0 {
+                let val = val.ln();
+
+                Value::Float { val, span }
+            } else {
+                Value::Error {
+                    error: ShellError::UnsupportedInput(
+                        "'ln' undefined for values outside the open interval (0, Inf).".into(),
+                        span,
+                    ),
+                }
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -12,6 +12,7 @@ mod cosh;
 mod euler;
 mod eval;
 mod floor;
+mod ln;
 pub mod math_;
 mod max;
 mod median;
@@ -64,3 +65,5 @@ pub use arctanh::SubCommand as MathArcTanH;
 
 pub use euler::SubCommand as MathEuler;
 pub use pi::SubCommand as MathPi;
+
+pub use ln::SubCommand as MathLn;

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -1,4 +1,7 @@
 mod abs;
+mod arccos;
+mod arcsin;
+mod arctan;
 mod avg;
 mod ceil;
 mod cos;
@@ -48,6 +51,10 @@ pub use sin::SubCommand as MathSin;
 pub use sinh::SubCommand as MathSinH;
 pub use tan::SubCommand as MathTan;
 pub use tanh::SubCommand as MathTanH;
+
+pub use arccos::SubCommand as MathArcCos;
+pub use arccosh::SubCommand as MathArcCosH;
+pub use arcsin::SubCommand as MathArcSin;
 
 pub use euler::SubCommand as MathEuler;
 pub use pi::SubCommand as MathPi;

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -1,7 +1,10 @@
 mod abs;
 mod arccos;
+mod arccosh;
 mod arcsin;
+mod arcsinh;
 mod arctan;
+mod arctanh;
 mod avg;
 mod ceil;
 mod cos;
@@ -55,6 +58,9 @@ pub use tanh::SubCommand as MathTanH;
 pub use arccos::SubCommand as MathArcCos;
 pub use arccosh::SubCommand as MathArcCosH;
 pub use arcsin::SubCommand as MathArcSin;
+pub use arcsinh::SubCommand as MathArcSinH;
+pub use arctan::SubCommand as MathArcTan;
+pub use arctanh::SubCommand as MathArcTanH;
 
 pub use euler::SubCommand as MathEuler;
 pub use pi::SubCommand as MathPi;

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -1,6 +1,7 @@
 mod abs;
 mod avg;
 mod ceil;
+mod euler;
 mod eval;
 mod floor;
 pub mod math_;
@@ -8,6 +9,7 @@ mod max;
 mod median;
 mod min;
 mod mode;
+mod pi;
 mod product;
 mod reducers;
 mod round;
@@ -33,3 +35,6 @@ pub use sqrt::SubCommand as MathSqrt;
 pub use stddev::SubCommand as MathStddev;
 pub use sum::SubCommand as MathSum;
 pub use variance::SubCommand as MathVariance;
+
+pub use euler::SubCommand as MathEuler;
+pub use pi::SubCommand as MathPi;

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -2,6 +2,7 @@ mod abs;
 mod avg;
 mod ceil;
 mod cos;
+mod cosh;
 mod euler;
 mod eval;
 mod floor;
@@ -15,10 +16,12 @@ mod product;
 mod reducers;
 mod round;
 mod sin;
+mod sinh;
 mod sqrt;
 mod stddev;
 mod sum;
 mod tan;
+mod tanh;
 mod utils;
 mod variance;
 
@@ -40,8 +43,11 @@ pub use sum::SubCommand as MathSum;
 pub use variance::SubCommand as MathVariance;
 
 pub use cos::SubCommand as MathCos;
+pub use cosh::SubCommand as MathCosH;
 pub use sin::SubCommand as MathSin;
+pub use sinh::SubCommand as MathSinH;
 pub use tan::SubCommand as MathTan;
+pub use tanh::SubCommand as MathTanH;
 
 pub use euler::SubCommand as MathEuler;
 pub use pi::SubCommand as MathPi;

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -1,6 +1,7 @@
 mod abs;
 mod avg;
 mod ceil;
+mod cos;
 mod euler;
 mod eval;
 mod floor;
@@ -13,9 +14,11 @@ mod pi;
 mod product;
 mod reducers;
 mod round;
+mod sin;
 mod sqrt;
 mod stddev;
 mod sum;
+mod tan;
 mod utils;
 mod variance;
 
@@ -35,6 +38,10 @@ pub use sqrt::SubCommand as MathSqrt;
 pub use stddev::SubCommand as MathStddev;
 pub use sum::SubCommand as MathSum;
 pub use variance::SubCommand as MathVariance;
+
+pub use cos::SubCommand as MathCos;
+pub use sin::SubCommand as MathSin;
+pub use tan::SubCommand as MathTan;
 
 pub use euler::SubCommand as MathEuler;
 pub use pi::SubCommand as MathPi;

--- a/crates/nu-command/src/math/pi.rs
+++ b/crates/nu-command/src/math/pi.rs
@@ -1,0 +1,61 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math pi"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math pi")
+            .input_output_types(vec![(Type::Any, Type::Float)])
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the mathematical constant π."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "constant"]
+    }
+
+    #[allow(clippy::approx_constant)]
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            example: "math pi | math round --precision 2",
+            description: "Get the first two decimal digits of π",
+            result: Some(Value::test_float(3.14)),
+        }]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        Ok(Value::Float {
+            val: std::f64::consts::PI,
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/sin.rs
+++ b/crates/nu-command/src/math/sin.rs
@@ -1,0 +1,107 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math sin"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math sin")
+            .switch("degrees", "Use degrees instead of radians", Some('d'))
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the sine of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let use_degrees = call.has_flag("degrees");
+        input.map(
+            move |value| operate(value, head, use_degrees),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Apply the sine to π/2",
+                example: "(math pi) / 2 | math sin",
+                result: Some(Value::test_float(1f64)),
+            },
+            Example {
+                description: "Apply the sine to a list of angles in degrees",
+                example: "[0 90 180 270 360] | math sin -d | math round --precision 4",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_float(0f64),
+                        Value::test_float(1f64),
+                        Value::test_float(0f64),
+                        Value::test_float(-1f64),
+                        Value::test_float(0f64),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            let val = if use_degrees { val.to_radians() } else { val };
+
+            Value::Float {
+                val: val.sin(),
+                span,
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/sinh.rs
+++ b/crates/nu-command/src/math/sinh.rs
@@ -1,0 +1,88 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math sinh"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math sinh")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the hyperbolic sine of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "hyperbolic"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        let e = std::f64::consts::E;
+        vec![Example {
+            description: "Apply the hyperpolic sine to 1",
+            example: "1 | math sinh",
+            result: Some(Value::test_float((e * e - 1.0) / (2.0 * e))),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            Value::Float {
+                val: val.sinh(),
+                span,
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/tan.rs
+++ b/crates/nu-command/src/math/tan.rs
@@ -1,0 +1,105 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math tan"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math tan")
+            .switch("degrees", "Use degrees instead of radians", Some('d'))
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the tangent of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        let use_degrees = call.has_flag("degrees");
+        input.map(
+            move |value| operate(value, head, use_degrees),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Apply the tangent to pi/4",
+                example: "(math pi) / 4 | math tan",
+                result: Some(Value::test_float(1f64)),
+            },
+            Example {
+                description: "Apply the tangent to a list of angles in degrees",
+                example: "[-45 0 45] | math tan -d",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_float(-1f64),
+                        Value::test_float(0f64),
+                        Value::test_float(1f64),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            let val = if use_degrees { val.to_radians() } else { val };
+
+            Value::Float {
+                val: val.tan(),
+                span,
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/tanh.rs
+++ b/crates/nu-command/src/math/tanh.rs
@@ -1,0 +1,87 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math tanh"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math tanh")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns the hyperbolic tangent of the number."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["trigonometry", "hyperbolic"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Apply the hyperpolic tangent to 10*pi",
+            example: "(math pi) * 10 | math tanh",
+            result: Some(Value::test_float(1f64)),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            Value::Float {
+                val: val.tanh(),
+                span,
+            }
+        }
+        other => Value::Error {
+            error: ShellError::UnsupportedInput(
+                format!(
+                    "Only numerical values are supported, input type: {:?}",
+                    other.get_type()
+                ),
+                other.span().unwrap_or(head),
+            ),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}


### PR DESCRIPTION
# Description

Work towards #7073	

- Add `math pi` and `math e` constants
- Add basic trigonometric functions
  - `math sin`
  - `math cos`
  - `math tan`
- Add basic hyperbolic functions
  - `math sinh`
  - `math cosh`
  - `math tanh`
- Add inverse for trigonometric functions  
    - `math arcsin`
    - `math arccos`
    - `math arctan`
- Add inverse hyperbolic functions    
    - `math arcsinh`
    - `math arccosh`
    - `math arctanh`
- Add natural logarithm
    - `math ln`  


# Tests + Formatting

- Examples for each new command
- Expand example test harness with `math pi`, `math e`, and `math round`
