### PR TITLE
Try to use the latest tagged virtualenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
 
         # Get only the latest tagged version for stability reasons
       - name: Install virtualenv
-        run: git clone https://github.com/pypa/virtualenv.git && git checkout $(git describe --tags | cut -d - -f 1)
+        run: git clone https://github.com/pypa/virtualenv.git && cd virtualenv && git checkout $(git describe --tags | cut -d - -f 1)
         shell: bash
 
       - name: Test Nushell in virtualenv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
 
         # Get only the latest tagged version for stability reasons
       - name: Install virtualenv
-        run: git clone https://github.com/pypa/virtualenv.git && git checkout $(git tag --contains | tail -1)
+        run: git clone https://github.com/pypa/virtualenv.git && git checkout $(git describe --tags | cut -d - -f 1)
         shell: bash
 
       - name: Test Nushell in virtualenv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,9 @@ jobs:
 
       - run: python -m pip install tox
 
+        # Get only the latest tagged version for stability reasons
       - name: Install virtualenv
-        run: git clone https://github.com/pypa/virtualenv.git
+        run: git clone https://github.com/pypa/virtualenv.git && git checkout $(git tag --contains | tail -1)
         shell: bash
 
       - name: Test Nushell in virtualenv


### PR DESCRIPTION
# Description

Currently the python-virtualenv tests are failing.
This seems to be related to the coverage setup and not the core test functionality.
Try to use the latest tag as a more stable source.

https://stackoverflow.com/a/27655270/15171257

# User-Facing Changes

None

# Tests + Formatting

Will not immediately reflect changes on the virtualenv side. Could be problematic if the activation script needs to change to keep up with language evolution.
