### PR TITLE
Remove unnecessary `echo` uses from examples

### DIFF
--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -50,7 +50,7 @@ impl Command for Histogram {
             },
             Example {
                 description: "Compute a histogram for a list of numbers",
-                example: "echo [1 2 1] | histogram",
+                example: "[1 2 1] | histogram",
                 result: Some(Value::List {
                         vals: vec![Value::Record {
                             cols: vec!["value".to_string(), "count".to_string(), "quantile".to_string(), "percentage".to_string(), "frequency".to_string()],
@@ -80,7 +80,7 @@ impl Command for Histogram {
             },
             Example {
                 description: "Compute a histogram for a list of numbers, and percentage is based on the maximum value",
-                example: "echo [1 2 3 1 1 1 2 2 1 1] | histogram --percentage-type relative",
+                example: "[1 2 3 1 1 1 2 2 1 1] | histogram --percentage-type relative",
                 result: None,
             }
         ]

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -54,7 +54,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Convert value to boolean in table",
-                example: "echo [[value]; ['false'] ['1'] [0] [1.0] [true]] | into bool value",
+                example: "[[value]; ['false'] ['1'] [0] [1.0] [true]] | into bool value",
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -65,7 +65,8 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Convert string to duration in table",
-                example: "[[value]; ['1sec'] ['2min'] ['3hr'] ['4day'] ['5wk']] | into duration value",
+                example:
+                    "[[value]; ['1sec'] ['2min'] ['3hr'] ['4day'] ['5wk']] | into duration value",
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -65,7 +65,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Convert string to duration in table",
-                example: "echo [[value]; ['1sec'] ['2min'] ['3hr'] ['4day'] ['5wk']] | into duration value",
+                example: "[[value]; ['1sec'] ['2min'] ['3hr'] ['4day'] ['5wk']] | into duration value",
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -92,7 +92,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Convert string to integer in table",
-                example: "echo [[num]; ['-5'] [4] [1.5]] | into int num",
+                example: "[[num]; ['-5'] [4] [1.5]] | into int num",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -49,7 +49,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Convert from one row table to record",
-                example: "echo [[value]; [false]] | into record",
+                example: "[[value]; [false]] | into record",
                 result: Some(Value::Record {
                     cols: vec!["value".to_string()],
                     vals: vec![Value::boolean(false, span)],

--- a/crates/nu-command/src/core_commands/debug.rs
+++ b/crates/nu-command/src/core_commands/debug.rs
@@ -74,7 +74,7 @@ impl Command for Debug {
             },
             Example {
                 description: "Debug print a table",
-                example: "echo [[version patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | debug",
+                example: "[[version patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | debug",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string("{version: 0.1.0, patch: false}"),

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -86,12 +86,12 @@ impl Command for LoadEnv {
         vec![
             Example {
                 description: "Load variables from an input stream",
-                example: r#"{NAME: ABE, AGE: UNKNOWN} | load-env; echo $env.NAME"#,
+                example: r#"{NAME: ABE, AGE: UNKNOWN} | load-env; $env.NAME"#,
                 result: Some(Value::test_string("ABE")),
             },
             Example {
                 description: "Load variables from an argument",
-                example: r#"load-env {NAME: ABE, AGE: UNKNOWN}; echo $env.NAME"#,
+                example: r#"load-env {NAME: ABE, AGE: UNKNOWN}; $env.NAME"#,
                 result: Some(Value::test_string("ABE")),
             },
         ]

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -64,7 +64,7 @@ impl Command for WithEnv {
             },
             Example {
                 description: "Set by row(e.g. `open x.json` or `from json`)",
-                example: r#"'{"X":"Y","W":"Z"}'|from json|with-env $in { echo $env.X $env.W }"#,
+                example: r#"'{"X":"Y","W":"Z"}'|from json|with-env $in { [$env.X $env.W] }"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -36,8 +36,8 @@ impl Command for IsAdmin {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Echo 'iamroot' if nushell is running with admin/root privileges, and 'iamnotroot' if not.",
-                example: r#"if is-admin { echo "iamroot" } else { echo "iamnotroot" }"#,
+                description: "Return 'iamroot' if nushell is running with admin/root privileges, and 'iamnotroot' if not.",
+                example: r#"if is-admin { "iamroot" } else { "iamnotroot" }"#,
                 result: Some(Value::string("iamnotroot", Span::test_data())),
             },
         ]

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -194,7 +194,7 @@ impl Command for Open {
             },
             Example {
                 description: "Open a file, using the input to get filename",
-                example: "echo 'myfile.txt' | open",
+                example: "'myfile.txt' | open",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/filters/collect.rs
+++ b/crates/nu-command/src/filters/collect.rs
@@ -85,7 +85,7 @@ impl Command for Collect {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Use the second value in the stream",
-            example: "echo 1 2 3 | collect { |x| echo $x.1 }",
+            example: "[1 2 3] | collect { |x| $x.1 }",
             result: Some(Value::test_int(2)),
         }]
     }

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -63,7 +63,7 @@ impl Command for DropColumn {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Remove the last column of a table",
-            example: "echo [[lib, extension]; [nu-lib, rs] [nu-core, rb]] | drop column",
+            example: "[[lib, extension]; [nu-lib, rs] [nu-core, rb]] | drop column",
             result: Some(Value::List {
                 vals: vec![
                     Value::Record {

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -75,7 +75,7 @@ impl Command for DropNth {
             },
             Example {
                 description: "Drop range rows from second to fourth",
-                example: "echo [first second third fourth fifth] | drop nth (1..3)",
+                example: "[first second third fourth fifth] | drop nth (1..3)",
                 result: Some(Value::List {
                     vals: vec![Value::test_string("first"), Value::test_string("fifth")],
                     span: Span::test_data(),

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -100,7 +100,7 @@ with 'transpose' first."#
                 }),
             },
             Example {
-                example: r#"[1 2 3] | each --keep-empty {|e| if $e == 2 { echo "found 2!"} }"#,
+                example: r#"[1 2 3] | each --keep-empty {|e| if $e == 2 { "found 2!"} }"#,
                 description: "Iterate over each element, keeping all results",
                 result: Some(Value::List {
                     vals: stream_test_2,

--- a/crates/nu-command/src/filters/group.rs
+++ b/crates/nu-command/src/filters/group.rs
@@ -51,7 +51,7 @@ impl Command for Group {
         ];
 
         vec![Example {
-            example: "echo [1 2 3 4] | group 2",
+            example: "[1 2 3 4] | group 2",
             description: "Group the a list by pairs",
             result: Some(Value::List {
                 vals: stream_test_1,

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -131,7 +131,7 @@ impl Command for Lines {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Split multi-line string into lines",
-            example: r#"echo $"two\nlines" | lines"#,
+            example: r#"$"two\nlines" | lines"#,
             result: Some(Value::List {
                 vals: vec![Value::test_string("two"), Value::test_string("lines")],
                 span: Span::test_data(),

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -49,7 +49,7 @@ impl Command for ParEach {
                 result: None,
             },
             Example {
-                example: r#"[1 2 3] | par-each -n { |it| if $it.item == 2 { echo $"found 2 at ($it.index)!"} }"#,
+                example: r#"[1 2 3] | par-each -n { |it| if $it.item == 2 { $"found 2 at ($it.index)!"} }"#,
                 description: "Iterate over each element, print the matching value and its index",
                 result: Some(Value::List {
                     vals: vec![Value::string("found 2 at 1!", Span::test_data())],

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -45,7 +45,7 @@ impl Command for Skip {
         vec![
             Example {
                 description: "Skip the first value of a list",
-                example: "echo [2 4 6 8] | skip 1",
+                example: "[2 4 6 8] | skip 1",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(4), Value::test_int(6), Value::test_int(8)],
                     span: Span::test_data(),
@@ -53,7 +53,7 @@ impl Command for Skip {
             },
             Example {
                 description: "Skip two rows of a table",
-                example: "echo [[editions]; [2015] [2018] [2021]] | skip 2",
+                example: "[[editions]; [2015] [2018] [2021]] | skip 2",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["editions".to_owned()],

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -88,7 +88,7 @@ impl Command for Sort {
             },
             Example {
                 description: "Sort strings (case-insensitive)",
-                example: "echo [airplane Truck Car] | sort -i",
+                example: "[airplane Truck Car] | sort -i",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string("airplane"),
@@ -100,7 +100,7 @@ impl Command for Sort {
             },
             Example {
                 description: "Sort strings (reversed case-insensitive)",
-                example: "echo [airplane Truck Car] | sort -i -r",
+                example: "[airplane Truck Car] | sort -i -r",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string("Truck"),

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -115,7 +115,7 @@ impl Command for Take {
             },
             Example {
                 description: "Return the first two rows of a table",
-                example: "echo [[editions]; [2015] [2018] [2021]] | take 2",
+                example: "[[editions]; [2015] [2018] [2021]] | take 2",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_record(vec!["editions"], vec![Value::test_int(2015)]),

--- a/crates/nu-command/src/hash/md5.rs
+++ b/crates/nu-command/src/hash/md5.rs
@@ -13,7 +13,7 @@ impl HashDigest for Md5 {
         vec![
             Example {
                 description: "Return the md5 hash of a string, hex-encoded",
-                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash md5",
+                example: "'abcdefghijklmnopqrstuvwxyz' | hash md5",
                 result: Some(Value::String {
                     val: "c3fcd3d76192e4007dfb496cca67e13b".to_owned(),
                     span: Span::test_data(),
@@ -21,7 +21,7 @@ impl HashDigest for Md5 {
             },
             Example {
                 description: "Return the md5 hash of a string, as binary",
-                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash md5 --binary",
+                example: "'abcdefghijklmnopqrstuvwxyz' | hash md5 --binary",
                 result: Some(Value::Binary {
                     val: vec![
                         0xc3, 0xfc, 0xd3, 0xd7, 0x61, 0x92, 0xe4, 0x00, 0x7d, 0xfb, 0x49, 0x6c,

--- a/crates/nu-command/src/hash/sha256.rs
+++ b/crates/nu-command/src/hash/sha256.rs
@@ -13,7 +13,7 @@ impl HashDigest for Sha256 {
         vec![
             Example {
                 description: "Return the sha256 hash of a string, hex-encoded",
-                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash sha256",
+                example: "'abcdefghijklmnopqrstuvwxyz' | hash sha256",
                 result: Some(Value::String {
                     val: "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73"
                         .to_owned(),
@@ -22,7 +22,7 @@ impl HashDigest for Sha256 {
             },
             Example {
                 description: "Return the sha256 hash of a string, as binary",
-                example: "echo 'abcdefghijklmnopqrstuvwxyz' | hash sha256 --binary",
+                example: "'abcdefghijklmnopqrstuvwxyz' | hash sha256 --binary",
                 result: Some(Value::Binary {
                     val: vec![
                         0x71, 0xc4, 0x80, 0xdf, 0x93, 0xd6, 0xae, 0x2f, 0x1e, 0xfa, 0xd1, 0x44,

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Get the variance of a list of numbers",
-                example: "echo [1 2 3 4 5] | math variance",
+                example: "[1 2 3 4 5] | math variance",
                 result: Some(Value::float(2.0, Span::test_data())),
             },
             Example {

--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -72,25 +72,25 @@ impl Command for SubCommand {
             Example {
             description: "draw text in a gradient with foreground start and end colors",
             example:
-                "echo 'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff --fgend 0xe81cff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff --fgend 0xe81cff",
             result: None,
         },
         Example {
             description: "draw text in a gradient with foreground start and end colors and background start and end colors",
             example:
-                "echo 'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff --fgend 0xe81cff --bgstart 0xe81cff --bgend 0x40c9ff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff --fgend 0xe81cff --bgstart 0xe81cff --bgend 0x40c9ff",
             result: None,
         },
         Example {
             description: "draw text in a gradient by specifying foreground start color - end color is assumed to be black",
             example:
-                "echo 'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff",
             result: None,
         },
         Example {
             description: "draw text in a gradient by specifying foreground end color - start color is assumed to be black",
             example:
-                "echo 'Hello, Nushell! This is a gradient.' | ansi gradient --fgend 0xe81cff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgend 0xe81cff",
             result: None,
         },
         ]

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -55,7 +55,7 @@ impl Command for DetectColumns {
         vec![
             Example {
                 description: "Splits string across multiple columns",
-                example: "echo 'a b c' | detect columns -n",
+                example: "'a b c' | detect columns -n",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec![
@@ -75,7 +75,7 @@ impl Command for DetectColumns {
             },
             Example {
                 description: "Splits a multi-line string into columns with headers detected",
-                example: "echo $'c1 c2 c3(char nl)a b c' | detect columns",
+                example: "$'c1 c2 c3(char nl)a b c' | detect columns",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -51,12 +51,12 @@ impl Command for DecodeBase64 {
         vec![
             Example {
                 description: "Base64 decode a value and output as UTF-8 string",
-                example: "echo 'U29tZSBEYXRh' | decode base64",
+                example: "'U29tZSBEYXRh' | decode base64",
                 result: Some(Value::string("Some Data", Span::test_data())),
             },
             Example {
                 description: "Base64 decode a value and output as binary",
-                example: "echo 'U29tZSBEYXRh' | decode base64 --binary",
+                example: "'U29tZSBEYXRh' | decode base64 --binary",
                 result: Some(Value::binary(
                     [0x53, 0x6f, 0x6d, 0x65, 0x20, 0x44, 0x61, 0x74, 0x61],
                     Span::test_data(),

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -40,12 +40,12 @@ impl Command for EncodeBase64 {
         vec![
             Example {
                 description: "Base64 encode a string with default settings",
-                example: "echo 'Some Data' | encode base64",
+                example: "'Some Data' | encode base64",
                 result: Some(Value::string("U29tZSBEYXRh", Span::test_data())),
             },
             Example {
                 description: "Base64 encode a string with the binhex character set",
-                example: "echo 'Some Data' | encode base64 --character-set binhex",
+                example: "'Some Data' | encode base64 --character-set binhex",
                 result: Some(Value::string(r#"7epXB5"%A@4J"#, Span::test_data())),
             },
         ]

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -78,7 +78,7 @@ impl Command for Format {
             },
             Example {
                 description: "Print elements from some columns of a table",
-                example: "echo [[col1, col2]; [v1, v2] [v3, v4]] | format '{col2}'",
+                example: "[[col1, col2]; [v1, v2] [v3, v4]] | format '{col2}'",
                 result: Some(Value::List {
                     vals: vec![Value::test_string("v2"), Value::test_string("v4")],
                     span: Span::test_data(),

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -63,7 +63,7 @@ impl Command for Parse {
                     vals: vec![Value::Record {
                         cols: vec!["name".to_string()],
                         vals: vec![Value::test_string("bar")],
-                        span: Span::test_data()
+                        span: Span::test_data(),
                     }],
                     span: Span::test_data(),
                 }),
@@ -76,24 +76,29 @@ impl Command for Parse {
                         Value::Record {
                             cols: vec!["Capture1".to_string(), "Capture2".to_string()],
                             vals: vec![Value::test_string(""), Value::test_string("foo")],
-                            span: Span::test_data()
+                            span: Span::test_data(),
                         },
                         Value::Record {
                             cols: vec!["Capture1".to_string(), "Capture2".to_string()],
                             vals: vec![Value::test_string("bar"), Value::test_string("")],
                             span: Span::test_data(),
-                        }],
+                        },
+                    ],
                     span: Span::test_data(),
                 }),
             },
             Example {
                 description: "Parse a string using fancy-regex look behind pattern",
-                example: "\" @another(foo bar)   \" | parse -r '\\s*(?<=[() ])(@\\w+)(\\([^)]*\\))?\\s*'",
+                example:
+                    "\" @another(foo bar)   \" | parse -r '\\s*(?<=[() ])(@\\w+)(\\([^)]*\\))?\\s*'",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["Capture1".to_string(), "Capture2".to_string()],
-                        vals: vec![Value::test_string("@another"), Value::test_string("(foo bar)")],
-                        span: Span::test_data()
+                        vals: vec![
+                            Value::test_string("@another"),
+                            Value::test_string("(foo bar)"),
+                        ],
+                        span: Span::test_data(),
                     }],
                     span: Span::test_data(),
                 }),
@@ -105,12 +110,11 @@ impl Command for Parse {
                     vals: vec![Value::Record {
                         cols: vec!["Capture1".to_string()],
                         vals: vec![Value::test_string("b")],
-                        span: Span::test_data()
+                        span: Span::test_data(),
                     }],
                     span: Span::test_data(),
                 }),
             },
-
         ]
     }
 

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -48,17 +48,17 @@ impl Command for Parse {
         vec![
             Example {
                 description: "Parse a string into two named columns",
-                example: "echo \"hi there\" | parse \"{foo} {bar}\"",
+                example: "\"hi there\" | parse \"{foo} {bar}\"",
                 result: Some(result.clone()),
             },
             Example {
                 description: "Parse a string using regex pattern",
-                example: "echo \"hi there\" | parse -r '(?P<foo>\\w+) (?P<bar>\\w+)'",
+                example: "\"hi there\" | parse -r '(?P<foo>\\w+) (?P<bar>\\w+)'",
                 result: Some(result),
             },
             Example {
                 description: "Parse a string using fancy-regex named capture group pattern",
-                example: "echo \"foo bar.\" | parse -r '\\s*(?<name>\\w+)(?=\\.)'",
+                example: "\"foo bar.\" | parse -r '\\s*(?<name>\\w+)(?=\\.)'",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["name".to_string()],
@@ -70,7 +70,7 @@ impl Command for Parse {
             },
             Example {
                 description: "Parse a string using fancy-regex capture group pattern",
-                example: "echo \"foo! bar.\" | parse -r '(\\w+)(?=\\.)|(\\w+)(?=!)'",
+                example: "\"foo! bar.\" | parse -r '(\\w+)(?=\\.)|(\\w+)(?=!)'",
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {
@@ -88,7 +88,7 @@ impl Command for Parse {
             },
             Example {
                 description: "Parse a string using fancy-regex look behind pattern",
-                example: "echo \" @another(foo bar)   \" | parse -r '\\s*(?<=[() ])(@\\w+)(\\([^)]*\\))?\\s*'",
+                example: "\" @another(foo bar)   \" | parse -r '\\s*(?<=[() ])(@\\w+)(\\([^)]*\\))?\\s*'",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["Capture1".to_string(), "Capture2".to_string()],
@@ -100,7 +100,7 @@ impl Command for Parse {
             },
             Example {
                 description: "Parse a string using fancy-regex look ahead atomic group pattern",
-                example: "echo \"abcd\" | parse -r '^a(bc(?=d)|b)cd$'",
+                example: "\"abcd\" | parse -r '^a(bc(?=d)|b)cd$'",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["Capture1".to_string()],

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -60,7 +60,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Split a string into columns by the specified separator",
-                example: "echo 'a--b--c' | split column '--'",
+                example: "'a--b--c' | split column '--'",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec![

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -54,7 +54,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Split a string into rows of char",
-                example: "echo 'abc' | split row ''",
+                example: "'abc' | split row ''",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string(""),
@@ -68,7 +68,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Split a string into rows by the specified separator",
-                example: "echo 'a--b--c' | split row '--'",
+                example: "'a--b--c' | split row '--'",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string("a"),
@@ -80,7 +80,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Split a string by '-'",
-                example: "echo '-a-b-c-' | split row '-'",
+                example: "'-a-b-c-' | split row '-'",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string(""),

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -193,7 +193,7 @@ impl Command for NuCheck {
             },
             Example {
                 description: "Parse a string as script",
-                example: "echo $'two(char nl)lines' | nu-check ",
+                example: "$'two(char nl)lines' | nu-check ",
                 result: None,
             },
             Example {


### PR DESCRIPTION
`echo` tends to confuse new Nu users; they expect it to work like `print` when it just passes a value to the next stage of the pipeline.

We haven't quite figured out what to do about `echo` in the long run, but I think a good start is to remove `echo` from command examples where it would be unnecessary and arguably unidiomatic.