### PR TITLE
prevent panic with format command

### DIFF
--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -149,7 +149,7 @@ fn extract_formatting_operations(input: String, error_span: Span, span_start: us
         }
 
         if column_span_end < column_span_start {
-            return Err(ShellError::DelimiterError("there are have unmatched curly braces".to_string(), error_span)); 
+            return Err(ShellError::DelimiterError("there are unmatched curly braces".to_string(), error_span)); 
         }
 
         if !column_name.is_empty() {

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -55,7 +55,11 @@ impl Command for Format {
                 let string_span = pattern.span()?;
                 // the string span is start as `"`, we don't need the character
                 // to generate proper span for sub expression.
-                let ops = extract_formatting_operations(string_pattern, call.head, string_span.start + 1)?;
+                let ops = extract_formatting_operations(
+                    string_pattern,
+                    call.head,
+                    string_span.start + 1,
+                )?;
 
                 format(
                     input_val,
@@ -112,7 +116,11 @@ enum FormatOperation {
 /// formatted according to the input pattern.
 /// FormatOperation::ValueNeedEval contains expression which need to eval, it has the following form:
 /// "$it.column1.column2" or "$variable"
-fn extract_formatting_operations(input: String, error_span: Span, span_start: usize) -> Result<Vec<FormatOperation>, ShellError> {
+fn extract_formatting_operations(
+    input: String,
+    error_span: Span,
+    span_start: usize,
+) -> Result<Vec<FormatOperation>, ShellError> {
     let mut output = vec![];
 
     let mut characters = input.char_indices();
@@ -149,7 +157,10 @@ fn extract_formatting_operations(input: String, error_span: Span, span_start: us
         }
 
         if column_span_end < column_span_start {
-            return Err(ShellError::DelimiterError("there are unmatched curly braces".to_string(), error_span)); 
+            return Err(ShellError::DelimiterError(
+                "there are unmatched curly braces".to_string(),
+                error_span,
+            ));
         }
 
         if !column_name.is_empty() {

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -55,7 +55,7 @@ impl Command for Format {
                 let string_span = pattern.span()?;
                 // the string span is start as `"`, we don't need the character
                 // to generate proper span for sub expression.
-                let ops = extract_formatting_operations(string_pattern, string_span.start + 1);
+                let ops = extract_formatting_operations(string_pattern, call.head, string_span.start + 1)?;
 
                 format(
                     input_val,
@@ -112,7 +112,7 @@ enum FormatOperation {
 /// formatted according to the input pattern.
 /// FormatOperation::ValueNeedEval contains expression which need to eval, it has the following form:
 /// "$it.column1.column2" or "$variable"
-fn extract_formatting_operations(input: String, span_start: usize) -> Vec<FormatOperation> {
+fn extract_formatting_operations(input: String, error_span: Span, span_start: usize) -> Result<Vec<FormatOperation>, ShellError> {
     let mut output = vec![];
 
     let mut characters = input.char_indices();
@@ -148,6 +148,10 @@ fn extract_formatting_operations(input: String, span_start: usize) -> Vec<Format
             column_name.push(ch);
         }
 
+        if column_span_end < column_span_start {
+            return Err(ShellError::DelimiterError("there are have unmatched curly braces".to_string(), error_span)); 
+        }
+
         if !column_name.is_empty() {
             if column_need_eval {
                 output.push(FormatOperation::ValueNeedEval(
@@ -166,7 +170,7 @@ fn extract_formatting_operations(input: String, span_start: usize) -> Vec<Format
             break;
         }
     }
-    output
+    Ok(output)
 }
 
 /// Format the incoming PipelineData according to the pattern

--- a/crates/nu-command/tests/commands/format.rs
+++ b/crates/nu-command/tests/commands/format.rs
@@ -43,6 +43,19 @@ fn can_use_variables() {
 }
 
 #[test]
+fn error_unmatched_brace() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+        open cargo_sample.toml
+            | format "{$it.package.name"
+        "#
+    ));
+
+    assert!(actual.err.contains("unmatched curly brace"));
+}
+
+#[test]
 fn format_filesize_works() {
     Playground::setup("format_filesize_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![


### PR DESCRIPTION
# Description

Related: #7211.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
