### PR TITLE
add interact-once switch to `rm`

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -322,8 +322,10 @@ fn interactive_copy(
     span: Span,
     copy_impl: impl Fn(PathBuf, PathBuf, Span) -> Value,
 ) -> Value {
-    let (interaction, confirmed) =
-        try_interaction(interactive, "cp: overwrite", &dst.to_string_lossy());
+    let (interaction, confirmed) = try_interaction(
+        interactive,
+        format!("cp: overwrite '{}'? ", dst.to_string_lossy()),
+    );
     if let Err(e) = interaction {
         Value::Error {
             error: ShellError::GenericError(

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -283,8 +283,10 @@ fn move_file(
     }
 
     if interactive && to.exists() {
-        let (interaction, confirmed) =
-            try_interaction(interactive, "mv: overwrite", &to.to_string_lossy());
+        let (interaction, confirmed) = try_interaction(
+            interactive,
+            format!("mv: overwrite '{}'? ", to.to_string_lossy()),
+        );
         if let Err(e) = interaction {
             return Err(ShellError::GenericError(
                 format!("Error during interaction: {:}", e),

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -90,11 +90,9 @@ impl Resource {}
 
 pub fn try_interaction(
     interactive: bool,
-    prompt_msg: &str,
-    file_name: &str,
+    prompt: String,
 ) -> (Result<Option<bool>, Box<dyn Error>>, bool) {
     let interaction = if interactive {
-        let prompt = format!("{} '{}'? ", prompt_msg, file_name);
         match get_interactive_confirmation(prompt) {
             Ok(i) => Ok(Some(i)),
             Err(e) => Err(e),


### PR DESCRIPTION
# Description

Fixes: #7216 

Adds `interact-once` switch which numbers out the number of files to delete and asks the user for confirmation.

```
/home/gabriel/test〉ls                                                                                                                                                  12/11/2022 11:25:42 AM
╭───┬───────┬──────┬──────┬──────────╮
│ # │ name  │ type │ size │ modified │
├───┼───────┼──────┼──────┼──────────┤
│ 0 │ a.txt │ file │  0 B │ now      │
│ 1 │ b.txt │ file │  0 B │ now      │
│ 2 │ c.txt │ file │  0 B │ now      │
╰───┴───────┴──────┴──────┴──────────╯
/home/gabriel/test〉rm *.txt -I                                                                                                                                         12/11/2022 11:25:42 AM
rm: remove 3 files? : y

/home/gabriel/test〉ls                                                                                                                                                  12/11/2022 11:25:51 AM
/home/gabriel/test〉                                                                                                                                                    12/11/2022 11:25:54 AM
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
