### PR TITLE
Fix generated doc for `explore` commands

### DIFF
--- a/crates/nu-command/src/viewers/explore.rs
+++ b/crates/nu-command/src/viewers/explore.rs
@@ -53,7 +53,7 @@ impl Command for Explore {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"Press <:> then <h> to get a help menu."#
+        r#"Press `:` then `h` to get a help menu."#
     }
 
     fn run(


### PR DESCRIPTION
# Description

Fix generated doc for `explore` commands, and resolve the static site build error: https://github.com/nushell/nushell.github.io/actions/runs/3889029668/jobs/6636921318

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
