### PR TITLE
Update release script to nu v0.71 and use ubuntu-20.04 to build nu binary

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -16,6 +16,9 @@ let flags = $env.TARGET_RUSTFLAGS
 let dist = $'($env.GITHUB_WORKSPACE)/output'
 let version = (open Cargo.toml | get package.version)
 
+$'Debugging info:'
+print { version: $version, bin: $bin, os: $os, target: $target, src: $src, flags: $flags, dist: $dist }; hr-line
+
 # $env
 
 $'(char nl)Packaging ($bin) v($version) for ($target) in ($src)...'; hr-line -b

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -17,9 +17,11 @@ let dist = $'($env.GITHUB_WORKSPACE)/output'
 let version = (open Cargo.toml | get package.version)
 
 $'Debugging info:'
-print { version: $version, bin: $bin, os: $os, target: $target, src: $src, flags: $flags, dist: $dist }; hr-line
+print { version: $version, bin: $bin, os: $os, target: $target, src: $src, flags: $flags, dist: $dist }; hr-line -b
 
 # $env
+
+let USE_UBUNTU = 'ubuntu-20.04'
 
 $'(char nl)Packaging ($bin) v($version) for ($target) in ($src)...'; hr-line -b
 if not ('Cargo.lock' | path exists) { cargo generate-lockfile }
@@ -29,8 +31,8 @@ $'Start building ($bin)...'; hr-line
 # ----------------------------------------------------------------------------
 # Build for Ubuntu and macOS
 # ----------------------------------------------------------------------------
-if $os in ['ubuntu-22.04', 'macos-latest'] {
-    if $os == 'ubuntu-22.04' {
+if $os in [$USE_UBUNTU, 'macos-latest'] {
+    if $os == $USE_UBUNTU {
         sudo apt-get install libxcb-composite0-dev -y
     }
     if $target == 'aarch64-unknown-linux-gnu' {
@@ -44,7 +46,7 @@ if $os in ['ubuntu-22.04', 'macos-latest'] {
     } else {
         # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'
         # Actually just for x86_64-unknown-linux-musl target
-        if $os == 'ubuntu-22.04' { sudo apt install musl-tools -y }
+        if $os == $USE_UBUNTU { sudo apt install musl-tools -y }
         cargo-build-nu $flags
     }
 }
@@ -91,7 +93,7 @@ if ($ver | str trim | is-empty) {
 # Create a release archive and send it to output for the following steps
 # ----------------------------------------------------------------------------
 cd $dist; $'(char nl)Creating release archive...'; hr-line
-if $os in ['ubuntu-22.04', 'macos-latest'] {
+if $os in [$USE_UBUNTU, 'macos-latest'] {
 
     let files = (ls | get name)
     let dest = $'($bin)-($version)-($target)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,22 @@ jobs:
           os: windows-latest
           target_rustflags: ''
         - target: x86_64-unknown-linux-gnu
-          os: ubuntu-latest
+          os: ubuntu-22.04
           target_rustflags: ''
         - target: x86_64-unknown-linux-musl
-          os: ubuntu-latest
+          os: ubuntu-22.04
           target_rustflags: ''
         - target: aarch64-unknown-linux-gnu
-          os: ubuntu-latest
+          os: ubuntu-22.04
           target_rustflags: ''
         - target: armv7-unknown-linux-gnueabihf
-          os: ubuntu-latest
+          os: ubuntu-22.04
           target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v3.0.2
+    - uses: actions/checkout@v3.1.0
 
     - name: Install Rust Toolchain Components
       uses: actions-rs/toolchain@v1.0.6
@@ -70,9 +70,9 @@ jobs:
         target: ${{ matrix.target }}
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v2.1
+      uses: hustcer/setup-nu@v3
       with:
-        version: 0.69.1
+        version: 0.72.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,16 @@ jobs:
           os: windows-latest
           target_rustflags: ''
         - target: x86_64-unknown-linux-gnu
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           target_rustflags: ''
         - target: x86_64-unknown-linux-musl
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           target_rustflags: ''
         - target: aarch64-unknown-linux-gnu
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           target_rustflags: ''
         - target: armv7-unknown-linux-gnueabihf
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           target_rustflags: ''
 
     runs-on: ${{matrix.os}}
@@ -72,7 +72,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.72.0
+        version: 0.71.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Description

1. Update nu to v0.71 for release script
2. Remove the usage of `set-output` see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
3. Use `ubuntu-20.04` instead of `ubuntu-latest` to fix #7282 

To check the workflow running result see: https://github.com/hustcer/nu-release/actions/runs/3588720720/jobs/6040412953

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
