### PR TITLE
Fix `math e` usage text

### DIFF
--- a/crates/nu-command/src/math/euler.rs
+++ b/crates/nu-command/src/math/euler.rs
@@ -17,7 +17,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the mathematical constant e (math exp 1)."
+        "Returns the mathematical constant e (exp(1)/'1 | math exp')."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/euler.rs
+++ b/crates/nu-command/src/math/euler.rs
@@ -17,7 +17,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the mathematical constant π."
+        "Returns the mathematical constant e (math exp 1)."
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
Closes #7401

# Tests + Formatting

Doesn't apply, doc fix
