### PR TITLE
last, skip, drop, take until, take while, skip until, skip while, where, reverse, shuffle, append, prepend and sort-by raise error when given non-lists 

### DIFF
--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -99,7 +99,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
         let metadata = input.metadata();
 
         Ok(input
-            .into_iter()
+            .into_iter_strict(call.head)?
             .chain(vec)
             .into_iter()
             .into_pipeline_data(engine_state.ctrlc.clone())

--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -91,7 +91,7 @@ impl Command for Drop {
     ) -> Result<PipelineData, ShellError> {
         let metadata = input.metadata();
         let rows: Option<i64> = call.opt(engine_state, stack, 0)?;
-        let v: Vec<_> = input.into_iter().collect();
+        let v: Vec<_> = input.into_iter_strict(call.head)?.collect();
         let vlen: i64 = v.len() as i64;
 
         let rows_to_drop = if let Some(quantity) = rows {

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -92,7 +92,7 @@ impl Command for Last {
 
         // only keep last `to_keep` rows in memory
         let mut buf = VecDeque::<_>::new();
-        for row in input.into_iter() {
+        for row in input.into_iter_strict(call.head)? {
             if buf.len() == to_keep {
                 buf.pop_front();
             }

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -105,7 +105,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
 
         Ok(vec
             .into_iter()
-            .chain(input)
+            .chain(input.into_iter_strict(call.head)?)
             .into_iter()
             .into_pipeline_data(engine_state.ctrlc.clone())
             .set_metadata(metadata))

--- a/crates/nu-command/src/filters/reverse.rs
+++ b/crates/nu-command/src/filters/reverse.rs
@@ -66,13 +66,13 @@ impl Command for Reverse {
         &self,
         engine_state: &EngineState,
         _stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let metadata = input.metadata();
 
         #[allow(clippy::needless_collect)]
-        let v: Vec<_> = input.into_iter().collect();
+        let v: Vec<_> = input.into_iter_strict(call.head)?.collect();
         let iter = v.into_iter().rev();
         Ok(iter
             .into_pipeline_data(engine_state.ctrlc.clone())

--- a/crates/nu-command/src/filters/shuffle.rs
+++ b/crates/nu-command/src/filters/shuffle.rs
@@ -31,11 +31,11 @@ impl Command for Shuffle {
         &self,
         engine_state: &EngineState,
         _stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let metadata = input.metadata();
-        let mut v: Vec<_> = input.into_iter().collect();
+        let mut v: Vec<_> = input.into_iter_strict(call.head)?.collect();
         v.shuffle(&mut thread_rng());
         let iter = v.into_iter();
         Ok(iter

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -141,7 +141,7 @@ impl Command for Skip {
                     .set_metadata(metadata))
             }
             _ => Ok(input
-                .into_iter()
+                .into_iter_strict(call.head)?
                 .skip(n)
                 .into_pipeline_data(ctrlc)
                 .set_metadata(metadata)),

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -94,7 +94,7 @@ impl Command for SkipUntil {
         let redirect_stderr = call.redirect_stderr;
 
         Ok(input
-            .into_iter()
+            .into_iter_strict(span)?
             .skip_while(move |value| {
                 if let Some(var_id) = var_id {
                     stack.add_var(var_id, value.clone());

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -95,7 +95,7 @@ impl Command for SkipWhile {
         let redirect_stderr = call.redirect_stderr;
 
         Ok(input
-            .into_iter()
+            .into_iter_strict(span)?
             .skip_while(move |value| {
                 if let Some(var_id) = var_id {
                     stack.add_var(var_id, value.clone());

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -84,7 +84,7 @@ impl Command for SortBy {
         let insensitive = call.has_flag("ignore-case");
         let natural = call.has_flag("natural");
         let metadata = &input.metadata();
-        let mut vec: Vec<_> = input.into_iter().collect();
+        let mut vec: Vec<_> = input.into_iter_strict(call.head)?.collect();
 
         if columns.is_empty() {
             return Err(ShellError::MissingParameter("columns".into(), call.head));

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -90,7 +90,7 @@ impl Command for TakeUntil {
         let redirect_stderr = call.redirect_stderr;
 
         Ok(input
-            .into_iter()
+            .into_iter_strict(span)?
             .take_while(move |value| {
                 if let Some(var_id) = var_id {
                     stack.add_var(var_id, value.clone());

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -90,7 +90,7 @@ impl Command for TakeWhile {
         let redirect_stderr = call.redirect_stderr;
 
         Ok(input
-            .into_iter()
+            .into_iter_strict(span)?
             .take_while(move |value| {
                 if let Some(var_id) = var_id {
                     stack.add_var(var_id, value.clone());

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -84,7 +84,7 @@ not supported."#
         let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
         Ok(input
-            .into_iter()
+            .into_iter_strict(span)?
             .enumerate()
             .filter_map(move |(idx, value)| {
                 stack.with_env(&orig_env_vars, &orig_env_hidden);

--- a/crates/nu-command/tests/commands/append.rs
+++ b/crates/nu-command/tests/commands/append.rs
@@ -13,3 +13,10 @@ fn adds_a_row_to_the_end() {
 
     assert_eq!(actual.out, "pollo loco");
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | append 3"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/append.rs
+++ b/crates/nu-command/tests/commands/append.rs
@@ -18,5 +18,5 @@ fn adds_a_row_to_the_end() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | append 3"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -95,5 +95,5 @@ fn nth_missing_first_argument() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | drop 50"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -65,7 +65,7 @@ fn rows() {
 
 #[test]
 fn more_rows_than_table_has() {
-    let actual = nu!(cwd: ".", "date | drop 50 | length");
+    let actual = nu!(cwd: ".", "[date] | drop 50 | length");
 
     assert_eq!(actual.out, "0");
 }

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -90,3 +90,10 @@ fn nth_missing_first_argument() {
 
     assert!(actual.err.contains("int or range"));
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | drop 50"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -91,3 +91,10 @@ fn last_errors_on_negative_index() {
 
     assert!(actual.err.contains("use a positive value"));
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | last"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -96,5 +96,5 @@ fn last_errors_on_negative_index() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | last"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -58,7 +58,7 @@ fn requests_more_rows_than_table_has() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        date | last 50 | length
+        [date] | last 50 | length
         "#
     ));
 

--- a/crates/nu-command/tests/commands/prepend.rs
+++ b/crates/nu-command/tests/commands/prepend.rs
@@ -27,3 +27,10 @@ fn adds_a_row_to_the_beginning() {
         assert_eq!(actual.out, "pollo loco");
     })
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | prepend 4"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/prepend.rs
+++ b/crates/nu-command/tests/commands/prepend.rs
@@ -32,5 +32,5 @@ fn adds_a_row_to_the_beginning() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | prepend 4"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/reverse.rs
+++ b/crates/nu-command/tests/commands/reverse.rs
@@ -14,5 +14,5 @@ fn can_get_reverse_first() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | reverse"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/reverse.rs
+++ b/crates/nu-command/tests/commands/reverse.rs
@@ -1,4 +1,4 @@
-use nu_test_support::nu;
+use nu_test_support::{nu, pipeline};
 
 #[test]
 fn can_get_reverse_first() {
@@ -8,4 +8,11 @@ fn can_get_reverse_first() {
     );
 
     assert_eq!(actual.out, "utf16.ini");
+}
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | reverse"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
 }

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -14,3 +14,10 @@ fn binary_skip() {
 
     assert_eq!(actual.out, "772");
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | skip 2"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -5,9 +5,9 @@ fn binary_skip() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            open sample_data.ods --raw | 
-            skip 2 | 
-            take 2 | 
+            open sample_data.ods --raw |
+            skip 2 |
+            take 2 |
             into int
         "#
     ));
@@ -19,5 +19,5 @@ fn binary_skip() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | skip 2"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -49,3 +49,10 @@ fn condition_is_met() {
         assert_eq!(actual.out, "6");
     })
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | skip until {|row| $row == 2}"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -54,5 +54,5 @@ fn condition_is_met() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | skip until {|row| $row == 2}"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -54,5 +54,5 @@ fn condition_is_met() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | skip while {|row| $row == 2}"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -49,3 +49,10 @@ fn condition_is_met() {
         assert_eq!(actual.out, "6");
     })
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | skip while {|row| $row == 2}"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -119,3 +119,10 @@ fn no_column_specified_fails() {
 
     assert!(actual.err.contains("missing parameter"));
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | sort-by"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -124,5 +124,5 @@ fn no_column_specified_fails() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | sort-by"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -123,7 +123,7 @@ fn converts_to_int() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            echo '{number_as_string: "1"}'
+            echo '[{number_as_string: "1"}]'
             | from json
             | into int number_as_string
             | rename number

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -51,7 +51,7 @@ fn fails_on_string() {
             "#
     ));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -51,7 +51,7 @@ fn fails_on_string() {
             "#
     ));
 
-    assert!(actual.err.contains("pipeline_mismatch"));
+    assert!(actual.err.contains("Only supports for specific types."));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -50,3 +50,10 @@ fn condition_is_met() {
         assert_eq!(actual.out, "8");
     })
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | take until {|row| $row == 2}"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -55,5 +55,5 @@ fn condition_is_met() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | take until {|row| $row == 2}"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -49,3 +49,10 @@ fn condition_is_met() {
         assert_eq!(actual.out, "4");
     })
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline("1 | take while {|row| $row == 2}"));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -54,5 +54,5 @@ fn condition_is_met() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline("1 | take while {|row| $row == 2}"));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -193,5 +193,5 @@ fn contains_operator() {
 fn fail_on_non_iterator() {
     let actual = nu!(cwd: ".", pipeline(r#"{"name": "foo", "size": 3} | where name == "foo""#));
 
-    assert!(actual.err.contains("Only supports for specific types."));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -188,3 +188,10 @@ fn contains_operator() {
 
     assert_eq!(actual.out, "2");
 }
+
+#[test]
+fn fail_on_non_iterator() {
+    let actual = nu!(cwd: ".", pipeline(r#"{"name": "foo", "size": 3} | where name == "foo""#));
+
+    assert!(actual.err.contains("Only supports for specific types."));
+}

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -229,7 +229,7 @@ impl PipelineData {
                 // Propagate errors by explicitly matching them before the final case.
                 Value::Error { error } => Err(error),
                 other => Err(ShellError::OnlySupportsThisInputType(
-                    "list, binary, exernal stream or range".into(),
+                    "list, binary, raw data or range".into(),
                     other.get_type().to_string(),
                     span,
                     // This line requires the Value::Error match above.
@@ -237,7 +237,7 @@ impl PipelineData {
                 )),
             },
             PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType(
-                "list, binary, external stream or range".into(),
+                "list, binary, raw data or range".into(),
                 "null".into(),
                 span,
                 span, // TODO: make PipelineData::Empty spanned, so that the span can be used here.

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -51,7 +51,7 @@ pub enum ShellError {
         #[label("value originates from here")] Span,
     ),
 
-    #[error("Pipeline mismatch.")]
+    #[error("Only supports for specific types.")]
     #[diagnostic(code(nu::shell::pipeline_mismatch), url(docsrs))]
     OnlySupportsThisInputType(
         String,

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -51,7 +51,7 @@ pub enum ShellError {
         #[label("value originates from here")] Span,
     ),
 
-    #[error("Only supports for specific types.")]
+    #[error("Only supports for specific input types.")]
     #[diagnostic(code(nu::shell::only_supports_this_input_type), url(docsrs))]
     OnlySupportsThisInputType(
         String,

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -52,7 +52,7 @@ pub enum ShellError {
     ),
 
     #[error("Only supports for specific types.")]
-    #[diagnostic(code(nu::shell::pipeline_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::shell::only_supports_this_input_type), url(docsrs))]
     OnlySupportsThisInputType(
         String,
         String,


### PR DESCRIPTION
# Description

Closes: #6941

## About the change
It seems that all these command need to check if input is a list, to avoid duplicate code, make a new method called `into_iter_strict` in `PipelineData`, so we just need to change from `into_iter` to `into_iter_restrict`.

It's slightly different to #7123, which has less overhead(especially if the input type is Binary), but I think it's ok because we have less code

# User-Facing Changes

```
❯ 1 | last
Error: nu::shell::only_supports_this_input_type (link)

  × Only supports for specific types.
   ╭─[entry #1:1:1]
 1 │ 1 | last
   · ┬   ──┬─
   · │     ╰── only list, binary, exernal stream or range input data is supported
   · ╰── input type: int
   ╰────
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
