### PR TITLE
Remove `engine_state` clones in REPL eval

### DIFF
--- a/crates/nu-cli/src/nu_highlight.rs
+++ b/crates/nu-cli/src/nu_highlight.rs
@@ -35,7 +35,7 @@ impl Command for NuHighlight {
         let head = call.head;
 
         let ctrlc = engine_state.ctrlc.clone();
-        let engine_state = engine_state.clone();
+        let engine_state = std::sync::Arc::new(engine_state.clone());
         let config = engine_state.get_config().clone();
 
         let highlighter = crate::NuHighlighter {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -176,11 +176,11 @@ pub fn evaluate_repl(
         let engine_reference = std::sync::Arc::new(engine_state.clone());
         line_editor = line_editor
             .with_highlighter(Box::new(NuHighlighter {
-                engine_state: engine_state.clone(),
+                engine_state: engine_reference.clone(),
                 config: config.clone(),
             }))
             .with_validator(Box::new(NuValidator {
-                engine_state: engine_state.clone(),
+                engine_state: engine_reference.clone(),
             }))
             .with_completer(Box::new(NuCompleter::new(
                 engine_reference.clone(),

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -6,9 +6,10 @@ use nu_protocol::ast::{Argument, Block, Expr, Expression, PipelineElement};
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 use nu_protocol::{Config, Span};
 use reedline::{Highlighter, StyledText};
+use std::sync::Arc;
 
 pub struct NuHighlighter {
-    pub engine_state: EngineState,
+    pub engine_state: Arc<EngineState>,
     pub config: Config,
 }
 

--- a/crates/nu-cli/src/validation.rs
+++ b/crates/nu-cli/src/validation.rs
@@ -1,9 +1,10 @@
 use nu_parser::{parse, ParseError};
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 use reedline::{ValidationResult, Validator};
+use std::sync::Arc;
 
 pub struct NuValidator {
-    pub engine_state: EngineState,
+    pub engine_state: Arc<EngineState>,
 }
 
 impl Validator for NuValidator {


### PR DESCRIPTION
A small but easy optimization for `evaluate_repl()`: clone `engine_state` 1x instead of 3x.

This reduces time spent in a simple REPL eval (`enter` key pressed with no command text) by about 10%, as measured in [Superluminal](https://superluminal.eu/).