### PR TITLE
Add a deprecation note for removed `build-string`

### DIFF
--- a/crates/nu-command/src/deprecated/deprecated_commands.rs
+++ b/crates/nu-command/src/deprecated/deprecated_commands.rs
@@ -14,5 +14,9 @@ pub fn deprecated_commands() -> HashMap<String, String> {
         ("all?".to_string(), "all".to_string()),
         ("any?".to_string(), "any".to_string()),
         ("empty?".to_string(), "is-empty".to_string()),
+        (
+            "build-string".to_string(),
+            "str join'/'string concatenation with '+'".to_string(),
+        ),
     ])
 }


### PR DESCRIPTION
# User-Facing Changes

Build string was removed for 0.72 by #7144

Adds a deprecation message
