### PR TITLE
update release-pkg.nu to include more recent less version

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -108,7 +108,7 @@ if $os in ['ubuntu-latest', 'macos-latest'] {
     let releaseStem = $'($bin)-($version)-($target)'
 
     $'(char nl)Download less related stuffs...'; hr-line
-    aria2c https://github.com/jftuga/less-Windows/releases/download/less-v590/less.exe -o less.exe
+    aria2c https://github.com/jftuga/less-Windows/releases/download/less-v608/less.exe -o less.exe
     aria2c https://raw.githubusercontent.com/jftuga/less-Windows/master/LICENSE -o LICENSE-for-less.txt
 
     # Create Windows msi release package


### PR DESCRIPTION
# Description

This PR upgrades the Windows less version from v590 to v608

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
