### PR TITLE
don't expand tilde if we quote external arguments

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -598,9 +598,11 @@ impl ExternalCommand {
                 span: arg.span,
             };
 
-            arg.item = nu_path::expand_tilde(arg.item)
-                .to_string_lossy()
-                .to_string();
+            if !keep_raw {
+                arg.item = nu_path::expand_tilde(arg.item)
+                    .to_string_lossy()
+                    .to_string();
+            }
 
             let cwd = PathBuf::from(cwd);
 

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -201,6 +201,18 @@ fn external_command_escape_args() {
     })
 }
 
+#[cfg(not(windows))]
+#[test]
+fn external_command_not_expand_tilde_with_quotes() {
+    Playground::setup(
+        "external command not expand tilde with quotes",
+        |dirs, _| {
+            let actual = nu!(cwd: dirs.test(), pipeline(r#"^echo "~""#));
+            assert_eq!(actual.out, r#"~"#);
+        },
+    )
+}
+
 #[cfg(windows)]
 #[test]
 fn explicit_glob_windows() {

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -201,13 +201,12 @@ fn external_command_escape_args() {
     })
 }
 
-#[cfg(not(windows))]
 #[test]
 fn external_command_not_expand_tilde_with_quotes() {
     Playground::setup(
         "external command not expand tilde with quotes",
         |dirs, _| {
-            let actual = nu!(cwd: dirs.test(), pipeline(r#"^echo "~""#));
+            let actual = nu!(cwd: dirs.test(), pipeline(r#"nu --testbin nonu "~""#));
             assert_eq!(actual.out, r#"~"#);
         },
     )


### PR DESCRIPTION
# Description

As title
Fixes: #7673
Fixes: #4205
Also possiblely fixes: https://github.com/nushell/nushell/issues/6993

# User-Facing Changes

Before:
```
> ^echo "~"
/Users/ttt
```

After:
```
> ^echo "~"
~
```
# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
