### PR TITLE
Fix error message when interrupting table with `ctrl+c`

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1725,8 +1725,14 @@ impl Iterator for PagingTableCreator {
                 Some(Ok(bytes))
             }
             Ok(None) => {
-                let term_width = get_width_param(self.width_param);
-                let msg = format!("Couldn't fit table into {} columns!", term_width);
+                let msg = if nu_utils::ctrl_c::was_pressed(&self.ctrlc) {
+                    "".into()
+                } else {
+                    // assume this failed because the table was too wide
+                    // TODO: more robust error classification
+                    let term_width = get_width_param(self.width_param);
+                    format!("Couldn't fit table into {} columns!", term_width)
+                };
                 Some(Ok(msg.as_bytes().to_vec()))
             }
             Err(err) => Some(Err(err)),


### PR DESCRIPTION
`table` was displaying an incorrect "Couldn't fit table into X columns!" error when streaming was interrupted by `ctrl+c`:
![image](https://user-images.githubusercontent.com/26268125/209415204-cc20964b-fc43-42a0-867f-1b01cefb3213.png)

This PR fixes that:
![image](https://user-images.githubusercontent.com/26268125/209415163-b3041357-7f16-4a17-b15a-170b4d50f5ee.png)