### PR TITLE
Make `get` hole errors and cell path hole errors identical (improvement on #7002)

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -734,60 +734,63 @@ pub fn eval_hook(
             }
         }
         Value::Record { .. } => {
-            let do_run_hook =
-                if let Ok(condition) = value.clone().follow_cell_path(&[condition_path], false) {
-                    match condition {
-                        Value::Block {
-                            val: block_id,
-                            span: block_span,
-                            ..
-                        }
-                        | Value::Closure {
-                            val: block_id,
-                            span: block_span,
-                            ..
-                        } => {
-                            match run_hook_block(
-                                engine_state,
-                                stack,
-                                block_id,
-                                None,
-                                arguments.clone(),
-                                block_span,
-                            ) {
-                                Ok(pipeline_data) => {
-                                    if let PipelineData::Value(Value::Bool { val, .. }, ..) =
-                                        pipeline_data
-                                    {
-                                        val
-                                    } else {
-                                        return Err(ShellError::UnsupportedConfigValue(
-                                            "boolean output".to_string(),
-                                            "other PipelineData variant".to_string(),
-                                            block_span,
-                                        ));
-                                    }
-                                }
-                                Err(err) => {
-                                    return Err(err);
+            let do_run_hook = if let Ok(condition) =
+                value
+                    .clone()
+                    .follow_cell_path(&[condition_path], false, false)
+            {
+                match condition {
+                    Value::Block {
+                        val: block_id,
+                        span: block_span,
+                        ..
+                    }
+                    | Value::Closure {
+                        val: block_id,
+                        span: block_span,
+                        ..
+                    } => {
+                        match run_hook_block(
+                            engine_state,
+                            stack,
+                            block_id,
+                            None,
+                            arguments.clone(),
+                            block_span,
+                        ) {
+                            Ok(pipeline_data) => {
+                                if let PipelineData::Value(Value::Bool { val, .. }, ..) =
+                                    pipeline_data
+                                {
+                                    val
+                                } else {
+                                    return Err(ShellError::UnsupportedConfigValue(
+                                        "boolean output".to_string(),
+                                        "other PipelineData variant".to_string(),
+                                        block_span,
+                                    ));
                                 }
                             }
-                        }
-                        other => {
-                            return Err(ShellError::UnsupportedConfigValue(
-                                "block".to_string(),
-                                format!("{}", other.get_type()),
-                                other.span()?,
-                            ));
+                            Err(err) => {
+                                return Err(err);
+                            }
                         }
                     }
-                } else {
-                    // always run the hook
-                    true
-                };
+                    other => {
+                        return Err(ShellError::UnsupportedConfigValue(
+                            "block".to_string(),
+                            format!("{}", other.get_type()),
+                            other.span()?,
+                        ));
+                    }
+                }
+            } else {
+                // always run the hook
+                true
+            };
 
             if do_run_hook {
-                match value.clone().follow_cell_path(&[code_path], false)? {
+                match value.clone().follow_cell_path(&[code_path], false, false)? {
                     Value::String {
                         val,
                         span: source_span,

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -109,7 +109,10 @@ fn dropcol(
                 let mut vals = vec![];
 
                 for path in &keep_columns {
-                    let fetcher = input_val.clone().follow_cell_path(&path.members, false)?;
+                    let fetcher =
+                        input_val
+                            .clone()
+                            .follow_cell_path(&path.members, false, false)?;
                     cols.push(path.into_string());
                     vals.push(fetcher);
                 }
@@ -133,7 +136,10 @@ fn dropcol(
                 let mut vals = vec![];
 
                 for path in &keep_columns {
-                    let fetcher = input_val.clone().follow_cell_path(&path.members, false)?;
+                    let fetcher =
+                        input_val
+                            .clone()
+                            .follow_cell_path(&path.members, false, false)?;
                     cols.push(path.into_string());
                     vals.push(fetcher);
                 }
@@ -149,7 +155,9 @@ fn dropcol(
             let mut vals = vec![];
 
             for cell_path in &keep_columns {
-                let result = v.clone().follow_cell_path(&cell_path.members, false)?;
+                let result = v
+                    .clone()
+                    .follow_cell_path(&cell_path.members, false, false)?;
 
                 cols.push(cell_path.into_string());
                 vals.push(result);

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -73,7 +73,7 @@ fn empty(
         for val in input {
             for column in &columns {
                 let val = val.clone();
-                match val.follow_cell_path(&column.members, false) {
+                match val.follow_cell_path(&column.members, false, false) {
                     Ok(Value::Nothing { .. }) => {}
                     Ok(_) => return Ok(Value::boolean(false, head).into_pipeline_data()),
                     Err(err) => return Err(err),

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -64,18 +64,9 @@ impl Command for Get {
         let metadata = input.metadata();
 
         if rest.is_empty() {
-            let output = input
-                .follow_cell_path(&cell_path.members, call.head, !sensitive)
-                .map(|x| x.into_pipeline_data());
-
-            if ignore_errors {
-                match output {
-                    Ok(output) => Ok(output),
-                    Err(_) => Ok(Value::Nothing { span: call.head }.into_pipeline_data()),
-                }
-            } else {
-                output
-            }
+            input
+                .follow_cell_path(&cell_path.members, call.head, !sensitive, ignore_errors)
+                .map(|x| x.into_pipeline_data())
         } else {
             let mut output = vec![];
 
@@ -84,15 +75,11 @@ impl Command for Get {
             let input = input.into_value(span);
 
             for path in paths {
-                let val = input.clone().follow_cell_path(&path.members, !sensitive);
+                let val = input
+                    .clone()
+                    .follow_cell_path(&path.members, !sensitive, false);
 
-                if ignore_errors {
-                    if let Ok(val) = val {
-                        output.push(val);
-                    }
-                } else {
-                    output.push(val?);
-                }
+                output.push(val?);
             }
 
             Ok(output.into_iter().into_pipeline_data(ctrlc))
@@ -120,17 +107,13 @@ impl Command for Get {
                 result: Some(Value::test_string("A0")),
             },
             Example {
-                description: "Extract the name of files as a list",
-                example: "ls | get name",
-                result: None,
-            },
-            Example {
-                description: "Extract the name of the 3rd entry of a file list",
+                description:
+                    "Extract the name of the 3rd record in a list (same as `ls | $in.name`)",
                 example: "ls | get name.2",
                 result: None,
             },
             Example {
-                description: "Extract the name of the 3rd entry of a file list (alternative)",
+                description: "Extract the name of the 3rd record in a list",
                 example: "ls | get 2.name",
                 result: None,
             },

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -74,29 +74,7 @@ impl Command for Get {
                     Err(_) => Ok(Value::Nothing { span: call.head }.into_pipeline_data()),
                 }
             } else {
-                match output {
-                    Ok(val) => {
-                        let val_check = val.into_value(span);
-                        match val_check {
-                            Value::List {
-                                ref vals,
-                                span: spanchild,
-                            } => {
-                                if vals.iter().any(|unit| unit.is_empty()) {
-                                    Err(nu_protocol::ShellError::CantFindColumn(
-                                        "Empty cell".to_string(),
-                                        spanchild,
-                                        span,
-                                    ))
-                                } else {
-                                    Ok(val_check.into_pipeline_data())
-                                }
-                            }
-                            val => Ok(val.into_pipeline_data()),
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
+                output
             }
         } else {
             let mut output = vec![];
@@ -109,18 +87,8 @@ impl Command for Get {
                 let val = input.clone().follow_cell_path(&path.members, !sensitive);
 
                 if ignore_errors {
-                    match val {
-                        Ok(Value::Nothing { span: spanchild }) => {
-                            return Err(nu_protocol::ShellError::CantFindColumn(
-                                "Nothing".to_string(),
-                                spanchild,
-                                span,
-                            ));
-                        }
-                        Ok(val) => {
-                            output.push(val);
-                        }
-                        Err(_) => {}
+                    if let Ok(val) = val {
+                        output.push(val);
                     }
                 } else {
                     output.push(val?);

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -81,7 +81,17 @@ fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellErr
         PipelineData::Value(Value::Nothing { .. }, ..) => {
             Ok(Value::int(0, call.head).into_pipeline_data())
         }
-        _ => Ok(Value::int(input.into_iter().count() as i64, call.head).into_pipeline_data()),
+        _ => {
+            let mut count: i64 = 0;
+            // Check for and propagate errors
+            for value in input.into_iter() {
+                if let Value::Error { error } = value {
+                    return Err(error);
+                }
+                count += 1
+            }
+            Ok(Value::int(count, call.head).into_pipeline_data())
+        }
     }
 }
 

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -156,7 +156,11 @@ fn select(
                     let mut vals = vec![];
                     for path in &columns {
                         //FIXME: improve implementation to not clone
-                        match input_val.clone().follow_cell_path(&path.members, false) {
+                        match input_val.clone().follow_cell_path(
+                            &path.members,
+                            false,
+                            ignore_errors,
+                        ) {
                             Ok(fetcher) => {
                                 allempty = false;
                                 cols.push(path.into_string().replace('.', "_"));
@@ -166,12 +170,7 @@ fn select(
                                 }
                             }
                             Err(e) => {
-                                if ignore_errors {
-                                    cols.push(path.into_string().replace('.', "_"));
-                                    vals.push(Value::Nothing { span })
-                                } else {
-                                    return Err(e);
-                                }
+                                return Err(e);
                             }
                         }
                     }
@@ -199,17 +198,15 @@ fn select(
                     let mut vals = vec![];
                     for path in &columns {
                         //FIXME: improve implementation to not clone
-                        match x.clone().follow_cell_path(&path.members, false) {
+                        match x
+                            .clone()
+                            .follow_cell_path(&path.members, false, ignore_errors)
+                        {
                             Ok(value) => {
                                 cols.push(path.into_string().replace('.', "_"));
                                 vals.push(value);
                             }
-                            Err(e) => {
-                                if ignore_errors {
-                                    return Ok(Value::nothing(call_span).into_pipeline_data());
-                                }
-                                return Err(e);
-                            }
+                            Err(e) => return Err(e),
                         }
                     }
                     values.push(Value::Record {
@@ -233,18 +230,15 @@ fn select(
 
                 for cell_path in columns {
                     // FIXME: remove clone
-                    match v.clone().follow_cell_path(&cell_path.members, false) {
+                    match v
+                        .clone()
+                        .follow_cell_path(&cell_path.members, false, ignore_errors)
+                    {
                         Ok(result) => {
                             cols.push(cell_path.into_string().replace('.', "_"));
                             vals.push(result);
                         }
-                        Err(e) => {
-                            if ignore_errors {
-                                return Ok(Value::nothing(call_span).into_pipeline_data());
-                            }
-
-                            return Err(e);
-                        }
+                        Err(e) => return Err(e),
                     }
                 }
 

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -282,7 +282,10 @@ fn format_record(
                         span: *span,
                     })
                     .collect();
-                match data_as_value.clone().follow_cell_path(&path_members, false) {
+                match data_as_value
+                    .clone()
+                    .follow_cell_path(&path_members, false, false)
+                {
                     Ok(value_at_column) => {
                         output.push_str(value_at_column.into_string(", ", config).as_str())
                     }

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -278,6 +278,7 @@ fn convert_to_list(
                                 span: head,
                             }],
                             false,
+                            false,
                         ),
                         _ => Ok(item.clone()),
                     };

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -76,7 +76,7 @@ prints out the list properly."#
         match input {
             PipelineData::Value(Value::List { vals, .. }, ..) => {
                 // dbg!("value::list");
-                let data = convert_to_list(vals, config, call.head);
+                let data = convert_to_list(vals, config, call.head)?;
                 if let Some(items) = data {
                     Ok(create_grid_output(
                         items,
@@ -93,7 +93,7 @@ prints out the list properly."#
             }
             PipelineData::ListStream(stream, ..) => {
                 // dbg!("value::stream");
-                let data = convert_to_list(stream, config, call.head);
+                let data = convert_to_list(stream, config, call.head)?;
                 if let Some(items) = data {
                     Ok(create_grid_output(
                         items,
@@ -251,7 +251,7 @@ fn convert_to_list(
     iter: impl IntoIterator<Item = Value>,
     config: &Config,
     head: Span,
-) -> Option<Vec<(usize, String, String)>> {
+) -> Result<Option<Vec<(usize, String, String)>>, ShellError> {
     let mut iter = iter.into_iter().peekable();
 
     if let Some(first) = iter.peek() {
@@ -267,7 +267,7 @@ fn convert_to_list(
             let mut row = vec![row_num.to_string()];
 
             if headers.is_empty() {
-                row.push(item.into_string(", ", config))
+                row.push(item.nonerror_into_string(", ", config)?)
             } else {
                 for header in headers.iter().skip(1) {
                     let result = match item {
@@ -282,7 +282,7 @@ fn convert_to_list(
                     };
 
                     match result {
-                        Ok(value) => row.push(value.into_string(", ", config)),
+                        Ok(value) => row.push(value.nonerror_into_string(", ", config)?),
                         Err(_) => row.push(String::new()),
                     }
                 }
@@ -315,9 +315,9 @@ fn convert_to_list(
             }
         }
 
-        Some(interleaved)
+        Ok(Some(interleaved))
     } else {
-        None
+        Ok(None)
     }
 }
 

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -247,6 +247,7 @@ fn create_grid_output(
     )
 }
 
+#[allow(clippy::type_complexity)]
 fn convert_to_list(
     iter: impl IntoIterator<Item = Value>,
     config: &Config,

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -5,10 +5,10 @@ use nu_engine::{column::get_columns, env_to_string, CallExt};
 use nu_protocol::TrimStrategy;
 use nu_protocol::{
     ast::{Call, PathMember},
-    engine::{Command, EngineState, Stack, StateWorkingSet},
-    format_error, Category, Config, DataSource, Example, FooterMode, IntoPipelineData, ListStream,
-    PipelineData, PipelineMetadata, RawStream, ShellError, Signature, Span, SyntaxShape,
-    TableIndexMode, Type, Value,
+    engine::{Command, EngineState, Stack},
+    Category, Config, DataSource, Example, FooterMode, IntoPipelineData, ListStream, PipelineData,
+    PipelineMetadata, RawStream, ShellError, Signature, Span, SyntaxShape, TableIndexMode, Type,
+    Value,
 };
 use nu_table::{string_width, Table as NuTable, TableConfig, TableTheme};
 use nu_utils::get_ls_colors;
@@ -331,12 +331,9 @@ fn handle_table_command(
             Ok(val.into_pipeline_data())
         }
         PipelineData::Value(Value::Error { error }, ..) => {
-            let working_set = StateWorkingSet::new(engine_state);
-            Ok(Value::String {
-                val: format_error(&working_set, &error),
-                span: call.head,
-            }
-            .into_pipeline_data())
+            // Propagate this error outward, so that it goes to stderr
+            // instead of stdout.
+            Err(error)
         }
         PipelineData::Value(Value::CustomValue { val, span }, ..) => {
             let base_pipeline = val.to_base_value(span)?.into_pipeline_data();

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -900,7 +900,7 @@ fn convert_to_table(
                                 val: text.clone(),
                                 span: head,
                             };
-                            let val = item.clone().follow_cell_path(&[path], false);
+                            let val = item.clone().follow_cell_path(&[path], false, false);
 
                             match val {
                                 Ok(val) => DeferredStyleComputation::Value { value: val },
@@ -1261,7 +1261,7 @@ fn create_table2_entry_basic(
         Value::Record { .. } => {
             let val = header.to_owned();
             let path = PathMember::String { val, span: head };
-            let val = item.clone().follow_cell_path(&[path], false);
+            let val = item.clone().follow_cell_path(&[path], false, false);
 
             match val {
                 Ok(val) => value_to_styled_string(&val, config, style_computer),
@@ -1289,7 +1289,7 @@ fn create_table2_entry(
         Value::Record { .. } => {
             let val = header.to_owned();
             let path = PathMember::String { val, span: head };
-            let val = item.clone().follow_cell_path(&[path], false);
+            let val = item.clone().follow_cell_path(&[path], false, false);
 
             match val {
                 Ok(val) => convert_to_table2_entry(

--- a/crates/nu-command/tests/commands/default.rs
+++ b/crates/nu-command/tests/commands/default.rs
@@ -24,7 +24,7 @@ fn adds_row_data_if_column_missing() {
             r#"
                 open los_tres_amigos.json
                 | get amigos
-                | default rusty_luck 1
+                | default 1 rusty_luck
                 | where rusty_luck == 1
                 | length
             "#

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -239,5 +239,5 @@ fn get_does_not_delve_too_deep_in_nested_lists() {
         r#"[[{foo: bar}]] | get foo"#
     );
 
-    assert!(actual.err.contains("did not find anything under this name"));
+    assert!(actual.err.contains("cannot find column"));
 }

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -179,7 +179,7 @@ fn parses_json() {
 fn parses_xml() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        "open jonathan.xml | get rss.children.channel.children | get -i 0.item.children | get 3.link.children.3.0"
+        "open jonathan.xml | get rss.children.channel.children | get 0.3.item.children | get 3.link.children.0"
     );
 
     assert_eq!(

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -23,7 +23,7 @@ fn regular_columns() {
 #[test]
 fn skip_cell_rejection() {
     let actual = nu!(cwd: ".", pipeline(
-        r#"[ {a: 1, b: 2,c:txt}, { a:val } ] | reject a | get c.0"#));
+        r#"[ {a: 1, b: 2,c:txt}, { a:val } ] | reject a | get 0.c"#));
 
     assert_eq!(actual.out, "txt");
 }

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -23,7 +23,7 @@ fn regular_columns() {
 #[test]
 fn skip_cell_rejection() {
     let actual = nu!(cwd: ".", pipeline(
-        r#"[ {a: 1, b: 2,c:txt}, { a:val } ] | reject a | get 0.c"#));
+        r#"[ {a: 1, b: 2,c:txt}, { a:val } ] | reject a | get c.0"#));
 
     assert_eq!(actual.out, "txt");
 }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -161,7 +161,7 @@ fn selects_many_rows() {
 }
 
 #[test]
-fn select_ignores_errors_succesfully1() {
+fn select_ignores_errors_successfully1() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
@@ -174,37 +174,40 @@ fn select_ignores_errors_succesfully1() {
 }
 
 #[test]
-fn select_ignores_errors_succesfully2() {
+fn select_ignores_errors_successfully2() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        [{a: 1} {a: 2} {a: 3}] | select -i b
+        [{a: 1} {a: 2} {a: 3}] | select -i b | to nuon
             "#
     ));
 
-    assert!(actual.out.is_empty());
+    assert_eq!(actual.out, "[[b]; [null], [null], [null]]".to_string());
     assert!(actual.err.is_empty());
 }
 
 #[test]
-fn select_ignores_errors_succesfull3() {
+fn select_ignores_errors_successfully3() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"sys | select -i invalid_key"#
+        r#"sys | select -i invalid_key | to nuon"#
     ));
 
-    assert!(actual.out.is_empty());
+    assert_eq!(actual.out, "{invalid_key: null}".to_string());
     assert!(actual.err.is_empty());
 }
 
 #[test]
-fn select_ignores_errors_succesfully4() {
+fn select_ignores_errors_successfully4() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#"[a b c] | select -i invalid_key"#
+        r#"[a b c] | select -i invalid_key | to nuon"#
     ));
 
-    assert!(actual.out.is_empty());
+    assert_eq!(
+        actual.out,
+        "[[invalid_key]; [null], [null], [null]]".to_string()
+    );
     assert!(actual.err.is_empty());
 }
 
@@ -223,10 +226,13 @@ fn select_ignores_errors_successfully5() {
 fn select_ignores_errors_successfully6() {
     let actual = nu!(
         cwd: ".", pipeline(
-        r#""key val\na 1\nb 2\n" | lines | split column -c " " | select -i "100""#
+        r#""key val\na 1\nb 2\n" | lines | split column -c " " | select -i "100" | to nuon"#
     ));
 
-    assert!(actual.out.is_empty());
+    assert_eq!(
+        actual.out,
+        r#"[["100"]; [null], [null], [null]]"#.to_string()
+    );
     assert!(actual.err.is_empty());
 }
 

--- a/crates/nu-command/tests/format_conversions/xml.rs
+++ b/crates/nu-command/tests/format_conversions/xml.rs
@@ -8,7 +8,7 @@ fn table_to_xml_text_and_from_xml_text_back_into_table() {
             open jonathan.xml
             | to xml
             | from xml
-            | get rss.children.channel.children.0.3.item.children.4.guid.attributes.isPermaLink
+            | get rss.children.channel.children.0.3.item.children.guid.4.attributes.isPermaLink
         "#
     ));
 

--- a/crates/nu-command/tests/format_conversions/xml.rs
+++ b/crates/nu-command/tests/format_conversions/xml.rs
@@ -8,7 +8,7 @@ fn table_to_xml_text_and_from_xml_text_back_into_table() {
             open jonathan.xml
             | to xml
             | from xml
-            | get rss.children.channel.children.0.3.item.children.guid.4.attributes.isPermaLink
+            | get rss.children.channel.children.0.3.item.children.4.guid.attributes.isPermaLink
         "#
     ));
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -302,7 +302,7 @@ pub fn eval_expression(
         Expr::FullCellPath(cell_path) => {
             let value = eval_expression(engine_state, stack, &cell_path.head)?;
 
-            value.follow_cell_path(&cell_path.tail, false)
+            value.follow_cell_path(&cell_path.tail, false, false)
         }
         Expr::ImportPattern(_) => Ok(Value::Nothing { span: expr.span }),
         Expr::Overlay(_) => {
@@ -476,6 +476,7 @@ pub fn eval_expression(
                                         // as the "config" environment variable.
                                         let vardata = lhs.follow_cell_path(
                                             &[cell_path.tail[0].clone()],
+                                            false,
                                             false,
                                         )?;
                                         match &cell_path.tail[0] {

--- a/crates/nu-explore/src/nu_common/table.rs
+++ b/crates/nu-explore/src/nu_common/table.rs
@@ -605,7 +605,7 @@ fn create_table2_entry_basic(
         Value::Record { .. } => {
             let val = header.to_owned();
             let path = PathMember::String { val, span: head };
-            let val = item.clone().follow_cell_path(&[path], false);
+            let val = item.clone().follow_cell_path(&[path], false, false);
 
             match val {
                 Ok(val) => value_to_styled_string(&val, config, style_computer),
@@ -633,7 +633,7 @@ fn create_table2_entry(
         Value::Record { .. } => {
             let val = header.to_owned();
             let path = PathMember::String { val, span: head };
-            let val = item.clone().follow_cell_path(&[path], false);
+            let val = item.clone().follow_cell_path(&[path], false, false);
 
             match val {
                 Ok(val) => convert_to_table2_entry(

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -170,7 +170,7 @@ fn record_lookup_value(item: &Value, header: &str) -> Value {
                 span: NuSpan::unknown(),
             };
 
-            let value = item.clone().follow_cell_path(&[path], false);
+            let value = item.clone().follow_cell_path(&[path], false, false);
             match value {
                 Ok(value) => value,
                 Err(_) => item.clone(),

--- a/crates/nu-parser/src/eval.rs
+++ b/crates/nu-parser/src/eval.rs
@@ -31,7 +31,7 @@ pub fn eval_constant(
         Expr::FullCellPath(cell_path) => {
             let value = eval_constant(working_set, &cell_path.head)?;
 
-            match value.follow_cell_path(&cell_path.tail, false) {
+            match value.follow_cell_path(&cell_path.tail, false, false) {
                 Ok(val) => Ok(val),
                 // TODO: Better error conversion
                 Err(shell_error) => Err(ParseError::LabeledError(

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -321,6 +321,7 @@ impl PipelineData {
         cell_path: &[PathMember],
         head: Span,
         insensitive: bool,
+        ignore_errors: bool,
     ) -> Result<Value, ShellError> {
         match self {
             // FIXME: there are probably better ways of doing this
@@ -328,8 +329,8 @@ impl PipelineData {
                 vals: stream.collect(),
                 span: head,
             }
-            .follow_cell_path(cell_path, insensitive),
-            PipelineData::Value(v, ..) => v.follow_cell_path(cell_path, insensitive),
+            .follow_cell_path(cell_path, insensitive, ignore_errors),
+            PipelineData::Value(v, ..) => v.follow_cell_path(cell_path, insensitive, ignore_errors),
             _ => Err(ShellError::IOError("can't follow stream paths".into())),
         }
     }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -671,9 +671,11 @@ impl PipelineData {
         to_stderr: bool,
     ) -> Result<i64, ShellError> {
         for item in self {
+            let mut is_err = false;
             let mut out = if let Value::Error { error } = item {
                 let working_set = StateWorkingSet::new(engine_state);
-
+                // Value::Errors must always go to stderr, not stdout.
+                is_err = true;
                 format_error(&working_set, &error)
             } else if no_newline {
                 item.into_string("", config)
@@ -685,7 +687,7 @@ impl PipelineData {
                 out.push('\n');
             }
 
-            if !to_stderr {
+            if !to_stderr && !is_err {
                 stdout_write_all_and_flush(out)?
             } else {
                 stderr_write_all_and_flush(out)?

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -737,10 +737,22 @@ impl Value {
                                     found_at_least_1_value = true;
                                     output.push(result);
                                 } else {
-                                    output.push(Value::Nothing { span: *span });
+                                    return Err(ShellError::CantFindColumn(
+                                        column_name.to_string(),
+                                        *origin_span,
+                                        // Get the exact span of the value, falling back to
+                                        // the list's span if it's a Value::Empty
+                                        val.span().unwrap_or(*span),
+                                    ));
                                 }
                             } else {
-                                output.push(Value::Nothing { span: *span });
+                                return Err(ShellError::CantFindColumn(
+                                    column_name.to_string(),
+                                    *origin_span,
+                                    // Get the exact span of the value, falling back to
+                                    // the list's span if it's a Value::Empty
+                                    val.span().unwrap_or(*span),
+                                ));
                             }
                         }
                         if found_at_least_1_value {
@@ -749,7 +761,11 @@ impl Value {
                                 span: *span,
                             };
                         } else {
-                            return Err(ShellError::NotFound(*span));
+                            return Err(ShellError::CantFindColumn(
+                                column_name.to_string(),
+                                *origin_span,
+                                *span,
+                            ));
                         }
                     }
                     Value::CustomValue { val, .. } => {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -700,7 +700,7 @@ impl Value {
                         // so only use this message for them.
                         Value::Record { .. } => {
                             return Err(ShellError::TypeMismatchGenericMessage {
-                                err_message: format!("Can't access record values with a row index. Try specifying a column name instead"),
+                                err_message: "Can't access record values with a row index. Try specifying a column name instead".into(),
                                 span: *origin_span, })
                         }
                         Value::Error { error } => return Err(error.to_owned()),

--- a/crates/nu_plugin_inc/src/inc.rs
+++ b/crates/nu_plugin_inc/src/inc.rs
@@ -72,7 +72,7 @@ impl Inc {
     pub fn inc(&self, head: Span, value: &Value) -> Result<Value, LabeledError> {
         if let Some(cell_path) = &self.cell_path {
             let working_value = value.clone();
-            let cell_value = working_value.follow_cell_path(&cell_path.members, false)?;
+            let cell_value = working_value.follow_cell_path(&cell_path.members, false, false)?;
 
             let cell_value = self.inc_value(head, &cell_value)?;
 

--- a/src/tests/test_cell_path.rs
+++ b/src/tests/test_cell_path.rs
@@ -68,8 +68,8 @@ fn list_single_field_failure() -> TestResult {
 // Test the scenario where the requested column is not present in all rows
 #[test]
 fn jagged_list_access_succeeds() -> TestResult {
-    run_test("[{foo: 'bar'}, {}].foo == ['bar', $nothing]", "true")?;
-    run_test("[{}, {foo: 'bar'}].foo == [$nothing, 'bar']", "true")
+    fail_test("[{foo: 'bar'}, {}].foo", "cannot find column")?;
+    fail_test("[{}, {foo: 'bar'}].foo", "cannot find column")
 }
 
 // test that accessing a nonexistent row fails
@@ -81,8 +81,5 @@ fn list_row_access_failure() -> TestResult {
 // regression test for an old bug
 #[test]
 fn do_not_delve_too_deep_in_nested_lists() -> TestResult {
-    fail_test(
-        "[[{foo: bar}]].foo",
-        "did not find anything under this name",
-    )
+    fail_test("[[{foo: bar}]].foo", "cannot find column")
 }

--- a/src/tests/test_cell_path.rs
+++ b/src/tests/test_cell_path.rs
@@ -8,7 +8,7 @@ fn nothing_fails_string() -> TestResult {
 
 #[test]
 fn nothing_fails_int() -> TestResult {
-    fail_test("$nothing.3", "Can't access")
+    fail_test("$nothing.3", "doesn't support cell paths")
 }
 
 // Tests for records
@@ -67,7 +67,7 @@ fn list_single_field_failure() -> TestResult {
 
 // Test the scenario where the requested column is not present in all rows
 #[test]
-fn jagged_list_access_succeeds() -> TestResult {
+fn jagged_list_access_fails() -> TestResult {
     fail_test("[{foo: 'bar'}, {}].foo", "cannot find column")?;
     fail_test("[{}, {foo: 'bar'}].foo", "cannot find column")
 }

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -256,8 +256,20 @@ fn length_defaulted_columns() -> TestResult {
 }
 
 #[test]
-fn get_fuzzy() -> TestResult {
-    run_test("(ls | get -i foo) == null", "true")
+fn nullify_errors() -> TestResult {
+    run_test("([{a:1} {a:2} {a:3}] | get -i foo | length) == 3", "true")?;
+    run_test(
+        "([{a:1} {a:2} {a:3}] | get -i foo | to nuon) == '[null, null, null]'",
+        "true",
+    )
+}
+
+#[test]
+fn nullify_holes() -> TestResult {
+    run_test(
+        "([{a:1} {b:2} {a:3}] | get -i a | to nuon) == '[1, null, 3]'",
+        "true",
+    )
 }
 
 #[test]

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -1,4 +1,4 @@
-use crate::tests::{run_test, TestResult};
+use crate::tests::{fail_test, run_test, TestResult};
 
 #[test]
 fn cell_path_subexpr1() -> TestResult {
@@ -172,11 +172,10 @@ fn update_cell_path_1() -> TestResult {
 }
 
 #[test]
-fn missing_column_fills_in_nothing() -> TestResult {
-    // The empty value will be replaced with null when fetching a column
-    run_test(
+fn missing_column_errors() -> TestResult {
+    fail_test(
         r#"[ { name: ABC, size: 20 }, { name: HIJ } ].size.1 == null"#,
-        "true",
+        "cannot find column",
     )
 }
 


### PR DESCRIPTION
# Description

This closes #7498, as well as fixes an issue reported in https://github.com/nushell/nushell/pull/7002#issuecomment-1368340773

BEFORE:
```
〉[{foo: 'bar'} {}] | get foo
Error: nu::shell::column_not_found (link)

  × Cannot find column
   ╭─[entry #5:1:1]
 1 │ [{foo: 'bar'} {}] | get foo
   · ────────┬────────   ─┬─
   ·         │            ╰── value originates here
   ·         ╰── cannot find column 'Empty cell'
   ╰────

〉[{foo: 'bar'} {}].foo
╭───┬─────╮
│ 0 │ bar │
│ 1 │     │
╰───┴─────╯
```
AFTER:
```
〉[{foo: 'bar'} {}] | get foo
Error: nu::shell::column_not_found (link)

  × Cannot find column
   ╭─[entry #1:1:1]
 1 │ [{foo: 'bar'} {}] | get foo
   ·               ─┬        ─┬─
   ·                │         ╰── cannot find column 'foo'
   ·                ╰── value originates here
   ╰────

〉[{foo: 'bar'} {}].foo
Error: nu::shell::column_not_found (link)

  × Cannot find column
   ╭─[entry #3:1:1]
 1 │ [{foo: 'bar'} {}].foo
   ·               ─┬  ─┬─
   ·                │   ╰── cannot find column 'foo'
   ·                ╰── value originates here       
   ╰────
```

EDIT: This also changes the semantics of `get`/`select` `-i` somewhat. I've decided to leave it like this because it works more intuitively with `default` and `compact`.
BEFORE:
```
〉[{a:1} {b:2} {a:3}] | select -i foo | to nuon
null
```
AFTER:
```
〉[{a:1} {b:2} {a:3}] | select -i foo | to nuon
[[foo]; [null], [null], [null]]
```

# User-Facing Changes

See above. EDIT: the issue with holes in cases like ` [{foo: 'bar'} {}].foo.0` versus ` [{foo: 'bar'} {}].0.foo` has been resolved.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
