### PR TITLE
Tweak new input type error message

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -51,7 +51,7 @@ pub enum ShellError {
         #[label("value originates from here")] Span,
     ),
 
-    #[error("Only supports for specific input types.")]
+    #[error("Input type not supported.")]
     #[diagnostic(code(nu::shell::only_supports_this_input_type), url(docsrs))]
     OnlySupportsThisInputType(
         String,


### PR DESCRIPTION
A tiny follow-up from https://github.com/nushell/nushell/pull/7623, changes "Only supports for specific input types" to "Input type not supported"

Before:

```
〉"asdf" | append "foo"
Error: nu::shell::only_supports_this_input_type (link)

  × Only supports for specific input types.
   ╭─[entry #2:1:1]
 1 │ "asdf" | append "foo"
   · ───┬──   ───┬──
   ·    │        ╰── only list, binary, raw data or range input data is supported
   ·    ╰── input type: string
   ╰────
```
   
After:
```
〉"asdf" | append "foo"
Error: nu::shell::only_supports_this_input_type (link)

  × Input type not supported.
   ╭─[entry #2:1:1]
 1 │ "asdf" | append "foo"
   · ───┬──   ───┬──
   ·    │        ╰── only list, binary, raw data or range input data is supported
   ·    ╰── input type: string
   ╰────
```