### PR TITLE
Handle `ctrl-c` in `RawStream` iterator

### DIFF
--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -77,6 +77,12 @@ impl Iterator for RawStream {
     type Item = Result<Value, ShellError>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if let Some(ctrlc) = &self.ctrlc {
+            if ctrlc.load(Ordering::SeqCst) {
+                return None;
+            }
+        }
+
         // If we know we're already binary, just output that
         if self.is_binary {
             match self.stream.next() {


### PR DESCRIPTION
Fixes #7246 and #1898.

Darren noticed that `open /dev/random` could not be interrupted by `ctrl+c`. Thankfully the solution was very simple; it looks like we just forgot to check `ctrlc` in the `impl Iterator for RawStream`!

To reproduce this, just run `open /dev/random` and then cancel it with `ctrl+c`.