### PR TITLE
add `:q!` alias to explore command

### DIFF
--- a/crates/nu-explore/src/command.rs
+++ b/crates/nu-explore/src/command.rs
@@ -62,8 +62,8 @@ impl CommandList {
         ]
     }
 
-    pub fn create_aliases() -> [(&'static str, &'static str); 2] {
-        [("h", HelpCmd::NAME), ("q", QuitCmd::NAME)]
+    pub fn create_aliases() -> [(&'static str, &'static str); 3] {
+        [("h", HelpCmd::NAME), ("q", QuitCmd::NAME), ("q!", QuitCmd::NAME)]
     }
 
     pub fn new(table_cfg: TableConfig) -> Self {

--- a/crates/nu-explore/src/command.rs
+++ b/crates/nu-explore/src/command.rs
@@ -63,7 +63,11 @@ impl CommandList {
     }
 
     pub fn create_aliases() -> [(&'static str, &'static str); 3] {
-        [("h", HelpCmd::NAME), ("q", QuitCmd::NAME), ("q!", QuitCmd::NAME)]
+        [
+            ("h", HelpCmd::NAME),
+            ("q", QuitCmd::NAME),
+            ("q!", QuitCmd::NAME),
+        ]
     }
 
     pub fn new(table_cfg: TableConfig) -> Self {


### PR DESCRIPTION
# Description

This simply adds an alias to the explore quit command in order to quit out of explore. `:q` and `:q!` work now.

# User-Facing Changes

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
