### PR TITLE
Add extra_usage messages for subcommand-only commands

### DIFF
--- a/crates/nu-command/src/bits/bits_.rs
+++ b/crates/nu-command/src/bits/bits_.rs
@@ -23,6 +23,10 @@ impl Command for Bits {
         "Various commands for working with bits"
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/bytes/bytes_.rs
+++ b/crates/nu-command/src/bytes/bytes_.rs
@@ -23,6 +23,10 @@ impl Command for Bytes {
         "Various commands for working with byte data"
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/conversions/into/command.rs
+++ b/crates/nu-command/src/conversions/into/command.rs
@@ -23,6 +23,10 @@ impl Command for Into {
         "Commands to convert data from one type to another."
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/core_commands/overlay/command.rs
+++ b/crates/nu-command/src/core_commands/overlay/command.rs
@@ -25,7 +25,9 @@ impl Command for Overlay {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nu.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html
+  
+  You must use one of the following subcommands. Using this command as-is will only produce this help message."#
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-command/src/date/date_.rs
+++ b/crates/nu-command/src/date/date_.rs
@@ -23,6 +23,10 @@ impl Command for Date {
         "Date-related commands"
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec![
             "time",

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -23,6 +23,10 @@ impl Command for ConfigMeta {
         "Edit nushell configuration files"
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/filters/roll/roll_.rs
+++ b/crates/nu-command/src/filters/roll/roll_.rs
@@ -25,6 +25,10 @@ impl Command for Roll {
         "Rolling commands for tables"
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/formats/from/command.rs
+++ b/crates/nu-command/src/formats/from/command.rs
@@ -21,6 +21,10 @@ impl Command for From {
             .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/formats/to/command.rs
+++ b/crates/nu-command/src/formats/to/command.rs
@@ -21,6 +21,10 @@ impl Command for To {
             .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/hash/hash_.rs
+++ b/crates/nu-command/src/hash/hash_.rs
@@ -21,6 +21,10 @@ impl Command for Hash {
         "Apply hash function."
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/math/math_.rs
+++ b/crates/nu-command/src/math/math_.rs
@@ -23,6 +23,10 @@ impl Command for MathCommand {
         "Use mathematical functions as aggregate functions on a list of numbers or tables."
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/path/path_.rs
+++ b/crates/nu-command/src/path/path_.rs
@@ -22,7 +22,9 @@ impl Command for PathCommand {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"There are three ways to represent a path:
+        r#"You must use one of the following subcommands. Using this command as-is will only produce this help message.
+        
+There are three ways to represent a path:
 
 * As a path literal, e.g., '/home/viking/spam.txt'
 * As a structured path: a table with 'parent', 'stem', and 'extension' (and

--- a/crates/nu-command/src/platform/reedline_commands/keybindings.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings.rs
@@ -23,6 +23,10 @@ impl Command for Keybindings {
         "Keybindings related commands"
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["shortcut", "hotkey"]
     }

--- a/crates/nu-command/src/random/random_.rs
+++ b/crates/nu-command/src/random/random_.rs
@@ -23,6 +23,10 @@ impl Command for RandomCommand {
         "Generate a random value."
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["generate", "generator"]
     }

--- a/crates/nu-command/src/strings/split/command.rs
+++ b/crates/nu-command/src/strings/split/command.rs
@@ -23,6 +23,10 @@ impl Command for SplitCommand {
         "Split contents across desired subcommand (like row, column) via the separator."
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/strings/str_/case/str_.rs
+++ b/crates/nu-command/src/strings/str_/case/str_.rs
@@ -23,6 +23,10 @@ impl Command for Str {
         "Various commands for working with string data"
     }
 
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,


### PR DESCRIPTION
# Description

The message reads "You must use one of the following subcommands. Using this command as-is will only produce this help message." and is added to commands like `into`, `bytes`, `str`, etc.

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
