### PR TITLE
`def`: make various punctuation misuses into errors

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -20,6 +20,24 @@ export def e [arg] {echo $arg}
 }
 
 #[test]
+fn def_with_param_comment() {
+    Playground::setup("def_with_param_comment", |dirs, _| {
+        let data = r#"
+export def e [
+param:string #My cool attractive param
+] {echo $param};
+            "#;
+        fs::write(dirs.root().join("def_test"), data).expect("Unable to write file");
+        let actual = nu!(
+            cwd: dirs.root(),
+            "use def_test e; help e"
+        );
+
+        assert!(actual.out.contains(r#"My cool attractive param"#));
+    })
+}
+
+#[test]
 fn def_errors_with_multiple_short_flags() {
     let actual = nu!(
         cwd: ".", pipeline(
@@ -29,6 +47,79 @@ fn def_errors_with_multiple_short_flags() {
     ));
 
     assert!(actual.err.contains("expected only one short flag"));
+}
+
+#[test]
+fn def_errors_with_comma_before_alternative_short_flag() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ --long, (-l) ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("expected parameter"));
+}
+
+#[test]
+fn def_errors_with_comma_before_equals() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ foo, = 1 ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("expected parameter"));
+}
+
+#[test]
+fn def_errors_with_comma_before_colon() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ foo, : int ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("expected parameter"));
+}
+
+#[test]
+fn def_errors_with_multiple_colons() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ foo::int ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("expected type"));
+}
+
+#[ignore = "This error condition is not implemented yet"]
+#[test]
+fn def_errors_with_multiple_types() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ foo:int:string ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("expected parameter"));
+}
+
+#[test]
+fn def_errors_with_multiple_commas() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ foo,,bar ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("expected parameter"));
 }
 
 #[test]

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -19,7 +19,7 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::extra_positional), url(docsrs), help("Usage: {0}"))]
     ExtraPositional(String, #[label = "extra positional argument"] Span),
 
-    #[error("Require positional parameter after optional parameter")]
+    #[error("Required positional parameter after optional parameter")]
     #[diagnostic(code(nu::parser::required_after_optional), url(docsrs))]
     RequiredAfterOptional(
         String,

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -316,7 +316,10 @@ fn default_value11() -> TestResult {
 
 #[test]
 fn default_value12() -> TestResult {
-    fail_test(r#"def foo [--x:int = "a"] { $x }"#, "default value not int")
+    fail_test(
+        r#"def foo [--x:int = "a"] { $x }"#,
+        "default value should be int",
+    )
 }
 
 #[test]


### PR DESCRIPTION
# Description

Closes #7604. Now, `def a [--foo, (-f)] {}` (instead of `def a [--foo (-f)] {}`) is an error. 

Also makes the following things into errors:
* doubled commas, like `def a [foo,,bar] {}`
* doubled colons, like `def a [foo::int] {}`

Also added a few more tests for `def`.

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
