### PR TITLE
Patch explore 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ version = "0.72.2"
 dependencies = [
  "ansi-str 0.7.2",
  "crossterm 0.24.0",
+ "lscolors",
  "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
@@ -2699,6 +2700,7 @@ dependencies = [
  "nu-parser",
  "nu-protocol",
  "nu-table",
+ "nu-utils",
  "strip-ansi-escapes",
  "terminal_size 0.2.1",
  "tui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,6 +2566,7 @@ version = "0.72.2"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
+ "nu-json",
  "nu-path",
  "nu-protocol",
  "nu-test-support",

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -19,3 +19,4 @@ nu-engine = { path = "../nu-engine", version = "0.72.2" }
 nu-test-support = { path="../nu-test-support", version = "0.72.2"  }
 # nu-path is used only for test support
 nu-path = { path="../nu-path", version = "0.72.2"  }
+nu-json = { path="../nu-json", version = "0.72.2"  }

--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -44,18 +44,14 @@ pub fn get_color_map(colors: &HashMap<String, Value>) -> HashMap<String, Style> 
 
 fn color_string_to_nustyle(color_string: String) -> Style {
     // eprintln!("color_string: {}", &color_string);
-    if color_string.chars().count() < 1 {
-        Style::default()
-    } else {
-        let nu_style = match nu_json::from_str::<NuStyle>(&color_string) {
-            Ok(s) => s,
-            Err(_) => NuStyle {
-                fg: None,
-                bg: None,
-                attr: None,
-            },
-        };
-
-        parse_nustyle(nu_style)
+    if color_string.is_empty() {
+        return Style::default();
     }
+
+    let nu_style = match nu_json::from_str::<NuStyle>(&color_string) {
+        Ok(s) => s,
+        Err(_) => return Style::default(),
+    };
+
+    parse_nustyle(nu_style)
 }

--- a/crates/nu-color-config/src/nu_style.rs
+++ b/crates/nu-color-config/src/nu_style.rs
@@ -106,6 +106,7 @@ pub fn color_record_to_nustyle(value: &Value) -> Style {
             }
         }
     }
+
     parse_nustyle(NuStyle { fg, bg, attr })
 }
 

