### PR TITLE
Add test for fix of issue #7754

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -175,7 +175,7 @@ impl NuCompleter {
                                 if span_end < span_start {
                                     span_start = flat.0.start;
                                     span_end = flat.0.end - 1;
-                                    offset = offset + span_offset;
+                                    offset += span_offset
                                 }
 
                                 let new_span = Span::new(span_start, span_end);

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -111,8 +111,13 @@ impl NuCompleter {
     }
 
     fn completion_helper(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        // pos: is the position of the cursor in the shell input.
+        // e.g. lets say you have an alias -> `alias ll = ls -l` and you type in the shell:
+        // > ll -a | c
+        // and your cursor is right after `c` then `pos` = 9
+        
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        let offset = working_set.next_span_start();
+        let mut offset = working_set.next_span_start(); // This is the offset of 
         let (mut new_line, alias_offset) = try_find_alias(line.as_bytes(), &working_set);
         let initial_line = line.to_string();
         let alias_total_offset: usize = alias_offset.iter().sum();
@@ -156,14 +161,22 @@ impl NuCompleter {
                                     most_left_variable(flat_idx, &working_set, flattened.clone());
 
                                 // Create a new span
-                                let new_span = if flat_idx == 0 {
-                                    Span::new(flat.0.start, flat.0.end - 1 - span_offset)
-                                } else {
-                                    Span::new(
-                                        flat.0.start - span_offset,
-                                        flat.0.end - 1 - span_offset,
-                                    )
-                                };
+                                // if flat_idx == 0
+                                let mut span_start = flat.0.start;
+                                let mut span_end = flat.0.end - 1 - span_offset;
+
+                                if flat_idx != 0 {
+                                    span_start = flat.0.start - span_offset;
+                                    span_end = flat.0.end - 1 - span_offset;
+                                }
+
+                                if span_end < span_start {
+                                    span_start = flat.0.start;
+                                    span_end = flat.0.end - 1;
+                                    offset = offset + span_offset;
+                                }
+
+                                let new_span = Span::new(span_start, span_end);
 
                                 // Parses the prefix. Completion should look up to the cursor position, not after.
                                 let mut prefix = working_set.get_span_contents(flat.0).to_vec();

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -115,12 +115,14 @@ impl NuCompleter {
         // e.g. lets say you have an alias -> `alias ll = ls -l` and you type in the shell:
         // > ll -a | c
         // and your cursor is right after `c` then `pos` = 9
-        
+
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        let mut offset = working_set.next_span_start(); // This is the offset of 
+        let mut offset = working_set.next_span_start();
         let (mut new_line, alias_offset) = try_find_alias(line.as_bytes(), &working_set);
-        let initial_line = line.to_string();
-        let alias_total_offset: usize = alias_offset.iter().sum();
+        // new_line: vector containing all alias "translations" so if it was `ll` now is `ls -l`.
+        // alias_offset:vector the offset between the name and the alias)
+        let initial_line = line.to_string(); // Entire line in the shell input.
+        let alias_total_offset: usize = alias_offset.iter().sum(); // the sum of all alias offsets.
         new_line.insert(alias_total_offset + pos, b'a');
         let pos = offset + pos;
         let config = self.engine_state.get_config();

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -827,7 +827,7 @@ fn alias_offset_bug_7754() {
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
     // Issue #7754
-    // Nushell crashes when an alias name is shorter than the alias command 
+    // Nushell crashes when an alias name is shorter than the alias command
     // and the alias command contains pipes.
     // This crashes before PR #7756
     let _suggestions = completer.complete("ll -a | c", 9);

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -825,7 +825,12 @@ fn alias_offset_bug_7754() {
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
-    let suggestions = completer.complete("ll -a | c", 9);
+
+    // Issue #7754
+    // Nushell crashes when an alias name is shorter than the alias command 
+    // and the alias command contains pipes.
+    // This crashes before PR #7756
+    let _suggestions = completer.complete("ll -a | c", 9);
 
     //println!(" --------- suggestions: {:?}", suggestions);
 }

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -815,3 +815,17 @@ fn extern_complete_flags(mut extern_completer: NuCompleter) {
     let expected: Vec<String> = vec!["--foo".into(), "-b".into(), "-f".into()];
     match_suggestions(expected, suggestions);
 }
+
+#[rstest]
+fn alias_offset_bug_7754() {
+    let (dir, _, mut engine, mut stack) = new_engine();
+
+    // Create an alias
+    let alias = r#"alias ll = ls -l"#;
+    assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir.clone()).is_ok());
+
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let suggestions = completer.complete("ll -a | c", 9);
+
+    //println!(" --------- suggestions: {:?}", suggestions);
+}


### PR DESCRIPTION
# Description

Fixes issue  #7754  which used to crash on when name of the alias was shorter than the command and if the command contains any pipes. check bellow for an example:

## before
add the next to your `$nu.config-path`
```
 alias ll = ls -l
```

Now press `tab` right after the `c`
```
# This will crash
> ll -a | c
[process exited with code 101 (0x00000065)]
```

## After
With the patch on this PR the shell no longer crashes on that situation.

# User-Facing Changes
None

# Tests + Formatting
Checking how to add test to this particular case.... Is it actually possible?

Make sure you've run and fixed any issues with these commands:
- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
