### PR TITLE
remove block input support in update, upsert

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -1,9 +1,9 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath, PathMember};
-use nu_protocol::engine::{Closure, Command, EngineState, Stack};
+use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, FromValue, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
-    ShellError, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
+    SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -16,7 +16,13 @@ impl Command for Update {
 
     fn signature(&self) -> Signature {
         Signature::build("update")
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
+                (Type::Record(vec![]), Type::Record(vec![])),
+            ])
             .required(
                 "field",
                 SyntaxShape::CellPath,
@@ -56,21 +62,12 @@ impl Command for Update {
                 }),
             },
             Example {
-                description: "Use in block form for more involved updating logic",
-                example: "[[count fruit]; [1 'apple']] | update count {|row index| ($row.fruit | str length) + $index }",
+                description: "Use a value at index 1",
+                example: "[1 2 3] | update 1 3",
                 result: Some(Value::List {
-                    vals: vec![Value::Record {
-                        cols: vec!["count".into(), "fruit".into()],
-                        vals: vec![Value::test_int(5), Value::test_string("apple")],
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::test_int(1), Value::test_int(3), Value::test_int(3)],
                     span: Span::test_data(),
                 }),
-            },
-            Example {
-                description: "Alter each value in the 'authors' column to use a single string instead of a list",
-                example: "[[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors {|row| $row.authors | str join ','}",
-                result: Some(Value::List { vals: vec![Value::Record { cols: vec!["project".into(), "authors".into()], vals: vec![Value::test_string("nu"), Value::test_string("Andrés,JT,Yehuda")], span: Span::test_data()}], span: Span::test_data()}),
             },
         ]
     }
