### PR TITLE
Fix where -b flag

### DIFF
--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -9,8 +9,8 @@ pub fn test_examples(cmd: impl Command + 'static) {
 #[cfg(test)]
 mod test_examples {
     use super::super::{
-        Ansi, Date, Echo, From, If, Into, LetEnv, Math, MathEuler, MathPi, MathRound, Path, Random,
-        Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace, Url, Wrap,
+        Ansi, Date, Echo, From, If, Into, Let, LetEnv, Math, MathEuler, MathPi, MathRound, Path,
+        Random, Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace, Url, Wrap,
     };
     use crate::{Break, Mut, To};
     use itertools::Itertools;
@@ -60,6 +60,7 @@ mod test_examples {
             // Base functions that are needed for testing
             // Try to keep this working set small to keep tests running as fast as possible
             let mut working_set = StateWorkingSet::new(&*engine_state);
+            working_set.add_decl(Box::new(Let));
             working_set.add_decl(Box::new(Str));
             working_set.add_decl(Box::new(StrJoin));
             working_set.add_decl(Box::new(StrLength));

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -49,7 +49,7 @@ impl Command for Where {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        if let Ok(Some(capture_block)) = call.get_flag::<Closure>(engine_state, stack, "block") {
+        if let Ok(Some(capture_block)) = call.get_flag::<Closure>(engine_state, stack, "closure") {
             let metadata = input.metadata();
             let ctrlc = engine_state.ctrlc.clone();
             let engine_state = engine_state.clone();
@@ -298,6 +298,14 @@ impl Command for Where {
             Example {
                 description: "Filter items of a list according to a condition",
                 example: "[1 2] | where {|x| $x > 1}",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(2)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Filter items of a list according to a stored condition",
+                example: "let cond = {|x| $x > 1}; [1 2] | where -b $cond",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(2)],
                     span: Span::test_data(),


### PR DESCRIPTION
# Description

The `where -b` flag was broken. The following now works:
```
let cond = {|x| $x.name !~ 'foo'}; ls | where -b $cond
```

This is just a quick fix. Ultimately, the `where` command shouldn't need the flag and `where $cond` should work. The first step, however, is to move `where` away from shape-directed parsing and make it a parser keyword.

# User-Facing Changes

`where -b` is not broken

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
