### PR TITLE
Check all user groups.

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -1,5 +1,6 @@
 use crate::filesystem::cd_query::query;
 use crate::{get_current_shell, get_shells};
+#[cfg(unix)]
 use libc::gid_t;
 use nu_engine::{current_dir, CallExt};
 use nu_protocol::ast::Call;

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -303,7 +303,11 @@ fn any_group(current_user_gid: gid_t, owner_group: u32) -> bool {
                     // Fixes https://github.com/ogham/rust-users/issues/44
                     // If a user isn't in more than one group then this fix won't work,
                     // However its common for a user to be in more than one group, so this should work for most.
-                    if groups.len() >= 2 {
+                    if groups.len() == 2 && groups[1].gid() == 0 {
+                        // We have no way of knowing if this is due to the issue or the user is actually in the root group
+                        // So we will assume they are in the root group and leave it.
+                        // It's not the end of the world if we are wrong, they will just get a permission denied error once inside.
+                    } else {
                         groups.pop();
                     }
 

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -291,7 +291,6 @@ fn have_permission(dir: impl AsRef<Path>) -> PermissionResult<'static> {
                                             groups.pop();
                                         }
 
-                                        println!("groups: {:?}", groups);
                                         groups
                                     })
                                     .unwrap_or_default()

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -253,16 +253,25 @@ fn have_permission(dir: impl AsRef<Path>) -> PermissionResult<'static> {
 
             let current_user_gid = users::get_current_gid();
             let mut current_user_groups = match users::get_current_username() {
-                None => return PermissionResult::PermissionDenied("Unable to get current user name"),
-                Some(name) => match users::get_user_groups(&name, current_user_gid) {
-                    None => return PermissionResult::PermissionDenied("Unable to get current user groups"),
-                    Some(groups) => groups.into_iter()
+                None => {
+                    return PermissionResult::PermissionDenied("Unable to get current user name")
                 }
+                Some(name) => match users::get_user_groups(&name, current_user_gid) {
+                    None => {
+                        return PermissionResult::PermissionDenied(
+                            "Unable to get current user groups",
+                        )
+                    }
+                    Some(groups) => groups.into_iter(),
+                },
             };
 
             let owner_user = metadata.uid();
             let owner_group = metadata.gid();
-            match (current_user_gid == owner_user, current_user_groups.any(|group| group.gid() == owner_group)) {
+            match (
+                current_user_gid == owner_user,
+                current_user_groups.any(|group| group.gid() == owner_group),
+            ) {
                 (true, _) => {
                     if has_bit(permission_mods::unix::USER_EXECUTE) {
                         PermissionResult::PermissionOk


### PR DESCRIPTION
Previously the group check was only for the current users gid, now we check against all the users groups.


# Description

Currently when using the `cd` command to enter a directory there was only a check against the current user id, and exact current group id, meaning if a directory had a group permission and that group wasn't the users group it was effectively ignored.

The fix simply implements a check through all the users current groups.