### PR TITLE
Bump to new development version `0.73.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "assert_cmd",
  "atty",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "atty",
  "chrono",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "Inflector",
  "alphanumeric-sort",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "chrono",
  "nu-glob",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "nu-explore"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "ansi-str 0.7.2",
  "crossterm 0.24.0",
@@ -2706,14 +2706,14 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "doc-comment",
 ]
 
 [[package]]
 name = "nu-json"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "linked-hash-map",
  "num-traits",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "bincode",
  "criterion",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "atty",
  "chrono",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "atty",
  "json_to_table",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "getset",
  "hamcrest2",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "crossterm_winapi",
  "lscolors",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "git2",
  "nu-engine",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "gjson",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.73.0"
+version = "0.73.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -45,20 +45,20 @@ ctrlc = "3.2.1"
 log = "0.4"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 nu-ansi-term = "0.46.0"
-nu-cli = { path="./crates/nu-cli", version = "0.73.0"  }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.73.0"  }
-nu-command = { path="./crates/nu-command", version = "0.73.0"  }
-nu-engine = { path="./crates/nu-engine", version = "0.73.0"  }
-nu-json = { path="./crates/nu-json", version = "0.73.0"  }
-nu-parser = { path="./crates/nu-parser", version = "0.73.0"  }
-nu-path = { path="./crates/nu-path", version = "0.73.0"  }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.73.0"  }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.73.0"  }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.73.0"  }
-nu-system = { path = "./crates/nu-system", version = "0.73.0" }
-nu-table = { path = "./crates/nu-table", version = "0.73.0"  }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.73.0"  }
-nu-utils = { path = "./crates/nu-utils", version = "0.73.0"  }
+nu-cli = { path="./crates/nu-cli", version = "0.73.1"  }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.73.1"  }
+nu-command = { path="./crates/nu-command", version = "0.73.1"  }
+nu-engine = { path="./crates/nu-engine", version = "0.73.1"  }
+nu-json = { path="./crates/nu-json", version = "0.73.1"  }
+nu-parser = { path="./crates/nu-parser", version = "0.73.1"  }
+nu-path = { path="./crates/nu-path", version = "0.73.1"  }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.73.1"  }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.73.1"  }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.73.1"  }
+nu-system = { path = "./crates/nu-system", version = "0.73.1" }
+nu-table = { path = "./crates/nu-table", version = "0.73.1"  }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.73.1"  }
+nu-utils = { path = "./crates/nu-utils", version = "0.73.1"  }
 reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 
 rayon = "1.5.1"
@@ -80,7 +80,7 @@ nix = { version = "0.25", default-features = false, features = ["signal", "proce
 atty = "0.2"
 
 [dev-dependencies]
-nu-test-support = { path="./crates/nu-test-support", version = "0.73.0"  }
+nu-test-support = { path="./crates/nu-test-support", version = "0.73.1"  }
 tempfile = "3.2.0"
 assert_cmd = "2.0.2"
 pretty_assertions = "1.0.0"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,21 +5,21 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.73.0"
+version = "0.73.1"
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.73.0"  }
-nu-command = { path = "../nu-command", version = "0.73.0" }
+nu-test-support = { path="../nu-test-support", version = "0.73.1"  }
+nu-command = { path = "../nu-command", version = "0.73.1" }
 rstest = {version = "0.15.0", default-features = false}
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.73.0"  }
-nu-path = { path = "../nu-path", version = "0.73.0"  }
-nu-parser = { path = "../nu-parser", version = "0.73.0"  }
-nu-protocol = { path = "../nu-protocol", version = "0.73.0"  }
-nu-utils = { path = "../nu-utils", version = "0.73.0"  }
+nu-engine = { path = "../nu-engine", version = "0.73.1"  }
+nu-path = { path = "../nu-path", version = "0.73.1"  }
+nu-parser = { path = "../nu-parser", version = "0.73.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1"  }
+nu-utils = { path = "../nu-utils", version = "0.73.1"  }
 nu-ansi-term = "0.46.0"
-nu-color-config = { path = "../nu-color-config", version = "0.73.0"  }
+nu-color-config = { path = "../nu-color-config", version = "0.73.1"  }
 reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 
 atty = "0.2.14"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,18 +5,18 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
 serde = { version="1.0.123", features=["derive"] }
 # used only for text_style Alignments
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 
-nu-protocol = { path = "../nu-protocol", version = "0.73.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1"  }
 nu-ansi-term = "0.46.0"
-nu-utils = { path = "../nu-utils", version = "0.73.0" }
-nu-engine = { path = "../nu-engine", version = "0.73.0" }
-nu-json = { path="../nu-json", version = "0.73.0"  }
+nu-utils = { path = "../nu-utils", version = "0.73.1" }
+nu-engine = { path = "../nu-engine", version = "0.73.1" }
+nu-json = { path="../nu-json", version = "0.73.1"  }
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.73.0"  }
+nu-test-support = { path="../nu-test-support", version = "0.73.1"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -5,25 +5,25 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
 edition = "2021"
 license = "MIT"
 name = "nu-command"
-version = "0.73.0"
+version = "0.73.1"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-color-config = { path = "../nu-color-config", version = "0.73.0"  }
-nu-engine = { path = "../nu-engine", version = "0.73.0"  }
-nu-glob = { path = "../nu-glob", version = "0.73.0" }
-nu-json = { path = "../nu-json", version = "0.73.0"  }
-nu-parser = { path = "../nu-parser", version = "0.73.0"  }
-nu-path = { path = "../nu-path", version = "0.73.0"  }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.73.0"  }
-nu-protocol = { path = "../nu-protocol", version = "0.73.0"  }
-nu-system = { path = "../nu-system", version = "0.73.0"  }
-nu-table = { path = "../nu-table", version = "0.73.0"  }
-nu-term-grid = { path = "../nu-term-grid", version = "0.73.0"  }
-nu-utils = { path = "../nu-utils", version = "0.73.0" }
-nu-explore = { path = "../nu-explore", version = "0.73.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.73.1"  }
+nu-engine = { path = "../nu-engine", version = "0.73.1"  }
+nu-glob = { path = "../nu-glob", version = "0.73.1" }
+nu-json = { path = "../nu-json", version = "0.73.1"  }
+nu-parser = { path = "../nu-parser", version = "0.73.1"  }
+nu-path = { path = "../nu-path", version = "0.73.1"  }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.73.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1"  }
+nu-system = { path = "../nu-system", version = "0.73.1"  }
+nu-table = { path = "../nu-table", version = "0.73.1"  }
+nu-term-grid = { path = "../nu-term-grid", version = "0.73.1"  }
+nu-utils = { path = "../nu-utils", version = "0.73.1" }
+nu-explore = { path = "../nu-explore", version = "0.73.1" }
 nu-ansi-term = "0.46.0"
 num-format = { version = "0.4.3" }
 
@@ -156,7 +156,7 @@ sqlite = ["rusqlite"] # TODO: given that rusqlite is included in reedline, shoul
 shadow-rs = { version = "0.16.1", default-features = false }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.73.0"  }
+nu-test-support = { path = "../nu-test-support", version = "0.73.1"  }
 
 hamcrest2 = "0.3.0"
 dirs-next = "2.0.0"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.73.0"  }
-nu-path = { path = "../nu-path", version = "0.73.0"  }
-nu-glob = { path = "../nu-glob", version = "0.73.0" }
-nu-utils = { path = "../nu-utils", version = "0.73.0"  }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.73.1"  }
+nu-path = { path = "../nu-path", version = "0.73.1"  }
+nu-glob = { path = "../nu-glob", version = "0.73.1" }
+nu-utils = { path = "../nu-utils", version = "0.73.1"  }
 
 chrono = { version="0.4.23", features = ["std"], default-features = false }
 sysinfo ="0.26.2"

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -5,17 +5,17 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"
 name = "nu-explore"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
 nu-ansi-term = "0.46.0"
-nu-protocol = { path = "../nu-protocol", version = "0.73.0" }
-nu-parser = { path = "../nu-parser", version = "0.73.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.73.0" }
-nu-engine = { path = "../nu-engine", version = "0.73.0" }
-nu-table = { path = "../nu-table", version = "0.73.0" }
-nu-json = { path = "../nu-json", version = "0.73.0"  }
-nu-utils = { path = "../nu-utils", version = "0.73.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1" }
+nu-parser = { path = "../nu-parser", version = "0.73.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.73.1" }
+nu-engine = { path = "../nu-engine", version = "0.73.1" }
+nu-table = { path = "../nu-table", version = "0.73.1" }
+nu-json = { path = "../nu-json", version = "0.73.1"  }
+nu-utils = { path = "../nu-utils", version = "0.73.1"  }
 
 terminal_size = "0.2.1"
 strip-ansi-escapes = "0.1.1"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.73.0"
+version = "0.73.1"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.73.0"
+version = "0.73.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,5 +19,5 @@ num-traits = "0.2.14"
 serde = "1.0"
 
 [dev-dependencies]
-# nu-path = { path="../nu-path", version = "0.73.0" }
+# nu-path = { path="../nu-path", version = "0.73.1" }
 # serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
 bytesize = "1.1.0"
@@ -14,10 +14,10 @@ itertools = "0.10"
 miette = {version = "5.1.0", features = ["fancy-no-backtrace"]}
 thiserror = "1.0.31"
 serde_json = "1.0"
-nu-path = {path = "../nu-path", version = "0.73.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.73.0" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.73.0"  }
-nu-engine = { path = "../nu-engine", version = "0.73.0" }
+nu-path = {path = "../nu-path", version = "0.73.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.73.1"  }
+nu-engine = { path = "../nu-engine", version = "0.73.1" }
 log = "0.4"
 
 [features]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
 dirs-next = "2.0.0"

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
 bincode = "1.3.3"
-nu-protocol = { path = "../nu-protocol", version = "0.73.0"  }
-nu-engine = { path = "../nu-engine", version = "0.73.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1"  }
+nu-engine = { path = "../nu-engine", version = "0.73.1"  }
 serde = { version = "1.0.143" }
 serde_json = { version = "1.0"}
 rmp = "0.8.11"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.73.0"
+version = "0.73.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.73.0"  }
-nu-json = { path = "../nu-json", version = "0.73.0"  }
+nu-utils = { path = "../nu-utils", version = "0.73.1"  }
+nu-json = { path = "../nu-json", version = "0.73.1"  }
 
 byte-unit = "4.0.9"
 chrono = { version="0.4.23", features= ["serde", "std"], default-features = false }
@@ -33,4 +33,4 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"
-nu-test-support = { path = "../nu-test-support", version = "0.73.0"  }
+nu-test-support = { path = "../nu-test-support", version = "0.73.1"  }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.73.0"
+version = "0.73.1"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,18 +5,18 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
 nu-ansi-term = "0.46.0"
-nu-protocol = { path = "../nu-protocol", version = "0.73.0" }
-nu-utils = { path = "../nu-utils", version = "0.73.0" }
-nu-engine = { path = "../nu-engine", version = "0.73.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.73.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1" }
+nu-utils = { path = "../nu-utils", version = "0.73.1" }
+nu-engine = { path = "../nu-engine", version = "0.73.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.73.1" }
 atty = "0.2.14"
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 json_to_table = { version = "0.3.1", features = ["color"] }
 serde_json = "1"
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.73.0"  }
+nu-test-support = { path="../nu-test-support", version = "0.73.1"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,9 +5,9 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
 unicode-width = "0.1.9"
 
-nu-utils = { path = "../nu-utils", version = "0.73.0"  }
+nu-utils = { path = "../nu-utils", version = "0.73.1"  }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,15 +5,15 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2018"
 license = "MIT"
 name = "nu-test-support"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-path = { path="../nu-path", version = "0.73.0"  }
-nu-glob = { path = "../nu-glob", version = "0.73.0" }
-nu-utils = { path="../nu-utils", version = "0.73.0"  }
+nu-path = { path="../nu-path", version = "0.73.1"  }
+nu-glob = { path = "../nu-glob", version = "0.73.1" }
+nu-utils = { path="../nu-utils", version = "0.73.1"  }
 once_cell = "1.16.0"
 num-format = "0.4.3"
 

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
 edition = "2021"
 license = "MIT"
 name = "nu-utils"
-version = "0.73.0"
+version = "0.73.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.73.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.73.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.73.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.73.1", features = ["plugin"] }
 serde = { version = "1.0", default-features = false }
 typetag = "0.1.8"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,8 +5,8 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.73.0"
+version = "0.73.1"
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1", features = ["plugin"]}

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,14 +5,14 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-engine = { path="../nu-engine", version = "0.73.0" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-engine = { path="../nu-engine", version = "0.73.1" }
 
 git2 = "0.15.0"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1", features = ["plugin"]}
 
 semver = "0.11.0"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,15 +5,15 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-engine = { path="../nu-engine", version = "0.73.0" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-engine = { path="../nu-engine", version = "0.73.1" }
 gjson = "0.8.0"
 scraper = { default-features = false, version = "0.13.0" }
 sxd-document = "0.3.2"

--- a/crates/old/nu_plugin_chart/Cargo.toml
+++ b/crates/old/nu_plugin_chart/Cargo.toml
@@ -4,18 +4,18 @@ description = "A plugin to display charts"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_chart"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-data = { path="../nu-data", version = "0.73.0" }
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
-nu-value-ext = { path="../nu-value-ext", version = "0.73.0" }
+nu-data = { path="../nu-data", version = "0.73.1" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
+nu-value-ext = { path="../nu-value-ext", version = "0.73.1" }
 
 crossterm = "0.19.0"
 tui = { version="0.15.0", default-features=false, features=["crossterm"] }

--- a/crates/old/nu_plugin_from_bson/Cargo.toml
+++ b/crates/old/nu_plugin_from_bson/Cargo.toml
@@ -4,7 +4,7 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_bson"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
@@ -12,9 +12,9 @@ doctest = false
 [dependencies]
 bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
 bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
 
 [build-dependencies]

--- a/crates/old/nu_plugin_from_mp4/Cargo.toml
+++ b/crates/old/nu_plugin_from_mp4/Cargo.toml
@@ -4,16 +4,16 @@ description = "A converter plugin to the mp4 format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_mp4"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
 tempfile = "3.2.0"
 mp4 = "0.9.0"
 

--- a/crates/old/nu_plugin_from_sqlite/Cargo.toml
+++ b/crates/old/nu_plugin_from_sqlite/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_from_sqlite"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 bigdecimal = { package = "bigdecimal", version = "0.3.0", features = ["serde"] }
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
 tempfile = "3.2.0"
 
 [dependencies.rusqlite]

--- a/crates/old/nu_plugin_s3/Cargo.toml
+++ b/crates/old/nu_plugin_s3/Cargo.toml
@@ -4,17 +4,17 @@ description = "An S3 plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_s3"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 futures = { version="0.3.12", features=["compat", "io-compat"] }
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
 s3handler = "0.7.5"
 
 [build-dependencies]

--- a/crates/old/nu_plugin_start/Cargo.toml
+++ b/crates/old/nu_plugin_start/Cargo.toml
@@ -4,17 +4,17 @@ description = "A plugin to open files/URLs directly from Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_start"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 glob = "0.3.0"
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
 url = "2.2.0"
 webbrowser = "0.5.5"
 
@@ -22,5 +22,5 @@ webbrowser = "0.5.5"
 open = "1.4.0"
 
 [build-dependencies]
-nu-errors = { version = "0.73.0", path="../nu-errors" }
-nu-source = { version = "0.73.0", path="../nu-source" }
+nu-errors = { version = "0.73.1", path="../nu-errors" }
+nu-source = { version = "0.73.1", path="../nu-source" }

--- a/crates/old/nu_plugin_to_bson/Cargo.toml
+++ b/crates/old/nu_plugin_to_bson/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the bson format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_bson"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 bson = { version = "2.0.1", features = [ "chrono-0_4" ] }
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
 num-traits = "0.2.14"
 
 [features]

--- a/crates/old/nu_plugin_to_sqlite/Cargo.toml
+++ b/crates/old/nu_plugin_to_sqlite/Cargo.toml
@@ -4,17 +4,17 @@ description = "A converter plugin to the SQLite format for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_to_sqlite"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 hex = "0.4.2"
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
-nu-source = { path="../nu-source", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
+nu-source = { path="../nu-source", version = "0.73.1" }
 tempfile = "3.2.0"
 
 [dependencies.rusqlite]

--- a/crates/old/nu_plugin_tree/Cargo.toml
+++ b/crates/old/nu_plugin_tree/Cargo.toml
@@ -4,16 +4,16 @@ description = "Tree viewer plugin for Nushell"
 edition = "2018"
 license = "MIT"
 name = "nu_plugin_tree"
-version = "0.73.0"
+version = "0.73.1"
 
 [lib]
 doctest = false
 
 [dependencies]
 derive-new = "0.5.8"
-nu-errors = { path="../nu-errors", version = "0.73.0" }
-nu-plugin = { path="../nu-plugin", version = "0.73.0" }
-nu-protocol = { path="../nu-protocol", version = "0.73.0" }
+nu-errors = { path="../nu-errors", version = "0.73.1" }
+nu-plugin = { path="../nu-plugin", version = "0.73.1" }
+nu-protocol = { path="../nu-protocol", version = "0.73.1" }
 ptree = { version = "0.4.0", default-features = false }
 
 


### PR DESCRIPTION
This is intended to indicate the development version for `0.74.0`

(may be used for hotfixes if necessary)

