### PR TITLE
early return for parsing closure and block with interchanged shape

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3963,6 +3963,13 @@ pub fn parse_block_expression(
 ) -> (Expression, Option<ParseError>) {
     trace!("parsing: block expression");
 
+    if let SyntaxShape::Closure(_) = shape {
+        return (
+            garbage(span),
+            Some(ParseError::Mismatch("block".into(), "closure".into(), span)),
+        );
+    }
+
     let bytes = working_set.get_span_contents(span);
     let mut error = None;
 
@@ -4094,6 +4101,13 @@ pub fn parse_closure_expression(
 ) -> (Expression, Option<ParseError>) {
     trace!("parsing: closure expression");
 
+    if let SyntaxShape::Block = shape {
+        return (
+            garbage(span),
+            Some(ParseError::Mismatch("closure".into(), "block".into(), span)),
+        );
+    }
+
     let bytes = working_set.get_span_contents(span);
     let mut error = None;
 
@@ -4105,7 +4119,7 @@ pub fn parse_closure_expression(
     } else {
         return (
             garbage(span),
-            Some(ParseError::Expected("block".into(), span)),
+            Some(ParseError::Expected("closure".into(), span)),
         );
     }
     if bytes.ends_with(b"}") {
@@ -4177,7 +4191,7 @@ pub fn parse_closure_expression(
                 error = error.or_else(|| {
                     Some(ParseError::Expected(
                         format!(
-                            "{} block parameter{}",
+                            "{} closure parameter{}",
                             v.len(),
                             if v.len() > 1 { "s" } else { "" }
                         ),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3963,13 +3963,6 @@ pub fn parse_block_expression(
 ) -> (Expression, Option<ParseError>) {
     trace!("parsing: block expression");
 
-    if let SyntaxShape::Closure(_) = shape {
-        return (
-            garbage(span),
-            Some(ParseError::Mismatch("block".into(), "closure".into(), span)),
-        );
-    }
-
     let bytes = working_set.get_span_contents(span);
     let mut error = None;
 
@@ -4100,13 +4093,6 @@ pub fn parse_closure_expression(
     expand_aliases_denylist: &[usize],
 ) -> (Expression, Option<ParseError>) {
     trace!("parsing: closure expression");
-
-    if let SyntaxShape::Block = shape {
-        return (
-            garbage(span),
-            Some(ParseError::Mismatch("closure".into(), "block".into(), span)),
-        );
-    }
 
     let bytes = working_set.get_span_contents(span);
     let mut error = None;

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -349,7 +349,10 @@ fn proper_missing_param() -> TestResult {
 
 #[test]
 fn block_arity_check1() -> TestResult {
-    fail_test(r#"ls | each { |x, y, z| 1}"#, "expected 2 block parameters")
+    fail_test(
+        r#"ls | each { |x, y, z| 1}"#,
+        "expected 2 closure parameters",
+    )
 }
 
 #[test]


### PR DESCRIPTION
# Description

- Try to add some constrains to early return parse error when parsing closure with block shape as input, and vice-versa 
- Update error message for closure

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
