### PR TITLE
fix `upsert` index of zero

### DIFF
--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -171,7 +171,7 @@ fn upsert(
                 } else if idx == 0 {
                     return Err(ShellError::AccessEmptyContent(*span));
                 } else {
-                    return Err(ShellError::AccessBeyondEnd(idx - 1, *span));
+                    return Err(ShellError::AccessBeyondEnd(idx, *span));
                 }
             }
 

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -168,8 +168,6 @@ fn upsert(
             for idx in 0..*val {
                 if let Some(v) = input.next() {
                     pre_elems.push(v);
-                } else if idx == 0 {
-                    return Err(ShellError::AccessEmptyContent(*span));
                 } else {
                     return Err(ShellError::AccessBeyondEnd(idx, *span));
                 }

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -168,6 +168,8 @@ fn upsert(
             for idx in 0..*val {
                 if let Some(v) = input.next() {
                     pre_elems.push(v);
+                } else if idx == 0 {
+                    return Err(ShellError::AccessEmptyContent(*span));
                 } else {
                     return Err(ShellError::AccessBeyondEnd(idx - 1, *span));
                 }

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -87,3 +87,23 @@ fn uses_optional_index_argument_updating() {
 
     assert_eq!(actual.out, "[[a]; [8], [8]]");
 }
+
+#[test]
+fn index_does_not_exist() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[1,2,3] | upsert 4 4"#
+    ));
+
+    assert!(actual.err.contains("index too large"));
+}
+
+#[test]
+fn upsert_empty() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[] | upsert 1 1"#
+    ));
+
+    assert!(actual.err.contains("index too large (empty content)"));
+}

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -105,5 +105,5 @@ fn upsert_empty() {
         r#"[] | upsert 1 1"#
     ));
 
-    assert!(actual.err.contains("index too large (empty content)"));
+    assert!(actual.err.contains("index too large (max: 0)"));
 }

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -95,7 +95,7 @@ fn index_does_not_exist() {
         r#"[1,2,3] | upsert 4 4"#
     ));
 
-    assert!(actual.err.contains("index too large"));
+    assert!(actual.err.contains("index too large (max: 3)"));
 }
 
 #[test]


### PR DESCRIPTION
# Description

Try to fix #7347, this pr does not fix the error message to `upserting beyond 1 + the list's length doesn't work,`, I feel this is still not explicit or general engouh, if we want to change, what would be the best message to be printed out ?

Add tests too

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
