### PR TITLE
`mkdir` change flag `-s` to `-v`

### DIFF
--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -24,7 +24,7 @@ impl Command for Mkdir {
                 SyntaxShape::Directory,
                 "the name(s) of the path(s) to create",
             )
-            .switch("show-created-paths", "show the path(s) created.", Some('s'))
+            .switch("verbose", "print created path(s).", Some('v'))
             .category(Category::FileSystem)
     }
 
@@ -50,7 +50,7 @@ impl Command for Mkdir {
             .map(|dir| path.join(dir))
             .peekable();
 
-        let show_created_paths = call.has_flag("show-created-paths");
+        let is_verbose = call.has_flag("verbose");
         let mut stream: VecDeque<Value> = VecDeque::new();
 
         if directories.peek().is_none() {
@@ -76,7 +76,7 @@ impl Command for Mkdir {
                 ));
             }
 
-            if show_created_paths {
+            if is_verbose {
                 let val = format!("{:}", dir.to_string_lossy());
                 stream.push_back(Value::String { val, span });
             }
@@ -96,7 +96,7 @@ impl Command for Mkdir {
             },
             Example {
                 description: "Make multiple directories and show the paths created",
-                example: "mkdir -s foo/bar foo2",
+                example: "mkdir -v foo/bar foo2",
                 result: None,
             },
         ]

--- a/crates/nu-command/tests/commands/mkdir.rs
+++ b/crates/nu-command/tests/commands/mkdir.rs
@@ -63,13 +63,13 @@ fn create_directory_two_parents_up_using_multiple_dots() {
 }
 
 #[test]
-fn show_created_paths() {
+fn print_created_paths() {
     Playground::setup("mkdir_test_2", |dirs, _| {
         let actual = nu!(
          cwd: dirs.test(),
          pipeline(
              r#"
-                 mkdir -s dir_1 dir_2 dir_3
+                 mkdir -v dir_1 dir_2 dir_3
                  | length
              "#
         ));


### PR DESCRIPTION
Change in `mkdir` `-s` flag to `-v` to be similar to other commands


# Description

Other commands like `rm`, `mv`, `cp` have a `-v` (`--verbose`) flag. `mkdir` has a `-s` (`--show-created-paths`), but should be consistent with other commands.

# User-Facing Changes

- flag `-s` replaced by `-v` in `mkdir` command.


# Tests + Formatting
```
> mkdir -v new_dir
╭───┬───────────────────────────────────╮
│ 0 │ C:\Users\ricardo.monteiro\new_dir │
╰───┴───────────────────────────────────╯
```

