### PR TITLE
(nu_plugin_python): Send back the signature required fields.

### DIFF
--- a/crates/nu_plugin_python/nu_plugin_python_example.py
+++ b/crates/nu_plugin_python/nu_plugin_python_example.py
@@ -71,6 +71,7 @@ def signatures():
                     "shape": "String",
                     "var_id": None,
                 },
+                "vectorizes_over_list": False,
                 "named": [
                     {
                         "long": "help",
@@ -97,6 +98,8 @@ def signatures():
                         "var_id": None,
                     },
                 ],
+                "input_output_types": [["Any", "Any"]],
+                "allow_variants_without_examples": True,
                 "search_terms": ["Python", "Example"],
                 "is_filter": False,
                 "creates_scope": False,


### PR DESCRIPTION
# Description

The `Signature` data structure has changed. We need to add the required fields for the nu plugin in python to work well when registering it.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
