### PR TITLE
Make `user` parameter optional in `fetch`

### DIFF
--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -169,6 +169,7 @@ fn helper(
     let login = match (user, password) {
         (Some(user), Some(password)) => Some(encode(format!("{}:{}", user, password))),
         (Some(user), _) => Some(encode(format!("{}:", user))),
+        (_, Some(password)) => Some(encode(format!(":{}", password))),
         _ => None,
     };
 


### PR DESCRIPTION
# Description

This commit makes the `user` parameter optional in the `fetch` command. Previously when attempting to _only_ pass a `password`, the command would ignore authentication. Now when a `user` is not supplied, but a `password` is, an empty user is implied.

Before this PR, consider the following:
```nushell
fetch -password "mypassword" $url
```
This would result in the `password` parameter being ignored entirely.

Now, with changes made in this PR, consider the same code snippet as above. The following HTTP header will be used:
```
Authentication: Basic <base64_encode(":{password}")>
```
Note that the `user` field is implied as empty if one is not supplied when `password` is.

# User-Facing Changes

* `fetch` now supports `password`-only authentication, using an empty `user` if one is not supplied.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
