### PR TITLE
Save errors fix

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -105,14 +105,8 @@ impl Command for Save {
                 }
             }
             input => {
-                let bytes = input_to_bytes(
-                    input,
-                    &Path::new(&path.item),
-                    raw,
-                    engine_state,
-                    stack,
-                    span,
-                )?;
+                let bytes =
+                    input_to_bytes(input, Path::new(&path.item), raw, engine_state, stack, span)?;
 
                 // Only open file after successful conversion
                 let (mut file, _) = get_files(&path, &stderr_path, append, force)?;
@@ -248,11 +242,11 @@ fn string_binary_list_value_to_bytes(value: Value, span: Span) -> Result<Vec<u8>
 
 /// Convert string path to [`Path`] and [`Span`] and check if this path
 /// can be used with given flags
-fn prepare_path<'a>(
-    path: &'a Spanned<String>,
+fn prepare_path(
+    path: &Spanned<String>,
     append: bool,
     force: bool,
-) -> Result<(&'a Path, Span), ShellError> {
+) -> Result<(&Path, Span), ShellError> {
     let span = path.span;
     let path = Path::new(&path.item);
 
@@ -315,7 +309,7 @@ fn get_files(
     let (path, path_span) = prepare_path(path, append, force)?;
     let stderr_path_and_span = stderr_path
         .as_ref()
-        .map(|stderr_path| prepare_path(&stderr_path, append, force))
+        .map(|stderr_path| prepare_path(stderr_path, append, force))
         .transpose()?;
 
     // Only if both files can be used open and possibly truncate them

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -237,3 +237,30 @@ fn save_not_overrides_err_by_default() {
         assert!(actual.err.contains("Destination file already exists"));
     })
 }
+
+#[test]
+fn save_override_works_stderr() {
+    Playground::setup("save_test_13", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            Stub::FileWithContent("log.txt", "Old"),
+            Stub::FileWithContent("err.txt", "Old Err"),
+        ]);
+
+        let expected_file = dirs.test().join("log.txt");
+        let expected_stderr_file = dirs.test().join("err.txt");
+
+        nu!(
+            cwd: dirs.root(),
+            r#"
+            let-env FOO = "New";
+            let-env BAZ = "New Err";
+            do -i {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -f -r save_test_13/log.txt --stderr save_test_13/err.txt"#,
+        );
+
+        let actual = file_contents(expected_file);
+        assert_eq!(actual, "New\n");
+
+        let actual = file_contents(expected_stderr_file);
+        assert_eq!(actual, "New Err\n");
+    })
+}

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -234,8 +234,6 @@ fn save_not_overrides_err_by_default() {
             do -i {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_12/log.txt --stderr save_test_12/err.txt"#,
         );
 
-        assert!(actual
-            .err
-            .contains("Destination file already exists"));
+        assert!(actual.err.contains("Destination file already exists"));
     })
 }

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -177,3 +177,19 @@ fn save_override_works() {
         assert_eq!(actual, "abcd");
     })
 }
+
+#[test]
+fn save_failure_not_overrides() {
+    Playground::setup("save_test_10", |dirs, sandbox| {
+        sandbox.with_files(vec![Stub::FileWithContent("result.toml", "Old content")]);
+
+        let expected_file = dirs.test().join("result.toml");
+        nu!(
+            cwd: dirs.root(),
+            // Writing number to file as toml fails
+            r#"3 | save save_test_10/result.toml -f"#
+        );
+        let actual = file_contents(expected_file);
+        assert_eq!(actual, "Old content");
+    })
+}


### PR DESCRIPTION
# Description

- Fixes #5178

- Fixes `save` command wiping file when saving to structured format and conversion fails.
  Before: 

  ![image](https://user-images.githubusercontent.com/17511668/209574061-ef5f8508-516b-439c-b634-f1344e0a3f80.png)

  After:
  
  ![image](https://user-images.githubusercontent.com/17511668/209574133-7c0f47b5-0721-4dab-8f67-4cac03a92d51.png)

- Fixes `save` not applying `--append` and `--force` correctly to stderr output file. See new tests: `save_append_works_on_stderr`, `save_not_overrides_err_by_default` and `save_override_works_stderr`.

- Refactoring and documentation.

# User-Facing Changes

- `--force` and `--append` now affect stderr file.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
