### PR TITLE
Slight edits to `ls` and `zip`'s help text

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -28,7 +28,12 @@ impl Command for Ls {
     }
 
     fn usage(&self) -> &str {
-        "List the files in a directory."
+        "List the filenames, sizes, and modification times of items in a directory"
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"If you want to simply obtain a list of filenames matching a pattern,
+consider using `glob` instead."#
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -54,7 +59,7 @@ impl Command for Ls {
             .switch("full-paths", "display paths as absolute paths", Some('f'))
             .switch(
                 "du",
-                "Display the apparent directory size in place of the directory metadata size",
+                "Display the apparent directory size (\"disk usage\") in place of the directory metadata size",
                 Some('d'),
             )
             .switch(
@@ -62,7 +67,7 @@ impl Command for Ls {
                 "List the specified directory itself instead of its contents",
                 Some('D'),
             )
-            .switch("mime-type", "Show mime-type in type column", Some('m'))
+            .switch("mime-type", "Show mime-type in type column instead of 'file' (based on filenames only; files' contents are not examined)", Some('m'))
             .category(Category::FileSystem)
     }
 

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -28,12 +28,7 @@ impl Command for Ls {
     }
 
     fn usage(&self) -> &str {
-        "List the filenames, sizes, and modification times of items in a directory"
-    }
-
-    fn extra_usage(&self) -> &str {
-        r#"If you want to simply obtain a list of filenames matching a pattern,
-consider using `glob` instead."#
+        "List the filenames, sizes, and modification times of items in a directory."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -70,11 +70,16 @@ impl Command for Zip {
             },
             Example {
                 example: "1..3 | zip 4..6",
-                description: "Zip two streams",
+                description: "Zip two ranges",
                 result: Some(Value::List {
                     vals: vec![test_row_1, test_row_2, test_row_3],
                     span: Span::test_data(),
                 }),
+            },
+            Example {
+                example: "glob *.ogg | zip ['bang.ogg', 'fanfare.ogg', 'laser.ogg'] | each { mv $in.0 $in.1 }",
+                description: "Rename .ogg files to match an existing list of filenames",
+                result: None,
             },
         ]
     }


### PR DESCRIPTION
# Description

* Changes wording of certain parts of `ls`'s help text for clarification.
* Adds a more useful example for `zip`

# User-Facing Changes

See above

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
