### PR TITLE
refactor: introduce is_external_failed to PipelineData, and simplify try logic

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -6,8 +6,8 @@ use nu_protocol::{
         Operator, PathMember, PipelineElement, Redirection,
     },
     engine::{EngineState, Stack},
-    Config, HistoryFileFormat, IntoInterruptiblePipelineData, IntoPipelineData, ListStream,
-    PipelineData, Range, RawStream, ShellError, Span, Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
+    Config, HistoryFileFormat, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
+    Range, ShellError, Span, Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
 use nu_utils::stdout_write_all_and_flush;
 use std::collections::HashMap;
@@ -698,86 +698,9 @@ pub fn eval_expression_with_input(
     Ok(might_consume_external_result(input))
 }
 
-// if the result is ExternalStream without redirecting output.
-// that indicates we have no more commands to execute currently.
-// we can try to catch and detect if external command runs to failed.
-//
-// This is useful to commands with semicolon, we can detect errors early to avoid
-// commands after semicolon running.
+// Try to catch and detect if external command runs to failed.
 fn might_consume_external_result(input: PipelineData) -> (PipelineData, bool) {
-    let mut runs_to_failed = false;
-    if let PipelineData::ExternalStream {
-        stdout: None,
-        stderr,
-        mut exit_code,
-        span,
-        metadata,
-        trim_end_newline,
-    } = input
-    {
-        let exit_code = exit_code.take();
-
-        // Note:
-        // In run-external's implementation detail, the result sender thread
-        // send out stderr message first, then stdout message, then exit_code.
-        //
-        // In this clause, we already make sure that `stdout` is None
-        // But not the case of `stderr`, so if `stderr` is not None
-        // We need to consume stderr message before reading external commands' exit code.
-        //
-        // Or we'll never have a chance to read exit_code if stderr producer produce too much stderr message.
-        // So we consume stderr stream and rebuild it.
-        let stderr = stderr.map(|stderr_stream| {
-            let stderr_ctrlc = stderr_stream.ctrlc.clone();
-            let stderr_span = stderr_stream.span;
-            let stderr_bytes = match stderr_stream.into_bytes() {
-                Err(_) => vec![],
-                Ok(bytes) => bytes.item,
-            };
-            RawStream::new(
-                Box::new(vec![Ok(stderr_bytes)].into_iter()),
-                stderr_ctrlc,
-                stderr_span,
-            )
-        });
-
-        match exit_code {
-            Some(exit_code_stream) => {
-                let ctrlc = exit_code_stream.ctrlc.clone();
-                let exit_code: Vec<Value> = exit_code_stream.into_iter().collect();
-                if let Some(Value::Int { val: code, .. }) = exit_code.last() {
-                    // if exit_code is not 0, it indicates error occured, return back Err.
-                    if *code != 0 {
-                        runs_to_failed = true;
-                    }
-                }
-                (
-                    PipelineData::ExternalStream {
-                        stdout: None,
-                        stderr,
-                        exit_code: Some(ListStream::from_stream(exit_code.into_iter(), ctrlc)),
-                        span,
-                        metadata,
-                        trim_end_newline,
-                    },
-                    runs_to_failed,
-                )
-            }
-            None => (
-                PipelineData::ExternalStream {
-                    stdout: None,
-                    stderr,
-                    exit_code: None,
-                    span,
-                    metadata,
-                    trim_end_newline,
-                },
-                runs_to_failed,
-            ),
-        }
-    } else {
-        (input, false)
-    }
+    input.is_external_failed()
 }
 
 pub fn eval_element_with_input(


### PR DESCRIPTION
# Description

Just spot that there are some duplicate code about checking external runs to failed, is pr is trying to refactor it and reduce lines of code

# User-Facing Changes

NaN

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
