### PR TITLE
update semver dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,7 +3020,7 @@ version = "0.74.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
- "semver 0.11.0",
+ "semver 1.0.16",
 ]
 
 [[package]]
@@ -3416,16 +3416,6 @@ name = "peresil"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57"
-
-[[package]]
-name = "pest"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
 
 [[package]]
 name = "phf"
@@ -4400,7 +4390,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver 1.0.16",
 ]
 
 [[package]]
@@ -4530,38 +4520,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "seq-macro"
@@ -5368,12 +5340,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "umask"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 nu-plugin = { path="../nu-plugin", version = "0.74.1" }
 nu-protocol = { path="../nu-protocol", version = "0.74.1", features = ["plugin"]}
 
-semver = "0.11.0"
+semver = "1.0.16"

--- a/crates/nu_plugin_inc/src/inc.rs
+++ b/crates/nu_plugin_inc/src/inc.rs
@@ -1,5 +1,6 @@
 use nu_plugin::LabeledError;
 use nu_protocol::{ast::CellPath, Span, Value};
+use semver::{BuildMetadata, Prerelease, Version};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Action {
@@ -35,9 +36,9 @@ impl Inc {
                 };
 
                 match act_on {
-                    SemVerAction::Major => ver.increment_major(),
-                    SemVerAction::Minor => ver.increment_minor(),
-                    SemVerAction::Patch => ver.increment_patch(),
+                    SemVerAction::Major => Self::increment_major(&mut ver),
+                    SemVerAction::Minor => Self::increment_minor(&mut ver),
+                    SemVerAction::Patch => Self::increment_patch(&mut ver),
                 }
 
                 Value::string(ver.to_string(), head)
@@ -47,6 +48,27 @@ impl Inc {
                 Err(_) => Value::string(input, head),
             },
         }
+    }
+
+    pub fn increment_patch(v: &mut Version) {
+        v.patch += 1;
+        v.pre = Prerelease::EMPTY;
+        v.build = BuildMetadata::EMPTY;
+    }
+
+    pub fn increment_minor(v: &mut Version) {
+        v.minor += 1;
+        v.patch = 0;
+        v.pre = Prerelease::EMPTY;
+        v.build = BuildMetadata::EMPTY;
+    }
+
+    pub fn increment_major(v: &mut Version) {
+        v.major += 1;
+        v.minor = 0;
+        v.patch = 0;
+        v.pre = Prerelease::EMPTY;
+        v.build = BuildMetadata::EMPTY;
     }
 
     pub fn for_semver(&mut self, part: SemVerAction) {


### PR DESCRIPTION
# Description

This PR updates the semver dependency and updates the `inc` plugin to use the latest api.

# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
