### PR TITLE
Fix quoting of empty string in `to nuon`

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -221,6 +221,9 @@ static NEEDS_QUOTES_REGEX: Lazy<Regex> = Lazy::new(|| {
 });
 
 fn needs_quotes(string: &str) -> bool {
+    if string.is_empty() {
+        return true;
+    }
     // These are case-sensitive keywords
     match string {
         // `true`/`false`/`null` are active keywords in JSON and NUON

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -320,7 +320,6 @@ fn to_nuon_quotes_empty_string_in_list() {
     assert_eq!(actual.out, "true")
 }
 
-
 #[test]
 fn to_nuon_quotes_empty_string_in_table() {
     let actual = nu!(

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -297,6 +297,42 @@ fn to_nuon_converts_columns_with_spaces() {
 }
 
 #[test]
+fn to_nuon_quotes_empty_string() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+    let test = ""; $test | to nuon
+    "#
+    ));
+    assert!(actual.err.is_empty());
+    assert_eq!(actual.out, r#""""#)
+}
+
+#[test]
+fn to_nuon_quotes_empty_string_in_list() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+    let test = [""]; $test | to nuon | from nuon | $in == [""]
+    "#
+    ));
+    assert!(actual.err.is_empty());
+    assert_eq!(actual.out, "true")
+}
+
+
+#[test]
+fn to_nuon_quotes_empty_string_in_table() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+    let test = [[a, b]; ['', la] [le lu]]; $test | to nuon | from nuon
+    "#
+    ));
+    assert!(actual.err.is_empty());
+}
+
+#[test]
 fn does_not_quote_strings_unnecessarily() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
@@ -331,7 +367,7 @@ fn quotes_some_strings_necessarily() {
             '-11.0..<-15.0', '11.0..<-15.0', '-11.0..<15.0',
             '-11.0..', '11.0..', '..15.0', '..-15.0', '..<15.0', '..<-15.0',
             '2000-01-01', '2022-02-02T14:30:00', '2022-02-02T14:30:00+05:00',
-            ',',
+            ',',''
             '&&'
             ] | to nuon | from nuon | describe
         "#


### PR DESCRIPTION
# Description

Closes #7631

The fix is absolutely trivial but the whole thing is a perfect lecture about things that can go wrong in the initial test design.

The proptest tests never generate the whole string but only characters in a larger string or a single character.
The main catch all test `quotes_some_strings_necessarily` is not powerful enough to catch the parser quirk that `[,]` is equivalent to an empty list and the comma or the empty string get ignored.
This only becomes apparent in a table literal as seen in #7631 but is a silent bug in other places.


# User-Facing Changes

Fixes a severe issue with `to nuon`. Broken files in the wild can not be directly recovered through this fix to the export_

# Tests + Formatting

Specific tests for the behavior and a mockup of the case in which it was detected

