### PR TITLE
Add more input/output type annotations

### DIFF
--- a/crates/nu-cli/src/nu_highlight.rs
+++ b/crates/nu-cli/src/nu_highlight.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Type, Value};
 use reedline::Highlighter;
 
 #[derive(Clone)]
@@ -12,7 +12,9 @@ impl Command for NuHighlight {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("nu-highlight").category(Category::Strings)
+        Signature::build("nu-highlight")
+            .category(Category::Strings)
+            .input_output_types(vec![(Type::String, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -2,7 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
+    Value,
 };
 
 #[derive(Clone)]
@@ -15,6 +16,7 @@ impl Command for Print {
 
     fn signature(&self) -> Signature {
         Signature::build("print")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .rest("rest", SyntaxShape::Any, "the values to print")
             .switch(
                 "no-newline",

--- a/crates/nu-command/src/bits/bits_.rs
+++ b/crates/nu-command/src/bits/bits_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for Bits {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("bits").category(Category::Bits)
+        Signature::build("bits")
+            .category(Category::Bits)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {
@@ -39,17 +41,5 @@ impl Command for Bits {
             span: call.head,
         }
         .into_pipeline_data())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::Bits;
-
-    #[test]
-    fn test_examples() {
-        use crate::test_examples;
-
-        test_examples(Bits {})
     }
 }

--- a/crates/nu-command/src/bytes/bytes_.rs
+++ b/crates/nu-command/src/bytes/bytes_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for Bytes {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("bytes").category(Category::Bytes)
+        Signature::build("bytes")
+            .category(Category::Bytes)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {
@@ -39,17 +41,5 @@ impl Command for Bytes {
             span: call.head,
         }
         .into_pipeline_data())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::Bytes;
-
-    #[test]
-    fn test_examples() {
-        use crate::test_examples;
-
-        test_examples(Bytes {})
     }
 }

--- a/crates/nu-command/src/conversions/into/command.rs
+++ b/crates/nu-command/src/conversions/into/command.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for Into {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("into").category(Category::Conversions)
+        Signature::build("into")
+            .category(Category::Conversions)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {
@@ -39,17 +41,5 @@ impl Command for Into {
             span: call.head,
         }
         .into_pipeline_data())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_examples() {
-        use crate::test_examples;
-
-        test_examples(Into {})
     }
 }

--- a/crates/nu-command/src/core_commands/error_make.rs
+++ b/crates/nu-command/src/core_commands/error_make.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -15,6 +15,7 @@ impl Command for ErrorMake {
 
     fn signature(&self) -> Signature {
         Signature::build("error make")
+            .input_output_types(vec![(Type::Nothing, Type::Error)])
             .required("error_struct", SyntaxShape::Record, "the error to create")
             .switch(
                 "unspanned",

--- a/crates/nu-command/src/core_commands/for_.rs
+++ b/crates/nu-command/src/core_commands/for_.rs
@@ -2,7 +2,7 @@ use nu_engine::{eval_block, eval_expression, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Block, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, ListStream, PipelineData, ShellError, Signature, SyntaxShape, Value,
+    Category, Example, ListStream, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -19,6 +19,8 @@ impl Command for For {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("for")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
             .required(
                 "var_name",
                 SyntaxShape::VarWithOptType,

--- a/crates/nu-command/src/core_commands/help_operators.rs
+++ b/crates/nu-command/src/core_commands/help_operators.rs
@@ -1,7 +1,7 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Value,
+    Category, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -17,7 +17,10 @@ impl Command for HelpOperators {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("help operators").category(Category::Core)
+        Signature::build("help operators")
+            .category(Category::Core)
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .allow_variants_without_examples(true)
     }
 
     fn run(

--- a/crates/nu-command/src/core_commands/loop_.rs
+++ b/crates/nu-command/src/core_commands/loop_.rs
@@ -2,7 +2,7 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Block, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -19,6 +19,8 @@ impl Command for Loop {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("loop")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
             .required("block", SyntaxShape::Block, "block to loop")
             .category(Category::Core)
     }

--- a/crates/nu-command/src/core_commands/overlay/command.rs
+++ b/crates/nu-command/src/core_commands/overlay/command.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for Overlay {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("overlay").category(Category::Core)
+        Signature::build("overlay")
+            .category(Category::Core)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {
@@ -48,17 +50,5 @@ impl Command for Overlay {
             span: call.head,
         }
         .into_pipeline_data())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_examples() {
-        use crate::test_examples;
-
-        test_examples(Overlay {})
     }
 }

--- a/crates/nu-command/src/core_commands/overlay/hide.rs
+++ b/crates/nu-command/src/core_commands/overlay/hide.rs
@@ -1,7 +1,9 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
+};
 
 #[derive(Clone)]
 pub struct OverlayHide;
@@ -17,6 +19,7 @@ impl Command for OverlayHide {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay hide")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .optional("name", SyntaxShape::String, "Overlay to hide")
             .switch(
                 "keep-custom",

--- a/crates/nu-command/src/core_commands/overlay/list.rs
+++ b/crates/nu-command/src/core_commands/overlay/list.rs
@@ -1,7 +1,7 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Type, Value,
 };
 
 #[derive(Clone)]
@@ -17,7 +17,9 @@ impl Command for OverlayList {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("overlay list").category(Category::Core)
+        Signature::build("overlay list")
+            .category(Category::Core)
+            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::String)))])
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/core_commands/overlay/new.rs
+++ b/crates/nu-command/src/core_commands/overlay/new.rs
@@ -1,7 +1,9 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
+};
 
 #[derive(Clone)]
 pub struct OverlayNew;
@@ -17,6 +19,8 @@ impl Command for OverlayNew {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay new")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
             .required("name", SyntaxShape::String, "Name of the overlay")
             // TODO:
             // .switch(

--- a/crates/nu-command/src/core_commands/overlay/use_.rs
+++ b/crates/nu-command/src/core_commands/overlay/use_.rs
@@ -3,7 +3,7 @@ use nu_parser::trim_quotes_str;
 use nu_protocol::ast::{Call, Expr};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type, Value,
 };
 
 use std::path::Path;
@@ -22,6 +22,8 @@ impl Command for OverlayUse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay use")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
             .required(
                 "name",
                 SyntaxShape::String,

--- a/crates/nu-command/src/core_commands/while_.rs
+++ b/crates/nu-command/src/core_commands/while_.rs
@@ -1,7 +1,9 @@
 use nu_engine::{eval_block, eval_expression, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Block, Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct While;
@@ -17,6 +19,8 @@ impl Command for While {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("while")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
             .required("cond", SyntaxShape::Expression, "condition to check")
             .required(
                 "block",

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -20,6 +20,9 @@ impl Command for IntoSqliteDb {
 
     fn signature(&self) -> Signature {
         Signature::build("into sqlite")
+            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .allow_variants_without_examples(true)
+            // TODO: narrow disallowed types
             .required(
                 "file_name",
                 SyntaxShape::String,

--- a/crates/nu-command/src/database/commands/query_db.rs
+++ b/crates/nu-command/src/database/commands/query_db.rs
@@ -18,6 +18,7 @@ impl Command for QueryDb {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .required(
                 "SQL",
                 SyntaxShape::String,

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -16,6 +16,7 @@ impl Command for SchemaDb {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .input_type(Type::Any)
             .output_type(Type::Any)
             .category(Category::Custom("database".into()))

--- a/crates/nu-command/src/date/date_.rs
+++ b/crates/nu-command/src/date/date_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+    Category, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for Date {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("date").category(Category::Date)
+        Signature::build("date")
+            .category(Category::Date)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/deprecated/source.rs
+++ b/crates/nu-command/src/deprecated/source.rs
@@ -1,7 +1,7 @@
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -14,6 +14,7 @@ impl Command for Source {
 
     fn signature(&self) -> Signature {
         Signature::build("source")
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .required(
                 "filename",
                 SyntaxShape::Filepath,

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for ConfigMeta {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Env)
+        Signature::build(self.name())
+            .category(Category::Env)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -2,7 +2,7 @@ use nu_engine::env_to_strings;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned,
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, Type,
 };
 
 use crate::ExternalCommand;
@@ -18,7 +18,10 @@ impl Command for ConfigEnv {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Env)
+        Signature::build(self.name())
+            .category(Category::Env)
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+        // TODO: Signature narrower than what run actually supports theoretically
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -2,7 +2,7 @@ use nu_engine::env_to_strings;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned,
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, Type,
 };
 
 use crate::ExternalCommand;
@@ -18,7 +18,10 @@ impl Command for ConfigNu {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Env)
+        Signature::build(self.name())
+            .category(Category::Env)
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+        // TODO: Signature narrower than what run actually supports theoretically
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/env/env_command.rs
+++ b/crates/nu-command/src/env/env_command.rs
@@ -2,7 +2,7 @@ use nu_engine::env_to_string;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -18,7 +18,9 @@ impl Command for Env {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("env").category(Category::Env)
+        Signature::build("env")
+            .category(Category::Env)
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
     }
 
     fn run(

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -2,7 +2,7 @@ use nu_engine::{eval_expression_with_input, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -19,6 +19,8 @@ impl Command for LetEnv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("let-env")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
             .required("var_name", SyntaxShape::String, "variable name")
             .required(
                 "initial_value",

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -1,7 +1,9 @@
 use nu_engine::{current_dir, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct LoadEnv;
@@ -17,6 +19,8 @@ impl Command for LoadEnv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("load-env")
+            .input_output_types(vec![(Type::Record(vec![]), Type::Nothing)])
+            .allow_variants_without_examples(true)
             .optional(
                 "update",
                 SyntaxShape::Record,

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -4,7 +4,7 @@ use nu_engine::{eval_block, find_in_dirs_env, redirect_env, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type, Value,
 };
 
 /// Source a file for environment variables.
@@ -18,6 +18,7 @@ impl Command for SourceEnv {
 
     fn signature(&self) -> Signature {
         Signature::build("source-env")
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .required(
                 "filename",
                 SyntaxShape::String, // type is string to avoid automatically canonicalizing the path

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -1,7 +1,9 @@
 use is_root::is_root;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Span, Value};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct IsAdmin;
@@ -16,7 +18,10 @@ impl Command for IsAdmin {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("is-admin").category(Category::Core)
+        Signature::build("is-admin")
+            .category(Category::Core)
+            .input_output_types(vec![(Type::Nothing, Type::Bool)])
+            .allow_variants_without_examples(true)
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -4,7 +4,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
-    Value,
+    Type, Value,
 };
 
 #[derive(Clone)]
@@ -21,6 +21,7 @@ impl Command for ViewSource {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("view-source")
+            .input_output_types(vec![(Type::Nothing, Type::String)])
             .required("item", SyntaxShape::Any, "name or block to view")
             .category(Category::Core)
     }

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -8,7 +8,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Closure, Command, EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
     format_error, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature,
-    Spanned, SyntaxShape, Value,
+    Spanned, SyntaxShape, Type, Value,
 };
 
 // durations chosen mostly arbitrarily
@@ -33,6 +33,7 @@ impl Command for Watch {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("watch")
+        .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .required("path", SyntaxShape::Filepath, "the path to watch. Can be a file or directory")
             .required("closure",
             SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),

--- a/crates/nu-command/src/filters/roll/roll_.rs
+++ b/crates/nu-command/src/filters/roll/roll_.rs
@@ -1,7 +1,7 @@
 use nu_engine::get_full_help;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
 
 #[derive(Clone)]
 pub struct Roll;
@@ -16,7 +16,9 @@ impl Command for Roll {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Filters)
+        Signature::build(self.name())
+            .category(Category::Filters)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/formats/from/command.rs
+++ b/crates/nu-command/src/formats/from/command.rs
@@ -1,7 +1,7 @@
 use nu_engine::get_full_help;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
 
 #[derive(Clone)]
 pub struct From;
@@ -16,7 +16,9 @@ impl Command for From {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("from").category(Category::Formats)
+        Signature::build("from")
+            .category(Category::Formats)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn run(

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -51,7 +51,9 @@ impl Command for FromYml {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("from yml").category(Category::Formats)
+        Signature::build("from yml")
+            .input_output_types(vec![(Type::String, Type::Any)])
+            .category(Category::Formats)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/formats/to/command.rs
+++ b/crates/nu-command/src/formats/to/command.rs
@@ -1,7 +1,7 @@
 use nu_engine::get_full_help;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
 
 #[derive(Clone)]
 pub struct To;
@@ -16,7 +16,9 @@ impl Command for To {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("to").category(Category::Formats)
+        Signature::build("to")
+            .category(Category::Formats)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn run(

--- a/crates/nu-command/src/hash/hash_.rs
+++ b/crates/nu-command/src/hash/hash_.rs
@@ -1,7 +1,7 @@
 use nu_engine::get_full_help;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
 
 #[derive(Clone)]
 pub struct Hash;
@@ -12,7 +12,9 @@ impl Command for Hash {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("hash").category(Category::Hash)
+        Signature::build("hash")
+            .category(Category::Hash)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/math/math_.rs
+++ b/crates/nu-command/src/math/math_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for MathCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("math").category(Category::Math)
+        Signature::build("math")
+            .category(Category::Math)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/misc/history.rs
+++ b/crates/nu-command/src/misc/history.rs
@@ -2,7 +2,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, HistoryFileFormat, IntoInterruptiblePipelineData, PipelineData, ShellError,
-    Signature, Span, Value,
+    Signature, Span, Type, Value,
 };
 use reedline::{
     FileBackedHistory, History as ReedlineHistory, HistoryItem, SearchDirection, SearchQuery,
@@ -23,6 +23,11 @@ impl Command for History {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("history")
+            .input_output_types(vec![
+                (Type::Nothing, Type::Table(vec![])),
+                (Type::Nothing, Type::Nothing),
+            ])
+            .allow_variants_without_examples(true)
             .switch("clear", "Clears out the history entries", Some('c'))
             .switch(
                 "long",

--- a/crates/nu-command/src/misc/history_session.rs
+++ b/crates/nu-command/src/misc/history_session.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Value};
+use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Type, Value};
 
 #[derive(Clone)]
 pub struct HistorySession;
@@ -15,7 +15,9 @@ impl Command for HistorySession {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("history session").category(Category::Misc)
+        Signature::build("history session")
+            .category(Category::Misc)
+            .input_output_types(vec![(Type::Nothing, Type::Int)])
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -4,7 +4,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
-    Value,
+    Type, Value,
 };
 
 #[derive(Clone)]
@@ -17,6 +17,8 @@ impl Command for Tutor {
 
     fn signature(&self) -> Signature {
         Signature::build("tutor")
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .allow_variants_without_examples(true)
             .optional(
                 "search",
                 SyntaxShape::String,

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -7,7 +7,7 @@ use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::RawStream;
 
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use reqwest::blocking::Response;
 
@@ -29,6 +29,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("fetch")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .required(
                 "URL",
                 SyntaxShape::String,

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -5,7 +5,7 @@ use nu_protocol::IntoPipelineData;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener};
 
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -18,6 +18,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("port")
+            .input_output_types(vec![(Type::Nothing, Type::Int)])
             .optional(
                 "start",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use std::collections::HashMap;
 use std::io::BufReader;
@@ -25,6 +25,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("post")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .required("path", SyntaxShape::String, "the URL to post to")
             .required("body", SyntaxShape::Any, "the contents of the post body")
             .named(

--- a/crates/nu-command/src/path/path_.rs
+++ b/crates/nu-command/src/path/path_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    IntoPipelineData, PipelineData, Signature, Value,
+    IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,7 @@ impl Command for PathCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("path")
+        Signature::build("path").input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -1,7 +1,7 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value,
 };
 use std::process::Command as CommandSys;
 
@@ -18,7 +18,9 @@ impl Command for Clear {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("clear").category(Category::Platform)
+        Signature::build("clear")
+            .category(Category::Platform)
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
     }
 
     fn run(

--- a/crates/nu-command/src/platform/du.rs
+++ b/crates/nu-command/src/platform/du.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Spanned,
-    SyntaxShape, Value,
+    SyntaxShape, Type, Value,
 };
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -43,6 +43,8 @@ impl Command for Du {
 
     fn signature(&self) -> Signature {
         Signature::build("du")
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .allow_variants_without_examples(true)
             .optional("path", SyntaxShape::GlobPattern, "starting directory")
             .switch(
                 "all",

--- a/crates/nu-command/src/platform/input.rs
+++ b/crates/nu-command/src/platform/input.rs
@@ -3,7 +3,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
+    Value,
 };
 use std::io::{Read, Write};
 
@@ -25,6 +26,11 @@ impl Command for Input {
 
     fn signature(&self) -> Signature {
         Signature::build("input")
+            .input_output_types(vec![
+                (Type::Nothing, Type::String),
+                (Type::Nothing, Type::Binary),
+            ])
+            .allow_variants_without_examples(true)
             .optional("prompt", SyntaxShape::String, "prompt to show the user")
             .named(
                 "bytes-until",

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -3,7 +3,7 @@ use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{ast::Call, span};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, Spanned, SyntaxShape, Value,
+    Signature, Spanned, SyntaxShape, Type, Value,
 };
 use std::process::{Command as CommandSys, Stdio};
 
@@ -21,6 +21,8 @@ impl Command for Kill {
 
     fn signature(&self) -> Signature {
         let signature = Signature::build("kill")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .allow_variants_without_examples(true)
             .required(
                 "pid",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/platform/reedline_commands/keybindings.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for Keybindings {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Platform)
+        Signature::build(self.name())
+            .category(Category::Platform)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_default.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_default.rs
@@ -1,7 +1,7 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, IntoPipelineData, PipelineData, Signature, Value,
+    Category, Example, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 use reedline::get_reedline_default_keybindings;
 
@@ -14,7 +14,9 @@ impl Command for KeybindingsDefault {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Platform)
+        Signature::build(self.name())
+            .category(Category::Platform)
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
@@ -1,7 +1,7 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, IntoPipelineData, PipelineData, Signature, Span, Value,
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span, Type, Value,
 };
 use reedline::{
     get_reedline_edit_commands, get_reedline_keybinding_modifiers, get_reedline_keycodes,
@@ -18,6 +18,7 @@ impl Command for KeybindingsList {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .switch("modifiers", "list of modifiers", Some('m'))
             .switch("keycodes", "list of keycodes", Some('k'))
             .switch("modes", "list of edit modes", Some('o'))

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_listen.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_listen.rs
@@ -3,7 +3,7 @@ use crossterm::{event::Event, event::KeyCode, event::KeyEvent, terminal};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Type, Value,
 };
 use std::io::{stdout, Write};
 
@@ -20,7 +20,10 @@ impl Command for KeybindingsListen {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build(self.name()).category(Category::Platform)
+        Signature::build(self.name())
+            .category(Category::Platform)
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .allow_variants_without_examples(true)
     }
 
     fn run(

--- a/crates/nu-command/src/platform/term_size.rs
+++ b/crates/nu-command/src/platform/term_size.rs
@@ -1,6 +1,8 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, IntoPipelineData, PipelineData, Signature, Span, Value};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, Signature, Span, Type, Value,
+};
 use terminal_size::{terminal_size, Height, Width};
 
 #[derive(Clone)]
@@ -16,7 +18,15 @@ impl Command for TermSize {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("term size").category(Category::Platform)
+        Signature::build("term size")
+            .category(Category::Platform)
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Record(vec![
+                    ("columns".into(), Type::Int),
+                    ("rows".into(), Type::Int),
+                ]),
+            )])
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/random/bool.rs
+++ b/crates/nu-command/src/random/bool.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type, Value,
 };
 use rand::prelude::{thread_rng, Rng};
 
@@ -16,6 +16,8 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random bool")
+            .input_output_types(vec![(Type::Nothing, Type::Bool)])
+            .allow_variants_without_examples(true)
             .named(
                 "bias",
                 SyntaxShape::Number,

--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -1,7 +1,9 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
 use rand::{
     distributions::{Alphanumeric, Distribution},
     thread_rng,
@@ -19,6 +21,8 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random chars")
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .allow_variants_without_examples(true)
             .named("length", SyntaxShape::Int, "Number of chars", Some('l'))
             .category(Category::Random)
     }

--- a/crates/nu-command/src/random/decimal.rs
+++ b/crates/nu-command/src/random/decimal.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, Range, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, Range, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use rand::prelude::{thread_rng, Rng};
 use std::cmp::Ordering;
@@ -17,6 +17,8 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random decimal")
+            .input_output_types(vec![(Type::Nothing, Type::Float)])
+            .allow_variants_without_examples(true)
             .optional("range", SyntaxShape::Range, "Range of values")
             .category(Category::Random)
     }

--- a/crates/nu-command/src/random/dice.rs
+++ b/crates/nu-command/src/random/dice.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, ListStream, PipelineData, ShellError, Signature, SyntaxShape, Value,
+    Category, Example, ListStream, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
 };
 use rand::prelude::{thread_rng, Rng};
 
@@ -16,6 +16,8 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random dice")
+            .input_output_types(vec![(Type::Nothing, Type::ListStream)])
+            .allow_variants_without_examples(true)
             .named(
                 "dice",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/random/integer.rs
+++ b/crates/nu-command/src/random/integer.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, Range, ShellError, Signature, SyntaxShape, Value,
+    Category, Example, PipelineData, Range, ShellError, Signature, SyntaxShape, Type, Value,
 };
 use rand::prelude::{thread_rng, Rng};
 use std::cmp::Ordering;
@@ -17,6 +17,8 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random integer")
+            .input_output_types(vec![(Type::Nothing, Type::Int)])
+            .allow_variants_without_examples(true)
             .optional("range", SyntaxShape::Range, "Range of values")
             .category(Category::Random)
     }

--- a/crates/nu-command/src/random/random_.rs
+++ b/crates/nu-command/src/random/random_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for RandomCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("random").category(Category::Random)
+        Signature::build("random")
+            .category(Category::Random)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/random/uuid.rs
+++ b/crates/nu-command/src/random/uuid.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Type, Value};
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -12,7 +12,10 @@ impl Command for SubCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("random uuid").category(Category::Random)
+        Signature::build("random uuid")
+            .category(Category::Random)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .allow_variants_without_examples(true)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/shells/enter.rs
+++ b/crates/nu-command/src/shells/enter.rs
@@ -2,7 +2,9 @@ use super::{get_current_shell, get_shells};
 use nu_engine::{current_dir, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -15,6 +17,7 @@ impl Command for Enter {
 
     fn signature(&self) -> Signature {
         Signature::build("enter")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required(
                 "path",
                 SyntaxShape::Filepath,

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -2,7 +2,9 @@ use super::{get_current_shell, get_last_shell, get_shells};
 use nu_engine::{current_dir, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Value};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct Exit;
@@ -14,6 +16,7 @@ impl Command for Exit {
 
     fn signature(&self) -> Signature {
         Signature::build("exit")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .optional(
                 "exit_code",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/shells/g.rs
+++ b/crates/nu-command/src/shells/g.rs
@@ -2,7 +2,9 @@ use super::{list_shells, switch_shell, SwitchTo};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
+};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -15,6 +17,10 @@ impl Command for GotoShell {
 
     fn signature(&self) -> Signature {
         Signature::build("g")
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::Nothing, Type::Table(vec![])),
+            ])
             .optional(
                 "shell_number",
                 SyntaxShape::String,

--- a/crates/nu-command/src/shells/n.rs
+++ b/crates/nu-command/src/shells/n.rs
@@ -1,7 +1,7 @@
 use super::{switch_shell, SwitchTo};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Type};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -13,7 +13,9 @@ impl Command for NextShell {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("n").category(Category::Shells)
+        Signature::build("n")
+            .category(Category::Shells)
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/shells/p.rs
+++ b/crates/nu-command/src/shells/p.rs
@@ -1,7 +1,7 @@
 use super::{switch_shell, SwitchTo};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Type};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -13,7 +13,9 @@ impl Command for PrevShell {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("p").category(Category::Shells)
+        Signature::build("p")
+            .category(Category::Shells)
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/shells/shells_.rs
+++ b/crates/nu-command/src/shells/shells_.rs
@@ -1,7 +1,7 @@
 use super::list_shells;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Type};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -13,7 +13,9 @@ impl Command for Shells {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("shells").category(Category::Shells)
+        Signature::build("shells")
+            .category(Category::Shells)
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/strings/split/command.rs
+++ b/crates/nu-command/src/strings/split/command.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for SplitCommand {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("split").category(Category::Strings)
+        Signature::build("split")
+            .category(Category::Strings)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {
@@ -41,16 +43,3 @@ impl Command for SplitCommand {
         .into_pipeline_data())
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::Command;
-//     use super::ShellError;
-
-//     #[test]
-//     fn examples_work_as_expected() -> Result<(), ShellError> {
-//         use crate::examples::test as test_examples;
-
-//         test_examples(Command {})
-//     }
-// }

--- a/crates/nu-command/src/strings/str_/case/str_.rs
+++ b/crates/nu-command/src/strings/str_/case/str_.rs
@@ -2,7 +2,7 @@ use nu_engine::get_full_help;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, IntoPipelineData, PipelineData, Signature, Value,
+    Category, IntoPipelineData, PipelineData, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -14,7 +14,9 @@ impl Command for Str {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("str").category(Category::Strings)
+        Signature::build("str")
+            .category(Category::Strings)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
     fn usage(&self) -> &str {
@@ -39,17 +41,5 @@ impl Command for Str {
             span: call.head,
         }
         .into_pipeline_data())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::Str;
-
-    #[test]
-    fn test_examples() {
-        use crate::test_examples;
-
-        test_examples(Str {})
     }
 }

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -1,7 +1,7 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -13,7 +13,9 @@ impl Command for Complete {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("complete").category(Category::System)
+        Signature::build("complete")
+            .category(Category::System)
+            .input_output_types(vec![(Type::Any, Type::Record(vec![]))])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -3,7 +3,7 @@ use nu_engine::{current_dir, env_to_strings, CallExt};
 use nu_protocol::{
     ast::{Call, Expr},
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
+    Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
 };
 use std::os::unix::process::CommandExt;
 
@@ -17,6 +17,7 @@ impl Command for Exec {
 
     fn signature(&self) -> Signature {
         Signature::build("exec")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .required("command", SyntaxShape::String, "the command to execute")
             .rest(
                 "rest",

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -3,7 +3,7 @@ use nu_parser::{parse, parse_module_block, unescape_unquote_string};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -16,6 +16,9 @@ impl Command for NuCheck {
 
     fn signature(&self) -> Signature {
         Signature::build("nu-check")
+            .input_output_types(vec![(Type::String, Type::Bool),
+            (Type::ListStream, Type::Bool),
+            (Type::List(Box::new(Type::Any)), Type::Bool)])
             // type is string to avoid automatically canonicalizing the path
             .optional("path", SyntaxShape::String, "File path to parse")
             .switch("as-module", "Parse content as module", Some('m'))

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Type,
+    Value,
 };
 
 #[derive(Clone)]
@@ -16,6 +17,7 @@ impl Command for Ps {
 
     fn signature(&self) -> Signature {
         Signature::build("ps")
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .switch(
                 "long",
                 "list all available columns for each entry",

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -3,7 +3,7 @@ use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, Span, Spanned, SyntaxShape, Value,
+    Signature, Span, Spanned, SyntaxShape, Type, Value,
 };
 use winreg::{enums::*, RegKey};
 
@@ -31,6 +31,7 @@ impl Command for RegistryQuery {
 
     fn signature(&self) -> Signature {
         Signature::build("registry query")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .switch("hkcr", "query the hkey_classes_root hive", None)
             .switch("hkcu", "query the hkey_current_user hive", None)
             .switch("hklm", "query the hkey_local_machine hive", None)

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -2,11 +2,13 @@ use fancy_regex::Regex;
 use itertools::Itertools;
 use nu_engine::env_to_strings;
 use nu_engine::CallExt;
-use nu_protocol::ast::{Expr, Expression};
-use nu_protocol::did_you_mean;
-use nu_protocol::engine::{EngineState, Stack};
-use nu_protocol::{ast::Call, engine::Command, ShellError, Signature, SyntaxShape, Value};
-use nu_protocol::{Category, Example, ListStream, PipelineData, RawStream, Span, Spanned};
+use nu_protocol::{
+    ast::{Call, Expr, Expression},
+    did_you_mean,
+    engine::{Command, EngineState, Stack},
+    Category, Example, ListStream, PipelineData, RawStream, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, Value,
+};
 use nu_system::ForegroundProcess;
 use pathdiff::diff_paths;
 use std::collections::HashMap;
@@ -34,6 +36,7 @@ impl Command for External {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build(self.name())
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .switch("redirect-stdout", "redirect stdout to the pipeline", None)
             .switch("redirect-stderr", "redirect stderr to the pipeline", None)
             .switch("trim-end-newline", "trimming end newlines", None)

--- a/crates/nu-command/src/system/sys.rs
+++ b/crates/nu-command/src/system/sys.rs
@@ -3,7 +3,7 @@ use chrono::Local;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Type, Value,
 };
 use std::time::{Duration, UNIX_EPOCH};
 use sysinfo::{ComponentExt, CpuExt, DiskExt, NetworkExt, System, SystemExt, UserExt};
@@ -17,7 +17,10 @@ impl Command for Sys {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("sys").filter().category(Category::System)
+        Signature::build("sys")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::Record(vec![]))])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
-    Spanned, SyntaxShape, Value,
+    Spanned, SyntaxShape, Type, Value,
 };
 
 use std::ffi::OsStr;
@@ -22,6 +22,8 @@ impl Command for Which {
 
     fn signature(&self) -> Signature {
         Signature::build("which")
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .allow_variants_without_examples(true)
             .required("application", SyntaxShape::String, "application")
             .rest("rest", SyntaxShape::String, "additional applications")
             .switch("all", "list all executables", Some('a'))

--- a/crates/nu-command/src/viewers/explore.rs
+++ b/crates/nu-command/src/viewers/explore.rs
@@ -9,7 +9,7 @@ use nu_explore::{
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use std::collections::HashMap;
 
@@ -31,6 +31,7 @@ impl Command for Explore {
         // if we set h i short flags it panics????
 
         Signature::build("explore")
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .named(
                 "head",
                 SyntaxShape::Boolean,

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
     engine::{Command, EngineState, Stack, StateWorkingSet},
     format_error, Category, Config, DataSource, Example, FooterMode, IntoPipelineData, ListStream,
     PipelineData, PipelineMetadata, RawStream, ShellError, Signature, Span, SyntaxShape,
-    TableIndexMode, Value,
+    TableIndexMode, Type, Value,
 };
 use nu_table::{string_width, Table as NuTable, TableConfig, TableTheme};
 use nu_utils::get_ls_colors;
@@ -57,6 +57,8 @@ impl Command for Table {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("table")
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            // TODO: make this more precise: what turns into string and what into raw stream
             .named(
                 "start-number",
                 SyntaxShape::Int,


### PR DESCRIPTION
# Description

Work for #7320

#### Note:

Weirdness for `config nu/env`, `exec`

#### Skipped

- deprecated commands
- In some cases used `Type::Any` liberally
- for most tables or records did not specify fields to leave some flexibility

## Commands covered:

- `bits`
- `bytes`
- `clear`
- `complete`
- `config`
- `config env`
- `config nu`
- `date`
- `du`
- `enter`
- `env`
- `error make`
- `exec`
- `exit`
- `explore`
- `fetch`
- `for`
- `from`
- `from yml`
- `g`
- `hash`
- `help operators`
- `history`
- `history session`
- `input`
- `into`
- `into sqlite`
- `is-admin`
- `keybindings`
- `keybindings default`
- `keybindings list`
- `keybindings listen`
- `kill`
- `let-env`
- `load-env`
- `loop`
- `math`
- `n`
- `nu-check`
- `nu-highlight`
- `overlay`
- `overlay hide`
- `overlay list`
- `overlay new`
- `overlay use`
- `p`
- `path`
- `port`
- `post`
- `print`
- `ps`
- `query db`
- `random`
- `random bool`
- `random chars`
- `random decimal`
- `random dice`
- `random integer`
- `random uuid`
- `roll`
- `run-external`
- `schema`
- `shells`
- `source`
- `source-env`
- `split`
- `str`
- `sys`
- `table`
- `term size`
- `to`
- `tutor`
- `view-source`
- `watch`
- `which`
- `while`


# User-Facing Changes

Should be none

# Tests + Formatting

Removed unnecessary example testing on the meta commands that only provide the help text for its subcommands.
