### PR TITLE
(WIP) Parse right hand side of assignment as expression; Add `|=` operator

### DIFF
--- a/crates/nu-command/src/core_commands/help_operators.rs
+++ b/crates/nu-command/src/core_commands/help_operators.rs
@@ -113,7 +113,8 @@ fn generate_operator_info() -> Vec<OperatorInfo> {
             op_type: "Assignment".into(),
             operator: "|=".into(),
             name: "PipeAssign".into(),
-            description: "Pipes a variable into an expression and replaces assigns it the result.".into(),
+            description: "Pipes a variable into an expression and replaces assigns it the result."
+                .into(),
             precedence: 10,
         },
         OperatorInfo {

--- a/crates/nu-command/src/core_commands/help_operators.rs
+++ b/crates/nu-command/src/core_commands/help_operators.rs
@@ -110,6 +110,13 @@ fn generate_operator_info() -> Vec<OperatorInfo> {
             precedence: 10,
         },
         OperatorInfo {
+            op_type: "Assignment".into(),
+            operator: "|=".into(),
+            name: "PipeAssign".into(),
+            description: "Pipes a variable into an expression and replaces assigns it the result.".into(),
+            precedence: 10,
+        },
+        OperatorInfo {
             op_type: "Comparison".into(),
             operator: "==".into(),
             name: "Equal".into(),

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -32,6 +32,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        // println!("math abs input: {:?}", input);
         let head = call.head;
         input.map(
             move |value| abs_helper(value, head),

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -33,6 +33,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        // println!("math sum input: {:?}", input);
         run_with_function(call, input, summation)
     }
 

--- a/crates/nu-command/tests/commands/assignment/mod.rs
+++ b/crates/nu-command/tests/commands/assignment/mod.rs
@@ -1,1 +1,2 @@
 mod append_assign;
+mod pipe_assign;

--- a/crates/nu-command/tests/commands/assignment/pipe_assign.rs
+++ b/crates/nu-command/tests/commands/assignment/pipe_assign.rs
@@ -1,0 +1,42 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn pipe_assign_int_list() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            mut a = [1 2];
+            $a |= append [3 4];
+            $a
+        "#
+    ));
+
+    let expected = nu!(
+        cwd: ".", pipeline(
+        r#"
+            [1 2 3 4]
+        "#
+    ));
+
+    print!("{}", actual.out);
+    print!("{}", expected.out);
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn pipe_assign_pipeline() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            mut a = [1 -1];
+            $a |= math abs | math sum;
+            $a
+        "#
+    ));
+
+    let expected = "2";
+
+    print!("{}", actual.out);
+    print!("{}", expected);
+    assert_eq!(actual.out, expected);
+}

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -300,18 +300,27 @@ pub fn lex(
     while let Some(c) = input.get(curr_offset) {
         let c = *c;
         if c == b'|' {
-            // If the next character is `|`, it's either `|` or `||`.
+            // If the next character is `|`, it's either `|`, `|=`, or `||`.
             let idx = curr_offset;
             let prev_idx = idx;
             curr_offset += 1;
 
-            // If the next character is `|`, we're looking at a `||`.
             if let Some(c) = input.get(curr_offset) {
                 if *c == b'|' {
+                    // If the next character is `|`, we're looking at a `||`.
                     let idx = curr_offset;
                     curr_offset += 1;
                     output.push(Token::new(
                         TokenContents::PipePipe,
+                        Span::new(span_offset + prev_idx, span_offset + idx + 1),
+                    ));
+                    continue;
+                } else if *c == b'=' {
+                    // If the next character is `=`, we're looking at a `|=` operator.
+                    let idx = curr_offset;
+                    curr_offset += 1;
+                    output.push(Token::new(
+                        TokenContents::Item,
                         Span::new(span_offset + prev_idx, span_offset + idx + 1),
                     ));
                     continue;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4726,9 +4726,8 @@ pub fn parse_math_expression(
                 parse_expression(
                     working_set,
                     &spans[idx..],
-                    // &SyntaxShape::Any,
                     expand_aliases_denylist,
-                    true, // not a sub-expression
+                    false, // not a sub-expression
                 ),
                 spans[idx..].len(),
             )

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4718,7 +4718,10 @@ pub fn parse_math_expression(
             ..
         } = op
         {
-            trace!("parsing: assignment: {:?}", String::from_utf8_lossy(working_set.get_span_contents(span(&spans[idx..]))));
+            trace!(
+                "parsing: assignment: {:?}",
+                String::from_utf8_lossy(working_set.get_span_contents(span(&spans[idx..])))
+            );
             (
                 parse_expression(
                     working_set,

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -55,6 +55,7 @@ pub enum Assignment {
     MinusAssign,
     MultiplyAssign,
     DivideAssign,
+    PipeAssign,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,6 +76,7 @@ impl Display for Operator {
             Operator::Assignment(Assignment::MinusAssign) => write!(f, "-="),
             Operator::Assignment(Assignment::MultiplyAssign) => write!(f, "*="),
             Operator::Assignment(Assignment::DivideAssign) => write!(f, "/="),
+            Operator::Assignment(Assignment::PipeAssign) => write!(f, "|="),
             Operator::Comparison(Comparison::Equal) => write!(f, "=="),
             Operator::Comparison(Comparison::NotEqual) => write!(f, "!="),
             Operator::Comparison(Comparison::LessThan) => write!(f, "<"),


### PR DESCRIPTION
# Description

Attempts to parse `$foo |= spam` as `$foo = ($foo | spam)`.

As a side-effect, right-hand side of assignment operators is now parsed as expressions instead of a single value to allow stuff like `$foo |= append [3 4]`.

However, the problem is if you want to use a longer pipeline, such as `$foo |= math abs | math sum` -- it is parsed as `($foo |= math abs) | math sum`. Alternative is `$foo |= (math abs | math sum)` which doesn't work (math commands get empty input). 

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
