### PR TITLE
spanned error on path exists command

### DIFF
--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -107,7 +107,11 @@ fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
     Value::Bool {
         val: match path.try_exists() {
             Ok(exists) => exists,
-            Err(err) => return Value::Error { error: err.into() },
+            Err(err) => {
+                return Value::Error {
+                    error: ShellError::IOErrorSpanned(err.to_string(), span),
+                }
+            }
         },
         span,
     }


### PR DESCRIPTION
# Description

Closes: #7696 

# User-Facing Changes

Before:
```
❯ 'temp/aa' | path exists
Error: nu::shell::io_error (link)

  × I/O error
  help: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
```

After:
```
❯ 'temp/aa' | path exists
Error: nu::shell::io_error (link)

  × I/O error
   ╭─[entry #42:1:1]
 1 │ 'temp/aa' | path exists
   · ────┬────
   ·     ╰── Permission denied (os error 13)
   ╰────
```
# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
