### PR TITLE
let `find` take linebreaks into account in `Value::String`

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -147,11 +147,10 @@ impl Command for Find {
     ) -> Result<PipelineData, ShellError> {
         let regex = call.get_flag::<String>(engine_state, stack, "regex")?;
 
-        let input = split_string_if_multiline(input);
-
         if let Some(regex) = regex {
             find_with_regex(regex, engine_state, stack, call, input)
         } else {
+            let input = split_string_if_multiline(input);
             find_with_rest_and_highlight(engine_state, stack, call, input)
         }
     }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -8,8 +8,8 @@ use nu_engine::{env_to_string, CallExt};
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Config, Example, IntoInterruptiblePipelineData, ListStream, PipelineData, ShellError,
-    Signature, Span, SyntaxShape, Type, Value,
+    Category, Config, Example, IntoInterruptiblePipelineData, IntoPipelineData, ListStream,
+    PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use nu_utils::get_ls_colors;
 
@@ -322,6 +322,21 @@ fn find_with_rest_and_highlight(
 
     match input {
         PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Value(Value::String { val, span }, _) => {
+            let list = Value::List {
+                vals: {
+                    let split_char = if val.contains("\r\n") { "\r\n" } else { "\n" };
+                    val.split(split_char)
+                        .map(|s| Value::String {
+                            val: s.to_string(),
+                            span,
+                        })
+                        .collect()
+                },
+                span,
+            };
+            find_with_rest_and_highlight(&engine_state, stack, call, list.into_pipeline_data())
+        }
         PipelineData::Value(_, _) => input
             .map(
                 move |mut x| match &mut x {

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -115,7 +115,7 @@ fn find_takes_into_account_linebreaks_in_string() {
     let actual = nu!(
     cwd: ".", pipeline(
     r#"
-        "atest\nanothertest" | find a | length
+        "atest\nanothertest\nnohit\n" | find a | length
         "#
     ));
 

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -109,3 +109,15 @@ fn find_with_filepath_search_with_multiple_patterns() {
         assert_eq!(actual.out, r#"["amigos.txt","arepas.clu"]"#);
     })
 }
+
+#[test]
+fn find_takes_into_account_linebreaks_in_string() {
+    let actual = nu!(
+    cwd: ".", pipeline(
+    r#"
+        "atest\nanothertest" | find a | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "2");
+}


### PR DESCRIPTION
# Description

Fixes #7774. The functionality should be the same as feeding all `PipelineDate::Value(Value::String(_,_),_)` into `lines` before putting it into `find`.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
