### PR TITLE
docs: 📝 missing catch block parameter example

### DIFF
--- a/crates/nu-command/src/core_commands/try_.rs
+++ b/crates/nu-command/src/core_commands/try_.rs
@@ -128,6 +128,11 @@ impl Command for Try {
                 example: "try { asdfasdf } catch { echo 'missing' } ",
                 result: Some(Value::test_string("missing")),
             },
+            Example {
+                description: "Try to run a missing command, and parse the error",
+                example: "try { asdfasdf } catch {|err| if ('executable was not found' in ($err | to text)) { 'Missing Command' } else { 'Unexpected Error' }}",
+                result: Some(Value::test_string("Missing Command")),
+            },
         ]
     }
 }


### PR DESCRIPTION
# Description

The fact that the catch block has an "optional" parameter (not sure of the proper terminology for block parameters) containing the error is not documented.
This tries to address that

## Proposed option

**Try to run a missing command, and parse the error**
```shell
> try { asdfasdf } catch {|err| if ('executable was not found' in ($err | to text)) { print 'Missing Command' } else { print 'Unexpected Error' }}
```

## Other considered options

1. **Try to run a missing command, do something and return the error.**: 
	```nu
	try { asdfasdf } catch {|err| echo 'missing' | $err }
	```
2. **Try to run a missing command, return the raw error as string**:
	```nu
	try { asdfasdf } catch {|err| print $"Got Error: ($err)"}
	```
	*Suggested by @kubouch , might be the most straightforward one actually*


# User-Facing Changes

NONE