### PR TITLE
Remove inactive actions-rs/toolchain@v1.0.6 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,15 @@ jobs:
     - uses: actions/checkout@v3.1.0
 
     - name: Install Rust Toolchain Components
-      uses: actions-rs/toolchain@v1.0.6
+      uses: dtolnay/rust-toolchain@stable
       with:
-        override: true
-        profile: minimal
         toolchain: stable
         target: ${{ matrix.target }}
+
+    - name: Update Rust Toolchain Target
+      run: |
+        echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
+        cat rust-toolchain.toml
 
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3


### PR DESCRIPTION
# Description

Remove inactive actions-rs/toolchain@v1.0.6 for release workflow, https://github.com/actions-rs/toolchain is inactive for more than two years, and have lots of unfixed warnings: https://github.com/actions-rs/toolchain/issues?q=is%3Aissue+is%3Aopen+warning

After this PR:

Workflow running result: https://github.com/hustcer/nu-release/actions/runs/3590194180
Release Test: https://github.com/hustcer/nu-release/releases/tag/v0.72.7

