### PR TITLE
Fix typos and use more idiomatic assertions

### DIFF
--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -161,7 +161,7 @@ fn remove_impl(input: &[u8], arg: &Arguments, span: Span) -> Value {
 
     // Note:
     // remove_all from start and end will generate the same result.
-    // so we'll put `remove_all` relative logic into else clouse.
+    // so we'll put `remove_all` relative logic into else clause.
     if arg.end && !remove_all {
         let (mut left, mut right) = (
             input.len() as isize - arg.pattern.len() as isize,
@@ -172,7 +172,7 @@ fn remove_impl(input: &[u8], arg: &Arguments, span: Span) -> Value {
             left -= 1;
             right -= 1;
         }
-        // append the remaining thing to result, this can be happeneed when
+        // append the remaining thing to result, this can be happening when
         // we have something to remove and remove_all is False.
         let mut remain = input[..left as usize].iter().copied().rev().collect();
         result.append(&mut remain);

--- a/crates/nu-command/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-command/src/dataframe/expressions/otherwise.rs
@@ -23,7 +23,7 @@ impl Command for ExprOtherwise {
             .required(
                 "otherwise expression",
                 SyntaxShape::Any,
-                "expressioini to apply when no when predicate matches",
+                "expression to apply when no when predicate matches",
             )
             .input_type(Type::Any)
             .output_type(Type::Custom("expression".into()))

--- a/crates/nu-command/src/math/cosh.rs
+++ b/crates/nu-command/src/math/cosh.rs
@@ -46,7 +46,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         let e = std::f64::consts::E;
         vec![Example {
-            description: "Apply the hyperpolic cosine to 1",
+            description: "Apply the hyperbolic cosine to 1",
             example: "1 | math cosh",
             result: Some(Value::test_float(((e * e) + 1.0) / (2.0 * e))),
         }]

--- a/crates/nu-command/src/math/sinh.rs
+++ b/crates/nu-command/src/math/sinh.rs
@@ -46,7 +46,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         let e = std::f64::consts::E;
         vec![Example {
-            description: "Apply the hyperpolic sine to 1",
+            description: "Apply the hyperbolic sine to 1",
             example: "1 | math sinh",
             result: Some(Value::test_float((e * e - 1.0) / (2.0 * e))),
         }]

--- a/crates/nu-command/src/math/tanh.rs
+++ b/crates/nu-command/src/math/tanh.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Apply the hyperpolic tangent to 10*pi",
+            description: "Apply the hyperbolic tangent to 10*pi",
             example: "(math pi) * 10 | math tanh",
             result: Some(Value::test_float(1f64)),
         }]

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -81,7 +81,7 @@ impl Command for SubCommand {
                 }),
             },
             Example {
-                description: "Encode all non anphanumeric chars with all flag",
+                description: "Encode all non alphanumeric chars with all flag",
                 example: "'https://example.com/foo bar' | url encode --all",
                 result: Some(Value::test_string("https%3A%2F%2Fexample%2Ecom%2Ffoo%20bar")),
             },

