### PR TITLE
Fix documentation for merge

### DIFF
--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -33,10 +33,10 @@ repeating this process with row 1, and so on."#
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .required(
-                "block",
+                "value",
                 // Both this and `update` should have a shape more like <record> | <table> than just <any>. -Leon 2022-10-27
                 SyntaxShape::Any,
-                "the new value to merge with, or a block that produces it",
+                "the new value to merge with",
             )
             .category(Category::Filters)
     }


### PR DESCRIPTION


# Description

`merge` no longer accepts blocks as arguments.

