### PR TITLE
fix dfr datetime conversion

### DIFF
--- a/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
@@ -519,7 +519,7 @@ pub fn create_column(
                             TimeUnit::Microseconds => 1_000_000,
                             TimeUnit::Milliseconds => 1_000,
                         };
-                        // elapsed time in milliseconds since 1970-01-01
+                        // elapsed time in nano/micro/milliseconds since 1970-01-01
                         let seconds = a / unit_divisor;
                         let naive_datetime = match NaiveDateTime::from_timestamp_opt(seconds, 0) {
                             Some(val) => val,


### PR DESCRIPTION
# Description

Closes #7257

This fixes an issue where dataframes would always try to convert datetimes with milliseconds. Since the timeunit is passed in, I make use of it and try to choose the appropriate divisor.


# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
