### PR TITLE
Clean up .sh scripts with shellcheck

### DIFF
--- a/build-all-maclin.sh
+++ b/build-all-maclin.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
 echo "---------------------------------------------------------------"
 echo "Building nushell (nu) with dataframes and all the plugins"
@@ -17,7 +18,7 @@ echo "Building nushell"
 cargo build --features=dataframe
 for plugin in "${NU_PLUGINS[@]}"
 do
-    echo '' && cd crates/$plugin
+    echo '' && cd crates/"$plugin"
     echo "Building $plugin..."
     echo "-----------------------------"
     cargo build && cd ../..

--- a/install-all.sh
+++ b/install-all.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
-
-# Usage: Just run `sh install-all.sh` in nushell root directory
+#!/usr/bin/env bash
+# Usage: Just run `./install-all.sh` in nushell root directory
+set -euo pipefail
 
 echo "-----------------------------------------------------------------"
 echo "Installing nushell (nu) with dataframes and all the plugins"
@@ -25,5 +25,5 @@ do
     echo "----------------------------------------------"
     echo "Install plugin $plugin from local..."
     echo "----------------------------------------------"
-    cd crates/$plugin && cargo install --path . && cd ../../
+    cd crates/"$plugin" && cargo install --path . && cd ../../
 done

--- a/uninstall-all.sh
+++ b/uninstall-all.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 echo ''
 echo "----------------------------------------------"
@@ -15,5 +17,5 @@ NU_PLUGINS=(
 cargo uninstall nu
 for plugin in "${NU_PLUGINS[@]}"
 do
-    cargo uninstall $plugin
+    cargo uninstall "$plugin"
 done


### PR DESCRIPTION
Ran [`shellcheck`](https://github.com/koalaman/shellcheck) on our 3 shell scripts and fixed the warnings. This caught that the scripts were [broken because of their shebang](https://www.shellcheck.net/wiki/SC3030):

```
〉./uninstall-all.sh

----------------------------------------------
Uninstall nu and all plugins from cargo/bin...
----------------------------------------------
./uninstall-all.sh: 8: Syntax error: "(" unexpected
```

```
〉shellcheck *.sh

In build-all-maclin.sh line 8:
NU_PLUGINS=(
           ^-- SC3030 (warning): In POSIX sh, arrays are undefined.


In build-all-maclin.sh line 18:
for plugin in "${NU_PLUGINS[@]}"
               ^--------------^ SC3054 (warning): In POSIX sh, array references are undefined.


In build-all-maclin.sh line 20:
    echo '' && cd crates/$plugin
               ^---------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
                         ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    echo '' && cd crates/"$plugin" || exit


In install-all.sh line 14:
NU_PLUGINS=(
           ^-- SC3030 (warning): In POSIX sh, arrays are undefined.


In install-all.sh line 22:
for plugin in "${NU_PLUGINS[@]}"
               ^--------------^ SC3054 (warning): In POSIX sh, array references are undefined.


In install-all.sh line 28:
    cd crates/$plugin && cargo install --path . && cd ../../
              ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    cd crates/"$plugin" && cargo install --path . && cd ../../


In uninstall-all.sh line 8:
NU_PLUGINS=(
           ^-- SC3030 (warning): In POSIX sh, arrays are undefined.


In uninstall-all.sh line 16:
for plugin in "${NU_PLUGINS[@]}"
               ^--------------^ SC3054 (warning): In POSIX sh, array references are undefined.


In uninstall-all.sh line 18:
    cargo uninstall $plugin
                    ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    cargo uninstall "$plugin"

For more information:
  https://www.shellcheck.net/wiki/SC2164 -- Use 'cd ... || exit' or 'cd ... |...
  https://www.shellcheck.net/wiki/SC3030 -- In POSIX sh, arrays are undefined.
  https://www.shellcheck.net/wiki/SC3054 -- In POSIX sh, array references are...
  ```
 
To fix SC2164  I used `set -euo pipefail` as per this Julia Evans suggestion:
  
![image](https://user-images.githubusercontent.com/26268125/204181003-22283dcb-924d-4c0d-91f6-1ea635dbf0fc.png)
