### PR TITLE
Fix the syntax highlighting in `help metadata`

### DIFF
--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -106,7 +106,7 @@ impl Command for Metadata {
         vec![
             Example {
                 description: "Get the metadata of a variable",
-                example: "metadata $a",
+                example: "let a = 42; metadata $a",
                 result: None,
             },
             Example {


### PR DESCRIPTION
# Description

The syntax highlighting seems to expect the variables to be in scope
![grafik](https://user-images.githubusercontent.com/15833959/209979250-281c8dcf-1ad9-43b1-92a3-37233ac47890.png)

Address this by explicitly adding the variable


