### PR TITLE
Impl Default trait for Expression to remove clone

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5845,7 +5845,7 @@ pub fn discover_captures_in_expr(
 
 fn wrap_element_with_collect(
     working_set: &mut StateWorkingSet,
-    element: &PipelineElement,
+    element: &mut PipelineElement,
 ) -> PipelineElement {
     match element {
         PipelineElement::Expression(span, expression) => {
@@ -5867,7 +5867,7 @@ fn wrap_element_with_collect(
     }
 }
 
-fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) -> Expression {
+fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &mut Expression) -> Expression {
     let span = expr.span;
 
     if let Some(decl_id) = working_set.find_decl(b"collect", &Type::Any) {
@@ -5883,7 +5883,7 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
             default_value: None,
         });
 
-        let mut expr = expr.clone();
+        let mut expr = std::mem::take(expr);
         expr.replace_in_variable(working_set, var_id);
 
         let block = Block {

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -13,6 +13,17 @@ pub struct Expression {
     pub custom_completion: Option<DeclId>,
 }
 
+impl Default for Expression {
+    fn default() -> Self {
+        Expression {
+            expr: Expr::Nothing,
+            span: Span::unknown(),
+            ty: Type::Nothing,
+            custom_completion: None,
+        }
+    }
+}
+
 impl Expression {
     pub fn garbage(span: Span) -> Expression {
         Expression {


### PR DESCRIPTION
# Description

There is no associated issue or bug to this pr, I just found out `wrap_expr_with_collect` calls the unnecessary `clone`,


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
