### PR TITLE
Remove deprecated `--numbered` flag from four commands

### DIFF
--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -9,9 +9,9 @@ pub fn test_examples(cmd: impl Command + 'static) {
 #[cfg(test)]
 mod test_examples {
     use super::super::{
-        Ansi, Date, Echo, Enumerate, From, If, Into, IntoString, Let, LetEnv, Math, MathEuler,
-        MathPi, MathRound, Path, Random, Sort, SortBy, Split, SplitColumn, SplitRow, Str, StrJoin,
-        StrLength, StrReplace, Url, Values, Wrap,
+        Ansi, Date, Echo, Enumerate, Flatten, From, Get, If, Into, IntoString, Let, LetEnv, Math,
+        MathEuler, MathPi, MathRound, Path, Random, Sort, SortBy, Split, SplitColumn, SplitRow,
+        Str, StrJoin, StrLength, StrReplace, Url, Values, Wrap,
     };
     use crate::{Break, Each, Mut, To};
     use itertools::Itertools;
@@ -63,6 +63,8 @@ mod test_examples {
             let mut working_set = StateWorkingSet::new(&engine_state);
             working_set.add_decl(Box::new(Each));
             working_set.add_decl(Box::new(Enumerate));
+            working_set.add_decl(Box::new(Flatten));
+            working_set.add_decl(Box::new(Get));
             working_set.add_decl(Box::new(Let));
             working_set.add_decl(Box::new(Sort));
             working_set.add_decl(Box::new(SortBy));

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -10,8 +10,8 @@ pub fn test_examples(cmd: impl Command + 'static) {
 mod test_examples {
     use super::super::{
         Ansi, Date, Echo, Enumerate, Flatten, From, Get, If, Into, IntoString, Let, LetEnv, Math,
-        MathEuler, MathPi, MathRound, Path, Random, Sort, SortBy, Split, SplitColumn, SplitRow,
-        Str, StrJoin, StrLength, StrReplace, Url, Values, Wrap,
+        MathEuler, MathPi, MathRound, ParEach, Path, Random, Sort, SortBy, Split, SplitColumn,
+        SplitRow, Str, StrJoin, StrLength, StrReplace, Update, Url, Values, Wrap,
     };
     use crate::{Break, Each, Mut, To};
     use itertools::Itertools;
@@ -61,40 +61,42 @@ mod test_examples {
             // Base functions that are needed for testing
             // Try to keep this working set small to keep tests running as fast as possible
             let mut working_set = StateWorkingSet::new(&engine_state);
+            working_set.add_decl(Box::new(Ansi));
+            working_set.add_decl(Box::new(Break));
+            working_set.add_decl(Box::new(Date));
             working_set.add_decl(Box::new(Each));
+            working_set.add_decl(Box::new(Echo));
             working_set.add_decl(Box::new(Enumerate));
             working_set.add_decl(Box::new(Flatten));
+            working_set.add_decl(Box::new(From));
             working_set.add_decl(Box::new(Get));
+            working_set.add_decl(Box::new(If));
+            working_set.add_decl(Box::new(Into));
+            working_set.add_decl(Box::new(IntoString));
             working_set.add_decl(Box::new(Let));
+            working_set.add_decl(Box::new(LetEnv));
+            working_set.add_decl(Box::new(Math));
+            working_set.add_decl(Box::new(MathEuler));
+            working_set.add_decl(Box::new(MathPi));
+            working_set.add_decl(Box::new(MathRound));
+            working_set.add_decl(Box::new(Mut));
+            working_set.add_decl(Box::new(Path));
+            working_set.add_decl(Box::new(ParEach));
+            working_set.add_decl(Box::new(Random));
             working_set.add_decl(Box::new(Sort));
             working_set.add_decl(Box::new(SortBy));
+            working_set.add_decl(Box::new(Split));
+            working_set.add_decl(Box::new(SplitColumn));
+            working_set.add_decl(Box::new(SplitRow));
             working_set.add_decl(Box::new(Str));
             working_set.add_decl(Box::new(StrJoin));
             working_set.add_decl(Box::new(StrLength));
             working_set.add_decl(Box::new(StrReplace));
-            working_set.add_decl(Box::new(From));
-            working_set.add_decl(Box::new(If));
             working_set.add_decl(Box::new(To));
-            working_set.add_decl(Box::new(Into));
-            working_set.add_decl(Box::new(IntoString));
-            working_set.add_decl(Box::new(Random));
-            working_set.add_decl(Box::new(Split));
-            working_set.add_decl(Box::new(SplitColumn));
-            working_set.add_decl(Box::new(SplitRow));
-            working_set.add_decl(Box::new(Math));
-            working_set.add_decl(Box::new(Path));
-            working_set.add_decl(Box::new(Date));
             working_set.add_decl(Box::new(Url));
+            working_set.add_decl(Box::new(Update));
             working_set.add_decl(Box::new(Values));
-            working_set.add_decl(Box::new(Ansi));
             working_set.add_decl(Box::new(Wrap));
-            working_set.add_decl(Box::new(LetEnv));
-            working_set.add_decl(Box::new(Echo));
-            working_set.add_decl(Box::new(Break));
-            working_set.add_decl(Box::new(Mut));
-            working_set.add_decl(Box::new(MathEuler));
-            working_set.add_decl(Box::new(MathPi));
-            working_set.add_decl(Box::new(MathRound));
             // Adding the command that is being tested to the working set
             working_set.add_decl(cmd);
 

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -9,9 +9,9 @@ pub fn test_examples(cmd: impl Command + 'static) {
 #[cfg(test)]
 mod test_examples {
     use super::super::{
-        Ansi, Date, Echo, From, If, Into, IntoString, Let, LetEnv, Math, MathEuler, MathPi,
-        MathRound, Path, Random, Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace,
-        Url, Values, Wrap,
+        Ansi, Date, Echo, Enumerate, From, If, Into, IntoString, Let, LetEnv, Math, MathEuler,
+        MathPi, MathRound, Path, Random, Sort, SortBy, Split, SplitColumn, SplitRow, Str, StrJoin,
+        StrLength, StrReplace, Url, Values, Wrap,
     };
     use crate::{Break, Each, Mut, To};
     use itertools::Itertools;
@@ -62,7 +62,10 @@ mod test_examples {
             // Try to keep this working set small to keep tests running as fast as possible
             let mut working_set = StateWorkingSet::new(&engine_state);
             working_set.add_decl(Box::new(Each));
+            working_set.add_decl(Box::new(Enumerate));
             working_set.add_decl(Box::new(Let));
+            working_set.add_decl(Box::new(Sort));
+            working_set.add_decl(Box::new(SortBy));
             working_set.add_decl(Box::new(Str));
             working_set.add_decl(Box::new(StrJoin));
             working_set.add_decl(Box::new(StrLength));

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -50,7 +50,7 @@ impl Command for All {
             },
             Example {
                 description: "Check that all values are equal to twice their index",
-                example: "[0 2 4 6] | enumerate | all { $in.item == $in.index * 2 }",
+                example: "[0 2 4 6] | enumerate | all {|i| $i.item == $i.index * 2 }",
                 result: Some(Value::test_bool(true)),
             },
             Example {

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -44,9 +44,15 @@ impl Command for All {
                 result: Some(Value::test_bool(true)),
             },
             Example {
+                description: "Check that each item is a string",
+                example: "[foo bar 2 baz] | all { ($in | describe) == 'string' }",
+                result: Some(Value::test_bool(false)),
+            },
+            Example {
                 description: "Check that all values are equal to twice their index",
-                example: "[0 2 4 6] | all {|el ind| $el == $ind * 2 }",
-                result: Some(Value::test_bool(true)),
+                example: "[0 2 4 6] | enumerate | all { $in.item == $in.index * 2 } | get item",
+                // This currently fails signature tests because of `enumerate`
+                result: None, //Some(Value::test_bool(true)),
             },
             Example {
                 description: "Check that all of the values are even, using a stored closure",
@@ -80,7 +86,7 @@ impl Command for All {
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
 
-        for (idx, value) in input.into_interruptible_iter(ctrlc).enumerate() {
+        for value in input.into_interruptible_iter(ctrlc) {
             // with_env() is used here to ensure that each iteration uses
             // a different set of environment variables.
             // Hence, a 'cd' in the first loop won't affect the next loop.
@@ -88,18 +94,6 @@ impl Command for All {
 
             if let Some(var_id) = var_id {
                 stack.add_var(var_id, value.clone());
-            }
-            // Optional index argument
-            if let Some(var) = block.signature.get_positional(1) {
-                if let Some(var_id) = &var.var_id {
-                    stack.add_var(
-                        *var_id,
-                        Value::Int {
-                            val: idx as i64,
-                            span,
-                        },
-                    );
-                }
             }
 
             let eval = eval_block(

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -50,9 +50,8 @@ impl Command for All {
             },
             Example {
                 description: "Check that all values are equal to twice their index",
-                example: "[0 2 4 6] | enumerate | all { $in.item == $in.index * 2 } | get item",
-                // This currently fails signature tests because of `enumerate`
-                result: None, //Some(Value::test_bool(true)),
+                example: "[0 2 4 6] | enumerate | all { $in.item == $in.index * 2 }",
+                result: Some(Value::test_bool(true)),
             },
             Example {
                 description: "Check that all of the values are even, using a stored closure",

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -50,9 +50,8 @@ impl Command for Any {
             },
             Example {
                 description: "Check if any value is equal to twice its own index",
-                example: "[9 8 7 6] | enumerate | any { $in.item == $in.index * 2 } | get item",
-                // This currently fails signature tests because of `enumerate`
-                result: None, //Some(Value::test_bool(true)),
+                example: "[9 8 7 6] | enumerate | any {|i| $i.item == $i.index * 2 }",
+                result: Some(Value::test_bool(true)),
             },
             Example {
                 description: "Check if any of the values are odd, using a stored closure",

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -35,10 +35,13 @@ with 'transpose' first."#
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("each")
-            .input_output_types(vec![(
-                Type::List(Box::new(Type::Any)),
-                Type::List(Box::new(Type::Any)),
-            )])
+            .input_output_types(vec![
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
+                (Type::Table(vec![]), Type::List(Box::new(Type::Any))),
+            ])
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
@@ -94,11 +97,10 @@ with 'transpose' first."#
                 example: r#"[1 2 3] | enumerate | each {|e| if $e.item == 2 { $"found 2 at ($e.index)!"} }"#,
                 description:
                     "Iterate over each element, producing a list showing indexes of any 2s",
-                // This currently fails signature tests because of `enumerate`
-                result: None, /*Some(Value::List {
-                                  vals: vec![Value::test_string("found 2 at 1!")],
-                                  span: Span::test_data(),
-                              }),*/
+                result: Some(Value::List {
+                    vals: vec![Value::test_string("found 2 at 1!")],
+                    span: Span::test_data(),
+                }),
             },
             Example {
                 example: r#"[1 2 3] | each --keep-empty {|e| if $e == 2 { "found 2!"} }"#,

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -24,10 +24,13 @@ impl Command for EachWhile {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(
-                Type::List(Box::new(Type::Any)),
-                Type::List(Box::new(Type::Any)),
-            )])
+            .input_output_types(vec![
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
+                (Type::Table(vec![]), Type::List(Box::new(Type::Any))),
+            ])
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
@@ -63,11 +66,10 @@ impl Command for EachWhile {
             Example {
                 example: r#"[1 2 3] | enumerate | each while {|e| if $e.item < 2 { $"value ($e.item) at ($e.index)!"} }"#,
                 description: "Iterate over each element, printing the matching value and its index",
-                // This currently fails signature tests because of `enumerate`
-                result: None, /*Some(Value::List {
-                                  vals: vec![Value::test_string("value 1 at 0!")],
-                                  span: Span::test_data(),
-                              }),*/
+                result: Some(Value::List {
+                    vals: vec![Value::test_string("value 1 at 0!")],
+                    span: Span::test_data(),
+                }),
             },
         ]
     }

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -61,12 +61,13 @@ impl Command for EachWhile {
                 }),
             },
             Example {
-                example: r#"[1 2 3] | each while {|el ind| if $el < 2 { $"value ($el) at ($ind)!"} }"#,
+                example: r#"[1 2 3] | enumerate | each while {|e| if $e.item < 2 { $"value ($e.item) at ($e.index)!"} }"#,
                 description: "Iterate over each element, printing the matching value and its index",
-                result: Some(Value::List {
-                    vals: vec![Value::test_string("value 1 at 0!")],
-                    span: Span::test_data(),
-                }),
+                // This currently fails signature tests because of `enumerate`
+                result: None, /*Some(Value::List {
+                                  vals: vec![Value::test_string("value 1 at 0!")],
+                                  span: Span::test_data(),
+                              }),*/
             },
         ]
     }
@@ -96,12 +97,9 @@ impl Command for EachWhile {
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::ListStream { .. } => Ok(input
-                // To enumerate over the input (for the index argument),
-                // it must be converted into an iterator using into_iter().
                 // TODO: Could this be changed to .into_interruptible_iter(ctrlc) ?
                 .into_iter()
-                .enumerate()
-                .map_while(move |(idx, x)| {
+                .map_while(move |x| {
                     // with_env() is used here to ensure that each iteration uses
                     // a different set of environment variables.
                     // Hence, a 'cd' in the first loop won't affect the next loop.
@@ -110,18 +108,6 @@ impl Command for EachWhile {
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
                             stack.add_var(*var_id, x.clone());
-                        }
-                    }
-                    // Optional second index argument
-                    if let Some(var) = block.signature.get_positional(1) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(
-                                *var_id,
-                                Value::Int {
-                                    val: idx as i64,
-                                    span,
-                                },
-                            );
                         }
                     }
 
@@ -216,17 +202,7 @@ impl Command for EachWhile {
 #[cfg(test)]
 mod test {
     use super::*;
-    use nu_test_support::{nu, pipeline};
 
-    #[test]
-    fn uses_optional_index_argument() {
-        let actual = nu!(
-            cwd: ".", pipeline(
-            r#"[7 8 9 10] | each while {|el ind| $el + $ind } | to nuon"#
-        ));
-
-        assert_eq!(actual.out, "[7, 9, 11, 13]");
-    }
     #[test]
     fn test_examples() {
         use crate::test_examples;

--- a/crates/nu-command/src/filters/each_while.rs
+++ b/crates/nu-command/src/filters/each_while.rs
@@ -33,11 +33,6 @@ impl Command for EachWhile {
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
                 "the closure to run",
             )
-            .switch(
-                "numbered",
-                "iterate with an index (deprecated; use a two-parameter closure instead)",
-                Some('n'),
-            )
             .category(Category::Filters)
     }
 
@@ -84,7 +79,6 @@ impl Command for EachWhile {
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let capture_block: Closure = call.req(engine_state, stack, 0)?;
-        let numbered = call.has_flag("numbered");
 
         let metadata = input.metadata();
         let ctrlc = engine_state.ctrlc.clone();
@@ -115,24 +109,7 @@ impl Command for EachWhile {
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x.clone(),
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x.clone());
-                            }
+                            stack.add_var(*var_id, x.clone());
                         }
                     }
                     // Optional second index argument
@@ -175,8 +152,7 @@ impl Command for EachWhile {
                 ..
             } => Ok(stream
                 .into_iter()
-                .enumerate()
-                .map_while(move |(idx, x)| {
+                .map_while(move |x| {
                     // with_env() is used here to ensure that each iteration uses
                     // a different set of environment variables.
                     // Hence, a 'cd' in the first loop won't affect the next loop.
@@ -189,24 +165,7 @@ impl Command for EachWhile {
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x.clone(),
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x.clone());
-                            }
+                            stack.add_var(*var_id, x.clone());
                         }
                     }
 

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -72,8 +72,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                 // To enumerate over the input (for the index argument),
                 // it must be converted into an iterator using into_iter().
                 .into_iter()
-                .enumerate()
-                .filter_map(move |(idx, x)| {
+                .filter_map(move |x| {
                     // with_env() is used here to ensure that each iteration uses
                     // a different set of environment variables.
                     // Hence, a 'cd' in the first loop won't affect the next loop.
@@ -82,18 +81,6 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
                             stack.add_var(*var_id, x.clone());
-                        }
-                    }
-                    // Optional index argument
-                    if let Some(var) = block.signature.get_positional(1) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(
-                                *var_id,
-                                Value::Int {
-                                    val: idx as i64,
-                                    span,
-                                },
-                            );
                         }
                     }
 
@@ -125,8 +112,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                 ..
             } => Ok(stream
                 .into_iter()
-                .enumerate()
-                .filter_map(move |(idx, x)| {
+                .filter_map(move |x| {
                     // see note above about with_env()
                     stack.with_env(&orig_env_vars, &orig_env_hidden);
 
@@ -138,18 +124,6 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
                             stack.add_var(*var_id, x.clone());
-                        }
-                    }
-                    // Optional index argument
-                    if let Some(var) = block.signature.get_positional(1) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(
-                                *var_id,
-                                Value::Int {
-                                    val: idx as i64,
-                                    span,
-                                },
-                            );
                         }
                     }
 

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -73,33 +73,35 @@ impl Command for Insert {
         },
         Example {
             description: "Insert a column with values equal to their row index, plus the value of 'foo' in each row",
-            example: "[[foo]; [7] [8] [9]] | enumerate | insert bar {|e| $e.item.foo + $e.index } | get item",
-            // This currently fails signature tests because of `enumerate`
-            result: None /*Some(Value::List {
+            example: "[[foo]; [7] [8] [9]] | enumerate | insert bar {|e| $e.item.foo + $e.index } | flatten",
+            result: Some(Value::List {
                 vals: vec![Value::Record {
-                    cols: vec!["foo".into(), "bar".into()],
+                    cols: vec!["index".into(), "foo".into(), "bar".into()],
                     vals: vec![
+                        Value::test_int(0),
                         Value::test_int(7),
                         Value::test_int(7),
                     ],
                     span: Span::test_data(),
                 }, Value::Record {
-                    cols: vec!["foo".into(), "bar".into()],
+                    cols: vec!["index".into(),"foo".into(), "bar".into()],
                     vals: vec![
+                        Value::test_int(1),
                         Value::test_int(8),
                         Value::test_int(9),
                     ],
                     span: Span::test_data(),
                 }, Value::Record {
-                    cols: vec!["foo".into(), "bar".into()],
+                    cols: vec!["index".into(), "foo".into(), "bar".into()],
                     vals: vec![
+                        Value::test_int(2),
                         Value::test_int(9),
                         Value::test_int(11),
                     ],
                     span: Span::test_data(),
                 }],
                 span: Span::test_data(),
-            }),*/
+            }),
         }]
     }
 }

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -32,11 +32,6 @@ impl Command for ParEach {
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
                 "the closure to run",
             )
-            .switch(
-                "numbered",
-                "iterate with an index (deprecated; use a two-parameter closure instead)",
-                Some('n'),
-            )
             .category(Category::Filters)
     }
 
@@ -49,7 +44,7 @@ impl Command for ParEach {
                 result: None,
             },
             Example {
-                example: r#"[1 2 3] | par-each -n { |it| if $it.item == 2 { $"found 2 at ($it.index)!"} }"#,
+                example: r#"[1 2 3] | par-each { |item index| if $item == 2 { $"found 2 at ($index)!"} }"#,
                 description: "Iterate over each element, print the matching value and its index",
                 result: Some(Value::List {
                     vals: vec![Value::test_string("found 2 at 1!")],
@@ -68,7 +63,6 @@ impl Command for ParEach {
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
         let capture_block: Closure = call.req(engine_state, stack, 0)?;
 
-        let numbered = call.has_flag("numbered");
         let metadata = input.metadata();
         let ctrlc = engine_state.ctrlc.clone();
         let block_id = capture_block.block_id;
@@ -90,24 +84,7 @@ impl Command for ParEach {
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x.clone(),
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x.clone());
-                            }
+                            stack.add_var(*var_id, x.clone());
                         }
                     }
                     // Optional second index argument
@@ -154,24 +131,7 @@ impl Command for ParEach {
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x.clone(),
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x.clone());
-                            }
+                            stack.add_var(*var_id, x.clone());
                         }
                     }
                     // Optional second index argument
@@ -217,24 +177,7 @@ impl Command for ParEach {
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x.clone(),
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x.clone());
-                            }
+                            stack.add_var(*var_id, x.clone());
                         }
                     }
                     // Optional second index argument
@@ -289,24 +232,7 @@ impl Command for ParEach {
 
                     if let Some(var) = block.signature.get_positional(0) {
                         if let Some(var_id) = &var.var_id {
-                            if numbered {
-                                stack.add_var(
-                                    *var_id,
-                                    Value::Record {
-                                        cols: vec!["index".into(), "item".into()],
-                                        vals: vec![
-                                            Value::Int {
-                                                val: idx as i64,
-                                                span,
-                                            },
-                                            x.clone(),
-                                        ],
-                                        span,
-                                    },
-                                );
-                            } else {
-                                stack.add_var(*var_id, x.clone());
-                            }
+                            stack.add_var(*var_id, x.clone());
                         }
                     }
                     // Optional second index argument

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -23,10 +23,13 @@ impl Command for ParEach {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("par-each")
-            .input_output_types(vec![(
-                Type::List(Box::new(Type::Any)),
-                Type::List(Box::new(Type::Any)),
-            )])
+            .input_output_types(vec![
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
+                (Type::Table(vec![]), Type::List(Box::new(Type::Any))),
+            ])
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
@@ -55,21 +58,23 @@ impl Command for ParEach {
                     span: Span::test_data(),
                 }),
             },
-            Example {
-                example: r#"1..20 | enumerate | par-each { update item { 2 * $in.item } } | sort-by index | get item | to nuon"#,
-                description: "Enumerate and sort-by can be used to reconstruct the original order",
-                // This currently fails signature tests because of `enumerate`
-                result: None, // Some(Value::test_string("[2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40]")),
-            },
+            // I'm not sure why this doesn't work.
+            // Example {
+            //     example: r#"1..3 | enumerate | par-each {|p| update item {$p.item + 1}} | sort-by item | get item"#,
+            //     description: "Enumerate and sort-by can be used to reconstruct the original order",
+            //     result: Some(Value::List {
+            //         vals: vec![Value::test_int(2), Value::test_int(4), Value::test_int(6)],
+            //         span: Span::test_data(),
+            //     }),
+            // },
             Example {
                 example: r#"[1 2 3] | enumerate | par-each { |e| if $e.item == 2 { $"found 2 at ($e.index)!"} }"#,
                 description:
                     "Iterate over each element, producing a list showing indexes of any 2s",
-                // This currently fails signature tests because of `enumerate`
-                result: None, /*Some(Value::List {
-                                  vals: vec![Value::test_string("found 2 at 1!")],
-                                  span: Span::test_data(),
-                              }),*/
+                result: Some(Value::List {
+                    vals: vec![Value::test_string("found 2 at 1!")],
+                    span: Span::test_data(),
+                }),
             },
         ]
     }

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -58,15 +58,14 @@ impl Command for ParEach {
                     span: Span::test_data(),
                 }),
             },
-            // I'm not sure why this doesn't work.
-            // Example {
-            //     example: r#"1..3 | enumerate | par-each {|p| update item {$p.item + 1}} | sort-by item | get item"#,
-            //     description: "Enumerate and sort-by can be used to reconstruct the original order",
-            //     result: Some(Value::List {
-            //         vals: vec![Value::test_int(2), Value::test_int(4), Value::test_int(6)],
-            //         span: Span::test_data(),
-            //     }),
-            // },
+            Example {
+                example: r#"1..3 | enumerate | par-each {|p| update item ($p.item * 2)} | sort-by item | get item"#,
+                description: "Enumerate and sort-by can be used to reconstruct the original order",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(2), Value::test_int(4), Value::test_int(6)],
+                    span: Span::test_data(),
+                }),
+            },
             Example {
                 example: r#"[1 2 3] | enumerate | par-each { |e| if $e.item == 2 { $"found 2 at ($e.index)!"} }"#,
                 description:

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -16,7 +16,10 @@ impl Command for Reduce {
 
     fn signature(&self) -> Signature {
         Signature::build("reduce")
-            .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Any)])
+            .input_output_types(vec![
+                (Type::List(Box::new(Type::Any)), Type::Any),
+                (Type::Table(vec![]), Type::Any),
+            ])
             .named(
                 "fold",
                 SyntaxShape::Any,
@@ -53,8 +56,7 @@ impl Command for Reduce {
                 example:
                     "[ 8 7 6 ] | enumerate | reduce -f 0 {|it, acc| $acc + $it.item + $it.index }",
                 description: "Sum values of a list, plus their indexes",
-                // This currently fails signature tests because of `enumerate`
-                result: None, //Some(Value::test_int(22)),
+                result: Some(Value::test_int(24)),
             },
             Example {
                 example: "[ 1 2 3 4 ] | reduce -f 10 {|it, acc| $acc + $it }",
@@ -70,8 +72,7 @@ impl Command for Reduce {
                 example: r#"['foo.gz', 'bar.gz', 'baz.gz'] | enumerate | reduce -f '' {|str all| $"($all)(if $str.index != 0 {'; '})($str.index + 1)-($str.item)" }"#,
                 description:
                     "Add ascending numbers to each of the filenames, and join with semicolons.",
-                // This currently fails signature tests because of `enumerate`
-                result: None, //Some(Value::test_string("1-foo.gz; 2-bar.gz; 3-baz.gz")),
+                result: Some(Value::test_string("1-foo.gz; 2-bar.gz; 3-baz.gz")),
             },
         ]
     }

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -61,15 +61,14 @@ impl Command for Update {
             Example {
                 description: "Use in closure form for more involved updating logic",
                 example: "[[count fruit]; [1 'apple']] | enumerate | update item.count {|e| ($e.item.fruit | str length) + $e.index } | get item",
-                // This currently fails signature tests because of `enumerate`
-                result: None /*Some(Value::List {
+                result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["count".into(), "fruit".into()],
                         vals: vec![Value::test_int(5), Value::test_string("apple")],
                         span: Span::test_data(),
                     }],
                     span: Span::test_data(),
-                }),*/
+                }),
             },
             Example {
                 description: "Alter each value in the 'authors' column to use a single string instead of a list",

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -72,8 +72,9 @@ impl Command for Upsert {
         }, Example {
             description: "Use in closure form for more involved updating logic",
             example: "[[count fruit]; [1 'apple']] | enumerate | upsert item.count {|e| ($e.item.fruit | str length) + $e.index } | get item",
-            // This currently fails signature tests because of `enumerate`
-            result: None //Some(Value::List { vals: vec![Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(5), Value::test_string("apple")], span: Span::test_data()}], span: Span::test_data()}),
+            result: Some(Value::List { vals: vec![
+                Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(5), Value::test_string("apple")], span: Span::test_data()}],
+                span: Span::test_data()}),
         },
         Example {
             description: "Upsert an int into a list, updating an existing value based on the index",

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -56,14 +56,24 @@ impl Command for Upsert {
             description: "Update a record's value",
             example: "{'name': 'nu', 'stars': 5} | upsert name 'Nushell'",
             result: Some(Value::Record { cols: vec!["name".into(), "stars".into()], vals: vec![Value::test_string("Nushell"), Value::test_int(5)], span: Span::test_data()}),
-        }, Example {
+        },
+        Example {
+            description: "Update each row of a table",
+            example: "[[name lang]; [Nushell ''] [Reedline '']] | upsert lang 'Rust'",
+            result: Some(Value::List { vals: vec![
+                Value::Record { cols: vec!["name".into(), "lang".into()], vals: vec![Value::test_string("Nushell"), Value::test_string("Rust")], span: Span::test_data()},
+                Value::Record { cols: vec!["name".into(), "lang".into()], vals: vec![Value::test_string("Reedline"), Value::test_string("Rust")], span: Span::test_data()}
+                ], span: Span::test_data()}),
+        },
+        Example {
             description: "Insert a new entry into a single record",
             example: "{'name': 'nu', 'stars': 5} | upsert language 'Rust'",
             result: Some(Value::Record { cols: vec!["name".into(), "stars".into(), "language".into()], vals: vec![Value::test_string("nu"), Value::test_int(5), Value::test_string("Rust")], span: Span::test_data()}),
         }, Example {
             description: "Use in closure form for more involved updating logic",
-            example: "[[count fruit]; [1 'apple']] | upsert count {|row index| ($row.fruit | str length) + $index }",
-            result: Some(Value::List { vals: vec![Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(5), Value::test_string("apple")], span: Span::test_data()}], span: Span::test_data()}),
+            example: "[[count fruit]; [1 'apple']] | enumerate | upsert item.count {|e| ($e.item.fruit | str length) + $e.index } | get item",
+            // This currently fails signature tests because of `enumerate`
+            result: None //Some(Value::List { vals: vec![Value::Record { cols: vec!["count".into(), "fruit".into()], vals: vec![Value::test_int(5), Value::test_string("apple")], span: Span::test_data()}], span: Span::test_data()}),
         },
         Example {
             description: "Upsert an int into a list, updating an existing value based on the index",
@@ -116,9 +126,6 @@ fn upsert(
         let orig_env_vars = stack.env_vars.clone();
         let orig_env_hidden = stack.env_hidden.clone();
 
-        // enumerate() can't be used here because it converts records into tables
-        // when combined with into_pipeline_data(). Hence, the index is tracked manually like so.
-        let mut idx: i64 = 0;
         input.map(
             move |mut input| {
                 // with_env() is used here to ensure that each iteration uses
@@ -130,13 +137,6 @@ fn upsert(
                     if let Some(var_id) = &var.var_id {
                         stack.add_var(*var_id, input.clone())
                     }
-                }
-                // Optional index argument
-                if let Some(var) = block.signature.get_positional(1) {
-                    if let Some(var_id) = &var.var_id {
-                        stack.add_var(*var_id, Value::Int { val: idx, span });
-                    }
-                    idx += 1;
                 }
 
                 let output = eval_block(

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -85,25 +85,12 @@ not supported."#
         let redirect_stderr = call.redirect_stderr;
         Ok(input
             .into_iter_strict(span)?
-            .enumerate()
-            .filter_map(move |(idx, value)| {
+            .filter_map(move |value| {
                 stack.with_env(&orig_env_vars, &orig_env_hidden);
 
                 if let Some(var) = block.signature.get_positional(0) {
                     if let Some(var_id) = &var.var_id {
                         stack.add_var(*var_id, value.clone());
-                    }
-                }
-                // Optional index argument
-                if let Some(var) = block.signature.get_positional(1) {
-                    if let Some(var_id) = &var.var_id {
-                        stack.add_var(
-                            *var_id,
-                            Value::Int {
-                                val: idx as i64,
-                                span,
-                            },
-                        );
                     }
                 }
                 let result = eval_block(
@@ -172,6 +159,11 @@ not supported."#
             Example {
                 description: "List all files that were modified in the last two weeks",
                 example: "ls | where modified >= (date now) - 2wk",
+                result: None,
+            },
+            Example {
+                description: "Find files whose filenames don't begin with the correct sequential number",
+                example: "ls | where type == file | sort-by name -n | enumerate | where {|e| $e.item.name !~ $'^($e.index + 1)' } | each { get item }",
                 result: None,
             },
         ]

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -109,16 +109,6 @@ fn early_exits_with_0_param_blocks() {
 }
 
 #[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9] | all {|el ind| print $ind | true }"#
-    ));
-
-    assert_eq!(actual.out, "012true");
-}
-
-#[test]
 fn unique_env_each_iteration() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -109,6 +109,16 @@ fn early_exits_with_0_param_blocks() {
 }
 
 #[test]
+fn all_uses_enumerate_index() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9] | enumerate | all {|el| print $el.index | true }"#
+    ));
+
+    assert_eq!(actual.out, "012true");
+}
+
+#[test]
 fn unique_env_each_iteration() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -85,6 +85,16 @@ fn early_exits_with_0_param_blocks() {
 }
 
 #[test]
+fn any_uses_enumerate_index() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9] | enumerate | any {|el| print $el.index | false }"#
+    ));
+
+    assert_eq!(actual.out, "012false");
+}
+
+#[test]
 fn unique_env_each_iteration() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -85,16 +85,6 @@ fn early_exits_with_0_param_blocks() {
 }
 
 #[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9] | any {|el ind| print $ind | false }"#
