### PR TITLE
(register-plugins.nu): Filter out files ending with .d on systems other than windows.

### DIFF
--- a/register-plugins.nu
+++ b/register-plugins.nu
@@ -9,11 +9,19 @@ def register_plugin [plugin] {
     nu -c $'register ($plugin)'
 }
 
+def windows? [] {
+    $nu.os-info.name == windows
+}
+
+def keep-plugin-executables [] {
+    if (windows?) { $in } else { where name !~ '\.d' }
+}
+
 # get list of all plugin files from their installed directory
 let plugin_location = ((which nu).path.0 | path dirname)
 
 # for each plugin file, print the name and launch another instance of nushell to register it
-for plugin in (ls $"($plugin_location)/nu_plugin_*") {
+for plugin in (ls $"($plugin_location)/nu_plugin_*" | keep-plugin-executables) {
     match ($plugin.name | path basename | str replace '\.exe$' '') {
         nu_plugin_custom_values: { register_plugin $plugin.name }
         nu_plugin_example: { register_plugin $plugin.name }


### PR DESCRIPTION
# Description

On my debug build the script considers files ending with '.d' and prevents the script working properly. This removes those files on systems not on Windows.

<img width="501" alt="Screen Shot 2022-12-15 at 14 11 55" src="https://user-images.githubusercontent.com/951128/207949399-9f26f470-c0e3-461c-8f53-b32aca522dca.png">


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
