### PR TITLE
Fix signatures of commands which accept records also

### DIFF
--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -16,10 +16,10 @@ impl Command for Columns {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(
-                Type::Table(vec![]),
-                Type::List(Box::new(Type::String)),
-            )])
+            .input_output_types(vec![
+                (Type::Table(vec![]), Type::List(Box::new(Type::String))),
+                (Type::Record(vec![]), Type::List(Box::new(Type::String))),
+            ])
             .category(Category::Filters)
     }
 
@@ -29,6 +29,17 @@ impl Command for Columns {
 
     fn examples(&self) -> Vec<Example> {
         vec![
+            Example {
+                example: "{ acronym:PWD, meaning:'Print Working Directory' } | columns",
+                description: "Get the columns from the record",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_string("acronym"),
+                        Value::test_string("meaning"),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
             Example {
                 example: "[[name,age,grade]; [bill,20,a]] | columns",
                 description: "Get the columns from the table",

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -33,10 +33,7 @@ impl Command for Columns {
                 example: "{ acronym:PWD, meaning:'Print Working Directory' } | columns",
                 description: "Get the columns from the record",
                 result: Some(Value::List {
-                    vals: vec![
-                        Value::test_string("acronym"),
-                        Value::test_string("meaning"),
-                    ],
+                    vals: vec![Value::test_string("acronym"), Value::test_string("meaning")],
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -34,7 +34,7 @@ impl Command for Headers {
         let columns = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         vec![
             Example {
-                description: "Returns headers from table",
+                description: "Sets the column names for a table created by `split column`",
                 example: r#""a b c|1 2 3" | split row "|" | split column " " | headers"#,
                 result: Some(Value::List {
                     vals: vec![Value::Record {
@@ -50,7 +50,7 @@ impl Command for Headers {
                 }),
             },
             Example {
-                description: "Don't panic on rows with different headers",
+                description: "Columns which don't have data in their first row are removed",
                 example: r#""a b c|1 2 3|1 2 3 4" | split row "|" | split column " " | headers"#,
                 result: Some(Value::List {
                     vals: vec![

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -18,11 +18,7 @@ impl Command for Insert {
         Signature::build("insert")
             .input_output_types(vec![
                 (Type::Record(vec![]), Type::Record(vec![])),
-                // TODO: It accepts table input also (in which case it repeats
-                // the value across all table rows) but currently there is no
-                // example of the table variant so it cannot be in the
-                // signature.
-                // (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .required(
                 "field",

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -27,8 +27,8 @@ impl Command for Move {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("move")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .rest("columns", SyntaxShape::String, "the columns to move")
             .named(

--- a/crates/nu-command/src/filters/roll/roll_left.rs
+++ b/crates/nu-command/src/filters/roll/roll_left.rs
@@ -22,7 +22,10 @@ impl Command for RollLeft {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .named(
                 "by",
                 SyntaxShape::Int,
@@ -38,7 +41,7 @@ impl Command for RollLeft {
     }
 
     fn usage(&self) -> &str {
-        "Roll table columns left"
+        "Roll record or table columns left"
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -46,7 +49,17 @@ impl Command for RollLeft {
         let rotated_columns = vec!["b".to_string(), "c".to_string(), "a".to_string()];
         vec![
             Example {
-                description: "Rolls columns to the left",
+                description: "Rolls columns of a record to the left",
+                example: "{a:1 b:2 c:3} | roll left",
+                result: Some(
+                    Value::Record {
+                    cols: rotated_columns.clone(),
+                    vals: vec![Value::test_int(2), Value::test_int(3), Value::test_int(1)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Rolls columns of a table to the left",
                 example: "[[a b c]; [1 2 3] [4 5 6]] | roll left",
                 result: Some(Value::List {
                     vals: vec![
@@ -65,7 +78,7 @@ impl Command for RollLeft {
                 }),
             },
             Example {
-                description: "Rolls columns to the left with fixed headers",
+                description: "Rolls columns to the left without changing column names",
                 example: "[[a b c]; [1 2 3] [4 5 6]] | roll left --cells-only",
                 result: Some(Value::List {
                     vals: vec![

--- a/crates/nu-command/src/filters/roll/roll_left.rs
+++ b/crates/nu-command/src/filters/roll/roll_left.rs
@@ -51,8 +51,7 @@ impl Command for RollLeft {
             Example {
                 description: "Rolls columns of a record to the left",
                 example: "{a:1 b:2 c:3} | roll left",
-                result: Some(
-                    Value::Record {
+                result: Some(Value::Record {
                     cols: rotated_columns.clone(),
                     vals: vec![Value::test_int(2), Value::test_int(3), Value::test_int(1)],
                     span: Span::test_data(),

--- a/crates/nu-command/src/filters/roll/roll_right.rs
+++ b/crates/nu-command/src/filters/roll/roll_right.rs
@@ -51,8 +51,7 @@ impl Command for RollRight {
             Example {
                 description: "Rolls columns of a record to the right",
                 example: "{a:1 b:2 c:3} | roll right",
-                result: Some(
-                    Value::Record {
+                result: Some(Value::Record {
                     cols: rotated_columns.clone(),
                     vals: vec![Value::test_int(3), Value::test_int(1), Value::test_int(2)],
                     span: Span::test_data(),

--- a/crates/nu-command/src/filters/roll/roll_right.rs
+++ b/crates/nu-command/src/filters/roll/roll_right.rs
@@ -22,7 +22,10 @@ impl Command for RollRight {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .named(
                 "by",
                 SyntaxShape::Int,
@@ -45,6 +48,16 @@ impl Command for RollRight {
         let columns = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         let rotated_columns = vec!["c".to_string(), "a".to_string(), "b".to_string()];
         vec![
+            Example {
+                description: "Rolls columns of a record to the right",
+                example: "{a:1 b:2 c:3} | roll right",
+                result: Some(
+                    Value::Record {
+                    cols: rotated_columns.clone(),
+                    vals: vec![Value::test_int(3), Value::test_int(1), Value::test_int(2)],
+                    span: Span::test_data(),
+                }),
+            },
             Example {
                 description: "Rolls columns to the right",
                 example: "[[a b c]; [1 2 3] [4 5 6]] | roll right",

--- a/crates/nu-command/src/filters/rotate.rs
+++ b/crates/nu-command/src/filters/rotate.rs
@@ -16,7 +16,10 @@ impl Command for Rotate {
 
     fn signature(&self) -> Signature {
         Signature::build("rotate")
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .switch("ccw", "rotate counter clockwise", None)
             .rest(
                 "rest",
@@ -27,14 +30,14 @@ impl Command for Rotate {
     }
 
     fn usage(&self) -> &str {
-        "Rotates a table clockwise (default) or counter-clockwise (use --ccw flag)."
+        "Rotates a table or record clockwise (default) or counter-clockwise (use --ccw flag)."
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Rotate 2x2 table clockwise",
-                example: "[[a b]; [1 2]] | rotate",
+                description: "Rotate a record clockwise, producing a table (like `transpose` but with column order reversed)",
+                example: "{a:1, b:2} | rotate",
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -18,8 +18,8 @@ impl Command for Select {
     fn signature(&self) -> Signature {
         Signature::build("select")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .switch(
                 "ignore-errors",

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -16,7 +16,10 @@ impl Command for Update {
 
     fn signature(&self) -> Signature {
         Signature::build("update")
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .required(
                 "field",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -16,7 +16,10 @@ impl Command for Upsert {
 
     fn signature(&self) -> Signature {
         Signature::build("upsert")
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .required(
                 "field",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/formats/to/url.rs
+++ b/crates/nu-command/src/formats/to/url.rs
@@ -14,20 +14,30 @@ impl Command for ToUrl {
 
     fn signature(&self) -> Signature {
         Signature::build("to url")
-            .input_output_types(vec![(Type::Table(vec![]), Type::String)])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::String),
+                (Type::Table(vec![]), Type::String),
+            ])
             .category(Category::Formats)
     }
 
     fn usage(&self) -> &str {
-        "Convert table into url-encoded text"
+        "Convert record or table into URL-encoded text"
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Outputs an URL string representing the contents of this table",
-            example: r#"[[foo bar]; ["1" "2"]] | to url"#,
-            result: Some(Value::test_string("foo=1&bar=2")),
-        }]
+        vec![
+            Example {
+                description: "Outputs a URL string representing the contents of this record",
+                example: r#"{ mode:normal userid:31415 } | to url"#,
+                result: Some(Value::test_string("mode=normal&userid=31415")),
+            },
+            Example {
+                description: "Outputs a URL string representing the contents of this 1-row table",
+                example: r#"[[foo bar]; ["1" "2"]] | to url"#,
+                result: Some(Value::test_string("foo=1&bar=2")),
+            },
+        ]
     }
 
     fn run(


### PR DESCRIPTION
# Description

Certain commands that operate on tables also work on bare records, but their type sig didn't reflect that. This corrects this.

I did not fix certain commands which, I feel, currently give unintended behaviour when given plain records. These are `sort-by` and `uniq-by`.

Also corrected the wording of some stuff in headers.rs, and removed a wrong comment in insert.rs.

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
