### PR TITLE
Fix usage of deprecated C-style logical `and`

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -307,7 +307,7 @@ impl Command for Ls {
             Example {
                 description:
                     "List all dirs in your home directory which have not been modified in 7 days",
-                example: "ls -as ~ | where type == dir && modified < ((date now) - 7day)",
+                example: "ls -as ~ | where type == dir and modified < ((date now) - 7day)",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -126,7 +126,7 @@ impl Command for Rm {
         });
         examples.push(Example {
             description: "Delete all 0KB files in the current directory",
-            example: "ls | where size == 0KB && type == file | each { rm $in.name } | null",
+            example: "ls | where size == 0KB and type == file | each { rm $in.name } | null",
             result: None,
         });
         examples


### PR DESCRIPTION
# Description

In untested examples we still had `&&`

Thx @melMass

# After Submitting

Needs to still be updated on the webdocs
