### PR TITLE
Make `to text` stream ListStreams

### DIFF
--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -90,6 +90,7 @@ mod split_row;
 mod str_;
 mod table;
 mod take;
+mod to_text;
 mod touch;
 mod transpose;
 mod try_;

--- a/crates/nu-command/tests/commands/to_text.rs
+++ b/crates/nu-command/tests/commands/to_text.rs
@@ -1,0 +1,19 @@
+use nu_test_support::nu;
+
+#[test]
+fn list_to_text() {
+    let actual = nu!(r#"["foo" "bar" "baz"] | to text"#);
+
+    // these actually have newlines between them in the real world but nu! strips newlines, grr
+    assert_eq!(actual.out, "foobarbaz");
+}
+
+// the output should be the same when `to text` gets a ListStream instead of a Value::List
+#[test]
+fn list_stream_to_text() {
+    // use `each` to convert the list to a ListStream
+    let actual = nu!(r#"["foo" "bar" "baz"] | each {|i| $i} | to text"#);
+
+    // these actually have newlines between them in the real world but nu! strips newlines, grr
+    assert_eq!(actual.out, "foobarbaz");
+}


### PR DESCRIPTION
This PR changes `to text` so that when given a `ListStream`, it streams the incoming values instead of collecting them all first.

The easiest way to observe/verify this PR is to convert a list to a very slow `ListStream` with `each`:
```bash
ls | get name | each {|n| sleep 1sec; $n} | to text
```
The `to text` output will appear 1 item at a time.