### PR TITLE
Add "fall-through" signatures

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -352,6 +352,7 @@ fn find_matching_block_end_in_expr(
                     let opt_expr = match arg {
                         Argument::Named((_, _, opt_expr)) => opt_expr.as_ref(),
                         Argument::Positional(inner_expr) => Some(inner_expr),
+                        Argument::Unknown(inner_expr) => Some(inner_expr),
                     };
 
                     if let Some(inner_expr) = opt_expr {

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -780,14 +780,14 @@ fn extern_custom_completion_positional(mut extern_completer: NuCompleter) {
 
 #[rstest]
 fn extern_custom_completion_long_flag_1(mut extern_completer: NuCompleter) {
-    let suggestions = extern_completer.complete("spam --foo=", 10);
+    let suggestions = extern_completer.complete("spam --foo=", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
     match_suggestions(expected, suggestions);
 }
 
 #[rstest]
 fn extern_custom_completion_long_flag_2(mut extern_completer: NuCompleter) {
-    let suggestions = extern_completer.complete("spam --foo ", 10);
+    let suggestions = extern_completer.complete("spam --foo ", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
     match_suggestions(expected, suggestions);
 }
@@ -808,7 +808,7 @@ fn extern_custom_completion_short_flag(mut extern_completer: NuCompleter) {
 
 #[rstest]
 fn extern_complete_flags(mut extern_completer: NuCompleter) {
-    let suggestions = extern_completer.complete("spam -", 5);
+    let suggestions = extern_completer.complete("spam -", 6);
     let expected: Vec<String> = vec!["--foo".into(), "-b".into(), "-f".into()];
     match_suggestions(expected, suggestions);
 }

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -34,6 +34,26 @@ fn completer_strings() -> NuCompleter {
     NuCompleter::new(std::sync::Arc::new(engine), stack)
 }
 
+#[fixture]
+fn extern_completer() -> NuCompleter {
+    // Create a new engine
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Add record value as example
+    let record = r#"
+        def animals [] { [ "cat", "dog", "eel" ] }
+        extern spam [
+            animal: string@animals
+            --foo (-f): string@animals
+            -b: string@animals
+        ]
+    "#;
+    assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
+
+    // Instantiate a new completer
+    NuCompleter::new(std::sync::Arc::new(engine), stack)
+}
+
 #[test]
 fn variables_dollar_sign_with_varialblecompletion() {
     let (_, _, engine, stack) = new_engine();
@@ -749,4 +769,46 @@ fn filecompletions_triggers_after_cursor() {
     ];
 
     match_suggestions(expected_paths, suggestions);
+}
+
+#[rstest]
+fn extern_custom_completion_positional(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam ", 5);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn extern_custom_completion_long_flag_1(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam --foo=", 10);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn extern_custom_completion_long_flag_2(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam --foo ", 10);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn extern_custom_completion_long_flag_short(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam -f ", 8);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn extern_custom_completion_short_flag(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam -b ", 8);
+    let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
+    match_suggestions(expected, suggestions);
+}
+
+#[rstest]
+fn extern_complete_flags(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam -", 5);
+    let expected: Vec<String> = vec!["--foo".into(), "-b".into(), "-f".into()];
+    match_suggestions(expected, suggestions);
 }

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -1,7 +1,7 @@
-use super::run_external::ExternalCommand;
-use nu_engine::{current_dir, env_to_strings, CallExt};
+use super::run_external::create_external_command;
+use nu_engine::{current_dir, CallExt};
 use nu_protocol::{
-    ast::{Call, Expr},
+    ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
 };
@@ -64,36 +64,22 @@ fn exec(
     let name: Spanned<String> = call.req(engine_state, stack, 0)?;
     let name_span = name.span;
 
-    let args: Vec<Spanned<String>> = call.rest(engine_state, stack, 1)?;
-    let args_expr: Vec<nu_protocol::ast::Expression> =
-        call.positional_iter().skip(1).cloned().collect();
-    let mut arg_keep_raw = vec![];
-    for one_arg_expr in args_expr {
-        match one_arg_expr.expr {
-            // refer to `parse_dollar_expr` function
-            // the expression type of $variable_name, $"($variable_name)"
-            // will be Expr::StringInterpolation, Expr::FullCellPath
-            Expr::StringInterpolation(_) | Expr::FullCellPath(_) => arg_keep_raw.push(true),
-            _ => arg_keep_raw.push(false),
-        }
-    }
+    let redirect_stdout = call.has_flag("redirect-stdout");
+    let redirect_stderr = call.has_flag("redirect-stderr");
+    let trim_end_newline = call.has_flag("trim-end-newline");
+
+    let external_command = create_external_command(
+        engine_state,
+        stack,
+        call,
+        redirect_stdout,
+        redirect_stderr,
+        trim_end_newline,
+    )?;
 
     let cwd = current_dir(engine_state, stack)?;
-    let env_vars = env_to_strings(engine_state, stack)?;
-    let current_dir = current_dir(engine_state, stack)?;
-
-    let external_command = ExternalCommand {
-        name,
-        args,
-        arg_keep_raw,
-        env_vars,
-        redirect_stdout: true,
-        redirect_stderr: false,
-        trim_end_newline: false,
-    };
-
     let mut command = external_command.spawn_simple_command(&cwd.to_string_lossy())?;
-    command.current_dir(current_dir);
+    command.current_dir(cwd);
 
     let err = command.exec(); // this replaces our process, should not return
 

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -18,11 +18,7 @@ impl Command for Exec {
     fn signature(&self) -> Signature {
         Signature::build("exec")
             .required("command", SyntaxShape::String, "the command to execute")
-            .rest(
-                "rest",
-                SyntaxShape::String,
-                "any additional arguments for the command",
-            )
+            .allows_unknown_args()
             .category(Category::System)
     }
 

--- a/crates/nu-command/tests/commands/exec.rs
+++ b/crates/nu-command/tests/commands/exec.rs
@@ -1,0 +1,58 @@
+use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn basic_exec() {
+    Playground::setup("test_exec_1", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu -c 'exec nu --testbin cococo a b c'
+            "#
+        ));
+
+        assert_eq!(actual.out, "a b c");
+    })
+}
+
+#[test]
+fn exec_complex_args() {
+    Playground::setup("test_exec_2", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu -c 'exec nu --testbin cococo b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --'
+            "#
+        ));
+
+        assert_eq!(actual.out, "b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --");
+    })
+}
+
+#[test]
+fn exec_fail_batched_short_args() {
+    Playground::setup("test_exec_3", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu -c 'exec nu --testbin cococo -ab 10'
+            "#
+        ));
+
+        assert_eq!(actual.out, "");
+    })
+}
+
+#[test]
+fn exec_misc_values() {
+    Playground::setup("test_exec_4", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                nu -c 'let x = "abc"; exec nu --testbin cococo $x [ a b c ]'
+            "#
+        ));
+
+        assert_eq!(actual.out, "abc a b c");
+    })
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -20,6 +20,7 @@ mod empty;
 mod enter;
 mod error_make;
 mod every;
