### PR TITLE
Rename `to url` command to `url build-query`

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -354,7 +354,6 @@ pub fn create_default_context() -> EngineState {
             Use,
             Upsert,
             Where,
-            ToUrlQuery,
             ToXml,
             ToYaml,
         };
@@ -436,6 +435,7 @@ pub fn create_default_context() -> EngineState {
             Fetch,
             Post,
             Url,
+            UrlBuildQuery,
             UrlEncode,
             UrlParse,
             Port,

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -354,7 +354,7 @@ pub fn create_default_context() -> EngineState {
             Use,
             Upsert,
             Where,
-            ToUrl,
+            ToUrlQuery,
             ToXml,
             ToYaml,
         };

--- a/crates/nu-command/src/formats/to/mod.rs
+++ b/crates/nu-command/src/formats/to/mod.rs
@@ -14,7 +14,7 @@ mod yaml;
 
 pub use self::csv::ToCsv;
 pub use self::toml::ToToml;
-pub use self::url::ToUrl;
+pub use self::url::ToUrlQuery;
 pub use command::To;
 pub use html::ToHtml;
 pub use json::ToJson;

--- a/crates/nu-command/src/formats/to/mod.rs
+++ b/crates/nu-command/src/formats/to/mod.rs
@@ -8,13 +8,11 @@ mod nuon;
 mod text;
 mod toml;
 mod tsv;
-mod url;
 mod xml;
 mod yaml;
 
 pub use self::csv::ToCsv;
 pub use self::toml::ToToml;
-pub use self::url::ToUrlQuery;
 pub use command::To;
 pub use html::ToHtml;
 pub use json::ToJson;

--- a/crates/nu-command/src/formats/to/url.rs
+++ b/crates/nu-command/src/formats/to/url.rs
@@ -5,15 +5,15 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct ToUrl;
+pub struct ToUrlQuery;
 
-impl Command for ToUrl {
+impl Command for ToUrlQuery {
     fn name(&self) -> &str {
-        "to url"
+        "to url query"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("to url")
+        Signature::build("to url query")
             .input_output_types(vec![
                 (Type::Record(vec![]), Type::String),
                 (Type::Table(vec![]), Type::String),
@@ -22,20 +22,25 @@ impl Command for ToUrl {
     }
 
     fn usage(&self) -> &str {
-        "Convert record or table into URL-encoded text"
+        "Convert record or table into query string applying percent-encoding."
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Outputs a URL string representing the contents of this record",
-                example: r#"{ mode:normal userid:31415 } | to url"#,
+                description: "Outputs a query string representing the contents of this record",
+                example: r#"{ mode:normal userid:31415 } | to url query"#,
                 result: Some(Value::test_string("mode=normal&userid=31415")),
             },
             Example {
-                description: "Outputs a URL string representing the contents of this 1-row table",
-                example: r#"[[foo bar]; ["1" "2"]] | to url"#,
+                description: "Outputs a query string representing the contents of this 1-row table",
+                example: r#"[[foo bar]; ["1" "2"]] | to url query"#,
                 result: Some(Value::test_string("foo=1&bar=2")),
+            },
+            Example {
+                description: "Outputs a query string representing the contents of this record",
+                example: r#"{a:"AT&T", b: "AT T"} | to url query"#,
+                result: Some(Value::test_string("a=AT%26T&b=AT+T")),
             },
         ]
     }
@@ -110,6 +115,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(ToUrl {})
+        test_examples(ToUrlQuery {})
     }
 }

--- a/crates/nu-command/src/network/url/build_query.rs
+++ b/crates/nu-command/src/network/url/build_query.rs
@@ -5,41 +5,45 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct ToUrlQuery;
+pub struct SubCommand;
 
-impl Command for ToUrlQuery {
+impl Command for SubCommand {
     fn name(&self) -> &str {
-        "to url query"
+        "url build-query"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("to url query")
+        Signature::build("url build-query")
             .input_output_types(vec![
                 (Type::Record(vec![]), Type::String),
                 (Type::Table(vec![]), Type::String),
             ])
-            .category(Category::Formats)
+            .category(Category::Network)
     }
 
     fn usage(&self) -> &str {
-        "Convert record or table into query string applying percent-encoding."
+        "Converts record or table into query string applying percent-encoding."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["query", "convert", "record", "table"]
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
                 description: "Outputs a query string representing the contents of this record",
-                example: r#"{ mode:normal userid:31415 } | to url query"#,
+                example: r#"{ mode:normal userid:31415 } | url build-query"#,
                 result: Some(Value::test_string("mode=normal&userid=31415")),
             },
             Example {
                 description: "Outputs a query string representing the contents of this 1-row table",
-                example: r#"[[foo bar]; ["1" "2"]] | to url query"#,
+                example: r#"[[foo bar]; ["1" "2"]] | url build-query"#,
                 result: Some(Value::test_string("foo=1&bar=2")),
             },
             Example {
                 description: "Outputs a query string representing the contents of this record",
-                example: r#"{a:"AT&T", b: "AT T"} | to url query"#,
+                example: r#"{a:"AT&T", b: "AT T"} | url build-query"#,
                 result: Some(Value::test_string("a=AT%26T&b=AT+T")),
             },
         ]
@@ -115,6 +119,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(ToUrlQuery {})
+        test_examples(SubCommand {})
     }
 }

--- a/crates/nu-command/src/network/url/build_query.rs
+++ b/crates/nu-command/src/network/url/build_query.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["query", "convert", "record", "table"]
+        vec!["convert", "record", "table"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/network/url/mod.rs
+++ b/crates/nu-command/src/network/url/mod.rs
@@ -1,3 +1,4 @@
+mod build_query;
 mod encode;
 mod parse;
 mod url_;
@@ -5,5 +6,6 @@ mod url_;
 use url::{self};
 
 pub use self::parse::SubCommand as UrlParse;
+pub use build_query::SubCommand as UrlBuildQuery;
 pub use encode::SubCommand as UrlEncode;
 pub use url_::Url;

--- a/crates/nu-command/tests/format_conversions/url.rs
+++ b/crates/nu-command/tests/format_conversions/url.rs
@@ -6,7 +6,7 @@ fn can_encode_and_decode_urlencoding() {
         cwd: "tests/fixtures/formats", pipeline(
             r#"
                 open sample.url
-                | to url
+                | url build-query
                 | from url
                 | get cheese
             "#


### PR DESCRIPTION
# Description

Refactor command: "to url" in: "to url query". Changed usage sentence.
Closes: #7495

# User-Facing Changes

Now we get a query string from a record or table by using command: "to url query".

```
> help to url query
Convert record or table into query string applying percent-encoding.

Usage:
  > to url query

Flags:
  -h, --help - Display the help message for this command

Signatures:
  <record> | to url query -> <string>
  <table> | to url query -> <string>

Examples:
  Outputs a query string representing the contents of this record
  > { mode:normal userid:31415 } | to url query

  Outputs a query string representing the contents of this 1-row table
  > [[foo bar]; ["1" "2"]] | to url query

  Outputs a query string representing the contents of this record
  > {a:"AT&T", b: "AT T"} | to url query
```

# Tests + Formatting

Added this test:
```
Example {
    description: "Outputs a query string representing the contents of this record",
    example: r#"{a:"AT&T", b: "AT T"} | to url query"#,
    result: Some(Value::test_string("a=AT%26T&b=AT+T")),
},
```
to ensure percent-encoding. 

# After Submitting

If PR is accepted I'll open another PR on documentation to notify changes on [this.](https://github.com/nushell/nushell.github.io/blob/main/book/commands/to_url.md)
