### PR TITLE
kill: don't show signal example on windows

### DIFF
--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -193,6 +193,7 @@ impl Command for Kill {
                 example: "kill --force 12345",
                 result: None,
             },
+            #[cfg(not(target_os = "windows"))]
             Example {
                 description: "Send INT signal",
                 example: "kill -s 2 12345",


### PR DESCRIPTION
# Description

Windows doesn't support the --signal(-s) option, so don't show the example in help.

# User-Facing Changes

N/A

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
