### PR TITLE
align durations to the right

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -126,7 +126,7 @@ impl<'a> StyleComputer<'a> {
 
             Value::Filesize { .. } => TextStyle::with_style(AlignmentHorizontal::Right, s),
 
-            Value::Duration { .. } => TextStyle::with_style(AlignmentHorizontal::Left, s),
+            Value::Duration { .. } => TextStyle::with_style(AlignmentHorizontal::Right, s),
 
             Value::Date { .. } => TextStyle::with_style(AlignmentHorizontal::Left, s),
 


### PR DESCRIPTION
# Description

This PR aligns durations to the right side versus the left.
Before this PR
![image](https://user-images.githubusercontent.com/343840/211092575-2199f4ce-7972-4726-a243-5499e656fb46.png)

After this PR
![image](https://user-images.githubusercontent.com/343840/211092601-ff63ecd2-9710-4e5f-8c32-85476f4b7110.png)


# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
