### PR TITLE
add input_output_types() to `ansi gradient`

### DIFF
--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -2,8 +2,9 @@ use nu_ansi_term::{build_all_gradient_text, gradient::TargetGround, Gradient, Rg
 use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call, ast::CellPath, engine::Command, engine::EngineState, engine::Stack, Category,
-    Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
+
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -43,6 +44,12 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "for a data structure input, add a gradient to strings at the given cell paths",
             )
+            .input_output_types(vec![
+                (Type::String, Type::String),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
+            .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .category(Category::Platform)
     }
 


### PR DESCRIPTION
# Description

Add the input_output_types() to the ansi gradient command in support of #7320

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
