### PR TITLE
add input_output_types() to benchmark,cd and config reset

### DIFF
--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -2,7 +2,7 @@ use chrono::Local;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature,
+    Category, Example, PipelineData, ShellError, Signature, Type,
 };
 use nu_utils::{get_default_config, get_default_env};
 use std::io::Write;
@@ -20,6 +20,8 @@ impl Command for ConfigReset {
             .switch("nu", "reset only nu config, config.nu", Some('n'))
             .switch("env", "reset only env config, env.nu", Some('e'))
             .switch("without-backup", "do not make a backup", Some('w'))
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
             .category(Category::Env)
     }
 

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -4,7 +4,7 @@ use nu_engine::{current_dir, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type, Value,
 };
 use std::path::Path;
 
@@ -49,6 +49,11 @@ impl Command for Cd {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("cd")
             .optional("path", SyntaxShape::Directory, "the path to change to")
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::String, Type::Nothing),
+            ])
+            .allow_variants_without_examples(true)
             .category(Category::FileSystem)
     }
 

--- a/crates/nu-command/src/system/benchmark.rs
+++ b/crates/nu-command/src/system/benchmark.rs
@@ -4,7 +4,7 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, Signature, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, Signature, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -22,6 +22,8 @@ impl Command for Benchmark {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("benchmark")
             .required("block", SyntaxShape::Block, "the block to run")
+            .input_output_types(vec![(Type::Block, Type::String)])
+            .allow_variants_without_examples(true)
             .category(Category::System)
     }
 

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -72,7 +72,7 @@ fn test_no_color_flag() {
     );
     assert_eq!(
         actual.out,
-        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help - Display the help message for this command<br><br>Parameters:<br>  (optional) path &lt;directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; cd -<br><br></body></html>"
+        r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help - Display the help message for this command<br><br>Signatures:<br>  &lt;nothing&gt; | cd &lt;string?&gt; -&gt; &lt;nothing&gt;<br>  &lt;string&gt; | cd &lt;string?&gt; -&gt; &lt;nothing&gt;<br><br>Parameters:<br>  (optional) path &lt;directory&gt;: the path to change to<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; cd -<br><br></body></html>"
     );
 }
 


### PR DESCRIPTION
# Description

add input_output_types() to benchmark, cd and config reset commands
It's an update to https://github.com/nushell/nushell/issues/7320


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
