### PR TITLE
Make stream info visible to users in `describe`

### DIFF
--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -13,7 +13,7 @@ mod test_examples {
         MathRound, Path, Random, Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace,
         Url, Values, Wrap,
     };
-    use crate::{Break, Mut, To};
+    use crate::{Break, Each, Mut, To};
     use itertools::Itertools;
     use nu_protocol::{
         ast::Block,
@@ -61,6 +61,7 @@ mod test_examples {
             // Base functions that are needed for testing
             // Try to keep this working set small to keep tests running as fast as possible
             let mut working_set = StateWorkingSet::new(&engine_state);
+            working_set.add_decl(Box::new(Each));
             working_set.add_decl(Box::new(Let));
             working_set.add_decl(Box::new(Str));
             working_set.add_decl(Box::new(StrJoin));

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -375,7 +375,7 @@ mod test {
             r#"[7,8,9,10] | par-each {|el ind| $ind } | describe"#
         ));
 
-        assert_eq!(actual.out, "list<int>");
+        assert_eq!(actual.out, "list<int> (stream)");
     }
 
     #[test]

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -77,7 +77,7 @@ fn gets_first_row_as_list_when_amount_given() {
             "#
     ));
 
-    assert_eq!(actual.out, "list<int>");
+    assert_eq!(actual.out, "list<int> (stream)");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -76,7 +76,7 @@ fn gets_last_row_as_list_when_amount_given() {
             "#
     ));
 
-    assert_eq!(actual.out, "list<int>");
+    assert_eq!(actual.out, "list<int> (stream)");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/seq.rs
+++ b/crates/nu-command/tests/commands/seq.rs
@@ -9,7 +9,7 @@ fn float_in_seq_leads_to_lists_of_floats() {
         "#
     ));
 
-    assert_eq!(actual.out, "list<float>");
+    assert_eq!(actual.out, "list<float> (stream)");
 }
 
 #[test]
@@ -21,5 +21,5 @@ fn ints_in_seq_leads_to_lists_of_ints() {
         "#
     ));
 
-    assert_eq!(actual.out, "list<int>");
+    assert_eq!(actual.out, "list<int> (stream)");
 }


### PR DESCRIPTION
Closes #7581.

After this PR, `describe` shows `(stream)` next to input that arrived at `describe` as a `ListStream`:
```bash
〉ls | describe
table<name: string, type: string, size: filesize, modified: date> (stream)
〉[1 2 3] | each {|i| $i} | describe
list<int> (stream)
```

`describe` must collect all items of the stream to display type information for lists and tables. If users need to avoid collecting input, they can use the `-n`/`--no-collect` flag:

```bash
〉[1 2 3] | each {|i| $i} | describe --no-collect
stream
```