### PR TITLE
Allow main command to define top-level module command

### DIFF
--- a/crates/nu-command/src/core_commands/help_modules.rs
+++ b/crates/nu-command/src/core_commands/help_modules.rs
@@ -151,15 +151,11 @@ pub fn help_modules(
         long_desc.push_str(&format!("{G}Module{RESET}: {C}{name}{RESET}"));
         long_desc.push_str("\n\n");
 
-        if !module.decls.is_empty() {
+        if !module.decls.is_empty() || module.main.is_some() {
             let commands: Vec<(Vec<u8>, DeclId)> = engine_state.get_decls_sorted(false).collect();
 
-            let mut module_commands: Vec<(&[u8], DeclId)> = module
-                .decls
-                .iter()
-                .map(|(name, id)| (name.as_ref(), *id))
-                .collect();
-            module_commands.sort_by(|a, b| a.0.cmp(b.0));
+            let mut module_commands = module.decls();
+            module_commands.sort_by(|a, b| a.0.cmp(&b.0));
 
             let commands_str = module_commands
                 .iter()

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -302,12 +302,14 @@ fn parse_module(
     is_debug: bool,
     span: Span,
 ) -> Result<PipelineData, ShellError> {
+    let filename = filename.unwrap_or_else(|| "empty".to_string());
+
     let start = working_set.next_span_start();
-    working_set.add_file(filename.unwrap_or_else(|| "empty".to_string()), contents);
+    working_set.add_file(filename.clone(), contents);
     let end = working_set.next_span_start();
 
     let new_span = Span::new(start, end);
-    let (_, _, _, err) = parse_module_block(working_set, new_span, &[]);
+    let (_, _, _, err) = parse_module_block(working_set, new_span, filename.as_bytes(), &[]);
 
     if err.is_some() {
         if is_debug {

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -314,3 +314,31 @@ fn help_usage_extra_usage() {
         assert!(!actual.out.contains("alias_line2"));
     })
 }
+
+#[test]
+fn help_modules_main_1() {
+    let inp = &[
+        r#"module spam {
+            export def main [] { 'foo' };
+        }"#,
+        "help spam",
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.out.contains("  spam"));
+}
+
+#[test]
+fn help_modules_main_2() {
+    let inp = &[
+        r#"module spam {
+            export def main [] { 'foo' };
+        }"#,
+        "help modules | where name == spam | get 0.commands.0",
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -229,7 +229,7 @@ fn use_main_1() {
 fn use_main_2() {
     let inp = &[
         r#"module spam { export def main [] { "spam" } }"#,
-        r#"use spam spam"#,
+        r#"use spam main"#,
         r#"spam"#,
     ];
 
@@ -242,7 +242,7 @@ fn use_main_2() {
 fn use_main_3() {
     let inp = &[
         r#"module spam { export def main [] { "spam" } }"#,
-        r#"use spam [ spam ]"#,
+        r#"use spam [ main ]"#,
         r#"spam"#,
     ];
 
@@ -267,9 +267,10 @@ fn use_main_4() {
 #[test]
 fn use_main_def_env() {
     let inp = &[
-        r#"module spam { export def-env main [] { "spam" } }"#,
+        r#"module spam { export def-env main [] { let-env SPAM = "spam" } }"#,
         r#"use spam"#,
         r#"spam"#,
+        r#"$env.SPAM"#,
     ];
 
     let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -211,3 +211,95 @@ fn use_module_creates_accurate_did_you_mean_2() {
         "command 'foo' was not found but it exists in module 'spam'; try importing it with `use`"
     ));
 }
+
+#[test]
+fn use_main_1() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn use_main_2() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"use spam spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn use_main_3() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"use spam [ spam ]"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn use_main_4() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"use spam *"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn use_main_def_env() {
+    let inp = &[
+        r#"module spam { export def-env main [] { "spam" } }"#,
+        r#"use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn use_main_def_known_external() {
+    // note: requires installed cargo
+    let inp = &[
+        r#"module cargo { export extern main [] }"#,
+        r#"use cargo"#,
+        r#"cargo --version"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.out.contains("cargo"));
+}
+
+#[test]
+fn use_main_not_exported() {
+    let inp = &[
+        r#"module spam { def main [] { "spam" } }"#,
+        r#"use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.err.contains("external_command"));
+}

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -505,9 +505,9 @@ impl<'e, 's> ScopeData<'e, 's> {
             let module = self.engine_state.get_module(**module_id);
 
             let export_commands: Vec<Value> = module
-                .decls
-                .keys()
-                .map(|bytes| Value::string(String::from_utf8_lossy(bytes), span))
+                .decls()
+                .iter()
+                .map(|(bytes, _)| Value::string(String::from_utf8_lossy(bytes), span))
                 .collect();
 
             let export_aliases: Vec<Value> = module

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -207,6 +207,14 @@ pub enum ParseError {
         #[label = "can't export from module {1}"] Span,
     ),
 
+    #[error("Can't export alias defined as 'main'.")]
+    #[diagnostic(
+        code(nu::parser::export_main_alias_not_allowed),
+        url(docsrs),
+        help("Exporting aliases as 'main' is not allowed. Either rename the alias or convert it to a custom command.")
+    )]
+    ExportMainAliasNotAllowed(#[label = "can't export from module"] Span),
+
     #[error("Active overlay not found.")]
     #[diagnostic(code(nu::parser::active_overlay_not_found), url(docsrs))]
     ActiveOverlayNotFound(#[label = "not an active overlay"] Span),
@@ -443,6 +451,7 @@ impl ParseError {
             ParseError::CommandDefNotValid(s) => *s,
             ParseError::ModuleNotFound(s) => *s,
             ParseError::NamedAsModule(_, _, s) => *s,
+            ParseError::ExportMainAliasNotAllowed(s) => *s,
             ParseError::CyclicalModuleImport(_, s) => *s,
             ParseError::ModuleOrOverlayNotFound(s) => *s,
             ParseError::ActiveOverlayNotFound(s) => *s,

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -195,6 +195,18 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::cyclical_module_import), url(docsrs), help("{0}"))]
     CyclicalModuleImport(String, #[label = "detected cyclical module import"] Span),
 
+    #[error("Can't export {0} named same as the module.")]
+    #[diagnostic(
+        code(nu::parser::named_as_module),
+        url(docsrs),
+        help("Module {1} can't export {0} named the same as the module. Either change the module name, or export `main` custom command.")
+    )]
+    NamedAsModule(
+        String,
+        String,
+        #[label = "can't export from module {1}"] Span,
+    ),
+
     #[error("Active overlay not found.")]
     #[diagnostic(code(nu::parser::active_overlay_not_found), url(docsrs))]
     ActiveOverlayNotFound(#[label = "not an active overlay"] Span),
@@ -430,6 +442,7 @@ impl ParseError {
             ParseError::AliasNotValid(s) => *s,
             ParseError::CommandDefNotValid(s) => *s,
             ParseError::ModuleNotFound(s) => *s,
+            ParseError::NamedAsModule(_, _, s) => *s,
             ParseError::CyclicalModuleImport(_, s) => *s,
             ParseError::ModuleOrOverlayNotFound(s) => *s,
             ParseError::ActiveOverlayNotFound(s) => *s,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -341,9 +341,11 @@ pub fn parse_def(
     let name = if let Some(name) = name_expr.as_string() {
         if let Some(mod_name) = module_name {
             if name.as_bytes() == mod_name {
+                let name_expr_span = name_expr.span;
+
                 return (
                     Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call.clone()),
+                        expr: Expr::Call(call),
                         span: call_span,
                         ty: Type::Any,
                         custom_completion: None,
@@ -351,7 +353,7 @@ pub fn parse_def(
                     Some(ParseError::NamedAsModule(
                         "command".to_string(),
                         name,
-                        name_expr.span,
+                        name_expr_span,
                     )),
                 );
             }
@@ -432,7 +434,7 @@ pub fn parse_def(
 
     (
         Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call.clone()),
+            expr: Expr::Call(call),
             span: call_span,
             ty: Type::Any,
             custom_completion: None,
@@ -518,9 +520,10 @@ pub fn parse_extern(
         if let (Some(name), Some(mut signature)) = (&name_expr.as_string(), sig.as_signature()) {
             if let Some(mod_name) = module_name {
                 if name.as_bytes() == mod_name {
+                    let name_expr_span = name_expr.span;
                     return (
                         Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call.clone()),
+                            expr: Expr::Call(call),
                             span: call_span,
                             ty: Type::Any,
                             custom_completion: None,
@@ -528,7 +531,7 @@ pub fn parse_extern(
                         Some(ParseError::NamedAsModule(
                             "known external".to_string(),
                             name.clone(),
-                            name_expr.span,
+                            name_expr_span,
                         )),
                     );
                 }
@@ -686,7 +689,7 @@ pub fn parse_alias(
                 };
 
                 if let Some(mod_name) = module_name {
-                    if &alias_name == mod_name {
+                    if alias_name == mod_name {
                         return (
                             Pipeline::from_vec(vec![Expression {
                                 expr: Expr::Call(call),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -540,13 +540,23 @@ pub fn parse_extern(
             if let Some(decl_id) = working_set.find_predecl(name.as_bytes()) {
                 let declaration = working_set.get_decl_mut(decl_id);
 
-                signature.name = name.clone();
+                let external_name = if let Some(mod_name) = module_name {
+                    if name.as_bytes() == b"main" {
+                        String::from_utf8_lossy(mod_name).to_string()
+                    } else {
+                        name.clone()
+                    }
+                } else {
+                    name.clone()
+                };
+
+                signature.name = external_name.clone();
                 signature.usage = usage.clone();
                 signature.extra_usage = extra_usage.clone();
                 signature.allows_unknown_args = true;
 
                 let decl = KnownExternal {
-                    name: name.to_string(),
+                    name: external_name,
                     usage: [usage, extra_usage].join("\n"),
                     signature,
                 };

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -701,6 +701,18 @@ pub fn parse_alias(
                             )),
                         );
                     }
+
+                    if &alias_name == b"main" {
+                        return (
+                            Pipeline::from_vec(vec![Expression {
+                                expr: Expr::Call(call),
+                                span: span(spans),
+                                ty: output,
+                                custom_completion: None,
+                            }]),
+                            Some(ParseError::ExportMainAliasNotAllowed(spans[split_id])),
+                        );
+                    }
                 }
 
                 let _equals = working_set.get_span_contents(spans[split_id + 1]);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5268,8 +5268,8 @@ pub fn parse_builtin_commands(
     let name = working_set.get_span_contents(lite_command.parts[0]);
 
     match name {
-        b"def" | b"def-env" => parse_def(working_set, lite_command, expand_aliases_denylist),
-        b"extern" => parse_extern(working_set, lite_command, expand_aliases_denylist),
+        b"def" | b"def-env" => parse_def(working_set, lite_command, None, expand_aliases_denylist),
+        b"extern" => parse_extern(working_set, lite_command, None, expand_aliases_denylist),
         b"let" | b"const" => {
             parse_let_or_const(working_set, &lite_command.parts, expand_aliases_denylist)
         }
@@ -5278,7 +5278,7 @@ pub fn parse_builtin_commands(
             let (expr, err) = parse_for(working_set, &lite_command.parts, expand_aliases_denylist);
             (Pipeline::from_vec(vec![expr]), err)
         }
-        b"alias" => parse_alias(working_set, lite_command, expand_aliases_denylist),
+        b"alias" => parse_alias(working_set, lite_command, None, expand_aliases_denylist),
         b"module" => parse_module(working_set, lite_command, expand_aliases_denylist),
         b"use" => {
             let (pipeline, _, err) =

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -170,7 +170,7 @@ impl EngineState {
             decls: vec![],
             aliases: vec![],
             blocks: vec![],
-            modules: vec![Module::new()],
+            modules: vec![Module::new(DEFAULT_OVERLAY_NAME.as_bytes().to_vec())],
             usage: Usage::new(),
             // make sure we have some default overlay:
             scope: ScopeFrame::with_empty_overlay(
@@ -651,24 +651,6 @@ impl EngineState {
         }
 
         None
-
-        // for (module_id, m) in self.modules.iter().enumerate() {
-        //     if m.has_decl(name) {
-        //         for overlay_frame in self.active_overlays(&[]).iter() {
-        //             let module_name = overlay_frame.modules.iter().find_map(|(key, &val)| {
-        //                 if val == module_id {
-        //                     Some(key)
-        //                 } else {
-        //                     None
-        //                 }
-        //             });
-        //             if let Some(final_name) = module_name {
-        //                 return Some(&final_name[..]);
-        //             }
-        //         }
-        //     }
-        // }
-        // None
     }
 
     pub fn find_overlay(&self, name: &[u8]) -> Option<OverlayId> {

--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -3,17 +3,14 @@ use crate::tests::{fail_test, run_test, TestResult};
 // TODO: Test the use/hide tests also as separate lines in REPL (i.e., with  merging the delta in between)
 #[test]
 fn hides_def() -> TestResult {
-    fail_test(
-        r#"def foo [] { "foo" }; hide foo; foo"#,
-        "", // we just care if it errors
-    )
+    fail_test(r#"def foo [] { "foo" }; hide foo; foo"#, "external_command")
 }
 
 #[test]
 fn hides_alias() -> TestResult {
     fail_test(
         r#"alias foo = echo "foo"; hide foo; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -52,7 +49,7 @@ fn hides_env_then_redefines() -> TestResult {
 fn hides_def_in_scope_1() -> TestResult {
     fail_test(
         r#"def foo [] { "foo" }; do { hide foo; foo }"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -68,7 +65,7 @@ fn hides_def_in_scope_2() -> TestResult {
 fn hides_def_in_scope_3() -> TestResult {
     fail_test(
         r#"def foo [] { "foo" }; do { hide foo; def foo [] { "bar" }; hide foo; foo }"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -76,7 +73,7 @@ fn hides_def_in_scope_3() -> TestResult {
 fn hides_def_in_scope_4() -> TestResult {
     fail_test(
         r#"def foo [] { "foo" }; do { def foo [] { "bar" }; hide foo; hide foo; foo }"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -84,7 +81,7 @@ fn hides_def_in_scope_4() -> TestResult {
 fn hides_alias_in_scope_1() -> TestResult {
     fail_test(
         r#"alias foo = echo "foo"; do { hide foo; foo }"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -100,7 +97,7 @@ fn hides_alias_in_scope_2() -> TestResult {
 fn hides_alias_in_scope_3() -> TestResult {
     fail_test(
         r#"alias foo = echo "foo"; do { hide foo; alias foo = echo "bar"; hide foo; foo }"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -108,7 +105,7 @@ fn hides_alias_in_scope_3() -> TestResult {
 fn hides_alias_in_scope_4() -> TestResult {
     fail_test(
         r#"alias foo = echo "foo"; do { alias foo = echo "bar"; hide foo; hide foo; foo }"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -213,7 +210,7 @@ fn hides_alias_runs_def_2() -> TestResult {
 fn hides_alias_and_def() -> TestResult {
     fail_test(
         r#"alias foo = echo "foo"; def foo [] { "bar" }; hide foo; hide foo; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -221,7 +218,7 @@ fn hides_alias_and_def() -> TestResult {
 fn hides_def_import_1() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "foo" } }; use spam; hide spam foo; spam foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -229,7 +226,7 @@ fn hides_def_import_1() -> TestResult {
 fn hides_def_import_2() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "foo" } }; use spam; hide spam; spam foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -237,7 +234,7 @@ fn hides_def_import_2() -> TestResult {
 fn hides_def_import_3() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "foo" } }; use spam; hide spam [foo]; spam foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -245,7 +242,7 @@ fn hides_def_import_3() -> TestResult {
 fn hides_def_import_4() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "foo" } }; use spam foo; hide foo; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -253,7 +250,7 @@ fn hides_def_import_4() -> TestResult {
 fn hides_def_import_5() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "foo" } }; use spam *; hide foo; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -261,7 +258,7 @@ fn hides_def_import_5() -> TestResult {
 fn hides_def_import_6() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "foo" } }; use spam *; hide spam *; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -277,7 +274,7 @@ fn hides_def_import_then_reimports() -> TestResult {
 fn hides_alias_import_1() -> TestResult {
     fail_test(
         r#"module spam { export alias foo = "foo" }; use spam; hide spam foo; spam foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -285,7 +282,7 @@ fn hides_alias_import_1() -> TestResult {
 fn hides_alias_import_2() -> TestResult {
     fail_test(
         r#"module spam { export alias foo = "foo" }; use spam; hide spam; spam foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -293,7 +290,7 @@ fn hides_alias_import_2() -> TestResult {
 fn hides_alias_import_3() -> TestResult {
     fail_test(
         r#"module spam { export alias foo = "foo" }; use spam; hide spam [foo]; spam foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -301,7 +298,7 @@ fn hides_alias_import_3() -> TestResult {
 fn hides_alias_import_4() -> TestResult {
     fail_test(
         r#"module spam { export alias foo = "foo" }; use spam foo; hide foo; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -309,7 +306,7 @@ fn hides_alias_import_4() -> TestResult {
 fn hides_alias_import_5() -> TestResult {
     fail_test(
         r#"module spam { export alias foo = "foo" }; use spam *; hide foo; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -317,7 +314,7 @@ fn hides_alias_import_5() -> TestResult {
 fn hides_alias_import_6() -> TestResult {
     fail_test(
         r#"module spam { export alias foo = "foo" }; use spam *; hide spam *; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -389,7 +386,7 @@ fn hide_shadowed_env() -> TestResult {
 fn hides_all_decls_within_scope() -> TestResult {
     fail_test(
         r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; use spam foo; hide foo; foo"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -405,7 +402,7 @@ fn hides_all_envs_within_scope() -> TestResult {
 fn hides_main_import_1() -> TestResult {
     fail_test(
         r#"module spam { export def main [] { "foo" } }; use spam; hide spam; spam"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -413,7 +410,7 @@ fn hides_main_import_1() -> TestResult {
 fn hides_main_import_2() -> TestResult {
     fail_test(
         r#"module spam { export def main [] { "foo" } }; use spam; hide spam main; spam"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -421,7 +418,7 @@ fn hides_main_import_2() -> TestResult {
 fn hides_main_import_3() -> TestResult {
     fail_test(
         r#"module spam { export def main [] { "foo" } }; use spam; hide spam [ main ]; spam"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }
 
@@ -429,6 +426,6 @@ fn hides_main_import_3() -> TestResult {
 fn hides_main_import_4() -> TestResult {
     fail_test(
         r#"module spam { export def main [] { "foo" } }; use spam; hide spam *; spam"#,
-        "", // we just care if it errors
+        "external_command",
     )
 }

--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -401,3 +401,35 @@ fn hides_all_envs_within_scope() -> TestResult {
         "",
     )
 }
+
+#[test]
+fn hides_main_import_1() -> TestResult {
+    fail_test(
+        r#"module spam { export def main [] { "foo" } }; use spam; hide spam; spam"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_main_import_2() -> TestResult {
+    fail_test(
+        r#"module spam { export def main [] { "foo" } }; use spam; hide spam main; spam"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_main_import_3() -> TestResult {
+    fail_test(
+        r#"module spam { export def main [] { "foo" } }; use spam; hide spam [ main ]; spam"#,
+        "", // we just care if it errors
+    )
+}
+
+#[test]
+fn hides_main_import_4() -> TestResult {
+    fail_test(
+        r#"module spam { export def main [] { "foo" } }; use spam; hide spam *; spam"#,
+        "", // we just care if it errors
+    )
+}

--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -338,7 +338,6 @@ fn hides_env_import_1() -> TestResult {
 }
 
 #[test]
-#[ignore = "Re-enable after virtualenv update"]
 fn hides_def_runs_env_import() -> TestResult {
     run_test(
         r#"module spam { export-env { let-env foo = "foo" }; export def foo [] { "bar" } }; use spam foo; hide foo; $env.foo"#,

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -474,3 +474,73 @@ fn module_import_const_module_name() {
         assert_eq!(actual.out, "foo");
     })
 }
+
+#[test]
+fn module_main_export_1() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn module_main_export_2() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"use spam main"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn module_main_export_3() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"use spam *"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn module_main_not_exported() {
+    let inp = &[
+        r#"module spam { def main [] { "spam" } }"#,
+        r#"use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.err.contains("external_command"));
+}
+
+#[test]
+fn module_invalid_def_name() {
+    let inp = &[r#"module spam { export def spam [] { "spam" } }"#];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.err, "TODO");
+}
+
+#[test]
+fn module_invalid_alias_name() {
+    let inp = &[r#"module spam { export alias spam = "spam" }"#];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.err, "TODO");
+}

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -476,81 +476,12 @@ fn module_import_const_module_name() {
 }
 
 #[test]
-fn module_main_export_1() {
-    let inp = &[
-        r#"module spam { export def main [] { "spam" } }"#,
-        r#"use spam"#,
-        r#"spam"#,
-    ];
+fn module_valid_def_name() {
+    let inp = &[r#"module spam { def spam [] { "spam" } }"#];
 
     let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
 
-    assert_eq!(actual.out, "spam");
-}
-
-#[test]
-fn module_main_export_2() {
-    let inp = &[
-        r#"module spam { export def main [] { "spam" } }"#,
-        r#"use spam spam"#,
-        r#"spam"#,
-    ];
-
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
-
-    assert_eq!(actual.out, "spam");
-}
-
-#[test]
-fn module_main_export_3() {
-    let inp = &[
-        r#"module spam { export def main [] { "spam" } }"#,
-        r#"use spam *"#,
-        r#"spam"#,
-    ];
-
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
-
-    assert_eq!(actual.out, "spam");
-}
-
-#[test]
-fn module_main_export_def_env() {
-    let inp = &[
-        r#"module spam { export def-env main [] { "spam" } }"#,
-        r#"use spam"#,
-        r#"spam"#,
-    ];
-
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
-
-    assert_eq!(actual.out, "spam");
-}
-
-#[test]
-fn module_main_export_def_known_external() {
-    let inp = &[
-        r#"module cargo { export extern main [] }"#,
-        r#"use cargo"#,
-        r#"cargo --version"#,
-    ];
-
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
-
-    assert!(actual.out.contains("cargo"));
-}
-
-#[test]
-fn module_main_not_exported() {
-    let inp = &[
-        r#"module spam { def main [] { "spam" } }"#,
-        r#"use spam"#,
-        r#"spam"#,
-    ];
-
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
-
-    assert!(actual.err.contains("external_command"));
+    assert_eq!(actual.out, "");
 }
 
 #[test]
@@ -563,12 +494,30 @@ fn module_invalid_def_name() {
 }
 
 #[test]
+fn module_valid_alias_name() {
+    let inp = &[r#"module spam { alias spam = "spam" }"#];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "");
+}
+
+#[test]
 fn module_invalid_alias_name() {
     let inp = &[r#"module spam { export alias spam = "spam" }"#];
 
     let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
 
     assert!(actual.err.contains("named_as_module"));
+}
+
+#[test]
+fn module_valid_known_external_name() {
+    let inp = &[r#"module spam { extern spam [] }"#];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "");
 }
 
 #[test]

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -492,7 +492,7 @@ fn module_main_export_1() {
 fn module_main_export_2() {
     let inp = &[
         r#"module spam { export def main [] { "spam" } }"#,
-        r#"use spam main"#,
+        r#"use spam spam"#,
         r#"spam"#,
     ];
 
@@ -515,6 +515,32 @@ fn module_main_export_3() {
 }
 
 #[test]
+fn module_main_export_def_env() {
+    let inp = &[
+        r#"module spam { export def-env main [] { "spam" } }"#,
+        r#"use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn module_main_export_def_known_external() {
+    let inp = &[
+        r#"module cargo { export extern main [] }"#,
+        r#"use cargo"#,
+        r#"cargo --version"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.out.contains("cargo"));
+}
+
+#[test]
 fn module_main_not_exported() {
     let inp = &[
         r#"module spam { def main [] { "spam" } }"#,
@@ -533,7 +559,7 @@ fn module_invalid_def_name() {
 
     let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
 
-    assert_eq!(actual.err, "TODO");
+    assert!(actual.err.contains("named_as_module"));
 }
 
 #[test]
@@ -542,5 +568,14 @@ fn module_invalid_alias_name() {
 
     let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
 
-    assert_eq!(actual.err, "TODO");
+    assert!(actual.err.contains("named_as_module"));
+}
+
+#[test]
+fn module_invalid_known_external_name() {
+    let inp = &[r#"module spam { export extern spam [] }"#];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.err.contains("named_as_module"));
 }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -494,8 +494,17 @@ fn module_invalid_def_name() {
 }
 
 #[test]
-fn module_valid_alias_name() {
+fn module_valid_alias_name_1() {
     let inp = &[r#"module spam { alias spam = "spam" }"#];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn module_valid_alias_name_2() {
+    let inp = &[r#"module spam { alias main = "spam" }"#];
 
     let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
 

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -512,6 +512,15 @@ fn module_invalid_alias_name() {
 }
 
 #[test]
+fn module_main_alias_not_allowed() {
+    let inp = &[r#"module spam { export alias main = 'spam' }"#];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.err.contains("export_main_alias_not_allowed"));
+}
+
+#[test]
 fn module_valid_known_external_name() {
     let inp = &[r#"module spam { extern spam [] }"#];
 

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -546,3 +546,19 @@ fn module_invalid_known_external_name() {
 
     assert!(actual.err.contains("named_as_module"));
 }
+
+#[test]
+fn main_inside_module_is_main() {
+    let inp = &[
+        r#"module spam {
+            export def main [] { 'foo' };
+            export def foo [] { main }
+        }"#,
+        "use spam foo",
+        "foo",
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "foo");
+}

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1193,3 +1193,70 @@ fn overlay_use_and_reolad_keep_custom() {
     assert_eq!(actual.out, "newfoonewfoonewfoo");
     assert_eq!(actual_repl.out, "newfoonewfoonewfoo");
 }
+
+#[test]
+fn overlay_use_main() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"overlay use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn overlay_use_main_prefix() {
+    let inp = &[
+        r#"module spam { export def main [] { "spam" } }"#,
+        r#"overlay use spam --prefix"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn overlay_use_main_def_env() {
+    let inp = &[
+        r#"module spam { export def-env main [] { let-env SPAM = "spam" } }"#,
+        r#"overlay use spam"#,
+        r#"spam"#,
+        r#"$env.SPAM"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn overlay_use_main_def_known_external() {
+    // note: requires installed cargo
+    let inp = &[
+        r#"module cargo { export extern main [] }"#,
+        r#"overlay use cargo"#,
+        r#"cargo --version"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.out.contains("cargo"));
+}
+
+#[test]
+fn overlay_use_main_not_exported() {
+    let inp = &[
+        r#"module spam { def main [] { "spam" } }"#,
+        r#"overlay use spam"#,
+        r#"spam"#,
+    ];
+
+    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+
+    assert!(actual.err.contains("external_command"));
+}


### PR DESCRIPTION
# Description

Adding `export def main [] { ... }` to a module allows defining a command named after the module. Applies to `def`, `def-env` and `extern`.

Example:
```
> module spam { 
    export def main [] { 'hello spam!' }
}

> use spam

> spam
hello spam!
```

# User-Facing Changes

* Adds a special case for `main` commands exported from modules
* Exporting a command from a module with the same name as the module is not allowed.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
