### PR TITLE
make split row works like python and rust ways

### DIFF
--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -57,9 +57,11 @@ impl Command for SubCommand {
                 example: "echo 'abc' | split row ''",
                 result: Some(Value::List {
                     vals: vec![
+                        Value::test_string(""),
                         Value::test_string("a"),
                         Value::test_string("b"),
                         Value::test_string("c"),
+                        Value::test_string(""),
                     ],
                     span: Span::test_data(),
                 }),

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -76,6 +76,20 @@ impl Command for SubCommand {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Split a string by '-'",
+                example: "echo '-a-b-c-' | split row '-'",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_string(""),
+                        Value::test_string("a"),
+                        Value::test_string("b"),
+                        Value::test_string("c"),
+                        Value::test_string(""),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }
@@ -107,23 +121,11 @@ fn split_row_helper(
                 match max_split {
                     Some(max_split) => s
                         .splitn(max_split, &separator.item)
-                        .filter_map(|s| {
-                            if s.trim() != "" {
-                                Some(Value::string(s, v_span))
-                            } else {
-                                None
-                            }
-                        })
+                        .map(|s| Value::string(s, v_span))
                         .collect(),
                     None => s
                         .split(&separator.item)
-                        .filter_map(|s| {
-                            if s.trim() != "" {
-                                Some(Value::string(s, v_span))
-                            } else {
-                                None
-                            }
-                        })
+                        .map(|s| Value::string(s, v_span))
                         .collect(),
                 }
             } else {


### PR DESCRIPTION
# Description

Fixes: #7389 

Make split row works more like python or rust, especially, when the input string stars/ends with separator, append a empty string to result.  Here are examples:

python:
```python
﻿﻿In [6]: "\nasdf\nghi\n".split("\n")
Out[6]: ['', 'asdf', 'ghi', '']
```
rust:
```rust
fn main() {
    let x = "\nabc\ndef\n";
    let y = x.split("\n").collect::<Vec<&str>>();
    println!("{:?}", y);   // outputs: ["", "abc", "def", ""]
}
```
# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
