### PR TITLE
Allow underscores in integers and floats

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -65,6 +65,29 @@ pub fn parse_int() {
 }
 
 #[test]
+pub fn parse_int_with_underscores() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let (block, err) = parse(&mut working_set, None, b"420_69_2023", true, &[]);
+
+    assert!(err.is_none());
+    assert_eq!(block.len(), 1);
+    let expressions = &block[0];
+    assert_eq!(expressions.len(), 1);
+    assert!(matches!(
+        expressions[0],
+        PipelineElement::Expression(
+            _,
+            Expression {
+                expr: Expr::Int(420692023),
+                ..
+            }
+        )
+    ))
+}
+
+#[test]
 pub fn parse_binary_with_hex_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -19,6 +19,16 @@ fn alias_1() -> TestResult {
 }
 
 #[test]
+fn ints_with_underscores() -> TestResult {
+    run_test("1_0000_0000_0000 + 10", "1000000000010")
+}
+
+#[test]
+fn floats_with_underscores() -> TestResult {
+    run_test("3.1415_9265_3589_793 * 2", "6.283185307179586")
+}
+
+#[test]
 fn alias_2() -> TestResult {
     run_test(
         "def foo [$x $y] { $x + $y + 10 }; alias f = foo 33; f 100",

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -29,6 +29,21 @@ fn floats_with_underscores() -> TestResult {
 }
 
 #[test]
+fn bin_ints_with_underscores() -> TestResult {
+    run_test("0b_10100_11101_10010", "21426")
+}
+
+#[test]
+fn oct_ints_with_underscores() -> TestResult {
+    run_test("0o2443_6442_7652_0044", "90422533333028")
+}
+
+#[test]
+fn hex_ints_with_underscores() -> TestResult {
+   run_test("0x68__9d__6a", "6856042")
+}
+
+#[test]
 fn alias_2() -> TestResult {
     run_test(
         "def foo [$x $y] { $x + $y + 10 }; alias f = foo 33; f 100",

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -40,7 +40,7 @@ fn oct_ints_with_underscores() -> TestResult {
 
 #[test]
 fn hex_ints_with_underscores() -> TestResult {
-   run_test("0x68__9d__6a", "6856042")
+    run_test("0x68__9d__6a", "6856042")
 }
 
 #[test]


### PR DESCRIPTION
# Description

This PR makes changes that allow underscores in numbers.

Example:
```nu
# allows underscores to be placed arbitrarily to enhance readability.
let pi = 3.1415_9265_3589_793

# works with integers
let num = 1_000_000_000_000
let fav_color = 0x68_9d_6a
```