### PR TITLE
Fix line-end trimming in subexpression

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -6,11 +6,7 @@ use crate::{
 use nu_utils::{stderr_write_all_and_flush, stdout_write_all_and_flush};
 use std::sync::{atomic::AtomicBool, Arc};
 
-const LINE_ENDING: &str = if cfg!(target_os = "windows") {
-    "\r\n"
-} else {
-    "\n"
-};
+const LINE_ENDING_PATTERN: &[char] = &['\r', '\n'];
 
 /// The foundational abstraction for input and output to commands
 ///
@@ -185,7 +181,7 @@ impl PipelineData {
                         }
                     }
                     if trim_end_newline {
-                        output.truncate(output.trim_end_matches(LINE_ENDING).len())
+                        output.truncate(output.trim_end_matches(LINE_ENDING_PATTERN).len())
                     }
                     Value::String {
                         val: output,
@@ -229,7 +225,7 @@ impl PipelineData {
                     }
                 }
                 if trim_end_newline {
-                    output.truncate(output.trim_end_matches(LINE_ENDING).len());
+                    output.truncate(output.trim_end_matches(LINE_ENDING_PATTERN).len());
                 }
                 Ok(output)
             }
@@ -326,7 +322,7 @@ impl PipelineData {
 
                 if let Ok(mut st) = String::from_utf8(collected.clone().item) {
                     if trim_end_newline {
-                        st.truncate(st.trim_end_matches(LINE_ENDING).len());
+                        st.truncate(st.trim_end_matches(LINE_ENDING_PATTERN).len());
                     }
                     Ok(f(Value::String {
                         val: st,
@@ -383,7 +379,7 @@ impl PipelineData {
 
                 if let Ok(mut st) = String::from_utf8(collected.clone().item) {
                     if trim_end_newline {
-                        st.truncate(st.trim_end_matches(LINE_ENDING).len())
+                        st.truncate(st.trim_end_matches(LINE_ENDING_PATTERN).len())
                     }
                     Ok(f(Value::String {
                         val: st,
@@ -435,7 +431,7 @@ impl PipelineData {
 
                 if let Ok(mut st) = String::from_utf8(collected.clone().item) {
                     if trim_end_newline {
-                        st.truncate(st.trim_end_matches(LINE_ENDING).len())
+                        st.truncate(st.trim_end_matches(LINE_ENDING_PATTERN).len())
                     }
                     let v = Value::String {
                         val: st,


### PR DESCRIPTION
# Description

Currently the implementation is different for Windows and Unix.

Thus certain operations will fail if the platform foreign line ending is used:

example failing under windows

```
git show (git merge-base main HEAD)
```

Temporary cheat is to strip all `\r` and `\n` from the end. Proper solution should trim them as correct patterns.

Also needed: test of behavior with both platform newline and platform-foreign line endings

cc @WindSoilder 


# User-Facing Changes

Line endings should be trimmed no matter the source and no matter the platform

# Tests + Formatting

Still missing

