### PR TITLE
Remove use of deprecated `actions-rs/cargo` GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,11 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
 
-      - name: Rustfmt
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
 
       - name: Clippy
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: clippy
-          args: --workspace --exclude nu_plugin_* -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+        run: cargo clippy --workspace --exclude nu_plugin_* -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
   nu-tests:
     env:
@@ -72,10 +66,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
 
       - name: Tests
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: test
-          args: --workspace --profile ci --exclude nu_plugin_* ${{ matrix.flags }}
+        run: cargo test --workspace --profile ci --exclude nu_plugin_* ${{ matrix.flags }}
 
   python-virtualenv:
     env:
@@ -99,10 +90,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
 
       - name: Install Nushell
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: install
-          args: --locked --path=. --profile ci --no-default-features
+        run: cargo install --locked --path=. --profile ci --no-default-features
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -141,13 +129,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
 
       - name: Clippy
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: clippy
-          args: --package nu_plugin_* ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
+        run: cargo clippy --package nu_plugin_* ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
 
       - name: Tests
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: test
-          args: --profile ci --package nu_plugin_*
+        run: cargo test --profile ci --package nu_plugin_*


### PR DESCRIPTION
Our CI actions have a lot of warnings like this:

>  nu-fmt-clippy (ubuntu-20.04, stable)
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-rs/cargo@v1.0.1

[It looks like `actions-rs/cargo` is abandoned](https://github.com/actions-rs/toolchain/issues/216). But the good news is we don't actually need it, we can just run `cargo` subcommands without a special action because we've already installed `cargo` with `actions-rust-lang/setup-rust-toolchain`.