### PR TITLE
fix external completions; add a caret when there is overlap

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -126,8 +126,11 @@ impl CommandCompletion {
                     append_whitespace: true,
                 });
 
+            let results_strings: Vec<String> =
+                results.clone().into_iter().map(|x| x.value).collect();
+
             for external in results_external {
-                if results.contains(&external) {
+                if results_strings.contains(&external.value) {
                     results.push(Suggestion {
                         value: format!("^{}", external.value),
                         description: None,


### PR DESCRIPTION
# Description

Fixes #5424. Checking the code, apparently this was always supposed to work; however, because it compared the `Suggestion`s directly, and internal commands had descriptions while external commands did not, it never did function properly.

# User-Facing Changes

Completing to external commands (with overlap) adds a caret so the external command is actually run.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