@@ -82,110 +79,47 @@ fn update(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let span = call.head;
-
     let cell_path: CellPath = call.req(engine_state, stack, 0)?;
     let replacement: Value = call.req(engine_state, stack, 1)?;
-
-    let redirect_stdout = call.redirect_stdout;
-    let redirect_stderr = call.redirect_stderr;
 
     let engine_state = engine_state.clone();
     let ctrlc = engine_state.ctrlc.clone();
 
-    // Replace is a block, so set it up and run it instead of using it as the replacement
-    if replacement.as_block().is_ok() {
-        let capture_block: Closure = FromValue::from_value(&replacement)?;
-        let block = engine_state.get_block(capture_block.block_id).clone();
+    if let Some(PathMember::Int { val, span }) = cell_path.members.get(0) {
+        let mut input = input.into_iter();
+        let mut pre_elems = vec![];
 
-        let mut stack = stack.captures_to_stack(&capture_block.captures);
-        let orig_env_vars = stack.env_vars.clone();
-        let orig_env_hidden = stack.env_hidden.clone();
+        for idx in 0..*val {
+            if let Some(v) = input.next() {
+                pre_elems.push(v);
+            } else if idx == 0 {
+                return Err(ShellError::AccessEmptyContent(*span));
+            } else {
+                return Err(ShellError::AccessBeyondEnd(idx - 1, *span));
+            }
+        }
 
-        // enumerate() can't be used here because it converts records into tables
-        // when combined with into_pipeline_data(). Hence, the index is tracked manually like so.
-        let mut idx: i64 = 0;
-        input.map(
-            move |mut input| {
-                // with_env() is used here to ensure that each iteration uses
-                // a different set of environment variables.
-                // Hence, a 'cd' in the first loop won't affect the next loop.
-                stack.with_env(&orig_env_vars, &orig_env_hidden);
+        // Skip over the replaced value
+        let _ = input.next();
 
-                if let Some(var) = block.signature.get_positional(0) {
-                    if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, input.clone())
-                    }
-                }
-                // Optional index argument
-                if let Some(var) = block.signature.get_positional(1) {
-                    if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, Value::Int { val: idx, span });
-                    }
-                    idx += 1;
-                }
+        return Ok(pre_elems
+            .into_iter()
+            .chain(vec![replacement])
+            .chain(input)
+            .into_pipeline_data(ctrlc));
+    }
+    input.map(
+        move |mut input| {
+            let replacement = replacement.clone();
 
-                let output = eval_block(
-                    &engine_state,
-                    &mut stack,
-                    &block,
-                    input.clone().into_pipeline_data(),
-                    redirect_stdout,
-                    redirect_stderr,
-                );
-
-                match output {
-                    Ok(pd) => {
-                        if let Err(e) =
-                            input.update_data_at_cell_path(&cell_path.members, pd.into_value(span))
-                        {
-                            return Value::Error { error: e };
-                        }
-
-                        input
-                    }
-                    Err(e) => Value::Error { error: e },
-                }
-            },
-            ctrlc,
-        )
-    } else {
-        if let Some(PathMember::Int { val, span }) = cell_path.members.get(0) {
-            let mut input = input.into_iter();
-            let mut pre_elems = vec![];
-
-            for idx in 0..*val {
-                if let Some(v) = input.next() {
-                    pre_elems.push(v);
-                } else if idx == 0 {
-                    return Err(ShellError::AccessEmptyContent(*span));
-                } else {
-                    return Err(ShellError::AccessBeyondEnd(idx - 1, *span));
-                }
+            if let Err(e) = input.update_data_at_cell_path(&cell_path.members, replacement) {
+                return Value::Error { error: e };
             }
 
-            // Skip over the replaced value
-            let _ = input.next();
-
-            return Ok(pre_elems
-                .into_iter()
-                .chain(vec![replacement])
-                .chain(input)
-                .into_pipeline_data(ctrlc));
-        }
-        input.map(
-            move |mut input| {
-                let replacement = replacement.clone();
-
-                if let Err(e) = input.update_data_at_cell_path(&cell_path.members, replacement) {
-                    return Value::Error { error: e };
-                }
-
-                input
-            },
-            ctrlc,
-        )
-    }
+            input
+        },
+        ctrlc,
+    )
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -1,9 +1,9 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath, PathMember};
-use nu_protocol::engine::{Closure, Command, EngineState, Stack};
+use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, FromValue, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
-    ShellError, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
+    SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -16,7 +16,13 @@ impl Command for Upsert {
 
     fn signature(&self) -> Signature {
         Signature::build("upsert")
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
+                (Type::Record(vec![]), Type::Record(vec![])),
+            ])
             .required(
                 "field",
                 SyntaxShape::CellPath,
@@ -49,40 +55,51 @@ impl Command for Upsert {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Update a record's value",
-            example: "{'name': 'nu', 'stars': 5} | upsert name 'Nushell'",
-            result: Some(Value::Record { cols: vec!["name".into(), "stars".into()], vals: vec![Value::test_string("Nushell"), Value::test_int(5)], span: Span::test_data()}),
-        }, Example {
-            description: "Insert a new entry into a single record",
-            example: "{'name': 'nu', 'stars': 5} | upsert language 'Rust'",
-            result: Some(Value::Record { cols: vec!["name".into(), "stars".into(), "language".into()], vals: vec![Value::test_string("nu"), Value::test_int(5), Value::test_string("Rust")], span: Span::test_data()}),
-        }, Example {
-            description: "Use in closure form for more involved updating logic",
-            example: "[[count fruit]; [1 'apple']] | upsert count {|row index| ($row.fruit | str length) + $index }",
-            result: Some(Value::List { vals: vec![Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(5), Value::test_string("apple")], span: Span::test_data()}], span: Span::test_data()}),
-        },
-        Example {
-            description: "Upsert an int into a list, updating an existing value based on the index",
-            example: "[1 2 3] | upsert 0 2",
-            result: Some(Value::List {
-                vals: vec![Value::test_int(2), Value::test_int(2), Value::test_int(3)],
-                span: Span::test_data(),
-            }),
-        },
-        Example {
-            description: "Upsert an int into a list, inserting a new value based on the index",
-            example: "[1 2 3] | upsert 3 4",
-            result: Some(Value::List {
-                vals: vec![
-                    Value::test_int(1),
-                    Value::test_int(2),
-                    Value::test_int(3),
-                    Value::test_int(4),
-                ],
-                span: Span::test_data(),
-            }),
-        },
+        vec![
+            Example {
+                description: "Update a record's value",
+                example: "{'name': 'nu', 'stars': 5} | upsert name 'Nushell'",
+                result: Some(Value::Record {
+                    cols: vec!["name".into(), "stars".into()],
+                    vals: vec![Value::test_string("Nushell"), Value::test_int(5)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Insert a new entry into a single record",
+                example: "{'name': 'nu', 'stars': 5} | upsert language 'Rust'",
+                result: Some(Value::Record {
+                    cols: vec!["name".into(), "stars".into(), "language".into()],
+                    vals: vec![
+                        Value::test_string("nu"),
+                        Value::test_int(5),
+                        Value::test_string("Rust"),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description:
+                    "Upsert an int into a list, updating an existing value based on the index",
+                example: "[1 2 3] | upsert 0 2",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(2), Value::test_int(2), Value::test_int(3)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Upsert an int into a list, inserting a new value based on the index",
+                example: "[1 2 3] | upsert 3 4",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_int(1),
+                        Value::test_int(2),
+                        Value::test_int(3),
+                        Value::test_int(4),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }
@@ -93,109 +110,46 @@ fn upsert(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let span = call.head;
-
     let cell_path: CellPath = call.req(engine_state, stack, 0)?;
     let replacement: Value = call.req(engine_state, stack, 1)?;
-
-    let redirect_stdout = call.redirect_stdout;
-    let redirect_stderr = call.redirect_stderr;
 
     let engine_state = engine_state.clone();
     let ctrlc = engine_state.ctrlc.clone();
 
-    // Replace is a block, so set it up and run it instead of using it as the replacement
-    if replacement.as_block().is_ok() {
-        let capture_block: Closure = FromValue::from_value(&replacement)?;
-        let block = engine_state.get_block(capture_block.block_id).clone();
+    if let Some(PathMember::Int { val, span }) = cell_path.members.get(0) {
+        let mut input = input.into_iter();
+        let mut pre_elems = vec![];
 
-        let mut stack = stack.captures_to_stack(&capture_block.captures);
-        let orig_env_vars = stack.env_vars.clone();
-        let orig_env_hidden = stack.env_hidden.clone();
-
-        // enumerate() can't be used here because it converts records into tables
-        // when combined with into_pipeline_data(). Hence, the index is tracked manually like so.
-        let mut idx: i64 = 0;
-        input.map(
-            move |mut input| {
-                // with_env() is used here to ensure that each iteration uses
-                // a different set of environment variables.
-                // Hence, a 'cd' in the first loop won't affect the next loop.
-                stack.with_env(&orig_env_vars, &orig_env_hidden);
-
-                if let Some(var) = block.signature.get_positional(0) {
-                    if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, input.clone())
-                    }
-                }
-                // Optional index argument
-                if let Some(var) = block.signature.get_positional(1) {
-                    if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, Value::Int { val: idx, span });
-                    }
-                    idx += 1;
-                }
-
-                let output = eval_block(
-                    &engine_state,
-                    &mut stack,
-                    &block,
-                    input.clone().into_pipeline_data(),
-                    redirect_stdout,
-                    redirect_stderr,
-                );
-
-                match output {
-                    Ok(pd) => {
-                        if let Err(e) =
-                            input.upsert_data_at_cell_path(&cell_path.members, pd.into_value(span))
-                        {
-                            return Value::Error { error: e };
-                        }
-
-                        input
-                    }
-                    Err(e) => Value::Error { error: e },
-                }
-            },
-            ctrlc,
-        )
-    } else {
-        if let Some(PathMember::Int { val, span }) = cell_path.members.get(0) {
-            let mut input = input.into_iter();
-            let mut pre_elems = vec![];
-
-            for idx in 0..*val {
-                if let Some(v) = input.next() {
-                    pre_elems.push(v);
-                } else {
-                    return Err(ShellError::AccessBeyondEnd(idx - 1, *span));
-                }
+        for idx in 0..*val {
+            if let Some(v) = input.next() {
+                pre_elems.push(v);
+            } else {
+                return Err(ShellError::AccessBeyondEnd(idx - 1, *span));
             }
-
-            // Skip over the replaced value
-            let _ = input.next();
-
-            return Ok(pre_elems
-                .into_iter()
-                .chain(vec![replacement])
-                .chain(input)
-                .into_pipeline_data(ctrlc));
         }
 
-        input.map(
-            move |mut input| {
-                let replacement = replacement.clone();
+        // Skip over the replaced value
+        let _ = input.next();
 
-                if let Err(e) = input.upsert_data_at_cell_path(&cell_path.members, replacement) {
-                    return Value::Error { error: e };
-                }
-
-                input
-            },
-            ctrlc,
-        )
+        return Ok(pre_elems
+            .into_iter()
+            .chain(vec![replacement])
+            .chain(input)
+            .into_pipeline_data(ctrlc));
     }
+
+    input.map(
+        move |mut input| {
+            let replacement = replacement.clone();
+
+            if let Err(e) = input.upsert_data_at_cell_path(&cell_path.members, replacement) {
+                return Value::Error { error: e };
+            }
+
+            input
+        },
+        ctrlc,
+    )
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -30,7 +30,7 @@ fn sets_the_column_from_a_block_run_output() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             open cargo_sample.toml
-            | update dev-dependencies.pretty_assertions { open cargo_sample.toml | get dev-dependencies.pretty_assertions | inc --minor }
+            | update dev-dependencies.pretty_assertions ( open cargo_sample.toml | get dev-dependencies.pretty_assertions | inc --minor )
             | get dev-dependencies.pretty_assertions
         "#
     ));
@@ -44,7 +44,7 @@ fn sets_the_column_from_a_block_full_stream_output() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             wrap content
-            | update content { open --raw cargo_sample.toml | lines | first 5 }
+            | update content ( open --raw cargo_sample.toml | lines | first 5 )
             | get content.1
             | str contains "nu"
         "#
@@ -119,7 +119,7 @@ fn update_nonexistent_column() {
 fn uses_optional_index_argument() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | update a {|el ind| $ind + 1 + $el.a } | to nuon"#
+        r#"[[a]; [7] [6]] | each {|el ind| update a ($ind + 1 + $el.a) } | to nuon"#
     ));
 
     assert_eq!(actual.out, "[[a]; [8], [8]]");

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -30,7 +30,7 @@ fn sets_the_column_from_a_block_run_output() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             open cargo_sample.toml
-            | upsert dev-dependencies.pretty_assertions { open cargo_sample.toml | get dev-dependencies.pretty_assertions | inc --minor }
+            | upsert dev-dependencies.pretty_assertions ( open cargo_sample.toml | get dev-dependencies.pretty_assertions | inc --minor )
             | get dev-dependencies.pretty_assertions
         "#
     ));
@@ -44,7 +44,7 @@ fn sets_the_column_from_a_block_full_stream_output() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             wrap content
-            | upsert content { open --raw cargo_sample.toml | lines | first 5 }
+            | upsert content ( open --raw cargo_sample.toml | lines | first 5 )
             | get content.1
             | str contains "nu"
         "#
@@ -72,7 +72,7 @@ fn sets_the_column_from_a_subexpression() {
 fn uses_optional_index_argument_inserting() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | upsert b {|el ind| $ind + 1 + $el.a } | to nuon"#
+        r#"[[a]; [7] [6]] | each {|el ind| upsert b ($ind + 1 + $el.a)} | to nuon"#
     ));
 
     assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");
@@ -82,7 +82,7 @@ fn uses_optional_index_argument_inserting() {
 fn uses_optional_index_argument_updating() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | upsert a {|el ind| $ind + 1 + $el.a } | to nuon"#
+        r#"[[a]; [7] [6]] | each {|el ind| upsert a ($ind + 1 + $el.a)} | to nuon"#
     ));
 
     assert_eq!(actual.out, "[[a]; [8], [8]]");


### PR DESCRIPTION
# Description

Closes: #6936 

As suggestion in the issue, after removal, we can use `each` to achieve original behavior.

Previous:
```
[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}] | upsert c {|it| $it.a + 4}
```
After
```
[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}] | each {|it| $it | upsert c ($it.a + 4)}
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
