### PR TITLE
Add example showing first class closure to `do`

### DIFF
--- a/crates/nu-command/src/core_commands/do_.rs
+++ b/crates/nu-command/src/core_commands/do_.rs
@@ -184,6 +184,11 @@ impl Command for Do {
                 result: Some(Value::test_string("hello")),
             },
             Example {
+                description: "Run a stored first-class closure",
+                example: r#"let text = "I am enclosed"; let hello = {|| echo $text}; do $hello"#,
+                result: Some(Value::test_string("I am enclosed")),
+            },
+            Example {
                 description: "Run the block and ignore both shell and program errors",
                 example: r#"do -i { thisisnotarealcommand }"#,
                 result: None,


### PR DESCRIPTION

# Description

Demonstrates that you can use `do` to execute stored closures and
evaluate their captures properly.

# Tests + Formatting

As an example test increases coverage of the usage to execute first class closures. 
Additional tests using that found in `tests/shell/pipeline/commands/internal.rs` 
