### PR TITLE
Make env-related tests more resilient

### DIFF
--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -194,7 +194,7 @@ fn source_env_eval_export_env_hide() {
 
         let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
 
-        assert!(actual.err.contains("cannot find column"));
+        assert!(actual.err.contains("not_found"));
     })
 }
 

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -97,7 +97,7 @@ fn use_eval_export_env_hide() {
 
         let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
 
-        assert!(actual.err.contains("cannot find column"));
+        assert!(actual.err.contains("not_found"));
     })
 }
 

--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -116,7 +116,7 @@ fn hides_alias_in_scope_4() -> TestResult {
 fn hides_env_in_scope_1() -> TestResult {
     fail_test(
         r#"let-env foo = "foo"; do { hide-env foo; $env.foo }"#,
-        "cannot find column",
+        "not_found",
     )
 }
 

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -337,8 +337,8 @@ fn remove_overlay_env() {
     let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
-    assert!(actual.err.contains("cannot find column"));
-    assert!(actual_repl.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
+    assert!(actual_repl.err.contains("not_found"));
 }
 
 #[test]
@@ -448,8 +448,8 @@ fn remove_overlay_discard_env() {
     let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
-    assert!(actual.err.contains("cannot find column"));
-    assert!(actual_repl.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
+    assert!(actual_repl.err.contains("not_found"));
 }
 
 #[test]
@@ -496,8 +496,8 @@ fn remove_overlay_dont_keep_env() {
     let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
-    assert!(actual.err.contains("cannot find column"));
-    assert!(actual_repl.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
+    assert!(actual_repl.err.contains("not_found"));
 }
 
 #[test]
@@ -550,8 +550,8 @@ fn remove_overlay_dont_keep_overwritten_env() {
     let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
-    assert!(actual.err.contains("cannot find column"));
-    assert!(actual_repl.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
+    assert!(actual_repl.err.contains("not_found"));
 }
 
 #[test]
@@ -604,8 +604,8 @@ fn remove_overlay_dont_keep_env_in_latest_overlay() {
     let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
-    assert!(actual.err.contains("cannot find column"));
-    assert!(actual_repl.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
+    assert!(actual_repl.err.contains("not_found"));
 }
 
 #[test]
@@ -799,8 +799,8 @@ fn overlay_use_export_env_hide() {
     let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
-    assert!(actual.err.contains("cannot find column"));
-    assert!(actual_repl.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
+    assert!(actual_repl.err.contains("not_found"));
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -392,7 +392,7 @@ fn let_env_hides_variable() {
     );
 
     assert_eq!(actual.out, "hello world");
-    assert!(actual.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
 }
 
 #[test]
@@ -411,7 +411,7 @@ fn let_env_hides_variable_in_parent_scope() {
     );
 
     assert_eq!(actual.out, "hello world");
-    assert!(actual.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
 }
 
 #[test]
@@ -424,7 +424,7 @@ fn unlet_env_variable() {
             echo $env.TEST_VAR
         "#
     );
-    assert!(actual.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
 }
 
 #[test]
@@ -469,7 +469,7 @@ fn let_env_doesnt_leak() {
         "#
     );
 
-    assert!(actual.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
 }
 
 #[test]
@@ -518,7 +518,7 @@ fn load_env_doesnt_leak() {
         "#
     );
 
-    assert!(actual.err.contains("cannot find column"));
+    assert!(actual.err.contains("not_found"));
 }
 
 #[test]


### PR DESCRIPTION
# Description

Fixes https://github.com/nushell/nushell/issues/6708

The error message of environment variable not found could change depending on the `$env` content which can produce random failures on different systems. This PR hopefully makes the tests more resilient.

# User-Facing Changes

None

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
