### PR TITLE
remove example missed from an earlier refactor

### DIFF
--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -112,11 +112,6 @@ impl Command for SeqDate {
                     span,
                 }),
             },
-            Example {
-                description: "starting on May 5th, 2020, print the next 10 days in your locale's date format, colon separated",
-                example: "seq date -o %x -s ':' -d 10 -b '2020-05-01'",
-                result: None,
-            },
         ]
     }
 


### PR DESCRIPTION
# Description

When `seq date` was changed to remove the `-s` param, the example was missed. This PR removes that example.

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
