### PR TITLE
add -f, --force for save command

### DIFF
--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -157,7 +157,7 @@ fn save_not_override_file_by_default() {
 
         let actual = nu!(
             cwd: dirs.root(),
-            r#""abcd" | save log.txt"#
+            r#""abcd" | save save_test_8/log.txt"#
         );
         assert!(actual.err.contains("Destination file already exists"));
     })
@@ -171,7 +171,7 @@ fn save_override_works() {
         let expected_file = dirs.test().join("log.txt");
         nu!(
             cwd: dirs.root(),
-            r#""abcd" | save log.txt -f"#
+            r#""abcd" | save save_test_9/log.txt -f"#
         );
         let actual = file_contents(expected_file);
         assert_eq!(actual, "abcd");

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -1,4 +1,4 @@
-use nu_test_support::fs::file_contents;
+use nu_test_support::fs::{file_contents, Stub};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use std::io::Write;
@@ -147,5 +147,33 @@ fn save_string_and_stream_as_raw() {
             actual,
             r#"<!DOCTYPE html><html><body><a href='http://example.org/'>Example</a></body></html>"#
         )
+    })
+}
+
+#[test]
+fn save_not_override_file_by_default() {
+    Playground::setup("save_test_8", |dirs, sandbox| {
+        sandbox.with_files(vec![Stub::EmptyFile("log.txt")]);
+
+        let actual = nu!(
+            cwd: dirs.root(),
+            r#""abcd" | save log.txt"#
+        );
+        assert!(actual.err.contains("Destination file already exists"));
+    })
+}
+
+#[test]
+fn save_override_works() {
+    Playground::setup("save_test_9", |dirs, sandbox| {
+        sandbox.with_files(vec![Stub::EmptyFile("log.txt")]);
+
+        let expected_file = dirs.test().join("log.txt");
+        nu!(
+            cwd: dirs.root(),
+            r#""abcd" | save log.txt -f"#
+        );
+        let actual = file_contents(expected_file);
+        assert_eq!(actual, "abcd");
     })
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -910,7 +910,15 @@ pub fn eval_element_with_input(
                                 Argument::Positional(expr.clone()),
                                 Argument::Named((
                                     Spanned {
-                                        item: "--raw".into(),
+                                        item: "raw".into(),
+                                        span: *span,
+                                    },
+                                    None,
+                                    None,
+                                )),
+                                Argument::Named((
+                                    Spanned {
+                                        item: "force".into(),
                                         span: *span,
                                     },
                                     None,


### PR DESCRIPTION
# Description

Closes: #6920 

# User-Facing Changes

```
❯ "asdf" | save dump.rdb
Error:
  × Destination file already exists
   ╭─[entry #21:1:1]
 1 │ "asdf" | save dump.rdb
   ·               ────┬───
   ·                   ╰── Destination file '/tmp/dump.rdb' already exists
   ╰────
  help: you can use -f, --force to force overwriting the destination
```
# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
