### PR TITLE
Replace row conditions with closures in commands

### DIFF
--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -44,12 +44,6 @@ impl Command for All {
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description:
-                    "Check that all of the values are even, using the built-in $it variable",
-                example: "[2 4 6 8] | all {|el| ($el mod 2) == 0 }",
-                result: Some(Value::test_bool(true)),
-            },
-            Example {
                 description: "Check that all values are equal to twice their index",
                 example: "[0 2 4 6] | all {|el ind| $el == $ind * 2 }",
                 result: Some(Value::test_bool(true)),

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -22,8 +22,8 @@ impl Command for All {
             ])
             .required(
                 "predicate",
-                SyntaxShape::RowCondition,
-                "the expression, or block, that must evaluate to a boolean",
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                "a closure that must evaluate to a boolean",
             )
             .category(Category::Filters)
     }
@@ -40,23 +40,23 @@ impl Command for All {
         vec![
             Example {
                 description: "Check if each row's status is the string 'UP'",
-                example: "[[status]; [UP] [UP]] | all status == UP",
+                example: "[[status]; [UP] [UP]] | all {|el| $el.status == UP }",
                 result: Some(Value::test_bool(true)),
             },
             Example {
                 description:
                     "Check that all of the values are even, using the built-in $it variable",
-                example: "[2 4 6 8] | all ($it mod 2) == 0",
-                result: Some(Value::test_bool(true)),
-            },
-            Example {
-                description: "Check that all of the values are even, using a block",
-                example: "[2 4 6 8] | all {|e| $e mod 2 == 0 }",
+                example: "[2 4 6 8] | all {|el| ($el mod 2) == 0 }",
                 result: Some(Value::test_bool(true)),
             },
             Example {
                 description: "Check that all values are equal to twice their index",
                 example: "[0 2 4 6] | all {|el ind| $el == $ind * 2 }",
+                result: Some(Value::test_bool(true)),
+            },
+            Example {
+                description: "Check that all of the values are even, using a stored closure",
+                example: "let cond = {|el| ($el mod 2) == 0 }; [2 4 6 8] | all $cond",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -22,8 +22,8 @@ impl Command for Any {
             ])
             .required(
                 "predicate",
-                SyntaxShape::RowCondition,
-                "the expression, or block, that should return a boolean",
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                "a closure that must evaluate to a boolean",
             )
             .category(Category::Filters)
     }
@@ -40,22 +40,17 @@ impl Command for Any {
         vec![
             Example {
                 description: "Check if any row's status is the string 'DOWN'",
-                example: "[[status]; [UP] [DOWN] [UP]] | any status == DOWN",
-                result: Some(Value::test_bool(true)),
-            },
-            Example {
-                description: "Check if any of the values is odd, using the built-in $it variable",
-                example: "[2 4 1 6 8] | any ($it mod 2) == 1",
-                result: Some(Value::test_bool(true)),
-            },
-            Example {
-                description: "Check if any of the values are odd, using a block",
-                example: "[2 4 1 6 8] | any {|e| $e mod 2 == 1 }",
+                example: "[[status]; [UP] [DOWN] [UP]] | any {|el| $el.status == DOWN }",
                 result: Some(Value::test_bool(true)),
             },
             Example {
                 description: "Check if any value is equal to twice its own index",
                 example: "[9 8 7 6] | any {|el ind| $el == $ind * 2 }",
+                result: Some(Value::test_bool(true)),
+            },
+            Example {
+                description: "Check if any of the values are odd, using a stored closure",
+                example: "let cond = {|e| $e mod 2 == 1 }; [2 4 1 6 8] | any $cond",
                 result: Some(Value::test_bool(true)),
             },
         ]

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -50,6 +50,14 @@ impl Command for SkipUntil {
                 }),
             },
             Example {
+                description: "Skip until the element is positive using stored condition",
+                example: "let cond = {|x| $x > 0 }; [-2 0 2 -1] | skip until $cond",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(2), Value::test_int(-1)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
                 description: "Skip until the field value is positive",
                 example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip until {|x| $x.a > 0 }",
                 result: Some(Value::List {

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -25,7 +25,7 @@ impl Command for SkipUntil {
             ])
             .required(
                 "predicate",
-                SyntaxShape::RowCondition,
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
                 "the predicate that skipped element must not match",
             )
             .category(Category::Filters)
@@ -43,7 +43,7 @@ impl Command for SkipUntil {
         vec![
             Example {
                 description: "Skip until the element is positive",
-                example: "[-2 0 2 -1] | skip until $it > 0",
+                example: "[-2 0 2 -1] | skip until {|x| $x > 0 }",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(2), Value::test_int(-1)],
                     span: Span::test_data(),
@@ -51,7 +51,7 @@ impl Command for SkipUntil {
             },
             Example {
                 description: "Skip until the field value is positive",
-                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip until $it.a > 0",
+                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip until {|x| $x.a > 0 }",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_record(vec!["a"], vec![Value::test_int(2)]),

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -25,7 +25,7 @@ impl Command for SkipWhile {
             ])
             .required(
                 "predicate",
-                SyntaxShape::RowCondition,
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
                 "the predicate that skipped element must match",
             )
             .category(Category::Filters)
@@ -43,7 +43,7 @@ impl Command for SkipWhile {
         vec![
             Example {
                 description: "Skip while the element is negative",
-                example: "[-2 0 2 -1] | skip while $it < 0",
+                example: "[-2 0 2 -1] | skip while {|x| $x < 0 }",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(0), Value::test_int(2), Value::test_int(-1)],
                     span: Span::test_data(),
@@ -51,7 +51,7 @@ impl Command for SkipWhile {
             },
             Example {
                 description: "Skip while the field value is negative",
-                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip while $it.a < 0",
+                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip while {|x| $x.a < 0 }",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_record(vec!["a"], vec![Value::test_int(0)]),

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -50,6 +50,14 @@ impl Command for SkipWhile {
                 }),
             },
             Example {
+                description: "Skip while the element is negative using stored condition",
+                example: "let cond = {|x| $x < 0 }; [-2 0 2 -1] | skip while $cond",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(0), Value::test_int(2), Value::test_int(-1)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
                 description: "Skip while the field value is negative",
                 example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip while {|x| $x.a < 0 }",
                 result: Some(Value::List {

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -46,6 +46,14 @@ impl Command for TakeUntil {
                 }),
             },
             Example {
+                description: "Take until the element is positive using stored condition",
+                example: "let cond = {|x| $x > 0 }; [-1 -2 9 1] | take until $cond",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(-1), Value::test_int(-2)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
                 description: "Take until the field value is positive",
                 example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take until {|x| $x.a > 0 }",
                 result: Some(Value::List {

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -25,7 +25,7 @@ impl Command for TakeUntil {
             ])
             .required(
                 "predicate",
-                SyntaxShape::RowCondition,
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
                 "the predicate that element(s) must not match",
             )
             .category(Category::Filters)
@@ -39,7 +39,7 @@ impl Command for TakeUntil {
         vec![
             Example {
                 description: "Take until the element is positive",
-                example: "[-1 -2 9 1] | take until $it > 0",
+                example: "[-1 -2 9 1] | take until {|x| $x > 0 }",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(-1), Value::test_int(-2)],
                     span: Span::test_data(),
@@ -47,7 +47,7 @@ impl Command for TakeUntil {
             },
             Example {
                 description: "Take until the field value is positive",
-                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take until $it.a > 0",
+                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take until {|x| $x.a > 0 }",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_record(vec!["a"], vec![Value::test_int(-1)]),

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -46,6 +46,14 @@ impl Command for TakeWhile {
                 }),
             },
             Example {
+                description: "Take while the element is negative using stored condition",
+                example: "let cond = {|x| $x < 0 }; [-1 -2 9 1] | take while $cond",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(-1), Value::test_int(-2)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
                 description: "Take while the field value is negative",
                 example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take while {|x| $x.a < 0 }",
                 result: Some(Value::List {

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -25,7 +25,7 @@ impl Command for TakeWhile {
             ])
             .required(
                 "predicate",
-                SyntaxShape::RowCondition,
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
                 "the predicate that element(s) must match",
             )
             .category(Category::Filters)
@@ -39,7 +39,7 @@ impl Command for TakeWhile {
         vec![
             Example {
                 description: "Take while the element is negative",
-                example: "[-1 -2 9 1] | take while $it < 0",
+                example: "[-1 -2 9 1] | take while {|x| $x < 0 }",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(-1), Value::test_int(-2)],
                     span: Span::test_data(),
@@ -47,7 +47,7 @@ impl Command for TakeWhile {
             },
             Example {
                 description: "Take while the field value is negative",
-                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take while $it.a < 0",
+                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take while {|x| $x.a < 0 }",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_record(vec!["a"], vec![Value::test_int(-1)]),

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -6,7 +6,7 @@ fn checks_all_rows_are_true() {
         cwd: ".", pipeline(
         r#"
                 echo  [ "Andrés", "Andrés", "Andrés" ]
-                | all $it == "Andrés"
+                | all {|it| $it == "Andrés" }
         "#
     ));
 
@@ -49,7 +49,7 @@ fn checks_all_columns_of_a_table_is_true() {
                         [      Darren, Schroeder, 10/11/2013,   1    ]
                         [      Yehuda,      Katz, 10/11/2013,   1    ]
                 ]
-                | all likes > 0
+                | all {|x| $x.likes > 0 }
         "#
     ));
 
@@ -61,7 +61,7 @@ fn checks_if_all_returns_error_with_invalid_command() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            [red orange yellow green blue purple] | all ($it | st length) > 4
+            [red orange yellow green blue purple] | all {|it| ($it | st length) > 4 }
         "#
     ));
 

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -6,7 +6,7 @@ fn checks_any_row_is_true() {
         cwd: ".", pipeline(
         r#"
                 echo  [ "Ecuador", "USA", "New Zealand" ]
-                | any $it == "New Zealand"
+                | any {|it| $it == "New Zealand" }
         "#
     ));
 
@@ -25,7 +25,7 @@ fn checks_any_column_of_a_table_is_true() {
                         [      Darren, Schroeder, 10/11/2013,   1    ]
                         [      Yehuda,      Katz, 10/11/2013,   1    ]
                 ]
-                | any rusty_at == 10/12/2013
+                | any {|x| $x.rusty_at == 10/12/2013 }
         "#
     ));
 
@@ -37,7 +37,7 @@ fn checks_if_any_returns_error_with_invalid_command() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            [red orange yellow green blue purple] | any ($it | st length) > 4
+            [red orange yellow green blue purple] | any {|it| ($it | st length) > 4 }
         "#
     ));
 

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -7,7 +7,7 @@ fn lines() {
         r#"
             open cargo_sample.toml -r
             | lines
-            | skip while $it != "[dependencies]"
+            | skip while {|it| $it != "[dependencies]" }
             | skip 1
             | first
             | split column "="

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -38,7 +38,7 @@ fn condition_is_met() {
                 | str trim
                 | str join (char nl)
                 | from csv
-                | skip until "Chicken Collection" == "Red Chickens"
+                | skip until {|row| $row."Chicken Collection" == "Red Chickens" }
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -38,7 +38,7 @@ fn condition_is_met() {
                 | str trim
                 | str join (char nl)
                 | from csv
-                | skip while "Chicken Collection" != "Red Chickens"
+                | skip while {|row| $row."Chicken Collection" != "Red Chickens" }
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -38,8 +38,8 @@ fn condition_is_met() {
                 | str trim
                 | str join (char nl)
                 | from csv
-                | skip while "Chicken Collection" != "Blue Chickens"
-                | take until "Chicken Collection" == "Red Chickens"
+                | skip while {|row| $row."Chicken Collection" != "Blue Chickens" }
+                | take until {|row| $row."Chicken Collection" == "Red Chickens" }
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -39,7 +39,7 @@ fn condition_is_met() {
                 | str join (char nl)
                 | from csv
                 | skip 1
-                | take while "Chicken Collection" != "Blue Chickens"
+                | take while {|row| $row."Chicken Collection" != "Blue Chickens"}
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -208,7 +208,7 @@ fn equals_separates_long_flag() -> TestResult {
 fn let_env_expressions() -> TestResult {
     let env = HashMap::from([("VENV_OLD_PATH", "Foobar"), ("Path", "Quux")]);
     run_test_with_env(
-        r#"let-env Path = if (env | any name == VENV_OLD_PATH) { $env.VENV_OLD_PATH } else { $env.Path }; echo $env.Path"#,
+        r#"let-env Path = if (env | any {|x| $x.name == VENV_OLD_PATH}) { $env.VENV_OLD_PATH } else { $env.Path }; echo $env.Path"#,
         "Foobar",
         &env,
     )


### PR DESCRIPTION
# Description

This PR changes some commands that previously accepted row conditions (like `$it > 5`) as parameter to accept closures instead. The reasons are:
a) The commands would need to move into parser keywords in the future while they feel more like commands to be implemented in Nushell code as a part of standard library.
b) In scripts, it is useful to store the predicate condition in a variable which you can't do with row conditions. 
c) These commands are not used that often to benefit enough from the shorter row condition syntax

# User-Facing Changes

The following commands now accept **closure** instead of a **row condition**:
- `take until`
- `take while`
- `skip until`
- `skip while`
- `any`
- `all`

This is a part of an effort to move away from shape-directed parsing. Related PR: https://github.com/nushell/nushell/pull/7365

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
