### PR TITLE
add metadata to wrap

### DIFF
--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -37,6 +37,7 @@ impl Command for Wrap {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let span = call.head;
         let name: String = call.req(engine_state, stack, 0)?;
+        let metadata = input.metadata();
 
         match input {
             PipelineData::Empty => Ok(PipelineData::Empty),
@@ -49,19 +50,22 @@ impl Command for Wrap {
                     vals: vec![x],
                     span,
                 })
-                .into_pipeline_data(engine_state.ctrlc.clone())),
+                .into_pipeline_data(engine_state.ctrlc.clone())
+                .set_metadata(metadata)),
             PipelineData::ExternalStream { .. } => Ok(Value::Record {
                 cols: vec![name],
                 vals: vec![input.into_value(call.head)],
                 span,
             }
-            .into_pipeline_data()),
+            .into_pipeline_data()
+            .set_metadata(metadata)),
             PipelineData::Value(input, ..) => Ok(Value::Record {
                 cols: vec![name],
                 vals: vec![input],
                 span,
             }
-            .into_pipeline_data()),
+            .into_pipeline_data()
+            .set_metadata(metadata)),
         }
     }
 


### PR DESCRIPTION
# Description

This PR allows `wrap` to pass through metadata.

# User-Facing Changes

This change allows this:
<img width="789" alt="Screenshot 2022-12-23 at 3 12 37 PM" src="https://user-images.githubusercontent.com/343840/209406010-1da9b814-1892-4961-bb01-9f88ddc83474.png">
Instead of this:
<img width="786" alt="Screenshot 2022-12-23 at 3 12 48 PM" src="https://user-images.githubusercontent.com/343840/209406021-6e5eb860-0911-42c4-a39e-5fe76c61af03.png">

Strangely enough, this command doesn't result in LS_COLORS `(ls | values).0 | wrap name`

/cc @webbedspace - we were talking about LS_COLORS in `values` earlier.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