--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -359,7 +359,7 @@ fn test_count_counts_lines() {
     const LS: &str = "\u{2028}"; // 0xe280a8
     const PS: &str = "\u{2029}"; // 0xe280a9
 
-    // * \r\n is a single graheme cluster
+    // * \r\n is a single grapheme cluster
     // * trailing newlines are counted
     // * NEL is 2 bytes
     // * FF is 1 byte

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -92,7 +92,7 @@ impl Command for Table {
             )
             .switch(
                 "collapse",
-                "expand the table structure in colapse mode.\nBe aware collapse mode currently doesn't support width control",
+                "expand the table structure in collapse mode.\nBe aware collapse mode currently doesn't support width control",
                 Some('c'),
             )
             .category(Category::Viewers)
@@ -1083,12 +1083,12 @@ fn convert_to_table2<'a>(
     for (col, header) in headers.into_iter().enumerate() {
         let is_last_col = col + 1 == count_columns;
 
-        let mut nessary_space = PADDING_SPACE;
+        let mut necessary_space = PADDING_SPACE;
         if !is_last_col {
-            nessary_space += SPLIT_LINE_SPACE;
+            necessary_space += SPLIT_LINE_SPACE;
         }
 
-        if available_width == 0 || available_width <= nessary_space {
+        if available_width == 0 || available_width <= necessary_space {
             // MUST NEVER HAPPEN (ideally)
             // but it does...
 
@@ -1096,7 +1096,7 @@ fn convert_to_table2<'a>(
             break;
         }
 
-        available_width -= nessary_space;
+        available_width -= necessary_space;
 
         let mut column_width = string_width(&header);
 
@@ -1136,7 +1136,7 @@ fn convert_to_table2<'a>(
         }
 
         if column_width >= available_width
-            || (!is_last_col && column_width + nessary_space >= available_width)
+            || (!is_last_col && column_width + necessary_space >= available_width)
         {
             // so we try to do soft landing
             // by doing a truncating in case there will be enough space for it.
@@ -1188,7 +1188,7 @@ fn convert_to_table2<'a>(
                 row.pop();
             }
 
-            available_width += nessary_space;
+            available_width += necessary_space;
 
             truncate = true;
             break;
@@ -1629,14 +1629,14 @@ impl PagingTableCreator {
         let table = match table_s {
             Some(s) => {
                 // check whether we need to expand table or not,
-                // todo: we can make it more effitient
+                // todo: we can make it more efficient
 
-                const EXPAND_TREASHHOLD: f32 = 0.80;
+                const EXPAND_THRESHOLD: f32 = 0.80;
 
                 let width = string_width(&s);
                 let used_percent = width as f32 / term_width as f32;
 
-                if width < term_width && used_percent > EXPAND_TREASHHOLD {
+                if width < term_width && used_percent > EXPAND_THRESHOLD {
                     let table_config = table_config.expand();
                     table.draw(table_config, term_width)
                 } else {

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -9,7 +9,7 @@ fn for_auto_print_in_each_iteration() {
             echo 1
         }"#
     );
-    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `11`
     // that's ok, our main concern is it auto print value in each iteration.
     assert_eq!(actual.out, "11");
@@ -25,7 +25,7 @@ fn for_break_on_external_failed() {
             nu --testbin fail
         }"#
     );
-    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`
     assert_eq!(actual.out, "1");
 }

--- a/crates/nu-command/tests/commands/loop_.rs
+++ b/crates/nu-command/tests/commands/loop_.rs
@@ -15,7 +15,7 @@ fn loop_auto_print_in_each_iteration() {
             echo 1
         }"#
     );
-    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `111`
     // that's ok, our main concern is it auto print value in each iteration.
     assert_eq!(actual.out, "111");
@@ -37,7 +37,7 @@ fn loop_break_on_external_failed() {
             nu --testbin fail;
         }"#
     );
-    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`.
     assert_eq!(actual.out, "1");
 }

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -479,25 +479,25 @@ fn can_list_system_folder() {
         cwd: "C:\\Windows\\System32", pipeline(
         r#"ls Configuration* | where name == "Configuration" | get size.0"#
     ));
-    assert!(file_size.out.trim() != "");
+    assert_ne!(file_size.out.trim(), "");
 
     let file_modified = nu!(
         cwd: "C:\\Windows\\System32", pipeline(
         r#"ls Configuration* | where name == "Configuration" | get modified.0"#
     ));
-    assert!(file_modified.out.trim() != "");
+    assert_ne!(file_modified.out.trim(), "");
 
     let file_accessed = nu!(
         cwd: "C:\\Windows\\System32", pipeline(
         r#"ls -l Configuration* | where name == "Configuration" | get accessed.0"#
     ));
-    assert!(file_accessed.out.trim() != "");
+    assert_ne!(file_accessed.out.trim(), "");
 
     let file_created = nu!(
         cwd: "C:\\Windows\\System32", pipeline(
         r#"ls -l Configuration* | where name == "Configuration" | get created.0"#
     ));
-    assert!(file_created.out.trim() != "");
+    assert_ne!(file_created.out.trim(), "");
 
     let ls_with_filter = nu!(
         cwd: "C:\\Windows\\System32", pipeline(

--- a/crates/nu-command/tests/commands/network/port.rs
+++ b/crates/nu-command/tests/commands/network/port.rs
@@ -41,7 +41,7 @@ fn port_with_already_usage() {
             return;
         }
     }
-    panic!("already check port report AddrInUse for seveval times, but still failed.");
+    panic!("already check port report AddrInUse for several times, but still failed.");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -34,7 +34,7 @@ mod simple {
     }
 
     #[test]
-    fn double_open_curly_evalutes_to_a_single_curly() {
+    fn double_open_curly_evaluates_to_a_single_curly() {
         Playground::setup("parse_test_regex_2", |dirs, _sandbox| {
             let actual = nu!(
                 cwd: dirs.test(), pipeline(

--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -41,9 +41,9 @@ fn table_expand_0() {
     );
 }
 
-// I am not sure whether the test is platform depent, cause we don't set a term_width on our own
+// I am not sure whether the test is platform dependent, cause we don't set a term_width on our own
 #[test]
-fn table_expand_exeed_overlap_0() {
+fn table_expand_exceed_overlap_0() {
     // no expand
 
     let actual = nu!(r#"[[a b, c]; [xxxxxxxxxxxxxxxxxxxxxx 2 3] [4 5 [1 2 3]]] | table --expand"#);

--- a/crates/nu-command/tests/commands/while_.rs
+++ b/crates/nu-command/tests/commands/while_.rs
@@ -16,7 +16,7 @@ fn while_auto_print_in_each_iteration() {
         cwd: ".",
         "mut total = 0; while $total < 2 { $total = $total + 1; echo 1 }"
     );
-    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `11`
     // that's ok, our main concern is it auto print value in each iteration.
     assert_eq!(actual.out, "11");
@@ -28,7 +28,7 @@ fn while_break_on_external_failed() {
         cwd: ".",
         "mut total = 0; while $total < 2 { $total = $total + 1; echo 1; nu --testbin fail }"
     );
-    // Note: nu! macro auto repalce "\n" and "\r\n" with ""
+    // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`
     assert_eq!(actual.out, "1");
 }

--- a/crates/nu-explore/src/nu_common/table.rs
+++ b/crates/nu-explore/src/nu_common/table.rs
@@ -263,12 +263,12 @@ fn build_expanded_table(
             // check whether we need to expand table or not,
             // todo: we can make it more effitient
 
-            const EXPAND_TREASHHOLD: f32 = 0.80;
+            const EXPAND_THRESHOLD: f32 = 0.80;
 
             let width = string_width(&s);
             let used_percent = width as f32 / term_width as f32;
 
-            if width < term_width && used_percent > EXPAND_TREASHHOLD {
+            if width < term_width && used_percent > EXPAND_THRESHOLD {
                 let table_config = table_config.expand();
                 table.draw(table_config, term_width)
             } else {
@@ -419,12 +419,12 @@ fn convert_to_table2<'a>(
     for (col, header) in headers.into_iter().enumerate() {
         let is_last_col = col + 1 == count_columns;
 
-        let mut nessary_space = PADDING_SPACE;
+        let mut necessary_space = PADDING_SPACE;
         if !is_last_col {
-            nessary_space += SPLIT_LINE_SPACE;
+            necessary_space += SPLIT_LINE_SPACE;
         }
 
-        if available_width == 0 || available_width <= nessary_space {
+        if available_width == 0 || available_width <= necessary_space {
             // MUST NEVER HAPPEN (ideally)
             // but it does...
 
@@ -432,7 +432,7 @@ fn convert_to_table2<'a>(
             break;
         }
 
-        available_width -= nessary_space;
+        available_width -= necessary_space;
 
         let mut column_width = string_width(&header);
 
@@ -474,7 +474,7 @@ fn convert_to_table2<'a>(
         }
 
         if column_width >= available_width
-            || (!is_last_col && column_width + nessary_space >= available_width)
+            || (!is_last_col && column_width + necessary_space >= available_width)
         {
             // so we try to do soft landing
             // by doing a truncating in case there will be enough space for it.
@@ -530,7 +530,7 @@ fn convert_to_table2<'a>(
                 row.pop();
             }
 
-            available_width += nessary_space;
+            available_width += necessary_space;
 
             truncate = true;
             break;

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -130,8 +130,8 @@ fn convert_records_to_dataset(cols: &Vec<String>, records: Vec<Value>) -> Vec<Ve
     } else if cols.len() == records.len() {
         vec![records]
     } else {
-        // I am not sure whether it's good to return records as its length LIKELY will not match columns,
-        // which makes no scense......
+        // I am not sure whether it's good to return records as its length LIKELY
+        // will not match columns, which makes no sense......
         //
         // BUT...
         // we can represent it as a list; which we do

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -615,7 +615,7 @@ fn highlight_search_results(f: &mut Frame, pager: &Pager, layout: &Layout, style
         return;
     }
 
-    let hightlight_block = Block::default().style(nu_style_to_tui(style));
+    let highlight_block = Block::default().style(nu_style_to_tui(style));
 
     for e in &layout.data {
         let text = ansi_str::AnsiStr::ansi_strip(&e.text);
@@ -626,7 +626,7 @@ fn highlight_search_results(f: &mut Frame, pager: &Pager, layout: &Layout, style
             let w = pager.search_buf.buf_cmd_input.len() as u16;
             let area = Rect::new(e.area.x + p as u16, e.area.y, w, 1);
 
-            f.render_widget(hightlight_block.clone(), area);
+            f.render_widget(highlight_block.clone(), area);
         }
     }
 }

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -621,21 +621,21 @@ fn convert_records_to_string(
 
 fn highlight_cell(f: &mut Frame, area: Rect, info: ElementInfo, theme: &CursorStyle) {
     if let Some(style) = theme.selected_column {
-        let hightlight_block = Block::default().style(nu_style_to_tui(style));
+        let highlight_block = Block::default().style(nu_style_to_tui(style));
         let area = Rect::new(info.area.x, area.y, info.area.width, area.height);
-        f.render_widget(hightlight_block.clone(), area);
+        f.render_widget(highlight_block.clone(), area);
     }
 
     if let Some(style) = theme.selected_row {
-        let hightlight_block = Block::default().style(nu_style_to_tui(style));
+        let highlight_block = Block::default().style(nu_style_to_tui(style));
         let area = Rect::new(area.x, info.area.y, area.width, 1);
-        f.render_widget(hightlight_block.clone(), area);
+        f.render_widget(highlight_block.clone(), area);
     }
 
     if let Some(style) = theme.selected_cell {
-        let hightlight_block = Block::default().style(nu_style_to_tui(style));
+        let highlight_block = Block::default().style(nu_style_to_tui(style));
         let area = Rect::new(info.area.x, info.area.y, info.area.width, 1);
-        f.render_widget(hightlight_block.clone(), area);
+        f.render_widget(highlight_block.clone(), area);
     }
 
     if theme.show_cursor {

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -921,21 +921,21 @@ mod test {
     #[test]
     fn test_pattern_from_str() {
         assert!("a*b".parse::<Pattern>().unwrap().matches("a_b"));
-        assert!("a/**b".parse::<Pattern>().unwrap_err().pos == 4);
+        assert_eq!("a/**b".parse::<Pattern>().unwrap_err().pos, 4);
     }
 
     #[test]
     fn test_wildcard_errors() {
-        assert!(Pattern::new("a/**b").unwrap_err().pos == 4);
-        assert!(Pattern::new("a/bc**").unwrap_err().pos == 3);
-        assert!(Pattern::new("a/*****").unwrap_err().pos == 4);
-        assert!(Pattern::new("a/b**c**d").unwrap_err().pos == 2);
-        assert!(Pattern::new("a**b").unwrap_err().pos == 0);
+        assert_eq!(Pattern::new("a/**b").unwrap_err().pos, 4);
+        assert_eq!(Pattern::new("a/bc**").unwrap_err().pos, 3);
+        assert_eq!(Pattern::new("a/*****").unwrap_err().pos, 4);
+        assert_eq!(Pattern::new("a/b**c**d").unwrap_err().pos, 2);
+        assert_eq!(Pattern::new("a**b").unwrap_err().pos, 0);
     }
 
     #[test]
     fn test_glob_errors() {
-        assert!(glob("a/**b").err().unwrap().pos == 4);
+        assert_eq!(glob("a/**b").err().unwrap().pos, 4);
     }
 
     // this test assumes that there is a /root directory and that

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -49,9 +49,9 @@ pub fn parse_int() {
     let (block, err) = parse(&mut working_set, None, b"3", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     assert!(matches!(
         expressions[0],
         PipelineElement::Expression(
@@ -72,9 +72,9 @@ pub fn parse_binary_with_hex_format() {
     let (block, err) = parse(&mut working_set, None, b"0x[13]", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert_eq!(expr.expr, Expr::Binary(vec![0x13]))
     } else {
@@ -90,9 +90,9 @@ pub fn parse_binary_with_incomplete_hex_format() {
     let (block, err) = parse(&mut working_set, None, b"0x[3]", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert_eq!(expr.expr, Expr::Binary(vec![0x03]))
     } else {
@@ -108,9 +108,9 @@ pub fn parse_binary_with_binary_format() {
     let (block, err) = parse(&mut working_set, None, b"0b[1010 1000]", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert_eq!(expr.expr, Expr::Binary(vec![0b10101000]))
     } else {
@@ -126,9 +126,9 @@ pub fn parse_binary_with_incomplete_binary_format() {
     let (block, err) = parse(&mut working_set, None, b"0b[10]", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert_eq!(expr.expr, Expr::Binary(vec![0b00000010]))
     } else {
@@ -144,9 +144,9 @@ pub fn parse_binary_with_octal_format() {
     let (block, err) = parse(&mut working_set, None, b"0o[250]", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert_eq!(expr.expr, Expr::Binary(vec![0o250]))
     } else {
@@ -162,9 +162,9 @@ pub fn parse_binary_with_incomplete_octal_format() {
     let (block, err) = parse(&mut working_set, None, b"0o[2]", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert_eq!(expr.expr, Expr::Binary(vec![0o2]))
     } else {
@@ -180,9 +180,9 @@ pub fn parse_binary_with_invalid_octal_format() {
     let (block, err) = parse(&mut working_set, None, b"0b[90]", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert!(!matches!(&expr.expr, Expr::Binary(_)))
     } else {
@@ -200,9 +200,9 @@ pub fn parse_binary_with_multi_byte_char() {
     let (block, err) = parse(&mut working_set, None, contents, true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     if let PipelineElement::Expression(_, expr) = &expressions[0] {
         assert!(!matches!(&expr.expr, Expr::Binary(_)))
     } else {
@@ -221,7 +221,7 @@ pub fn parse_call() {
     let (block, err) = parse(&mut working_set, None, b"foo", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
 
     let expressions = &block[0];
     assert_eq!(expressions.len(), 1);
@@ -329,10 +329,10 @@ fn test_nothing_comparison_eq() {
     let (block, err) = parse(&mut working_set, None, b"2 == null", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
 
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     assert!(matches!(
         &expressions[0],
         PipelineElement::Expression(
@@ -352,10 +352,10 @@ fn test_nothing_comparison_neq() {
     let (block, err) = parse(&mut working_set, None, b"2 != null", true, &[]);
 
     assert!(err.is_none());
-    assert!(block.len() == 1);
+    assert_eq!(block.len(), 1);
 
     let expressions = &block[0];
-    assert!(expressions.len() == 1);
+    assert_eq!(expressions.len(), 1);
     assert!(matches!(
         &expressions[0],
         PipelineElement::Expression(
@@ -379,9 +379,9 @@ mod string {
         let (block, err) = parse(&mut working_set, None, b"\"hello nushell\"", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         if let PipelineElement::Expression(_, expr) = &expressions[0] {
             assert_eq!(expr.expr, Expr::String("hello nushell".to_string()))
         } else {
@@ -403,9 +403,9 @@ mod string {
         );
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         if let PipelineElement::Expression(_, expr) = &expressions[0] {
             assert_eq!(expr.expr, Expr::String("hello nushell".to_string()))
         } else {
@@ -426,10 +426,10 @@ mod string {
             let (block, err) = parse(&mut working_set, None, b"$\"hello (39 + 3)\"", true, &[]);
 
             assert!(err.is_none());
-            assert!(block.len() == 1);
+            assert_eq!(block.len(), 1);
 
             let expressions = &block[0];
-            assert!(expressions.len() == 1);
+            assert_eq!(expressions.len(), 1);
 
             if let PipelineElement::Expression(_, expr) = &expressions[0] {
                 let subexprs: Vec<&Expr>;
@@ -462,10 +462,10 @@ mod string {
 
             assert!(err.is_none());
 
-            assert!(block.len() == 1);
+            assert_eq!(block.len(), 1);
             let expressions = &block[0];
 
-            assert!(expressions.len() == 1);
+            assert_eq!(expressions.len(), 1);
 
             if let PipelineElement::Expression(_, expr) = &expressions[0] {
                 let subexprs: Vec<&Expr>;
@@ -502,10 +502,10 @@ mod string {
 
             assert!(err.is_none());
 
-            assert!(block.len() == 1);
+            assert_eq!(block.len(), 1);
             let expressions = &block[0];
 
-            assert!(expressions.len() == 1);
+            assert_eq!(expressions.len(), 1);
 
             if let PipelineElement::Expression(_, expr) = &expressions[0] {
                 let subexprs: Vec<&Expr>;
@@ -544,10 +544,10 @@ mod string {
 
             assert!(err.is_none());
 
-            assert!(block.len() == 1);
+            assert_eq!(block.len(), 1);
             let expressions = &block[0];
 
-            assert!(expressions.len() == 1);
+            assert_eq!(expressions.len(), 1);
 
             if let PipelineElement::Expression(_, expr) = &expressions[0] {
                 let subexprs: Vec<&Expr>;
@@ -632,10 +632,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"0..10", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -664,10 +664,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"0..<10", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -696,10 +696,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"10..0", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -728,10 +728,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"(3 - 3)..<(8 + 2)", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -762,10 +762,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"let a = 2; $a..10", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 2);
+        assert_eq!(block.len(), 2);
 
         let expressions = &block[1];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -802,10 +802,10 @@ mod range {
         );
 
         assert!(err.is_none());
-        assert!(block.len() == 2);
+        assert_eq!(block.len(), 2);
 
         let expressions = &block[1];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -834,10 +834,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"0..", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -866,10 +866,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"..10", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -898,10 +898,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"-10..-3", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -930,10 +930,10 @@ mod range {
         let (block, err) = parse(&mut working_set, None, b"2.0..4.0..10.0", true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 1);
+        assert_eq!(expressions.len(), 1);
         assert!(matches!(
             expressions[0],
             PipelineElement::Expression(
@@ -1278,10 +1278,10 @@ mod input_types {
         let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 3);
+        assert_eq!(expressions.len(), 3);
 
         match &expressions[0] {
             PipelineElement::Expression(
@@ -1342,7 +1342,7 @@ mod input_types {
         let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 3);
+        assert_eq!(block.len(), 3);
 
         let expressions = &block[2];
         match &expressions[1] {
@@ -1373,7 +1373,7 @@ mod input_types {
         let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 2);
+        assert_eq!(block.len(), 2);
 
         let expressions = &block[1];
         match &expressions[1] {
@@ -1405,7 +1405,7 @@ mod input_types {
         let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 3);
+        assert_eq!(block.len(), 3);
 
         let expressions = &block[1];
         match &expressions[1] {
@@ -1449,10 +1449,10 @@ mod input_types {
         let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
-        assert!(expressions.len() == 2);
+        assert_eq!(expressions.len(), 2);
 
         match &expressions[0] {
             PipelineElement::Expression(
@@ -1515,7 +1515,7 @@ mod input_types {
                                 let block = engine_state.get_block(*id);
 
                                 let expressions = &block[0];
-                                assert!(expressions.len() == 2);
+                                assert_eq!(expressions.len(), 2);
 
                                 match &expressions[1] {
                                     PipelineElement::Expression(
@@ -1555,7 +1555,7 @@ mod input_types {
         let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
         assert!(err.is_none());
-        assert!(block.len() == 1);
+        assert_eq!(block.len(), 1);
 
         let expressions = &block[0];
         match &expressions[2] {
@@ -1609,7 +1609,7 @@ mod input_types {
             let (block, err) = parse(&mut working_set, None, input.as_bytes(), true, &[]);
 
             assert!(err.is_none(), "testing: {}", input);
-            assert!(block.len() == 2, "testing: {}", input);
+            assert_eq!(block.len(), 2, "testing: {}", input);
         }
     }
 

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -168,7 +168,7 @@ mod tests {
     fn check_not_expanded(s: &str) {
         let home = PathBuf::from("/home");
         let expanded = expand_tilde_with_home(Path::new(s), Some(home));
-        assert!(expanded == Path::new(s));
+        assert_eq!(expanded, Path::new(s));
     }
 
     #[test]

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -211,7 +211,7 @@ mod tests {
             PluginResponse::Value(_) => panic!("returned wrong call type"),
             PluginResponse::PluginData(..) => panic!("returned wrong call type"),
             PluginResponse::Signature(returned_signature) => {
-                assert!(returned_signature.len() == 1);
+                assert_eq!(returned_signature.len(), 1);
                 assert_eq!(signature.name, returned_signature[0].name);
                 assert_eq!(signature.usage, returned_signature[0].usage);
                 assert_eq!(signature.extra_usage, returned_signature[0].extra_usage);

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -210,7 +210,7 @@ mod tests {
             PluginResponse::Value(_) => panic!("returned wrong call type"),
             PluginResponse::PluginData(..) => panic!("returned wrong call type"),
             PluginResponse::Signature(returned_signature) => {
-                assert!(returned_signature.len() == 1);
+                assert_eq!(returned_signature.len(), 1);
                 assert_eq!(signature.name, returned_signature[0].name);
                 assert_eq!(signature.usage, returned_signature[0].usage);
                 assert_eq!(signature.extra_usage, returned_signature[0].extra_usage);

--- a/crates/nu-pretty-hex/tests/tests.rs
+++ b/crates/nu-pretty-hex/tests/tests.rs
@@ -157,7 +157,7 @@ fn test_config() {
 // This test case checks that hex_write works even without the alloc crate.
 // Decorators to this function like simple_hex_write or PrettyHex::hex_dump()
 // will be tested when the alloc feature is selected because it feels quite
-// cumbersome to set up these tests without the comodity from `alloc`.
+// cumbersome to set up these tests without the commodity from `alloc`.
 #[test]
 fn test_hex_write_with_simple_config() {
     let config = HexConfig::simple();

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -786,7 +786,7 @@ impl EngineState {
         aliases.into_iter()
     }
 
-    /// Get all commands within scope, sorted by the commads' names
+    /// Get all commands within scope, sorted by the commands' names
     pub fn get_decls_sorted(
         &self,
         include_hidden: bool,

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -68,9 +68,9 @@ impl Visibility {
 
 #[derive(Debug, Clone)]
 pub struct ScopeFrame {
-    /// List of both active and incactive overlays in this ScopeFrame.
+    /// List of both active and inactive overlays in this ScopeFrame.
     ///
-    /// The order does not have any menaning. Indexed locally (within this ScopeFrame) by
+    /// The order does not have any meaning. Indexed locally (within this ScopeFrame) by
     /// OverlayIds in active_overlays.
     pub overlays: Vec<(Vec<u8>, OverlayFrame)>,
 

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -50,7 +50,7 @@ impl Range {
             Ok(Value::Bool { val: true, .. })
         );
 
-        // Convert the next value into the inctement
+        // Convert the next value into the increment
         let incr = if let Value::Nothing { .. } = next {
             if moves_up {
                 Value::int(1i64, expr_span)

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -387,13 +387,13 @@ where
 }
 
 fn maybe_truncate_columns(data: &mut Data, theme: &TableTheme, termwidth: usize) -> bool {
-    const TERMWIDTH_TRESHHOLD: usize = 120;
+    const TERMWIDTH_THRESHOLD: usize = 120;
 
     if data.count_columns() == 0 {
         return true;
     }
 
-    let truncate = if termwidth > TERMWIDTH_TRESHHOLD {
+    let truncate = if termwidth > TERMWIDTH_THRESHOLD {
         truncate_columns_by_columns
     } else {
         truncate_columns_by_content

--- a/crates/nu-table/src/util.rs
+++ b/crates/nu-table/src/util.rs
@@ -7,7 +7,7 @@ pub fn string_width(text: &str) -> usize {
 pub fn string_wrap(text: &str, width: usize, keep_words: bool) -> String {
     // todo: change me...
     //
-    // well... it's not effitient to build a table to wrap a string,
+    // well... it's not efficient to build a table to wrap a string,
     // but ... it's better than a copy paste (is it?)
 
     if text.is_empty() {

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -356,7 +356,7 @@ fn env_change_block_dont_preserve_command() {
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
     #[cfg(windows)]
-    assert!(actual_repl.out != "foo");
+    assert_ne!(actual_repl.out, "foo");
     #[cfg(not(windows))]
     assert!(actual_repl.err.contains("ExternalCommand"));
 }

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -268,7 +268,7 @@ fn add_overlay_scoped() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "foo");
+    assert_ne!(actual_repl.out, "foo");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -339,7 +339,7 @@ fn remove_overlay() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "foo");
+    assert_ne!(actual_repl.out, "foo");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -358,7 +358,7 @@ fn remove_last_overlay() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "foo");
+    assert_ne!(actual_repl.out, "foo");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -466,7 +466,7 @@ fn remove_overlay_discard_decl() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "bagr");
+    assert_ne!(actual_repl.out, "bagr");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -485,7 +485,7 @@ fn remove_overlay_discard_alias() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "bagr");
+    assert_ne!(actual_repl.out, "bagr");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -568,7 +568,7 @@ fn remove_overlay_dont_keep_overwritten_decl() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "bagr");
+    assert_ne!(actual_repl.out, "bagr");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -587,7 +587,7 @@ fn remove_overlay_dont_keep_overwritten_alias() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "bagr");
+    assert_ne!(actual_repl.out, "bagr");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -1091,7 +1091,7 @@ fn overlay_trim_single_quote_hide() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "foo");
+    assert_ne!(actual_repl.out, "foo");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }
@@ -1122,7 +1122,7 @@ fn overlay_trim_double_quote_hide() {
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
-    assert!(actual_repl.out != "foo");
+    assert_ne!(actual_repl.out, "foo");
     #[cfg(not(windows))]
     assert!(!actual_repl.err.is_empty());
 }


### PR DESCRIPTION
I have changed `assert!(a == b)` calls to `assert_eq!(a, b)`, which give better error messages. Similarly for `assert!(a != b)` and `assert_ne!(a, b)`. Basically all instances were comparing primitives (string slices or integers), so there is no loss of generality from special-case macros,

I have also fixed a number of typos in comments, variable names, and a few user-facing messages.