### PR TITLE
fix complete missing exit_code, when external commands' exit code stream is None

### DIFF
--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -94,13 +94,25 @@ impl Command for Complete {
                     vals.push(res)
                 };
 
-                if let Some(exit_code) = exit_code {
-                    let mut v: Vec<_> = exit_code.collect();
+                // exit_code can be None due to `do -i` command.
+                cols.push("exit_code".to_string());
+                match exit_code {
+                    Some(exit_code_stream) => {
+                        let mut v: Vec<_> = exit_code_stream.collect();
 
-                    if let Some(v) = v.pop() {
-                        cols.push("exit_code".to_string());
-                        vals.push(v);
+                        if let Some(v) = v.pop() {
+                            vals.push(v);
+                        } else {
+                            vals.push(Value::Int {
+                                val: 0,
+                                span: call.head,
+                            })
+                        }
                     }
+                    None => vals.push(Value::Int {
+                        val: 0,
+                        span: call.head,
+                    }),
                 }
 
                 Ok(Value::Record {

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -99,6 +99,15 @@ fn ignore_error_should_work_for_external_command() {
 }
 
 #[test]
+fn ignore_error_with_complete_should_have_exit_code() {
+    let actual = nu!(cwd: ".", pipeline(
+        r#"(do -i { nu --testbin fail asdf } | complete).exit_code"#
+    ));
+
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
 #[cfg(not(windows))]
 fn ignore_error_with_too_much_stderr_not_hang_nushell() {
     use nu_test_support::fs::Stub::FileWithContent;


### PR DESCRIPTION
# Description

Fixes: #7283

# User-Facing Changes
```
❯ (do -i { nu --testbin fail asdf } | complete)
╭───────────┬───╮
│ stdout    │   │
│ stderr    │   │
│ exit_code │ 0 │
╰───────────┴───╯
```
# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
