### PR TITLE
Reduced LOC by replacing several instances of `Value::Int {}`, `Value::Float{}`, `Value::Bool {}`, and `Value::String {}` with `Value::int()`, `Value::float()`, `Value::boolean()` and `Value::string()`

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -77,10 +77,7 @@ impl NuCompleter {
                     Value::List {
                         vals: spans
                             .iter()
-                            .map(|it| Value::String {
-                                val: it.to_string(),
-                                span: Span::unknown(),
-                            })
+                            .map(|it| Value::string(it, Span::unknown()))
                             .collect(),
                         span: Span::unknown(),
                     },

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -52,10 +52,7 @@ impl Completer for NuMenuCompleter {
 
         if let Some(position) = block.signature.get_positional(1) {
             if let Some(position_id) = &position.var_id {
-                let line_buffer = Value::Int {
-                    val: pos as i64,
-                    span: self.span,
-                };
+                let line_buffer = Value::int(pos as i64, self.span);
                 self.stack.add_var(*position_id, line_buffer);
             }
         }

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -42,10 +42,7 @@ impl Completer for NuMenuCompleter {
 
         if let Some(buffer) = block.signature.get_positional(0) {
             if let Some(buffer_id) = &buffer.var_id {
-                let line_buffer = Value::String {
-                    val: parsed.remainder.to_string(),
-                    span: self.span,
-                };
+                let line_buffer = Value::string(parsed.remainder, self.span);
                 self.stack.add_var(*buffer_id, line_buffer);
             }
         }

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -993,10 +993,7 @@ mod test {
     #[test]
     fn test_send_event() {
         let cols = vec!["send".to_string()];
-        let vals = vec![Value::String {
-            val: "Enter".to_string(),
-            span: Span::test_data(),
-        }];
+        let vals = vec![Value::string("Enter", Span::test_data())];
 
         let span = Span::test_data();
         let b = EventType::try_from_columns(&cols, &vals, &span).unwrap();
@@ -1016,10 +1013,7 @@ mod test {
     #[test]
     fn test_edit_event() {
         let cols = vec!["edit".to_string()];
-        let vals = vec![Value::String {
-            val: "Clear".to_string(),
-            span: Span::test_data(),
-        }];
+        let vals = vec![Value::string("Clear", Span::test_data())];
 
         let span = Span::test_data();
         let b = EventType::try_from_columns(&cols, &vals, &span).unwrap();
@@ -1043,14 +1037,8 @@ mod test {
     fn test_send_menu() {
         let cols = vec!["send".to_string(), "name".to_string()];
         let vals = vec![
-            Value::String {
-                val: "Menu".to_string(),
-                span: Span::test_data(),
-            },
-            Value::String {
-                val: "history_menu".to_string(),
-                span: Span::test_data(),
-            },
+            Value::string("Menu", Span::test_data()),
+            Value::string("history_menu", Span::test_data()),
         ];
 
         let span = Span::test_data();
@@ -1076,14 +1064,8 @@ mod test {
         // Menu event
         let cols = vec!["send".to_string(), "name".to_string()];
         let vals = vec![
-            Value::String {
-                val: "Menu".to_string(),
-                span: Span::test_data(),
-            },
-            Value::String {
-                val: "history_menu".to_string(),
-                span: Span::test_data(),
-            },
+            Value::string("Menu", Span::test_data()),
+            Value::string("history_menu", Span::test_data()),
         ];
 
         let menu_event = Value::Record {
@@ -1094,10 +1076,7 @@ mod test {
 
         // Enter event
         let cols = vec!["send".to_string()];
-        let vals = vec![Value::String {
-            val: "Enter".to_string(),
-            span: Span::test_data(),
-        }];
+        let vals = vec![Value::string("Enter", Span::test_data())];
 
         let enter_event = Value::Record {
             cols,
@@ -1138,14 +1117,8 @@ mod test {
         // Menu event
         let cols = vec!["send".to_string(), "name".to_string()];
         let vals = vec![
-            Value::String {
-                val: "Menu".to_string(),
-                span: Span::test_data(),
-            },
-            Value::String {
-                val: "history_menu".to_string(),
-                span: Span::test_data(),
-            },
+            Value::string("Menu", Span::test_data()),
+            Value::string("history_menu", Span::test_data()),
         ];
 
         let menu_event = Value::Record {
@@ -1156,10 +1129,7 @@ mod test {
 
         // Enter event
         let cols = vec!["send".to_string()];
-        let vals = vec![Value::String {
-            val: "Enter".to_string(),
-            span: Span::test_data(),
-        }];
+        let vals = vec![Value::string("Enter", Span::test_data())];
 
         let enter_event = Value::Record {
             cols,
@@ -1187,10 +1157,7 @@ mod test {
     #[test]
     fn test_error() {
         let cols = vec!["not_exist".to_string()];
-        let vals = vec![Value::String {
-            val: "Enter".to_string(),
-            span: Span::test_data(),
-        }];
+        let vals = vec![Value::string("Enter", Span::test_data())];
 
         let span = Span::test_data();
         let b = EventType::try_from_columns(&cols, &vals, &span);

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -80,13 +80,7 @@ pub fn evaluate_repl(
         },
     );
 
-    stack.add_env_var(
-        "LAST_EXIT_CODE".into(),
-        Value::Int {
-            val: 0,
-            span: Span::unknown(),
-        },
-    );
+    stack.add_env_var("LAST_EXIT_CODE".into(), Value::int(0, Span::unknown()));
 
     info!(
         "load config initially {}:{}:{}",

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -74,10 +74,7 @@ pub fn evaluate_repl(
     // seed env vars
     stack.add_env_var(
         "CMD_DURATION_MS".into(),
-        Value::String {
-            val: "0823".to_string(),
-            span: Span::unknown(),
-        },
+        Value::string("0823", Span::unknown()),
     );
 
     stack.add_env_var("LAST_EXIT_CODE".into(), Value::int(0, Span::unknown()));

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -289,10 +289,7 @@ pub fn eval_source(
 fn set_last_exit_code(stack: &mut Stack, exit_code: i64) {
     stack.add_env_var(
         "LAST_EXIT_CODE".to_string(),
-        Value::Int {
-            val: exit_code,
-            span: Span::unknown(),
-        },
+        Value::int(exit_code, Span::unknown()),
     );
 }
 

--- a/crates/nu-command/src/bits/and.rs
+++ b/crates/nu-command/src/bits/and.rs
@@ -54,10 +54,7 @@ impl Command for SubCommand {
             Example {
                 description: "Apply bits and to two numbers",
                 example: "2 | bits and 2",
-                result: Some(Value::Int {
-                    val: 2,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(2, Span::test_data())),
             },
             Example {
                 description: "Apply logical and to a list of numbers",

--- a/crates/nu-command/src/bits/or.rs
+++ b/crates/nu-command/src/bits/or.rs
@@ -54,10 +54,7 @@ impl Command for SubCommand {
             Example {
                 description: "Apply bits or to two numbers",
                 example: "2 | bits or 6",
-                result: Some(Value::Int {
-                    val: 6,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(6, Span::test_data())),
             },
             Example {
                 description: "Apply logical or to a list of numbers",

--- a/crates/nu-command/src/bits/rotate_left.rs
+++ b/crates/nu-command/src/bits/rotate_left.rs
@@ -76,10 +76,7 @@ impl Command for SubCommand {
             Example {
                 description: "Rotate left a number with 2 bits",
                 example: "17 | bits rol 2",
-                result: Some(Value::Int {
-                    val: 68,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(68, Span::test_data())),
             },
             Example {
                 description: "Rotate left a list of numbers with 2 bits",

--- a/crates/nu-command/src/bits/rotate_right.rs
+++ b/crates/nu-command/src/bits/rotate_right.rs
@@ -76,10 +76,7 @@ impl Command for SubCommand {
             Example {
                 description: "Rotate right a number with 60 bits",
                 example: "17 | bits ror 60",
-                result: Some(Value::Int {
-                    val: 272,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(272, Span::test_data())),
             },
             Example {
                 description: "Rotate right a list of numbers of one byte",

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -76,26 +76,17 @@ impl Command for SubCommand {
             Example {
                 description: "Shift left a number by 7 bits",
                 example: "2 | bits shl 7",
-                result: Some(Value::Int {
-                    val: 256,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(256, Span::test_data())),
             },
             Example {
                 description: "Shift left a number with 1 byte by 7 bits",
                 example: "2 | bits shl 7 -n 1",
-                result: Some(Value::Int {
-                    val: 0,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(0, Span::test_data())),
             },
             Example {
                 description: "Shift left a signed number by 1 bit",
                 example: "0x7F | bits shl 1 -s",
-                result: Some(Value::Int {
-                    val: 254,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(254, Span::test_data())),
             },
             Example {
                 description: "Shift left a list of numbers",

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -76,10 +76,7 @@ impl Command for SubCommand {
             Example {
                 description: "Shift right a number with 2 bits",
                 example: "8 | bits shr 2",
-                result: Some(Value::Int {
-                    val: 2,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(2, Span::test_data())),
             },
             Example {
                 description: "Shift right a list of numbers",

--- a/crates/nu-command/src/bits/xor.rs
+++ b/crates/nu-command/src/bits/xor.rs
@@ -54,10 +54,7 @@ impl Command for SubCommand {
             Example {
                 description: "Apply bits xor to two numbers",
                 example: "2 | bits xor 2",
-                result: Some(Value::Int {
-                    val: 0,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(0, Span::test_data())),
             },
             Example {
                 description: "Apply logical xor to a list of numbers",

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -68,26 +68,17 @@ impl Command for BytesEndsWith {
             Example {
                 description: "Checks if binary ends with `0x[AA]`",
                 example: "0x[1F FF AA AA] | bytes ends-with 0x[AA]",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Checks if binary ends with `0x[FF AA AA]`",
                 example: "0x[1F FF AA AA] | bytes ends-with 0x[FF AA AA]",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Checks if binary ends with `0x[11]`",
                 example: "0x[1F FF AA AA] | bytes ends-with 0x[11]",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
         ]
     }
@@ -98,10 +89,7 @@ fn ends_with(val: &Value, args: &Arguments, span: Span) -> Value {
         Value::Binary {
             val,
             span: val_span,
-        } => Value::Bool {
-            val: val.ends_with(&args.pattern),
-            span: *val_span,
-        },
+        } => Value::boolean(val.ends_with(&args.pattern), *val_span),
         other => Value::Error {
             error: ShellError::UnsupportedInput(
                 format!(

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -70,10 +70,7 @@ fn length(val: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         Value::Binary {
             val,
             span: val_span,
-        } => Value::Int {
-            val: val.len() as i64,
-            span: *val_span,
-        },
+        } => Value::int(val.len() as i64, *val_span),
         other => Value::Error {
             error: ShellError::UnsupportedInput(
                 format!(

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -74,26 +74,17 @@ impl Command for BytesStartsWith {
             Example {
                 description: "Checks if binary starts with `0x[1F FF AA]`",
                 example: "0x[1F FF AA AA] | bytes starts-with 0x[1F FF AA]",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Checks if binary starts with `0x[1F]`",
                 example: "0x[1F FF AA AA] | bytes starts-with 0x[1F]",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Checks if binary starts with `0x[1F]`",
                 example: "0x[1F FF AA AA] | bytes starts-with 0x[11]",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
         ]
     }
@@ -104,10 +95,7 @@ fn starts_with(val: &Value, args: &Arguments, span: Span) -> Value {
         Value::Binary {
             val,
             span: val_span,
-        } => Value::Bool {
-            val: val.starts_with(&args.pattern),
-            span: *val_span,
-        },
+        } => Value::boolean(val.starts_with(&args.pattern), *val_span),
         other => Value::Error {
             error: ShellError::UnsupportedInput(
                 format!(

--- a/crates/nu-command/src/conversions/fmt.rs
+++ b/crates/nu-command/src/conversions/fmt.rs
@@ -44,38 +44,14 @@ impl Command for Fmt {
                     "upperhex".into(),
                 ],
                 vals: vec![
-                    Value::String {
-                        val: "0b101010".to_string(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "42".to_string(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "42".to_string(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "4.2e1".to_string(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "0x2a".to_string(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "0o52".to_string(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "4.2E1".to_string(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "0x2A".to_string(),
-                        span: Span::test_data(),
-                    },
+                    Value::string("0b101010", Span::test_data()),
+                    Value::string("42", Span::test_data()),
+                    Value::string("42", Span::test_data()),
+                    Value::string("4.2e1", Span::test_data()),
+                    Value::string("0x2a", Span::test_data()),
+                    Value::string("0o52", Span::test_data()),
+                    Value::string("4.2E1", Span::test_data()),
+                    Value::string("0x2A", Span::test_data()),
                 ],
                 span: Span::test_data(),
             }),

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -86,7 +86,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
             let other = s.trim();
 
             match other.parse::<f64>() {
-                Ok(x) => Value::Float { val: x, span: head },
+                Ok(x) => Value::float(x, head),
                 Err(reason) => Value::Error {
                     error: ShellError::CantConvert(
                         "float".to_string(),
@@ -97,10 +97,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
                 },
             }
         }
-        Value::Int { val: v, span } => Value::Float {
-            val: *v as f64,
-            span: *span,
-        },
+        Value::Int { val: v, span } => Value::float(*v as f64, *span),
         Value::Bool { val: b, span } => Value::Float {
             val: match b {
                 true => 1.0,

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -113,10 +113,7 @@ impl Command for SubCommand {
             Example {
                 description: "Convert file size to integer",
                 example: "4KB | into int",
-                result: Some(Value::Int {
-                    val: 4000,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(4000, Span::test_data())),
             },
             Example {
                 description: "Convert bool to integer",
@@ -233,20 +230,14 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                 }
                 val.resize(8, 0);
 
-                Value::Int {
-                    val: LittleEndian::read_i64(&val),
-                    span: *span,
-                }
+                Value::int(LittleEndian::read_i64(&val), *span)
             } else {
                 while val.len() < 8 {
                     val.insert(0, 0);
                 }
                 val.resize(8, 0);
 
-                Value::Int {
-                    val: BigEndian::read_i64(&val),
-                    span: *span,
-                }
+                Value::int(BigEndian::read_i64(&val), *span)
             }
         }
         _ => Value::Error {
@@ -269,13 +260,13 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
             // octal
             {
                 match int_from_string(val, head) {
-                    Ok(x) => return Value::Int { val: x, span: head },
+                    Ok(x) => return Value::int(x, head),
                     Err(e) => return Value::Error { error: e },
                 }
             } else if val.starts_with("00") {
                 // It's a padded string
                 match i64::from_str_radix(val, radix) {
-                    Ok(n) => return Value::Int { val: n, span: head },
+                    Ok(n) => return Value::int(n, head),
                     Err(e) => {
                         return Value::Error {
                             error: ShellError::CantConvert(
@@ -300,7 +291,7 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
         }
     };
     match i64::from_str_radix(i.trim(), radix) {
-        Ok(n) => Value::Int { val: n, span: head },
+        Ok(n) => Value::int(n, head),
         Err(_reason) => Value::Error {
             error: ShellError::CantConvert("string".to_string(), "int".to_string(), head, None),
         },

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -79,34 +79,22 @@ impl Command for SubCommand {
             Example {
                 description: "convert integer to string and append three decimal places",
                 example: "5 | into string -d 3",
-                result: Some(Value::String {
-                    val: "5.000".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("5.000", Span::test_data())),
             },
             Example {
                 description: "convert decimal to string and round to nearest integer",
                 example: "1.7 | into string -d 0",
-                result: Some(Value::String {
-                    val: "2".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("2", Span::test_data())),
             },
             Example {
                 description: "convert decimal to string",
                 example: "1.7 | into string -d 1",
-                result: Some(Value::String {
-                    val: "1.7".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("1.7", Span::test_data())),
             },
             Example {
                 description: "convert decimal to string and limit to 2 decimals",
                 example: "1.734 | into string -d 2",
-                result: Some(Value::String {
-                    val: "1.73".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("1.73", Span::test_data())),
             },
             Example {
                 description: "try to convert decimal to string and provide negative decimal points",
@@ -123,26 +111,17 @@ impl Command for SubCommand {
             Example {
                 description: "convert decimal to string",
                 example: "4.3 | into string",
-                result: Some(Value::String {
-                    val: "4.3".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("4.3", Span::test_data())),
             },
             Example {
                 description: "convert string to string",
                 example: "'1234' | into string",
-                result: Some(Value::String {
-                    val: "1234".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("1234", Span::test_data())),
             },
             Example {
                 description: "convert boolean to string",
                 example: "true | into string",
-                result: Some(Value::String {
-                    val: "true".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("true", Span::test_data())),
             },
             // TODO: This should work but does not; see https://github.com/nushell/nushell/issues/7032
             // Example {

--- a/crates/nu-command/src/core_commands/def_env.rs
+++ b/crates/nu-command/src/core_commands/def_env.rs
@@ -72,10 +72,7 @@ def-env cd_with_fallback [arg = ""] {
         vec![Example {
             description: "Set environment variable by call a custom command",
             example: r#"def-env foo [] { let-env BAR = "BAZ" }; foo; $env.BAR"#,
-            result: Some(Value::String {
-                val: "BAZ".to_string(),
-                span: Span::test_data(),
-            }),
+            result: Some(Value::string("BAZ", Span::test_data())),
         }]
     }
 }

--- a/crates/nu-command/src/core_commands/echo.rs
+++ b/crates/nu-command/src/core_commands/echo.rs
@@ -51,13 +51,7 @@ little reason to use this over just writing the values as-is."#
                 std::cmp::Ordering::Equal => PipelineData::Value(to_be_echoed[0].clone(), None),
 
                 //  When there are no elements, we echo the empty string
-                std::cmp::Ordering::Less => PipelineData::Value(
-                    Value::String {
-                        val: "".to_string(),
-                        span: call.head,
-                    },
-                    None,
-                ),
+                std::cmp::Ordering::Less => PipelineData::Value(Value::string("", call.head), None),
             }
         })
     }

--- a/crates/nu-command/src/core_commands/export.rs
+++ b/crates/nu-command/src/core_commands/export.rs
@@ -56,10 +56,7 @@ impl Command for ExportCommand {
         vec![Example {
             description: "Export a definition from a module",
             example: r#"module utils { export def my-command [] { "hello" } }; use utils my-command; my-command"#,
-            result: Some(Value::String {
-                val: "hello".to_string(),
-                span: Span::test_data(),
-            }),
+            result: Some(Value::string("hello", Span::test_data())),
         }]
     }
 

--- a/crates/nu-command/src/core_commands/export_def.rs
+++ b/crates/nu-command/src/core_commands/export_def.rs
@@ -46,10 +46,7 @@ impl Command for ExportDef {
         vec![Example {
             description: "Define a custom command in a module and call it",
             example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
-            result: Some(Value::String {
-                val: "foo".to_string(),
-                span: Span::test_data(),
-            }),
+            result: Some(Value::string("foo", Span::test_data())),
         }]
     }
 

--- a/crates/nu-command/src/core_commands/export_def_env.rs
+++ b/crates/nu-command/src/core_commands/export_def_env.rs
@@ -72,10 +72,7 @@ export def-env cd_with_fallback [arg = ""] {
         vec![Example {
             description: "Define a custom command that participates in the environment in a module and call it",
             example: r#"module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
-            result: Some(Value::String {
-                val: "BAZ".to_string(),
-                span: Span::test_data(),
-            }),
+            result: Some(Value::string("BAZ", Span::test_data())),
         }]
     }
 

--- a/crates/nu-command/src/core_commands/export_use.rs
+++ b/crates/nu-command/src/core_commands/export_use.rs
@@ -48,10 +48,7 @@ impl Command for ExportUse {
     use eggs foo
     foo
             "#,
-            result: Some(Value::String {
-                val: "foo".to_string(),
-                span: Span::test_data(),
-            }),
+            result: Some(Value::string("foo", Span::test_data())),
         }]
     }
 

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -91,13 +91,7 @@ impl Command for For {
                         if numbered {
                             Value::Record {
                                 cols: vec!["index".into(), "item".into()],
-                                vals: vec![
-                                    Value::Int {
-                                        val: idx as i64,
-                                        span: head,
-                                    },
-                                    x,
-                                ],
+                                vals: vec![Value::int(idx as i64, head), x],
                                 span: head,
                             }
                         } else {
@@ -136,13 +130,7 @@ impl Command for For {
                         if numbered {
                             Value::Record {
                                 cols: vec!["index".into(), "item".into()],
-                                vals: vec![
-                                    Value::Int {
-                                        val: idx as i64,
-                                        span: head,
-                                    },
-                                    x,
-                                ],
+                                vals: vec![Value::int(idx as i64, head), x],
                                 span: head,
                             }
                         } else {

--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -131,10 +131,7 @@ fn help(
                 });
 
                 cols.push("category".into());
-                vals.push(Value::String {
-                    val: sig.category.to_string(),
-                    span: head,
-                });
+                vals.push(Value::string(sig.category.to_string(), head));
 
                 cols.push("command_type".into());
                 vals.push(Value::String {
@@ -231,10 +228,7 @@ fn help(
                 });
 
                 cols.push("category".into());
-                vals.push(Value::String {
-                    val: sig.category.to_string(),
-                    span: head,
-                });
+                vals.push(Value::string(sig.category.to_string(), head));
 
                 cols.push("command_type".into());
                 vals.push(Value::String {
@@ -334,11 +328,7 @@ Get the processes on your system actively using CPU:
 
 You can also learn more at https://www.nushell.sh/book/"#;
 
-        Ok(Value::String {
-            val: msg.into(),
-            span: head,
-        }
-        .into_pipeline_data())
+        Ok(Value::string(msg, head).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/core_commands/loop_.rs
+++ b/crates/nu-command/src/core_commands/loop_.rs
@@ -80,10 +80,7 @@ impl Command for Loop {
         vec![Example {
             description: "Loop while a condition is true",
             example: "mut x = 0; loop { if $x > 10 { break }; $x = $x + 1 }; $x",
-            result: Some(Value::Int {
-                val: 11,
-                span: Span::test_data(),
-            }),
+            result: Some(Value::int(11, Span::test_data())),
         }]
     }
 }

--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -81,19 +81,13 @@ impl Command for Metadata {
                             data_source: DataSource::Ls,
                         } => {
                             cols.push("source".into());
-                            vals.push(Value::String {
-                                val: "ls".into(),
-                                span: head,
-                            })
+                            vals.push(Value::string("ls", head))
                         }
                         PipelineMetadata {
                             data_source: DataSource::HtmlThemes,
                         } => {
                             cols.push("source".into());
-                            vals.push(Value::String {
-                                val: "into html --list".into(),
-                                span: head,
-                            })
+                            vals.push(Value::string("into html --list", head))
                         }
                     }
                 }
@@ -152,19 +146,13 @@ fn build_metadata_record(arg: &Value, metadata: &Option<PipelineMetadata>, head:
                 data_source: DataSource::Ls,
             } => {
                 cols.push("source".into());
-                vals.push(Value::String {
-                    val: "ls".into(),
-                    span: head,
-                })
+                vals.push(Value::string("ls", head))
             }
             PipelineMetadata {
                 data_source: DataSource::HtmlThemes,
             } => {
                 cols.push("source".into());
-                vals.push(Value::String {
-                    val: "into html --list".into(),
-                    span: head,
-                })
+                vals.push(Value::string("into html --list", head))
             }
         }
     }

--- a/crates/nu-command/src/core_commands/module.rs
+++ b/crates/nu-command/src/core_commands/module.rs
@@ -46,26 +46,17 @@ impl Command for Module {
             Example {
                 description: "Define a custom command in a module and call it",
                 example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
-                result: Some(Value::String {
-                    val: "foo".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("foo", Span::test_data())),
             },
             Example {
                 description: "Define an environment variable in a module",
                 example: r#"module foo { export-env { let-env FOO = "BAZ" } }; use foo; $env.FOO"#,
-                result: Some(Value::String {
-                    val: "BAZ".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("BAZ", Span::test_data())),
             },
             Example {
                 description: "Define a custom command that participates in the environment in a module and call it",
                 example: r#"module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
-                result: Some(Value::String {
-                    val: "BAZ".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("BAZ", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/core_commands/overlay/list.rs
+++ b/crates/nu-command/src/core_commands/overlay/list.rs
@@ -50,10 +50,7 @@ impl Command for OverlayList {
             example: r#"module spam { export def foo [] { "foo" } }
     overlay use spam
     overlay list | last"#,
-            result: Some(Value::String {
-                val: "spam".to_string(),
-                span: Span::test_data(),
-            }),
+            result: Some(Value::string("spam", Span::test_data())),
         }]
     }
 }

--- a/crates/nu-command/src/core_commands/overlay/use_.rs
+++ b/crates/nu-command/src/core_commands/overlay/use_.rs
@@ -135,10 +135,7 @@ impl Command for OverlayUse {
                     let mut parent = path.clone();
                     parent.pop();
 
-                    let file_pwd = Value::String {
-                        val: parent.to_string_lossy().to_string(),
-                        span: call.head,
-                    };
+                    let file_pwd = Value::string(parent.to_string_lossy(), call.head);
 
                     caller_stack.add_env_var("FILE_PWD".to_string(), file_pwd);
                 }

--- a/crates/nu-command/src/core_commands/use_.rs
+++ b/crates/nu-command/src/core_commands/use_.rs
@@ -79,10 +79,7 @@ impl Command for Use {
 
                 // If so, set the currently evaluated directory (file-relative PWD)
                 if let Some(parent) = maybe_parent {
-                    let file_pwd = Value::String {
-                        val: parent.to_string_lossy().to_string(),
-                        span: call.head,
-                    };
+                    let file_pwd = Value::string(parent.to_string_lossy(), call.head);
                     callee_stack.add_env_var("FILE_PWD".to_string(), file_pwd);
                 }
 
@@ -120,18 +117,12 @@ impl Command for Use {
             Example {
                 description: "Define a custom command in a module and call it",
                 example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
-                result: Some(Value::String {
-                    val: "foo".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("foo", Span::test_data())),
             },
             Example {
                 description: "Define a custom command that participates in the environment in a module and call it",
                 example: r#"module foo { export def-env bar [] { let-env FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
-                result: Some(Value::String {
-                    val: "BAZ".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("BAZ", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/core_commands/version.rs
+++ b/crates/nu-command/src/core_commands/version.rs
@@ -54,97 +54,64 @@ pub fn version(
     let mut vals = vec![];
 
     cols.push("version".to_string());
-    vals.push(Value::String {
-        val: env!("CARGO_PKG_VERSION").to_string(),
-        span: tag,
-    });
+    vals.push(Value::string(env!("CARGO_PKG_VERSION"), tag));
 
     cols.push("branch".to_string());
-    vals.push(Value::String {
-        val: shadow::BRANCH.to_string(),
-        span: call.head,
-    });
+    vals.push(Value::string(shadow::BRANCH, call.head));
 
     let commit_hash: Option<&str> = option_env!("NU_COMMIT_HASH");
     if let Some(commit_hash) = commit_hash {
         cols.push("commit_hash".to_string());
-        vals.push(Value::String {
-            val: commit_hash.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(commit_hash, call.head));
     }
 
     let build_os: Option<&str> = Some(shadow::BUILD_OS).filter(|x| !x.is_empty());
     if let Some(build_os) = build_os {
         cols.push("build_os".to_string());
-        vals.push(Value::String {
-            val: build_os.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(build_os, call.head));
     }
 
     let build_target: Option<&str> = Some(shadow::BUILD_TARGET).filter(|x| !x.is_empty());
     if let Some(build_target) = build_target {
         cols.push("build_target".to_string());
-        vals.push(Value::String {
-            val: build_target.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(build_target, call.head));
     }
 
     let rust_version: Option<&str> = Some(shadow::RUST_VERSION).filter(|x| !x.is_empty());
     if let Some(rust_version) = rust_version {
         cols.push("rust_version".to_string());
-        vals.push(Value::String {
-            val: rust_version.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(rust_version, call.head));
     }
 
     let rust_channel: Option<&str> = Some(shadow::RUST_CHANNEL).filter(|x| !x.is_empty());
     if let Some(rust_channel) = rust_channel {
         cols.push("rust_channel".to_string());
-        vals.push(Value::String {
-            val: rust_channel.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(rust_channel, call.head));
     }
 
     let cargo_version: Option<&str> = Some(shadow::CARGO_VERSION).filter(|x| !x.is_empty());
     if let Some(cargo_version) = cargo_version {
         cols.push("cargo_version".to_string());
-        vals.push(Value::String {
-            val: cargo_version.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(cargo_version, call.head));
     }
 
     let pkg_version: Option<&str> = Some(shadow::PKG_VERSION).filter(|x| !x.is_empty());
     if let Some(pkg_version) = pkg_version {
         cols.push("pkg_version".to_string());
-        vals.push(Value::String {
-            val: pkg_version.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(pkg_version, call.head));
     }
 
     let build_time: Option<&str> = Some(shadow::BUILD_TIME).filter(|x| !x.is_empty());
     if let Some(build_time) = build_time {
         cols.push("build_time".to_string());
-        vals.push(Value::String {
-            val: build_time.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(build_time, call.head));
     }
 
     let build_rust_channel: Option<&str> =
         Some(shadow::BUILD_RUST_CHANNEL).filter(|x| !x.is_empty());
     if let Some(build_rust_channel) = build_rust_channel {
         cols.push("build_rust_channel".to_string());
-        vals.push(Value::String {
-            val: build_rust_channel.to_string(),
-            span: call.head,
-        });
+        vals.push(Value::string(build_rust_channel, call.head));
     }
 
     cols.push("features".to_string());

--- a/crates/nu-command/src/dataframe/eager/columns.rs
+++ b/crates/nu-command/src/dataframe/eager/columns.rs
@@ -30,14 +30,8 @@ impl Command for ColumnsDF {
             example: "[[a b]; [1 2] [3 4]] | into df | columns",
             result: Some(Value::List {
                 vals: vec![
-                    Value::String {
-                        val: "a".into(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "b".into(),
-                        span: Span::test_data(),
-                    },
+                    Value::string("a", Span::test_data()),
+                    Value::string("b", Span::test_data()),
                 ],
                 span: Span::test_data(),
             }),
@@ -67,10 +61,7 @@ fn command(
         .as_ref()
         .get_column_names()
         .iter()
-        .map(|v| Value::String {
-            val: v.to_string(),
-            span: call.head,
-        })
+        .map(|v| Value::string(*v, call.head))
         .collect();
 
     let names = Value::List {

--- a/crates/nu-command/src/dataframe/eager/dtypes.rs
+++ b/crates/nu-command/src/dataframe/eager/dtypes.rs
@@ -82,10 +82,7 @@ fn command(
                 span: call.head,
             });
 
-            Value::String {
-                val: v.to_string(),
-                span: call.head,
-            }
+            Value::string(*v, call.head)
         })
         .collect();
 

--- a/crates/nu-command/src/dataframe/eager/list.rs
+++ b/crates/nu-command/src/dataframe/eager/list.rs
@@ -61,15 +61,9 @@ impl Command for ListDF {
                     span: call.head,
                 };
 
-                let columns = Value::Int {
-                    val: df.as_ref().width() as i64,
-                    span: call.head,
-                };
+                let columns = Value::int(df.as_ref().width() as i64, call.head);
 
-                let rows = Value::Int {
-                    val: df.as_ref().height() as i64,
-                    span: call.head,
-                };
+                let rows = Value::int(df.as_ref().height() as i64, call.head);
 
                 let cols = vec![
                     "name".to_string(),

--- a/crates/nu-command/src/dataframe/eager/shape.rs
+++ b/crates/nu-command/src/dataframe/eager/shape.rs
@@ -61,15 +61,9 @@ fn command(
 ) -> Result<PipelineData, ShellError> {
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
-    let rows = Value::Int {
-        val: df.as_ref().height() as i64,
-        span: call.head,
-    };
+    let rows = Value::int(df.as_ref().height() as i64, call.head);
 
-    let cols = Value::Int {
-        val: df.as_ref().width() as i64,
-        span: call.head,
-    };
+    let cols = Value::int(df.as_ref().width() as i64, call.head);
 
     let rows_col = Column::new("rows".to_string(), vec![rows]);
     let cols_col = Column::new("columns".to_string(), vec![cols]);

--- a/crates/nu-command/src/dataframe/expressions/as_nu.rs
+++ b/crates/nu-command/src/dataframe/expressions/as_nu.rs
@@ -32,14 +32,8 @@ impl Command for ExprAsNu {
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![
-                    Value::String {
-                        val: "column".into(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "a".into(),
-                        span: Span::test_data(),
-                    },
+                    Value::string("column", Span::test_data()),
+                    Value::string("a", Span::test_data()),
                 ],
                 span: Span::test_data(),
             }),

--- a/crates/nu-command/src/dataframe/expressions/col.rs
+++ b/crates/nu-command/src/dataframe/expressions/col.rs
@@ -38,14 +38,8 @@ impl Command for ExprCol {
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![
-                    Value::String {
-                        val: "column".into(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "a".into(),
-                        span: Span::test_data(),
-                    },
+                    Value::string("column", Span::test_data()),
+                    Value::string("a", Span::test_data()),
                 ],
                 span: Span::test_data(),
             }),

--- a/crates/nu-command/src/dataframe/expressions/lit.rs
+++ b/crates/nu-command/src/dataframe/expressions/lit.rs
@@ -37,14 +37,8 @@ impl Command for ExprLit {
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![
-                    Value::String {
-                        val: "literal".into(),
-                        span: Span::test_data(),
-                    },
-                    Value::String {
-                        val: "2i64".into(),
-                        span: Span::test_data(),
-                    },
+                    Value::string("literal", Span::test_data()),
+                    Value::string("2i64", Span::test_data()),
                 ],
                 span: Span::test_data(),
             }),

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -86,10 +86,7 @@ fn command(
         )
     })?;
 
-    let value = Value::Bool {
-        val: !bool.any(),
-        span: call.head,
-    };
+    let value = Value::boolean(!bool.any(), call.head);
 
     NuDataFrame::try_from_columns(vec![Column::new("all_false".to_string(), vec![value])])
         .map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -86,10 +86,7 @@ fn command(
         )
     })?;
 
-    let value = Value::Bool {
-        val: bool.all(),
-        span: call.head,
-    };
+    let value = Value::boolean(bool.all(), call.head);
 
     NuDataFrame::try_from_columns(vec![Column::new("all_true".to_string(), vec![value])])
         .map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/series/n_null.rs
+++ b/crates/nu-command/src/dataframe/series/n_null.rs
@@ -61,10 +61,7 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let res = df.as_series(call.head)?.null_count();
-    let value = Value::Int {
-        val: res as i64,
-        span: call.head,
-    };
+    let value = Value::int(res as i64, call.head);
 
     NuDataFrame::try_from_columns(vec![Column::new("count_null".to_string(), vec![value])])
         .map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -67,10 +67,7 @@ fn command(
         )
     })?;
 
-    let value = Value::Int {
-        val: res as i64,
-        span: call.head,
-    };
+    let value = Value::int(res as i64, call.head);
 
     NuDataFrame::try_from_columns(vec![Column::new("count_unique".to_string(), vec![value])])
         .map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))

--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -110,10 +110,7 @@ impl Command for SubCommand {
             Example {
                 description: "Format a given date using a given format string.",
                 example: r#""2021-10-22 20:00:12 +01:00" | date format "%Y-%m-%d""#,
-                result: Some(Value::String {
-                    val: "2021-10-22".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("2021-10-22", Span::test_data())),
             },
         ]
     }
@@ -429,18 +426,9 @@ pub(crate) fn generate_strftime_list(head: Span, show_parse_only_formats: bool) 
         .map(|s| Value::Record {
             cols: column_names.clone(),
             vals: vec![
-                Value::String {
-                    val: s.spec.to_string(),
-                    span: head,
-                },
-                Value::String {
-                    val: now.format(s.spec).to_string(),
-                    span: head,
-                },
-                Value::String {
-                    val: s.description.to_string(),
-                    span: head,
-                },
+                Value::string(s.spec, head),
+                Value::string(now.format(s.spec).to_string(), head),
+                Value::string(s.description, head),
             ],
             span: head,
         })
@@ -459,19 +447,15 @@ pub(crate) fn generate_strftime_list(head: Span, show_parse_only_formats: bool) 
         records.push(Value::Record {
             cols: column_names,
             vals: vec![
-                Value::String {
-                    val: "%#z".to_string(),
-                    span: head,
-                },
+                Value::string("%#z", head),
                 Value::String {
                     val: example,
                     span: head,
                 },
-                Value::String {
-                    val: "Parsing only: Same as %z but allows minutes to be missing or present."
-                        .to_string(),
-                    span: head,
-                },
+                Value::string(
+                    "Parsing only: Same as %z but allows minutes to be missing or present.",
+                    head,
+                ),
             ],
             span: head,
         });

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -110,30 +110,12 @@ fn parse_date_into_table(date: Result<DateTime<FixedOffset>, Value>, head: Span)
     match date {
         Ok(x) => {
             let vals = vec![
-                Value::Int {
-                    val: x.year() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.month() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.day() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.hour() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.minute() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.second() as i64,
-                    span: head,
-                },
+                Value::int(x.year() as i64, head),
+                Value::int(x.month() as i64, head),
+                Value::int(x.day() as i64, head),
+                Value::int(x.hour() as i64, head),
+                Value::int(x.minute() as i64, head),
+                Value::int(x.second() as i64, head),
                 Value::String {
                     val: x.offset().to_string(),
                     span: head,

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -116,10 +116,7 @@ fn parse_date_into_table(date: Result<DateTime<FixedOffset>, Value>, head: Span)
                 Value::int(x.hour() as i64, head),
                 Value::int(x.minute() as i64, head),
                 Value::int(x.second() as i64, head),
-                Value::String {
-                    val: x.offset().to_string(),
-                    span: head,
-                },
+                Value::string(x.offset().to_string(), head),
             ];
             Value::Record {
                 cols,

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -113,30 +113,12 @@ fn parse_date_into_table(date: Result<DateTime<FixedOffset>, Value>, head: Span)
     match date {
         Ok(x) => {
             let vals = vec![
-                Value::Int {
-                    val: x.year() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.month() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.day() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.hour() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.minute() as i64,
-                    span: head,
-                },
-                Value::Int {
-                    val: x.second() as i64,
-                    span: head,
-                },
+                Value::int(x.year() as i64, head),
+                Value::int(x.month() as i64, head),
+                Value::int(x.day() as i64, head),
+                Value::int(x.hour() as i64, head),
+                Value::int(x.minute() as i64, head),
+                Value::int(x.second() as i64, head),
                 Value::String {
                     val: x.offset().to_string(),
                     span: head,

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -119,10 +119,7 @@ fn parse_date_into_table(date: Result<DateTime<FixedOffset>, Value>, head: Span)
                 Value::int(x.hour() as i64, head),
                 Value::int(x.minute() as i64, head),
                 Value::int(x.second() as i64, head),
-                Value::String {
-                    val: x.offset().to_string(),
-                    span: head,
-                },
+                Value::string(x.offset().to_string(), head),
             ];
             Value::List {
                 vals: vec![Value::Record {

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -46,13 +46,7 @@ impl Command for LoadEnv {
                         let cwd = current_dir(engine_state, stack)?;
                         let rhs = rhs.as_string()?;
                         let rhs = nu_path::expand_path_with(rhs, cwd);
-                        stack.add_env_var(
-                            env_var,
-                            Value::String {
-                                val: rhs.to_string_lossy().to_string(),
-                                span: call.head,
-                            },
-                        );
+                        stack.add_env_var(env_var, Value::string(rhs.to_string_lossy(), call.head));
                     } else {
                         stack.add_env_var(env_var, rhs);
                     }
@@ -72,10 +66,7 @@ impl Command for LoadEnv {
                             let rhs = nu_path::expand_path_with(rhs, cwd);
                             stack.add_env_var(
                                 env_var,
-                                Value::String {
-                                    val: rhs.to_string_lossy().to_string(),
-                                    span: call.head,
-                                },
+                                Value::string(rhs.to_string_lossy(), call.head),
                             );
                         } else {
                             stack.add_env_var(env_var, rhs);

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -53,10 +53,7 @@ impl Command for SourceEnv {
         };
         parent.pop();
 
-        let file_pwd = Value::String {
-            val: parent.to_string_lossy().to_string(),
-            span: call.head,
-        };
+        let file_pwd = Value::string(parent.to_string_lossy(), call.head);
 
         caller_stack.add_env_var("FILE_PWD".to_string(), file_pwd);
 

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -208,10 +208,7 @@ mod test_examples {
         // Set up PWD
         stack.add_env_var(
             "PWD".to_string(),
-            Value::String {
-                val: cwd.to_string_lossy().to_string(),
-                span: Span::test_data(),
-            },
+            Value::string(cwd.to_string_lossy(), Span::test_data()),
         );
 
         engine_state
@@ -296,10 +293,7 @@ mod test_examples {
 
         stack.add_env_var(
             "PWD".to_string(),
-            Value::String {
-                val: cwd.to_string_lossy().to_string(),
-                span: Span::test_data(),
-            },
+            Value::string(cwd.to_string_lossy(), Span::test_data()),
         );
 
         match nu_engine::eval_block(engine_state, &mut stack, &block, input, true, true) {

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -38,10 +38,7 @@ impl Command for IsAdmin {
             Example {
                 description: "Echo 'iamroot' if nushell is running with admin/root privileges, and 'iamnotroot' if not.",
                 example: r#"if is-admin { echo "iamroot" } else { echo "iamnotroot" }"#,
-                result: Some(Value::String {
-                    val: "iamnotroot".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("iamnotroot", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -30,11 +30,7 @@ impl Command for IsAdmin {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        Ok(Value::Bool {
-            val: is_root(),
-            span: call.head,
-        }
-        .into_pipeline_data())
+        Ok(Value::boolean(is_root(), call.head).into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -166,42 +166,27 @@ impl Command for ViewSource {
             Example {
                 description: "View the source of a code block",
                 example: r#"let abc = { echo 'hi' }; view-source $abc"#,
-                result: Some(Value::String {
-                    val: "{ echo 'hi' }".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("{ echo 'hi' }", Span::test_data())),
             },
             Example {
                 description: "View the source of a custom command",
                 example: r#"def hi [] { echo 'Hi!' }; view-source hi"#,
-                result: Some(Value::String {
-                    val: "{ echo 'Hi!' }".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("{ echo 'Hi!' }", Span::test_data())),
             },
             Example {
                 description: "View the source of a custom command, which participates in the caller environment",
                 example: r#"def-env foo [] { let-env BAR = 'BAZ' }; view-source foo"#,
-                result: Some(Value::String {
-                    val: "{ let-env BAR = 'BAZ' }".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("{ let-env BAR = 'BAZ' }", Span::test_data())),
             },
             Example {
                 description: "View the source of a module",
                 example: r#"module mod-foo { export-env { let-env FOO_ENV = 'BAZ' } }; view-source mod-foo"#,
-                result: Some(Value::String {
-                    val: " export-env { let-env FOO_ENV = 'BAZ' }".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string(" export-env { let-env FOO_ENV = 'BAZ' }", Span::test_data())),
             },
             Example {
                 description: "View the source of an alias",
                 example: r#"alias hello = echo hi; view-source hello"#,
-                result: Some(Value::String {
-                    val: "echo hi".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("echo hi", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -163,10 +163,7 @@ impl Command for Cd {
 
         let path_tointo = path.clone();
         let path_value = Value::String { val: path, span };
-        let cwd = Value::String {
-            val: cwd.to_string_lossy().to_string(),
-            span: call.head,
-        };
+        let cwd = Value::string(cwd.to_string_lossy(), call.head);
 
         let mut shells = get_shells(engine_state, stack, cwd);
         let current_shell = get_current_shell(engine_state, stack);

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -181,10 +181,7 @@ impl Command for Cd {
         );
         stack.add_env_var(
             "NUSHELL_CURRENT_SHELL".into(),
-            Value::Int {
-                val: current_shell as i64,
-                span: call.head,
-            },
+            Value::int(current_shell as i64, call.head),
         );
 
         if let Some(oldpwd) = stack.get_env_var(engine_state, "PWD") {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -170,13 +170,7 @@ impl Command for Watch {
 
                     if let Some(position) = block.signature.get_positional(0) {
                         if let Some(position_id) = &position.var_id {
-                            stack.add_var(
-                                *position_id,
-                                Value::String {
-                                    val: operation.to_string(),
-                                    span: call.span(),
-                                },
-                            );
+                            stack.add_var(*position_id, Value::string(operation, call.span()));
                         }
                     }
 
@@ -184,10 +178,7 @@ impl Command for Watch {
                         if let Some(position_id) = &position.var_id {
                             stack.add_var(
                                 *position_id,
-                                Value::String {
-                                    val: path.to_string_lossy().to_string(),
-                                    span: call.span(),
-                                },
+                                Value::string(path.to_string_lossy(), call.span()),
                             );
                         }
                     }
@@ -196,13 +187,10 @@ impl Command for Watch {
                         if let Some(position_id) = &position.var_id {
                             stack.add_var(
                                 *position_id,
-                                Value::String {
-                                    val: new_path
-                                        .unwrap_or_else(|| "".into())
-                                        .to_string_lossy()
-                                        .to_string(),
-                                    span: call.span(),
-                                },
+                                Value::string(
+                                    new_path.unwrap_or_else(|| "".into()).to_string_lossy(),
+                                    call.span(),
+                                ),
                             );
                         }
                     }

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -55,18 +55,9 @@ with 'transpose' first."#
 
     fn examples(&self) -> Vec<Example> {
         let stream_test_1 = vec![
-            Value::Int {
-                val: 2,
-                span: Span::test_data(),
-            },
-            Value::Int {
-                val: 4,
-                span: Span::test_data(),
-            },
-            Value::Int {
-                val: 6,
-                span: Span::test_data(),
-            },
+            Value::int(2, Span::test_data()),
+            Value::int(4, Span::test_data()),
+            Value::int(6, Span::test_data()),
         ];
 
         let stream_test_2 = vec![

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -64,10 +64,7 @@ with 'transpose' first."#
             Value::Nothing {
                 span: Span::test_data(),
             },
-            Value::String {
-                val: "found 2!".to_string(),
-                span: Span::test_data(),
-            },
+            Value::string("found 2!", Span::test_data()),
             Value::Nothing {
                 span: Span::test_data(),
             },
@@ -87,14 +84,8 @@ with 'transpose' first."#
                 description: "Produce a list that has \"two\" for each 2 in the input",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::String {
-                            val: "two".to_string(),
-                            span: Span::test_data(),
-                        },
-                        Value::String {
-                            val: "two".to_string(),
-                            span: Span::test_data(),
-                        },
+                        Value::string("two", Span::test_data()),
+                        Value::string("two", Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),
@@ -104,10 +95,7 @@ with 'transpose' first."#
                 description:
                     "Iterate over each element, producing a list showing indexes of any 2s",
                 result: Some(Value::List {
-                    vals: vec![Value::String {
-                        val: "found 2 at 1!".to_string(),
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::string("found 2 at 1!", Span::test_data())],
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -43,14 +43,8 @@ impl Command for EachWhile {
 
     fn examples(&self) -> Vec<Example> {
         let stream_test_1 = vec![
-            Value::Int {
-                val: 2,
-                span: Span::test_data(),
-            },
-            Value::Int {
-                val: 4,
-                span: Span::test_data(),
-            },
+            Value::int(2, Span::test_data()),
+            Value::int(4, Span::test_data()),
         ];
         let stream_test_2 = vec![
             Value::String {

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -47,14 +47,8 @@ impl Command for EachWhile {
             Value::int(4, Span::test_data()),
         ];
         let stream_test_2 = vec![
-            Value::String {
-                val: "Output: 1".into(),
-                span: Span::test_data(),
-            },
-            Value::String {
-                val: "Output: 2".into(),
-                span: Span::test_data(),
-            },
+            Value::string("Output: 1", Span::test_data()),
+            Value::string("Output: 2", Span::test_data()),
         ];
 
         vec![
@@ -78,10 +72,7 @@ impl Command for EachWhile {
                 example: r#"[1 2 3] | each while {|el ind| if $el < 2 { $"value ($el) at ($ind)!"} }"#,
                 description: "Iterate over each element, printing the matching value and its index",
                 result: Some(Value::List {
-                    vals: vec![Value::String {
-                        val: "value 1 at 0!".to_string(),
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::string("value 1 at 0!", Span::test_data())],
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -43,27 +43,18 @@ impl Command for Empty {
             Example {
                 description: "Check if a string is empty",
                 example: "'' | is-empty",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Check if a list is empty",
                 example: "[] | is-empty",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 // TODO: revisit empty cell path semantics for a record.
                 description: "Check if more than one column are empty",
                 example: "[[meal size]; [arepa small] [taco '']] | is-empty meal size",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
         ]
     }
@@ -84,23 +75,13 @@ fn empty(
                 let val = val.clone();
                 match val.follow_cell_path(&column.members, false) {
                     Ok(Value::Nothing { .. }) => {}
-                    Ok(_) => {
-                        return Ok(Value::Bool {
-                            val: false,
-                            span: head,
-                        }
-                        .into_pipeline_data())
-                    }
+                    Ok(_) => return Ok(Value::boolean(false, head).into_pipeline_data()),
                     Err(err) => return Err(err),
                 }
             }
         }
 
-        Ok(Value::Bool {
-            val: true,
-            span: head,
-        }
-        .into_pipeline_data())
+        Ok(Value::boolean(true, head).into_pipeline_data())
     } else {
         match input {
             PipelineData::Empty => Ok(PipelineData::Empty),
@@ -109,30 +90,18 @@ fn empty(
                     let bytes = s.into_bytes();
 
                     match bytes {
-                        Ok(s) => Ok(Value::Bool {
-                            val: s.item.is_empty(),
-                            span: head,
-                        }
-                        .into_pipeline_data()),
+                        Ok(s) => Ok(Value::boolean(s.item.is_empty(), head).into_pipeline_data()),
                         Err(err) => Err(err),
                     }
                 }
-                None => Ok(Value::Bool {
-                    val: true,
-                    span: head,
-                }
-                .into_pipeline_data()),
+                None => Ok(Value::boolean(true, head).into_pipeline_data()),
             },
-            PipelineData::ListStream(s, ..) => Ok(Value::Bool {
-                val: s.count() == 0,
-                span: head,
+            PipelineData::ListStream(s, ..) => {
+                Ok(Value::boolean(s.count() == 0, head).into_pipeline_data())
             }
-            .into_pipeline_data()),
-            PipelineData::Value(value, ..) => Ok(Value::Bool {
-                val: value.is_empty(),
-                span: head,
+            PipelineData::Value(value, ..) => {
+                Ok(Value::boolean(value.is_empty(), head).into_pipeline_data())
             }
-            .into_pipeline_data()),
         }
     }
 }

--- a/crates/nu-command/src/filters/group.rs
+++ b/crates/nu-command/src/filters/group.rs
@@ -36,27 +36,15 @@ impl Command for Group {
         let stream_test_1 = vec![
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 1,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 2,
-                        span: Span::test_data(),
-                    },
+                    Value::int(1, Span::test_data()),
+                    Value::int(2, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 3,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 4,
-                        span: Span::test_data(),
-                    },
+                    Value::int(3, Span::test_data()),
+                    Value::int(4, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -149,10 +149,7 @@ pub fn group_by(
                             }
 
                             let value = match collection.get(0) {
-                                Some(Value::Error { .. }) | None => Value::String {
-                                    val: error_key.to_string(),
-                                    span: name,
-                                },
+                                Some(Value::Error { .. }) | None => Value::string(error_key, name),
                                 Some(return_value) => return_value.clone(),
                             };
 

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -78,16 +78,10 @@ fn length_col(
 
 fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellError> {
     match input {
-        PipelineData::Value(Value::Nothing { .. }, ..) => Ok(Value::Int {
-            val: 0,
-            span: call.head,
+        PipelineData::Value(Value::Nothing { .. }, ..) => {
+            Ok(Value::int(0, call.head).into_pipeline_data())
         }
-        .into_pipeline_data()),
-        _ => Ok(Value::Int {
-            val: input.into_iter().count() as i64,
-            span: call.head,
-        }
-        .into_pipeline_data()),
+        _ => Ok(Value::int(input.into_iter().count() as i64, call.head).into_pipeline_data()),
     }
 }
 

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -173,10 +173,10 @@ impl Iterator for RawStreamLinesAdapter {
                 // inner is complete, feed out remaining state
                 if self.inner_complete {
                     if !self.incomplete_line.is_empty() {
-                        let r = Some(Ok(Value::String {
-                            val: self.incomplete_line.to_string(),
-                            span: self.span,
-                        }));
+                        let r = Some(Ok(Value::string(
+                            self.incomplete_line.to_string(),
+                            self.span,
+                        )));
                         self.incomplete_line = String::new();
                         return r;
                     }

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -52,10 +52,7 @@ impl Command for ParEach {
                 example: r#"[1 2 3] | par-each -n { |it| if $it.item == 2 { echo $"found 2 at ($it.index)!"} }"#,
                 description: "Iterate over each element, print the matching value and its index",
                 result: Some(Value::List {
-                    vals: vec![Value::String {
-                        val: "found 2 at 1!".to_string(),
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::string("found 2 at 1!", Span::test_data())],
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -54,26 +54,17 @@ impl Command for Reduce {
             Example {
                 example: "[ 1 2 3 4 ] | reduce {|it, acc| $it + $acc }",
                 description: "Sum values of a list (same as 'math sum')",
-                result: Some(Value::Int {
-                    val: 10,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(10, Span::test_data())),
             },
             Example {
                 example: "[ 8 7 6 ] | reduce {|it, acc, ind| $acc + $it + $ind }",
                 description: "Sum values of a list, plus their indexes",
-                result: Some(Value::Int {
-                    val: 22,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(22, Span::test_data())),
             },
             Example {
                 example: "[ 1 2 3 4 ] | reduce -f 10 {|it, acc| $acc + $it }",
                 description: "Sum values with a starting value (fold)",
-                result: Some(Value::Int {
-                    val: 20,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(20, Span::test_data())),
             },
             Example {
                 example: r#"[ i o t ] | reduce -f "Arthur, King of the Britons" {|it, acc| $acc | str replace -a $it "X" }"#,

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -68,10 +68,7 @@ impl Command for Reject {
                 example: "{a: 1, b: 2} | reject a",
                 result: Some(Value::Record {
                     cols: vec!["b".into()],
-                    vals: vec![Value::Int {
-                        val: 2,
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::int(2, Span::test_data())],
                     span: Span::test_data(),
                 }),
             },
@@ -82,10 +79,7 @@ impl Command for Reject {
                     cols: vec!["a".into()],
                     vals: vec![Value::Record {
                         cols: vec!["c".into()],
-                        vals: vec![Value::Int {
-                            val: 5,
-                            span: Span::test_data(),
-                        }],
+                        vals: vec![Value::int(5, Span::test_data())],
                         span: Span::test_data(),
                     }],
                     span: Span::test_data(),

--- a/crates/nu-command/src/filters/rotate.rs
+++ b/crates/nu-command/src/filters/rotate.rs
@@ -313,10 +313,7 @@ pub fn rotate(
     for (idx, val) in columns_iter {
         // when rotating counter clockwise, the old columns names become the first column's values
         let mut res = if ccw {
-            vec![Value::String {
-                val: val.to_string(),
-                span: call.head,
-            }]
+            vec![Value::string(val, call.head)]
         } else {
             vec![]
         };
@@ -329,10 +326,7 @@ pub fn rotate(
             }
             // when rotating clockwise, the old column names become the last column's values
             if !ccw {
-                res.push(Value::String {
-                    val: val.to_string(),
-                    span: call.head,
-                });
+                res.push(Value::string(val, call.head));
             }
             res.to_vec()
         };

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -206,13 +206,7 @@ fn generate_results_with_count(head: Span, uniq_values: Vec<ValueCounter>) -> Ve
         .into_iter()
         .map(|item| Value::Record {
             cols: vec!["value".to_string(), "count".to_string()],
-            vals: vec![
-                item.val,
-                Value::Int {
-                    val: item.count,
-                    span: head,
-                },
-            ],
+            vals: vec![item.val, Value::int(item.count, head)],
             span: head,
         })
         .collect()

--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -43,40 +43,22 @@ impl Command for Window {
         let stream_test_1 = vec![
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 1,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 2,
-                        span: Span::test_data(),
-                    },
+                    Value::int(1, Span::test_data()),
+                    Value::int(2, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 2,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 3,
-                        span: Span::test_data(),
-                    },
+                    Value::int(2, Span::test_data()),
+                    Value::int(3, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 3,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 4,
-                        span: Span::test_data(),
-                    },
+                    Value::int(3, Span::test_data()),
+                    Value::int(4, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
@@ -85,40 +67,22 @@ impl Command for Window {
         let stream_test_2 = vec![
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 1,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 2,
-                        span: Span::test_data(),
-                    },
+                    Value::int(1, Span::test_data()),
+                    Value::int(2, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 4,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 5,
-                        span: Span::test_data(),
-                    },
+                    Value::int(4, Span::test_data()),
+                    Value::int(5, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 7,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 8,
-                        span: Span::test_data(),
-                    },
+                    Value::int(7, Span::test_data()),
+                    Value::int(8, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
@@ -127,31 +91,16 @@ impl Command for Window {
         let stream_test_3 = vec![
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 1,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 2,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 3,
-                        span: Span::test_data(),
-                    },
+                    Value::int(1, Span::test_data()),
+                    Value::int(2, Span::test_data()),
+                    Value::int(3, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },
             Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 4,
-                        span: Span::test_data(),
-                    },
-                    Value::Int {
-                        val: 5,
-                        span: Span::test_data(),
-                    },
+                    Value::int(4, Span::test_data()),
+                    Value::int(5, Span::test_data()),
                 ],
                 span: Span::test_data(),
             },

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -37,42 +37,24 @@ impl Command for Zip {
     fn examples(&self) -> Vec<Example> {
         let test_row_1 = Value::List {
             vals: vec![
-                Value::Int {
-                    val: 1,
-                    span: Span::test_data(),
-                },
-                Value::Int {
-                    val: 4,
-                    span: Span::test_data(),
-                },
+                Value::int(1, Span::test_data()),
+                Value::int(4, Span::test_data()),
             ],
             span: Span::test_data(),
         };
 
         let test_row_2 = Value::List {
             vals: vec![
-                Value::Int {
-                    val: 2,
-                    span: Span::test_data(),
-                },
-                Value::Int {
-                    val: 5,
-                    span: Span::test_data(),
-                },
+                Value::int(2, Span::test_data()),
+                Value::int(5, Span::test_data()),
             ],
             span: Span::test_data(),
         };
 
         let test_row_3 = Value::List {
             vals: vec![
-                Value::Int {
-                    val: 3,
-                    span: Span::test_data(),
-                },
-                Value::Int {
-                    val: 6,
-                    span: Span::test_data(),
-                },
+                Value::int(3, Span::test_data()),
+                Value::int(6, Span::test_data()),
             ],
             span: Span::test_data(),
         };

--- a/crates/nu-command/src/formats/from/eml.rs
+++ b/crates/nu-command/src/formats/from/eml.rs
@@ -168,10 +168,7 @@ fn headerfieldvalue_to_value(head: Span, value: &HeaderFieldValue) -> Value {
                 .collect(),
             span: head,
         },
-        Unstructured(s) => Value::String {
-            val: s.to_string(),
-            span: head,
-        },
+        Unstructured(s) => Value::string(s, head),
         Empty => Value::nothing(head),
     }
 }

--- a/crates/nu-command/src/formats/from/ini.rs
+++ b/crates/nu-command/src/formats/from/ini.rs
@@ -34,14 +34,8 @@ b=2' | from ini",
                 vals: vec![Value::Record {
                     cols: vec!["a".to_string(), "b".to_string()],
                     vals: vec![
-                        Value::String {
-                            val: "1".to_string(),
-                            span: Span::test_data(),
-                        },
-                        Value::String {
-                            val: "2".to_string(),
-                            span: Span::test_data(),
-                        },
+                        Value::string("1", Span::test_data()),
+                        Value::string("2", Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }],

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -31,10 +31,7 @@ impl Command for FromJson {
                 description: "Converts json formatted string to table",
                 result: Some(Value::Record {
                     cols: vec!["a".to_string()],
-                    vals: vec![Value::Int {
-                        val: 1,
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::int(1, Span::test_data())],
                     span: Span::test_data(),
                 }),
             },
@@ -44,20 +41,11 @@ impl Command for FromJson {
                 result: Some(Value::Record {
                     cols: vec!["a".to_string(), "b".to_string()],
                     vals: vec![
-                        Value::Int {
-                            val: 1,
-                            span: Span::test_data(),
-                        },
+                        Value::int(1, Span::test_data()),
                         Value::List {
                             vals: vec![
-                                Value::Int {
-                                    val: 1,
-                                    span: Span::test_data(),
-                                },
-                                Value::Int {
-                                    val: 2,
-                                    span: Span::test_data(),
-                                },
+                                Value::int(1, Span::test_data()),
+                                Value::int(2, Span::test_data()),
                             ],
                             span: Span::test_data(),
                         },

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -29,10 +29,7 @@ impl Command for FromNuon {
                 description: "Converts nuon formatted string to table",
                 result: Some(Value::Record {
                     cols: vec!["a".to_string()],
-                    vals: vec![Value::Int {
-                        val: 1,
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::int(1, Span::test_data())],
                     span: Span::test_data(),
                 }),
             },
@@ -42,20 +39,11 @@ impl Command for FromNuon {
                 result: Some(Value::Record {
                     cols: vec!["a".to_string(), "b".to_string()],
                     vals: vec![
-                        Value::Int {
-                            val: 1,
-                            span: Span::test_data(),
-                        },
+                        Value::int(1, Span::test_data()),
                         Value::List {
                             vals: vec![
-                                Value::Int {
-                                    val: 1,
-                                    span: Span::test_data(),
-                                },
-                                Value::Int {
-                                    val: 2,
-                                    span: Span::test_data(),
-                                },
+                                Value::int(1, Span::test_data()),
+                                Value::int(2, Span::test_data()),
                             ],
                             span: Span::test_data(),
                         },

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -133,10 +133,7 @@ fn from_ods(
                     let value = match cell {
                         DataType::Empty => Value::nothing(head),
                         DataType::String(s) => Value::string(s, head),
-                        DataType::Float(f) => Value::Float {
-                            val: *f,
-                            span: head,
-                        },
+                        DataType::Float(f) => Value::float(*f, head),
                         DataType::Int(i) => Value::int(*i, head),
                         DataType::Bool(b) => Value::boolean(*b, head),
                         _ => Value::nothing(head),

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -141,10 +141,7 @@ fn from_ods(
                             val: *i,
                             span: head,
                         },
-                        DataType::Bool(b) => Value::Bool {
-                            val: *b,
-                            span: head,
-                        },
+                        DataType::Bool(b) => Value::boolean(*b, head),
                         _ => Value::nothing(head),
                     };
 

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -137,10 +137,7 @@ fn from_ods(
                             val: *f,
                             span: head,
                         },
-                        DataType::Int(i) => Value::Int {
-                            val: *i,
-                            span: head,
-                        },
+                        DataType::Int(i) => Value::int(*i, head),
                         DataType::Bool(b) => Value::boolean(*b, head),
                         _ => Value::nothing(head),
                     };

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -44,13 +44,13 @@ impl Command for FromSsv {
             example: r#"'FOO   BAR
 1   2' | from ssv"#,
             description: "Converts ssv formatted string to table",
-            result: Some(Value::List { vals: vec![Value::Record { cols: vec!["FOO".to_string(), "BAR".to_string()], vals: vec![Value::String { val: "1".to_string(), span: Span::test_data() }, Value::String { val: "2".to_string(), span: Span::test_data() }], span: Span::test_data() }], span: Span::test_data() }),
+            result: Some(Value::List { vals: vec![Value::Record { cols: vec!["FOO".to_string(), "BAR".to_string()], vals: vec![Value::string("1", Span::test_data()), Value::string("2", Span::test_data())], span: Span::test_data() }], span: Span::test_data() }),
         }, Example {
             example: r#"'FOO   BAR
 1   2' | from ssv -n"#,
             description: "Converts ssv formatted string to table but not treating the first row as column names",
             result: Some(
-                Value::List { vals: vec![Value::Record { cols: vec!["column1".to_string(), "column2".to_string()], vals: vec![Value::String { val: "FOO".to_string(), span: Span::test_data() }, Value::String { val: "BAR".to_string(), span: Span::test_data() }], span: Span::test_data() }, Value::Record { cols: vec!["column1".to_string(), "column2".to_string()], vals: vec![Value::String { val: "1".to_string(), span: Span::test_data() }, Value::String { val: "2".to_string(), span: Span::test_data() }], span: Span::test_data() }], span: Span::test_data() }),
+                Value::List { vals: vec![Value::Record { cols: vec!["column1".to_string(), "column2".to_string()], vals: vec![Value::string("FOO", Span::test_data()), Value::string("BAR", Span::test_data())], span: Span::test_data() }, Value::Record { cols: vec!["column1".to_string(), "column2".to_string()], vals: vec![Value::string("1", Span::test_data()), Value::string("2", Span::test_data())], span: Span::test_data() }], span: Span::test_data() }),
         }]
     }
 

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -29,10 +29,7 @@ impl Command for FromToml {
                 description: "Converts toml formatted string to record",
                 result: Some(Value::Record {
                     cols: vec!["a".to_string()],
-                    vals: vec![Value::Int {
-                        val: 1,
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::int(1, Span::test_data())],
                     span: Span::test_data(),
                 }),
             },
@@ -43,20 +40,11 @@ b = [1, 2]' | from toml",
                 result: Some(Value::Record {
                     cols: vec!["a".to_string(), "b".to_string()],
                     vals: vec![
-                        Value::Int {
-                            val: 1,
-                            span: Span::test_data(),
-                        },
+                        Value::int(1, Span::test_data()),
                         Value::List {
                             vals: vec![
-                                Value::Int {
-                                    val: 1,
-                                    span: Span::test_data(),
-                                },
-                                Value::Int {
-                                    val: 2,
-                                    span: Span::test_data(),
-                                },
+                                Value::int(1, Span::test_data()),
+                                Value::int(2, Span::test_data()),
                             ],
                             span: Span::test_data(),
                         },

--- a/crates/nu-command/src/formats/from/vcf.rs
+++ b/crates/nu-command/src/formats/from/vcf.rs
@@ -57,14 +57,8 @@ END:VCARD' | from vcf",
                                     "params".to_string(),
                                 ],
                                 vals: vec![
-                                    Value::String {
-                                        val: "N".to_string(),
-                                        span: Span::test_data(),
-                                    },
-                                    Value::String {
-                                        val: "Foo".to_string(),
-                                        span: Span::test_data(),
-                                    },
+                                    Value::string("N", Span::test_data()),
+                                    Value::string("Foo", Span::test_data()),
                                     Value::Nothing {
                                         span: Span::test_data(),
                                     },
@@ -78,14 +72,8 @@ END:VCARD' | from vcf",
                                     "params".to_string(),
                                 ],
                                 vals: vec![
-                                    Value::String {
-                                        val: "FN".to_string(),
-                                        span: Span::test_data(),
-                                    },
-                                    Value::String {
-                                        val: "Bar".to_string(),
-                                        span: Span::test_data(),
-                                    },
+                                    Value::string("FN", Span::test_data()),
+                                    Value::string("Bar", Span::test_data()),
                                     Value::Nothing {
                                         span: Span::test_data(),
                                     },
@@ -99,14 +87,8 @@ END:VCARD' | from vcf",
                                     "params".to_string(),
                                 ],
                                 vals: vec![
-                                    Value::String {
-                                        val: "EMAIL".to_string(),
-                                        span: Span::test_data(),
-                                    },
-                                    Value::String {
-                                        val: "foo@bar.com".to_string(),
-                                        span: Span::test_data(),
-                                    },
+                                    Value::string("EMAIL", Span::test_data()),
+                                    Value::string("foo@bar.com", Span::test_data()),
                                     Value::Nothing {
                                         span: Span::test_data(),
                                     },

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -137,10 +137,7 @@ fn from_xlsx(
                             val: *f,
                             span: head,
                         },
-                        DataType::Int(i) => Value::Int {
-                            val: *i,
-                            span: head,
-                        },
+                        DataType::Int(i) => Value::int(*i, head),
                         DataType::Bool(b) => Value::boolean(*b, head),
                         _ => Value::nothing(head),
                     };

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -133,10 +133,7 @@ fn from_xlsx(
                     let value = match cell {
                         DataType::Empty => Value::nothing(head),
                         DataType::String(s) => Value::string(s, head),
-                        DataType::Float(f) => Value::Float {
-                            val: *f,
-                            span: head,
-                        },
+                        DataType::Float(f) => Value::float(*f, head),
                         DataType::Int(i) => Value::int(*i, head),
                         DataType::Bool(b) => Value::boolean(*b, head),
                         _ => Value::nothing(head),

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -141,10 +141,7 @@ fn from_xlsx(
                             val: *i,
                             span: head,
                         },
-                        DataType::Bool(b) => Value::Bool {
-                            val: *b,
-                            span: head,
-                        },
+                        DataType::Bool(b) => Value::boolean(*b, head),
                         _ => Value::nothing(head),
                     };
 

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -54,10 +54,7 @@ impl Command for FromXml {
                                     cols: vec!["children".to_string(), "attributes".to_string()],
                                     vals: vec![
                                         Value::List {
-                                            vals: vec![Value::String {
-                                                val: "Event".to_string(),
-                                                span: Span::test_data(),
-                                            }],
+                                            vals: vec![Value::string("Event", Span::test_data())],
                                             span: Span::test_data(),
                                         },
                                         Value::Record {
@@ -201,10 +198,7 @@ mod tests {
     use nu_protocol::{Spanned, Value};
 
     fn string(input: impl Into<String>) -> Value {
-        Value::String {
-            val: input.into(),
-            span: Span::test_data(),
-        }
+        Value::string(input, Span::test_data())
     }
 
     fn row(entries: IndexMap<String, Value>) -> Value {

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -181,10 +181,7 @@ pub fn get_examples() -> Vec<Example> {
             description: "Converts yaml formatted string to table",
             result: Some(Value::Record {
                 cols: vec!["a".to_string()],
-                vals: vec![Value::Int {
-                    val: 1,
-                    span: Span::test_data(),
-                }],
+                vals: vec![Value::int(1, Span::test_data())],
                 span: Span::test_data(),
             }),
         },

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -237,10 +237,7 @@ mod test {
                 input: r#"value: "{{ something }}""#,
                 expected: Ok(Value::Record {
                     cols: vec!["value".to_string()],
-                    vals: vec![Value::String {
-                        val: "{{ something }}".to_string(),
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::string("{{ something }}", Span::test_data())],
                     span: Span::test_data(),
                 }),
             },
@@ -249,10 +246,7 @@ mod test {
                 input: r#"value: {{ something }}"#,
                 expected: Ok(Value::Record {
                     cols: vec!["value".to_string()],
-                    vals: vec![Value::String {
-                        val: "{{ something }}".to_string(),
-                        span: Span::test_data(),
-                    }],
+                    vals: vec![Value::string("{{ something }}", Span::test_data())],
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -307,20 +307,14 @@ fn add_month_to_table(
         if should_show_year_column {
             indexmap.insert(
                 "year".to_string(),
-                Value::Int {
-                    val: month_helper.selected_year as i64,
-                    span: tag,
-                },
+                Value::int(month_helper.selected_year as i64, tag),
             );
         }
 
         if should_show_quarter_column {
             indexmap.insert(
                 "quarter".to_string(),
-                Value::Int {
-                    val: month_helper.quarter_number as i64,
-                    span: tag,
-                },
+                Value::int(month_helper.quarter_number as i64, tag),
             );
         }
 
@@ -331,10 +325,7 @@ fn add_month_to_table(
                     span: tag,
                 }
             } else {
-                Value::Int {
-                    val: month_helper.selected_month as i64,
-                    span: tag,
-                }
+                Value::int(month_helper.selected_month as i64, tag)
             };
 
             indexmap.insert("month".to_string(), month_value);
@@ -349,10 +340,7 @@ fn add_month_to_table(
             if should_add_day_number_to_table {
                 let adjusted_day_number = day_number - total_start_offset;
 
-                value = Value::Int {
-                    val: adjusted_day_number as i64,
-                    span: tag,
-                };
+                value = Value::int(adjusted_day_number as i64, tag);
 
                 if let Some(current_day) = current_day_option {
                     if current_day == adjusted_day_number {

--- a/crates/nu-command/src/generators/seq.rs
+++ b/crates/nu-command/src/generators/seq.rs
@@ -187,10 +187,7 @@ impl Iterator for FloatSeq {
             return None;
         }
         self.index += 1;
-        Some(Value::Float {
-            val: count,
-            span: self.span,
-        })
+        Some(Value::float(count, self.span))
     }
 }
 

--- a/crates/nu-command/src/generators/seq.rs
+++ b/crates/nu-command/src/generators/seq.rs
@@ -208,10 +208,7 @@ impl Iterator for IntSeq {
         {
             return None;
         }
-        let ret = Some(Value::Int {
-            val: self.count,
-            span: self.span,
-        });
+        let ret = Some(Value::int(self.count, self.span));
         self.count += self.step;
         ret
     }

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -46,10 +46,7 @@ impl Command for SubCommand {
             result: Some(Value::List {
                 vals: vec![
                     Value::test_int(50),
-                    Value::Float {
-                        val: 100.0,
-                        span: Span::test_data(),
-                    },
+                    Value::float(100.0, Span::test_data()),
                     Value::test_int(25),
                 ],
                 span: Span::test_data(),

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -50,14 +50,7 @@ impl Command for SubCommand {
 
 pub fn average(values: &[Value], head: &Span) -> Result<Value, ShellError> {
     let sum = reducer_for(Reduce::Summation);
-    let total = &sum(
-        Value::Int {
-            val: 0,
-            span: *head,
-        },
-        values.to_vec(),
-        *head,
-    )?;
+    let total = &sum(Value::int(0, *head), values.to_vec(), *head)?;
     match total {
         Value::Filesize { val, span } => Ok(Value::Filesize {
             val: val / values.len() as i64,
@@ -67,14 +60,7 @@ pub fn average(values: &[Value], head: &Span) -> Result<Value, ShellError> {
             val: val / values.len() as i64,
             span: *span,
         }),
-        _ => total.div(
-            *head,
-            &Value::Int {
-                val: values.len() as i64,
-                span: *head,
-            },
-            *head,
-        ),
+        _ => total.div(*head, &Value::int(values.len() as i64, *head), *head),
     }
 }
 

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -40,10 +40,7 @@ impl Command for SubCommand {
         vec![Example {
             description: "Compute the average of a list of numbers",
             example: "[-50 100.0 25] | math avg",
-            result: Some(Value::Float {
-                val: 25.0,
-                span: Span::test_data(),
-            }),
+            result: Some(Value::float(25.0, Span::test_data())),
         }]
     }
 }

--- a/crates/nu-command/src/math/euler.rs
+++ b/crates/nu-command/src/math/euler.rs
@@ -40,11 +40,7 @@ impl Command for SubCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        Ok(Value::Float {
-            val: std::f64::consts::E,
-            span: call.head,
-        }
-        .into_pipeline_data())
+        Ok(Value::float(std::f64::consts::E, call.head).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/math/eval.rs
+++ b/crates/nu-command/src/math/eval.rs
@@ -47,10 +47,7 @@ impl Command for SubCommand {
         vec![Example {
             description: "Evaluate math in the pipeline",
             example: "'10 / 4' | math eval",
-            result: Some(Value::Float {
-                val: 2.5,
-                span: Span::test_data(),
-            }),
+            result: Some(Value::float(2.5, Span::test_data())),
         }]
     }
 }
@@ -104,10 +101,7 @@ pub fn parse(math_expression: &str, span: &Span) -> Result<Value, String> {
     ctx.var("tau", std::f64::consts::TAU);
     match meval::eval_str_with_context(math_expression, &ctx) {
         Ok(num) if num.is_infinite() || num.is_nan() => Err("cannot represent result".to_string()),
-        Ok(num) => Ok(Value::Float {
-            val: num,
-            span: *span,
-        }),
+        Ok(num) => Ok(Value::float(num, *span)),
         Err(error) => Err(error.to_string().to_lowercase()),
     }
 }

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -46,10 +46,7 @@ impl Command for SubCommand {
             Example {
                 description: "Compute the median of a list of numbers",
                 example: "[3 8 9 12 12 15] | math median",
-                result: Some(Value::Float {
-                    val: 10.5,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::float(10.5, Span::test_data())),
             },
             Example {
                 description: "Compute the medians of the columns of a table",

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -172,10 +172,7 @@ fn recreate_value(hashable_value: &HashableType, head: Span) -> Value {
     let bytes = hashable_value.bytes;
     match &hashable_value.original_type {
         NumberTypes::Int => Value::int(i64::from_ne_bytes(bytes), head),
-        NumberTypes::Float => Value::Float {
-            val: f64::from_ne_bytes(bytes),
-            span: head,
-        },
+        NumberTypes::Float => Value::float(f64::from_ne_bytes(bytes), head),
         NumberTypes::Duration => Value::Duration {
             val: i64::from_ne_bytes(bytes),
             span: head,

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -171,10 +171,7 @@ pub fn mode(values: &[Value], head: &Span) -> Result<Value, ShellError> {
 fn recreate_value(hashable_value: &HashableType, head: Span) -> Value {
     let bytes = hashable_value.bytes;
     match &hashable_value.original_type {
-        NumberTypes::Int => Value::Int {
-            val: i64::from_ne_bytes(bytes),
-            span: head,
-        },
+        NumberTypes::Int => Value::int(i64::from_ne_bytes(bytes), head),
         NumberTypes::Float => Value::Float {
             val: f64::from_ne_bytes(bytes),
             span: head,

--- a/crates/nu-command/src/math/pi.rs
+++ b/crates/nu-command/src/math/pi.rs
@@ -40,11 +40,7 @@ impl Command for SubCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        Ok(Value::Float {
-            val: std::f64::consts::PI,
-            span: call.head,
-        }
-        .into_pipeline_data())
+        Ok(Value::float(std::f64::consts::PI, call.head).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -80,10 +80,7 @@ pub fn sum(data: Vec<Value>, head: Span) -> Result<Value, ShellError> {
             val: 0,
             span: *span,
         }),
-        Some(Value::Int { span, .. }) | Some(Value::Float { span, .. }) => Ok(Value::Int {
-            val: 0,
-            span: *span,
-        }),
+        Some(Value::Int { span, .. }) | Some(Value::Float { span, .. }) => Ok(Value::int(0, *span)),
         None => Err(ShellError::UnsupportedInput(
             "Empty input".to_string(),
             head,
@@ -114,10 +111,7 @@ pub fn product(data: Vec<Value>, head: Span) -> Result<Value, ShellError> {
     let initial_value = data.get(0);
 
     let mut acc = match initial_value {
-        Some(Value::Int { span, .. }) | Some(Value::Float { span, .. }) => Ok(Value::Int {
-            val: 1,
-            span: *span,
-        }),
+        Some(Value::Int { span, .. }) | Some(Value::Float { span, .. }) => Ok(Value::int(1, *span)),
         None => Err(ShellError::UnsupportedInput(
             "Empty input".to_string(),
             head,

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -64,18 +64,9 @@ impl Command for SubCommand {
                 example: "[1.555 2.333 -3.111] | math round -p 2",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::Float {
-                            val: 1.56,
-                            span: Span::test_data(),
-                        },
-                        Value::Float {
-                            val: 2.33,
-                            span: Span::test_data(),
-                        },
-                        Value::Float {
-                            val: -3.11,
-                            span: Span::test_data(),
-                        },
+                        Value::float(1.56, Span::test_data()),
+                        Value::float(2.33, Span::test_data()),
+                        Value::float(-3.11, Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -54,18 +54,12 @@ impl Command for SubCommand {
             Example {
                 description: "Compute the standard deviation of a list of numbers",
                 example: "[1 2 3 4 5] | math stddev",
-                result: Some(Value::Float {
-                    val: std::f64::consts::SQRT_2,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::float(std::f64::consts::SQRT_2, Span::test_data())),
             },
             Example {
                 description: "Compute the sample standard deviation of a list of numbers",
                 example: "[1 2 3 4 5] | math stddev -s",
-                result: Some(Value::Float {
-                    val: 1.5811388300841898,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::float(1.5811388300841898, Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/math/tau.rs
+++ b/crates/nu-command/src/math/tau.rs
@@ -40,11 +40,7 @@ impl Command for SubCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        Ok(Value::Float {
-            val: std::f64::consts::TAU,
-            span: call.head,
-        }
-        .into_pipeline_data())
+        Ok(Value::float(std::f64::consts::TAU, call.head).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -46,18 +46,12 @@ impl Command for SubCommand {
             Example {
                 description: "Get the variance of a list of numbers",
                 example: "echo [1 2 3 4 5] | math variance",
-                result: Some(Value::Float {
-                    val: 2.0,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::float(2.0, Span::test_data())),
             },
             Example {
                 description: "Get the sample variance of a list of numbers",
                 example: "[1 2 3 4 5] | math variance -s",
-                result: Some(Value::Float {
-                    val: 2.5,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::float(2.5, Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -64,18 +64,9 @@ impl Command for SubCommand {
 }
 
 fn sum_of_squares(values: &[Value], span: &Span) -> Result<Value, ShellError> {
-    let n = Value::Int {
-        val: values.len() as i64,
-        span: *span,
-    };
-    let mut sum_x = Value::Int {
-        val: 0,
-        span: *span,
-    };
-    let mut sum_x2 = Value::Int {
-        val: 0,
-        span: *span,
-    };
+    let n = Value::int(values.len() as i64, *span);
+    let mut sum_x = Value::int(0, *span);
+    let mut sum_x2 = Value::int(0, *span);
     for value in values {
         let v = match &value {
             Value::Int { .. }
@@ -116,10 +107,7 @@ pub fn compute_variance(sample: bool) -> impl Fn(&[Value], &Span) -> Result<Valu
             )),
             other => other,
         }?;
-        let n = Value::Int {
-            val: n as i64,
-            span: *span,
-        };
+        let n = Value::int(n as i64, *span);
         ss.div(*span, &n, *span)
     }
 }

--- a/crates/nu-command/src/misc/history.rs
+++ b/crates/nu-command/src/misc/history.rs
@@ -93,10 +93,7 @@ impl Command for History {
                                             val: entry.command_line,
                                             span: head,
                                         },
-                                        Value::Int {
-                                            val: idx as i64,
-                                            span: head,
-                                        },
+                                        Value::int(idx as i64, head),
                                     ],
                                     span: head,
                                 })
@@ -183,14 +180,8 @@ impl Command for History {
                                             },
                                             span: head,
                                         },
-                                        Value::Int {
-                                            val: entry.exit_status.unwrap_or(0),
-                                            span: head,
-                                        },
-                                        Value::Int {
-                                            val: idx as i64,
-                                            span: head,
-                                        },
+                                        Value::int(entry.exit_status.unwrap_or(0), head),
+                                        Value::int(idx as i64, head),
                                     ],
                                     span: head,
                                 })

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -418,11 +418,7 @@ fn display(help: &str, engine_state: &EngineState, stack: &mut Stack, span: Span
                     engine_state,
                     stack,
                     &Call::new(span),
-                    Value::String {
-                        val: item.to_string(),
-                        span: Span::unknown(),
-                    }
-                    .into_pipeline_data(),
+                    Value::string(item, Span::unknown()).into_pipeline_data(),
                 ) {
                     let result = output.into_value(Span::unknown());
                     match result.as_string() {

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -50,10 +50,7 @@ impl Command for SubCommand {
             Example {
                 description: "get a free port between 3121 and 4000",
                 example: "port 3121 4000",
-                result: Some(Value::Int {
-                    val: 3121,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::int(3121, Span::test_data())),
             },
             Example {
                 description: "get a free port from system",
@@ -101,9 +98,5 @@ fn get_free_port(
     };
 
     let free_port = listener.local_addr()?.port();
-    Ok(Value::Int {
-        val: free_port as i64,
-        span: call.head,
-    }
-    .into_pipeline_data())
+    Ok(Value::int(free_port as i64, call.head).into_pipeline_data())
 }

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -69,10 +69,7 @@ If you need to distinguish dirs and files, please use `path type`."#
             Example {
                 description: "Check if a file exists",
                 example: "'C:\\Users\\joe\\todo.txt' | path exists",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
             Example {
                 description: "Check if a file exists in a column",
@@ -88,10 +85,7 @@ If you need to distinguish dirs and files, please use `path type`."#
             Example {
                 description: "Check if a file exists",
                 example: "'/home/joe/todo.txt' | path exists",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
             Example {
                 description: "Check if a file exists in a column",

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
@@ -95,15 +95,9 @@ fn get_records(entry_type: &str, span: &Span) -> Vec<Value> {
 }
 
 fn convert_to_record(edit: &str, entry_type: &str, span: &Span) -> Value {
-    let entry_type = Value::String {
-        val: entry_type.to_string(),
-        span: *span,
-    };
+    let entry_type = Value::string(entry_type, *span);
 
-    let name = Value::String {
-        val: edit.to_string(),
-        span: *span,
-    };
+    let name = Value::string(edit, *span);
 
     Value::Record {
         cols: vec!["type".to_string(), "name".to_string()],

--- a/crates/nu-command/src/platform/term_size.rs
+++ b/crates/nu-command/src/platform/term_size.rs
@@ -56,14 +56,8 @@ impl Command for TermSize {
         Ok(Value::Record {
             cols: vec!["columns".into(), "rows".into()],
             vals: vec![
-                Value::Int {
-                    val: cols.0 as i64,
-                    span: Span::test_data(),
-                },
-                Value::Int {
-                    val: rows.0 as i64,
-                    span: Span::test_data(),
-                },
+                Value::int(cols.0 as i64, Span::test_data()),
+                Value::int(rows.0 as i64, Span::test_data()),
             ],
             span: head,
         }

--- a/crates/nu-command/src/shells/enter.rs
+++ b/crates/nu-command/src/shells/enter.rs
@@ -68,10 +68,7 @@ impl Command for Enter {
 
         stack.add_env_var(
             "NUSHELL_LAST_SHELL".into(),
-            Value::Int {
-                val: current_shell as i64,
-                span: call.head,
-            },
+            Value::int(current_shell as i64, call.head),
         );
 
         if current_shell + 1 > shells.len() {
@@ -91,10 +88,7 @@ impl Command for Enter {
         );
         stack.add_env_var(
             "NUSHELL_CURRENT_SHELL".into(),
-            Value::Int {
-                val: current_shell as i64,
-                span: call.head,
-            },
+            Value::int(current_shell as i64, call.head),
         );
 
         stack.add_env_var("PWD".into(), new_path);

--- a/crates/nu-command/src/shells/enter.rs
+++ b/crates/nu-command/src/shells/enter.rs
@@ -53,15 +53,9 @@ impl Command for Enter {
             ));
         }
 
-        let new_path = Value::String {
-            val: new_path.to_string_lossy().to_string(),
-            span: call.head,
-        };
+        let new_path = Value::string(new_path.to_string_lossy(), call.head);
 
-        let cwd = Value::String {
-            val: cwd.to_string_lossy().to_string(),
-            span: call.head,
-        };
+        let cwd = Value::string(cwd.to_string_lossy(), call.head);
 
         let mut shells = get_shells(engine_state, stack, cwd);
         let mut current_shell = get_current_shell(engine_state, stack);

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -86,17 +86,11 @@ impl Command for Exit {
             );
             stack.add_env_var(
                 "NUSHELL_CURRENT_SHELL".into(),
-                Value::Int {
-                    val: current_shell as i64,
-                    span: call.head,
-                },
+                Value::int(current_shell as i64, call.head),
             );
             stack.add_env_var(
                 "NUSHELL_LAST_SHELL".into(),
-                Value::Int {
-                    val: last_shell as i64,
-                    span: call.head,
-                },
+                Value::int(last_shell as i64, call.head),
             );
 
             stack.add_env_var("PWD".into(), new_path);

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -53,10 +53,7 @@ impl Command for Exit {
         }
 
         let cwd = current_dir(engine_state, stack)?;
-        let cwd = Value::String {
-            val: cwd.to_string_lossy().to_string(),
-            span: call.head,
-        };
+        let cwd = Value::string(cwd.to_string_lossy(), call.head);
 
         let mut shells = get_shells(engine_state, stack, cwd);
         let mut current_shell = get_current_shell(engine_state, stack);

--- a/crates/nu-command/src/shells/mod.rs
+++ b/crates/nu-command/src/shells/mod.rs
@@ -105,18 +105,12 @@ fn switch_shell(
 
     stack.add_env_var(
         "NUSHELL_CURRENT_SHELL".into(),
-        Value::Int {
-            val: new_shell as i64,
-            span: call.head,
-        },
+        Value::int(new_shell as i64, call.head),
     );
 
     stack.add_env_var(
         "NUSHELL_LAST_SHELL".into(),
-        Value::Int {
-            val: current_shell as i64,
-            span: call.head,
-        },
+        Value::int(current_shell as i64, call.head),
     );
 
     stack.add_env_var("PWD".into(), new_path);

--- a/crates/nu-command/src/shells/mod.rs
+++ b/crates/nu-command/src/shells/mod.rs
@@ -61,10 +61,7 @@ fn switch_shell(
     switch_to: SwitchTo,
 ) -> Result<PipelineData, ShellError> {
     let cwd = current_dir(engine_state, stack)?;
-    let cwd = Value::String {
-        val: cwd.to_string_lossy().to_string(),
-        span: call.head,
-    };
+    let cwd = Value::string(cwd.to_string_lossy(), call.head);
 
     let shells = get_shells(engine_state, stack, cwd);
     let current_shell = get_current_shell(engine_state, stack);

--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -55,26 +55,11 @@ impl Command for Size {
                         "graphemes".into(),
                     ],
                     vals: vec![
-                        Value::Int {
-                            val: 1,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 7,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 38,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 38,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 38,
-                            span: Span::test_data(),
-                        },
+                        Value::int(1, Span::test_data()),
+                        Value::int(7, Span::test_data()),
+                        Value::int(38, Span::test_data()),
+                        Value::int(38, Span::test_data()),
+                        Value::int(38, Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),
@@ -91,26 +76,11 @@ impl Command for Size {
                         "graphemes".into(),
                     ],
                     vals: vec![
-                        Value::Int {
-                            val: 1,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 6,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 18,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 6,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 6,
-                            span: Span::test_data(),
-                        },
+                        Value::int(1, Span::test_data()),
+                        Value::int(6, Span::test_data()),
+                        Value::int(18, Span::test_data()),
+                        Value::int(6, Span::test_data()),
+                        Value::int(6, Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),
@@ -127,26 +97,11 @@ impl Command for Size {
                         "graphemes".into(),
                     ],
                     vals: vec![
-                        Value::Int {
-                            val: 1,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 2,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 15,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 14,
-                            span: Span::test_data(),
-                        },
-                        Value::Int {
-                            val: 13,
-                            span: Span::test_data(),
-                        },
+                        Value::int(1, Span::test_data()),
+                        Value::int(2, Span::test_data()),
+                        Value::int(15, Span::test_data()),
+                        Value::int(14, Span::test_data()),
+                        Value::int(13, Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -50,26 +50,17 @@ impl Command for SubCommand {
             Example {
                 description: "convert a string to camelCase",
                 example: " 'NuShell' | str camel-case",
-                result: Some(Value::String {
-                    val: "nuShell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nuShell", Span::test_data())),
             },
             Example {
                 description: "convert a string to camelCase",
                 example: "'this-is-the-first-case' | str camel-case",
-                result: Some(Value::String {
-                    val: "thisIsTheFirstCase".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("thisIsTheFirstCase", Span::test_data())),
             },
             Example {
                 description: "convert a string to camelCase",
                 example: " 'this_is_the_second_case' | str camel-case",
-                result: Some(Value::String {
-                    val: "thisIsTheSecondCase".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("thisIsTheSecondCase", Span::test_data())),
             },
             Example {
                 description: "convert a column from a table to camelCase",
@@ -79,10 +70,7 @@ impl Command for SubCommand {
                         span: Span::test_data(),
                         cols: vec!["lang".to_string(), "gems".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "nuTest".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("nuTest", Span::test_data()),
                             Value::test_int(100),
                         ],
                     }],

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -48,18 +48,12 @@ impl Command for SubCommand {
             Example {
                 description: "Capitalize contents",
                 example: "'good day' | str capitalize",
-                result: Some(Value::String {
-                    val: "Good day".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("Good day", Span::test_data())),
             },
             Example {
                 description: "Capitalize contents",
                 example: "'anton' | str capitalize",
-                result: Some(Value::String {
-                    val: "Anton".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("Anton", Span::test_data())),
             },
             Example {
                 description: "Capitalize a column in a table",
@@ -69,10 +63,7 @@ impl Command for SubCommand {
                         span: Span::test_data(),
                         cols: vec!["lang".to_string(), "gems".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "Nu_test".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("Nu_test", Span::test_data()),
                             Value::test_int(100),
                         ],
                     }],

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -48,18 +48,12 @@ impl Command for SubCommand {
             Example {
                 description: "Downcase contents",
                 example: "'NU' | str downcase",
-                result: Some(Value::String {
-                    val: "nu".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nu", Span::test_data())),
             },
             Example {
                 description: "Downcase contents",
                 example: "'TESTa' | str downcase",
-                result: Some(Value::String {
-                    val: "testa".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("testa", Span::test_data())),
             },
             Example {
                 description: "Downcase contents",
@@ -68,14 +62,8 @@ impl Command for SubCommand {
                     vals: vec![Value::Record {
                         cols: vec!["ColA".to_string(), "ColB".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "test".to_string(),
-                                span: Span::test_data(),
-                            },
-                            Value::String {
-                                val: "ABC".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("test", Span::test_data()),
+                            Value::string("ABC", Span::test_data()),
                         ],
                         span: Span::test_data(),
                     }],
@@ -89,14 +77,8 @@ impl Command for SubCommand {
                     vals: vec![Value::Record {
                         cols: vec!["ColA".to_string(), "ColB".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "test".to_string(),
-                                span: Span::test_data(),
-                            },
-                            Value::String {
-                                val: "abc".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("test", Span::test_data()),
+                            Value::string("abc", Span::test_data()),
                         ],
                         span: Span::test_data(),
                     }],

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -50,26 +50,17 @@ impl Command for SubCommand {
             Example {
                 description: "convert a string to kebab-case",
                 example: "'NuShell' | str kebab-case",
-                result: Some(Value::String {
-                    val: "nu-shell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nu-shell", Span::test_data())),
             },
             Example {
                 description: "convert a string to kebab-case",
                 example: "'thisIsTheFirstCase' | str kebab-case",
-                result: Some(Value::String {
-                    val: "this-is-the-first-case".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("this-is-the-first-case", Span::test_data())),
             },
             Example {
                 description: "convert a string to kebab-case",
                 example: "'THIS_IS_THE_SECOND_CASE' | str kebab-case",
-                result: Some(Value::String {
-                    val: "this-is-the-second-case".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("this-is-the-second-case", Span::test_data())),
             },
             Example {
                 description: "convert a column from a table to kebab-case",
@@ -79,10 +70,7 @@ impl Command for SubCommand {
                         span: Span::test_data(),
                         cols: vec!["lang".to_string(), "gems".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "nu-test".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("nu-test", Span::test_data()),
                             Value::test_int(100),
                         ],
                     }],

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -50,26 +50,17 @@ impl Command for SubCommand {
             Example {
                 description: "convert a string to PascalCase",
                 example: "'nu-shell' | str pascal-case",
-                result: Some(Value::String {
-                    val: "NuShell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("NuShell", Span::test_data())),
             },
             Example {
                 description: "convert a string to PascalCase",
                 example: "'this-is-the-first-case' | str pascal-case",
-                result: Some(Value::String {
-                    val: "ThisIsTheFirstCase".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("ThisIsTheFirstCase", Span::test_data())),
             },
             Example {
                 description: "convert a string to PascalCase",
                 example: "'this_is_the_second_case' | str pascal-case",
-                result: Some(Value::String {
-                    val: "ThisIsTheSecondCase".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("ThisIsTheSecondCase", Span::test_data())),
             },
             Example {
                 description: "convert a column from a table to PascalCase",
@@ -79,10 +70,7 @@ impl Command for SubCommand {
                         span: Span::test_data(),
                         cols: vec!["lang".to_string(), "gems".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "NuTest".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("NuTest", Span::test_data()),
                             Value::test_int(100),
                         ],
                     }],

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -49,26 +49,17 @@ impl Command for SubCommand {
             Example {
                 description: "convert a string to SCREAMING_SNAKE_CASE",
                 example: r#" "NuShell" | str screaming-snake-case"#,
-                result: Some(Value::String {
-                    val: "NU_SHELL".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("NU_SHELL", Span::test_data())),
             },
             Example {
                 description: "convert a string to SCREAMING_SNAKE_CASE",
                 example: r#" "this_is_the_second_case" | str screaming-snake-case"#,
-                result: Some(Value::String {
-                    val: "THIS_IS_THE_SECOND_CASE".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("THIS_IS_THE_SECOND_CASE", Span::test_data())),
             },
             Example {
                 description: "convert a string to SCREAMING_SNAKE_CASE",
                 example: r#""this-is-the-first-case" | str screaming-snake-case"#,
-                result: Some(Value::String {
-                    val: "THIS_IS_THE_FIRST_CASE".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("THIS_IS_THE_FIRST_CASE", Span::test_data())),
             },
             Example {
                 description: "convert a column from a table to SCREAMING_SNAKE_CASE",
@@ -78,10 +69,7 @@ impl Command for SubCommand {
                         span: Span::test_data(),
                         cols: vec!["lang".to_string(), "gems".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "NU_TEST".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("NU_TEST", Span::test_data()),
                             Value::test_int(100),
                         ],
                     }],

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -49,26 +49,17 @@ impl Command for SubCommand {
             Example {
                 description: "convert a string to snake_case",
                 example: r#" "NuShell" | str snake-case"#,
-                result: Some(Value::String {
-                    val: "nu_shell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nu_shell", Span::test_data())),
             },
             Example {
                 description: "convert a string to snake_case",
                 example: r#" "this_is_the_second_case" | str snake-case"#,
-                result: Some(Value::String {
-                    val: "this_is_the_second_case".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("this_is_the_second_case", Span::test_data())),
             },
             Example {
                 description: "convert a string to snake_case",
                 example: r#""this-is-the-first-case" | str snake-case"#,
-                result: Some(Value::String {
-                    val: "this_is_the_first_case".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("this_is_the_first_case", Span::test_data())),
             },
             Example {
                 description: "convert a column from a table to snake_case",
@@ -78,10 +69,7 @@ impl Command for SubCommand {
                         span: Span::test_data(),
                         cols: vec!["lang".to_string(), "gems".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "nu_test".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("nu_test", Span::test_data()),
                             Value::test_int(100),
                         ],
                     }],

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -50,18 +50,12 @@ impl Command for SubCommand {
             Example {
                 description: "convert a string to Title Case",
                 example: "'nu-shell' | str title-case",
-                result: Some(Value::String {
-                    val: "Nu Shell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("Nu Shell", Span::test_data())),
             },
             Example {
                 description: "convert a string to Title Case",
                 example: "'this is a test case' | str title-case",
-                result: Some(Value::String {
-                    val: "This Is A Test Case".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("This Is A Test Case", Span::test_data())),
             },
             Example {
                 description: "convert a column from a table to Title Case",
@@ -71,10 +65,7 @@ impl Command for SubCommand {
                         span: Span::test_data(),
                         cols: vec!["title".to_string(), "count".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "Nu Test".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("Nu Test", Span::test_data()),
                             Value::test_int(100),
                         ],
                     }],

--- a/crates/nu-command/src/strings/str_/collect.rs
+++ b/crates/nu-command/src/strings/str_/collect.rs
@@ -74,18 +74,12 @@ impl Command for StrCollect {
             Example {
                 description: "Create a string from input",
                 example: "['nu', 'shell'] | str collect",
-                result: Some(Value::String {
-                    val: "nushell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nushell", Span::test_data())),
             },
             Example {
                 description: "Create a string from input with a separator",
                 example: "['nu', 'shell'] | str collect '-'",
-                result: Some(Value::String {
-                    val: "nu-shell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nu-shell", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -73,18 +73,12 @@ impl Command for SubCommand {
             Example {
                 description: "Check if input contains string",
                 example: "'my_library.rb' | str contains '.rb'",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Check if input contains string case insensitive",
                 example: "'my_library.rb' | str contains -i '.RB'",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Check if input contains string in a table",
@@ -93,10 +87,7 @@ impl Command for SubCommand {
                     vals: vec![Value::Record {
                         cols: vec!["ColA".to_string(), "ColB".to_string()],
                         vals: vec![
-                            Value::Bool {
-                                val: true,
-                                span: Span::test_data(),
-                            },
+                            Value::boolean(true, Span::test_data()),
                             Value::test_int(100),
                         ],
                         span: Span::test_data(),
@@ -111,10 +102,7 @@ impl Command for SubCommand {
                     vals: vec![Value::Record {
                         cols: vec!["ColA".to_string(), "ColB".to_string()],
                         vals: vec![
-                            Value::Bool {
-                                val: true,
-                                span: Span::test_data(),
-                            },
+                            Value::boolean(true, Span::test_data()),
                             Value::test_int(100),
                         ],
                         span: Span::test_data(),
@@ -129,14 +117,8 @@ impl Command for SubCommand {
                     vals: vec![Value::Record {
                         cols: vec!["ColA".to_string(), "ColB".to_string()],
                         vals: vec![
-                            Value::Bool {
-                                val: true,
-                                span: Span::test_data(),
-                            },
-                            Value::Bool {
-                                val: true,
-                                span: Span::test_data(),
-                            },
+                            Value::boolean(true, Span::test_data()),
+                            Value::boolean(true, Span::test_data()),
                         ],
                         span: Span::test_data(),
                     }],
@@ -146,28 +128,16 @@ impl Command for SubCommand {
             Example {
                 description: "Check if input string contains 'banana'",
                 example: "'hello' | str contains 'banana'",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
             Example {
                 description: "Check if list contains string",
                 example: "[one two three] | str contains o",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::Bool {
-                            val: true,
-                            span: Span::test_data(),
-                        },
-                        Value::Bool {
-                            val: true,
-                            span: Span::test_data(),
-                        },
-                        Value::Bool {
-                            val: false,
-                            span: Span::test_data(),
-                        },
+                        Value::boolean(true, Span::test_data()),
+                        Value::boolean(true, Span::test_data()),
+                        Value::boolean(false, Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),
@@ -177,18 +147,9 @@ impl Command for SubCommand {
                 example: "[one two three] | str contains -n o",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::Bool {
-                            val: false,
-                            span: Span::test_data(),
-                        },
-                        Value::Bool {
-                            val: false,
-                            span: Span::test_data(),
-                        },
-                        Value::Bool {
-                            val: true,
-                            span: Span::test_data(),
-                        },
+                        Value::boolean(false, Span::test_data()),
+                        Value::boolean(false, Span::test_data()),
+                        Value::boolean(true, Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),
@@ -208,8 +169,8 @@ fn action(
     head: Span,
 ) -> Value {
     match input {
-        Value::String { val, .. } => Value::Bool {
-            val: match case_insensitive {
+        Value::String { val, .. } => Value::boolean(
+            match case_insensitive {
                 true => {
                     if *not_contain {
                         !val.to_lowercase()
@@ -227,8 +188,8 @@ fn action(
                     }
                 }
             },
-            span: head,
-        },
+            head,
+        ),
         other => Value::Error {
             error: ShellError::UnsupportedInput(
                 format!(

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -95,10 +95,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     match &input {
         Value::String { val, .. } => {
             let distance = levenshtein_distance(val, compare_string);
-            Value::Int {
-                val: distance as i64,
-                span: head,
-            }
+            Value::int(distance as i64, head)
         }
         other => Value::Error {
             error: ShellError::UnsupportedInput(

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -67,18 +67,12 @@ impl Command for SubCommand {
             Example {
                 description: "Checks if string ends with '.rb'",
                 example: "'my_library.rb' | str ends-with '.rb'",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Checks if string ends with '.txt'",
                 example: "'my_library.rb' | str ends-with '.txt'",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
         ]
     }
@@ -86,10 +80,7 @@ impl Command for SubCommand {
 
 fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     match input {
-        Value::String { val, .. } => Value::Bool {
-            val: val.ends_with(&args.substring),
-            span: head,
-        },
+        Value::String { val, .. } => Value::boolean(val.ends_with(&args.substring), head),
         other => Value::Error {
             error: ShellError::UnsupportedInput(
                 format!(

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -143,26 +143,14 @@ fn action(
 
             if *end {
                 if let Some(result) = s[start_index..end_index].rfind(&**substring) {
-                    Value::Int {
-                        val: result as i64 + start_index as i64,
-                        span: head,
-                    }
+                    Value::int(result as i64 + start_index as i64, head)
                 } else {
-                    Value::Int {
-                        val: -1,
-                        span: head,
-                    }
+                    Value::int(-1, head)
                 }
             } else if let Some(result) = s[start_index..end_index].find(&**substring) {
-                Value::Int {
-                    val: result as i64 + start_index as i64,
-                    span: head,
-                }
+                Value::int(result as i64 + start_index as i64, head)
             } else {
-                Value::Int {
-                    val: -1,
-                    span: head,
-                }
+                Value::int(-1, head)
             }
         }
         other => Value::Error {

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -126,10 +126,7 @@ fn action(
 ) -> Value {
     let range = match range {
         Some(range) => range.clone(),
-        None => Value::String {
-            val: "".to_string(),
-            span: head,
-        },
+        None => Value::string("", head),
     };
 
     let r = process_range(input, &range, head);

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -78,18 +78,12 @@ impl Command for StrJoin {
             Example {
                 description: "Create a string from input",
                 example: "['nu', 'shell'] | str join",
-                result: Some(Value::String {
-                    val: "nushell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nushell", Span::test_data())),
             },
             Example {
                 description: "Create a string from input with a separator",
                 example: "['nu', 'shell'] | str join '-'",
-                result: Some(Value::String {
-                    val: "nu-shell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nu-shell", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -66,10 +66,7 @@ impl Command for SubCommand {
 
 fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
     match input {
-        Value::String { val, .. } => Value::Int {
-            val: val.len() as i64,
-            span: head,
-        },
+        Value::String { val, .. } => Value::int(val.len() as i64, head),
         other => Value::Error {
             error: ShellError::UnsupportedInput(
                 format!(

--- a/crates/nu-command/src/strings/str_/lpad.rs
+++ b/crates/nu-command/src/strings/str_/lpad.rs
@@ -82,34 +82,22 @@ impl Command for SubCommand {
             Example {
                 description: "Left-pad a string with asterisks until it's 10 characters wide",
                 example: "'nushell' | str lpad -l 10 -c '*'",
-                result: Some(Value::String {
-                    val: "***nushell".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("***nushell", Span::test_data())),
             },
             Example {
                 description: "Left-pad a string with zeroes until it's 10 character wide",
                 example: "'123' | str lpad -l 10 -c '0'",
-                result: Some(Value::String {
-                    val: "0000000123".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("0000000123", Span::test_data())),
             },
             Example {
                 description: "Use lpad to truncate a string to its last three characters",
                 example: "'123456789' | str lpad -l 3 -c '0'",
-                result: Some(Value::String {
-                    val: "789".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("789", Span::test_data())),
             },
             Example {
                 description: "Use lpad to pad Unicode",
                 example: "'▉' | str lpad -l 10 -c '▉'",
-                result: Some(Value::String {
-                    val: "▉▉▉▉▉▉▉▉▉▉".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("▉▉▉▉▉▉▉▉▉▉", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -94,18 +94,12 @@ impl Command for SubCommand {
             Example {
                 description: "Find and replace contents with capture group",
                 example: "'my_library.rb' | str replace '(.+).rb' '$1.nu'",
-                result: Some(Value::String {
-                    val: "my_library.nu".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("my_library.nu", Span::test_data())),
             },
             Example {
                 description: "Find and replace all occurrences of find string",
                 example: "'abc abc abc' | str replace -a 'b' 'z'",
-                result: Some(Value::String {
-                    val: "azc azc azc".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("azc azc azc", Span::test_data())),
             },
             Example {
                 description: "Find and replace all occurrences of find string in table",
@@ -115,18 +109,9 @@ impl Command for SubCommand {
                     vals: vec![Value::Record {
                         cols: vec!["ColA".to_string(), "ColB".to_string(), "ColC".to_string()],
                         vals: vec![
-                            Value::String {
-                                val: "azc".to_string(),
-                                span: Span::test_data(),
-                            },
-                            Value::String {
-                                val: "abc".to_string(),
-                                span: Span::test_data(),
-                            },
-                            Value::String {
-                                val: "ads".to_string(),
-                                span: Span::test_data(),
-                            },
+                            Value::string("azc", Span::test_data()),
+                            Value::string("abc", Span::test_data()),
+                            Value::string("ads", Span::test_data()),
                         ],
                         span: Span::test_data(),
                     }],
@@ -136,42 +121,27 @@ impl Command for SubCommand {
             Example {
                 description: "Find and replace contents without using the replace parameter as a regular expression",
                 example: r#"'dogs_$1_cats' | str replace '\$1' '$2' -n"#,
-                result: Some(Value::String {
-                    val: "dogs_$2_cats".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("dogs_$2_cats", Span::test_data())),
             },
             Example {
                 description: "Find and replace the first occurence using string replacement *not* regular expressions",
                 example: r#"'c:\some\cool\path' | str replace 'c:\some\cool' '~' -s"#,
-                result: Some(Value::String {
-                    val: "~\\path".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("~\\path", Span::test_data())),
             },
             Example {
                 description: "Find and replace all occurences using string replacement *not* regular expressions",
                 example: r#"'abc abc abc' | str replace -a 'b' 'z' -s"#,
-                result: Some(Value::String {
-                    val: "azc azc azc".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("azc azc azc", Span::test_data())),
             },
             Example {
                 description: "Find and replace with fancy-regex",
                 example: r#"'a sucessful b' | str replace '\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b' '${1}ucce$2'"#,
-                result: Some(Value::String {
-                    val: "a successful b".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("a successful b", Span::test_data())),
             },
             Example {
                 description: "Find and replace with fancy-regex",
                 example: r#"'GHIKK-9+*' | str replace '[*[:xdigit:]+]' 'z'"#,
-                result: Some(Value::String {
-                    val: "GHIKK-z+*".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("GHIKK-z+*", Span::test_data())),
             },
 
         ]
@@ -277,10 +247,7 @@ mod tests {
 
     #[test]
     fn can_have_capture_groups() {
-        let word = Value::String {
-            val: "Cargo.toml".to_string(),
-            span: Span::test_data(),
-        };
+        let word = Value::string("Cargo.toml", Span::test_data());
 
         let options = Arguments {
             find: test_spanned_string("Cargo.(.+)"),
@@ -292,12 +259,6 @@ mod tests {
         };
 
         let actual = action(&word, &options, Span::test_data());
-        assert_eq!(
-            actual,
-            Value::String {
-                val: "Carga.toml".to_string(),
-                span: Span::test_data()
-            }
-        );
+        assert_eq!(actual, Value::string("Carga.toml", Span::test_data()));
     }
 }

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -51,28 +51,16 @@ impl Command for SubCommand {
             Example {
                 description: "Reverse a single string",
                 example: "'Nushell' | str reverse",
-                result: Some(Value::String {
-                    val: "llehsuN".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("llehsuN", Span::test_data())),
             },
             Example {
                 description: "Reverse multiple strings in a list",
                 example: "['Nushell' 'is' 'cool'] | str reverse",
                 result: Some(Value::List {
                     vals: vec![
-                        Value::String {
-                            val: "llehsuN".to_string(),
-                            span: Span::test_data(),
-                        },
-                        Value::String {
-                            val: "si".to_string(),
-                            span: Span::test_data(),
-                        },
-                        Value::String {
-                            val: "looc".to_string(),
-                            span: Span::test_data(),
-                        },
+                        Value::string("llehsuN", Span::test_data()),
+                        Value::string("si", Span::test_data()),
+                        Value::string("looc", Span::test_data()),
                     ],
                     span: Span::test_data(),
                 }),

--- a/crates/nu-command/src/strings/str_/rpad.rs
+++ b/crates/nu-command/src/strings/str_/rpad.rs
@@ -82,34 +82,22 @@ impl Command for SubCommand {
             Example {
                 description: "Right-pad a string with asterisks until it's 10 characters wide",
                 example: "'nushell' | str rpad -l 10 -c '*'",
-                result: Some(Value::String {
-                    val: "nushell***".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("nushell***", Span::test_data())),
             },
             Example {
                 description: "Right-pad a string with zeroes until it's 10 characters wide",
                 example: "'123' | str rpad -l 10 -c '0'",
-                result: Some(Value::String {
-                    val: "1230000000".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("1230000000", Span::test_data())),
             },
             Example {
                 description: "Use rpad to truncate a string to its first three characters",
                 example: "'123456789' | str rpad -l 3 -c '0'",
-                result: Some(Value::String {
-                    val: "123".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("123", Span::test_data())),
             },
             Example {
                 description: "Use rpad to pad Unicode",
                 example: "'▉' | str rpad -l 10 -c '▉'",
-                result: Some(Value::String {
-                    val: "▉▉▉▉▉▉▉▉▉▉".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("▉▉▉▉▉▉▉▉▉▉", Span::test_data())),
             },
         ]
     }

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -70,26 +70,17 @@ impl Command for SubCommand {
             Example {
                 description: "Checks if input string starts with 'my'",
                 example: "'my_library.rb' | str starts-with 'my'",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Checks if input string starts with 'my'",
                 example: "'Cargo.toml' | str starts-with 'Car'",
-                result: Some(Value::Bool {
-                    val: true,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(true, Span::test_data())),
             },
             Example {
                 description: "Checks if input string starts with 'my'",
                 example: "'Cargo.toml' | str starts-with '.toml'",
-                result: Some(Value::Bool {
-                    val: false,
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::boolean(false, Span::test_data())),
             },
         ]
     }
@@ -99,10 +90,7 @@ fn action(input: &Value, Arguments { substring, .. }: &Arguments, head: Span) ->
     match input {
         Value::String { val: s, .. } => {
             let starts_with = s.starts_with(substring);
-            Value::Bool {
-                val: starts_with,
-                span: head,
-            }
+            Value::boolean(starts_with, head)
         }
         other => Value::Error {
             error: ShellError::UnsupportedInput(

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -134,10 +134,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
 
             if start < len && end >= 0 {
                 match start.cmp(&end) {
-                    Ordering::Equal => Value::String {
-                        val: "".to_string(),
-                        span: head,
-                    },
+                    Ordering::Equal => Value::string("", head),
                     Ordering::Greater => Value::Error {
                         error: ShellError::UnsupportedInput(
                             "End must be greater than or equal to Start".to_string(),
@@ -165,10 +162,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                     },
                 }
             } else {
-                Value::String {
-                    val: "".to_string(),
-                    span: head,
-                }
+                Value::string("", head)
             }
         }
         other => Value::Error {
@@ -304,10 +298,7 @@ mod tests {
 
     #[test]
     fn substrings_indexes() {
-        let word = Value::String {
-            val: "andres".to_string(),
-            span: Span::test_data(),
-        };
+        let word = Value::string("andres", Span::test_data());
 
         let cases = vec![
             expectation("a", (0, 1)),
@@ -346,13 +337,7 @@ mod tests {
                 Span::test_data(),
             );
 
-            assert_eq!(
-                actual,
-                Value::String {
-                    val: expected.to_string(),
-                    span: Span::test_data()
-                }
-            );
+            assert_eq!(actual, Value::string(expected, Span::test_data()));
         }
     }
 }

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -295,10 +295,7 @@ mod tests {
             cols: cols.iter().map(|x| x.to_string()).collect(),
             vals: vals
                 .iter()
-                .map(|x| Value::String {
-                    val: x.to_string(),
-                    span: Span::test_data(),
-                })
+                .map(|x| Value::string(x.to_string(), Span::test_data()))
                 .collect(),
             span: Span::test_data(),
         }
@@ -308,10 +305,7 @@ mod tests {
         Value::List {
             vals: vals
                 .iter()
-                .map(|x| Value::String {
-                    val: x.to_string(),
-                    span: Span::test_data(),
-                })
+                .map(|x| Value::string(x.to_string(), Span::test_data()))
                 .collect(),
             span: Span::test_data(),
         }
@@ -475,29 +469,17 @@ mod tests {
     fn global_trims_table_all_white_space() {
         let row = Value::List {
             vals: vec![
-                Value::String {
-                    val: "  nu      shell   ".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("  nu      shell   ", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: "  d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("  d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
         let expected = Value::List {
             vals: vec![
-                Value::String {
-                    val: "nushell".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("nushell", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: "d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
@@ -559,29 +541,17 @@ mod tests {
     fn global_trims_table_all_custom_character() {
         let row = Value::List {
             vals: vec![
-                Value::String {
-                    val: "##nu####shell##".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("##nu####shell##", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: "#d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("#d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
         let expected = Value::List {
             vals: vec![
-                Value::String {
-                    val: "nushell".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("nushell", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: "d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
@@ -681,29 +651,17 @@ mod tests {
     fn global_trim_left_table() {
         let row = Value::List {
             vals: vec![
-                Value::String {
-                    val: "  a  ".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("  a  ", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: " d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string(" d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
         let expected = Value::List {
             vals: vec![
-                Value::String {
-                    val: "a  ".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("a  ", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: "d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
@@ -818,29 +776,17 @@ mod tests {
     fn global_trim_right_table() {
         let row = Value::List {
             vals: vec![
-                Value::String {
-                    val: "  a  ".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("  a  ", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: " d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string(" d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
         let expected = Value::List {
             vals: vec![
-                Value::String {
-                    val: "  a".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("  a", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: " d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string(" d", Span::test_data()),
             ],
             span: Span::test_data(),
         };
@@ -957,29 +903,17 @@ mod tests {
     fn global_trim_format_flag_table() {
         let row = Value::List {
             vals: vec![
-                Value::String {
-                    val: "  a    b     c    d  ".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("  a    b     c    d  ", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: " b c  d e   f".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string(" b c  d e   f", Span::test_data()),
             ],
             span: Span::test_data(),
         };
         let expected = Value::List {
             vals: vec![
-                Value::String {
-                    val: "a b c d".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("a b c d", Span::test_data()),
                 Value::int(65, Span::test_data()),
-                Value::String {
-                    val: "b c d e f".to_string(),
-                    span: Span::test_data(),
-                },
+                Value::string("b c d e f", Span::test_data()),
             ],
             span: Span::test_data(),
         };

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -479,10 +479,7 @@ mod tests {
                     val: "  nu      shell   ".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: "  d".to_string(),
                     span: Span::test_data(),
@@ -496,10 +493,7 @@ mod tests {
                     val: "nushell".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: "d".to_string(),
                     span: Span::test_data(),
@@ -569,10 +563,7 @@ mod tests {
                     val: "##nu####shell##".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: "#d".to_string(),
                     span: Span::test_data(),
@@ -586,10 +577,7 @@ mod tests {
                     val: "nushell".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: "d".to_string(),
                     span: Span::test_data(),
@@ -697,10 +685,7 @@ mod tests {
                     val: "  a  ".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: " d".to_string(),
                     span: Span::test_data(),
@@ -714,10 +699,7 @@ mod tests {
                     val: "a  ".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: "d".to_string(),
                     span: Span::test_data(),
@@ -840,10 +822,7 @@ mod tests {
                     val: "  a  ".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: " d".to_string(),
                     span: Span::test_data(),
@@ -857,10 +836,7 @@ mod tests {
                     val: "  a".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: " d".to_string(),
                     span: Span::test_data(),
@@ -985,10 +961,7 @@ mod tests {
                     val: "  a    b     c    d  ".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: " b c  d e   f".to_string(),
                     span: Span::test_data(),
@@ -1002,10 +975,7 @@ mod tests {
                     val: "a b c d".to_string(),
                     span: Span::test_data(),
                 },
-                Value::Int {
-                    val: 65,
-                    span: Span::test_data(),
-                },
+                Value::int(65, Span::test_data()),
                 Value::String {
                     val: "b c d e f".to_string(),
                     span: Span::test_data(),

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -407,17 +407,11 @@ impl ExternalCommand {
                                 }
                             }
                             if let Some(code) = x.code() {
-                                let _ = exit_code_tx.send(Value::Int {
-                                    val: code as i64,
-                                    span: head,
-                                });
+                                let _ = exit_code_tx.send(Value::int(code as i64, head));
                             } else if x.success() {
-                                let _ = exit_code_tx.send(Value::Int { val: 0, span: head });
+                                let _ = exit_code_tx.send(Value::int(0, head));
                             } else {
-                                let _ = exit_code_tx.send(Value::Int {
-                                    val: -1,
-                                    span: head,
-                                });
+                                let _ = exit_code_tx.send(Value::int(-1, head));
                             }
                             Ok(())
                         }

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -140,42 +140,27 @@ prints out the list properly."#
             Example {
                 description: "Render a simple list to a grid",
                 example: "[1 2 3 a b c] | grid",
-                result: Some(Value::String {
-                    val: "1 │ 2 │ 3 │ a │ b │ c\n".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("1 │ 2 │ 3 │ a │ b │ c\n", Span::test_data())),
             },
             Example {
                 description: "The above example is the same as:",
                 example: "[1 2 3 a b c] | wrap name | grid",
-                result: Some(Value::String {
-                    val: "1 │ 2 │ 3 │ a │ b │ c\n".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("1 │ 2 │ 3 │ a │ b │ c\n", Span::test_data())),
             },
             Example {
                 description: "Render a record to a grid",
                 example: "{name: 'foo', b: 1, c: 2} | grid",
-                result: Some(Value::String {
-                    val: "foo\n".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("foo\n", Span::test_data())),
             },
             Example {
                 description: "Render a list of records to a grid",
                 example: "[{name: 'A', v: 1} {name: 'B', v: 2} {name: 'C', v: 3}] | grid",
-                result: Some(Value::String {
-                    val: "A │ B │ C\n".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("A │ B │ C\n", Span::test_data())),
             },
             Example {
                 description: "Render a table with 'name' column in it to a grid",
                 example: "[[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid",
-                result: Some(Value::String {
-                    val: "0.1.0 │ 0.1.1 │ 0.2.0\n".to_string(),
-                    span: Span::test_data(),
-                }),
+                result: Some(Value::string("0.1.0 │ 0.1.1 │ 0.2.0\n", Span::test_data())),
             },
         ]
     }
@@ -251,10 +236,7 @@ fn create_grid_output(
 
     Ok(
         if let Some(grid_display) = grid.fit_into_width(cols as usize) {
-            Value::String {
-                val: grid_display.to_string(),
-                span: call.head,
-            }
+            Value::string(grid_display.to_string(), call.head)
         } else {
             Value::String {
                 val: format!("Couldn't fit grid into {} columns!", cols),

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -187,11 +187,7 @@ fn get_documentation(
                 engine_state,
                 stack,
                 &Call::new(Span::unknown()),
-                Value::String {
-                    val: example.example.to_string(),
-                    span: Span::unknown(),
-                }
-                .into_pipeline_data(),
+                Value::string(example.example, Span::unknown()).into_pipeline_data(),
             ) {
                 Ok(output) => {
                     let result = output.into_value(Span::unknown());

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -124,13 +124,7 @@ pub fn eval_call(
 
                             callee_stack.add_var(var_id, result);
                         } else {
-                            callee_stack.add_var(
-                                var_id,
-                                Value::Bool {
-                                    val: true,
-                                    span: call.head,
-                                },
-                            )
+                            callee_stack.add_var(var_id, Value::boolean(true, call.head))
                         }
                         found = true;
                     }
@@ -138,13 +132,7 @@ pub fn eval_call(
 
                 if !found {
                     if named.arg.is_none() {
-                        callee_stack.add_var(
-                            var_id,
-                            Value::Bool {
-                                val: false,
-                                span: call.head,
-                            },
-                        )
+                        callee_stack.add_var(var_id, Value::boolean(false, call.head))
                     } else if let Some(arg) = &named.default_value {
                         let result = eval_expression(engine_state, caller_stack, arg)?;
 
@@ -267,10 +255,7 @@ pub fn eval_expression(
     expr: &Expression,
 ) -> Result<Value, ShellError> {
     match &expr.expr {
-        Expr::Bool(b) => Ok(Value::Bool {
-            val: *b,
-            span: expr.span,
-        }),
+        Expr::Bool(b) => Ok(Value::boolean(*b, expr.span)),
         Expr::Int(i) => Ok(Value::Int {
             val: *i,
             span: expr.span,
@@ -364,10 +349,7 @@ pub fn eval_expression(
         Expr::UnaryNot(expr) => {
             let lhs = eval_expression(engine_state, stack, expr)?;
             match lhs {
-                Value::Bool { val, .. } => Ok(Value::Bool {
-                    val: !val,
-                    span: expr.span,
-                }),
+                Value::Bool { val, .. } => Ok(Value::boolean(!val, expr.span)),
                 _ => Err(ShellError::TypeMismatch("bool".to_string(), expr.span)),
             }
         }
@@ -381,10 +363,7 @@ pub fn eval_expression(
                     match boolean {
                         Boolean::And => {
                             if lhs.is_false() {
-                                Ok(Value::Bool {
-                                    val: false,
-                                    span: expr.span,
-                                })
+                                Ok(Value::boolean(false, expr.span))
                             } else {
                                 let rhs = eval_expression(engine_state, stack, rhs)?;
                                 lhs.and(op_span, &rhs, expr.span)
@@ -392,10 +371,7 @@ pub fn eval_expression(
                         }
                         Boolean::Or => {
                             if lhs.is_true() {
-                                Ok(Value::Bool {
-                                    val: true,
-                                    span: expr.span,
-                                })
+                                Ok(Value::boolean(true, expr.span))
                             } else {
                                 let rhs = eval_expression(engine_state, stack, rhs)?;
                                 lhs.or(op_span, &rhs, expr.span)

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -256,10 +256,7 @@ pub fn eval_expression(
 ) -> Result<Value, ShellError> {
     match &expr.expr {
         Expr::Bool(b) => Ok(Value::boolean(*b, expr.span)),
-        Expr::Int(i) => Ok(Value::Int {
-            val: *i,
-            span: expr.span,
-        }),
+        Expr::Int(i) => Ok(Value::int(*i, expr.span)),
         Expr::Float(f) => Ok(Value::Float {
             val: *f,
             span: expr.span,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -610,35 +610,23 @@ pub fn eval_expression(
             let cwd = current_dir_str(engine_state, stack)?;
             let path = expand_path_with(s, cwd);
 
-            Ok(Value::String {
-                val: path.to_string_lossy().to_string(),
-                span: expr.span,
-            })
+            Ok(Value::string(path.to_string_lossy(), expr.span))
         }
         Expr::Directory(s) => {
             if s == "-" {
-                Ok(Value::String {
-                    val: "-".to_string(),
-                    span: expr.span,
-                })
+                Ok(Value::string("-", expr.span))
             } else {
                 let cwd = current_dir_str(engine_state, stack)?;
                 let path = expand_path_with(s, cwd);
 
-                Ok(Value::String {
-                    val: path.to_string_lossy().to_string(),
-                    span: expr.span,
-                })
+                Ok(Value::string(path.to_string_lossy(), expr.span))
             }
         }
         Expr::GlobPattern(s) => {
             let cwd = current_dir_str(engine_state, stack)?;
             let path = expand_path_with(s, cwd);
 
-            Ok(Value::String {
-                val: path.to_string_lossy().to_string(),
-                span: expr.span,
-            })
+            Ok(Value::string(path.to_string_lossy(), expr.span))
         }
         Expr::Signature(_) => Ok(Value::Nothing { span: expr.span }),
         Expr::Garbage => Ok(Value::Nothing { span: expr.span }),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -257,10 +257,7 @@ pub fn eval_expression(
     match &expr.expr {
         Expr::Bool(b) => Ok(Value::boolean(*b, expr.span)),
         Expr::Int(i) => Ok(Value::int(*i, expr.span)),
-        Expr::Float(f) => Ok(Value::Float {
-            val: *f,
-            span: expr.span,
-        }),
+        Expr::Float(f) => Ok(Value::float(*f, expr.span)),
         Expr::Binary(b) => Ok(Value::Binary {
             val: b.clone(),
             span: expr.span,

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -128,10 +128,7 @@ fn help_frame_data(
 
     macro_rules! nu_str {
         ($text:expr) => {
-            Value::String {
-                val: $text.to_string(),
-                span: NuSpan::unknown(),
-            }
+            Value::string($text.to_string(), NuSpan::unknown())
         };
     }
 
@@ -191,10 +188,7 @@ fn help_frame_data(
 fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Vec<Vec<Value>>) {
     macro_rules! nu_str {
         ($text:expr) => {
-            Value::String {
-                val: $text.to_string(),
-                span: NuSpan::unknown(),
-            }
+            Value::string($text, NuSpan::unknown())
         };
     }
 

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -621,10 +621,7 @@ fn transpose_table(layer: &mut RecordLayer<'_>) {
         let mut data = _transpose_table(&layer.records, count_rows, count_columns);
 
         for (column, column_name) in layer.columns.iter().enumerate() {
-            let value = Value::String {
-                val: column_name.to_string(),
-                span: NuSpan::unknown(),
-            };
+            let value = Value::string(column_name, NuSpan::unknown());
 
             data[column].insert(0, value);
         }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -109,10 +109,7 @@ pub enum Value {
 impl Clone for Value {
     fn clone(&self) -> Self {
         match self {
-            Value::Bool { val, span } => Value::Bool {
-                val: *val,
-                span: *span,
-            },
+            Value::Bool { val, span } => Value::boolean(*val, *span),
             Value::Int { val, span } => Value::Int {
                 val: *val,
                 span: *span,
@@ -3418,10 +3415,7 @@ mod tests {
                         val: 0.0,
                         span: Span::unknown(),
                     },
-                    Value::Bool {
-                        val: false,
-                        span: Span::unknown(),
-                    },
+                    Value::boolean(false, Span::unknown()),
                 ],
                 span: Span::unknown(),
             };

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -127,10 +127,7 @@ impl Clone for Value {
                 val: val.clone(),
                 span: *span,
             },
-            Value::Float { val, span } => Value::Float {
-                val: *val,
-                span: *span,
-            },
+            Value::Float { val, span } => Value::float(*val, *span),
             Value::String { val, span } => Value::String {
                 val: val.clone(),
                 span: *span,
@@ -3374,29 +3371,20 @@ mod tests {
                 span: Span::unknown(),
             };
             let list_of_floats = Value::List {
-                vals: vec![Value::Float {
-                    val: 0.0,
-                    span: Span::unknown(),
-                }],
+                vals: vec![Value::float(0.0, Span::unknown())],
                 span: Span::unknown(),
             };
             let list_of_ints_and_floats = Value::List {
                 vals: vec![
                     Value::int(0, Span::unknown()),
-                    Value::Float {
-                        val: 0.0,
-                        span: Span::unknown(),
-                    },
+                    Value::float(0.0, Span::unknown()),
                 ],
                 span: Span::unknown(),
             };
             let list_of_ints_and_floats_and_bools = Value::List {
                 vals: vec![
                     Value::int(0, Span::unknown()),
-                    Value::Float {
-                        val: 0.0,
-                        span: Span::unknown(),
-                    },
+                    Value::float(0.0, Span::unknown()),
                     Value::boolean(false, Span::unknown()),
                 ],
                 span: Span::unknown(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1321,10 +1321,7 @@ impl Value {
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors.
     pub fn test_string(s: impl Into<String>) -> Value {
-        Value::String {
-            val: s.into(),
-            span: Span::test_data(),
-        }
+        Value::string(s, Span::test_data())
     }
 
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -110,10 +110,7 @@ impl Clone for Value {
     fn clone(&self) -> Self {
         match self {
             Value::Bool { val, span } => Value::boolean(*val, *span),
-            Value::Int { val, span } => Value::Int {
-                val: *val,
-                span: *span,
-            },
+            Value::Int { val, span } => Value::int(*val, *span),
             Value::Filesize { val, span } => Value::Filesize {
                 val: *val,
                 span: *span,
@@ -665,10 +662,7 @@ impl Value {
                         }
                         Value::Binary { val, .. } => {
                             if let Some(item) = val.get(*count) {
-                                current = Value::Int {
-                                    val: *item as i64,
-                                    span: *origin_span,
-                                };
+                                current = Value::int(*item as i64, *origin_span);
                             } else if val.is_empty() {
                                 return Err(ShellError::AccessEmptyContent(*origin_span))
                             } else {
@@ -3379,10 +3373,7 @@ mod tests {
         #[test]
         fn test_list() {
             let list_of_ints = Value::List {
-                vals: vec![Value::Int {
-                    val: 0,
-                    span: Span::unknown(),
-                }],
+                vals: vec![Value::int(0, Span::unknown())],
                 span: Span::unknown(),
             };
             let list_of_floats = Value::List {
@@ -3394,10 +3385,7 @@ mod tests {
             };
             let list_of_ints_and_floats = Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 0,
-                        span: Span::unknown(),
-                    },
+                    Value::int(0, Span::unknown()),
                     Value::Float {
                         val: 0.0,
                         span: Span::unknown(),
@@ -3407,10 +3395,7 @@ mod tests {
             };
             let list_of_ints_and_floats_and_bools = Value::List {
                 vals: vec![
-                    Value::Int {
-                        val: 0,
-                        span: Span::unknown(),
-                    },
+                    Value::int(0, Span::unknown()),
                     Value::Float {
                         val: 0.0,
                         span: Span::unknown(),

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -29,25 +29,16 @@ impl Range {
         // Select from & to values if they're not specified
         // TODO: Replace the placeholder values with proper min/max for range based on data type
         let from = if let Value::Nothing { .. } = from {
-            Value::Int {
-                val: 0i64,
-                span: expr_span,
-            }
+            Value::int(0i64, expr_span)
         } else {
             from
         };
 
         let to = if let Value::Nothing { .. } = to {
             if let Ok(Value::Bool { val: true, .. }) = next.lt(expr_span, &from, expr_span) {
-                Value::Int {
-                    val: i64::MIN,
-                    span: expr_span,
-                }
+                Value::int(i64::MIN, expr_span)
             } else {
-                Value::Int {
-                    val: i64::MAX,
-                    span: expr_span,
-                }
+                Value::int(i64::MAX, expr_span)
             }
         } else {
             to
@@ -62,24 +53,15 @@ impl Range {
         // Convert the next value into the inctement
         let incr = if let Value::Nothing { .. } = next {
             if moves_up {
-                Value::Int {
-                    val: 1i64,
-                    span: expr_span,
-                }
+                Value::int(1i64, expr_span)
             } else {
-                Value::Int {
-                    val: -1i64,
-                    span: expr_span,
-                }
+                Value::int(-1i64, expr_span)
             }
         } else {
             next.sub(operator.next_op_span, &from, expr_span)?
         };
 
-        let zero = Value::Int {
-            val: 0i64,
-            span: expr_span,
-        };
+        let zero = Value::int(0i64, expr_span);
 
         // Increment must be non-zero, otherwise we iterate forever
         if matches!(

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -4,10 +4,7 @@ use nu_protocol::{Span, Value};
 fn test_comparison_nothing() {
     let values = vec![
         Value::int(1, Span::test_data()),
-        Value::String {
-            val: "string".into(),
-            span: Span::test_data(),
-        },
+        Value::string("string", Span::test_data()),
         Value::Float {
             val: 1.0,
             span: Span::test_data(),

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -5,10 +5,7 @@ fn test_comparison_nothing() {
     let values = vec![
         Value::int(1, Span::test_data()),
         Value::string("string", Span::test_data()),
-        Value::Float {
-            val: 1.0,
-            span: Span::test_data(),
-        },
+        Value::float(1.0, Span::test_data()),
     ];
 
     let nothing = Value::Nothing {

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -3,10 +3,7 @@ use nu_protocol::{Span, Value};
 #[test]
 fn test_comparison_nothing() {
     let values = vec![
-        Value::Int {
-            val: 1,
-            span: Span::test_data(),
-        },
+        Value::int(1, Span::test_data()),
         Value::String {
             val: "string".into(),
             span: Span::test_data(),

--- a/crates/nu_plugin_example/src/example.rs
+++ b/crates/nu_plugin_example/src/example.rs
@@ -62,10 +62,7 @@ impl Example {
         let vals = (0..10i64)
             .map(|i| {
                 let vals = (0..3)
-                    .map(|v| Value::Int {
-                        val: v * i,
-                        span: call.head,
-                    })
+                    .map(|v| Value::int(v * i, call.head))
                     .collect::<Vec<Value>>();
 
                 Value::Record {

--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -254,25 +254,13 @@ impl GStat {
         cols.push("stashes".into());
         vals.push(Value::int(-1, *span));
         cols.push("repo_name".into());
-        vals.push(Value::String {
-            val: "no_repository".to_string(),
-            span: *span,
-        });
+        vals.push(Value::string("no_repository", *span));
         cols.push("tag".into());
-        vals.push(Value::String {
-            val: "no_tag".to_string(),
-            span: *span,
-        });
+        vals.push(Value::string("no_tag", *span));
         cols.push("branch".into());
-        vals.push(Value::String {
-            val: "no_branch".to_string(),
-            span: *span,
-        });
+        vals.push(Value::string("no_branch", *span));
         cols.push("remote".into());
-        vals.push(Value::String {
-            val: "no_remote".to_string(),
-            span: *span,
-        });
+        vals.push(Value::string("no_remote", *span));
 
         Value::Record {
             cols,

--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -152,80 +152,35 @@ impl GStat {
         let mut vals = vec![];
 
         cols.push("idx_added_staged".into());
-        vals.push(Value::Int {
-            val: stats.idx_added_staged as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.idx_added_staged as i64, *span));
         cols.push("idx_modified_staged".into());
-        vals.push(Value::Int {
-            val: stats.idx_modified_staged as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.idx_modified_staged as i64, *span));
         cols.push("idx_deleted_staged".into());
-        vals.push(Value::Int {
-            val: stats.idx_deleted_staged as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.idx_deleted_staged as i64, *span));
         cols.push("idx_renamed".into());
-        vals.push(Value::Int {
-            val: stats.idx_renamed as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.idx_renamed as i64, *span));
         cols.push("idx_type_changed".into());
-        vals.push(Value::Int {
-            val: stats.idx_type_changed as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.idx_type_changed as i64, *span));
         cols.push("wt_untracked".into());
-        vals.push(Value::Int {
-            val: stats.wt_untracked as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.wt_untracked as i64, *span));
         cols.push("wt_modified".into());
-        vals.push(Value::Int {
-            val: stats.wt_modified as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.wt_modified as i64, *span));
         cols.push("wt_deleted".into());
-        vals.push(Value::Int {
-            val: stats.wt_deleted as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.wt_deleted as i64, *span));
         cols.push("wt_type_changed".into());
-        vals.push(Value::Int {
-            val: stats.wt_type_changed as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.wt_type_changed as i64, *span));
         cols.push("wt_renamed".into());
-        vals.push(Value::Int {
-            val: stats.wt_renamed as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.wt_renamed as i64, *span));
         cols.push("ignored".into());
-        vals.push(Value::Int {
-            val: stats.ignored as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.ignored as i64, *span));
         cols.push("conflicts".into());
-        vals.push(Value::Int {
-            val: stats.conflicts as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.conflicts as i64, *span));
         cols.push("ahead".into());
-        vals.push(Value::Int {
-            val: stats.ahead as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.ahead as i64, *span));
         cols.push("behind".into());
-        vals.push(Value::Int {
-            val: stats.behind as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.behind as i64, *span));
         cols.push("stashes".into());
-        vals.push(Value::Int {
-            val: stats.stashes as i64,
-            span: *span,
-        });
+        vals.push(Value::int(stats.stashes as i64, *span));
         cols.push("repo_name".into());
         vals.push(Value::String {
             val: repo_name,
@@ -269,80 +224,35 @@ impl GStat {
         let mut vals = vec![];
 
         cols.push("idx_added_staged".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("idx_modified_staged".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("idx_deleted_staged".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("idx_renamed".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("idx_type_changed".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("wt_untracked".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("wt_modified".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("wt_deleted".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("wt_type_changed".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("wt_renamed".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("ignored".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("conflicts".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("ahead".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("behind".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("stashes".into());
-        vals.push(Value::Int {
-            val: -1,
-            span: *span,
-        });
+        vals.push(Value::int(-1, *span));
         cols.push("repo_name".into());
         vals.push(Value::String {
             val: "no_repository".to_string(),

--- a/crates/nu_plugin_inc/src/inc.rs
+++ b/crates/nu_plugin_inc/src/inc.rs
@@ -31,12 +31,7 @@ impl Inc {
             Some(Action::SemVerAction(act_on)) => {
                 let mut ver = match semver::Version::parse(input) {
                     Ok(parsed_ver) => parsed_ver,
-                    Err(_) => {
-                        return Value::String {
-                            val: input.to_string(),
-                            span: head,
-                        }
-                    }
+                    Err(_) => return Value::string(input, head),
                 };
 
                 match act_on {
@@ -45,20 +40,11 @@ impl Inc {
                     SemVerAction::Patch => ver.increment_patch(),
                 }
 
-                Value::String {
-                    val: ver.to_string(),
-                    span: head,
-                }
+                Value::string(ver.to_string(), head)
             }
             Some(Action::Default) | None => match input.parse::<u64>() {
-                Ok(v) => Value::String {
-                    val: (v + 1).to_string(),
-                    span: head,
-                },
-                Err(_) => Value::String {
-                    val: input.to_string(),
-                    span: head,
-                },
+                Ok(v) => Value::string((v + 1).to_string(), head),
+                Err(_) => Value::string(input, head),
             },
         }
     }
@@ -134,10 +120,7 @@ mod tests {
 
         #[test]
         fn major() {
-            let expected = Value::String {
-                val: "1.0.0".to_string(),
-                span: Span::test_data(),
-            };
+            let expected = Value::string("1.0.0", Span::test_data());
             let mut inc = Inc::new();
             inc.for_semver(SemVerAction::Major);
             assert_eq!(inc.apply("0.1.3", Span::test_data()), expected)
@@ -145,10 +128,7 @@ mod tests {
 
         #[test]
         fn minor() {
-            let expected = Value::String {
-                val: "0.2.0".to_string(),
-                span: Span::test_data(),
-            };
+            let expected = Value::string("0.2.0", Span::test_data());
             let mut inc = Inc::new();
             inc.for_semver(SemVerAction::Minor);
             assert_eq!(inc.apply("0.1.3", Span::test_data()), expected)
@@ -156,10 +136,7 @@ mod tests {
 
         #[test]
         fn patch() {
-            let expected = Value::String {
-                val: "0.1.4".to_string(),
-                span: Span::test_data(),
-            };
+            let expected = Value::string("0.1.4", Span::test_data());
             let mut inc = Inc::new();
             inc.for_semver(SemVerAction::Patch);
             assert_eq!(inc.apply("0.1.3", Span::test_data()), expected)

--- a/crates/nu_plugin_inc/src/inc.rs
+++ b/crates/nu_plugin_inc/src/inc.rs
@@ -105,10 +105,7 @@ impl Inc {
 
     pub fn inc_value(&self, head: Span, value: &Value) -> Result<Value, LabeledError> {
         match value {
-            Value::Int { val, span } => Ok(Value::Int {
-                val: val + 1,
-                span: *span,
-            }),
+            Value::Int { val, span } => Ok(Value::int(val + 1, *span)),
             Value::String { val, .. } => Ok(self.apply(val, head)),
             x => {
                 let msg = x.as_string().map_err(|e| LabeledError {

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -151,10 +151,7 @@ pub fn nu_repl() {
 
     stack.add_env_var(
         "PWD".to_string(),
-        Value::String {
-            val: cwd.to_string_lossy().to_string(),
-            span: Span::test_data(),
-        },
+        Value::string(cwd.to_string_lossy(), Span::test_data()),
     );
 
     let mut last_output = String::new();


### PR DESCRIPTION
# Description

While perusing Value.rs, I noticed the `Value::int()`, `Value::float()`, `Value::boolean()` and `Value::string()` constructors, which seem designed to make it easier to construct various Values, but which aren't used often at all in the codebase. So, using a few find-replaces regexes, I increased their usage. This reduces overall LOC because structures like this:
```
Value::Int {
  val: a,
  span: head
}
```
are changed into
```
Value::int(a, head)
```
and are respected as such by the project's formatter.
There are little readability concerns because the second argument to all of these is `span`, and it's almost always extremely obvious which is the span at every callsite.

# User-Facing Changes

None.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
