### PR TITLE
fix: empty cell in select

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -149,7 +149,7 @@ fn select(
         ) => {
             let mut output = vec![];
             let mut columns_with_value = Vec::new();
-
+            let mut allempty = true;
             for input_val in input_vals {
                 if !columns.is_empty() {
                     let mut cols = vec![];
@@ -158,6 +158,7 @@ fn select(
                         //FIXME: improve implementation to not clone
                         match input_val.clone().follow_cell_path(&path.members, false) {
                             Ok(fetcher) => {
+                                allempty = false;
                                 cols.push(path.into_string().replace('.', "_"));
                                 vals.push(fetcher);
                                 if !columns_with_value.contains(&path) {
@@ -166,9 +167,11 @@ fn select(
                             }
                             Err(e) => {
                                 if ignore_errors {
-                                    return Ok(Value::nothing(call_span).into_pipeline_data());
+                                    cols.push(path.into_string().replace('.', "_"));
+                                    vals.push(Value::Nothing { span })
+                                } else {
+                                    return Err(e);
                                 }
-                                return Err(e);
                             }
                         }
                     }
@@ -178,11 +181,14 @@ fn select(
                     output.push(input_val)
                 }
             }
-
-            Ok(output
-                .into_iter()
-                .into_pipeline_data(engine_state.ctrlc.clone())
-                .set_metadata(metadata))
+            if allempty {
+                Ok(Value::nothing(call_span).into_pipeline_data())
+            } else {
+                Ok(output
+                    .into_iter()
+                    .into_pipeline_data(engine_state.ctrlc.clone())
+                    .set_metadata(metadata))
+            }
         }
         PipelineData::ListStream(stream, metadata, ..) => {
             let mut values = vec![];

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -165,11 +165,11 @@ fn select_ignores_errors_succesfully1() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        [{a: 1, b: 2} {a: 3, b: 5} {a: 3}] | select -i b
-            "#
+        [{a: 1, b: 2} {a: 3, b: 5} {a: 3}] | select -i b | length
+        "#
     ));
 
-    assert!(actual.out.is_empty());
+    assert_eq!(actual.out, "3".to_string());
     assert!(actual.err.is_empty());
 }
 


### PR DESCRIPTION
Log: fix empty cell in select command


# Description

before
![image](https://user-images.githubusercontent.com/60290287/210127428-fd047dd1-fddb-4a0a-8a06-143a2c569a03.png)

after
![image](https://user-images.githubusercontent.com/60290287/210127437-5e96c78d-2294-4ad5-8e23-aa2ff1ae3d68.png)


# User-Facing Changes

after this pull request https://github.com/nushell/nushell/pull/6896, select command cannot select a row which contains empty cell

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
