### PR TITLE
make external signatures do not enforce flag checking

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -498,6 +498,7 @@ pub fn parse_extern(
 
                 signature.name = name.clone();
                 signature.usage = usage.clone();
+                signature.is_known_external = true;
 
                 let decl = KnownExternal {
                     name: name.to_string(),

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -118,6 +118,7 @@ pub struct Signature {
     pub allow_variants_without_examples: bool,
     pub is_filter: bool,
     pub creates_scope: bool,
+    pub is_known_external: bool,
     // Signature category used to classify commands stored in the list of declarations
     pub category: Category,
 }
@@ -220,6 +221,7 @@ impl Signature {
             is_filter: false,
             creates_scope: false,
             category: Category::Default,
+            is_known_external: false,
         }
     }
 


### PR DESCRIPTION
# Description

It's just a two-steps furthur to #6567 made by @merelymyself 

Fixes https://github.com/nushell/nushell/issues/4659. Fixes https://github.com/nushell/nushell/issues/6020. Kind of Fixes https://github.com/nushell/nushell/issues/5103. Fixes https://github.com/nushell/nushell/issues/5294. Fixes https://github.com/nushell/nushell/issues/6124

Unlike #6567, this prevents only flag parsing error for export extern

# User-Facing Changes
```
❯ export extern "git" []
# don't check for unknown flag
❯ git --version
git version 2.37.3
❯ git -v
git version 2.37.3
# still check for positional arguments
❯ git asdf
Error: nu::parser::extra_positional (link)

  × Extra positional argument.
   ╭─[entry #9:1:1]
 1 │ git asdf
   ·     ──┬─
   ·       ╰── extra positional argument
   ╰────
  help: Usage: git
```

## One restriction for unknown flag
Because it's unknown, we don't know if it's taking value or not, so some flags which take values will not likely work

Take the following extern as example:
```
❯ export extern "git commit" []
```
We can't pass an unknown flag which takes values, which means the following doesn't work:
```
git commit -m "first commit"
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.