### PR TITLE
Update `powierza-coefficient` to `1.0.2`

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -65,7 +65,7 @@ num = { version = "0.4.0", optional = true }
 num-traits = "0.2.14"
 once_cell = "1.0"
 pathdiff = "0.2.1"
-powierza-coefficient = "1.0.1"
+powierza-coefficient = "1.0.2"
 quick-xml = "0.25"
 rand = "0.8"
 rayon = "1.5.1"


### PR DESCRIPTION
# Description

This PR updates [`powierza-coefficient`](https://crates.io/crates/powierza-coefficient) to `1.0.2`. I discovered a bug in the previous version (`1.0.1`) and I'm going to yank it in the near future. The new version has also been thoroughly tested and fuzzed. The API has not changed.