### PR TITLE
Fix failing test after #7051

### DIFF
--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -515,8 +515,8 @@ fn adding_tables() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            [[a b]; [1 2]] ++ [[4 5]; [10 11]] | to nuon
+            [[a b]; [1 2]] ++ [[c d]; [10 11]] | to nuon
         "#
     ));
-    assert_eq!(actual.out, "[{a: 1, b: 2}, {4: 10, 5: 11}]");
+    assert_eq!(actual.out, "[{a: 1, b: 2}, {c: 10, d: 11}]");
 }


### PR DESCRIPTION
Numerics as record names have to be quoted
Changed to string
