### PR TITLE
Update `Cargo.lock` to `powierza-coefficient 1.0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "powierza-coefficient"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e2c03bca73af2a7a2c021a6b3b4991658b760b2e0a84e3e425a9c9eda2ba7f"
+checksum = "04123079750026568dff0e68efe1ca676f6686023f3bf7686b87dab661c0375b"
 
 [[package]]
 name = "ppv-lite86"


### PR DESCRIPTION
# Description

Follow-up to #7625


