### PR TITLE
Allow `ls` to display git status of files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,6 +2618,7 @@ dependencies = [
  "filesize",
  "filetime",
  "fs_extra",
+ "git2",
  "hamcrest2",
  "htmlescape",
  "ical",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "new_mime_guess"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d684d1b59e0dc07b37e2203ef576987473288f530082512aff850585c61b1f"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "nix"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2630,7 @@ dependencies = [
  "md-5",
  "meval",
  "mime",
+ "new_mime_guess",
  "notify",
  "nu-ansi-term",
  "nu-color-config",
@@ -5237,6 +5248,15 @@ name = "uncased"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
  "version_check",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,16 +2422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "new_mime_guess"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d684d1b59e0dc07b37e2203ef576987473288f530082512aff850585c61b1f"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "nix"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,7 +2632,6 @@ dependencies = [
  "meval",
  "mime",
  "mime_guess",
- "new_mime_guess",
  "notify",
  "nu-ansi-term",
  "nu-color-config",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -94,7 +94,6 @@ reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0" }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
-new_mime_guess = "4.0.1"
 git2 = "0.15.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -93,6 +93,7 @@ reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 wax = { version =  "0.5.0" }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
+new_mime_guess = "4.0.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -94,6 +94,7 @@ wax = { version =  "0.5.0" }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.23.0", features = ["serde"], optional = true }
 new_mime_guess = "4.0.1"
+git2 = "0.15.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -318,6 +318,11 @@ impl Command for Ls {
                 result: None,
             },
             Example {
+                description: "List all files untracked by git in the current directory",
+                example: "ls -g | where git_status == untracked",
+                result: None,
+            },
+            Example {
                 description: "List all dirs in your home directory",
                 example: "ls -a ~ | where type == dir",
                 result: None,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -86,9 +86,6 @@ impl Command for Ls {
         let short_names = call.has_flag("short-names");
         let full_paths = call.has_flag("full-paths");
         let du = call.has_flag("du");
-        let full_type = call.has_flag("full-type");
-        let base_type = call.has_flag("base-type");
-        let show_type = call.has_flag("type") || full_type || base_type;
         let git = call.has_flag("git");
         let directory = call.has_flag("directory");
         let use_mime_type = call.has_flag("mime-type");
@@ -408,7 +405,7 @@ pub fn get_file_type(md: &std::fs::Metadata, display_name: &str, use_mime_type: 
             } else if ft.is_char_device() {
                 file_type = String::from("char device");
             } else if ft.is_fifo() {
-                file_type = String::from("fifo");
+                file_type = String::from("pipe");
             } else if ft.is_socket() {
                 file_type = String::from("socket");
             }

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -314,7 +314,7 @@ impl Command for Ls {
             },
             Example {
                 description: "List all images in the current directory",
-                example: "ls -at | where type =~ image/",
+                example: "ls -am | where type =~ image/",
                 result: None,
             },
             Example {


### PR DESCRIPTION
# Description

_(Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.)_

_(Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.)_
This PR adds the `-g` flag to `ls` which allows it to display the git status of a file. It also adds a matching example in the command's examples.

![Preview of ls with the new -g flag](https://cdn.kdcf.me/img/kodi/2022-12-27_23-30-04_1264x1316.png)
![Preview of the ls --help command](https://cdn.kdcf.me/img/kodi/2022-12-27_23-28-39_1394x1816.png)

It's worth noting that the current implementation lacks any caching and is very slow. Just like with `-d`, it must not be enabled by default.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_
`ls` now has the `-g` flag which adds a `git_status` column listing the git status of various files, if any. Related entries in the command's Examples are also added.