### PR TITLE
Add cursor shape configuration for each edit mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "chrono-humanize",
+ "crossterm 0.24.0",
  "fancy-regex",
  "indexmap",
  "lru",
@@ -2845,6 +2846,7 @@ dependencies = [
  "nu-test-support",
  "nu-utils",
  "num-format",
+ "reedline",
  "serde",
  "serde_json",
  "strum",
@@ -4080,8 +4082,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d91d2a38dbdaf0c748a96055c14aa4746be9add5f4aea4b1460e6e6492f770"
+source = "git+https://github.com/nushell/reedline.git?branch=main#3d83306b2dadd17d065d9d25ea62a36c3a0a76b2"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce69ed202df415a3d4a01e6f3341320ca88b9bd4f0bf37be6fa239cdea06d9bf"
 dependencies = [
  "fxhash",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -1603,12 +1613,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.1",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1781,7 +1800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -2167,11 +2186,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2596,7 +2615,7 @@ dependencies = [
  "atty",
  "chrono",
  "crossterm 0.24.0",
- "fancy-regex",
+ "fancy-regex 0.10.0",
  "fuzzy-matcher",
  "is_executable",
  "log",
@@ -2654,7 +2673,7 @@ dependencies = [
  "dtparse",
  "eml-parser",
  "encoding_rs",
- "fancy-regex",
+ "fancy-regex 0.10.0",
  "filesize",
  "filetime",
  "fs_extra",
@@ -2837,8 +2856,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "chrono-humanize",
- "crossterm 0.24.0",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "indexmap",
  "lru",
  "miette",
@@ -2846,7 +2864,6 @@ dependencies = [
  "nu-test-support",
  "nu-utils",
  "num-format",
- "reedline",
  "serde",
  "serde_json",
  "strum",
@@ -3570,7 +3587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aac9a1d70c683cda8dd4958bd489d8c0206c5ab1435a656a14563c6415f5a64"
 dependencies = [
  "arrow2",
- "hashbrown",
+ "hashbrown 0.12.3",
  "num 0.4.0",
  "serde",
  "thiserror",
@@ -3588,7 +3605,7 @@ dependencies = [
  "bitflags",
  "chrono",
  "comfy-table",
- "hashbrown",
+ "hashbrown 0.12.3",
  "indexmap",
  "num 0.4.0",
  "once_cell",
@@ -3671,7 +3688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa865a4fc6dcfb9967505c4714c29277898e21dd29ea7633a3f9d1abbe879a7d"
 dependencies = [
  "enum_dispatch",
- "hashbrown",
+ "hashbrown 0.12.3",
  "num 0.4.0",
  "polars-core",
  "polars-io",
@@ -5336,7 +5353,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,15 +1659,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.1",
-]
-
-[[package]]
 name = "hashlink"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,7 +3634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d5e894b6908d288ea24b56c8d99c2944f4b94af51ba662d58631c04806511b7"
 dependencies = [
  "arrow2",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "num 0.4.0",
  "serde",
  "thiserror",
@@ -3661,7 +3652,7 @@ dependencies = [
  "bitflags",
  "chrono",
  "comfy-table",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "indexmap",
  "num 0.4.0",
  "once_cell",
@@ -3747,7 +3738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1bb37bd32c44defa19be36fcab9387d5b3ad4c683596479caf414e5a00e82af"
 dependencies = [
  "enum_dispatch",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "num 0.4.0",
  "polars-arrow",
  "polars-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ path = "src/main.rs"
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 
 # Criterion benchmarking setup
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -105,7 +105,7 @@ impl Prompt for NushellPrompt {
         if let Some(prompt_string) = &self.left_prompt_string {
             prompt_string.replace('\n', "\r\n").into()
         } else {
-            let default = DefaultPrompt::new();
+            let default = DefaultPrompt::default();
             default
                 .render_prompt_left()
                 .to_string()
@@ -118,7 +118,7 @@ impl Prompt for NushellPrompt {
         if let Some(prompt_string) = &self.right_prompt_string {
             prompt_string.replace('\n', "\r\n").into()
         } else {
-            let default = DefaultPrompt::new();
+            let default = DefaultPrompt::default();
             default
                 .render_prompt_right()
                 .to_string()

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -16,11 +16,13 @@ nu-json = { path = "../nu-json", version = "0.74.1"  }
 byte-unit = "4.0.9"
 chrono = { version="0.4.23", features= ["serde", "std"], default-features = false }
 chrono-humanize = "0.2.1"
+crossterm = "0.24.0"
 fancy-regex = "0.10.0"
 indexmap = { version="1.7" }
 lru = "0.8.1"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 num-format = "0.4.3"
+reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 serde = {version = "1.0.143", default-features = false }
 serde_json = { version = "1.0", optional = true }
 strum = "0.24"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -10,20 +10,21 @@ version = "0.74.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.74.1"  }
-nu-json = { path = "../nu-json", version = "0.74.1"  }
+nu-utils = { path = "../nu-utils", version = "0.74.1" }
+nu-json = { path = "../nu-json", version = "0.74.1" }
 
 byte-unit = "4.0.9"
-chrono = { version="0.4.23", features= ["serde", "std"], default-features = false }
+chrono = { version = "0.4.23", features = [
+    "serde",
+    "std",
+], default-features = false }
 chrono-humanize = "0.2.1"
-crossterm = "0.24.0"
-fancy-regex = "0.10.0"
-indexmap = { version="1.7" }
-lru = "0.8.1"
+fancy-regex = "0.11.0"
+indexmap = { ve0.11.0 = "1.7" }
+lru = "0.9.0"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 num-format = "0.4.3"
-reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
-serde = {version = "1.0.143", default-features = false }
+serde = { version = "1.0.143", default-features = false }
 serde_json = { version = "1.0", optional = true }
 strum = "0.24"
 strum_macros = "0.24"
@@ -36,4 +37,4 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"
-nu-test-support = { path = "../nu-test-support", version = "0.74.1"  }
+nu-test-support = { path = "../nu-test-support", version = "0.74.1" }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4.23", features = [
 ], default-features = false }
 chrono-humanize = "0.2.1"
 fancy-regex = "0.11.0"
-indexmap = { ve0.11.0 = "1.7" }
+indexmap = { version = "1.7" }
 lru = "0.9.0"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 num-format = "0.4.3"

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -1,6 +1,4 @@
 use crate::{ShellError, Span, Value};
-// use crossterm::cursor::CursorShape;
-// use reedline::CursorConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{ShellError, Span, Value};
-use crossterm::cursor::CursorShape;
-use reedline::CursorConfig;
+// use crossterm::cursor::CursorShape;
+// use reedline::CursorConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -54,8 +54,8 @@ impl Default for Hooks {
     }
 }
 
-/// Definition of a Nushell CursorShape
-#[derive(Serialize, Deserialize, Clone, Debug)]
+/// Definition of a Nushell CursorShape (to be mapped to crossterm::cursor::CursorShape)
+#[derive(Serialize, Deserialize, Clone, Debug, Copy)]
 pub enum NuCursorShape {
     UnderScore,
     Line,
@@ -645,34 +645,10 @@ impl Value {
                         }
                     }
                     "cursor_shape" => {
-                        macro_rules! reconstruct_cursor_shape_vi_insert {
-                            ($span:expr) => {
+                        macro_rules! reconstruct_cursor_shape {
+                            ($name:expr, $span:expr) => {
                                 Value::string(
-                                    match config.cursor_shape_vi_insert {
-                                        NuCursorShape::Line => "line",
-                                        NuCursorShape::Block => "block",
-                                        NuCursorShape::UnderScore => "underscore",
-                                    },
-                                    *$span,
-                                )
-                            };
-                        }
-                        macro_rules! reconstruct_cursor_shape_vi_normal {
-                            ($span:expr) => {
-                                Value::string(
-                                    match config.cursor_shape_vi_normal {
-                                        NuCursorShape::Line => "line",
-                                        NuCursorShape::Block => "block",
-                                        NuCursorShape::UnderScore => "underscore",
-                                    },
-                                    *$span,
-                                )
-                            };
-                        }
-                        macro_rules! reconstruct_cursor_shape_emacs {
-                            ($span:expr) => {
-                                Value::string(
-                                    match config.cursor_shape_emacs {
+                                    match $name {
                                         NuCursorShape::Line => "line",
                                         NuCursorShape::Block => "block",
                                         NuCursorShape::UnderScore => "underscore",
@@ -686,7 +662,7 @@ impl Value {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
                                 match key2 {
-                                    "cursor_shape_vi_insert" => {
+                                    "vi_insert" => {
                                         if let Ok(v) = value.as_string() {
                                             let val_str = v.to_lowercase();
                                             match val_str.as_ref() {
@@ -698,7 +674,7 @@ impl Value {
                                                     config.cursor_shape_vi_insert =
                                                         NuCursorShape::Block;
                                                 }
-                                                "underline" => {
+                                                "underscore" => {
                                                     config.cursor_shape_vi_insert =
                                                         NuCursorShape::UnderScore;
                                                 }
@@ -707,14 +683,90 @@ impl Value {
                                                         "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', or 'underscore'"
                                                     );
                                                     // Reconstruct
-                                                    vals[index] =
-                                                        reconstruct_cursor_shape_vi_insert!(span);
+                                                    vals[index] = reconstruct_cursor_shape!(
+                                                        config.cursor_shape_vi_insert,
+                                                        span
+                                                    );
                                                 }
                                             };
                                         } else {
                                             invalid!(Some(*span), "should be a string");
                                             // Reconstruct
-                                            vals[index] = reconstruct_cursor_shape_vi_insert!(span);
+                                            vals[index] = reconstruct_cursor_shape!(
+                                                config.cursor_shape_vi_insert,
+                                                span
+                                            );
+                                        }
+                                    }
+                                    "vi_normal" => {
+                                        if let Ok(v) = value.as_string() {
+                                            let val_str = v.to_lowercase();
+                                            match val_str.as_ref() {
+                                                "line" => {
+                                                    config.cursor_shape_vi_normal =
+                                                        NuCursorShape::Line;
+                                                }
+                                                "block" => {
+                                                    config.cursor_shape_vi_normal =
+                                                        NuCursorShape::Block;
+                                                }
+                                                "underscore" => {
+                                                    config.cursor_shape_vi_normal =
+                                                        NuCursorShape::UnderScore;
+                                                }
+                                                _ => {
+                                                    invalid!(Some(*span),
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', or 'underscore'"
+                                                    );
+                                                    // Reconstruct
+                                                    vals[index] = reconstruct_cursor_shape!(
+                                                        config.cursor_shape_vi_normal,
+                                                        span
+                                                    );
+                                                }
+                                            };
+                                        } else {
+                                            invalid!(Some(*span), "should be a string");
+                                            // Reconstruct
+                                            vals[index] = reconstruct_cursor_shape!(
+                                                config.cursor_shape_vi_normal,
+                                                span
+                                            );
+                                        }
+                                    }
+                                    "emacs" => {
+                                        if let Ok(v) = value.as_string() {
+                                            let val_str = v.to_lowercase();
+                                            match val_str.as_ref() {
+                                                "line" => {
+                                                    config.cursor_shape_emacs = NuCursorShape::Line;
+                                                }
+                                                "block" => {
+                                                    config.cursor_shape_emacs =
+                                                        NuCursorShape::Block;
+                                                }
+                                                "underscore" => {
+                                                    config.cursor_shape_emacs =
+                                                        NuCursorShape::UnderScore;
+                                                }
+                                                _ => {
+                                                    invalid!(Some(*span),
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', or 'underscore'"
+                                                    );
+                                                    // Reconstruct
+                                                    vals[index] = reconstruct_cursor_shape!(
+                                                        config.cursor_shape_emacs,
+                                                        span
+                                                    );
+                                                }
+                                            };
+                                        } else {
+                                            invalid!(Some(*span), "should be a string");
+                                            // Reconstruct
+                                            vals[index] = reconstruct_cursor_shape!(
+                                                config.cursor_shape_emacs,
+                                                span
+                                            );
                                         }
                                     }
                                     x => {
@@ -732,21 +784,16 @@ impl Value {
                             invalid!(vals[index].span().ok(), "should be a record");
                             // Reconstruct
                             vals[index] = Value::record(
+                                vec!["vi_insert".into(), "vi_normal".into(), "emacs".into()],
                                 vec![
-                                    "cursor_shape_vi_insert".into(),
-                                    "cursor_shape_vi_normal".into(),
-                                    "cursor_shape_emacs".into(),
-                                ],
-                                vec![
-                                    reconstruct_cursor_shape_vi_insert!(span),
-                                    reconstruct_cursor_shape_vi_normal!(span),
-                                    reconstruct_cursor_shape_emacs!(span),
+                                    reconstruct_cursor_shape!(config.cursor_shape_vi_insert, span),
+                                    reconstruct_cursor_shape!(config.cursor_shape_vi_normal, span),
+                                    reconstruct_cursor_shape!(config.cursor_shape_emacs, span),
                                 ],
                                 *span,
                             );
                         }
                     }
-
                     "table" => {
                         macro_rules! reconstruct_index_mode {
                             ($span:expr) => {
@@ -1267,6 +1314,67 @@ impl Value {
                             invalid!(Some(*span), "should be a string");
                         }
                     }
+                    "cursor_shape_vi_insert" => {
+                        legacy_options_used = true;
+                        if let Ok(b) = value.as_string() {
+                            let val_str = b.to_lowercase();
+                            config.cursor_shape_vi_insert = match val_str.as_ref() {
+                                "block" => NuCursorShape::Block,
+                                "underline" => NuCursorShape::UnderScore,
+                                "line" => NuCursorShape::Line,
+                                _ => {
+                                    invalid!(
+                                        Some(*span),
+                                        "unrecognized $env.config.{key} '{val_str}'"
+                                    );
+                                    NuCursorShape::Line
+                                }
+                            };
+                        } else {
+                            invalid!(Some(*span), "should be a string");
+                        }
+                    }
+                    "cursor_shape_vi_normal" => {
+                        legacy_options_used = true;
+                        if let Ok(b) = value.as_string() {
+                            let val_str = b.to_lowercase();
+                            config.cursor_shape_vi_normal = match val_str.as_ref() {
+                                "block" => NuCursorShape::Block,
+                                "underline" => NuCursorShape::UnderScore,
+                                "line" => NuCursorShape::Line,
+                                _ => {
+                                    invalid!(
+                                        Some(*span),
+                                        "unrecognized $env.config.{key} '{val_str}'"
+                                    );
+                                    NuCursorShape::Line
+                                }
+                            };
+                        } else {
+                            invalid!(Some(*span), "should be a string");
+                        }
+                    }
+                    "cursor_shape_emacs" => {
+                        legacy_options_used = true;
+                        if let Ok(b) = value.as_string() {
+                            let val_str = b.to_lowercase();
+                            config.cursor_shape_emacs = match val_str.as_ref() {
+                                "block" => NuCursorShape::Block,
+                                "underline" => NuCursorShape::UnderScore,
+                                "line" => NuCursorShape::Line,
+                                _ => {
+                                    invalid!(
+                                        Some(*span),
+                                        "unrecognized $env.config.{key} '{val_str}'"
+                                    );
+                                    NuCursorShape::Line
+                                }
+                            };
+                        } else {
+                            invalid!(Some(*span), "should be a string");
+                        }
+                    }
+
                     // End legacy options
                     x => {
                         invalid_key!(

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod ast;
 mod cli_error;
-mod config;
+pub mod config;
 pub mod engine;
 mod example;
 mod exportable;

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -395,6 +395,11 @@ let-env config = {
     metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
     format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
   }
+  cursor_shape: {
+    emacs: line # block, underscore, line (line is the default)
+    vi_insert: block # block, underscore, line (block is the default)
+    vi_normal: underscore # block, underscore, line  (underscore is the default)
+  }
   color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
   use_grid_icons: true
   footer_mode: "25" # always, never, number_of_rows, auto


### PR DESCRIPTION
# Description

This PR allows the configuration of cursor shapes in nushell for each edit mode. This is the change that is in the default_config.nu file.
```
  cursor_shape: {
    emacs: line # block, underscore, line (line is the default)
    vi_insert: block # block, underscore, line (block is the default)
    vi_normal: underscore # block, underscore, line  (underscore is the default)
  }
```

# User-Facing Changes

See above. If you'd prefer a different default, please speak up and let us know.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
