### PR TITLE
Add config mutation tests

### DIFF
--- a/src/tests/test_config.rs
+++ b/src/tests/test_config.rs
@@ -11,7 +11,7 @@ fn mutate_nu_config() -> TestResult {
 }
 
 #[test]
-fn mutate_nu_config_nested() -> TestResult {
+fn mutate_nu_config_nested_ls() -> TestResult {
     run_test_with_default_config(
         r#"$env.config.ls.user_ls_colors = false; $env.config.ls.user_ls_colors"#,
         "false",
@@ -19,9 +19,57 @@ fn mutate_nu_config_nested() -> TestResult {
 }
 
 #[test]
-fn mutate_nu_config_nested2() -> TestResult {
+fn mutate_nu_config_nested_table() -> TestResult {
     run_test_with_default_config(
         r#"$env.config.table.trim.wrapping_try_keep_words = false; $env.config.table.trim.wrapping_try_keep_words"#,
         "false",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested_menu() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.menu.2.type.columns = 3; $env.config.menu.2.type.columns"#,
+        "3",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested_keybindings() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.keybindings.5.keycode = 'char_x'; $env.config.keybindings.5.keycode"#,
+        "char_x",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested_color_nested() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.color_config.shape_flag = 'cyan'; $env.config.color_config.shape_flag"#,
+        "cyan",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested_completion() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.completions.external.enable = false; $env.config.completions.external.enable"#,
+        "false",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested_history() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.history.max_size = 100; $env.config.history.max_size"#,
+        "100",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested_filesize() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.filesize.format = 'kb'; $env.config.filesize.format"#,
+        "kb",
     )
 }

--- a/src/tests/test_config.rs
+++ b/src/tests/test_config.rs
@@ -1,0 +1,27 @@
+use crate::tests::{run_test, TestResult};
+
+use super::run_test_with_default_config;
+
+#[test]
+fn mutate_nu_config() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.footer_mode = 30; $env.config.footer_mode"#,
+        "30",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.ls.user_ls_colors = false; $env.config.ls.user_ls_colors"#,
+        "false",
+    )
+}
+
+#[test]
+fn mutate_nu_config_nested2() -> TestResult {
+    run_test_with_default_config(
+        r#"$env.config.table.trim.wrapping_try_keep_words = false; $env.config.table.trim.wrapping_try_keep_words"#,
+        "false",
+    )
+}


### PR DESCRIPTION
# Description

Env config can be mutated by `=`, this pr is to add a few tests 

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
