### PR TITLE
ensure that when nu evaluates files, it allows early returns

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -39,6 +39,7 @@ pub fn read_plugin_file(
                 &contents,
                 &plugin_filename,
                 PipelineData::empty(),
+                false,
             );
         }
     }
@@ -86,6 +87,7 @@ pub fn eval_config_contents(
                 &contents,
                 &config_filename,
                 PipelineData::empty(),
+                false,
             );
 
             // Merge the environment in case env vars changed in the config

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -106,13 +106,21 @@ pub fn evaluate_file(
             &file,
             file_path_str,
             PipelineData::empty(),
+            true,
         ) {
             std::process::exit(1);
         }
-        if !eval_source(engine_state, stack, args.as_bytes(), "<commandline>", input) {
+        if !eval_source(
+            engine_state,
+            stack,
+            args.as_bytes(),
+            "<commandline>",
+            input,
+            true,
+        ) {
             std::process::exit(1);
         }
-    } else if !eval_source(engine_state, stack, &file, file_path_str, input) {
+    } else if !eval_source(engine_state, stack, &file, file_path_str, input, true) {
         std::process::exit(1);
     }
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -139,6 +139,7 @@ pub fn evaluate_repl(
             s.item.as_bytes(),
             &format!("entry #{}", entry_num),
             PipelineData::empty(),
+            false,
         );
         engine_state.merge_env(stack, get_guaranteed_cwd(engine_state, stack))?;
     }
@@ -423,6 +424,7 @@ pub fn evaluate_repl(
                         s.as_bytes(),
                         &format!("entry #{}", entry_num),
                         PipelineData::empty(),
+                        false,
                     );
                 }
                 let cmd_duration = start_time.elapsed();

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -1,5 +1,5 @@
 use crate::repl::eval_hook;
-use nu_engine::eval_block;
+use nu_engine::{eval_block, eval_block_with_early_return};
 use nu_parser::{escape_quote_string, lex, parse, unescape_unquote_string, Token, TokenContents};
 use nu_protocol::engine::StateWorkingSet;
 use nu_protocol::CliError;
@@ -203,6 +203,7 @@ pub fn eval_source(
     source: &[u8],
     fname: &str,
     input: PipelineData,
+    allow_return: bool,
 ) -> bool {
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);
@@ -228,7 +229,13 @@ pub fn eval_source(
         return false;
     }
 
-    match eval_block(engine_state, stack, &block, input, false, false) {
+    let b = if allow_return {
+        eval_block_with_early_return(engine_state, stack, &block, input, false, false)
+    } else {
+        eval_block(engine_state, stack, &block, input, false, false)
+    };
+
+    match b {
         Ok(pipeline_data) => {
             let config = engine_state.get_config();
             let result;

--- a/crates/nu-command/src/deprecated/source.rs
+++ b/crates/nu-command/src/deprecated/source.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::{eval_block_with_early_return, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type};
@@ -48,7 +48,7 @@ impl Command for Source {
         let block_id: i64 = call.req_parser_info(engine_state, stack, 0)?;
 
         let block = engine_state.get_block(block_id as usize).clone();
-        eval_block(
+        eval_block_with_early_return(
             engine_state,
             stack,
             &block,

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use nu_engine::{eval_block, find_in_dirs_env, redirect_env, CallExt};
+use nu_engine::{eval_block_with_early_return, find_in_dirs_env, redirect_env, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -62,7 +62,7 @@ impl Command for SourceEnv {
         let block = engine_state.get_block(block_id as usize).clone();
         let mut callee_stack = caller_stack.gather_captures(&block.captures);
 
-        let result = eval_block(
+        let result = eval_block_with_early_return(
             engine_state,
             &mut callee_stack,
             &block,

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -23,3 +23,15 @@ fn early_return_if_false() {
 
     assert_eq!(actual.out, r#"100"#);
 }
+
+#[test]
+fn return_works_in_script_without_def_main() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            exec (ls ../../../target/*/nu | get name.0) early_return.nu
+        "#
+    ));
+
+    assert!(actual.err.is_empty());
+}

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -24,13 +24,12 @@ fn early_return_if_false() {
     assert_eq!(actual.out, r#"100"#);
 }
 
-#[cfg(not(windows))]
 #[test]
 fn return_works_in_script_without_def_main() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            exec (ls ../../../target/*/nu | get name.0) early_return.nu
+            nu early_return.nu
         "#
     ));
 

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -24,12 +24,26 @@ fn early_return_if_false() {
     assert_eq!(actual.out, r#"100"#);
 }
 
+#[cfg(not(windows))]
 #[test]
 fn return_works_in_script_without_def_main() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             exec (ls ../../../target/*/nu | get name.0) early_return.nu
+        "#
+    ));
+
+    assert!(actual.err.is_empty());
+}
+
+#[cfg(windows)]
+#[test]
+fn return_works_in_script_without_def_main() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            exec (ls ../../../target/*/nu.exe | get name.0) early_return.nu
         "#
     ));
 

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -36,16 +36,3 @@ fn return_works_in_script_without_def_main() {
 
     assert!(actual.err.is_empty());
 }
-
-#[cfg(windows)]
-#[test]
-fn return_works_in_script_without_def_main() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            exec (ls ../../../target/*/nu.exe | get name.0) early_return.nu
-        "#
-    ));
-
-    assert!(actual.err.is_empty());
-}

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -315,3 +315,15 @@ fn source_env_const_file() {
         assert_eq!(actual.out, "foo");
     })
 }
+
+#[test]
+fn source_respects_early_return() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            source early_return.nu
+        "#
+    ));
+
+    assert!(actual.err.is_empty());
+}

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -138,6 +138,7 @@ pub(crate) fn read_default_env_file(engine_state: &mut EngineState, stack: &mut 
         config_file.as_bytes(),
         "default_env.nu",
         PipelineData::empty(),
+        false,
     );
 
     info!("read_config_file {}:{}:{}", file!(), line!(), column!());
@@ -174,6 +175,7 @@ fn eval_default_config(
             "default_config.nu"
         },
         PipelineData::empty(),
+        false,
     );
 
     // Merge the environment in case env vars changed in the config

--- a/tests/fixtures/formats/early_return.nu
+++ b/tests/fixtures/formats/early_return.nu
@@ -1,0 +1,3 @@
+echo "a"
+return 1
+error make {msg: "this should not show"}


### PR DESCRIPTION
# Description

Fixes #7301.

# User-Facing Changes

`return` can now be used in scripts without explicit `def main`.

# Tests + Formatting

Don't forget to add tests that cover your changes. (I'm not sure how to test this.)

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
