### PR TITLE
add `--mime-type(-m)` to `ls` in the `type` column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2630,7 @@ dependencies = [
  "md-5",
  "meval",
  "mime",
+ "mime_guess",
  "notify",
  "nu-ansi-term",
  "nu-color-config",
@@ -5237,6 +5248,15 @@ name = "uncased"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
  "version_check",
 ]

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -459,7 +459,7 @@ fn flag_completions() {
     // Test completions for the 'ls' flags
     let suggestions = completer.complete("ls -", 4);
 
-    assert_eq!(14, suggestions.len());
+    assert_eq!(16, suggestions.len());
 
     let expected: Vec<String> = vec![
         "--all".into(),
@@ -468,6 +468,7 @@ fn flag_completions() {
         "--full-paths".into(),
         "--help".into(),
         "--long".into(),
+        "--mime-type".into(),
         "--short-names".into(),
         "-D".into(),
         "-a".into(),
@@ -475,6 +476,7 @@ fn flag_completions() {
         "-f".into(),
         "-h".into(),
         "-l".into(),
+        "-m".into(),
         "-s".into(),
     ];
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -59,6 +59,7 @@ lscolors = { version = "0.12.0", features = ["crossterm"], default-features = fa
 md5 = { package = "md-5", version = "0.10.0" }
 meval = "0.2.0"
 mime = "0.3.16"
+mime_guess = "2.0.4"
 notify = "4.0.17"
 num = { version = "0.4.0", optional = true }
 num-traits = "0.2.14"


### PR DESCRIPTION
# Description

This PR adds the `mime-type` to the `type` column if you add the `--mime-type(-m)` flag to `ls`.
<img width="853" alt="Screenshot 2022-12-27 at 11 43 20 AM" src="https://user-images.githubusercontent.com/343840/209705499-27fe40fe-0356-4d9d-97f2-4b2dc52e0963.png">

<img width="781" alt="Screenshot 2022-12-27 at 11 45 53 AM" src="https://user-images.githubusercontent.com/343840/209705509-4d677389-fd68-401e-a7af-3fc6052743b6.png">

# User-Facing Changes

If you specify the `-m` flag, you get the "guessed at" mime type. The guess is based on the file name and uses this crate https://docs.rs/mime_guess/latest/mime_guess/ for the guessing.

Part of issue #7612 and and #7524

There's some debate on if the `mime-type` should be added to the `type` column or if there should be a separate `mime` column. I tend to lean on the side of `type` since it's technically a type and it's only in that column if you ask it to be there. Also, I'd prefer to reuse a column rather than having a list of sprawling columns. Also, as @KodiCraft suggested, there is precedence as with `ls -d` where the summed size is in the size column.

I could go either way and if someone wants to create a `mime` column, we'd probably accept it.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
