### PR TITLE
Detailed message during core dumped

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -429,7 +429,7 @@ impl ExternalCommand {
                                             let sigstr: &'static CStr = CStr::from_ptr(sigstr_ptr);
                                             sigstr.to_str().ok()
                                         })
-                                        .unwrap_or("Unknown cause");
+                                        .unwrap_or("Something went wrong");
 
                                     let style = Style::new().bold().on(Color::Red);
                                     eprintln!(

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -442,7 +442,7 @@ impl ExternalCommand {
                                     let _ = exit_code_tx.send(Value::Error {
                                         error: ShellError::ExternalCommand(
                                             "core dumped".to_string(),
-                                            format!("Child process '{commandname}' core dumped"),
+                                            format!("{cause}: child process '{commandname}' core dumped"),
                                             head,
                                         ),
                                     });

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -425,6 +425,7 @@ impl ExternalCommand {
                                     let cause = x
                                         .signal()
                                         .and_then(|sig| unsafe {
+                                            // SAFETY: We should be the first to call `char * strsignal(int sig)`
                                             let sigstr_ptr = libc::strsignal(sig);
                                             let sigstr: &'static CStr = CStr::from_ptr(sigstr_ptr);
                                             sigstr.to_str().ok()

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -427,6 +427,11 @@ impl ExternalCommand {
                                         .and_then(|sig| unsafe {
                                             // SAFETY: We should be the first to call `char * strsignal(int sig)`
                                             let sigstr_ptr = libc::strsignal(sig);
+                                            if sigstr_ptr.is_null() {
+                                                return None;
+                                            }
+
+                                            // SAFETY: The pointer points to a valid non-null string
                                             let sigstr: &'static CStr = CStr::from_ptr(sigstr_ptr);
                                             sigstr.to_str().ok()
                                         })


### PR DESCRIPTION
# Description

In bash when a program crashes, it prints the reason for what happened:
```
$ ./division_by_zero
Floating point exception (core dumped)
$ ./segfault
Segmentation fault (core dumped)
```

Nushell always prints the same thing in this case:
```
> ./division_by_zero
nushell: oops, process './division_by_zero' core dumped
Error: nu::shell::external_command (link)
# etc..
```

This PR adds more detailed error printing, like in bash:
```
> ./division_by_zero
Floating point exception: oops, process './division_by_zero' core dumped
Error: nu::shell::external_command (link)
# etc..
```

I made this message format as an example:
```
Floating point exception: oops, process './division_by_zero' core dumped
```
Instead of `nushell:` it writes a meaningful message, but I can change this format as per the suggestions.

I tested the change only on linux, but it should work on other unix systems.

# User-Facing Changes

The error message only.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
