### PR TITLE
Extend config support from F1-F12 to F1-F20, #7666

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -679,9 +679,9 @@ fn add_parsed_keybinding(
             let fn_num: u8 = c[1..]
                 .parse()
                 .ok()
-                .filter(|num| matches!(num, 1..=12))
+                .filter(|num| matches!(num, 1..=20))
                 .ok_or(ShellError::UnsupportedConfigValue(
-                    "(f1|f2|...|f12)".to_string(),
+                    "(f1|f2|...|f20)".to_string(),
                     format!("unknown function key: {}", c),
                     keybinding.keycode.span()?,
                 ))?;


### PR DESCRIPTION
Extend support for additional (F13 to F20, with conformance with VT220) function keys in keybindings, as described in #7666. Compiled and tested.