### PR TITLE
fix register-plugins script

### DIFF
--- a/register-plugins.nu
+++ b/register-plugins.nu
@@ -5,7 +5,7 @@ def windows? [] {
 
 # filter out files that end in .d
 def keep-plugin-executables [] {
-    if (windows?) { $in } else { where name !~ '\.d' }
+    if (windows?) { where name ends-with '.exe' } else { where name !~ '\.d' }
 }
 
 # get list of all plugin files from their installed directory


### PR DESCRIPTION
# Description

The register-plugins.nu script was broken on Windows where it was trying to register files that ended in .d. Hopefully this will fix it once and for all.

# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
