### PR TITLE
fix `cal` input_output_types signature

### DIFF
--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -49,6 +49,7 @@ impl Command for Cal {
                 None,
             )
             .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .category(Category::Generators)
     }
 

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -5,7 +5,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value,
+    SyntaxShape, Type, Value,
 };
 use std::collections::VecDeque;
 
@@ -48,6 +48,7 @@ impl Command for Cal {
                 "Display the month names instead of integers",
                 None,
             )
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .category(Category::Generators)
     }
 


### PR DESCRIPTION
# Description

This is one of many commands that needs the `input_output_types()` part of the signature filled in so that `$nu.scope.commands` shows the signature properly which leads to the documentation being updated properly.

TIL that when commands like `cal` don't have Example tests that can easily be expressed and require the use of `None` results that we need to use this as part of the signature.

```rust
.allow_variants_without_examples(true) // TODO: supply exhaustive examples
```

Related to https://github.com/nushell/nushell/issues/7287

# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