-    ));
-
-    assert_eq!(actual.out, "012false");
-}
-
-#[test]
 fn unique_env_each_iteration() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -71,23 +71,3 @@ fn each_implicit_it_in_block() {
 
     assert_eq!(actual.out, "ace");
 }
-
-#[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9 10] | each {|el ind| $ind } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[0, 1, 2, 3]");
-}
-
-#[test]
-fn each_while_uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9 10] | each while {|el ind| $ind } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[0, 1, 2, 3]");
-}

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -71,3 +71,23 @@ fn each_implicit_it_in_block() {
 
     assert_eq!(actual.out, "ace");
 }
+
+#[test]
+fn each_uses_enumerate_index() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9 10] | enumerate | each {|el| $el.index } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[0, 1, 2, 3]");
+}
+
+#[test]
+fn each_while_uses_enumerate_index() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[7 8 9 10] | enumerate | each while {|el| $el.index } | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[0, 1, 2, 3]");
+}

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -85,13 +85,3 @@ fn insert_past_end_list() {
 
     assert_eq!(actual.out, r#"[1,2,3,null,null,"abc"]"#);
 }
-
-#[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | insert b {|el ind| $ind + 1 + $el.a } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");
-}

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -85,3 +85,13 @@ fn insert_past_end_list() {
 
     assert_eq!(actual.out, r#"[1,2,3,null,null,"abc"]"#);
 }
+
+#[test]
+fn insert_uses_enumerate_index() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | enumerate | insert b {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[index, a, b]; [0, 7, 8], [1, 6, 8]]");
+}

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -47,35 +47,6 @@ fn reduce_rows_example() {
 }
 
 #[test]
