### PR TITLE
chore: make the config setup messages consistent

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -74,7 +74,16 @@ pub(crate) fn read_config_file(
                 "y" | "" => match File::create(&config_path) {
                     Ok(mut output) => match write!(output, "{}", config_file) {
                         Ok(_) => {
-                            println!("Config file created at: {}", config_path.to_string_lossy())
+                            let config_type = if is_env_config {
+                                "Environment config"
+                            } else {
+                                "Config"
+                            };
+                            println!(
+                                "{} file created at: {}",
+                                config_type,
+                                config_path.to_string_lossy()
+                            );
                         }
                         Err(_) => {
                             eprintln!(


### PR DESCRIPTION
# Description

Purely made due to my OCD being triggered due to looking at the inconsistency whenever I had to re-setup nu. Feel free to close the PR, only exists because I felt like I had to give fixing it a shot.

# User-Facing Changes

Makes the `file created` msg consistent with `file found` msg.

# Tests + Formatting

Should be formatted and clippy'd, also ran the tests just in case.