### PR TITLE
ensure `get` doesn't delve too deep in nested lists

### DIFF
--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -219,3 +219,13 @@ fn quoted_column_access() {
 
     assert_eq!(actual.out, "4");
 }
+
+#[test]
+fn get_does_not_delve_too_deep_in_nested_lists() {
+    let actual = nu!(
+        cwd: ".",
+        r#"[[{foo: bar}]] | get foo"#
+    );
+
+    assert!(actual.err.contains("did not find anything under this name"));
+}

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -179,7 +179,7 @@ fn parses_json() {
 fn parses_xml() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open jonathan.xml | get rss.children.channel.children | get item.children | get link.children.0.3.3.0"
+        "open jonathan.xml | get rss.children.channel.children | get 0.item.children | get 0.link.children.0.0"
     );
 
     assert_eq!(

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -717,6 +717,7 @@ impl Value {
                         let mut output = vec![];
                         let mut hasvalue = false;
                         let mut temp: Result<Value, ShellError> = Err(ShellError::NotFound(*span));
+                        let vals = vals.iter().filter(|v| matches!(v, Value::Record { .. }));
                         for val in vals {
                             temp = val.clone().follow_cell_path(
                                 &[PathMember::String {


### PR DESCRIPTION
# Description

Fixes #7494.

```
/home/gabriel/CodingProjects/nushell〉[[{foo: bar}]] | get foo          12/16/2022 12:31:17 PM
Error: nu::parser::not_found (link)

  × Not found.
   ╭─[entry #1:1:1]
 1 │ [[{foo: bar}]] | get foo
   · ───────┬──────
   ·        ╰── did not find anything under this name
   ╰────

```

# User-Facing Changes

cell paths no longer drill into nested tables.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
