### PR TITLE
let `UnknownFlag` error list out available flags

### DIFF
--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -569,5 +569,7 @@ fn list_unknown_flag() {
             "#
     ));
 
-    assert!(actual.err.contains("Available flags: --help(-h), --all(-a),"));
+    assert!(actual
+        .err
+        .contains("Available flags: --help(-h), --all(-a),"));
 }

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -559,3 +559,15 @@ fn list_ignores_ansi() {
         assert!(actual.err.is_empty());
     })
 }
+
+#[test]
+fn list_unknown_flag() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+                ls -r
+            "#
+    ));
+
+    assert!(actual.err.contains("Available flags: --help(-h), --all(-a), --long(-l), --short-names(-s), --full-paths(-f), --du(-d), --directory(-D). Use `--help` for more information."));
+}

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -569,5 +569,5 @@ fn list_unknown_flag() {
             "#
     ));
 
-    assert!(actual.err.contains("Available flags: --help(-h), --all(-a), --long(-l), --short-names(-s), --full-paths(-f), --du(-d), --directory(-D). Use `--help` for more information."));
+    assert!(actual.err.contains("Available flags: --help(-h), --all(-a),"));
 }

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -251,11 +251,7 @@ pub enum ParseError {
     NonUtf8(#[label = "non-UTF8 string"] Span),
 
     #[error("The `{0}` command doesn't have flag `{1}`.")]
-    #[diagnostic(
-        code(nu::parser::unknown_flag),
-        url(docsrs),
-        help("{3}. Use `--help` for more information.")
-    )]
+    #[diagnostic(code(nu::parser::unknown_flag), url(docsrs), help("{3}"))]
     UnknownFlag(String, String, #[label = "unknown flag"] Span, String),
 
     #[error("Unknown type.")]

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -254,9 +254,9 @@ pub enum ParseError {
     #[diagnostic(
         code(nu::parser::unknown_flag),
         url(docsrs),
-        help("use {0} --help for a list of flags")
+        help("{3}. Use `--help` for more information.")
     )]
-    UnknownFlag(String, String, #[label = "unknown flag"] Span),
+    UnknownFlag(String, String, #[label = "unknown flag"] Span, String),
 
     #[error("Unknown type.")]
     #[diagnostic(code(nu::parser::unknown_type), url(docsrs))]
@@ -422,7 +422,7 @@ impl ParseError {
             ParseError::DuplicateCommandDef(s) => *s,
             ParseError::UnknownCommand(s) => *s,
             ParseError::NonUtf8(s) => *s,
-            ParseError::UnknownFlag(_, _, s) => *s,
+            ParseError::UnknownFlag(_, _, s, _) => *s,
             ParseError::RequiredAfterOptional(_, s) => *s,
             ParseError::UnknownType(s) => *s,
             ParseError::MissingFlagParam(_, s) => *s,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -432,6 +432,7 @@ fn parse_long_flag(
                         sig.name.clone(),
                         long_name.clone(),
                         arg_span,
+                        sig.clone().formatted_flags(),
                     )),
                 )
             }
@@ -497,6 +498,7 @@ fn parse_short_flags(
                                 sig.name.clone(),
                                 format!("-{}", String::from_utf8_lossy(contents)),
                                 *first,
+                                sig.clone().formatted_flags(),
                             ))
                         });
                     }
@@ -507,6 +509,7 @@ fn parse_short_flags(
                             sig.name.clone(),
                             format!("-{}", String::from_utf8_lossy(contents)),
                             *first,
+                            sig.clone().formatted_flags(),
                         ))
                     });
                 }
@@ -517,6 +520,7 @@ fn parse_short_flags(
                         sig.name.clone(),
                         format!("-{}", String::from_utf8_lossy(contents)),
                         *first,
+                        sig.clone().formatted_flags(),
                     ))
                 });
             }
@@ -528,6 +532,7 @@ fn parse_short_flags(
                         sig.name.clone(),
                         format!("-{}", String::from_utf8_lossy(contents)),
                         *first,
+                        sig.clone().formatted_flags(),
                     ))
                 });
             }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -612,16 +612,34 @@ impl Signature {
     }
 
     pub fn formatted_flags(self) -> String {
-        let mut s = "Available flags:".to_string();
-        for flag in self.named {
-            if let Some(short) = flag.short {
-                s = format!("{s} --{}(-{}),", flag.long, short);
-            } else {
-                s = format!("{s} --{},", flag.long);
+        if self.named.len() < 11 {
+            let mut s = "Available flags:".to_string();
+            for flag in self.named {
+                if let Some(short) = flag.short {
+                    let _ = write!(s, " --{}(-{}),", flag.long, short);
+                } else {
+                    let _ = write!(s, " --{},", flag.long);
+                }
             }
+            s.remove(s.len() - 1);
+            let _ = write!(s, ". Use `--help` for more information.");
+            s
+        } else {
+            let mut s = "Some available flags:".to_string();
+            for flag in self.named {
+                if let Some(short) = flag.short {
+                    let _ = write!(s, " --{}(-{}),", flag.long, short);
+                } else {
+                    let _ = write!(s, " --{},", flag.long);
+                }
+            }
+            s.remove(s.len() - 1);
+            let _ = write!(
+                s,
+                "... Use `--help` for a full list of flags and more information."
+            );
+            s
         }
-        s.remove(s.len() - 1);
-        s
     }
 }
 

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -610,6 +610,19 @@ impl Signature {
             block_id,
         })
     }
+
+    pub fn formatted_flags(self) -> String {
+        let mut s = "Available flags:".to_string();
+        for flag in self.named {
+            if let Some(short) = flag.short {
+                s = format!("{s} --{}(-{}),", flag.long, short);
+            } else {
+                s = format!("{s} --{},", flag.long);
+            }
+        }
+        s.remove(s.len() - 1);
+        s
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
# Description
Fixes #6773.

```
/home/gabriel/CodingProjects/nushell〉ls -r                                                                                                                             12/12/2022 02:57:35 PM
Error: nu::parser::unknown_flag (link)

  × The `ls` command doesn't have flag `-r`.
   ╭─[entry #1:1:1]
 1 │ ls -r
   ·     ┬
   ·     ╰── unknown flag
   ╰────
  help: Available flags: --help(-h), --all(-a), --long(-l), --short-names(-s), --full-paths(-f), --du(-d), --directory(-D). Use `--help` for more information.
```

# User-Facing Changes

Different error for unknown flag.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
