### PR TITLE
avoid panic when using from nuon

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -340,8 +340,8 @@ fn quotes_some_strings_necessarily() {
 
 #[test]
 fn read_code_should_fail_rather_than_panic() {
-    let actual = nu!(cwd: ".", pipeline(
-        r#"open $nu.config-path | from nuon"#
+    let actual = nu!(cwd: "tests/fixtures/formats", pipeline(
+        r#"open code.nu | from nuon"#
     ));
     assert!(actual.err.contains("could not load nuon text"))
 }

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -338,6 +338,14 @@ fn quotes_some_strings_necessarily() {
     assert_eq!(actual.out, "list<string>");
 }
 
+#[test]
+fn read_code_should_fail_rather_than_panic() {
+    let actual = nu!(cwd: ".", pipeline(
+        r#"open $nu.config-path | from nuon"#
+    ));
+    assert!(actual.err.contains("could not load nuon text"))
+}
+
 proptest! {
     #[test]
     fn to_nuon_from_nuon(c: char) {

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -343,7 +343,7 @@ fn read_code_should_fail_rather_than_panic() {
     let actual = nu!(cwd: "tests/fixtures/formats", pipeline(
         r#"open code.nu | from nuon"#
     ));
-    assert!(actual.err.contains("could not load nuon text"))
+    assert!(actual.err.contains("error when parsing"))
 }
 
 proptest! {

--- a/tests/fixtures/formats/code.nu
+++ b/tests/fixtures/formats/code.nu
@@ -1,0 +1,1 @@
+register


### PR DESCRIPTION
# Description

Fixes #5996 

Just found a relative easy way to fix the issue

# User-Facing Changes

```
❯ open $nu.plugin-path | from nuon
Error:
  × error when loading nuon text
   ╭─[entry #36:1:1]
 1 │ open $nu.plugin-path | from nuon
   ·                        ────┬────
   ·                            ╰── could not load nuon text
   ╰────

Error:
  × Error when loading


❯ open $nu.config-path | from nuon
Error:
  × error when loading nuon text
   ╭─[entry #37:1:1]
 1 │ open $nu.config-path | from nuon
   ·                        ────┬────
   ·                            ╰── could not load nuon text
   ╰────

Error:
  × error when loading
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
