### PR TITLE
break `for`, `loop`, `while` execution when external command runs to failed

### DIFF
--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -118,7 +118,10 @@ impl Command for For {
                             return Err(err);
                         }
                         Ok(pipeline) => {
-                            let _ = pipeline.print(&engine_state, stack, false, false)?;
+                            let exit_code = pipeline.print(&engine_state, stack, false, false)?;
+                            if exit_code != 0 {
+                                break;
+                            }
                         }
                     }
                 }
@@ -157,7 +160,10 @@ impl Command for For {
                             return Err(err);
                         }
                         Ok(pipeline) => {
-                            let _ = pipeline.print(&engine_state, stack, false, false)?;
+                            let exit_code = pipeline.print(&engine_state, stack, false, false)?;
+                            if exit_code != 0 {
+                                break;
+                            }
                         }
                     }
                 }

--- a/crates/nu-command/src/core_commands/loop_.rs
+++ b/crates/nu-command/src/core_commands/loop_.rs
@@ -69,7 +69,10 @@ impl Command for Loop {
                     return Err(err);
                 }
                 Ok(pipeline) => {
-                    let _ = pipeline.print(engine_state, stack, false, false)?;
+                    let exit_code = pipeline.print(engine_state, stack, false, false)?;
+                    if exit_code != 0 {
+                        break;
+                    }
                 }
             }
         }

--- a/crates/nu-command/src/core_commands/while_.rs
+++ b/crates/nu-command/src/core_commands/while_.rs
@@ -77,7 +77,11 @@ impl Command for While {
                                 return Err(err);
                             }
                             Ok(pipeline) => {
-                                let _ = pipeline.print(engine_state, stack, false, false)?;
+                                let exit_code =
+                                    pipeline.print(engine_state, stack, false, false)?;
+                                if exit_code != 0 {
+                                    break;
+                                }
                             }
                         }
                     } else {

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -14,3 +14,18 @@ fn for_auto_print_in_each_iteration() {
     // that's ok, our main concern is it auto print value in each iteration.
     assert_eq!(actual.out, "11");
 }
+
+#[test]
+fn for_break_on_external_failed() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        for i in 1..2 {
+            echo 1;
+            nu --testbin fail
+        }"#
+    );
+    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // so our output will be `1`
+    assert_eq!(actual.out, "1");
+}

--- a/crates/nu-command/tests/commands/loop_.rs
+++ b/crates/nu-command/tests/commands/loop_.rs
@@ -20,3 +20,24 @@ fn loop_auto_print_in_each_iteration() {
     // that's ok, our main concern is it auto print value in each iteration.
     assert_eq!(actual.out, "111");
 }
+
+#[test]
+fn loop_break_on_external_failed() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        mut total = 0;
+        loop {
+            if $total == 3 {
+                break;
+            } else {
+                $total += 1;
+            }
+            echo 1;
+            nu --testbin fail;
+        }"#
+    );
+    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // so our output will be `1`.
+    assert_eq!(actual.out, "1");
+}

--- a/crates/nu-command/tests/commands/while_.rs
+++ b/crates/nu-command/tests/commands/while_.rs
@@ -21,3 +21,14 @@ fn while_auto_print_in_each_iteration() {
     // that's ok, our main concern is it auto print value in each iteration.
     assert_eq!(actual.out, "11");
 }
+
+#[test]
+fn while_break_on_external_failed() {
+    let actual = nu!(
+        cwd: ".",
+        "mut total = 0; while $total < 2 { $total = $total + 1; echo 1; nu --testbin fail }"
+    );
+    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // so our output will be `1`
+    assert_eq!(actual.out, "1");
+}


### PR DESCRIPTION
# Description

Fixes: #7467

# User-Facing Changes

## for
```
❯ for i in 1..2 { echo 1;  ^false }
1
```

## loop
```
❯ loop { echo bb; ^false }
bb
```

## while
```
❯ mut x = 1; while $x < 3 { $x = $x + 1; echo bb; ^false }
bb
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
