### PR TITLE
Add benchmarks for evaluating default env+config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,13 @@ path = "src/main.rs"
 # Run all benchmarks with `cargo bench`
 # Run individual benchmarks like `cargo bench -- <regex>` e.g. `cargo bench -- parse`
 [[bench]]
-name = "parser_benchmark"
+name = "encoder_benchmark"
 harness = false
 
 [[bench]]
-name = "encoder_benchmark"
+name = "eval_benchmark"
+harness = false
+
+[[bench]]
+name = "parser_benchmark"
 harness = false

--- a/benches/eval_benchmark.rs
+++ b/benches/eval_benchmark.rs
@@ -1,0 +1,42 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use nu_cli::eval_source;
+use nu_protocol::{PipelineData, Span, Value};
+use nu_utils::{get_default_config, get_default_env};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("eval default_env.nu", |b| {
+        b.iter(|| {
+            let mut engine_state = nu_command::create_default_context();
+            let mut stack = nu_protocol::engine::Stack::new();
+            eval_source(
+                &mut engine_state,
+                &mut stack,
+                get_default_env().as_bytes(),
+                "default_env.nu",
+                PipelineData::empty(),
+            )
+        })
+    });
+
+    c.bench_function("eval default_config.nu", |b| {
+        b.iter(|| {
+            let mut engine_state = nu_command::create_default_context();
+            // parsing config.nu breaks without PWD set
+            engine_state.add_env_var(
+                "PWD".into(),
+                Value::string("/some/dir".to_string(), Span::test_data()),
+            );
+            let mut stack = nu_protocol::engine::Stack::new();
+            eval_source(
+                &mut engine_state,
+                &mut stack,
+                get_default_config().as_bytes(),
+                "default_config.nu",
+                PipelineData::empty(),
+            )
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
A quick follow-up to https://github.com/nushell/nushell/pull/7686. This adds benchmarks for evaluating `default_env.nu` and `default_config.nu`, because evaluating config takes up the lion's share of Nushell's startup time. The benchmarks will help us speed up Nu's startup and test execution.

```
eval default_env.nu     time:   [4.2417 ms 4.2596 ms 4.2780 ms]
...
eval default_config.nu  time:   [1.9362 ms 1.9439 ms 1.9523 ms]
```