-fn reduce_numbered_example() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        echo one longest three bar
-        | reduce -n { |it, acc| if ($it.item | str length) > ($acc.item | str length) {echo $it} else {echo $acc}}
-        | get index
-        "#
-        )
-    );
-
-    assert_eq!(actual.out, "1");
-}
-
-#[test]
-fn reduce_numbered_integer_addition_example() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        echo [1 2 3 4]
-        | reduce -n { |it, acc| $acc.item + $it.item }
-        "#
-        )
-    );
-
-    assert_eq!(actual.out, "10");
-}
-
-#[test]
 fn folding_with_tables() {
     let actual = nu!(
         cwd: ".", pipeline(

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -106,7 +106,7 @@ fn reduce_numbered_example() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        [one longest three bar] | reduce --fold ['', -1] {|it, acc, idx| if ($it | str length) > ($acc.0 | str length) { [$it $idx] } else { $acc }} | get 0
+        [one longest three bar] | reduce --fold ['' -1] {|it, acc, idx| if ($it | str length) > ($acc.0 | str length) { [$it $idx] } else { $acc }} | get 1
         "#
         )
     );

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -47,6 +47,37 @@ fn reduce_rows_example() {
 }
 
 #[test]
+fn reduce_enumerate_example() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo one longest three bar | enumerate
+        | reduce { |it, acc| if ($it.item | str length) > ($acc.item | str length) {echo $it} else {echo $acc}}
+        | get index
+        "#
+        )
+    );
+
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn reduce_enumerate_integer_addition_example() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo [1 2 3 4]
+        | enumerate
+        | reduce { |it, acc| { index: ($it.index) item: ($acc.item + $it.item)} }
+        | get item
+        "#
+        )
+    );
+
+    assert_eq!(actual.out, "10");
+}
+
+#[test]
 fn folding_with_tables() {
     let actual = nu!(
         cwd: ".", pipeline(

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -92,21 +92,11 @@ fn error_reduce_empty() {
 }
 
 #[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[18 19 20] | reduce -f 0 {|elem accum index| $accum + $index } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "3");
-}
-
-#[test]
-fn reduce_numbered_example() {
+fn enumerate_reduce_example() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        [one longest three bar] | reduce --fold ['' -1] {|it, acc, idx| if ($it | str length) > ($acc.0 | str length) { [$it $idx] } else { $acc }} | get 1
+        [one longest three bar] | enumerate | reduce {|it, acc| if ($it.item | str length) > ($acc.item | str length) { $it } else { $acc }} | get index
         "#
         )
     );

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -100,3 +100,16 @@ fn uses_optional_index_argument() {
 
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn reduce_numbered_example() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        [one longest three bar] | reduce --fold ['', -1] {|it, acc, idx| if ($it | str length) > ($acc.0 | str length) { [$it $idx] } else { $acc }} | get 0
+        "#
+        )
+    );
+
+    assert_eq!(actual.out, "1");
+}

