### PR TITLE
Fix and Allow Number and Boolean type to be key in `from yaml`

### DIFF
--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -126,6 +126,16 @@ fn convert_yaml_value_to_nu_value(
                     val_span,
                 );
                 match (k, v) {
+                    (serde_yaml::Value::Number(k), _) => {
+                        collected
+                            .item
+                            .insert(k.to_string(), convert_yaml_value_to_nu_value(v, span, val_span)?);
+                    }
+                    (serde_yaml::Value::Bool(k), _) => {
+                        collected
+                            .item
+                            .insert(k.to_string(), convert_yaml_value_to_nu_value(v, span, val_span)?);
+                    }
                     (serde_yaml::Value::String(k), _) => {
                         collected.item.insert(
                             k.clone(),

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -127,14 +127,16 @@ fn convert_yaml_value_to_nu_value(
                 );
                 match (k, v) {
                     (serde_yaml::Value::Number(k), _) => {
-                        collected
-                            .item
-                            .insert(k.to_string(), convert_yaml_value_to_nu_value(v, span, val_span)?);
+                        collected.item.insert(
+                            k.to_string(),
+                            convert_yaml_value_to_nu_value(v, span, val_span)?,
+                        );
                     }
                     (serde_yaml::Value::Bool(k), _) => {
-                        collected
-                            .item
-                            .insert(k.to_string(), convert_yaml_value_to_nu_value(v, span, val_span)?);
+                        collected.item.insert(
+                            k.to_string(),
+                            convert_yaml_value_to_nu_value(v, span, val_span)?,
+                        );
                     }
                     (serde_yaml::Value::String(k), _) => {
                         collected.item.insert(

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -14,3 +14,40 @@ fn table_to_yaml_text_and_from_yaml_text_back_into_table() {
 
     assert_eq!(actual.out, "nushell");
 }
+
+#[test]
+fn convert_dict_to_yaml_with_boolean_key() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "true: BooleanKey " | from yaml
+        "#
+    ));
+    assert!(actual.out.contains("BooleanKey"));
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn convert_dict_to_yaml_with_integer_key() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "200: [] " | from yaml
+        "#
+    ));
+
+    assert!(actual.out.contains("200"));
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn convert_dict_to_yaml_with_integer_floats_key() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "2.11: "1" " | from yaml
+        "#
+    ));
+    assert!(actual.out.contains("2.11"));
+    assert!(actual.err.is_empty());
+}


### PR DESCRIPTION
Fix and Allow Number and Boolean type to be key in Yaml .

For example : 
`"200 : " | from yaml` not allowed because of Number key type.

PR allow , we can use Boolean and Number for key. 
For example :
`"true : false" | from yaml`
`"5050 : it is number" | from yaml`

Fixes #7222 .
