### PR TITLE
revert changes on prepend and append

### DIFF
--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -99,7 +99,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
         let metadata = input.metadata();
 
         Ok(input
-            .into_iter_strict(call.head)?
+            .into_iter()
             .chain(vec)
             .into_iter()
             .into_pipeline_data(engine_state.ctrlc.clone())

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -105,7 +105,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
 
         Ok(vec
             .into_iter()
-            .chain(input.into_iter_strict(call.head)?)
+            .chain(input.into_iter())
             .into_iter()
             .into_pipeline_data(engine_state.ctrlc.clone())
             .set_metadata(metadata))

--- a/crates/nu-command/tests/commands/append.rs
+++ b/crates/nu-command/tests/commands/append.rs
@@ -13,10 +13,3 @@ fn adds_a_row_to_the_end() {
 
     assert_eq!(actual.out, "pollo loco");
 }
-
-#[test]
-fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | append 3"));
-
-    assert!(actual.err.contains("only_supports_this_input_type"));
-}

--- a/crates/nu-command/tests/commands/prepend.rs
+++ b/crates/nu-command/tests/commands/prepend.rs
@@ -27,10 +27,3 @@ fn adds_a_row_to_the_beginning() {
         assert_eq!(actual.out, "pollo loco");
     })
 }
-
-#[test]
-fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | prepend 4"));
-
-    assert!(actual.err.contains("only_supports_this_input_type"));
-}


### PR DESCRIPTION
# Description

#7623 causes a break on PATH convertion, this pr is going to revert `prepend` and `append` bahavior.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