--- a/crates/nu-command/src/viewers/explore.rs
+++ b/crates/nu-command/src/viewers/explore.rs
@@ -81,7 +81,9 @@ impl Command for Explore {
 
         let style = style_from_config(&config);
 
-        let mut config = PagerConfig::new(nu_config, &style_computer, config);
+        let lscolors = nu_explore::util::create_lscolors(engine_state, stack);
+
+        let mut config = PagerConfig::new(nu_config, &style_computer, &lscolors, config);
         config.style = style;
         config.reverse = is_reverse;
         config.peek_value = peek_value;

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -14,10 +14,12 @@ nu-parser = { path = "../nu-parser", version = "0.72.2" }
 nu-color-config = { path = "../nu-color-config", version = "0.72.2" }
 nu-engine = { path = "../nu-engine", version = "0.72.2" }
 nu-table = { path = "../nu-table", version = "0.72.2" }
-nu-json = { path="../nu-json", version = "0.72.2"  }
+nu-json = { path = "../nu-json", version = "0.72.2"  }
+nu-utils = { path = "../nu-utils", version = "0.72.2"  }
 
 terminal_size = "0.2.1"
 strip-ansi-escapes = "0.1.1"
 crossterm = "0.24.0"
 tui = "0.19.0"
 ansi-str = "0.7.2"
+lscolors = { version = "0.12.0", features = ["crossterm"], default-features = false }

--- a/crates/nu-explore/src/lib.rs
+++ b/crates/nu-explore/src/lib.rs
@@ -23,7 +23,7 @@ use views::{InformationView, Orientation, Preview, RecordView};
 pub use pager::{PagerConfig, StyleConfig};
 
 pub mod util {
-    pub use super::nu_common::{create_map, map_into_value};
+    pub use super::nu_common::{create_lscolors, create_map, map_into_value};
 }
 
 pub fn run_pager(

--- a/crates/nu-explore/src/nu_common/lscolor.rs
+++ b/crates/nu-explore/src/nu_common/lscolor.rs
@@ -1,0 +1,115 @@
+use std::fs::symlink_metadata;
+
+use lscolors::LsColors;
+use nu_ansi_term::{Color, Style};
+use nu_engine::env_to_string;
+use nu_protocol::engine::{EngineState, Stack};
+use nu_utils::get_ls_colors;
+
+use super::NuText;
+
+pub fn create_lscolors(engine_state: &EngineState, stack: &Stack) -> LsColors {
+    let colors = stack
+        .get_env_var(engine_state, "LS_COLORS")
+        .and_then(|v| env_to_string("LS_COLORS", &v, engine_state, stack).ok());
+
+    get_ls_colors(colors)
+}
+
+pub fn lscolorize(header: &[String], data: &mut [Vec<NuText>], lscolors: &LsColors) {
+    for (col, col_name) in header.iter().enumerate() {
+        if col_name != "name" {
+            continue;
+        }
+
+        for row in data.iter_mut() {
+            let (path, text_style) = &mut row[col];
+
+            let style = get_path_style(path, lscolors);
+            if let Some(style) = style {
+                *text_style = text_style.style(style);
+            }
+        }
+    }
+}
+
+fn get_path_style(path: &str, ls_colors: &LsColors) -> Option<Style> {
+    let stripped_path = nu_utils::strip_ansi_unlikely(path);
+
+    let style = match symlink_metadata(stripped_path.as_ref()) {
+        Ok(metadata) => {
+            ls_colors.style_for_path_with_metadata(stripped_path.as_ref(), Some(&metadata))
+        }
+        Err(_) => ls_colors.style_for_path(stripped_path.as_ref()),
+    };
+
+    style.map(lsstyle_to_nu_style)
+}
+
+fn lsstyle_to_nu_style(s: &lscolors::Style) -> Style {
+    let mut out = Style::default();
+    if let Some(clr) = &s.background {
+        out.background = lscolor_to_nu_color(clr);
+    }
+
+    if let Some(clr) = &s.foreground {
+        out.foreground = lscolor_to_nu_color(clr);
+    }
+
+    if s.font_style.slow_blink | s.font_style.rapid_blink {
+        out.is_blink = true;
+    }
+
+    if s.font_style.bold {
+        out.is_bold = true;
+    }
+
+    if s.font_style.dimmed {
+        out.is_dimmed = true;
+    }
+
+    if s.font_style.hidden {
+        out.is_hidden = true;
+    }
+
+    if s.font_style.reverse {
+        out.is_reverse = true;
+    }
+
+    if s.font_style.italic {
+        out.is_italic = true;
+    }
+
+    if s.font_style.underline {
+        out.is_underline = true;
+    }
+
+    out
+}
+
+fn lscolor_to_nu_color(clr: &lscolors::Color) -> Option<Color> {
+    use lscolors::Color::*;
+
+    let clr = match clr {
+        Black => Color::Black,
+        BrightBlack => Color::DarkGray,
+        Red => Color::Red,
+        BrightRed => Color::LightRed,
+        Green => Color::Green,
+        BrightGreen => Color::LightGreen,
+        Yellow => Color::Yellow,
+        BrightYellow => Color::LightYellow,
+        Blue => Color::Blue,
+        BrightBlue => Color::LightBlue,
+        Magenta => Color::Magenta,
+        BrightMagenta => Color::LightMagenta,
+        Cyan => Color::Cyan,
+        BrightCyan => Color::LightCyan,
+        White => Color::White,
+        BrightWhite => Color::LightGray,
+        &Fixed(i) => Color::Fixed(i),
+        &RGB(r, g, b) => Color::Rgb(r, g, b),
+    };
+
+    Some(clr)
+}

--- a/crates/nu-explore/src/nu_common/mod.rs
+++ b/crates/nu-explore/src/nu_common/mod.rs
@@ -1,4 +1,5 @@
 mod command;
+mod lscolor;
 mod string;
 mod table;
 mod value;
@@ -15,6 +16,7 @@ pub type NuText = (String, TextStyle);
 pub type CtrlC = Option<Arc<AtomicBool>>;
 
 pub use command::{is_ignored_command, run_command_with_value, run_nu_command};
+pub use lscolor::{create_lscolors, lscolorize};
 pub use string::truncate_str;
 pub use table::try_build_table;
 pub use value::{collect_input, collect_pipeline, create_map, map_into_value, nu_str};

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -30,7 +30,7 @@ fn collect_list_stream(mut stream: ListStream) -> (Vec<String>, Vec<Vec<Value>>)
     let mut cols = get_columns(&records);
     let data = convert_records_to_dataset(&cols, records);
 
-    // trying to deal with 'not standard input'
+    // trying to deal with 'non-standard input'
     if cols.is_empty() && !data.is_empty() {
         let min_column_length = data.iter().map(|row| row.len()).min().unwrap_or(0);
         if min_column_length > 0 {

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -30,7 +30,7 @@ fn collect_list_stream(mut stream: ListStream) -> (Vec<String>, Vec<Vec<Value>>)
     let mut cols = get_columns(&records);
     let data = convert_records_to_dataset(&cols, records);
 
-    // trying to deal with 'not standart input'
+    // trying to deal with 'not standard input'
     if cols.is_empty() && !data.is_empty() {
         let min_column_length = data.iter().map(|row| row.len()).min().unwrap_or(0);
         if min_column_length > 0 {

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -18,6 +18,7 @@ use crossterm::{
         LeaveAlternateScreen,
     },
 };
+use lscolors::LsColors;
 use nu_color_config::{lookup_ansi_color_style, StyleComputer};
 use nu_protocol::{
     engine::{EngineState, Stack},
@@ -142,6 +143,7 @@ impl<'a> Pager<'a> {
                 self.config.nu_config,
                 self.config.style_computer,
                 &self.config.config,
+                self.config.lscolors,
             ))
         }
 
@@ -161,6 +163,7 @@ pub enum Transition {
 pub struct PagerConfig<'a> {
     pub nu_config: &'a NuConfig,
     pub style_computer: &'a StyleComputer<'a>,
+    pub lscolors: &'a LsColors,
     pub config: ConfigMap,
     pub style: StyleConfig,
     pub peek_value: bool,
@@ -173,12 +176,14 @@ impl<'a> PagerConfig<'a> {
     pub fn new(
         nu_config: &'a NuConfig,
         style_computer: &'a StyleComputer,
+        lscolors: &'a LsColors,
         config: ConfigMap,
     ) -> Self {
         Self {
             nu_config,
             style_computer,
             config,
+            lscolors,
             peek_value: false,
             exit_esc: true,
             reverse: false,
@@ -267,6 +272,7 @@ fn render_ui(
                         pager.config.nu_config,
                         pager.config.style_computer,
                         &pager.config.config,
+                        pager.config.lscolors,
                     );
 
                     page.view.draw(f, available_area, cfg, &mut layout);
@@ -422,6 +428,7 @@ fn run_command(
                                     pager.config.nu_config,
                                     pager.config.style_computer,
                                     &pager.config.config,
+                                    pager.config.lscolors,
                                 ));
                             }
 
@@ -430,6 +437,7 @@ fn run_command(
                                     pager.config.nu_config,
                                     pager.config.style_computer,
                                     &pager.config.config,
+                                    pager.config.lscolors,
                                 ));
                             }
                         }
@@ -458,6 +466,7 @@ fn run_command(
                         pager.config.nu_config,
                         pager.config.style_computer,
                         &pager.config.config,
+                        pager.config.lscolors,
                     ));
 
                     *view = Some(Page::raw(new_view, is_light));

--- a/crates/nu-explore/src/views/mod.rs
+++ b/crates/nu-explore/src/views/mod.rs
@@ -7,6 +7,7 @@ mod record;
 pub mod util;
 
 use crossterm::event::KeyEvent;
+use lscolors::LsColors;
 use nu_color_config::StyleComputer;
 use nu_protocol::{
     engine::{EngineState, Stack},
@@ -61,6 +62,7 @@ pub struct ViewConfig<'a> {
     pub nu_config: &'a NuConfig,
     pub style_computer: &'a StyleComputer<'a>,
     pub config: &'a ConfigMap,
+    pub lscolors: &'a LsColors,
 }
 
 impl<'a> ViewConfig<'a> {
@@ -68,11 +70,13 @@ impl<'a> ViewConfig<'a> {
         nu_config: &'a NuConfig,
         style_computer: &'a StyleComputer<'a>,
         config: &'a ConfigMap,
+        lscolors: &'a LsColors,
     ) -> Self {
         Self {
             nu_config,
             style_computer,
             config,
+            lscolors,
         }
     }
 }

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -11,7 +11,7 @@ use nu_protocol::{
 use tui::{layout::Rect, widgets::Block};
 
 use crate::{
-    nu_common::{collect_input, NuConfig, NuSpan, NuStyle, NuText},
+    nu_common::{collect_input, lscolorize, NuConfig, NuSpan, NuStyle, NuText},
     pager::{
         report::{Report, Severity},
         ConfigMap, Frame, Transition, ViewInfo,
@@ -208,7 +208,9 @@ impl<'a> RecordView<'a> {
 
     fn create_tablew(&'a self, cfg: ViewConfig<'a>) -> TableW<'a> {
         let layer = self.get_layer_last();
-        let data = convert_records_to_string(&layer.records, cfg.nu_config, cfg.style_computer);
+        let mut data = convert_records_to_string(&layer.records, cfg.nu_config, cfg.style_computer);
+
+        lscolorize(&layer.columns, &mut data, cfg.lscolors);
 
         let headers = layer.columns.as_ref();
         let style_computer = cfg.style_computer;

--- a/crates/nu-explore/src/views/util.rs
+++ b/crates/nu-explore/src/views/util.rs
@@ -107,13 +107,7 @@ pub fn nu_ansi_color_to_tui_color(clr: NuColor) -> Option<tui::style::Color> {
 pub fn text_style_to_tui_style(style: TextStyle) -> tui::style::Style {
     let mut out = tui::style::Style::default();
     if let Some(style) = style.color_style {
-        if let Some(clr) = style.background {
-            out.bg = nu_ansi_color_to_tui_color(clr);
-        }
-
-        if let Some(clr) = style.foreground {
-            out.fg = nu_ansi_color_to_tui_color(clr);
-        }
+        out = nu_style_to_tui(style);
     }
 
     out


### PR DESCRIPTION
ref #7339 - This PR updates explore to take some of the colors from nushell, namely the line colors and the ls_colors.

note: Not sure why this regression appeared maybe it's a feature or it's no longer supposed to be supported?