### PR TITLE
clean up some extra logging code in the cli

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -1,6 +1,5 @@
 use crate::util::report_error;
 use crate::NushellPrompt;
-use log::info;
 use nu_engine::eval_subexpression;
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
@@ -39,13 +38,6 @@ fn get_prompt_string(
                 // Use eval_subexpression to force a redirection of output, so we can use everything in prompt
                 let ret_val =
                     eval_subexpression(engine_state, &mut stack, block, PipelineData::empty());
-                info!(
-                    "get_prompt_string (block) {}:{}:{}",
-                    file!(),
-                    line!(),
-                    column!()
-                );
-
                 match ret_val {
                     Ok(ret_val) => Some(ret_val),
                     Err(err) => {
@@ -59,13 +51,6 @@ fn get_prompt_string(
                 let block = engine_state.get_block(block_id);
                 // Use eval_subexpression to force a redirection of output, so we can use everything in prompt
                 let ret_val = eval_subexpression(engine_state, stack, block, PipelineData::empty());
-                info!(
-                    "get_prompt_string (block) {}:{}:{}",
-                    file!(),
-                    line!(),
-                    column!()
-                );
-
                 match ret_val {
                     Ok(ret_val) => Some(ret_val),
                     Err(err) => {
@@ -147,8 +132,5 @@ pub(crate) fn update_prompt<'prompt>(
         config.render_right_prompt_on_last_line,
     );
 
-    let ret_val = nu_prompt as &dyn Prompt;
-    info!("update_prompt {}:{}:{}", file!(), line!(), column!());
-
-    ret_val
+    nu_prompt as &dyn Prompt
 }

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -1,5 +1,6 @@
 use crate::util::report_error;
 use crate::NushellPrompt;
+use log::trace;
 use nu_engine::eval_subexpression;
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
@@ -38,6 +39,13 @@ fn get_prompt_string(
                 // Use eval_subexpression to force a redirection of output, so we can use everything in prompt
                 let ret_val =
                     eval_subexpression(engine_state, &mut stack, block, PipelineData::empty());
+                trace!(
+                    "get_prompt_string (block) {}:{}:{}",
+                    file!(),
+                    line!(),
+                    column!()
+                );
+
                 match ret_val {
                     Ok(ret_val) => Some(ret_val),
                     Err(err) => {
@@ -51,6 +59,13 @@ fn get_prompt_string(
                 let block = engine_state.get_block(block_id);
                 // Use eval_subexpression to force a redirection of output, so we can use everything in prompt
                 let ret_val = eval_subexpression(engine_state, stack, block, PipelineData::empty());
+                trace!(
+                    "get_prompt_string (block) {}:{}:{}",
+                    file!(),
+                    line!(),
+                    column!()
+                );
+
                 match ret_val {
                     Ok(ret_val) => Some(ret_val),
                     Err(err) => {
@@ -132,5 +147,8 @@ pub(crate) fn update_prompt<'prompt>(
         config.render_right_prompt_on_last_line,
     );
 
-    nu_prompt as &dyn Prompt
+    let ret_val = nu_prompt as &dyn Prompt;
+    trace!("update_prompt {}:{}:{}", file!(), line!(), column!());
+
+    ret_val
 }


### PR DESCRIPTION
I have been recently going through some info logging in the cli and noticed that there is too much info being printed to get a handle on whats going on...

This is an attempt to do some minor logging clean up to print out "less stuff",
in info logging mode mainly having to do with the prompt...

If someone really want to see what is going on they can very easily add it
back in without too much trouble.