### PR TITLE
Add riscv64 binary release target

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -48,6 +48,7 @@ $'Start building ($bin)...'; hr-line
 # ----------------------------------------------------------------------------
 if $os in [$USE_UBUNTU, 'macos-latest'] {
     if $os == $USE_UBUNTU {
+        sudo apt update
         sudo apt-get install libxcb-composite0-dev -y
     }
     if $target == 'aarch64-unknown-linux-gnu' {
@@ -57,6 +58,10 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
     } else if $target == 'armv7-unknown-linux-gnueabihf' {
         sudo apt-get install pkg-config gcc-arm-linux-gnueabihf -y
         let-env CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER = 'arm-linux-gnueabihf-gcc'
+        cargo-build-nu $flags
+    } else if $target == 'riscv64gc-unknown-linux-gnu' {
+        sudo apt-get install gcc-riscv64-linux-gnu -y
+        let-env CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER = 'riscv64-linux-gnu-gcc'
         cargo-build-nu $flags
     } else {
         # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
         - armv7-unknown-linux-gnueabihf
+        - riscv64gc-unknown-linux-gnu
         extra: ['bin']
         include:
         - target: aarch64-apple-darwin
@@ -55,6 +56,9 @@ jobs:
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-20.04
           target_rustflags: ''
+        - target: riscv64gc-unknown-linux-gnu
+          os: ubuntu-20.04
+          target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 
@@ -71,7 +75,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.71.0
+        version: 0.72.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Description

Add `riscv64gc-unknown-linux-gnu` release target

TEST release workflow:  https://github.com/hustcer/nu-release/actions/runs/3693191329
TEST release: https://github.com/hustcer/nu-release/releases/tag/v0.73.0

# User-Facing Changes

New `nu-*-riscv64gc-unknown-linux-gnu.tar.gz` package  will be added to the following release

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
