### PR TITLE
Add cross-rs config

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,9 @@
+# Configuration for cross-rs: https://github.com/cross-rs/cross
+# Run cross-rs like this:
+# cross build --target aarch64-unknown-linux-musl --release
+
+[target.aarch64-unknown-linux-gnu]
+dockerfile = "./docker/cross-rs/aarch64-unknown-linux-gnu.dockerfile"
+
+[target.aarch64-unknown-linux-musl]
+dockerfile = "./docker/cross-rs/aarch64-unknown-linux-musl.dockerfile"

--- a/docker/cross-rs/aarch64-unknown-linux-gnu.dockerfile
+++ b/docker/cross-rs/aarch64-unknown-linux-gnu.dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest
+
+RUN dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install --assume-yes libssl-dev:arm64 clang

--- a/docker/cross-rs/aarch64-unknown-linux-musl.dockerfile
+++ b/docker/cross-rs/aarch64-unknown-linux-musl.dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:latest
+
+RUN dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install --assume-yes libssl-dev:arm64 clang


### PR DESCRIPTION
Cross-compiling Nu can be a little tricky due to dependencies. This PR makes it easy to use [`cross-rs`](https://github.com/cross-rs/cross), a popular tool for cross-compiling Rust code using Docker:
```bash
cross build --target aarch64-unknown-linux-musl --release
```

I find this useful for compiling ARM binaries from x64. Easy to add more target triples later as needed.