+#[cfg(not(windows))]
 mod exec;
 mod export_def;
 mod find;

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -20,6 +20,7 @@ mod empty;
 mod enter;
 mod error_make;
 mod every;
+mod exec;
 mod export_def;
 mod find;
 mod first;

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -96,6 +96,7 @@ impl Command for KnownExternal {
                         extern_call.add_positional(arg.clone());
                     }
                 }
+                Argument::Unknown(unknown) => extern_call.add_unknown(unknown.clone()),
             }
         }
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -498,6 +498,7 @@ pub fn parse_extern(
 
                 signature.name = name.clone();
                 signature.usage = usage.clone();
+                signature.allows_unknown_args = true;
 
                 let decl = KnownExternal {
                     name: name.to_string(),

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -7,6 +7,7 @@ use crate::{DeclId, Span, Spanned};
 pub enum Argument {
     Positional(Expression),
     Named((Spanned<String>, Option<Spanned<String>>, Option<Expression>)),
+    Unknown(Expression), // unknown argument used in "fall-through" signatures
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -36,6 +37,7 @@ impl Call {
         self.arguments.iter().filter_map(|arg| match arg {
             Argument::Named(named) => Some(named),
             Argument::Positional(_) => None,
+            Argument::Unknown(_) => None,
         })
     }
 
@@ -46,6 +48,7 @@ impl Call {
         self.arguments.iter_mut().filter_map(|arg| match arg {
             Argument::Named(named) => Some(named),
             Argument::Positional(_) => None,
+            Argument::Unknown(_) => None,
         })
     }
 
@@ -64,10 +67,15 @@ impl Call {
         self.arguments.push(Argument::Positional(positional));
     }
 
+    pub fn add_unknown(&mut self, unknown: Expression) {
+        self.arguments.push(Argument::Unknown(unknown));
+    }
+
     pub fn positional_iter(&self) -> impl Iterator<Item = &Expression> {
         self.arguments.iter().filter_map(|arg| match arg {
             Argument::Named(_) => None,
             Argument::Positional(positional) => Some(positional),
+            Argument::Unknown(unknown) => Some(unknown),
         })
     }
 
@@ -75,6 +83,7 @@ impl Call {
         self.arguments.iter_mut().filter_map(|arg| match arg {
             Argument::Named(_) => None,
             Argument::Positional(positional) => Some(positional),
+            Argument::Unknown(unknown) => Some(unknown),
         })
     }
 

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -118,6 +118,7 @@ pub struct Signature {
     pub allow_variants_without_examples: bool,
     pub is_filter: bool,
     pub creates_scope: bool,
+    pub allows_unknown_args: bool,
     // Signature category used to classify commands stored in the list of declarations
     pub category: Category,
 }
@@ -220,6 +221,7 @@ impl Signature {
             is_filter: false,
             creates_scope: false,
             category: Category::Default,
+            allows_unknown_args: false,
         }
     }
 
@@ -271,6 +273,12 @@ impl Signature {
             .collect();
         self.extra_usage = command.extra_usage().to_string();
         self.usage = command.usage().to_string();
+        self
+    }
+
+    /// Allow unknown signature parameters
+    pub fn allows_unknown_args(mut self) -> Signature {
+        self.allows_unknown_args = true;
         self
     }
 

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -101,7 +101,6 @@ module completions {
     --dry-run(-n)                                   # dry run
     --exec: string                                  # receive pack program
     --follow-tags                                   # push missing but relevant tags
-    --force-with-lease                              # require old value of ref to be at this value
     --force(-f)                                     # force updates
     --ipv4(-4)                                      # use IPv4 addresses only
     --ipv6(-6)                                      # use IPv6 addresses only
@@ -292,7 +291,7 @@ let light_theme = {
 }
 
 # External completer example
-# let carapace_completer = {|spans| 
+# let carapace_completer = {|spans|
 #     carapace $spans.0 nushell $spans | from json
 # }
 
@@ -325,31 +324,31 @@ let-env config = {
 
     command_bar_text: '#C4C9C6'
     # command_bar: {fg: '#C4C9C6' bg: '#223311' }
-    
+
     status_bar_background: {fg: '#1D1F21' bg: '#C4C9C6' }
     # status_bar_text: {fg: '#C4C9C6' bg: '#223311' }
 
     highlight: {bg: 'yellow' fg: 'black' }
 
     status: {
-      # warn: {bg: 'yellow', fg: 'blue'} 
-      # error: {bg: 'yellow', fg: 'blue'} 
+      # warn: {bg: 'yellow', fg: 'blue'}
+      # error: {bg: 'yellow', fg: 'blue'}
       # info: {bg: 'yellow', fg: 'blue'}
     }
 
     try: {
-      # border_color: 'red' 
+      # border_color: 'red'
       # highlighted_color: 'blue'
 
       # reactive: false
     }
 
     table: {
-      split_line: '#404040' 
+      split_line: '#404040'
 
       cursor: true
 
-      line_index: true 
+      line_index: true
       line_shift: true
       line_head_top: true
       line_head_bottom: true
@@ -357,14 +356,14 @@ let-env config = {
       show_head: true
       show_index: true
 
-      # selected_cell: {fg: 'white', bg: '#777777'} 
-      # selected_row: {fg: 'yellow', bg: '#C1C2A3'} 
+      # selected_cell: {fg: 'white', bg: '#777777'}
+      # selected_row: {fg: 'yellow', bg: '#C1C2A3'}
       # selected_column: blue
 
-      # padding_column_right: 2 
+      # padding_column_right: 2
       # padding_column_left: 2
 
-      # padding_index_left: 2 
+      # padding_index_left: 2
       # padding_index_right: 1
     }
 

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -10,10 +10,7 @@ fn known_external_runs() -> TestResult {
 
 #[test]
 fn known_external_unknown_flag() -> TestResult {
-    fail_test(
-        r#"extern "cargo version" []; cargo version --no-such-flag"#,
-        "command doesn't have flag",
-    )
+    run_test_contains(r#"extern "cargo" []; cargo --version"#, "cargo")
 }
 
 /// GitHub issues #5179, #4618
@@ -31,5 +28,21 @@ fn known_external_subcommand_alias() -> TestResult {
     run_test_contains(
         r#"extern "cargo version" []; alias c = cargo; c version"#,
         "cargo",
+    )
+}
+
+#[test]
+fn known_external_complex_unknown_args() -> TestResult {
+    run_test_contains(
+        "extern echo []; echo foo -b -as -9 --abc -- -Dxmy=AKOO - bar",
+        "foo -b -as -9 --abc -- -Dxmy=AKOO - bar",
+    )
+}
+
+#[test]
+fn known_external_batched_short_flag_arg_disallowed() -> TestResult {
+    fail_test(
+        "extern echo [-a, -b: int]; echo -ab 10",
+        "short flag batches",
     )
 }

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -1,4 +1,4 @@
-use crate::tests::{fail_test, run_test_contains, TestResult};
+use crate::tests::{fail_test, run_test, run_test_contains, TestResult};
 
 // cargo version prints a string of the form:
 // cargo 1.60.0 (d1fd9fe2c 2022-03-01)
@@ -44,5 +44,35 @@ fn known_external_batched_short_flag_arg_disallowed() -> TestResult {
     fail_test(
         "extern echo [-a, -b: int]; echo -ab 10",
         "short flag batches",
+    )
+}
+
+#[test]
+fn known_external_missing_positional() -> TestResult {
+    fail_test("extern echo [a]; echo", "missing_positional")
+}
+
+#[test]
+fn known_external_type_mismatch() -> TestResult {
+    fail_test("extern echo [a: int]; echo 1.234", "mismatch")
+}
+
+#[test]
+fn known_external_missing_flag_param() -> TestResult {
+    fail_test(
+        "extern echo [--foo: string]; echo --foo",
+        "missing_flag_param",
+    )
+}
+
+#[test]
+fn known_external_misc_values() -> TestResult {
+    run_test(
+        r#"
+            let x = 'abc'
+            extern echo []
+            echo $x [ a b c ]
+        "#,
+        "abc a b c",
     )
 }


### PR DESCRIPTION
# Description

Adds a "fall-through" type of signature which does not throw errors if is called with unknown flags/positionals. This type of signatures is enabled for known externals defined with `extern` and the `exec` built-in command.

The PR is a continuation of https://github.com/nushell/nushell/pull/6567 made by @merelymyself and https://github.com/nushell/nushell/pull/7461 made by @WindSoilder.

Fixes https://github.com/nushell/nushell/issues/4659. Fixes https://github.com/nushell/nushell/issues/5294. Fixes https://github.com/nushell/nushell/issues/6124.

Does not fix: https://github.com/nushell/nushell/issues/5103

## Problematic flags

These flags remain somewhat tricky:
* `-0`: gets parsed as `0` integer and re-printed as `0` instead of `-0`
* `-h`, `--help`: Prints the help message of `exec` and doesn't pass the flag to the external. If defined as `extern` the command will pass the `-h` flag to the external but won't print the help message.

# User-Facing Changes

* Signatures defined with `extern` now allow unknown arguments
* `exec` now allows unknown arguments same as known external
* tweaks to `exec`argument handling so their behavior is consistent with running other externals (e.g., `exec foo $x [ a b c ] -90` will now work correctly)
* The Signature struct changed which means you need to delete `$nu.plugin-file` and re-`register` all of your plugins.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
