### PR TITLE
fix docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,8 +19,9 @@ RUN echo '/usr/bin/nu' >> /etc/shells \
     |cut -f4 -d '"' \
     |xargs -I{} wget {} \
     && tar -xzf nu* \
-    && chmod +x nu \
+    && cd nu*-musl \
     && mv nu /usr/bin/nu \
+    && chmod +x /usr/bin/nu \
     && chown -R nushell:nushell /home/nushell/.config/nushell \
     && rm -rf /tmp/*
 


### PR DESCRIPTION
# Description

Docker build fails with the latest release 0.72.1
```bash
Sending build context to Docker daemon  3.072kB
Step 1/6 : FROM alpine
 ---> 49176f190c7e
Step 2/6 : LABEL maintainer=nushell
 ---> Using cache
 ---> 7afa6864f008
Step 3/6 : RUN echo '/usr/bin/nu' >> /etc/shells     && adduser -D -s /usr/bin/nu nushell     && mkdir -p /home/nushell/.config/nushell/     && wget -q https://raw.githubusercontent.com/nushell/nushell/main/crates/nu-utils/src/sample_config/default_config.nu -O /home/nushell/.config/nushell/config.nu     && wget -q https://raw.githubusercontent.com/nushell/nushell/main/crates/nu-utils/src/sample_config/default_env.nu -O /home/nushell/.config/nushell/env.nu     && cd /tmp     && wget -qO - https://api.github.com/repos/nushell/nushell/releases/latest     |grep browser_download_url     |grep musl     |cut -f4 -d '"'     |xargs -I{} wget {}     && tar -xzf nu*     && chmod +x nu     && mv nu /usr/bin/nu     && chown -R nushell:nushell /home/nushell/.config/nushell     && rm -rf /tmp/*
 ---> Running in fa544239a3ea
Connecting to github.com (140.82.121.4:443)
Connecting to objects.githubusercontent.com (185.199.108.133:443)
saving to 'nu-0.72.1-x86_64-unknown-linux-musl.tar.gz'
nu-0.72.1-x86_64-unk   3% |*                               |  552k  0:00:29 ETA
nu-0.72.1-x86_64-unk  93% |*****************************   | 15.2M  0:00:00 ETA
nu-0.72.1-x86_64-unk 100% |********************************| 16.2M  0:00:00 ETA
'nu-0.72.1-x86_64-unknown-linux-musl.tar.gz' saved
chmod: nu: No such file or directory
```