### PR TITLE
move BufferedReader out of nu-command

### DIFF
--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -25,5 +25,4 @@ pub use rm::Rm;
 pub use save::Save;
 pub use start::Start;
 pub use touch::Touch;
-pub use util::BufferedReader;
 pub use watch::Watch;

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -1,7 +1,7 @@
-use crate::filesystem::util::BufferedReader;
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::util::BufferedReader;
 use nu_protocol::{
     Category, Example, PipelineData, RawStream, ShellError, Signature, Spanned, SyntaxShape, Type,
     Value,

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -7,7 +7,6 @@ use nu_protocol::ShellError;
 
 use dialoguer::Input;
 use std::error::Error;
-use std::io::{BufRead, BufReader, Read};
 
 #[derive(Default)]
 pub struct FileStructure {
@@ -131,39 +130,5 @@ fn get_interactive_confirmation(prompt: String) -> Result<bool, Box<dyn Error>> 
         Ok(true)
     } else {
         Ok(false)
-    }
-}
-
-pub struct BufferedReader<R: Read> {
-    pub input: BufReader<R>,
-}
-
-impl<R: Read> BufferedReader<R> {
-    pub fn new(input: BufReader<R>) -> Self {
-        Self { input }
-    }
-}
-
-impl<R: Read> Iterator for BufferedReader<R> {
-    type Item = Result<Vec<u8>, ShellError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let buffer = self.input.fill_buf();
-        match buffer {
-            Ok(s) => {
-                let result = s.to_vec();
-
-                let buffer_len = s.len();
-
-                if buffer_len == 0 {
-                    None
-                } else {
-                    self.input.consume(buffer_len);
-
-                    Some(Ok(result))
-                }
-            }
-            Err(e) => Some(Err(ShellError::IOError(e.to_string()))),
-        }
     }
 }

--- a/crates/nu-command/src/network/fetch.rs
+++ b/crates/nu-command/src/network/fetch.rs
@@ -1,9 +1,8 @@
-use crate::BufferedReader;
-
 use base64::encode;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::util::BufferedReader;
 use nu_protocol::RawStream;
 
 use nu_protocol::{

--- a/crates/nu-command/src/network/post.rs
+++ b/crates/nu-command/src/network/post.rs
@@ -1,9 +1,9 @@
 use crate::formats::value_to_json_value;
-use crate::BufferedReader;
 use base64::encode;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::util::BufferedReader;
 use nu_protocol::RawStream;
 use reqwest::{blocking::Response, StatusCode};
 use std::path::PathBuf;

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -13,6 +13,7 @@ mod signature;
 pub mod span;
 mod syntax_shape;
 mod ty;
+pub mod util;
 mod value;
 mod variable;
 
@@ -29,5 +30,6 @@ pub use signature::*;
 pub use span::*;
 pub use syntax_shape::*;
 pub use ty::*;
+pub use util::BufferedReader;
 pub use value::*;
 pub use variable::*;

--- a/crates/nu-protocol/src/util.rs
+++ b/crates/nu-protocol/src/util.rs
@@ -1,0 +1,36 @@
+use crate::ShellError;
+use std::io::{BufRead, BufReader, Read};
+
+pub struct BufferedReader<R: Read> {
+    pub input: BufReader<R>,
+}
+
+impl<R: Read> BufferedReader<R> {
+    pub fn new(input: BufReader<R>) -> Self {
+        Self { input }
+    }
+}
+
+impl<R: Read> Iterator for BufferedReader<R> {
+    type Item = Result<Vec<u8>, ShellError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let buffer = self.input.fill_buf();
+        match buffer {
+            Ok(s) => {
+                let result = s.to_vec();
+
+                let buffer_len = s.len();
+
+                if buffer_len == 0 {
+                    None
+                } else {
+                    self.input.consume(buffer_len);
+
+                    Some(Ok(result))
+                }
+            }
+            Err(e) => Some(Err(ShellError::IOError(e.to_string()))),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,14 @@ use nu_cli::{
     evaluate_commands, evaluate_file, evaluate_repl, gather_parent_env_vars, get_init_cwd,
     report_error, report_error_new,
 };
-use nu_command::{create_default_context, BufferedReader};
+use nu_command::create_default_context;
 use nu_engine::{get_full_help, CallExt};
 use nu_parser::{escape_for_script_arg, escape_quote_string, parse};
 use nu_path::canonicalize_with;
 use nu_protocol::{
     ast::{Call, Expr, Expression, PipelineElement},
     engine::{Command, EngineState, Stack, StateWorkingSet},
+    util::BufferedReader,
     Category, Example, IntoPipelineData, PipelineData, RawStream, ShellError, Signature, Spanned,
     SyntaxShape, Value,
 };


### PR DESCRIPTION

src/main.rs has a dependency on BufferedReader
which is currently located in nu_command.

I am moving BufferedReader to a more relevant
location (crate) which will allow / eliminate main's dependency
on nu_command in a benchmark / testing environment...

now that @rgwood  has landed benches I want
to start experimenting with benchmarks related
to the parser.

For benchmark purposes when dealing with parsing
you need a very simple set of commands that show
how well the parser is doing, in other words
just the core commands... Not all of nu_command...

Having a smaller nu binary when running the benchmark CI
would enable building nushell quickly, yet still show us
how well the parser is performing...

Once this PR lands the only dependency main will have
on nu_command is create_default_context ---
meaning for benchmark purposes we can swap in a tiny
crate of commands instead of the gigantic nu_command
which has its "own" create_default_context...

It will also enable other crates going forward to
use BufferedReader.  Right now it is not accessible
to other lower level crates because it is located in a
"top of the stack crate".
