### PR TITLE
Disallow `^` in `def` command names

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -3,7 +3,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn alias_simple() {
     let actual = nu!(
-        cwd: ".", pipeline(
+        cwd: "tests/fixtures/formats", pipeline(
         r#"
             alias bar = use sample_def.nu greet;
             bar;
@@ -17,7 +17,7 @@ fn alias_simple() {
 #[test]
 fn alias_hiding_1() {
     let actual = nu!(
-        cwd: ".", pipeline(
+        cwd: "tests/fixtures/formats", pipeline(
         r#"
             overlay use ./activate-foo.nu;
             $nu.scope.aliases | find deactivate-foo | length
@@ -30,7 +30,7 @@ fn alias_hiding_1() {
 #[test]
 fn alias_hiding_2() {
     let actual = nu!(
-        cwd: ".", pipeline(
+        cwd: "tests/fixtures/formats", pipeline(
         r#"
             overlay use ./activate-foo.nu;
             deactivate-foo;

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -3,7 +3,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn alias_simple() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             alias bar = use sample_def.nu greet;
             bar;
@@ -17,7 +17,7 @@ fn alias_simple() {
 #[test]
 fn alias_hiding_1() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             overlay use ./activate-foo.nu;
             $nu.scope.aliases | find deactivate-foo | length
@@ -30,7 +30,7 @@ fn alias_hiding_1() {
 #[test]
 fn alias_hiding_2() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             overlay use ./activate-foo.nu;
             deactivate-foo;
@@ -43,35 +43,46 @@ fn alias_hiding_2() {
 
 #[test]
 fn alias_fails_with_invalid_name() {
+    let err_msg = "alias name can't be a number, a filesize, or contain a hash # or caret ^";
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             alias 1234 = echo "test"   
         "#
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number, a filesize, or contain a hash"));
+        .contains(err_msg));
 
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             alias 5gib = echo "test"   
         "#
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number, a filesize, or contain a hash"));
+        .contains(err_msg));
 
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             alias "te#t" = echo "test"   
         "#
     ));
     assert!(actual
         .err
-        .contains("alias name can't be a number, a filesize, or contain a hash"));
+        .contains(err_msg));
+
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            alias ^foo = "bar"
+        "#
+    ));
+    assert!(actual
+        .err
+        .contains(err_msg));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -50,9 +50,7 @@ fn alias_fails_with_invalid_name() {
             alias 1234 = echo "test"   
         "#
     ));
-    assert!(actual
-        .err
-        .contains(err_msg));
+    assert!(actual.err.contains(err_msg));
 
     let actual = nu!(
         cwd: ".", pipeline(
@@ -60,9 +58,7 @@ fn alias_fails_with_invalid_name() {
             alias 5gib = echo "test"   
         "#
     ));
-    assert!(actual
-        .err
-        .contains(err_msg));
+    assert!(actual.err.contains(err_msg));
 
     let actual = nu!(
         cwd: ".", pipeline(
@@ -70,9 +66,7 @@ fn alias_fails_with_invalid_name() {
             alias "te#t" = echo "test"   
         "#
     ));
-    assert!(actual
-        .err
-        .contains(err_msg));
+    assert!(actual.err.contains(err_msg));
 
     let actual = nu!(
         cwd: ".", pipeline(
@@ -80,9 +74,7 @@ fn alias_fails_with_invalid_name() {
             alias ^foo = "bar"
         "#
     ));
-    assert!(actual
-        .err
-        .contains(err_msg));
+    assert!(actual.err.contains(err_msg));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -28,38 +28,33 @@ fn def_errors_with_multiple_short_flags() {
         "#
     ));
 
-    assert!(actual.err.contains("expected one short flag"));
+    assert!(actual.err.contains("expected only one short flag"));
 }
 
 #[test]
 fn def_fails_with_invalid_name() {
+    let err_msg = "command name can't be a number, a filesize, or contain a hash # or caret ^";
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             def 1234 = echo "test"
         "#
     ));
-    assert!(actual
-        .err
-        .contains("command name can't be a number, a filesize, or contain a hash"));
+    assert!(actual.err.contains(err_msg));
 
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
             def 5gib = echo "test"
         "#
     ));
-    assert!(actual
-        .err
-        .contains("command name can't be a number, a filesize, or contain a hash"));
+    assert!(actual.err.contains(err_msg));
 
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        cwd: ".", pipeline(
         r#"
-            def "te#t" = echo "test"
+            def ^foo [] {}
         "#
     ));
-    assert!(actual
-        .err
-        .contains("command name can't be a number, a filesize, or contain a hash"));
+    assert!(actual.err.contains(err_msg));
 }

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -172,7 +172,9 @@ pub enum ParseError {
 
     #[error("Alias name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
-    AliasNotValid(#[label = "alias name can't be a number, a filesize, or contain a hash"] Span),
+    AliasNotValid(
+        #[label = "alias name can't be a number, a filesize, or contain a hash # or caret ^"] Span,
+    ),
 
     #[error("Command name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -177,7 +177,8 @@ pub enum ParseError {
     #[error("Command name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
     CommandDefNotValid(
-        #[label = "command name can't be a number, a filesize, or contain a hash"] Span,
+        #[label = "command name can't be a number, a filesize, or contain a hash # or caret ^"]
+        Span,
     ),
 
     #[error("Module not found.")]

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -662,6 +662,7 @@ pub fn parse_alias(
 
                 let checked_name = String::from_utf8_lossy(&alias_name);
                 if checked_name.contains('#')
+                    || checked_name.contains('^')
                     || checked_name.parse::<bytesize::ByteSize>().is_ok()
                     || checked_name.parse::<f64>().is_ok()
                 {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -58,6 +58,7 @@ pub fn parse_def_predecl(
         working_set.exit_scope();
         if let (Some(name), Some(mut signature)) = (name, signature) {
             if name.contains('#')
+                || name.contains('^')
                 || name.parse::<bytesize::ByteSize>().is_ok()
                 || name.parse::<f64>().is_ok()
             {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3294,18 +3294,6 @@ pub fn parse_signature_helper(
                 } else {
                     match parse_mode {
                         ParseMode::ArgMode => {
-                            macro_rules! valid_variable_name {
-                                ($name:expr) => {
-                                    if !is_variable($name) {
-                                        error = error.or_else(|| {
-                                            Some(ParseError::Expected(
-                                                "valid variable name".into(),
-                                                span,
-                                            ))
-                                        })
-                                    }
-                                };
-                            }
                             // Long flag with optional short form, e.g. --output, --age (-a)
                             if contents.starts_with(b"--") && contents.len() > 2 {
                                 // Split the long flag from the short flag with the ( character as delimiter.
@@ -3322,7 +3310,14 @@ pub fn parse_signature_helper(
                                     }
                                 });
 
-                                valid_variable_name!(&variable_name);
+                                if !is_variable(&variable_name) {
+                                    error = error.or_else(|| {
+                                        Some(ParseError::Expected(
+                                            "valid variable name".into(),
+                                            span,
+                                        ))
+                                    })
+                                }
 
                                 let var_id =
                                     working_set.add_variable(variable_name, span, Type::Any, false);
@@ -3376,7 +3371,14 @@ pub fn parse_signature_helper(
                                         }
                                     });
 
-                                    valid_variable_name!(&variable_name);
+                                    if !is_variable(&variable_name) {
+                                        error = error.or_else(|| {
+                                            Some(ParseError::Expected(
+                                                "valid variable name".into(),
+                                                span,
+                                            ))
+                                        })
+                                    }
 
                                     let var_id = working_set.add_variable(
                                         variable_name,
@@ -3417,7 +3419,15 @@ pub fn parse_signature_helper(
                                 let mut encoded_var_name = vec![0u8; 4];
                                 let len = chars[0].encode_utf8(&mut encoded_var_name).len();
                                 let variable_name = encoded_var_name[0..len].to_vec();
-                                valid_variable_name!(&variable_name);
+
+                                if !is_variable(&variable_name) {
+                                    error = error.or_else(|| {
+                                        Some(ParseError::Expected(
+                                            "valid variable name".into(),
+                                            span,
+                                        ))
+                                    })
+                                }
 
                                 let var_id =
                                     working_set.add_variable(variable_name, span, Type::Any, false);
@@ -3483,7 +3493,14 @@ pub fn parse_signature_helper(
                                 let contents: Vec<_> = contents[..(contents.len() - 1)].into();
                                 let name = String::from_utf8_lossy(&contents).to_string();
 
-                                valid_variable_name!(&contents);
+                                if !is_variable(&contents) {
+                                    error = error.or_else(|| {
+                                        Some(ParseError::Expected(
+                                            "valid variable name".into(),
+                                            span,
+                                        ))
+                                    })
+                                }
 
                                 let var_id =
                                     working_set.add_variable(contents, span, Type::Any, false);
@@ -3503,7 +3520,15 @@ pub fn parse_signature_helper(
                             else if let Some(contents) = contents.strip_prefix(b"...") {
                                 let name = String::from_utf8_lossy(contents).to_string();
                                 let contents_vec: Vec<u8> = contents.to_vec();
-                                valid_variable_name!(&contents_vec);
+
+                                if !is_variable(&contents_vec) {
+                                    error = error.or_else(|| {
+                                        Some(ParseError::Expected(
+                                            "valid variable name".into(),
+                                            span,
+                                        ))
+                                    })
+                                }
 
                                 let var_id =
                                     working_set.add_variable(contents_vec, span, Type::Any, false);
@@ -3521,7 +3546,14 @@ pub fn parse_signature_helper(
                                 let name = String::from_utf8_lossy(contents).to_string();
                                 let contents_vec = contents.to_vec();
 
-                                valid_variable_name!(&contents_vec);
+                                if !is_variable(&contents_vec) {
+                                    error = error.or_else(|| {
+                                        Some(ParseError::Expected(
+                                            "valid variable name".into(),
+                                            span,
+                                        ))
+                                    })
+                                }
 
                                 let var_id =
                                     working_set.add_variable(contents_vec, span, Type::Any, false);

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -320,6 +320,11 @@ fn default_value12() -> TestResult {
 }
 
 #[test]
+fn default_value_expression() -> TestResult {
+    run_test(r#"def foo [x = ("foo" | str length)] { $x }; foo"#, "3")
+}
+
+#[test]
 fn loose_each() -> TestResult {
     run_test(r#"[[1, 2, 3], [4, 5, 6]] | each { $in.1 } | math sum"#, "7")
 }


### PR DESCRIPTION
# Description

Closes #7273.

Also slightly edits/tidies up parser.rs.

# User-Facing Changes

`^` is now forbidden in `def` and `def-env` command names. EDIT: also `alias`.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
