### PR TITLE
Make hook execution stream instead of collecting

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -964,6 +964,7 @@ pub fn run_hook_block(
                 return Err(error);
             }
 
+            // If all went fine, preserve the environment of the called block
             let caller_env_vars = stack.get_env_var_names(engine_state);
 
             // remove env vars that are present in the caller but not in the callee


### PR DESCRIPTION
Closes #7431. In a nutshell:
- `run_hook_block()` in repl.rs was collecting all input into a `Value` instead of handling streaming input properly
- this was a problem because now we have a default `display_output` hook that _everything_ gets piped to
- this PR fixes the problem by tweaking `run_hook_block()` to return a `PipelineData` instead of a `Value`

After this change, individual pages are rendered as they finish. This is a little easier to see if I tweak `STREAM_PAGE_SIZE` in table.rs to 10:
![image](https://user-images.githubusercontent.com/26268125/206935370-412b2ee9-9401-4222-bc93-5bd5a9adc13b.png)

## Future work

This does _not_ fix https://github.com/nushell/nushell/issues/7342.