### PR TITLE
tighter restrictions on `alias` and `def` names

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -51,7 +51,8 @@ fn alias_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number or a filesize"));
+        .contains("alias name can't be a number, a filesize, or contain a hashtag"));
+
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
@@ -60,7 +61,17 @@ fn alias_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number or a filesize"));
+        .contains("alias name can't be a number, a filesize, or contain a hashtag"));
+
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            alias "te#t" = echo "test"   
+        "#
+    ));
+    assert!(actual
+        .err
+        .contains("alias name can't be a number, a filesize, or contain a hashtag"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -51,7 +51,7 @@ fn alias_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number, a filesize, or contain a hashtag"));
+        .contains("alias name can't be a number, a filesize, or contain a hash"));
 
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
@@ -61,7 +61,7 @@ fn alias_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number, a filesize, or contain a hashtag"));
+        .contains("alias name can't be a number, a filesize, or contain a hash"));
 
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
@@ -71,7 +71,7 @@ fn alias_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number, a filesize, or contain a hashtag"));
+        .contains("alias name can't be a number, a filesize, or contain a hash"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -41,7 +41,7 @@ fn def_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("command name can't be a number, a filesize, or contain a hashtag"));
+        .contains("command name can't be a number, a filesize, or contain a hash"));
 
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
@@ -51,7 +51,7 @@ fn def_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("command name can't be a number, a filesize, or contain a hashtag"));
+        .contains("command name can't be a number, a filesize, or contain a hash"));
 
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
@@ -61,5 +61,5 @@ fn def_fails_with_invalid_name() {
     ));
     assert!(actual
         .err
-        .contains("command name can't be a number, a filesize, or contain a hashtag"));
+        .contains("command name can't be a number, a filesize, or contain a hash"));
 }

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -30,3 +30,36 @@ fn def_errors_with_multiple_short_flags() {
 
     assert!(actual.err.contains("expected one short flag"));
 }
+
+#[test]
+fn def_fails_with_invalid_name() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            def 1234 = echo "test"
+        "#
+    ));
+    assert!(actual
+        .err
+        .contains("command name can't be a number, a filesize, or contain a hashtag"));
+
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            def 5gib = echo "test"
+        "#
+    ));
+    assert!(actual
+        .err
+        .contains("command name can't be a number, a filesize, or contain a hashtag"));
+
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            def "te#t" = echo "test"
+        "#
+    ));
+    assert!(actual
+        .err
+        .contains("command name can't be a number, a filesize, or contain a hashtag"));
+}

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -172,12 +172,12 @@ pub enum ParseError {
 
     #[error("Alias name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
-    AliasNotValid(#[label = "alias name can't be a number, a filesize, or contain a hashtag"] Span),
+    AliasNotValid(#[label = "alias name can't be a number, a filesize, or contain a hash"] Span),
 
     #[error("Command name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
     CommandDefNotValid(
-        #[label = "command name can't be a number, a filesize, or contain a hashtag"] Span,
+        #[label = "command name can't be a number, a filesize, or contain a hash"] Span,
     ),
 
     #[error("Module not found.")]

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -172,7 +172,13 @@ pub enum ParseError {
 
     #[error("Alias name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
-    AliasNotValid(#[label = "alias name can't be a number or a filesize"] Span),
+    AliasNotValid(#[label = "alias name can't be a number, a filesize, or contain a hashtag"] Span),
+
+    #[error("Command name not supported.")]
+    #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
+    CommandDefNotValid(
+        #[label = "command name can't be a number, a filesize, or contain a hashtag"] Span,
+    ),
 
     #[error("Module not found.")]
     #[diagnostic(
@@ -410,6 +416,7 @@ impl ParseError {
             ParseError::VariableNotFound(s) => *s,
             ParseError::VariableNotValid(s) => *s,
             ParseError::AliasNotValid(s) => *s,
+            ParseError::CommandDefNotValid(s) => *s,
             ParseError::ModuleNotFound(s) => *s,
             ParseError::CyclicalModuleImport(_, s) => *s,
             ParseError::ModuleOrOverlayNotFound(s) => *s,


### PR DESCRIPTION
# Description

Prevent a situation where a `def` can't be run due to a poor choice of name. Related: #6335. Hashtags, numbers and filesizes are no longer allowed. `alias` check has been moved because previously `alias 123` would be caught but `alias "123"` would be permitted.

# User-Facing Changes

Some definitions can no longer be made, but because they couldn't be run previously anyway, it doesn't really matter.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
