### PR TITLE
ensure error in `else` is forwarded appropriately

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1402,4 +1402,17 @@ mod input_types {
             assert!(block.len() == 2, "testing: {}", input);
         }
     }
+
+    #[test]
+    fn else_errors_correctly() {
+        let mut engine_state = EngineState::new();
+        add_declations(&mut engine_state);
+
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let (_, err) = parse(&mut working_set, None, b"if false { 'a' } else { $foo }", true, &[]);
+        
+        let err = err.unwrap();
+
+        assert!(matches!(err, ParseError::VariableNotFound(_)));
+    }
 }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1409,8 +1409,14 @@ mod input_types {
         add_declations(&mut engine_state);
 
         let mut working_set = StateWorkingSet::new(&engine_state);
-        let (_, err) = parse(&mut working_set, None, b"if false { 'a' } else { $foo }", true, &[]);
-        
+        let (_, err) = parse(
+            &mut working_set,
+            None,
+            b"if false { 'a' } else { $foo }",
+            true,
+            &[],
+        );
+
         let err = err.unwrap();
 
         assert!(matches!(err, ParseError::VariableNotFound(_)));


### PR DESCRIPTION
# Description

Fixes #7407. 

```
/home/gabriel/CodingProjects/nushell〉if false { 'a' } else { $foo }    12/09/2022 08:14:48 PM
Error: nu::parser::variable_not_found (link)

  × Variable not found.
   ╭─[entry #1:1:1]
 1 │ if false { 'a' } else { $foo }
   ·                         ──┬─
   ·                           ╰── variable not found
   ╰────
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
