### PR TITLE
fix semicolon doesn't work for some commands

### DIFF
--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -183,12 +183,12 @@ fn into_record(
             Value::Record { cols, vals, span }
         }
         Value::Record { cols, vals, span } => Value::Record { cols, vals, span },
-        other => Value::Error {
-            error: ShellError::UnsupportedInput(
+        other => {
+            return Err(ShellError::UnsupportedInput(
                 "'into record' does not support this input".into(),
                 other.span().unwrap_or(call.head),
-            ),
-        },
+            ))
+        }
     };
     Ok(res.into_pipeline_data())
 }

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -91,17 +91,12 @@ impl Command for Save {
         let mut file = match file {
             Ok(file) => file,
             Err(err) => {
-                return Ok(PipelineData::Value(
-                    Value::Error {
-                        error: ShellError::GenericError(
-                            "Permission denied".into(),
-                            err.to_string(),
-                            Some(arg_span),
-                            None,
-                            Vec::new(),
-                        ),
-                    },
+                return Err(ShellError::GenericError(
+                    "Permission denied".into(),
+                    err.to_string(),
+                    Some(arg_span),
                     None,
+                    Vec::new(),
                 ));
             }
         };
@@ -117,17 +112,12 @@ impl Command for Save {
                     match std::fs::File::create(stderr_path) {
                         Ok(file) => Some(file),
                         Err(err) => {
-                            return Ok(PipelineData::Value(
-                                Value::Error {
-                                    error: ShellError::GenericError(
-                                        "Permission denied".into(),
-                                        err.to_string(),
-                                        Some(stderr_span),
-                                        None,
-                                        Vec::new(),
-                                    ),
-                                },
+                            return Err(ShellError::GenericError(
+                                "Permission denied".into(),
+                                err.to_string(),
+                                Some(stderr_span),
                                 None,
+                                Vec::new(),
                             ))
                         }
                     }

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -135,17 +135,12 @@ impl Command for SubCommand {
                         Err(err) => {
                             let arg_span =
                                 call.get_named_arg("output").expect("arg should exist").span;
-                            return Ok(PipelineData::Value(
-                                Value::Error {
-                                    error: ShellError::GenericError(
-                                        "Permission denied".into(),
-                                        err.to_string(),
-                                        Some(arg_span),
-                                        None,
-                                        Vec::new(),
-                                    ),
-                                },
+                            return Err(ShellError::GenericError(
+                                "Permission denied".into(),
+                                err.to_string(),
+                                Some(arg_span),
                                 None,
+                                Vec::new(),
                             ));
                         }
                     };

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -146,16 +146,13 @@ fn registry_query(
                         }
                         .into_pipeline_data())
                     }
-                    Err(_) => Ok(Value::Error {
-                        error: ShellError::GenericError(
-                            "Unable to find registry key/value".to_string(),
-                            format!("Registry value: {} was not found", value.item),
-                            Some(value.span),
-                            None,
-                            Vec::new(),
-                        ),
-                    }
-                    .into_pipeline_data()),
+                    Err(_) => Err(ShellError::GenericError(
+                        "Unable to find registry key/value".to_string(),
+                        format!("Registry value: {} was not found", value.item),
+                        Some(value.span),
+                        None,
+                        Vec::new(),
+                    )),
                 }
             }
             None => Ok(Value::nothing(Span::test_data()).into_pipeline_data()),


### PR DESCRIPTION
# Description

Fix semicolon working for the following commands which runs to failed:

1. into record (example: `into record; echo 'aa'`)  -- the final aa shouldn't be printed
2. save ( example: `touch a;  chmod a-w a;  echo 'aa' | save a; echo asdf` )  -- the final asdf shouldn't be printed
3. fetch ( example: `touch a;  chmod a-w a; fetch https://www.google.com -o a; echo asdf` ) -- the final asdf shouldn't be printed
4. registry_query (I don't have window machine, sorry for that I can't demo for it)

I've reviewed most of built-in commands, and it seems that other commands works fine.

# User-Facing Changes

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
