### PR TITLE
Reorder flags in `nu --help`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -646,28 +646,35 @@ impl Command for Nu {
     }
 
     fn signature(&self) -> Signature {
-        let signature = Signature::build("nu")
+        let mut signature = Signature::build("nu")
             .usage("The nushell language and shell.")
-            .switch(
-                "stdin",
-                "redirect standard input to a command (with `-c`) or a script file",
-                None,
-            )
-            .switch("login", "start as a login shell", Some('l'))
-            .switch("interactive", "start as an interactive shell", Some('i'))
-            .switch("version", "print the version", Some('v'))
-            .named(
-                "testbin",
-                SyntaxShape::String,
-                "run internal test binary",
-                None,
-            )
             .named(
                 "commands",
                 SyntaxShape::String,
                 "run the given commands and then exit",
                 Some('c'),
             )
+            .named(
+                "execute",
+                SyntaxShape::String,
+                "run the given commands and then enter an interactive shell",
+                Some('e'),
+            )
+            .switch("interactive", "start as an interactive shell", Some('i'))
+            .switch("login", "start as a login shell", Some('l'))
+            .named(
+                "table-mode",
+                SyntaxShape::String,
+                "the table mode to use. rounded is default.",
+                Some('m'),
+            )
+            .named(
+                "threads",
+                SyntaxShape::Int,
+                "threads to use for parallel commands",
+                Some('t'),
+            )
+            .switch("version", "print the version", Some('v'))
             .named(
                 "config",
                 SyntaxShape::String,
@@ -679,7 +686,19 @@ impl Command for Nu {
                 SyntaxShape::String,
                 "start with an alternate environment config file",
                 None,
-            )
+            );
+
+        #[cfg(feature = "plugin")]
+        {
+            signature = signature.named(
+                "plugin-config",
+                SyntaxShape::String,
+                "start with an alternate plugin signature file",
+                None,
+            );
+        }
+
+        signature
             .named(
                 "log-level",
                 SyntaxShape::String,
@@ -692,23 +711,16 @@ impl Command for Nu {
                 "set the target for the log to output. stdout, stderr(default), mixed or file",
                 None,
             )
-            .named(
-                "execute",
-                SyntaxShape::String,
-                "run the given commands and then enter an interactive shell",
-                Some('e'),
+            .switch(
+                "stdin",
+                "redirect standard input to a command (with `-c`) or a script file",
+                None,
             )
             .named(
-                "threads",
-                SyntaxShape::Int,
-                "threads to use for parallel commands",
-                Some('t'),
-            )
-            .named(
-                "table-mode",
+                "testbin",
                 SyntaxShape::String,
-                "the table mode to use. rounded is default.",
-                Some('m'),
+                "run internal test binary",
+                None,
             )
             .optional(
                 "script file",
@@ -720,22 +732,7 @@ impl Command for Nu {
                 SyntaxShape::String,
                 "parameters to the script file",
             )
-            .category(Category::System);
-
-        #[cfg(feature = "plugin")]
-        {
-            signature.named(
-                "plugin-config",
-                SyntaxShape::String,
-                "start with an alternate plugin signature file",
-                None,
-            )
-        }
-
-        #[cfg(not(feature = "plugin"))]
-        {
-            signature
-        }
+            .category(Category::System)
     }
 
     fn usage(&self) -> &str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -698,7 +698,7 @@ impl Command for Nu {
             );
         }
 
-        signature
+        signature = signature
             .named(
                 "log-level",
                 SyntaxShape::String,
@@ -732,7 +732,9 @@ impl Command for Nu {
                 SyntaxShape::String,
                 "parameters to the script file",
             )
-            .category(Category::System)
+            .category(Category::System);
+
+        signature
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION
The ordering of flags in `nu --help` was a bit of a mess; I think it grew organically over time. Related commands (like `--config`/`--env-config`/`--plugin-config`) weren't grouped together, common flags weren't near the top, and we weren't following alphabetical ordering.

### Before

```bash
Flags:
  -h, --help - Display the help message for this command
  --stdin - redirect standard input to a command (with `-c`) or a script file
  -l, --login - start as a login shell
  -i, --interactive - start as an interactive shell
  -v, --version - print the version
  --testbin <String> - run internal test binary
  -c, --commands <String> - run the given commands and then exit
  --config <String> - start with an alternate config file
  --env-config <String> - start with an alternate environment config file
  --log-level <String> - log level for diagnostic logs (error, warn, info, debug, trace). Off by default
  --log-target <String> - set the target for the log to output. stdout, stderr(default), mixed or file
  -e, --execute <String> - run the given commands and then enter an interactive shell
  -t, --threads <Int> - threads to use for parallel commands
  -m, --table-mode <String> - the table mode to use. rounded is default.
  --plugin-config <String> - start with an alternate plugin signature file
```

### After

```bash
Flags:
  -h, --help - Display the help message for this command
  -c, --commands <String> - run the given commands and then exit
  -e, --execute <String> - run the given commands and then enter an interactive shell
  -i, --interactive - start as an interactive shell
  -l, --login - start as a login shell
  -m, --table-mode <String> - the table mode to use. rounded is default.
  -t, --threads <Int> - threads to use for parallel commands
  -v, --version - print the version
  --config <String> - start with an alternate config file
  --env-config <String> - start with an alternate environment config file
  --plugin-config <String> - start with an alternate plugin signature file
  --log-level <String> - log level for diagnostic logs (error, warn, info, debug, trace). Off by default
  --log-target <String> - set the target for the log to output. stdout, stderr(default), mixed or file
  --stdin - redirect standard input to a command (with `-c`) or a script file
  --testbin <String> - run internal test binary
```

The new ordering:

1. Groups commands with short flags together, sorted alphabetically by short flag
1. Groups commands with only long flags together, sorted alphabetically (with the exception of `--plugin-config` so we can keep related flags together)

Conveniently, this puts the very commonly used `-c` at the top and the very rarely used `--testbin` at the bottom.