### PR TITLE
Re-enable `test_bits`

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,4 @@
+mod test_bits;
 mod test_cell_path;
 mod test_conditionals;
 mod test_config_path;

--- a/src/tests/test_bits.rs
+++ b/src/tests/test_bits.rs
@@ -1,4 +1,4 @@
-use crate::tests::{fail_test, run_test, TestResult};
+use crate::tests::{run_test, TestResult};
 
 #[test]
 fn bits_and() -> TestResult {
@@ -27,7 +27,10 @@ fn bits_or_negative() -> TestResult {
 
 #[test]
 fn bits_or_list() -> TestResult {
-    run_test("[1 2 3 8 9 10] | bits or 2 | str join '.'", "3.2.3.10.11.10")
+    run_test(
+        "[1 2 3 8 9 10] | bits or 2 | str join '.'",
+        "3.2.3.10.11.10",
+    )
 }
 
 #[test]
@@ -42,7 +45,10 @@ fn bits_xor_negative() -> TestResult {
 
 #[test]
 fn bits_xor_list() -> TestResult {
-    run_test("[1 2 3 8 9 10] | bits xor 2 | str join '.'", "3.0.1.10.11.8")
+    run_test(
+        "[1 2 3 8 9 10] | bits xor 2 | str join '.'",
+        "3.0.1.10.11.8",
+    )
 }
 
 #[test]
@@ -57,7 +63,10 @@ fn bits_shift_left_negative() -> TestResult {
 
 #[test]
 fn bits_shift_left_list() -> TestResult {
-    run_test("[1 2 7 32 9 10] | bits shl 3 | str join '.'", "8.16.56.256.72.80")
+    run_test(
+        "[1 2 7 32 9 10] | bits shl 3 | str join '.'",
+        "8.16.56.256.72.80",
+    )
 }
 
 #[test]
@@ -72,7 +81,10 @@ fn bits_shift_right_negative() -> TestResult {
 
 #[test]
 fn bits_shift_right_list() -> TestResult {
-    run_test("[12 98 7 64 900 10] | bits shr 3 | str join '.'", "1.12.0.8.112.1")
+    run_test(
+        "[12 98 7 64 900 10] | bits shr 3 | str join '.'",
+        "1.12.0.8.112.1",
+    )
 }
 
 #[test]
@@ -87,7 +99,10 @@ fn bits_rotate_left_negative() -> TestResult {
 
 #[test]
 fn bits_rotate_left_list() -> TestResult {
-    run_test("[1 2 7 32 9 10] | bits rol 3 | str join '.'", "8.16.56.256.72.80")
+    run_test(
+        "[1 2 7 32 9 10] | bits rol 3 | str join '.'",
+        "8.16.56.256.72.80",
+    )
 }
 
 #[test]
@@ -102,5 +117,8 @@ fn bits_rotate_right_negative() -> TestResult {
 
 #[test]
 fn bits_rotate_right_list() -> TestResult {
-    run_test("[1 2 7 32 23 10] | bits ror 60 | str join '.'", "16.32.112.512.368.160")
+    run_test(
+        "[1 2 7 32 23 10] | bits ror 60 | str join '.'",
+        "16.32.112.512.368.160",
+    )
 }


### PR DESCRIPTION
The tests in `src/tests/test_bits.rs` weren't being run because we were missing a `mod test_bits;`. Fixed.