### PR TITLE
Clarify `url` base command

### DIFF
--- a/crates/nu-command/src/network/url/url_.rs
+++ b/crates/nu-command/src/network/url/url_.rs
@@ -15,12 +15,16 @@ impl Command for Url {
 
     fn signature(&self) -> Signature {
         Signature::build("url")
-            .input_output_types(vec![(Type::String, Type::String)])
+            .input_output_types(vec![(Type::Nothing, Type::String)])
             .category(Category::Network)
     }
 
     fn usage(&self) -> &str {
-        "Apply url function."
+        "Various commands for working with URLs"
+    }
+
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
I noticed that the help for the `url` command was confusing (it wasn't clear that `url` is just a base command that does nothing itself) and the input type was also wrong. Fixed.

Before:
```bash
〉help url
Apply url function.

Search terms: network, parse

Usage:
  > url 

Subcommands:
  url parse - Parses a url

Flags:
  -h, --help - Display the help message for this command

Signatures:
  <string> | url -> <string>
```

After:
```bash
〉help url
Various commands for working with URLs

You must use one of the following subcommands. Using this command as-is will only produce this help message.

Search terms: network, parse

Usage:
  > url 

Subcommands:
  url parse - Parses a url

Flags:
  -h, --help - Display the help message for this command

Signatures:
  <nothing> | url -> <string>
  ```