### PR TITLE
Tweak "Cannot convert {x} to a string argument" error in run_external

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -58,7 +58,7 @@ impl Command for External {
         // Translate environment variables from Values to Strings
         let env_vars_str = env_to_strings(engine_state, stack)?;
 
-        fn value_as_spanned(value: Value) -> Result<Spanned<String>, ShellError> {
+        fn value_as_spanned(value: Value, name: &String) -> Result<Spanned<String>, ShellError> {
             let span = value.span()?;
 
             value
@@ -66,7 +66,11 @@ impl Command for External {
                 .map(|item| Spanned { item, span })
                 .map_err(|_| {
                     ShellError::ExternalCommand(
-                        format!("Cannot convert {} to a string", value.get_type()),
+                        format!(
+                            "Cannot convert {} to a string argument for '{}'",
+                            value.get_type(),
+                            name
+                        ),
                         "All arguments to an external command need to be string-compatible".into(),
                         span,
                     )
@@ -83,13 +87,13 @@ impl Command for External {
                     // Example: one_arg may be something like ["ls" "-a"]
                     // convert it to "ls" "-a"
                     for v in vals {
-                        spanned_args.push(value_as_spanned(v)?);
+                        spanned_args.push(value_as_spanned(v, &name.item)?);
                         // for arguments in list, it's always treated as a whole arguments
                         arg_keep_raw.push(true);
                     }
                 }
                 val => {
-                    spanned_args.push(value_as_spanned(val)?);
+                    spanned_args.push(value_as_spanned(val, &name.item)?);
                     match one_arg_expr.expr {
                         // refer to `parse_dollar_expr` function
                         // the expression type of $variable_name, $"($variable_name)"


### PR DESCRIPTION
# Description

The message arrow is altered to show the external command name in case it wasn't obvious. (See example for an occasion where it is non-obvious).

BEFORE:
```
〉else if (2mb) > 4mb
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #35:1:1]
 1 │ else if (2mb) > 4mb
   ·           ─┬
   ·            ╰── Cannot convert filesize to a string
   ╰────
  help: All arguments to an external command need to be string-compatible
```
AFTER:
```
〉else if (2mb) > 4mb
Error: nu::shell::external_command (link)

  × External command failed
   ╭─[entry #3:1:1]
 1 │ else if (2mb) > 4mb
   ·           ─┬
   ·            ╰── Cannot convert filesize to a string argument for 'else'
   ╰────
  help: All arguments to an external command need to be string-compatible

```
# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
