### PR TITLE
`table`: Check stream timeout on every item

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -17,7 +17,6 @@ use terminal_size::{Height, Width};
 use url::Url;
 
 const STREAM_PAGE_SIZE: usize = 1000;
-const STREAM_TIMEOUT_CHECK_INTERVAL: usize = 100;
 const INDEX_COLUMN_NAME: &str = "index";
 
 type NuText = (String, TextStyle);
@@ -1552,13 +1551,9 @@ impl Iterator for PagingTableCreator {
             batch.push(item);
             idx += 1;
 
-            if idx % STREAM_TIMEOUT_CHECK_INTERVAL == 0 {
-                let end_time = Instant::now();
-
-                // If we've been buffering over a second, go ahead and send out what we have so far
-                if (end_time - start_time).as_secs() >= 1 {
-                    break;
-                }
+            // If we've been buffering over a second, go ahead and send out what we have so far
+            if (Instant::now() - start_time).as_secs() >= 1 {
+                break;
             }
 
             if idx == STREAM_PAGE_SIZE {


### PR DESCRIPTION
`table` handles slow `ListStream`s in a special way: every 100 items, it checks whether 1 second has elapsed since the last table page, and if so it outputs a new page with all the items in its buffer.

**I would like to remove the "every 100 items" condition and always output whatever we have if a second has elapsed.** I think this will be a better user experience for very slow streams.

As a motivating example, imagine tailing a log file and doing some string parsing/projection on each line. The user will be really annoyed if they have to wait for 100 lines to be written to the log before seeing new results!

I did some quick performance measurements with Criterion, and the elapsed-time check takes about 16ns on my machine (Linux, 12900k). I think the performance impact of checking that for every item will be negligible.