### PR TITLE
fix `split list` when separater is the first element of list

### DIFF
--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -95,6 +95,24 @@ impl Command for SubCommand {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Split a list of chars into two lists",
+                example: "[a, b, c, d, e, f, g] | split list a",
+                result: Some(Value::List {
+                    vals: vec![Value::List {
+                        vals: vec![
+                            Value::test_string("b"),
+                            Value::test_string("c"),
+                            Value::test_string("d"),
+                            Value::test_string("e"),
+                            Value::test_string("f"),
+                            Value::test_string("g"),
+                        ],
+                        span: Span::test_data(),
+                    }],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }
@@ -110,12 +128,14 @@ fn split_list(
     let mut returned_list = Vec::new();
     let iter = input.into_interruptible_iter(engine_state.ctrlc.clone());
     for val in iter {
-        if val == separator && !temp_list.is_empty() {
-            returned_list.push(Value::List {
-                vals: temp_list.clone(),
-                span: call.head,
-            });
-            temp_list = Vec::new();
+        if val == separator {
+            if !temp_list.is_empty() {
+                returned_list.push(Value::List {
+                    vals: temp_list.clone(),
+                    span: call.head,
+                });
+                temp_list = Vec::new();
+            }
         } else {
             temp_list.push(val);
         }

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -97,19 +97,26 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Split a list of chars into two lists",
-                example: "[a, b, c, d, e, f, g] | split list a",
+                example: "[a, b, c, d, a, e, f, g] | split list a",
                 result: Some(Value::List {
-                    vals: vec![Value::List {
-                        vals: vec![
-                            Value::test_string("b"),
-                            Value::test_string("c"),
-                            Value::test_string("d"),
-                            Value::test_string("e"),
-                            Value::test_string("f"),
-                            Value::test_string("g"),
-                        ],
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![
+                        Value::List {
+                            vals: vec![
+                                Value::test_string("b"),
+                                Value::test_string("c"),
+                                Value::test_string("d"),
+                            ],
+                            span: Span::test_data(),
+                        },
+                        Value::List {
+                            vals: vec![
+                                Value::test_string("e"),
+                                Value::test_string("f"),
+                                Value::test_string("g"),
+                            ],
+                            span: Span::test_data(),
+                        },
+                    ],
                     span: Span::test_data(),
                 }),
             },


### PR DESCRIPTION
# Description

Fixes: #7278

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
