### PR TITLE
add `--long` flag to `history` command for sqlite history

### DIFF
--- a/crates/nu-command/src/misc/history.rs
+++ b/crates/nu-command/src/misc/history.rs
@@ -24,7 +24,11 @@ impl Command for History {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("history")
             .switch("clear", "Clears out the history entries", Some('c'))
-            .switch("long", "Show long listing of history entries", Some('l'))
+            .switch(
+                "long",
+                "Show long listing of entries for sqlite history",
+                Some('l'),
+            )
             .category(Category::Misc)
     }
 


### PR DESCRIPTION
# Description

This command introduces a `--long` flag to the `history` command for sqlite history mode. The `history` command defaults to short/normal mode.

Normal
<img width="1722" alt="Screenshot 2022-12-14 at 8 20 04 PM" src="https://user-images.githubusercontent.com/343840/207757115-7773cc38-b1ca-4094-8580-f7c9690ee85e.png">


Long
<img width="1715" alt="Screenshot 2022-12-14 at 8 19 25 PM" src="https://user-images.githubusercontent.com/343840/207757052-7cbe0ebd-ae10-4d05-ad89-bc621c0abccb.png">




# User-Facing Changes

Defaulting to "short" mode is a breaking change.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
