### PR TITLE
Change other instances of `$nothing` to `null`

### DIFF
--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -165,7 +165,7 @@ fn from_nothing() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        $nothing | into string
+        null | into string
         "#
     ));
 

--- a/crates/nu-command/tests/commands/with_env.rs
+++ b/crates/nu-command/tests/commands/with_env.rs
@@ -72,7 +72,7 @@ fn with_env_hides_variables_in_parent_scope() {
         r#"
         let-env FOO = "1"
         echo $env.FOO
-        with-env [FOO $nothing] {
+        with-env [FOO null] {
             echo $env.FOO
         }
         echo $env.FOO
@@ -91,10 +91,10 @@ fn with_env_shorthand_can_not_hide_variables() {
         r#"
         let-env FOO = "1"
         echo $env.FOO
-        FOO=$nothing echo $env.FOO
+        FOO=null echo $env.FOO
         echo $env.FOO
         "#
     );
 
-    assert_eq!(actual.out, "1$nothing1");
+    assert_eq!(actual.out, "1null1");
 }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -323,10 +323,10 @@ pub fn parse_call_missing_req_flag() {
 }
 
 #[test]
-fn test_nothing_comparisson_eq() {
+fn test_nothing_comparison_eq() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
-    let (block, err) = parse(&mut working_set, None, b"2 == $nothing", true, &[]);
+    let (block, err) = parse(&mut working_set, None, b"2 == null", true, &[]);
 
     assert!(err.is_none());
     assert!(block.len() == 1);
@@ -346,10 +346,10 @@ fn test_nothing_comparisson_eq() {
 }
 
 #[test]
-fn test_nothing_comparisson_neq() {
+fn test_nothing_comparison_neq() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
-    let (block, err) = parse(&mut working_set, None, b"2 != $nothing", true, &[]);
+    let (block, err) = parse(&mut working_set, None, b"2 != null", true, &[]);
 
     assert!(err.is_none());
     assert!(block.len() == 1);

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -409,14 +409,14 @@ let-env config = {
 
   hooks: {
     pre_prompt: [{
-      $nothing  # replace with source code to run before the prompt is shown
+      null  # replace with source code to run before the prompt is shown
     }]
     pre_execution: [{
-      $nothing  # replace with source code to run before the repl input is run
+      null  # replace with source code to run before the repl input is run
     }]
     env_change: {
       PWD: [{|before, after|
-        $nothing  # replace with source code to run if the PWD environment is different since the last repl input
+        null  # replace with source code to run if the PWD environment is different since the last repl input
       }]
     }
     display_output: {

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -114,7 +114,7 @@ fn def_with_no_dollar() -> TestResult {
 #[test]
 fn allow_missing_optional_params() -> TestResult {
     run_test(
-        "def foo [x?:int] { if $x != $nothing { $x + 10 } else { 5 } }; foo",
+        "def foo [x?:int] { if $x != null { $x + 10 } else { 5 } }; foo",
         "5",
     )
 }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -75,7 +75,7 @@ fn earlier_errors() -> TestResult {
 #[test]
 fn missing_flags_are_nothing() -> TestResult {
     run_test(
-        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo"#,
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == null { 10 } else { $aaa }) + (if $bbb == null { 100 } else { $bbb }) }; foo"#,
         "110",
     )
 }
@@ -83,7 +83,7 @@ fn missing_flags_are_nothing() -> TestResult {
 #[test]
 fn missing_flags_are_nothing2() -> TestResult {
     run_test(
-        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo -a 90"#,
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == null { 10 } else { $aaa }) + (if $bbb == null { 100 } else { $bbb }) }; foo -a 90"#,
         "190",
     )
 }
@@ -91,7 +91,7 @@ fn missing_flags_are_nothing2() -> TestResult {
 #[test]
 fn missing_flags_are_nothing3() -> TestResult {
     run_test(
-        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo -b 45"#,
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == null { 10 } else { $aaa }) + (if $bbb == null { 100 } else { $bbb }) }; foo -b 45"#,
         "55",
     )
 }
@@ -99,7 +99,7 @@ fn missing_flags_are_nothing3() -> TestResult {
 #[test]
 fn missing_flags_are_nothing4() -> TestResult {
     run_test(
-        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == $nothing { 10 } else { $aaa }) + (if $bbb == $nothing { 100 } else { $bbb }) }; foo -a 3 -b 10000"#,
+        r#"def foo [--aaa(-a): int, --bbb(-b): int] { (if $aaa == null { 10 } else { $aaa }) + (if $bbb == null { 100 } else { $bbb }) }; foo -a 3 -b 10000"#,
         "10003",
     )
 }

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -173,9 +173,9 @@ fn update_cell_path_1() -> TestResult {
 
 #[test]
 fn missing_column_fills_in_nothing() -> TestResult {
-    // The empty value will be replaced with $nothing when fetching a column
+    // The empty value will be replaced with null when fetching a column
     run_test(
-        r#"[ { name: ABC, size: 20 }, { name: HIJ } ].size.1 == $nothing"#,
+        r#"[ { name: ABC, size: 20 }, { name: HIJ } ].size.1 == null"#,
         "true",
     )
 }
@@ -258,7 +258,7 @@ fn length_defaulted_columns() -> TestResult {
 
 #[test]
 fn get_fuzzy() -> TestResult {
-    run_test("(ls | get -i foo) == $nothing", "true")
+    run_test("(ls | get -i foo) == null", "true")
 }
 
 #[test]

--- a/tests/shell/environment/nu_env.rs
+++ b/tests/shell/environment/nu_env.rs
@@ -61,7 +61,7 @@ fn picks_up_and_lets_go_env_keys_when_entering_trusted_directory_with_implied_cd
         let actual = nu!(
             cwd: dirs.test(),
             r#"
-            do {autoenv trust -q foo ; = $nothing }
+            do {autoenv trust -q foo ; = null }
             foo
             echo $env.testkey"#
         );
@@ -70,7 +70,7 @@ fn picks_up_and_lets_go_env_keys_when_entering_trusted_directory_with_implied_cd
         let actual = nu!(
             cwd: dirs.test(),
             r#"
-            do {autoenv trust -q foo; = $nothing } ;
+            do {autoenv trust -q foo; = null } ;
             foo
             ..
             echo $env.testkey
@@ -81,8 +81,8 @@ fn picks_up_and_lets_go_env_keys_when_entering_trusted_directory_with_implied_cd
         let actual = nu!(
             cwd: dirs.test(),
             r#"
-            do {autoenv trust -q foo; = $nothing } ;
-            do {autoenv trust -q foo/bar; = $nothing } ;
+            do {autoenv trust -q foo; = null } ;
+            do {autoenv trust -q foo/bar; = null } ;
             foo/bar
             echo $env.testkey
             echo $env.bar
@@ -324,7 +324,7 @@ fn given_a_hierachy_of_trusted_directories_when_entering_in_any_nested_ones_shou
 
         let actual = Trusted::in_path(&dirs, || {
             nu!(cwd: dirs.test().parent().unwrap(), r#"
-                do { autoenv trust -q autoenv_test_9/nu_plugin_rb ; = $nothing } # Silence autoenv trust -q message from output
+                do { autoenv trust -q autoenv_test_9/nu_plugin_rb ; = null } # Silence autoenv trust -q message from output
                 cd autoenv_test_9/nu_plugin_rb
                 echo $env.organization
             "#)
@@ -355,7 +355,7 @@ fn given_a_hierachy_of_trusted_directories_nested_ones_should_overwrite_variable
 
         let actual = Trusted::in_path(&dirs, || {
             nu!(cwd: dirs.test().parent().unwrap(), r#"
-                do { autoenv trust -q autoenv_test_10/nu_plugin_rb ; = $nothing } # Silence autoenv trust -q message from output
+                do { autoenv trust -q autoenv_test_10/nu_plugin_rb ; = null } # Silence autoenv trust -q message from output
                 cd autoenv_test_10/nu_plugin_rb
                 echo $env.organization
             "#)

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -532,7 +532,7 @@ fn proper_shadow_load_env_aliases() {
     assert_eq!(actual.out, "truefalsetrue");
 }
 
-//FIXME: jt: load-env can not currently hide variables because $nothing no longer hides
+//FIXME: jt: load-env can not currently hide variables because null no longer hides
 #[ignore]
 #[test]
 fn load_env_can_hide_var_envs() {
@@ -541,7 +541,7 @@ fn load_env_can_hide_var_envs() {
         r#"
         let-env DEBUG = "1"
         echo $env.DEBUG
-        load-env [[name, value]; [DEBUG $nothing]]
+        load-env [[name, value]; [DEBUG null]]
         echo $env.DEBUG
         "#
     );
@@ -550,7 +550,7 @@ fn load_env_can_hide_var_envs() {
     assert!(actual.err.contains("Unknown column"));
 }
 
-//FIXME: jt: load-env can not currently hide variables because $nothing no longer hides
+//FIXME: jt: load-env can not currently hide variables because null no longer hides
 #[ignore]
 #[test]
 fn load_env_can_hide_var_envs_in_parent_scope() {
@@ -560,7 +560,7 @@ fn load_env_can_hide_var_envs_in_parent_scope() {
         let-env DEBUG = "1"
         echo $env.DEBUG
         do {
-            load-env [[name, value]; [DEBUG $nothing]]
+            load-env [[name, value]; [DEBUG null]]
             echo $env.DEBUG
         }
         echo $env.DEBUG
@@ -1176,7 +1176,7 @@ fn nothing_string_1() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        $nothing == "foo"
+        null == "foo"
         "#)
     );
 


### PR DESCRIPTION
# Description

Purely for consistency, various remaining instances of `$nothing` (almost all of which were in test code) have been changed to `null`. Now, the only place that refers to `$nothing` is the parser code which implements it.

# User-Facing Changes

The default config.nu now uses `null` in certain places where it used `$nothing`.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
