### PR TITLE
Use `nu-path` correctly in `nu!` test macro to make dev-dependency transitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,7 +2777,6 @@ dependencies = [
  "indexmap",
  "miette",
  "nu-json",
- "nu-path",
  "nu-test-support",
  "nu-utils",
  "num-format",

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -12,8 +12,6 @@ version = "0.72.2"
 [dependencies]
 nu-utils = { path = "../nu-utils", version = "0.72.2"  }
 nu-json = { path = "../nu-json", version = "0.72.2"  }
-nu-path = { path = "../nu-path", version = "0.72.2"  } # Used for test support
-nu-test-support = { path = "../nu-test-support", version = "0.72.2"  }
 
 byte-unit = "4.0.9"
 chrono = { version="0.4.23", features= ["serde", "std"], default-features = false }
@@ -35,3 +33,4 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"
+nu-test-support = { path = "../nu-test-support", version = "0.72.2"  }

--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -3,6 +3,8 @@ pub mod fs;
 pub mod locale_override;
 pub mod macros;
 pub mod playground;
+// Needs to be reexported for `nu!` macro
+pub use nu_path;
 
 pub struct Outcome {
     pub out: String,

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -138,7 +138,7 @@ macro_rules! nu {
         let test_bins = $crate::fs::binaries();
 
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
-        let test_bins = nu_path::canonicalize_with(&test_bins, cwd).unwrap_or_else(|e| {
+        let test_bins = $crate::nu_path::canonicalize_with(&test_bins, cwd).unwrap_or_else(|e| {
             panic!(
                 "Couldn't canonicalize dummy binaries path {}: {:?}",
                 test_bins.display(),


### PR DESCRIPTION
## Fix `nu-path` usage in `nu!` testing macro

The `nu-path` crate needs to be properly re-exported so the generated code is valid if `nu-path` is not present among the dependencies of the using crate.

Usage of crates in `macro_rules!` macros has to follow the `$crate::symbol_in_crate` path pattern (With an absolute path-spec also for macros defined in submodules)

## Move `nu-test-support` to devdeps in `nu-protocol`

Also remove the now unnecessary direct dependency on `nu-path`.
`nu!` macro had to be changed to make it a proper transitive dependency.
