### PR TITLE
Add LRU regex cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,6 +2111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "lscolors"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2787,7 @@ dependencies = [
  "chrono-humanize",
  "fancy-regex",
  "indexmap",
+ "lru",
  "miette",
  "nu-json",
  "nu-test-support",

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -402,9 +402,11 @@ pub fn eval_expression(
                         Comparison::NotEqual => lhs.ne(op_span, &rhs, expr.span),
                         Comparison::In => lhs.r#in(op_span, &rhs, expr.span),
                         Comparison::NotIn => lhs.not_in(op_span, &rhs, expr.span),
-                        Comparison::RegexMatch => lhs.regex_match(op_span, &rhs, false, expr.span),
+                        Comparison::RegexMatch => {
+                            lhs.regex_match(engine_state, op_span, &rhs, false, expr.span)
+                        }
                         Comparison::NotRegexMatch => {
-                            lhs.regex_match(op_span, &rhs, true, expr.span)
+                            lhs.regex_match(engine_state, op_span, &rhs, true, expr.span)
                         }
                         Comparison::StartsWith => lhs.starts_with(op_span, &rhs, expr.span),
                         Comparison::EndsWith => lhs.ends_with(op_span, &rhs, expr.span),

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version="0.4.23", features= ["serde", "std"], default-features = fals
 chrono-humanize = "0.2.1"
 fancy-regex = "0.10.0"
 indexmap = { version="1.7" }
+lru = "0.8.1"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 num-format = "0.4.3"
 serde = {version = "1.0.143", default-features = false }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -146,7 +146,7 @@ impl EngineState {
             history_session_id: 0,
             currently_parsed_cwd: None,
             regex_cache: Arc::new(Mutex::new(LruCache::new(
-                NonZeroUsize::new(REGEX_CACHE_SIZE).unwrap(),
+                NonZeroUsize::new(REGEX_CACHE_SIZE).expect("tried to create cache of size zero"),
             ))),
         }
     }


### PR DESCRIPTION
Closes #7572 by adding a cache for compiled regexes of type `Arc<Mutex<LruCache<String, Regex>>>` to `EngineState` .

The cache is limited to 100 entries (limit chosen arbitrarily) and evicts least-recently-used items first.

This PR makes a noticeable difference when using regexes for `color_config`, e.g.: 
```bash
#first set string formatting in config.nu like:
string: { if $in =~ '^#\w{6}$' { $in } else { 'white' } }`

# then try displaying and exploring a table with many strings
# this is instant after the PR, but takes hundreds of milliseconds before
['#ff0033', '#0025ee', '#0087aa', 'string', '#4101ff', '#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff', '#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff', '#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff', '#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff','#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff','#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff','#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff','#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff','#ff0033', '#0025ee', '#0087aa', 'string', '#6103ff']
```

## New dependency (`lru`)
This uses [the popular `lru` crate](https://lib.rs/crates/lru). The new dependency adds 19.8KB to a Linux release build of Nushell. I think this is OK, especially since the crate can be useful elsewhere in Nu.