--- a/crates/nu-command/tests/commands/roll.rs
+++ b/crates/nu-command/tests/commands/roll.rs
@@ -135,8 +135,8 @@ mod columns {
             transpose bit --ignore-titles
             | get bit
             | reverse
-            | each --numbered { |it|
-                $it.item * (2 ** $it.index)
+            | each { |it index|
+                $it * (2 ** $index)
             }
             | math sum
         "#,

--- a/crates/nu-command/tests/commands/roll.rs
+++ b/crates/nu-command/tests/commands/roll.rs
@@ -135,8 +135,9 @@ mod columns {
             transpose bit --ignore-titles
             | get bit
             | reverse
-            | each { |it index|
-                $it * (2 ** $index)
+            | enumerate
+            | each { |it|
+                $it.item * (2 ** $it.index)
             }
             | math sum
         "#,

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -114,13 +114,3 @@ fn update_nonexistent_column() {
 
     assert!(actual.err.contains("cannot find column 'b'"));
 }
-
-#[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | update a {|el ind| $ind + 1 + $el.a } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[[a]; [8], [8]]");
-}

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -114,3 +114,13 @@ fn update_nonexistent_column() {
 
     assert!(actual.err.contains("cannot find column 'b'"));
 }
+
+#[test]
+fn update_uses_enumerate_index() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | enumerate | update item.a {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[index, a]; [0, 8], [1, 8]]");
+}

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -69,6 +69,26 @@ fn sets_the_column_from_a_subexpression() {
 }
 
 #[test]
+fn upsert_uses_enumerate_index_inserting() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | enumerate | upsert b {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[index, a, b]; [0, 7, 8], [1, 6, 8]]");
+}
+
+#[test]
+fn upsert_uses_enumerate_index_updating() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"[[a]; [7] [6]] | enumerate | upsert a {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
+    ));
+
+    assert_eq!(actual.out, "[[index, a]; [0, 8], [1, 8]]");
+}
+
+#[test]
 fn index_does_not_exist() {
     let actual = nu!(
         cwd: ".", pipeline(

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -69,26 +69,6 @@ fn sets_the_column_from_a_subexpression() {
 }
 
 #[test]
-fn uses_optional_index_argument_inserting() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | upsert b {|el ind| $ind + 1 + $el.a } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[[a, b]; [7, 8], [6, 8]]");
-}
-
-#[test]
-fn uses_optional_index_argument_updating() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | upsert a {|el ind| $ind + 1 + $el.a } | to nuon"#
-    ));
-
-    assert_eq!(actual.out, "[[a]; [8], [8]]");
-}
-
-#[test]
 fn index_does_not_exist() {
     let actual = nu!(
         cwd: ".", pipeline(

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -81,6 +81,16 @@ fn where_not_in_table() {
     assert_eq!(actual.out, "4");
 }
 
+#[test]
+fn where_uses_enumerate_index() {
+    let actual = nu!(
+        cwd: ".",
+        r#"[7 8 9 10] | enumerate | where {|el| $el.index < 2 } | to nuon"#
+    );
+
+    assert_eq!(actual.out, "[[index, item]; [0, 7], [1, 8]]");
+}
+
 #[cfg(feature = "sqlite")]
 #[test]
 fn binary_operator_comparisons() {

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -81,16 +81,6 @@ fn where_not_in_table() {
     assert_eq!(actual.out, "4");
 }
 
-#[test]
-fn uses_optional_index_argument() {
-    let actual = nu!(
-        cwd: ".",
-        r#"[7 8 9 10] | where {|el ind| $ind < 2 } | to nuon"#
-    );
-
-    assert_eq!(actual.out, "[7, 8]");
-}
-
 #[cfg(feature = "sqlite")]
 #[test]
 fn binary_operator_comparisons() {

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -53,7 +53,7 @@ fn in_and_if_else() -> TestResult {
 
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
-    run_test(r#"each --help | lines | length"#, "43")
+    run_test(r#"each --help | lines | length"#, "42")
 }
 
 #[test]

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -53,7 +53,7 @@ fn in_and_if_else() -> TestResult {
 
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
-    run_test(r#"each --help | lines | length"#, "42")
+    run_test(r#"each --help | lines | length"#, "43")
 }
 
 #[test]

--- a/src/tests/test_iteration.rs
+++ b/src/tests/test_iteration.rs
@@ -3,7 +3,7 @@ use crate::tests::{run_test, TestResult};
 #[test]
 fn better_block_types() -> TestResult {
     run_test(
-        r#"([1, 2, 3] | each { |item index| $"($index) is ($item)" }).1"#,
+        r#"([1, 2, 3] | enumerate | each { |e| $"($e.index) is ($e.item)" }).1"#,
         "1 is 2",
     )
 }
@@ -29,13 +29,5 @@ fn row_condition2() -> TestResult {
     run_test(
         "[[name, size]; [a, 1], [b, 2], [c, 3]] | where $it.size > 2 | length",
         "1",
-    )
-}
-
-#[test]
-fn par_each() -> TestResult {
-    run_test(
-        r#"1..10 | par-each { |it index| ([[index, item]; [$index, ($it > 5)]]).0 } | where index == 4 | get item.0"#,
-        "false",
     )
 }

--- a/src/tests/test_iteration.rs
+++ b/src/tests/test_iteration.rs
@@ -3,7 +3,7 @@ use crate::tests::{run_test, TestResult};
 #[test]
 fn better_block_types() -> TestResult {
     run_test(
-        r#"([1, 2, 3] | each -n { |it| $"($it.index) is ($it.item)" }).1"#,
+        r#"([1, 2, 3] | each { |item index| $"($index) is ($item)" }).1"#,
         "1 is 2",
     )
 }
@@ -35,7 +35,7 @@ fn row_condition2() -> TestResult {
 #[test]
 fn par_each() -> TestResult {
     run_test(
-        r#"1..10 | par-each --numbered { |it| ([[index, item]; [$it.index, ($it.item > 5)]]).0 } | where index == 4 | get item.0"#,
+        r#"1..10 | par-each { |it index| ([[index, item]; [$index, ($it > 5)]]).0 } | where index == 4 | get item.0"#,
         "false",
     )
 }

--- a/src/tests/test_iteration.rs
+++ b/src/tests/test_iteration.rs
@@ -31,3 +31,11 @@ fn row_condition2() -> TestResult {
         "1",
     )
 }
+
+#[test]
+fn par_each() -> TestResult {
+    run_test(
+        r#"1..10 | enumerate | par-each { |it| ([[index, item]; [$it.index, ($it.item > 5)]]).0 } | where index == 4 | get item.0"#,
+        "false",
+    )
+}

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -147,8 +147,8 @@ fn bad_var_name2() -> TestResult {
 #[test]
 fn long_flag() -> TestResult {
     run_test(
-        r#"([a, b, c] | each --numbered { |it| if $it.index == 1 { 100 } else { 0 } }).1"#,
-        "100",
+        r#"([a, b, c] | each --keep-empty { |it index| if $index != 1 { 100 }}).1 | to nuon"#,
+        "null",
     )
 }
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -147,7 +147,7 @@ fn bad_var_name2() -> TestResult {
 #[test]
 fn long_flag() -> TestResult {
     run_test(
-        r#"([a, b, c] | each --keep-empty { |it index| if $index != 1 { 100 }}).1 | to nuon"#,
+        r#"([a, b, c] | enumerate | each --keep-empty { |e| if $e.index != 1 { 100 }}).1 | to nuon"#,
         "null",
     )
 }


### PR DESCRIPTION
# Description

Remove `--numbered` from ~~`for`~~, `each`, `par-each`, `reduce` and `each while`. These all provide indexes (numbering) via the optional second param to their closures.

EDIT: Closes #6986.

# User-Facing Changes

Every command that had `--numbered` listed as "deprecated" in their help docs is affected.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
