### PR TITLE
Rename `$env.config.explore_config` to `$env.config.explore` (for consistency with `$env.config.ls`, `$env.config.table` etc.)

### DIFF
--- a/crates/nu-command/src/viewers/explore.rs
+++ b/crates/nu-command/src/viewers/explore.rs
@@ -71,7 +71,7 @@ impl Command for Explore {
 
         let config = engine_state.get_config();
         let color_hm = get_color_config(config);
-        let style = theme_from_config(&config.explore_config);
+        let style = theme_from_config(&config.explore);
 
         let view_cfg = ViewConfig::new(config, &color_hm, &style);
 

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -87,7 +87,7 @@ pub struct Config {
     pub show_banner: bool,
     pub show_clickable_links_in_ls: bool,
     pub render_right_prompt_on_last_line: bool,
-    pub explore_config: HashMap<String, Value>,
+    pub explore: HashMap<String, Value>,
 }
 
 impl Default for Config {
@@ -126,7 +126,7 @@ impl Default for Config {
             show_banner: true,
             show_clickable_links_in_ls: true,
             render_right_prompt_on_last_line: false,
-            explore_config: HashMap::new(),
+            explore: HashMap::new(),
         }
     }
 }
@@ -528,7 +528,7 @@ impl Value {
                     }
                     "explore" => {
                         if let Ok(map) = create_map(value, &config) {
-                            config.explore_config = map;
+                            config.explore = map;
                         } else {
                             eprintln!("$env.config.{} is not a record", key)
                         }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -526,6 +526,13 @@ impl Value {
                             eprintln!("$env.config.{} is not a record", key)
                         }
                     }
+                    "explore" => {
+                        if let Ok(map) = create_map(value, &config) {
+                            config.explore_config = map;
+                        } else {
+                            eprintln!("$env.config.{} is not a record", key)
+                        }
+                    }
                     // Misc. options
                     "color_config" => {
                         if let Ok(map) = create_map(value, &config) {
@@ -811,13 +818,6 @@ impl Value {
                             config.filesize_format = v.to_lowercase();
                         } else {
                             eprintln!("$env.config.filesize_format is not a string")
-                        }
-                    }
-                    "explore_config" => {
-                        if let Ok(map) = create_map(value, &config) {
-                            config.explore_config = map;
-                        } else {
-                            eprintln!("$env.config.explore_config is not a map")
                         }
                     }
                     // End legacy options

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -262,6 +262,20 @@ let-env config = {
       truncating_suffix: "..." # A suffix used by the 'truncating' methodology
     }
   }
+  explore: {
+    highlight: { bg: 'yellow', fg: 'black' }
+    status_bar: { bg: '#C4C9C6', fg: '#1D1F21' }
+    command_bar: { fg: '#C4C9C6' }
+    split_line: '#404040'
+    cursor: true
+    # selected_column: 'blue'
+    # selected_row: { fg: 'yellow', bg: '#C1C2A3' }
+    # selected_cell: { fg: 'white', bg: '#777777' }
+    # line_shift: false,
+    # line_index: false,
+    # line_head_top: false,
+    # line_head_bottom: false,
+  }
   history: {
     max_size: 10000 # Session has to be reloaded for this to take effect
     sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
@@ -292,22 +306,6 @@ let-env config = {
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
   show_banner: true # true or false to enable or disable the banner
   render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
-
-  # A 'explore' utility config
-  explore_config: {
-    highlight: { bg: 'yellow', fg: 'black' }
-    status_bar: { bg: '#C4C9C6', fg: '#1D1F21' }
-    command_bar: { fg: '#C4C9C6' }
-    split_line: '#404040'
-    cursor: true
-    # selected_column: 'blue'
-    # selected_row: { fg: 'yellow', bg: '#C1C2A3' }
-    # selected_cell: { fg: 'white', bg: '#777777' }
-    # line_shift: false,
-    # line_index: false,
-    # line_head_top: false,
-    # line_head_bottom: false,
-  }
 
   hooks: {
     pre_prompt: [{


### PR DESCRIPTION
# Description

* `$env.config.explore_config` renamed to `$env.config.explore`. This follows the principle that config subrecords relating to single commands (as this relates to `explore`) should be exactly named after the command (see `ls`, `rm`, `table` etc.)
* In `into_config()`, moved the match arm relating to `$env.config.explore` out of the "legacy options" section (which is slated for removal in a later version).

# User-Facing Changes

`explore` is not in any public releases yet, so this has no end-user impact.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
